### PR TITLE
feat: inferred tool types via codegen

### DIFF
--- a/docs/superpowers/plans/2026-04-20-inferred-tool-types.md
+++ b/docs/superpowers/plans/2026-04-20-inferred-tool-types.md
@@ -1,0 +1,1346 @@
+# Inferred Tool Types Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Generate tool types automatically from properly typed tool functions so route files get full `context.tools` type safety without manual type aliases.
+
+**Architecture:** A new `@dawn/core` module uses the TypeScript compiler API to extract input and return types from tool file default exports, then renders them into the existing `dawn.generated.d.ts` alongside route path/param types. The vite plugin triggers typegen on dev startup and file watch. The `dawn typegen` CLI command remains for standalone use.
+
+**Tech Stack:** TypeScript compiler API (`typescript` package), Vitest, existing `@dawn/core` typegen pipeline
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|------|----------------|
+| `packages/core/src/typegen/extract-tool-types.ts` | **New.** Uses TS compiler API to extract input + return types from tool default exports. Returns `RouteToolTypes[]`. |
+| `packages/core/src/typegen/render-tool-types.ts` | **New.** Renders `DawnRouteTools` interface and `RouteTools` type alias as TypeScript source text. |
+| `packages/core/src/typegen/render-route-types.ts` | **Modified.** Add `renderDawnTypes()` that composes route types + tool types into one `declare module`. |
+| `packages/core/src/types.ts` | **Modified.** Add `ExtractedToolType` and `RouteToolTypes` interfaces. |
+| `packages/core/src/index.ts` | **Modified.** Export new functions and types. |
+| `packages/core/package.json` | **Modified.** Add `typescript` dependency. |
+| `packages/cli/src/commands/typegen.ts` | **Modified.** Call `extractToolTypes` + `renderDawnTypes` instead of `renderRouteTypes`. |
+| `packages/cli/src/commands/verify.ts` | **Modified.** Call updated rendering pipeline. |
+| `packages/vite-plugin/src/index.ts` | **Modified.** Add `configureServer` and `buildStart` hooks to trigger typegen. |
+| `packages/vite-plugin/package.json` | **Modified.** Add `@dawn/core` dependency. |
+| `packages/devkit/templates/app-basic/.../tools/greet.ts` | **Modified.** Properly typed input parameter. |
+| `packages/devkit/templates/app-basic/.../index.ts` | **Modified.** Use `RouteTools` instead of manual `HelloTools`. |
+| `packages/devkit/templates/app-basic/src/app/dawn.generated.d.ts` | **New.** Pre-generated types for template. |
+| `packages/core/test/extract-tool-types.test.ts` | **New.** Tests for tool type extraction. |
+| `packages/core/test/render-tool-types.test.ts` | **New.** Tests for tool type rendering. |
+| `test/generated/fixtures/basic.expected.json` | **Modified.** Updated `typegenOutput` and `renderedBytes`. |
+| `test/generated/fixtures/custom-app-dir.expected.json` | **Modified.** Updated `typegenOutput` and `renderedBytes`. |
+
+---
+
+### Task 1: Add TypeScript dependency to `@dawn/core`
+
+**Files:**
+- Modify: `packages/core/package.json`
+
+- [ ] **Step 1: Add `typescript` to dependencies**
+
+In `packages/core/package.json`, add `typescript` to the `dependencies` object:
+
+```json
+"dependencies": {
+  "@dawn/sdk": "workspace:*",
+  "tsx": "^4.8.1",
+  "typescript": "5.8.3"
+}
+```
+
+Use the same version as `packages/vite-plugin/package.json` (`5.8.3`).
+
+- [ ] **Step 2: Install**
+
+Run: `pnpm install`
+Expected: lockfile updates, no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/core/package.json pnpm-lock.yaml
+git commit -m "chore: add typescript dependency to @dawn/core for tool type extraction"
+```
+
+---
+
+### Task 2: Add `ExtractedToolType` and `RouteToolTypes` types
+
+**Files:**
+- Modify: `packages/core/src/types.ts`
+- Modify: `packages/core/src/index.ts`
+
+- [ ] **Step 1: Add types to `packages/core/src/types.ts`**
+
+Add at the end of the file:
+
+```typescript
+export interface ExtractedToolType {
+  readonly name: string
+  readonly inputType: string
+  readonly outputType: string
+}
+
+export interface RouteToolTypes {
+  readonly pathname: string
+  readonly tools: readonly ExtractedToolType[]
+}
+```
+
+- [ ] **Step 2: Export from `packages/core/src/index.ts`**
+
+Add `ExtractedToolType` and `RouteToolTypes` to the existing type export:
+
+```typescript
+export type {
+  DawnConfig,
+  DiscoveredDawnApp,
+  DiscoverRoutesOptions,
+  ExtractedToolType,
+  FindDawnAppOptions,
+  LoadDawnConfigOptions,
+  LoadedDawnConfig,
+  RouteDefinition,
+  RouteKind,
+  RouteManifest,
+  RouteSegment,
+  RouteToolTypes,
+} from "./types.js"
+```
+
+- [ ] **Step 3: Verify build**
+
+Run: `cd packages/core && pnpm build`
+Expected: Builds successfully.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/core/src/types.ts packages/core/src/index.ts
+git commit -m "feat: add ExtractedToolType and RouteToolTypes interfaces"
+```
+
+---
+
+### Task 3: Implement tool type extraction
+
+**Files:**
+- Create: `packages/core/src/typegen/extract-tool-types.ts`
+- Create: `packages/core/test/extract-tool-types.test.ts`
+- Modify: `packages/core/src/index.ts`
+
+This is the core of the feature. The extractor uses the TypeScript compiler API to resolve input parameter and return types from tool file default exports, then renders them as TypeScript source strings.
+
+- [ ] **Step 1: Write the failing test for basic extraction**
+
+Create `packages/core/test/extract-tool-types.test.ts`:
+
+```typescript
+import { mkdtemp, mkdir, writeFile, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { afterEach, describe, expect, test } from "vitest"
+
+import { extractToolTypesForRoute } from "../src/typegen/extract-tool-types"
+
+let tempDir: string | undefined
+
+afterEach(async () => {
+  if (tempDir) {
+    await rm(tempDir, { recursive: true })
+    tempDir = undefined
+  }
+})
+
+async function createTempToolDir(tools: Record<string, string>): Promise<string> {
+  tempDir = await mkdtemp(join(tmpdir(), "dawn-tool-extract-"))
+  const toolsDir = join(tempDir, "tools")
+  await mkdir(toolsDir, { recursive: true })
+
+  for (const [name, source] of Object.entries(tools)) {
+    await writeFile(join(toolsDir, `${name}.ts`), source, "utf8")
+  }
+
+  return tempDir
+}
+
+describe("extractToolTypesForRoute", () => {
+  test("extracts input and return types from a properly typed tool", async () => {
+    const routeDir = await createTempToolDir({
+      greet: `export default async (input: { readonly tenant: string }) => {
+  return { greeting: \`Hello, \${input.tenant}!\` }
+}`,
+    })
+
+    const result = await extractToolTypesForRoute({
+      routeDir,
+      sharedToolsDir: undefined,
+    })
+
+    expect(result).toEqual([
+      {
+        name: "greet",
+        inputType: "{ readonly tenant: string; }",
+        outputType: "{ greeting: string; }",
+      },
+    ])
+  })
+
+  test("extracts multiple tools sorted by name", async () => {
+    const routeDir = await createTempToolDir({
+      beta: `export default async (input: { id: number }) => {
+  return { found: true }
+}`,
+      alpha: `export default async (input: { name: string }) => {
+  return { ok: true }
+}`,
+    })
+
+    const result = await extractToolTypesForRoute({
+      routeDir,
+      sharedToolsDir: undefined,
+    })
+
+    expect(result).toHaveLength(2)
+    expect(result[0]!.name).toBe("alpha")
+    expect(result[1]!.name).toBe("beta")
+  })
+
+  test("returns empty array when no tools directory exists", async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "dawn-tool-extract-"))
+
+    const result = await extractToolTypesForRoute({
+      routeDir: tempDir,
+      sharedToolsDir: undefined,
+    })
+
+    expect(result).toEqual([])
+  })
+
+  test("uses unknown for untyped input parameter", async () => {
+    const routeDir = await createTempToolDir({
+      greet: `export default async (input: unknown) => {
+  return { greeting: "hello" }
+}`,
+    })
+
+    const result = await extractToolTypesForRoute({
+      routeDir,
+      sharedToolsDir: undefined,
+    })
+
+    expect(result).toEqual([
+      {
+        name: "greet",
+        inputType: "unknown",
+        outputType: "{ greeting: string; }",
+      },
+    ])
+  })
+
+  test("extracts void input when tool has no parameters", async () => {
+    const routeDir = await createTempToolDir({
+      ping: `export default async () => {
+  return { pong: true }
+}`,
+    })
+
+    const result = await extractToolTypesForRoute({
+      routeDir,
+      sharedToolsDir: undefined,
+    })
+
+    expect(result).toEqual([
+      {
+        name: "ping",
+        inputType: "void",
+        outputType: "{ pong: boolean; }",
+      },
+    ])
+  })
+
+  test("route-local tools shadow shared tools of the same name", async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "dawn-tool-extract-"))
+
+    const sharedDir = join(tempDir, "shared")
+    const sharedToolsDir = join(sharedDir, "tools")
+    await mkdir(sharedToolsDir, { recursive: true })
+    await writeFile(
+      join(sharedToolsDir, "greet.ts"),
+      `export default async (input: { name: string }) => {
+  return { greeting: "shared" }
+}`,
+      "utf8",
+    )
+
+    const routeDir = join(tempDir, "route")
+    const routeToolsDir = join(routeDir, "tools")
+    await mkdir(routeToolsDir, { recursive: true })
+    await writeFile(
+      join(routeToolsDir, "greet.ts"),
+      `export default async (input: { tenant: string }) => {
+  return { greeting: "local" }
+}`,
+      "utf8",
+    )
+
+    const result = await extractToolTypesForRoute({
+      routeDir,
+      sharedToolsDir: sharedDir,
+    })
+
+    expect(result).toEqual([
+      {
+        name: "greet",
+        inputType: "{ tenant: string; }",
+        outputType: "{ greeting: string; }",
+      },
+    ])
+  })
+
+  test("merges shared and route-local tools", async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "dawn-tool-extract-"))
+
+    const sharedDir = join(tempDir, "shared")
+    const sharedToolsDir = join(sharedDir, "tools")
+    await mkdir(sharedToolsDir, { recursive: true })
+    await writeFile(
+      join(sharedToolsDir, "shared-tool.ts"),
+      `export default async (input: { x: number }) => {
+  return { result: 1 }
+}`,
+      "utf8",
+    )
+
+    const routeDir = join(tempDir, "route")
+    const routeToolsDir = join(routeDir, "tools")
+    await mkdir(routeToolsDir, { recursive: true })
+    await writeFile(
+      join(routeToolsDir, "local-tool.ts"),
+      `export default async (input: { y: string }) => {
+  return { result: "ok" }
+}`,
+      "utf8",
+    )
+
+    const result = await extractToolTypesForRoute({
+      routeDir,
+      sharedToolsDir: sharedDir,
+    })
+
+    expect(result).toHaveLength(2)
+    expect(result[0]!.name).toBe("local-tool")
+    expect(result[1]!.name).toBe("shared-tool")
+  })
+
+  test("skips .d.ts files", async () => {
+    const routeDir = await createTempToolDir({
+      greet: `export default async (input: { tenant: string }) => {
+  return { greeting: "hello" }
+}`,
+    })
+    await writeFile(
+      join(routeDir, "tools", "types.d.ts"),
+      `export type Foo = string`,
+      "utf8",
+    )
+
+    const result = await extractToolTypesForRoute({
+      routeDir,
+      sharedToolsDir: undefined,
+    })
+
+    expect(result).toHaveLength(1)
+    expect(result[0]!.name).toBe("greet")
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd packages/core && pnpm test -- extract-tool-types`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement `extractToolTypesForRoute`**
+
+Create `packages/core/src/typegen/extract-tool-types.ts`:
+
+```typescript
+import { readdir } from "node:fs/promises"
+import { basename, join } from "node:path"
+
+import ts from "typescript"
+
+import type { ExtractedToolType } from "../types.js"
+
+interface ExtractToolTypesOptions {
+  readonly routeDir: string
+  readonly sharedToolsDir: string | undefined
+}
+
+export async function extractToolTypesForRoute(
+  options: ExtractToolTypesOptions,
+): Promise<readonly ExtractedToolType[]> {
+  const sharedTools = options.sharedToolsDir
+    ? await discoverToolFiles(join(options.sharedToolsDir, "tools"))
+    : []
+  const routeLocalTools = await discoverToolFiles(join(options.routeDir, "tools"))
+
+  const toolFiles = new Map<string, string>()
+
+  for (const file of sharedTools) {
+    toolFiles.set(basename(file, ".ts"), file)
+  }
+
+  for (const file of routeLocalTools) {
+    toolFiles.set(basename(file, ".ts"), file)
+  }
+
+  if (toolFiles.size === 0) {
+    return []
+  }
+
+  const filePaths = [...toolFiles.values()]
+  const program = createProgram(filePaths)
+  const checker = program.getTypeChecker()
+
+  const extracted: ExtractedToolType[] = []
+
+  for (const [name, filePath] of [...toolFiles.entries()].sort(([a], [b]) =>
+    a.localeCompare(b),
+  )) {
+    const sourceFile = program.getSourceFile(filePath)
+    if (!sourceFile) continue
+
+    const tool = extractFromSourceFile(sourceFile, checker)
+    if (!tool) continue
+
+    extracted.push({ name, ...tool })
+  }
+
+  return extracted
+}
+
+async function discoverToolFiles(toolsDir: string): Promise<readonly string[]> {
+  const entries = await readdir(toolsDir, { withFileTypes: true }).catch(() => null)
+
+  if (!entries) {
+    return []
+  }
+
+  return entries
+    .filter(
+      (entry) => entry.isFile() && entry.name.endsWith(".ts") && !entry.name.endsWith(".d.ts"),
+    )
+    .map((entry) => join(toolsDir, entry.name))
+    .sort((left, right) => left.localeCompare(right))
+}
+
+function createProgram(filePaths: readonly string[]): ts.Program {
+  const options: ts.CompilerOptions = {
+    target: ts.ScriptTarget.ES2022,
+    module: ts.ModuleKind.ESNext,
+    moduleResolution: ts.ModuleResolutionKind.Bundler,
+    strict: true,
+    noEmit: true,
+    lib: ["lib.es2022.d.ts"],
+  }
+
+  return ts.createProgram([...filePaths], options)
+}
+
+function extractFromSourceFile(
+  sourceFile: ts.SourceFile,
+  checker: ts.TypeChecker,
+): { readonly inputType: string; readonly outputType: string } | null {
+  const moduleSymbol = checker.getSymbolAtLocation(sourceFile)
+  if (!moduleSymbol) return null
+
+  const exports = checker.getExportsOfModule(moduleSymbol)
+  const defaultExport = exports.find((e) => e.escapedName === "default")
+  if (!defaultExport) return null
+
+  const exportType = checker.getTypeOfSymbolAtLocation(defaultExport, sourceFile)
+  const signatures = checker.getSignaturesOfType(exportType, ts.SignatureKind.Call)
+  if (signatures.length === 0) return null
+
+  const signature = signatures[0]!
+  const params = signature.getParameters()
+
+  let inputType: string
+  if (params.length === 0) {
+    inputType = "void"
+  } else {
+    const firstParam = params[0]!
+    const paramType = checker.getTypeOfSymbolAtLocation(firstParam, sourceFile)
+    inputType = checker.typeToString(
+      paramType,
+      sourceFile,
+      ts.TypeFormatFlags.NoTruncation | ts.TypeFormatFlags.UseFullyQualifiedType,
+    )
+  }
+
+  const returnType = checker.getReturnTypeOfSignature(signature)
+  const unwrappedReturn = unwrapPromise(returnType, checker)
+  const outputType = checker.typeToString(
+    unwrappedReturn,
+    sourceFile,
+    ts.TypeFormatFlags.NoTruncation | ts.TypeFormatFlags.UseFullyQualifiedType,
+  )
+
+  return { inputType, outputType }
+}
+
+function unwrapPromise(type: ts.Type, checker: ts.TypeChecker): ts.Type {
+  const symbol = type.getSymbol()
+  if (symbol?.getName() === "Promise") {
+    const typeArgs = (type as ts.TypeReference).typeArguments
+    if (typeArgs && typeArgs.length === 1 && typeArgs[0]) {
+      return typeArgs[0]
+    }
+  }
+  return type
+}
+```
+
+- [ ] **Step 4: Export from index**
+
+Add to `packages/core/src/index.ts`:
+
+```typescript
+export { extractToolTypesForRoute } from "./typegen/extract-tool-types.js"
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cd packages/core && pnpm test -- extract-tool-types`
+Expected: All tests pass. If `checker.typeToString` produces slightly different formatting (e.g. `{ readonly tenant: string; }` vs `{ readonly tenant: string }`), update test expectations to match the actual compiler output.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/core/src/typegen/extract-tool-types.ts packages/core/test/extract-tool-types.test.ts packages/core/src/index.ts
+git commit -m "feat: implement tool type extraction using TypeScript compiler API"
+```
+
+---
+
+### Task 4: Implement tool type rendering
+
+**Files:**
+- Create: `packages/core/src/typegen/render-tool-types.ts`
+- Create: `packages/core/test/render-tool-types.test.ts`
+- Modify: `packages/core/src/index.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/core/test/render-tool-types.test.ts`:
+
+```typescript
+import { describe, expect, test } from "vitest"
+
+import { renderToolTypes } from "../src/typegen/render-tool-types"
+import type { RouteToolTypes } from "../src/types"
+
+describe("renderToolTypes", () => {
+  test("renders tool types for a single route with one tool", () => {
+    const routeTools: readonly RouteToolTypes[] = [
+      {
+        pathname: "/hello/[tenant]",
+        tools: [
+          {
+            name: "greet",
+            inputType: "{ readonly tenant: string; }",
+            outputType: "{ greeting: string; }",
+          },
+        ],
+      },
+    ]
+
+    expect(renderToolTypes(routeTools)).toMatchInlineSnapshot(`
+      "  export interface DawnRouteTools {
+        "/hello/[tenant]": {
+          readonly greet: (input: { readonly tenant: string; }) => Promise<{ greeting: string; }>;
+        };
+      }
+
+        export type RouteTools<P extends DawnRoutePath> = DawnRouteTools[P];"
+    `)
+  })
+
+  test("renders multiple tools for a route sorted by name", () => {
+    const routeTools: readonly RouteToolTypes[] = [
+      {
+        pathname: "/hello/[tenant]",
+        tools: [
+          {
+            name: "farewell",
+            inputType: "{ name: string; }",
+            outputType: "{ message: string; }",
+          },
+          {
+            name: "greet",
+            inputType: "{ tenant: string; }",
+            outputType: "{ greeting: string; }",
+          },
+        ],
+      },
+    ]
+
+    const result = renderToolTypes(routeTools)
+    expect(result).toContain("readonly farewell:")
+    expect(result).toContain("readonly greet:")
+  })
+
+  test("renders empty interface when no routes have tools", () => {
+    const routeTools: readonly RouteToolTypes[] = []
+
+    expect(renderToolTypes(routeTools)).toMatchInlineSnapshot(`
+      "  export interface DawnRouteTools {}
+
+        export type RouteTools<P extends DawnRoutePath> = DawnRouteTools[P];"
+    `)
+  })
+
+  test("renders void input as no-arg function", () => {
+    const routeTools: readonly RouteToolTypes[] = [
+      {
+        pathname: "/ping",
+        tools: [
+          {
+            name: "ping",
+            inputType: "void",
+            outputType: "{ pong: boolean; }",
+          },
+        ],
+      },
+    ]
+
+    const result = renderToolTypes(routeTools)
+    expect(result).toContain("readonly ping: () => Promise<{ pong: boolean; }>;")
+  })
+
+  test("skips routes with no tools", () => {
+    const routeTools: readonly RouteToolTypes[] = [
+      {
+        pathname: "/no-tools",
+        tools: [],
+      },
+      {
+        pathname: "/has-tools",
+        tools: [
+          {
+            name: "action",
+            inputType: "{ x: number; }",
+            outputType: "{ ok: boolean; }",
+          },
+        ],
+      },
+    ]
+
+    const result = renderToolTypes(routeTools)
+    expect(result).not.toContain("/no-tools")
+    expect(result).toContain("/has-tools")
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd packages/core && pnpm test -- render-tool-types`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement `renderToolTypes`**
+
+Create `packages/core/src/typegen/render-tool-types.ts`:
+
+```typescript
+import type { RouteToolTypes } from "../types.js"
+
+export function renderToolTypes(routeTools: readonly RouteToolTypes[]): string {
+  const routesWithTools = routeTools.filter((route) => route.tools.length > 0)
+
+  if (routesWithTools.length === 0) {
+    return [
+      "  export interface DawnRouteTools {}",
+      "",
+      "  export type RouteTools<P extends DawnRoutePath> = DawnRouteTools[P];",
+    ].join("\n")
+  }
+
+  const entries = routesWithTools.map((route) => {
+    const toolLines = route.tools.map((tool) => {
+      const signature =
+        tool.inputType === "void"
+          ? `() => Promise<${tool.outputType}>`
+          : `(input: ${tool.inputType}) => Promise<${tool.outputType}>`
+      return `      readonly ${tool.name}: ${signature};`
+    })
+    return [`    ${JSON.stringify(route.pathname)}: {`, ...toolLines, "    };"].join("\n")
+  })
+
+  return [
+    "  export interface DawnRouteTools {",
+    ...entries,
+    "  }",
+    "",
+    "  export type RouteTools<P extends DawnRoutePath> = DawnRouteTools[P];",
+  ].join("\n")
+}
+```
+
+- [ ] **Step 4: Export from index**
+
+Add to `packages/core/src/index.ts`:
+
+```typescript
+export { renderToolTypes } from "./typegen/render-tool-types.js"
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cd packages/core && pnpm test -- render-tool-types`
+Expected: All tests pass. Adjust inline snapshots if whitespace differs.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/core/src/typegen/render-tool-types.ts packages/core/test/render-tool-types.test.ts packages/core/src/index.ts
+git commit -m "feat: implement tool type rendering for dawn.generated.d.ts"
+```
+
+---
+
+### Task 5: Compose unified `renderDawnTypes` function
+
+**Files:**
+- Modify: `packages/core/src/typegen/render-route-types.ts`
+- Modify: `packages/core/test/render-route-types.test.ts`
+- Modify: `packages/core/src/index.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Add a new test to `packages/core/test/render-route-types.test.ts`:
+
+```typescript
+import { renderDawnTypes } from "../src/typegen/render-route-types"
+import type { RouteToolTypes } from "../src/types"
+
+// ... inside existing describe block, add:
+
+describe("renderDawnTypes", () => {
+  test("composes route types and tool types into single declare module", () => {
+    const manifest: RouteManifest = {
+      appRoot: "/tmp/example-app",
+      routes: [
+        {
+          id: "/hello/[tenant]",
+          pathname: "/hello/[tenant]",
+          kind: "workflow",
+          entryFile: "/tmp/example-app/src/app/(public)/hello/[tenant]/index.ts",
+          routeDir: "/tmp/example-app/src/app/(public)/hello/[tenant]",
+          segments: [
+            { kind: "static", raw: "hello" },
+            { kind: "dynamic", name: "tenant", raw: "[tenant]" },
+          ],
+        },
+      ],
+    }
+
+    const toolTypes: readonly RouteToolTypes[] = [
+      {
+        pathname: "/hello/[tenant]",
+        tools: [
+          {
+            name: "greet",
+            inputType: "{ readonly tenant: string; }",
+            outputType: "{ greeting: string; }",
+          },
+        ],
+      },
+    ]
+
+    const result = renderDawnTypes(manifest, toolTypes)
+
+    expect(result).toContain('declare module "dawn:routes"')
+    expect(result).toContain("export type DawnRoutePath")
+    expect(result).toContain("export interface DawnRouteParams")
+    expect(result).toContain("export interface DawnRouteTools")
+    expect(result).toContain("export type RouteTools<P extends DawnRoutePath>")
+    // Should be a single declare module block, not two
+    expect(result.match(/declare module/g)).toHaveLength(1)
+  })
+
+  test("renders empty tool interface when no tools exist", () => {
+    const manifest: RouteManifest = {
+      appRoot: "/tmp/example-app",
+      routes: [],
+    }
+
+    const result = renderDawnTypes(manifest, [])
+    expect(result).toContain("export interface DawnRouteTools {}")
+    expect(result).toContain("export type RouteTools<P extends DawnRoutePath>")
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd packages/core && pnpm test -- render-route-types`
+Expected: FAIL — `renderDawnTypes` not exported.
+
+- [ ] **Step 3: Add `renderDawnTypes` to `render-route-types.ts`**
+
+Add to the end of `packages/core/src/typegen/render-route-types.ts`:
+
+```typescript
+import type { RouteToolTypes } from "../types.js"
+import { renderToolTypes } from "./render-tool-types.js"
+
+export function renderDawnTypes(
+  manifest: RouteManifest,
+  toolTypes: readonly RouteToolTypes[],
+): string {
+  const pathUnion =
+    manifest.routes.length > 0
+      ? manifest.routes.map((route) => JSON.stringify(route.pathname)).join(" | ")
+      : "never"
+
+  const paramLines = manifest.routes.map((route) => {
+    const params = renderParamsForSegments(route.segments)
+    return `  ${JSON.stringify(route.pathname)}: ${params};`
+  })
+
+  const paramBlock =
+    paramLines.length === 0
+      ? "  export interface DawnRouteParams {}"
+      : ["  export interface DawnRouteParams {", ...paramLines, "  }"].join("\n")
+
+  const toolBlock = renderToolTypes(toolTypes)
+
+  return [
+    'declare module "dawn:routes" {',
+    `  export type DawnRoutePath = ${pathUnion};`,
+    "",
+    paramBlock,
+    "",
+    toolBlock,
+    "}",
+    "",
+  ].join("\n")
+}
+```
+
+Note: the import for `RouteManifest` and `RouteSegment` is already present via the existing `import type { RouteManifest, RouteSegment } from "../types.js"` at the top of the file.
+
+- [ ] **Step 4: Export from index**
+
+Update `packages/core/src/index.ts` to also export `renderDawnTypes`:
+
+```typescript
+export { renderDawnTypes, renderRouteTypes } from "./typegen/render-route-types.js"
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cd packages/core && pnpm test -- render-route-types`
+Expected: All tests pass (both old and new).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/core/src/typegen/render-route-types.ts packages/core/test/render-route-types.test.ts packages/core/src/index.ts
+git commit -m "feat: add renderDawnTypes composing route + tool types"
+```
+
+---
+
+### Task 6: Update `dawn typegen` CLI command
+
+**Files:**
+- Modify: `packages/cli/src/commands/typegen.ts`
+
+- [ ] **Step 1: Update the typegen command to extract tool types and use `renderDawnTypes`**
+
+Replace the content of `runTypegenCommand` in `packages/cli/src/commands/typegen.ts`:
+
+```typescript
+import { mkdir, writeFile } from "node:fs/promises"
+import { dirname, join } from "node:path"
+
+import {
+  discoverRoutes,
+  extractToolTypesForRoute,
+  findDawnApp,
+  renderDawnTypes,
+} from "@dawn/core"
+import type { RouteToolTypes } from "@dawn/core"
+import type { Command } from "commander"
+
+import { CliError, type CommandIo, formatErrorMessage, writeLine } from "../lib/output.js"
+
+interface TypegenOptions {
+  readonly cwd?: string
+}
+
+const OUTPUT_FILE = "dawn.generated.d.ts"
+
+export function registerTypegenCommand(program: Command, io: CommandIo): void {
+  program
+    .command("typegen")
+    .description("Generate Dawn route and tool types")
+    .option("--cwd <path>", "Path to the Dawn app root or a child directory within it")
+    .action(async (options: TypegenOptions) => {
+      await runTypegenCommand(options, io)
+    })
+}
+
+export async function runTypegenCommand(options: TypegenOptions, io: CommandIo): Promise<void> {
+  try {
+    const app = await findDawnApp(options.cwd ? { cwd: options.cwd } : {})
+    const manifest = await discoverRoutes({ appRoot: app.appRoot })
+
+    const sharedToolsDir = join(app.appRoot, "src")
+
+    const routeToolTypes: RouteToolTypes[] = []
+    for (const route of manifest.routes) {
+      const tools = await extractToolTypesForRoute({
+        routeDir: route.routeDir,
+        sharedToolsDir,
+      })
+      routeToolTypes.push({ pathname: route.pathname, tools })
+    }
+
+    const outputPath = join(app.routesDir, OUTPUT_FILE)
+
+    await mkdir(dirname(outputPath), { recursive: true })
+    await writeFile(outputPath, renderDawnTypes(manifest, routeToolTypes), "utf8")
+
+    writeLine(io.stdout, `Wrote route types to ${outputPath}`)
+  } catch (error) {
+    throw new CliError(`Failed to generate route types: ${formatErrorMessage(error)}`)
+  }
+}
+```
+
+- [ ] **Step 2: Run existing typegen tests**
+
+Run: `cd packages/cli && pnpm test -- typegen-command`
+Expected: Tests pass. The `Wrote route types` message is unchanged.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/cli/src/commands/typegen.ts
+git commit -m "feat: update dawn typegen to include tool types"
+```
+
+---
+
+### Task 7: Update `dawn verify` command
+
+**Files:**
+- Modify: `packages/cli/src/commands/verify.ts`
+
+- [ ] **Step 1: Update verify to use `renderDawnTypes`**
+
+In `packages/cli/src/commands/verify.ts`, update the typegen section (around lines 153–165). Change the import to include `extractToolTypesForRoute` and `renderDawnTypes`, and replace the `renderRouteTypes` call:
+
+Update the import at the top:
+```typescript
+import {
+  discoverRoutes,
+  extractToolTypesForRoute,
+  findDawnApp,
+  renderDawnTypes,
+} from "@dawn/core"
+import type { RouteToolTypes } from "@dawn/core"
+```
+
+Replace the typegen section:
+```typescript
+  let renderedTypes: string
+
+  try {
+    const sharedToolsDir = join(app.appRoot, "src")
+    const routeToolTypes: RouteToolTypes[] = []
+    for (const route of manifest.routes) {
+      const tools = await extractToolTypesForRoute({
+        routeDir: route.routeDir,
+        sharedToolsDir,
+      })
+      routeToolTypes.push({ pathname: route.pathname, tools })
+    }
+    renderedTypes = renderDawnTypes(manifest, routeToolTypes)
+  } catch (error) {
+    return createVerifyFailureResult(app.appRoot, checks, "typegen", error)
+  }
+```
+
+Add the `join` import from `node:path` if not already present.
+
+- [ ] **Step 2: Run existing verify tests**
+
+Run: `cd packages/cli && pnpm test -- verify-command`
+Expected: Tests pass. The `renderedBytes` value may change — that's expected and will be addressed in the fixture update task.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/cli/src/commands/verify.ts
+git commit -m "feat: update dawn verify to include tool types in typegen check"
+```
+
+---
+
+### Task 8: Update template tool and route files
+
+**Files:**
+- Modify: `packages/devkit/templates/app-basic/src/app/(public)/hello/[tenant]/tools/greet.ts`
+- Modify: `packages/devkit/templates/app-basic/src/app/(public)/hello/[tenant]/index.ts`
+- Create: `packages/devkit/templates/app-basic/src/app/dawn.generated.d.ts`
+
+- [ ] **Step 1: Update `greet.ts` to use proper types**
+
+Replace the content of `packages/devkit/templates/app-basic/src/app/(public)/hello/[tenant]/tools/greet.ts`:
+
+```typescript
+export default async (input: { readonly tenant: string }) => {
+  return { greeting: `Hello, ${input.tenant}!` }
+}
+```
+
+- [ ] **Step 2: Update route `index.ts` to use `RouteTools`**
+
+Replace the content of `packages/devkit/templates/app-basic/src/app/(public)/hello/[tenant]/index.ts`:
+
+```typescript
+import type { RuntimeContext } from "@dawn/sdk"
+import type { RouteTools } from "dawn:routes"
+
+import type { HelloState } from "./state.js"
+
+export async function workflow(
+  state: HelloState,
+  context: RuntimeContext<RouteTools<"/hello/[tenant]">>,
+): Promise<HelloState> {
+  const result = await context.tools.greet({ tenant: state.tenant })
+
+  return {
+    ...state,
+    greeting: result.greeting,
+  }
+}
+```
+
+- [ ] **Step 3: Generate the pre-baked `dawn.generated.d.ts`**
+
+Run typegen against the template to produce the exact output, then create the file. First, determine the exact output by running:
+
+```bash
+cd /Users/blove/repos/dawn && pnpm build
+```
+
+Then manually construct the file based on the template's route structure. Create `packages/devkit/templates/app-basic/src/app/dawn.generated.d.ts`:
+
+```typescript
+declare module "dawn:routes" {
+  export type DawnRoutePath = "/hello/[tenant]";
+
+  export interface DawnRouteParams {
+  "/hello/[tenant]": { tenant: string };
+  }
+
+  export interface DawnRouteTools {
+    "/hello/[tenant]": {
+      readonly greet: (input: { readonly tenant: string; }) => Promise<{ greeting: string; }>;
+    };
+  }
+
+  export type RouteTools<P extends DawnRoutePath> = DawnRouteTools[P];
+}
+```
+
+Note: The exact formatting of the generated type strings (e.g. semicolons after properties) must match what the TypeScript compiler's `typeToString` produces. Run `dawn typegen` on a test app with the updated tool to see the exact output, then use that.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/devkit/templates/app-basic/src/app/\(public\)/hello/\[tenant\]/tools/greet.ts packages/devkit/templates/app-basic/src/app/\(public\)/hello/\[tenant\]/index.ts packages/devkit/templates/app-basic/src/app/dawn.generated.d.ts
+git commit -m "feat: update template to use inferred tool types via RouteTools"
+```
+
+---
+
+### Task 9: Wire vite plugin to trigger typegen
+
+**Files:**
+- Modify: `packages/vite-plugin/src/index.ts`
+- Modify: `packages/vite-plugin/package.json`
+
+- [ ] **Step 1: Add `@dawn/core` dependency to vite-plugin**
+
+In `packages/vite-plugin/package.json`, add `@dawn/core` to dependencies:
+
+```json
+"dependencies": {
+  "@dawn/core": "workspace:*",
+  "typescript": "5.8.3"
+}
+```
+
+Run: `pnpm install`
+
+- [ ] **Step 2: Update the plugin to accept options and add typegen hooks**
+
+Update `packages/vite-plugin/src/index.ts`. Add the typegen triggering logic alongside the existing `dawnToolSchemaPlugin`:
+
+```typescript
+import { mkdir, writeFile } from "node:fs/promises"
+import { dirname, join } from "node:path"
+
+import {
+  discoverRoutes,
+  extractToolTypesForRoute,
+  findDawnApp,
+  renderDawnTypes,
+} from "@dawn/core"
+import type { RouteToolTypes } from "@dawn/core"
+
+import { extractJsDoc } from "./jsdoc-extractor.js"
+import { extractParameterType } from "./type-extractor.js"
+import { generateZodSchema } from "./zod-generator.js"
+
+// Keep all existing re-exports
+export { extractJsDoc, type JsDocInfo } from "./jsdoc-extractor.js"
+export { extractParameterType } from "./type-extractor.js"
+export { generateZodSchema } from "./zod-generator.js"
+
+const TOOLS_DIR_PATTERN = /\/tools\/[^/]+\.ts$/
+const OUTPUT_FILE = "dawn.generated.d.ts"
+
+interface DawnPluginOptions {
+  readonly appRoot?: string
+}
+
+export function dawnToolSchemaPlugin(options?: DawnPluginOptions): {
+  name: string
+  configureServer?(server: {
+    readonly watcher: {
+      on(event: string, callback: (path: string) => void): void
+    }
+  }): void | Promise<void>
+  buildStart?(): void | Promise<void>
+  transform(code: string, id: string): { code: string } | null
+} {
+  let debounceTimer: ReturnType<typeof setTimeout> | undefined
+
+  return {
+    name: "dawn-tool-schema",
+
+    async configureServer(server) {
+      await runTypegen(options?.appRoot)
+
+      const debouncedTypegen = () => {
+        if (debounceTimer) clearTimeout(debounceTimer)
+        debounceTimer = setTimeout(() => {
+          void runTypegen(options?.appRoot)
+        }, 300)
+      }
+
+      const isToolFile = (path: string) => TOOLS_DIR_PATTERN.test(path)
+
+      server.watcher.on("change", (path) => {
+        if (isToolFile(path)) debouncedTypegen()
+      })
+      server.watcher.on("add", (path) => {
+        if (isToolFile(path)) debouncedTypegen()
+      })
+      server.watcher.on("unlink", (path) => {
+        if (isToolFile(path)) debouncedTypegen()
+      })
+    },
+
+    async buildStart() {
+      await runTypegen(options?.appRoot)
+    },
+
+    transform(code: string, id: string): { code: string } | null {
+      if (!TOOLS_DIR_PATTERN.test(id)) {
+        return null
+      }
+
+      const transformed = transformToolSource(code, id)
+
+      if (!transformed) {
+        return null
+      }
+
+      return { code: transformed }
+    },
+  }
+}
+
+async function runTypegen(appRoot?: string): Promise<void> {
+  try {
+    const app = await findDawnApp(appRoot ? { appRoot } : {})
+    const manifest = await discoverRoutes({ appRoot: app.appRoot })
+
+    const sharedToolsDir = join(app.appRoot, "src")
+    const routeToolTypes: RouteToolTypes[] = []
+
+    for (const route of manifest.routes) {
+      const tools = await extractToolTypesForRoute({
+        routeDir: route.routeDir,
+        sharedToolsDir,
+      })
+      routeToolTypes.push({ pathname: route.pathname, tools })
+    }
+
+    const outputPath = join(app.routesDir, OUTPUT_FILE)
+    await mkdir(dirname(outputPath), { recursive: true })
+    await writeFile(outputPath, renderDawnTypes(manifest, routeToolTypes), "utf8")
+  } catch {
+    // Silently ignore typegen errors during dev — the CLI command gives explicit errors
+  }
+}
+
+export function transformToolSource(source: string, fileName: string): string | null {
+  const hasExistingDescription = /export\s+const\s+description\s*=/.test(source)
+  const hasExistingSchema = /export\s+const\s+schema\s*=/.test(source)
+
+  if (hasExistingDescription && hasExistingSchema) {
+    return null
+  }
+
+  const jsDoc = extractJsDoc(source, fileName)
+  const typeInfo = extractParameterType(source, fileName)
+
+  const needsDescription = !hasExistingDescription && jsDoc.description !== undefined
+  const needsSchema = !hasExistingSchema && typeInfo !== null && typeInfo.kind !== "unknown"
+
+  if (!needsDescription && !needsSchema) {
+    return null
+  }
+
+  const injections: string[] = []
+
+  if (needsDescription) {
+    injections.push(`export const description = ${JSON.stringify(jsDoc.description)}`)
+  }
+
+  if (needsSchema && typeInfo) {
+    const paramDescriptions = new Map(Object.entries(jsDoc.params))
+    if (typeInfo.kind === "object") {
+      for (const prop of typeInfo.properties) {
+        const desc = paramDescriptions.get(prop.name)
+        if (desc && !prop.description) {
+          ;(prop as { description?: string }).description = desc
+        }
+      }
+    }
+    const zodCode = generateZodSchema(typeInfo, paramDescriptions)
+    injections.push(`import { z } from "zod"`)
+    injections.push(`export const schema = ${zodCode}`)
+  }
+
+  return `${injections.join("\n")}\n${source}`
+}
+```
+
+- [ ] **Step 3: Run existing vite-plugin tests**
+
+Run: `cd packages/vite-plugin && pnpm test`
+Expected: All existing tests pass. The `transformToolSource` function is unchanged; only the plugin wrapper gained new hooks.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/vite-plugin/src/index.ts packages/vite-plugin/package.json pnpm-lock.yaml
+git commit -m "feat: wire vite plugin to trigger typegen on dev start and file watch"
+```
+
+---
+
+### Task 10: Update harness test fixtures
+
+**Files:**
+- Modify: `test/generated/fixtures/basic.expected.json`
+- Modify: `test/generated/fixtures/custom-app-dir.expected.json`
+
+The typegen output now includes tool types, which changes both the `typegenOutput` string and the `renderedBytes` count in the expected fixtures.
+
+- [ ] **Step 1: Build the project**
+
+Run: `pnpm build`
+Expected: Builds successfully.
+
+- [ ] **Step 2: Run the generated app tests to see the new expected values**
+
+Run: `cd /Users/blove/repos/dawn && pnpm vitest --run test/generated/run-generated-app.test.ts`
+
+This will likely fail with a diff showing the new `typegenOutput` and `renderedBytes`. Copy the actual values from the test output.
+
+- [ ] **Step 3: Update `basic.expected.json`**
+
+Update the `typegenOutput` field in `test/generated/fixtures/basic.expected.json` to include the tool types. The value will be the full `dawn.generated.d.ts` content as a JSON-escaped string. Also update `renderedBytes` to match the new byte count.
+
+The `typegenOutput` will look something like (exact formatting depends on compiler output):
+
+```
+"typegenOutput": "declare module \"dawn:routes\" {\n  export type DawnRoutePath = \"/hello/[tenant]\";\n\n  export interface DawnRouteParams {\n  \"/hello/[tenant]\": { tenant: string };\n  }\n\n  export interface DawnRouteTools {\n    \"/hello/[tenant]\": {\n      readonly greet: (input: { readonly tenant: string; }) => Promise<{ greeting: string; }>;\n    };\n  }\n\n  export type RouteTools<P extends DawnRoutePath> = DawnRouteTools[P];\n}\n"
+```
+
+And update `renderedBytes` to the byte length of that string.
+
+- [ ] **Step 4: Update `custom-app-dir.expected.json`**
+
+Update `test/generated/fixtures/custom-app-dir.expected.json` similarly. The custom-app-dir route has no tools, so its `DawnRouteTools` will be empty:
+
+```
+"typegenOutput": "declare module \"dawn:routes\" {\n  export type DawnRoutePath = \"/support/[tenant]\";\n\n  export interface DawnRouteParams {\n  \"/support/[tenant]\": { tenant: string };\n  }\n\n  export interface DawnRouteTools {}\n\n  export type RouteTools<P extends DawnRoutePath> = DawnRouteTools[P];\n}\n"
+```
+
+Update `renderedBytes` accordingly.
+
+- [ ] **Step 5: Re-run the generated app tests**
+
+Run: `cd /Users/blove/repos/dawn && pnpm vitest --run test/generated/run-generated-app.test.ts`
+Expected: Tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add test/generated/fixtures/basic.expected.json test/generated/fixtures/custom-app-dir.expected.json
+git commit -m "test: update harness fixtures for tool type generation"
+```
+
+---
+
+### Task 11: Run full CI validation
+
+**Files:**
+- None (verification only)
+
+- [ ] **Step 1: Run full CI validation**
+
+Run: `pnpm ci:validate`
+Expected: All steps pass — lint, build, typecheck, source tests, harness tests.
+
+- [ ] **Step 2: Fix any failures**
+
+If tests fail, check:
+- `renderedBytes` values in fixtures match actual output
+- `typegenOutput` strings match exactly (watch for trailing newlines, indentation)
+- TypeScript `typeToString` formatting differences between the plan's examples and actual output
+- Verify that `@dawn/core`'s `typescript` dependency doesn't cause version conflicts
+
+- [ ] **Step 3: Commit any fixes**
+
+```bash
+git add -A
+git commit -m "fix: address CI failures in tool type generation"
+```

--- a/docs/superpowers/specs/2026-04-20-inferred-tool-types-design.md
+++ b/docs/superpowers/specs/2026-04-20-inferred-tool-types-design.md
@@ -1,0 +1,280 @@
+# Inferred Tool Types via Codegen
+
+## Goal
+
+Eliminate manually authored tool type aliases (e.g. `HelloTools`) from route files. Dawn generates tool types automatically from properly typed tool functions, so developers get full autocomplete and type safety on `context.tools` without restating input/output shapes.
+
+## Background
+
+Today a route author must manually define a tools type that duplicates information already present in tool files:
+
+```typescript
+// tools/greet.ts
+export default async (input: unknown) => {
+  const { tenant } = input as { readonly tenant: string }
+  return { greeting: `Hello, ${tenant}!` }
+}
+
+// index.ts — manual duplication
+type HelloTools = {
+  readonly greet: RuntimeTool<
+    { readonly tenant: string },
+    { readonly greeting: string }
+  >;
+};
+
+export async function workflow(
+  state: HelloState,
+  context: RuntimeContext<HelloTools>,
+): Promise<HelloState> { ... }
+```
+
+This is error-prone (types drift from implementation), tedious, and unnecessary — Dawn already knows which tools belong to each route at discovery time. The vite plugin already uses the TypeScript compiler API to extract input parameter types for Zod schema generation. The same technique can extract both input and return types and render them into generated type declarations.
+
+## Design
+
+### Tool authoring convention
+
+Tool files use plain typed functions. No `input: unknown`, no wrappers:
+
+```typescript
+// src/app/(public)/hello/[tenant]/tools/greet.ts
+export default async (input: { readonly tenant: string }) => {
+  return { greeting: `Hello, ${input.tenant}!` }
+}
+```
+
+TypeScript resolves both the input parameter type and the return type from this signature. This is the only supported convention for type extraction — tools with `input: unknown` will produce `unknown` input types in the generated output.
+
+### Type extraction
+
+A new module in `@dawn/core` (`src/typegen/extract-tool-types.ts`) uses the TypeScript compiler API to extract input and return types from each tool file's default export function.
+
+For each route in the manifest, the extractor scans:
+- `{routeDir}/tools/*.ts` — route-local tools
+- `{appRoot}/src/tools/*.ts` — shared tools
+
+Route-local tools shadow shared tools of the same name, matching runtime behavior in `tool-discovery.ts`.
+
+The extractor produces a per-route record of tool names mapped to their input/output type strings:
+
+```typescript
+interface ExtractedToolType {
+  readonly name: string
+  readonly inputType: string   // e.g. "{ readonly tenant: string }"
+  readonly outputType: string  // e.g. "{ readonly greeting: string }"
+}
+
+interface RouteToolTypes {
+  readonly pathname: string
+  readonly tools: readonly ExtractedToolType[]
+}
+```
+
+The `inputType` and `outputType` fields are TypeScript source text rendered from the compiler's type representation. The rendering walks the resolved type and emits type literal syntax — the same approach as `type-extractor.ts` in the vite plugin, but outputting TypeScript source strings instead of the intermediate `TypeInfo` IR.
+
+When a tool's default export has no parameters, `inputType` is `void`. When the return type cannot be resolved, `outputType` is `unknown`. When there is no default export or it is not callable, the tool is skipped with a warning (not a hard error — this allows partially typed codebases to still get types for the tools that are properly typed).
+
+### Generated output
+
+The existing `dawn.generated.d.ts` is extended. A new `renderDawnTypes` function composes `renderRouteTypes` and `renderToolTypes` to produce both route param types and tool types in a single file:
+
+```typescript
+declare module "dawn:routes" {
+  export type DawnRoutePath = "/hello/[tenant]";
+
+  export interface DawnRouteParams {
+    "/hello/[tenant]": { tenant: string };
+  }
+
+  export interface DawnRouteTools {
+    "/hello/[tenant]": {
+      readonly greet: (
+        input: { readonly tenant: string },
+      ) => Promise<{ readonly greeting: string }>;
+    };
+  }
+
+  export type RouteTools<P extends DawnRoutePath> = DawnRouteTools[P];
+}
+```
+
+The `RouteTools<P>` type alias provides the ergonomic lookup. Tool function signatures use the `(input: T) => Promise<O>` form rather than `RuntimeTool<T, O>` to avoid a dependency on `@dawn/sdk` inside the generated declaration file.
+
+### Developer consumption
+
+```typescript
+import type { RuntimeContext } from "@dawn/sdk"
+import type { RouteTools } from "dawn:routes"
+import type { HelloState } from "./state.js"
+
+export async function workflow(
+  state: HelloState,
+  context: RuntimeContext<RouteTools<"/hello/[tenant]">>,
+): Promise<HelloState> {
+  // context.tools.greet is fully typed:
+  //   input: { readonly tenant: string }
+  //   return: Promise<{ readonly greeting: string }>
+  const result = await context.tools.greet({ tenant: state.tenant })
+  return { ...state, greeting: result.greeting }
+}
+```
+
+### Triggers
+
+Three entry points call the same `@dawn/core` generation logic:
+
+**`dawn typegen` (CLI)**
+The existing command at `packages/cli/src/commands/typegen.ts` calls the generation logic. No behavioral change other than the output now includes tool types alongside route types.
+
+**`dawn dev` (vite plugin — startup + watch)**
+The vite plugin gains a new `configureServer` hook that:
+1. Runs typegen once on server start
+2. Watches `**/tools/*.ts` and `**/tools/**/*.ts` files for changes
+3. Re-runs typegen on change (debounced)
+
+This ensures types stay fresh during development without manual intervention.
+
+**`dawn build` (vite plugin — build)**
+The vite plugin gains a `buildStart` hook that runs typegen before compilation, ensuring types are current for the typecheck step.
+
+### Vite plugin changes
+
+The `dawnToolSchemaPlugin` in `packages/vite-plugin/src/index.ts` is extended with two new hooks. The plugin needs access to the app root to call the generation logic, so it accepts an options parameter:
+
+```typescript
+export function dawnToolSchemaPlugin(options?: {
+  readonly appRoot?: string
+}): Plugin {
+  return {
+    name: "dawn-tool-schema",
+    async configureServer(server) {
+      // Run typegen on startup
+      await runTypegen(appRoot)
+      // Watch tools directories, re-run on change (debounced)
+      server.watcher.on("change", (file) => { ... })
+      server.watcher.on("add", (file) => { ... })
+      server.watcher.on("unlink", (file) => { ... })
+    },
+    async buildStart() {
+      await runTypegen(appRoot)
+    },
+    transform(code, id) {
+      // Existing tool schema injection (unchanged)
+    },
+  }
+}
+```
+
+The `runTypegen` helper calls `discoverRoutes` + `extractToolTypes` + `renderDawnTypes` from `@dawn/core` and writes `dawn.generated.d.ts`.
+
+### Template updates
+
+**`packages/devkit/templates/app-basic/src/app/(public)/hello/[tenant]/tools/greet.ts`**
+
+Before:
+```typescript
+export default async (input: unknown) => {
+  const { tenant } = input as { readonly tenant: string }
+  return { greeting: `Hello, ${tenant}!` }
+}
+```
+
+After:
+```typescript
+export default async (input: { readonly tenant: string }) => {
+  return { greeting: `Hello, ${input.tenant}!` }
+}
+```
+
+**`packages/devkit/templates/app-basic/src/app/(public)/hello/[tenant]/index.ts`**
+
+Before:
+```typescript
+import type { RuntimeContext, RuntimeTool } from "@dawn/sdk"
+import type { HelloState } from "./state.js"
+
+type HelloTools = {
+  readonly greet: RuntimeTool<
+    { readonly tenant: string },
+    { readonly greeting: string }
+  >;
+};
+
+export async function workflow(
+  state: HelloState,
+  context: RuntimeContext<HelloTools>,
+): Promise<HelloState> {
+  const result = await context.tools.greet({ tenant: state.tenant })
+  return { ...state, greeting: result.greeting }
+}
+```
+
+After:
+```typescript
+import type { RuntimeContext } from "@dawn/sdk"
+import type { RouteTools } from "dawn:routes"
+import type { HelloState } from "./state.js"
+
+export async function workflow(
+  state: HelloState,
+  context: RuntimeContext<RouteTools<"/hello/[tenant]">>,
+): Promise<HelloState> {
+  const result = await context.tools.greet({ tenant: state.tenant })
+  return { ...state, greeting: result.greeting }
+}
+```
+
+**`packages/devkit/templates/app-basic/src/app/dawn.generated.d.ts`**
+
+A pre-generated declaration file ships with the template so types work immediately after scaffold without running typegen first:
+
+```typescript
+declare module "dawn:routes" {
+  export type DawnRoutePath = "/hello/[tenant]";
+
+  export interface DawnRouteParams {
+    "/hello/[tenant]": { tenant: string };
+  }
+
+  export interface DawnRouteTools {
+    "/hello/[tenant]": {
+      readonly greet: (
+        input: { readonly tenant: string },
+      ) => Promise<{ readonly greeting: string }>;
+    };
+  }
+
+  export type RouteTools<P extends DawnRoutePath> = DawnRouteTools[P];
+}
+```
+
+### Files modified
+
+**New:**
+- `packages/core/src/typegen/extract-tool-types.ts` — TypeScript compiler-based tool type extraction
+- `packages/core/src/typegen/render-tool-types.ts` — renders `DawnRouteTools` interface and `RouteTools` type alias
+- `packages/devkit/templates/app-basic/src/app/dawn.generated.d.ts` — pre-generated types for template
+
+**Modified:**
+- `packages/core/src/typegen/render-route-types.ts` — add `renderDawnTypes` that composes `renderRouteTypes` + `renderToolTypes` into unified output
+- `packages/core/src/index.ts` — export new extraction and rendering functions
+- `packages/core/src/types.ts` — add `RouteToolTypes` and `ExtractedToolType` interfaces
+- `packages/cli/src/commands/typegen.ts` — call updated generation pipeline (tool extraction + unified render)
+- `packages/vite-plugin/src/index.ts` — add `configureServer` and `buildStart` hooks for typegen triggering
+- `packages/devkit/templates/app-basic/.../tools/greet.ts` — properly typed input parameter
+- `packages/devkit/templates/app-basic/.../index.ts` — use `RouteTools` instead of manual `HelloTools`
+
+**Tests:**
+- `packages/core/test/typegen/extract-tool-types.test.ts` — extraction from properly typed tools, `unknown` input fallback, return type resolution, shared vs route-local shadowing
+- `packages/core/test/typegen/render-tool-types.test.ts` — rendering tool types into declaration source text
+- Update existing `render-route-types.test.ts` — verify unified output includes both sections
+- Update harness tests and fixtures that assert on generated template output
+
+### What does not change
+
+- `RuntimeContext`, `RuntimeTool`, `ToolRegistry` types in `@dawn/sdk` — unchanged
+- Runtime tool discovery (`tool-discovery.ts`) — unchanged, still loads tools dynamically
+- Vite plugin's existing `transform` hook for Zod schema injection — unchanged
+- Route discovery (`discover-routes.ts`) — unchanged, tool extraction is a separate pass
+- `DawnRoutePath` and `DawnRouteParams` generation — unchanged, just composed into the same output

--- a/packages/cli/src/commands/typegen.ts
+++ b/packages/cli/src/commands/typegen.ts
@@ -1,7 +1,8 @@
 import { mkdir, writeFile } from "node:fs/promises"
 import { dirname, join } from "node:path"
 
-import { discoverRoutes, findDawnApp, renderRouteTypes } from "@dawn/core"
+import { discoverRoutes, extractToolTypesForRoute, findDawnApp, renderDawnTypes } from "@dawn/core"
+import type { RouteToolTypes } from "@dawn/core"
 import type { Command } from "commander"
 
 import { CliError, type CommandIo, formatErrorMessage, writeLine } from "../lib/output.js"
@@ -15,7 +16,7 @@ const OUTPUT_FILE = "dawn.generated.d.ts"
 export function registerTypegenCommand(program: Command, io: CommandIo): void {
   program
     .command("typegen")
-    .description("Generate Dawn route types")
+    .description("Generate Dawn route and tool types")
     .option("--cwd <path>", "Path to the Dawn app root or a child directory within it")
     .action(async (options: TypegenOptions) => {
       await runTypegenCommand(options, io)
@@ -28,8 +29,18 @@ export async function runTypegenCommand(options: TypegenOptions, io: CommandIo):
     const manifest = await discoverRoutes({ appRoot: app.appRoot })
     const outputPath = join(app.routesDir, OUTPUT_FILE)
 
+    const sharedToolsDir = join(app.appRoot, "src")
+    const routeToolTypes: RouteToolTypes[] = []
+    for (const route of manifest.routes) {
+      const tools = await extractToolTypesForRoute({
+        routeDir: route.routeDir,
+        sharedToolsDir,
+      })
+      routeToolTypes.push({ pathname: route.pathname, tools })
+    }
+
     await mkdir(dirname(outputPath), { recursive: true })
-    await writeFile(outputPath, renderRouteTypes(manifest), "utf8")
+    await writeFile(outputPath, renderDawnTypes(manifest, routeToolTypes), "utf8")
 
     writeLine(io.stdout, `Wrote route types to ${outputPath}`)
   } catch (error) {

--- a/packages/cli/src/commands/typegen.ts
+++ b/packages/cli/src/commands/typegen.ts
@@ -1,8 +1,7 @@
 import { mkdir, writeFile } from "node:fs/promises"
 import { dirname, join } from "node:path"
-
-import { discoverRoutes, extractToolTypesForRoute, findDawnApp, renderDawnTypes } from "@dawn/core"
 import type { RouteToolTypes } from "@dawn/core"
+import { discoverRoutes, extractToolTypesForRoute, findDawnApp, renderDawnTypes } from "@dawn/core"
 import type { Command } from "commander"
 
 import { CliError, type CommandIo, formatErrorMessage, writeLine } from "../lib/output.js"

--- a/packages/cli/src/commands/verify.ts
+++ b/packages/cli/src/commands/verify.ts
@@ -1,7 +1,8 @@
 import { existsSync } from "node:fs"
 import { dirname, join, resolve } from "node:path"
 
-import { discoverRoutes, findDawnApp, renderRouteTypes } from "@dawn/core"
+import { discoverRoutes, extractToolTypesForRoute, findDawnApp, renderDawnTypes } from "@dawn/core"
+import type { RouteToolTypes } from "@dawn/core"
 import { type Command, CommanderError } from "commander"
 
 import { CliError, type CommandIo, formatErrorMessage, writeLine } from "../lib/output.js"
@@ -153,7 +154,16 @@ async function verifyApp(
   let renderedTypes: string
 
   try {
-    renderedTypes = renderRouteTypes(manifest)
+    const sharedToolsDir = join(app.appRoot, "src")
+    const routeToolTypes: RouteToolTypes[] = []
+    for (const route of manifest.routes) {
+      const tools = await extractToolTypesForRoute({
+        routeDir: route.routeDir,
+        sharedToolsDir,
+      })
+      routeToolTypes.push({ pathname: route.pathname, tools })
+    }
+    renderedTypes = renderDawnTypes(manifest, routeToolTypes)
   } catch (error) {
     return createVerifyFailureResult(app.appRoot, checks, "typegen", error)
   }

--- a/packages/cli/src/commands/verify.ts
+++ b/packages/cli/src/commands/verify.ts
@@ -1,8 +1,7 @@
 import { existsSync } from "node:fs"
 import { dirname, join, resolve } from "node:path"
-
-import { discoverRoutes, extractToolTypesForRoute, findDawnApp, renderDawnTypes } from "@dawn/core"
 import type { RouteToolTypes } from "@dawn/core"
+import { discoverRoutes, extractToolTypesForRoute, findDawnApp, renderDawnTypes } from "@dawn/core"
 import { type Command, CommanderError } from "commander"
 
 import { CliError, type CommandIo, formatErrorMessage, writeLine } from "../lib/output.js"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -37,7 +37,8 @@
   },
   "dependencies": {
     "@dawn/sdk": "workspace:*",
-    "tsx": "^4.8.1"
+    "tsx": "^4.8.1",
+    "typescript": "5.8.3"
   },
   "devDependencies": {
     "@dawn/config-typescript": "workspace:*",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -9,6 +9,7 @@ export {
 export { extractToolTypesForRoute } from "./typegen/extract-tool-types.js"
 export type { ExtractToolTypesOptions } from "./typegen/extract-tool-types.js"
 export { renderRouteTypes } from "./typegen/render-route-types.js"
+export { renderToolTypes } from "./typegen/render-tool-types.js"
 export type {
   DawnConfig,
   DiscoveredDawnApp,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -11,6 +11,7 @@ export type {
   DawnConfig,
   DiscoveredDawnApp,
   DiscoverRoutesOptions,
+  ExtractedToolType,
   FindDawnAppOptions,
   LoadDawnConfigOptions,
   LoadedDawnConfig,
@@ -18,4 +19,5 @@ export type {
   RouteKind,
   RouteManifest,
   RouteSegment,
+  RouteToolTypes,
 } from "./types.js"

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -8,7 +8,7 @@ export {
 } from "./discovery/route-segments.js"
 export { extractToolTypesForRoute } from "./typegen/extract-tool-types.js"
 export type { ExtractToolTypesOptions } from "./typegen/extract-tool-types.js"
-export { renderRouteTypes } from "./typegen/render-route-types.js"
+export { renderDawnTypes, renderRouteTypes } from "./typegen/render-route-types.js"
 export { renderToolTypes } from "./typegen/render-tool-types.js"
 export type {
   DawnConfig,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -6,8 +6,8 @@ export {
   isRouteGroupSegment,
   toRouteSegments,
 } from "./discovery/route-segments.js"
-export { extractToolTypesForRoute } from "./typegen/extract-tool-types.js"
 export type { ExtractToolTypesOptions } from "./typegen/extract-tool-types.js"
+export { extractToolTypesForRoute } from "./typegen/extract-tool-types.js"
 export { renderDawnTypes, renderRouteTypes } from "./typegen/render-route-types.js"
 export { renderToolTypes } from "./typegen/render-tool-types.js"
 export type {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -6,6 +6,8 @@ export {
   isRouteGroupSegment,
   toRouteSegments,
 } from "./discovery/route-segments.js"
+export { extractToolTypesForRoute } from "./typegen/extract-tool-types.js"
+export type { ExtractToolTypesOptions } from "./typegen/extract-tool-types.js"
 export { renderRouteTypes } from "./typegen/render-route-types.js"
 export type {
   DawnConfig,

--- a/packages/core/src/typegen/extract-tool-types.ts
+++ b/packages/core/src/typegen/extract-tool-types.ts
@@ -1,0 +1,107 @@
+import { existsSync, readdirSync } from "node:fs"
+import { join } from "node:path"
+import ts from "typescript"
+
+import type { ExtractedToolType } from "../types.js"
+
+export interface ExtractToolTypesOptions {
+  readonly routeDir: string
+  readonly sharedToolsDir: string | undefined
+}
+
+export async function extractToolTypesForRoute(
+  options: ExtractToolTypesOptions,
+): Promise<readonly ExtractedToolType[]> {
+  const routeToolFiles = discoverToolFiles(join(options.routeDir, "tools"))
+  const sharedToolFiles = options.sharedToolsDir
+    ? discoverToolFiles(join(options.sharedToolsDir, "tools"))
+    : new Map<string, string>()
+
+  // Merge: route-local tools shadow shared tools
+  const merged = new Map<string, string>(sharedToolFiles)
+  for (const [name, filePath] of routeToolFiles) {
+    merged.set(name, filePath)
+  }
+
+  if (merged.size === 0) return []
+
+  const allFilePaths = [...merged.values()]
+  const compilerOptions: ts.CompilerOptions = {
+    target: ts.ScriptTarget.ES2022,
+    module: ts.ModuleKind.ESNext,
+    moduleResolution: ts.ModuleResolutionKind.Bundler,
+    strict: true,
+    noEmit: true,
+    lib: ["lib.es2022.d.ts"],
+  }
+
+  const program = ts.createProgram(allFilePaths, compilerOptions)
+  const checker = program.getTypeChecker()
+
+  const results: ExtractedToolType[] = []
+
+  for (const [name, filePath] of merged) {
+    const sourceFile = program.getSourceFile(filePath)
+    if (!sourceFile) continue
+
+    const moduleSymbol = checker.getSymbolAtLocation(sourceFile)
+    if (!moduleSymbol) continue
+
+    const exports = checker.getExportsOfModule(moduleSymbol)
+    const defaultExport = exports.find((e) => e.escapedName === "default")
+    if (!defaultExport) continue
+
+    const exportType = checker.getTypeOfSymbolAtLocation(defaultExport, sourceFile)
+    const signatures = checker.getSignaturesOfType(exportType, ts.SignatureKind.Call)
+    if (signatures.length === 0) continue
+
+    const signature = signatures[0]!
+    const params = signature.getParameters()
+
+    let inputType: string
+    if (params.length === 0) {
+      inputType = "void"
+    } else {
+      const paramType = checker.getTypeOfSymbolAtLocation(params[0]!, sourceFile)
+      inputType = checker.typeToString(paramType)
+    }
+
+    const returnType = checker.getReturnTypeOfSignature(signature)
+    const outputType = unwrapPromise(returnType, checker)
+
+    results.push({
+      name,
+      inputType,
+      outputType: checker.typeToString(outputType),
+    })
+  }
+
+  results.sort((a, b) => a.name.localeCompare(b.name))
+  return results
+}
+
+function unwrapPromise(type: ts.Type, checker: ts.TypeChecker): ts.Type {
+  const symbol = type.getSymbol()
+  if (symbol && symbol.getName() === "Promise") {
+    const typeArgs = (type as ts.TypeReference).typeArguments
+    if (typeArgs && typeArgs.length > 0) {
+      return typeArgs[0]!
+    }
+  }
+  return type
+}
+
+function discoverToolFiles(toolsDir: string): Map<string, string> {
+  const files = new Map<string, string>()
+  if (!existsSync(toolsDir)) return files
+
+  const entries = readdirSync(toolsDir)
+  for (const entry of entries) {
+    if (!entry.endsWith(".ts")) continue
+    if (entry.endsWith(".d.ts")) continue
+    const name = entry.replace(/\.ts$/, "")
+    files.set(name, join(toolsDir, entry))
+  }
+
+  return files
+}

--- a/packages/core/src/typegen/extract-tool-types.ts
+++ b/packages/core/src/typegen/extract-tool-types.ts
@@ -55,19 +55,22 @@ export async function extractToolTypesForRoute(
     const signatures = checker.getSignaturesOfType(exportType, ts.SignatureKind.Call)
     if (signatures.length === 0) continue
 
-    const signature = signatures[0]!
+    const signature = signatures[0]
+    if (!signature) continue
     const params = signature.getParameters()
 
     let inputType: string
     if (params.length === 0) {
       inputType = "void"
     } else {
-      const paramType = checker.getTypeOfSymbolAtLocation(params[0]!, sourceFile)
+      const firstParam = params[0]
+      if (!firstParam) continue
+      const paramType = checker.getTypeOfSymbolAtLocation(firstParam, sourceFile)
       inputType = checker.typeToString(paramType)
     }
 
     const returnType = checker.getReturnTypeOfSignature(signature)
-    const outputType = unwrapPromise(returnType, checker)
+    const outputType = unwrapPromise(returnType)
 
     results.push({
       name,
@@ -80,12 +83,12 @@ export async function extractToolTypesForRoute(
   return results
 }
 
-function unwrapPromise(type: ts.Type, checker: ts.TypeChecker): ts.Type {
+function unwrapPromise(type: ts.Type): ts.Type {
   const symbol = type.getSymbol()
   if (symbol && symbol.getName() === "Promise") {
     const typeArgs = (type as ts.TypeReference).typeArguments
-    if (typeArgs && typeArgs.length > 0) {
-      return typeArgs[0]!
+    if (typeArgs && typeArgs.length > 0 && typeArgs[0]) {
+      return typeArgs[0]
     }
   }
   return type

--- a/packages/core/src/typegen/render-route-types.ts
+++ b/packages/core/src/typegen/render-route-types.ts
@@ -1,4 +1,38 @@
-import type { RouteManifest, RouteSegment } from "../types.js"
+import type { RouteManifest, RouteSegment, RouteToolTypes } from "../types.js"
+import { renderToolTypes } from "./render-tool-types.js"
+
+export function renderDawnTypes(
+  manifest: RouteManifest,
+  toolTypes: readonly RouteToolTypes[],
+): string {
+  const pathUnion =
+    manifest.routes.length > 0
+      ? manifest.routes.map((route) => JSON.stringify(route.pathname)).join(" | ")
+      : "never"
+
+  const paramLines = manifest.routes.map((route) => {
+    const params = renderParamsForSegments(route.segments)
+    return `  ${JSON.stringify(route.pathname)}: ${params};`
+  })
+
+  const paramBlock =
+    paramLines.length === 0
+      ? "  export interface DawnRouteParams {}"
+      : ["  export interface DawnRouteParams {", ...paramLines, "  }"].join("\n")
+
+  const toolBlock = renderToolTypes(toolTypes).trimEnd()
+
+  return [
+    'declare module "dawn:routes" {',
+    `  export type DawnRoutePath = ${pathUnion};`,
+    "",
+    paramBlock,
+    "",
+    toolBlock,
+    "}",
+    "",
+  ].join("\n")
+}
 
 export function renderRouteTypes(manifest: RouteManifest): string {
   const pathUnion =

--- a/packages/core/src/typegen/render-tool-types.ts
+++ b/packages/core/src/typegen/render-tool-types.ts
@@ -1,0 +1,33 @@
+import type { RouteToolTypes } from "../types.js"
+
+export function renderToolTypes(routeTools: readonly RouteToolTypes[]): string {
+  const routesWithTools = routeTools.filter((r) => r.tools.length > 0)
+
+  const routeToolsType = "  export type RouteTools<P extends DawnRoutePath> = DawnRouteTools[P];"
+
+  if (routesWithTools.length === 0) {
+    return ["  export interface DawnRouteTools {}", "", routeToolsType, ""].join("\n")
+  }
+
+  const routeLines: string[] = []
+  for (const route of routesWithTools) {
+    routeLines.push(`    ${JSON.stringify(route.pathname)}: {`)
+    for (const tool of route.tools) {
+      const sig =
+        tool.inputType === "void"
+          ? `() => Promise<${tool.outputType}>`
+          : `(input: ${tool.inputType}) => Promise<${tool.outputType}>`
+      routeLines.push(`      readonly ${tool.name}: ${sig};`)
+    }
+    routeLines.push("    };")
+  }
+
+  return [
+    "  export interface DawnRouteTools {",
+    ...routeLines,
+    "  }",
+    "",
+    routeToolsType,
+    "",
+  ].join("\n")
+}

--- a/packages/core/src/typegen/render-tool-types.ts
+++ b/packages/core/src/typegen/render-tool-types.ts
@@ -22,12 +22,7 @@ export function renderToolTypes(routeTools: readonly RouteToolTypes[]): string {
     routeLines.push("    };")
   }
 
-  return [
-    "  export interface DawnRouteTools {",
-    ...routeLines,
-    "  }",
-    "",
-    routeToolsType,
-    "",
-  ].join("\n")
+  return ["  export interface DawnRouteTools {", ...routeLines, "  }", "", routeToolsType, ""].join(
+    "\n",
+  )
 }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -56,3 +56,14 @@ export interface DiscoverRoutesOptions {
   readonly appRoot?: string
   readonly cwd?: string
 }
+
+export interface ExtractedToolType {
+  readonly name: string
+  readonly inputType: string
+  readonly outputType: string
+}
+
+export interface RouteToolTypes {
+  readonly pathname: string
+  readonly tools: readonly ExtractedToolType[]
+}

--- a/packages/core/test/extract-tool-types.test.ts
+++ b/packages/core/test/extract-tool-types.test.ts
@@ -75,8 +75,8 @@ export default async function alpha(input: { a: string }): Promise<{ result: str
     })
 
     expect(result).toHaveLength(2)
-    expect(result[0]!.name).toBe("alpha")
-    expect(result[1]!.name).toBe("zeta")
+    expect(result[0]?.name).toBe("alpha")
+    expect(result[1]?.name).toBe("zeta")
   })
 
   test("returns empty array when no tools directory exists", async () => {
@@ -209,8 +209,8 @@ export default async function sharedTool(input: { a: number }): Promise<{ b: num
     })
 
     expect(result).toHaveLength(2)
-    expect(result[0]!.name).toBe("local-tool")
-    expect(result[1]!.name).toBe("shared-tool")
+    expect(result[0]?.name).toBe("local-tool")
+    expect(result[1]?.name).toBe("shared-tool")
   })
 
   test("skips .d.ts files", async () => {
@@ -239,6 +239,6 @@ export default function types(input: { bad: string }): Promise<{ bad: string }>
     })
 
     expect(result).toHaveLength(1)
-    expect(result[0]!.name).toBe("real")
+    expect(result[0]?.name).toBe("real")
   })
 })

--- a/packages/core/test/extract-tool-types.test.ts
+++ b/packages/core/test/extract-tool-types.test.ts
@@ -1,0 +1,244 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { afterEach, beforeEach, describe, expect, test } from "vitest"
+
+import { extractToolTypesForRoute } from "../src/typegen/extract-tool-types"
+
+let tempDir: string
+
+beforeEach(() => {
+  tempDir = mkdtempSync(join(tmpdir(), "dawn-extract-tools-"))
+})
+
+afterEach(() => {
+  rmSync(tempDir, { recursive: true, force: true })
+})
+
+function writeToolFile(dir: string, name: string, content: string): void {
+  const toolsDir = join(dir, "tools")
+  mkdirSync(toolsDir, { recursive: true })
+  writeFileSync(join(toolsDir, `${name}.ts`), content)
+}
+
+describe("extractToolTypesForRoute", () => {
+  test("extracts input and output types from a properly typed tool", async () => {
+    const routeDir = join(tempDir, "route")
+    writeToolFile(
+      routeDir,
+      "greet",
+      `
+export default async function greet(input: { name: string }): Promise<{ message: string }> {
+  return { message: "hello " + input.name }
+}
+`,
+    )
+
+    const result = await extractToolTypesForRoute({
+      routeDir,
+      sharedToolsDir: undefined,
+    })
+
+    expect(result).toEqual([
+      {
+        name: "greet",
+        inputType: "{ name: string; }",
+        outputType: "{ message: string; }",
+      },
+    ])
+  })
+
+  test("returns multiple tools sorted alphabetically by name", async () => {
+    const routeDir = join(tempDir, "route")
+    writeToolFile(
+      routeDir,
+      "zeta",
+      `
+export default async function zeta(input: { z: number }): Promise<{ ok: boolean }> {
+  return { ok: true }
+}
+`,
+    )
+    writeToolFile(
+      routeDir,
+      "alpha",
+      `
+export default async function alpha(input: { a: string }): Promise<{ result: string }> {
+  return { result: input.a }
+}
+`,
+    )
+
+    const result = await extractToolTypesForRoute({
+      routeDir,
+      sharedToolsDir: undefined,
+    })
+
+    expect(result).toHaveLength(2)
+    expect(result[0]!.name).toBe("alpha")
+    expect(result[1]!.name).toBe("zeta")
+  })
+
+  test("returns empty array when no tools directory exists", async () => {
+    const routeDir = join(tempDir, "empty-route")
+    mkdirSync(routeDir, { recursive: true })
+
+    const result = await extractToolTypesForRoute({
+      routeDir,
+      sharedToolsDir: undefined,
+    })
+
+    expect(result).toEqual([])
+  })
+
+  test("extracts unknown inputType for input: unknown", async () => {
+    const routeDir = join(tempDir, "route")
+    writeToolFile(
+      routeDir,
+      "flexible",
+      `
+export default async function flexible(input: unknown): Promise<{ done: boolean }> {
+  return { done: true }
+}
+`,
+    )
+
+    const result = await extractToolTypesForRoute({
+      routeDir,
+      sharedToolsDir: undefined,
+    })
+
+    expect(result).toEqual([
+      {
+        name: "flexible",
+        inputType: "unknown",
+        outputType: "{ done: boolean; }",
+      },
+    ])
+  })
+
+  test("extracts void inputType for tools with no parameters", async () => {
+    const routeDir = join(tempDir, "route")
+    writeToolFile(
+      routeDir,
+      "ping",
+      `
+export default async function ping(): Promise<{ pong: boolean }> {
+  return { pong: true }
+}
+`,
+    )
+
+    const result = await extractToolTypesForRoute({
+      routeDir,
+      sharedToolsDir: undefined,
+    })
+
+    expect(result).toEqual([
+      {
+        name: "ping",
+        inputType: "void",
+        outputType: "{ pong: boolean; }",
+      },
+    ])
+  })
+
+  test("route-local tools shadow shared tools of the same name", async () => {
+    const routeDir = join(tempDir, "route")
+    const sharedDir = join(tempDir, "shared")
+
+    writeToolFile(
+      routeDir,
+      "lookup",
+      `
+export default async function lookup(input: { id: number }): Promise<{ local: true }> {
+  return { local: true }
+}
+`,
+    )
+    writeToolFile(
+      sharedDir,
+      "lookup",
+      `
+export default async function lookup(input: { query: string }): Promise<{ shared: true }> {
+  return { shared: true }
+}
+`,
+    )
+
+    const result = await extractToolTypesForRoute({
+      routeDir,
+      sharedToolsDir: sharedDir,
+    })
+
+    expect(result).toEqual([
+      {
+        name: "lookup",
+        inputType: "{ id: number; }",
+        outputType: "{ local: true; }",
+      },
+    ])
+  })
+
+  test("merges shared and route-local tools", async () => {
+    const routeDir = join(tempDir, "route")
+    const sharedDir = join(tempDir, "shared")
+
+    writeToolFile(
+      routeDir,
+      "local-tool",
+      `
+export default async function localTool(input: { x: string }): Promise<{ y: string }> {
+  return { y: input.x }
+}
+`,
+    )
+    writeToolFile(
+      sharedDir,
+      "shared-tool",
+      `
+export default async function sharedTool(input: { a: number }): Promise<{ b: number }> {
+  return { b: input.a }
+}
+`,
+    )
+
+    const result = await extractToolTypesForRoute({
+      routeDir,
+      sharedToolsDir: sharedDir,
+    })
+
+    expect(result).toHaveLength(2)
+    expect(result[0]!.name).toBe("local-tool")
+    expect(result[1]!.name).toBe("shared-tool")
+  })
+
+  test("skips .d.ts files", async () => {
+    const routeDir = join(tempDir, "route")
+    const toolsDir = join(routeDir, "tools")
+    mkdirSync(toolsDir, { recursive: true })
+
+    writeFileSync(
+      join(toolsDir, "real.ts"),
+      `
+export default async function real(input: { ok: boolean }): Promise<{ done: boolean }> {
+  return { done: input.ok }
+}
+`,
+    )
+    writeFileSync(
+      join(toolsDir, "types.d.ts"),
+      `
+export default function types(input: { bad: string }): Promise<{ bad: string }>
+`,
+    )
+
+    const result = await extractToolTypesForRoute({
+      routeDir,
+      sharedToolsDir: undefined,
+    })
+
+    expect(result).toHaveLength(1)
+    expect(result[0]!.name).toBe("real")
+  })
+})

--- a/packages/core/test/render-route-types.test.ts
+++ b/packages/core/test/render-route-types.test.ts
@@ -2,8 +2,8 @@ import { readFile } from "node:fs/promises"
 import { fileURLToPath } from "node:url"
 import { describe, expect, test } from "vitest"
 
-import { renderRouteTypes } from "../src/typegen/render-route-types"
-import type { RouteManifest, RouteSegment } from "../src/types"
+import { renderDawnTypes, renderRouteTypes } from "../src/typegen/render-route-types"
+import type { RouteManifest, RouteSegment, RouteToolTypes } from "../src/types"
 
 const MANIFEST_SNAPSHOT_PATH = fileURLToPath(
   new URL("../../../test/fixtures/contracts/manifest.snap.json", import.meta.url),
@@ -33,6 +33,81 @@ async function loadManifestSnapshot(): Promise<RouteManifest> {
     })),
   }
 }
+
+describe("renderDawnTypes", () => {
+  test("renders a single declare module block with route params and tool types", () => {
+    const manifest: RouteManifest = {
+      appRoot: "/tmp/example-app",
+      routes: [
+        {
+          id: "/hello/[tenant]",
+          pathname: "/hello/[tenant]",
+          kind: "workflow",
+          entryFile: "/tmp/example-app/hello/[tenant].tsx",
+          routeDir: "/tmp/example-app/hello/[tenant]",
+          segments: [
+            { kind: "static", value: "hello" },
+            { kind: "dynamic", name: "tenant" },
+          ],
+        },
+      ],
+    }
+
+    const toolTypes: RouteToolTypes[] = [
+      {
+        pathname: "/hello/[tenant]",
+        tools: [
+          {
+            name: "greet",
+            inputType: "{ readonly tenant: string; }",
+            outputType: "{ greeting: string; }",
+          },
+        ],
+      },
+    ]
+
+    expect(renderDawnTypes(manifest, toolTypes)).toMatchInlineSnapshot(`
+      "declare module "dawn:routes" {
+        export type DawnRoutePath = "/hello/[tenant]";
+
+        export interface DawnRouteParams {
+        "/hello/[tenant]": { tenant: string };
+        }
+
+        export interface DawnRouteTools {
+          "/hello/[tenant]": {
+            readonly greet: (input: { readonly tenant: string; }) => Promise<{ greeting: string; }>;
+          };
+        }
+
+        export type RouteTools<P extends DawnRoutePath> = DawnRouteTools[P];
+      }
+      "
+    `)
+  })
+
+  test("renders correct output for empty manifest and empty tools", () => {
+    const manifest: RouteManifest = {
+      appRoot: "/tmp/example-app",
+      routes: [],
+    }
+
+    const toolTypes: RouteToolTypes[] = []
+
+    expect(renderDawnTypes(manifest, toolTypes)).toMatchInlineSnapshot(`
+      "declare module "dawn:routes" {
+        export type DawnRoutePath = never;
+
+        export interface DawnRouteParams {}
+
+        export interface DawnRouteTools {}
+
+        export type RouteTools<P extends DawnRoutePath> = DawnRouteTools[P];
+      }
+      "
+    `)
+  })
+})
 
 describe("renderRouteTypes", () => {
   test("renders valid TypeScript for an empty manifest", () => {

--- a/packages/core/test/render-tool-types.test.ts
+++ b/packages/core/test/render-tool-types.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, test } from "vitest"
+
+import { renderToolTypes } from "../src/typegen/render-tool-types"
+import type { RouteToolTypes } from "../src/types"
+
+describe("renderToolTypes", () => {
+  test("empty routeTools renders empty interface", () => {
+    const result = renderToolTypes([])
+    expect(result).toMatchInlineSnapshot(`
+      "  export interface DawnRouteTools {}
+
+        export type RouteTools<P extends DawnRoutePath> = DawnRouteTools[P];
+      "
+    `)
+  })
+
+  test("single route with one tool renders correctly", () => {
+    const routeTools: RouteToolTypes[] = [
+      {
+        pathname: "/hello/[tenant]",
+        tools: [
+          {
+            name: "greet",
+            inputType: "{ readonly tenant: string; }",
+            outputType: "{ greeting: string; }",
+          },
+        ],
+      },
+    ]
+
+    const result = renderToolTypes(routeTools)
+    expect(result).toMatchInlineSnapshot(`
+      "  export interface DawnRouteTools {
+          "/hello/[tenant]": {
+            readonly greet: (input: { readonly tenant: string; }) => Promise<{ greeting: string; }>;
+          };
+        }
+
+        export type RouteTools<P extends DawnRoutePath> = DawnRouteTools[P];
+      "
+    `)
+  })
+
+  test("single route with multiple tools renders all tools", () => {
+    const routeTools: RouteToolTypes[] = [
+      {
+        pathname: "/api/users",
+        tools: [
+          {
+            name: "getUser",
+            inputType: "{ id: string }",
+            outputType: "{ name: string }",
+          },
+          {
+            name: "listUsers",
+            inputType: "void",
+            outputType: "{ users: string[] }",
+          },
+        ],
+      },
+    ]
+
+    const result = renderToolTypes(routeTools)
+    expect(result).toMatchInlineSnapshot(`
+      "  export interface DawnRouteTools {
+          "/api/users": {
+            readonly getUser: (input: { id: string }) => Promise<{ name: string }>;
+            readonly listUsers: () => Promise<{ users: string[] }>;
+          };
+        }
+
+        export type RouteTools<P extends DawnRoutePath> = DawnRouteTools[P];
+      "
+    `)
+  })
+
+  test("void input renders as no-arg function signature", () => {
+    const routeTools: RouteToolTypes[] = [
+      {
+        pathname: "/ping",
+        tools: [
+          {
+            name: "ping",
+            inputType: "void",
+            outputType: "{ pong: boolean }",
+          },
+        ],
+      },
+    ]
+
+    const result = renderToolTypes(routeTools)
+    expect(result).toMatchInlineSnapshot(`
+      "  export interface DawnRouteTools {
+          "/ping": {
+            readonly ping: () => Promise<{ pong: boolean }>;
+          };
+        }
+
+        export type RouteTools<P extends DawnRoutePath> = DawnRouteTools[P];
+      "
+    `)
+  })
+
+  test("routes with zero tools are skipped", () => {
+    const routeTools: RouteToolTypes[] = [
+      {
+        pathname: "/no-tools",
+        tools: [],
+      },
+      {
+        pathname: "/has-tools",
+        tools: [
+          {
+            name: "doThing",
+            inputType: "{ x: number }",
+            outputType: "{ result: number }",
+          },
+        ],
+      },
+    ]
+
+    const result = renderToolTypes(routeTools)
+    expect(result).toMatchInlineSnapshot(`
+      "  export interface DawnRouteTools {
+          "/has-tools": {
+            readonly doThing: (input: { x: number }) => Promise<{ result: number }>;
+          };
+        }
+
+        export type RouteTools<P extends DawnRoutePath> = DawnRouteTools[P];
+      "
+    `)
+  })
+
+  test("multiple routes each with tools render all routes", () => {
+    const routeTools: RouteToolTypes[] = [
+      {
+        pathname: "/route-a",
+        tools: [
+          {
+            name: "toolA",
+            inputType: "string",
+            outputType: "number",
+          },
+        ],
+      },
+      {
+        pathname: "/route-b",
+        tools: [
+          {
+            name: "toolB",
+            inputType: "void",
+            outputType: "boolean",
+          },
+        ],
+      },
+    ]
+
+    const result = renderToolTypes(routeTools)
+    expect(result).toMatchInlineSnapshot(`
+      "  export interface DawnRouteTools {
+          "/route-a": {
+            readonly toolA: (input: string) => Promise<number>;
+          };
+          "/route-b": {
+            readonly toolB: () => Promise<boolean>;
+          };
+        }
+
+        export type RouteTools<P extends DawnRoutePath> = DawnRouteTools[P];
+      "
+    `)
+  })
+})

--- a/packages/devkit/templates/app-basic/src/app/(public)/hello/[tenant]/index.ts
+++ b/packages/devkit/templates/app-basic/src/app/(public)/hello/[tenant]/index.ts
@@ -1,22 +1,16 @@
-import type { RuntimeContext, RuntimeTool } from "@dawn/sdk";
+import type { RuntimeContext } from "@dawn/sdk"
+import type { RouteTools } from "dawn:routes"
 
-import type { HelloState } from "./state.js";
-
-type HelloTools = {
-  readonly greet: RuntimeTool<
-    { readonly tenant: string },
-    { readonly greeting: string }
-  >;
-};
+import type { HelloState } from "./state.js"
 
 export async function workflow(
   state: HelloState,
-  context: RuntimeContext<HelloTools>,
+  context: RuntimeContext<RouteTools<"/hello/[tenant]">>,
 ): Promise<HelloState> {
-  const result = await context.tools.greet({ tenant: state.tenant });
+  const result = await context.tools.greet({ tenant: state.tenant })
 
   return {
     ...state,
     greeting: result.greeting,
-  };
+  }
 }

--- a/packages/devkit/templates/app-basic/src/app/(public)/hello/[tenant]/tools/greet.ts
+++ b/packages/devkit/templates/app-basic/src/app/(public)/hello/[tenant]/tools/greet.ts
@@ -1,7 +1,3 @@
-export default async (input: unknown) => {
-  const { tenant } = input as { readonly tenant: string }
-
-  return {
-    greeting: `Hello, ${tenant}!`,
-  }
+export default async (input: { readonly tenant: string }) => {
+  return { greeting: `Hello, ${input.tenant}!` }
 }

--- a/packages/devkit/templates/app-basic/src/app/dawn.generated.d.ts
+++ b/packages/devkit/templates/app-basic/src/app/dawn.generated.d.ts
@@ -1,0 +1,15 @@
+declare module "dawn:routes" {
+  export type DawnRoutePath = "/hello/[tenant]";
+
+  export interface DawnRouteParams {
+  "/hello/[tenant]": { tenant: string };
+  }
+
+  export interface DawnRouteTools {
+    "/hello/[tenant]": {
+      readonly greet: (input: { readonly tenant: string; }) => Promise<{ greeting: string; }>;
+    };
+  }
+
+  export type RouteTools<P extends DawnRoutePath> = DawnRouteTools[P];
+}

--- a/packages/vite-plugin/package.json
+++ b/packages/vite-plugin/package.json
@@ -36,6 +36,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@dawn/core": "workspace:*",
     "typescript": "5.8.3"
   },
   "devDependencies": {

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -1,3 +1,14 @@
+import { mkdir, writeFile } from "node:fs/promises"
+import { dirname, join } from "node:path"
+
+import {
+  discoverRoutes,
+  extractToolTypesForRoute,
+  findDawnApp,
+  renderDawnTypes,
+} from "@dawn/core"
+import type { RouteToolTypes } from "@dawn/core"
+
 import { extractJsDoc } from "./jsdoc-extractor.js"
 import { extractParameterType } from "./type-extractor.js"
 import { generateZodSchema } from "./zod-generator.js"
@@ -8,13 +19,61 @@ export { extractParameterType } from "./type-extractor.js"
 export { generateZodSchema } from "./zod-generator.js"
 
 const TOOLS_DIR_PATTERN = /\/tools\/[^/]+\.ts$/
+const OUTPUT_FILE = "dawn.generated.d.ts"
 
-export function dawnToolSchemaPlugin(): {
+export interface DawnPluginOptions {
+  readonly appRoot?: string
+}
+
+export function dawnToolSchemaPlugin(options?: DawnPluginOptions): {
   name: string
+  configureServer?(server: {
+    readonly watcher: {
+      on(event: string, callback: (path: string) => void): void
+    }
+  }): void | Promise<void>
+  buildStart?(): void | Promise<void>
   transform(code: string, id: string): { code: string } | null
 } {
   return {
     name: "dawn-tool-schema",
+
+    async configureServer(server) {
+      // Run typegen once on startup
+      await runTypegen(options?.appRoot)
+
+      // Debounce helper
+      let debounceTimer: ReturnType<typeof setTimeout> | undefined
+
+      const scheduleTypegen = () => {
+        clearTimeout(debounceTimer)
+        debounceTimer = setTimeout(() => {
+          void runTypegen(options?.appRoot)
+        }, 300)
+      }
+
+      // Watch tool files for changes
+      server.watcher.on("change", (path) => {
+        if (TOOLS_DIR_PATTERN.test(path)) {
+          scheduleTypegen()
+        }
+      })
+      server.watcher.on("add", (path) => {
+        if (TOOLS_DIR_PATTERN.test(path)) {
+          scheduleTypegen()
+        }
+      })
+      server.watcher.on("unlink", (path) => {
+        if (TOOLS_DIR_PATTERN.test(path)) {
+          scheduleTypegen()
+        }
+      })
+    },
+
+    async buildStart() {
+      await runTypegen(options?.appRoot)
+    },
+
     transform(code: string, id: string): { code: string } | null {
       if (!TOOLS_DIR_PATTERN.test(id)) {
         return null
@@ -28,6 +87,31 @@ export function dawnToolSchemaPlugin(): {
 
       return { code: transformed }
     },
+  }
+}
+
+async function runTypegen(appRoot?: string): Promise<void> {
+  try {
+    const app = await findDawnApp(appRoot ? { appRoot } : {})
+    const manifest = await discoverRoutes(appRoot ? { appRoot } : {})
+
+    const sharedToolsDir = join(app.appRoot, "src")
+    const toolTypesPerRoute: RouteToolTypes[] = []
+    for (const route of manifest.routes) {
+      const tools = await extractToolTypesForRoute({
+        routeDir: route.routeDir,
+        sharedToolsDir,
+      })
+      toolTypesPerRoute.push({ pathname: route.pathname, tools })
+    }
+
+    const content = renderDawnTypes(manifest, toolTypesPerRoute)
+    const outputPath = join(app.routesDir, OUTPUT_FILE)
+
+    await mkdir(dirname(outputPath), { recursive: true })
+    await writeFile(outputPath, content, "utf-8")
+  } catch {
+    // Silently catch errors — typegen during dev should not crash the server
   }
 }
 

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -1,13 +1,7 @@
 import { mkdir, writeFile } from "node:fs/promises"
 import { dirname, join } from "node:path"
-
-import {
-  discoverRoutes,
-  extractToolTypesForRoute,
-  findDawnApp,
-  renderDawnTypes,
-} from "@dawn/core"
 import type { RouteToolTypes } from "@dawn/core"
+import { discoverRoutes, extractToolTypesForRoute, findDawnApp, renderDawnTypes } from "@dawn/core"
 
 import { extractJsDoc } from "./jsdoc-extractor.js"
 import { extractParameterType } from "./type-extractor.js"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -184,6 +184,9 @@ importers:
 
   packages/vite-plugin:
     dependencies:
+      '@dawn/core':
+        specifier: workspace:*
+        version: link:../core
       typescript:
         specifier: 5.8.3
         version: 5.8.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -108,6 +108,9 @@ importers:
       tsx:
         specifier: ^4.8.1
         version: 4.21.0
+      typescript:
+        specifier: 5.8.3
+        version: 5.8.3
     devDependencies:
       '@dawn/config-typescript':
         specifier: workspace:*

--- a/test/generated/fixtures/basic.expected.json
+++ b/test/generated/fixtures/basic.expected.json
@@ -47,7 +47,7 @@
       },
       {
         "name": "typegen",
-        "renderedBytes": 165,
+        "renderedBytes": 405,
         "status": "passed"
       }
     ],
@@ -81,5 +81,5 @@
       }
     ]
   },
-  "typegenOutput": "declare module \"dawn:routes\" {\n  export type DawnRoutePath = \"/hello/[tenant]\";\n\n  export interface DawnRouteParams {\n  \"/hello/[tenant]\": { tenant: string };\n  }\n}\n"
+  "typegenOutput": "declare module \"dawn:routes\" {\n  export type DawnRoutePath = \"/hello/[tenant]\";\n\n  export interface DawnRouteParams {\n  \"/hello/[tenant]\": { tenant: string };\n  }\n\n  export interface DawnRouteTools {\n    \"/hello/[tenant]\": {\n      readonly greet: (input: { readonly tenant: string; }) => Promise<{ greeting: string; }>;\n    };\n  }\n\n  export type RouteTools<P extends DawnRoutePath> = DawnRouteTools[P];\n}\n"
 }

--- a/test/generated/fixtures/custom-app-dir.expected.json
+++ b/test/generated/fixtures/custom-app-dir.expected.json
@@ -47,7 +47,7 @@
       },
       {
         "name": "typegen",
-        "renderedBytes": 169,
+        "renderedBytes": 279,
         "status": "passed"
       }
     ],
@@ -81,5 +81,5 @@
       }
     ]
   },
-  "typegenOutput": "declare module \"dawn:routes\" {\n  export type DawnRoutePath = \"/support/[tenant]\";\n\n  export interface DawnRouteParams {\n  \"/support/[tenant]\": { tenant: string };\n  }\n}\n"
+  "typegenOutput": "declare module \"dawn:routes\" {\n  export type DawnRoutePath = \"/support/[tenant]\";\n\n  export interface DawnRouteParams {\n  \"/support/[tenant]\": { tenant: string };\n  }\n\n  export interface DawnRouteTools {}\n\n  export type RouteTools<P extends DawnRoutePath> = DawnRouteTools[P];\n}\n"
 }


### PR DESCRIPTION
## Summary

- Dawn now generates tool types automatically from properly typed tool functions via `dawn typegen`, eliminating manual `HelloTools`-style type aliases in route files
- New `RouteTools<"/path">` type in `dawn:routes` ambient module provides full `context.tools` autocomplete and type safety
- Vite plugin triggers typegen on dev startup and file watch, so types stay fresh during development

## Test plan
- [x] All 31 `@dawn/core` unit tests pass (extraction, rendering, composition)
- [x] All CLI tests pass (typegen-command, verify-command)
- [x] All vite-plugin tests pass
- [x] Full `pnpm ci:validate` green — framework, runtime, and smoke harness lanes all pass
- [x] Fixture assertions updated for new typegen output format
