### PR TITLE
feat: resolve routes by pathname in dawn run and dawn test

### DIFF
--- a/docs/superpowers/plans/2026-04-20-route-pathname-resolution.md
+++ b/docs/superpowers/plans/2026-04-20-route-pathname-resolution.md
@@ -1,0 +1,697 @@
+# Route Pathname Resolution Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace filesystem-path-based route resolution in `dawn run` and `dawn test` with route pathname lookup via `discoverRoutes`, so developers type `dawn run '/hello/[tenant]'` instead of `dawn run 'src/app/(public)/hello/[tenant]'`.
+
+**Architecture:** `resolveRouteTarget` drops its `toAbsolutePath` + `stat()` approach and instead calls `discoverRoutes` to get the `RouteManifest`, then looks up the provided pathname. `load-run-scenarios.ts` narrowing similarly switches from filesystem resolution to route pathname prefix matching. All `invocationCwd` plumbing is removed.
+
+**Tech Stack:** TypeScript, vitest, `@dawn/core` route discovery
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|------|--------|---------------|
+| `packages/cli/src/lib/runtime/resolve-route-target.ts` | Rewrite | Route pathname → `ResolvedRouteTarget` via `discoverRoutes` |
+| `packages/cli/src/commands/run.ts` | Modify | Remove `invocationCwd` from `resolveRouteTarget` call |
+| `packages/cli/src/lib/runtime/load-run-scenarios.ts` | Modify | Replace `resolveNarrowingTarget` with route pathname prefix matching |
+| `packages/cli/src/commands/test.ts` | Modify | Remove `invocationCwd` from `loadRunScenarios` call |
+| `packages/cli/test/run-command.test.ts` | Modify | Update all route path arguments from filesystem paths to route pathnames |
+| `packages/cli/test/test-command.test.ts` | Modify | Update narrowing path arguments to route pathnames |
+| `test/smoke/run-smoke.test.ts` | Modify | Update `executeCanonicalFlow` to pass route pathname to `dawn run` |
+
+---
+
+### Task 1: Rewrite `resolveRouteTarget` to use route discovery
+
+**Files:**
+- Modify: `packages/cli/src/lib/runtime/resolve-route-target.ts`
+
+- [ ] **Step 1: Rewrite the module**
+
+Replace the entire implementation of `resolveRouteTarget`. The new version:
+- Calls `discoverRoutes` to build a `RouteManifest`
+- Normalizes the input pathname (ensures leading `/`)
+- Looks up the route by `pathname` match
+- Returns `ResolvedRouteTarget` on match, or a failure listing available routes
+
+```typescript
+import { relative, sep } from "node:path"
+
+import { discoverRoutes } from "@dawn/core"
+import {
+  createRuntimeFailureResult,
+  formatErrorMessage,
+  type RuntimeExecutionFailureResult,
+} from "./result.js"
+
+export interface ResolveRouteTargetOptions {
+  readonly cwd?: string
+  readonly routePath: string
+}
+
+export interface ResolvedRouteTarget {
+  readonly appRoot: string
+  readonly routeId: string
+  readonly routeFile: string
+  readonly routePath: string
+}
+
+export async function resolveRouteTarget(
+  options: ResolveRouteTargetOptions,
+): Promise<ResolvedRouteTarget | RuntimeExecutionFailureResult> {
+  const startedAt = Date.now()
+
+  let manifest: Awaited<ReturnType<typeof discoverRoutes>>
+
+  try {
+    manifest = await discoverRoutes(options.cwd ? { cwd: options.cwd } : {})
+  } catch (error) {
+    return createRuntimeFailureResult({
+      appRoot: null,
+      executionSource: "in-process",
+      kind: "app_discovery_error",
+      message: formatErrorMessage(error),
+      routePath: options.routePath,
+      startedAt,
+    })
+  }
+
+  const normalizedPathname = normalizePathname(options.routePath)
+  const route = manifest.routes.find(
+    (candidate) => candidate.pathname === normalizedPathname,
+  )
+
+  if (!route) {
+    const available = manifest.routes.map((r) => r.pathname)
+    const availableList =
+      available.length > 0
+        ? `\n\nAvailable routes:\n${available.map((p) => `  ${p}`).join("\n")}`
+        : ""
+
+    return createRuntimeFailureResult({
+      appRoot: manifest.appRoot,
+      executionSource: "in-process",
+      kind: "route_resolution_error",
+      message: `Route not found: ${normalizedPathname}${availableList}`,
+      routePath: options.routePath,
+      startedAt,
+    })
+  }
+
+  return {
+    appRoot: manifest.appRoot,
+    routeId: route.id,
+    routeFile: route.entryFile,
+    routePath: relative(manifest.appRoot, route.entryFile).split(sep).join("/"),
+  }
+}
+
+function normalizePathname(input: string): string {
+  if (input.startsWith("/")) {
+    return input
+  }
+
+  return `/${input}`
+}
+```
+
+Remove these deleted items:
+- `toAbsolutePath` function
+- `LEGACY_BASENAMES` constant
+- `discoverApp` function
+- `ok` function
+- `failure` function
+- All `stat()` imports and calls
+- `invocationCwd` from `ResolveRouteTargetOptions`
+- Import of `deriveRouteIdentity`
+- Imports of `Stats`, `stat`, `basename`, `resolve` from node
+
+- [ ] **Step 2: Run the existing test suite to verify the rewrite compiles**
+
+Run: `cd packages/cli && pnpm exec tsc --noEmit`
+
+Expected: Compilation succeeds (the callers still pass `invocationCwd` but it's just an extra property that TypeScript allows on object literals — wait, TypeScript does check excess properties on object literals). So this step will surface type errors in `run.ts` and `test.ts` that pass `invocationCwd`. That's expected — we fix those in the next tasks.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/cli/src/lib/runtime/resolve-route-target.ts
+git commit -m "refactor: rewrite resolveRouteTarget to use route discovery"
+```
+
+---
+
+### Task 2: Update `dawn run` command
+
+**Files:**
+- Modify: `packages/cli/src/commands/run.ts`
+
+- [ ] **Step 1: Remove `invocationCwd` from the `resolveRouteTarget` call**
+
+In `run.ts`, the `runRunCommand` function currently passes:
+
+```typescript
+const resolvedTarget = await resolveRouteTarget({
+  ...(options.cwd ? { cwd: options.cwd } : {}),
+  invocationCwd: process.cwd(),
+  routePath,
+})
+```
+
+Change to:
+
+```typescript
+const resolvedTarget = await resolveRouteTarget({
+  ...(options.cwd ? { cwd: options.cwd } : {}),
+  routePath,
+})
+```
+
+- [ ] **Step 2: Verify compilation**
+
+Run: `cd packages/cli && pnpm exec tsc --noEmit`
+
+Expected: May still fail due to `test.ts` and `load-run-scenarios.ts` — that's OK, we fix those next.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/cli/src/commands/run.ts
+git commit -m "refactor: remove invocationCwd from dawn run command"
+```
+
+---
+
+### Task 3: Update `load-run-scenarios.ts` narrowing to use route discovery
+
+**Files:**
+- Modify: `packages/cli/src/lib/runtime/load-run-scenarios.ts`
+
+- [ ] **Step 1: Replace `resolveNarrowingTarget` with route-pathname-based narrowing**
+
+The current `discoverScenarioFiles` function uses `resolveNarrowingTarget` (filesystem path resolution) to narrow scenario discovery. Replace this with route pathname prefix matching via `discoverRoutes`.
+
+The `loadRunScenarios` function changes from:
+
+```typescript
+export async function loadRunScenarios(
+  options: LoadRunScenariosOptions,
+): Promise<readonly LoadedRunScenario[]> {
+  const app = await findDawnApp(options.cwd ? { cwd: options.cwd } : {})
+  const scenarioFiles = await discoverScenarioFiles({
+    appRoot: app.appRoot,
+    ...(options.invocationCwd ? { invocationCwd: options.invocationCwd } : {}),
+    ...(options.narrowingPath ? { narrowingPath: options.narrowingPath } : {}),
+    routesDir: app.routesDir,
+  })
+  // ... rest unchanged
+```
+
+To:
+
+```typescript
+export async function loadRunScenarios(
+  options: LoadRunScenariosOptions,
+): Promise<readonly LoadedRunScenario[]> {
+  const app = await findDawnApp(options.cwd ? { cwd: options.cwd } : {})
+  const scenarioFiles = await discoverScenarioFiles({
+    ...(options.narrowingPath ? { narrowingPath: options.narrowingPath } : {}),
+    routesDir: app.routesDir,
+  })
+  // ... rest unchanged
+```
+
+Remove `invocationCwd` from `LoadRunScenariosOptions`:
+
+```typescript
+export interface LoadRunScenariosOptions {
+  readonly cwd?: string
+  readonly narrowingPath?: string
+}
+```
+
+Replace `discoverScenarioFiles`:
+
+```typescript
+async function discoverScenarioFiles(options: {
+  readonly narrowingPath?: string
+  readonly routesDir: string
+}): Promise<readonly string[]> {
+  if (!options.narrowingPath) {
+    return await collectScenarioFiles(options.routesDir)
+  }
+
+  const normalizedPathname = options.narrowingPath.startsWith("/")
+    ? options.narrowingPath
+    : `/${options.narrowingPath}`
+
+  const { discoverRoutes } = await import("@dawn/core")
+  const manifest = await discoverRoutes()
+  const matchingRoutes = manifest.routes.filter(
+    (route) =>
+      route.pathname === normalizedPathname ||
+      route.pathname.startsWith(`${normalizedPathname}/`),
+  )
+
+  if (matchingRoutes.length === 0) {
+    throw new RunScenarioLoadError(
+      `No routes match narrowing path: ${normalizedPathname}`,
+    )
+  }
+
+  const scenarioFiles: string[] = []
+
+  for (const route of matchingRoutes) {
+    const routeScenarios = await collectScenarioFiles(route.routeDir)
+    scenarioFiles.push(...routeScenarios)
+  }
+
+  return scenarioFiles.sort((left, right) => left.localeCompare(right))
+}
+```
+
+Delete `resolveNarrowingTarget` function entirely.
+
+Remove unused imports: `resolve` from `node:path` (check if still needed by other code — `join` and `dirname` are still used). Remove `constants` and `access` from `node:fs` if `pathExists` is still needed elsewhere in the file.
+
+Note: `pathExists` is still used in `loadScenarioFile` to check sibling `index.ts`, so keep that. But `resolve` can be removed if `resolveNarrowingTarget` was the only consumer.
+
+Actually, `resolve` is used in `loadScenarioFile` line 160: `const indexFile = resolve(dirname(options.scenarioFile), "index.ts")`. So keep the `resolve` import.
+
+Also: `discoverRoutes` is already imported at the top via `findDawnApp` from `@dawn/core`. Instead of dynamic import, add `discoverRoutes` to the existing static import:
+
+```typescript
+import { discoverRoutes, findDawnApp } from "@dawn/core"
+```
+
+- [ ] **Step 2: Verify compilation**
+
+Run: `cd packages/cli && pnpm exec tsc --noEmit`
+
+Expected: May still fail if `test.ts` still passes `invocationCwd`. That's OK — next task.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/cli/src/lib/runtime/load-run-scenarios.ts
+git commit -m "refactor: replace filesystem narrowing with route pathname prefix matching"
+```
+
+---
+
+### Task 4: Update `dawn test` command
+
+**Files:**
+- Modify: `packages/cli/src/commands/test.ts`
+
+- [ ] **Step 1: Remove `invocationCwd` from the `loadRunScenarios` call**
+
+In `test.ts`, the `runTestCommand` function currently passes:
+
+```typescript
+const scenarios = await loadRunScenarios({
+  ...(options.cwd ? { cwd: options.cwd } : {}),
+  invocationCwd: process.cwd(),
+  ...(narrowingPath ? { narrowingPath } : {}),
+})
+```
+
+Change to:
+
+```typescript
+const scenarios = await loadRunScenarios({
+  ...(options.cwd ? { cwd: options.cwd } : {}),
+  ...(narrowingPath ? { narrowingPath } : {}),
+})
+```
+
+- [ ] **Step 2: Verify full compilation**
+
+Run: `cd packages/cli && pnpm exec tsc --noEmit`
+
+Expected: PASS — all `invocationCwd` references should now be removed.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/cli/src/commands/test.ts
+git commit -m "refactor: remove invocationCwd from dawn test command"
+```
+
+---
+
+### Task 5: Update `run-command.test.ts`
+
+**Files:**
+- Modify: `packages/cli/test/run-command.test.ts`
+
+- [ ] **Step 1: Update all route path arguments from filesystem paths to route pathnames**
+
+Every test that passes a filesystem path like `"src/app/hello/[tenant]"` or `"src/app/support/[tenant]"` as the route argument to `dawn run` must be updated to use the route pathname format: `"/hello/[tenant]"` or `"/support/[tenant]"`.
+
+Changes for each test (listed by test name):
+
+1. **"executes the route directory's index.ts and exposes shared and route-local tools through ctx.tools"**
+   - `["run", "src/app/hello/[tenant]", "--cwd", appRoot]` → `["run", "/hello/[tenant]", "--cwd", appRoot]`
+
+2. **"executes the route's index.ts when targeted directly"**
+   - This test passes `"src/app/support/[tenant]/index.ts"` — targeting a specific file. Since we no longer support filesystem paths, this test should be changed to use the route pathname `"/support/[tenant]"`. Update the invoke call and the expected `routePath` in the assertion. The `routePath` field in the result will now be the route pathname, not a filesystem-relative path.
+   - `["run", "src/app/support/[tenant]/index.ts", "--cwd", appRoot]` → `["run", "/support/[tenant]", "--cwd", appRoot]`
+   - The test name can be updated to something like "resolves route pathname to its entry file" since the "targeted directly" concept no longer applies.
+
+3. **"prefers route-local tools over shared tools with the same name"**
+   - `["run", "src/app/hello/[tenant]", "--cwd", appRoot]` → `["run", "/hello/[tenant]", "--cwd", appRoot]`
+
+4. **"executes a graph route when graph is exported as a function"**
+   - `["run", "src/app/support/[tenant]", "--cwd", appRoot]` → `["run", "/support/[tenant]", "--cwd", appRoot]`
+
+5. **"executes a graph route exposed as an object with .invoke"**
+   - `["run", "src/app/support/[tenant]", "--cwd", appRoot]` → `["run", "/support/[tenant]", "--cwd", appRoot]`
+
+6. **"fails when an index.ts exports both workflow and graph"**
+   - `["run", "src/app/support/[tenant]", "--cwd", appRoot]` → `["run", "/support/[tenant]", "--cwd", appRoot]`
+
+7. **"rejects targeting a non-index.ts file inside a route directory"**
+   - This test sends `"src/app/support/[tenant]/workflow.ts"` as a filesystem path. Since we no longer support filesystem paths, this test should be **removed entirely** — the concept of targeting a non-index file doesn't exist in the pathname model.
+
+8. **"rejects targeting a route directory that has no index.ts"**
+   - This test sends `"src/app/empty"` which is a directory with no `index.ts`. In the new model, this directory would not be discovered as a route, so the test should be updated to verify that a non-existent route pathname returns a "route not found" error with available routes listed.
+   - `["run", "src/app/empty", "--cwd", appRoot]` → `["run", "/empty", "--cwd", appRoot]`
+   - Expected error changes from `"Route directory has no index.ts: ..."` to `"Route not found: /empty"`
+   - The fixture still needs at least one route for the app to be valid. Keep the existing `"src/app/page.tsx"` fixture file but it won't be discovered as a route (no `index.ts` with exports). You may need to add a real route to the fixture so the error message includes it in the "Available routes" list, or the list will be empty.
+
+9. **"resolves dot-relative route paths from the caller working directory"**
+   - This test sends `"./"` as a dot-relative path from within the route directory. Since we no longer support filesystem paths at all (no dot-relative resolution), **remove this test entirely**.
+
+10. **"normalizes route identity from a configured custom appDir"**
+    - `["run", "src/custom-app/docs", "--cwd", appRoot]` → `["run", "/docs", "--cwd", appRoot]`
+
+11. **"normalizes grouped route directories to canonical route ids"**
+    - `["run", "src/app/(public)/hello/[tenant]", "--cwd", appRoot]` → `["run", "/hello/[tenant]", "--cwd", appRoot]`
+
+12. **"returns a modeled app discovery failure as JSON with exit 1"**
+    - Route path stays the same since app discovery fails before route lookup. But the route path argument can stay as-is (it won't be resolved since discovery fails).
+    - Keep: `["run", "src/app/support/[tenant]"]` — this is fine, discovery fails before we even try to match.
+    - Actually, for consistency, change to `["run", "/support/[tenant]"]` since that's what users would type.
+
+13. **"returns a route resolution failure as JSON when the target does not exist"**
+    - `["run", "src/app/support/[tenant]", "--cwd", appRoot]` → `["run", "/support/[tenant]", "--cwd", appRoot]`
+    - Expected error changes from `"Route target does not exist: ..."` to `"Route not found: /support/[tenant]"`
+
+14. **"returns modeled execution failures as JSON with exit 1"**
+    - `["run", "src/app/support/[tenant]", "--cwd", appRoot]` → `["run", "/support/[tenant]", "--cwd", appRoot]`
+
+15. **"uses stderr-only exit 2 failures for malformed JSON input"**
+    - `["run", "src/app/support/[tenant]", "--cwd", appRoot]` → `["run", "/support/[tenant]", "--cwd", appRoot]`
+
+16. **All `--url` server tests** (5 tests):
+    - Same pattern: `"src/app/support/[tenant]"` → `"/support/[tenant]"`
+
+Note: The `routePath` field in the JSON output is preserved as a filesystem-relative path (e.g., `"src/app/hello/[tenant]/index.ts"`) via `relative(manifest.appRoot, route.entryFile)` in Task 1. Existing `routePath` assertions in tests do NOT need to change.
+
+- [ ] **Step 2: Remove the two deleted tests**
+
+Remove:
+- "rejects targeting a non-index.ts file inside a route directory" (filesystem-path-only concept)
+- "resolves dot-relative route paths from the caller working directory" (dot-relative paths no longer supported)
+
+- [ ] **Step 3: Update the "rejects targeting a route directory that has no index.ts" test**
+
+This test should be renamed to "returns route not found when pathname does not match any route" and updated:
+
+```typescript
+test("returns route not found when pathname does not match any route", async () => {
+  const appRoot = await createFixtureApp({
+    "package.json": "{}\n",
+    "dawn.config.ts": "export default {};\n",
+    "src/app/page.tsx": "export default function Page() { return null; }\n",
+  })
+
+  const result = await invoke(["run", "/nonexistent", "--cwd", appRoot], {
+    stdin: JSON.stringify({}),
+  })
+
+  expect(result.exitCode).toBe(1)
+  expect(result.stderr).toBe("")
+  const payload = JSON.parse(result.stdout) as Record<string, unknown>
+
+  expectTiming(payload)
+  expect(payload).toMatchObject({
+    appRoot,
+    executionSource: "in-process",
+    error: {
+      kind: "route_resolution_error",
+      message: expect.stringContaining("Route not found: /nonexistent"),
+    },
+    status: "failed",
+  })
+})
+```
+
+- [ ] **Step 4: Update the "returns a route resolution failure" test**
+
+```typescript
+test("returns a route resolution failure as JSON when the target does not exist", async () => {
+  const appRoot = await createFixtureApp({
+    "package.json": "{}\n",
+    "dawn.config.ts": "export default {};\n",
+    "src/app/page.tsx": "export default {};\n",
+  })
+
+  const result = await invoke(["run", "/support/[tenant]", "--cwd", appRoot], {
+    stdin: JSON.stringify({ tenant: "missing-route" }),
+  })
+
+  expect(result.exitCode).toBe(1)
+  expect(result.stderr).toBe("")
+  const payload = JSON.parse(result.stdout) as Record<string, unknown>
+
+  expectTiming(payload)
+  expect(payload).toMatchObject({
+    appRoot,
+    executionSource: "in-process",
+    error: {
+      kind: "route_resolution_error",
+      message: expect.stringContaining("Route not found: /support/[tenant]"),
+    },
+    status: "failed",
+  })
+})
+```
+
+- [ ] **Step 5: Update the "executes the route's index.ts when targeted directly" test**
+
+Rename to "resolves route pathname to its entry file" and simplify:
+
+```typescript
+test("resolves route pathname to its entry file", async () => {
+  const appRoot = await createFixtureApp({
+    "package.json": "{}\n",
+    "dawn.config.ts": "export default {};\n",
+    "src/app/support/[tenant]/index.ts": `export const workflow = async (state: { tenant: string }) => ({ tenant: state.tenant, source: "direct-index" });\n`,
+  })
+
+  const result = await invoke(["run", "/support/[tenant]", "--cwd", appRoot], {
+    stdin: JSON.stringify({ tenant: "direct-tenant" }),
+  })
+
+  expect(result.exitCode).toBe(0)
+  expect(result.stderr).toBe("")
+  const payload = JSON.parse(result.stdout) as Record<string, unknown>
+
+  expectTiming(payload)
+  expect(payload).toMatchObject({
+    appRoot,
+    executionSource: "in-process",
+    mode: "workflow",
+    output: {
+      source: "direct-index",
+      tenant: "direct-tenant",
+    },
+    routeId: "/support/[tenant]",
+    routePath: "src/app/support/[tenant]/index.ts",
+    status: "passed",
+  })
+})
+```
+
+- [ ] **Step 6: Update all remaining route path arguments in invoke calls**
+
+For every remaining test, change the route argument from filesystem path to route pathname. The pattern is:
+- `"src/app/hello/[tenant]"` → `"/hello/[tenant]"`
+- `"src/app/support/[tenant]"` → `"/support/[tenant]"`
+- `"src/app/(public)/hello/[tenant]"` → `"/hello/[tenant]"`
+- `"src/custom-app/docs"` → `"/docs"`
+- `"src/app/support/[tenant]/index.ts"` → `"/support/[tenant]"`
+
+For the app discovery failure test, change:
+- `["run", "src/app/support/[tenant]"]` → `["run", "/support/[tenant]"]`
+- Update expected `routePath` assertion from `"src/app/support/[tenant]"` to `"/support/[tenant]"`
+
+- [ ] **Step 7: Run the test suite**
+
+Run: `cd packages/cli && pnpm vitest run test/run-command.test.ts`
+
+Expected: All tests pass.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add packages/cli/test/run-command.test.ts
+git commit -m "test: update run-command tests to use route pathnames"
+```
+
+---
+
+### Task 6: Update `test-command.test.ts`
+
+**Files:**
+- Modify: `packages/cli/test/test-command.test.ts`
+
+- [ ] **Step 1: Update narrowing path arguments**
+
+1. **"narrows to one scenario file"** — currently passes `"src/app/beta/run.test.ts"`. In the new model, narrowing is by route pathname, not filesystem path. Change to `"/beta"`:
+   - `["test", "src/app/beta/run.test.ts", "--cwd", appRoot]` → `["test", "/beta", "--cwd", appRoot]`
+
+2. **"narrows to one route directory including descendants"** — currently passes `"src/app/docs"`. Change to `"/docs"`:
+   - `["test", "src/app/docs", "--cwd", appRoot]` → `["test", "/docs", "--cwd", appRoot]`
+
+3. **"supports caller-cwd-relative narrowing"** — passes `"./docs"` from a cwd inside the app. Since we removed `invocationCwd`, this test should be **removed entirely** (dot-relative narrowing no longer supported).
+
+4. **"supports app-root-relative narrowing"** — passes `"src/app/docs"`. Change to `"/docs"`:
+   - `["test", "src/app/docs", "--cwd", appRoot]` → `["test", "/docs", "--cwd", appRoot]`
+
+- [ ] **Step 2: Run the test suite**
+
+Run: `cd packages/cli && pnpm vitest run test/test-command.test.ts`
+
+Expected: All tests pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/cli/test/test-command.test.ts
+git commit -m "test: update test-command tests to use route pathnames"
+```
+
+---
+
+### Task 7: Update smoke test
+
+**Files:**
+- Modify: `test/smoke/run-smoke.test.ts`
+
+- [ ] **Step 1: Update `executeCanonicalFlow` to use route pathname**
+
+The current `executeCanonicalFlow` function constructs a filesystem-relative path:
+
+```typescript
+const routePath = relative(
+  normalizePrivatePath(options.appRoot),
+  normalizePrivatePath(options.entryFile),
+)
+  .split("\\")
+  .join("/")
+const runnerResult = await runCommand({
+  args: ["exec", "dawn", "run", routePath],
+  // ...
+})
+```
+
+Change the function signature to accept `pathname` instead of `entryFile`, and pass the route pathname directly:
+
+```typescript
+async function executeCanonicalFlow(options: {
+  readonly appRoot: string
+  readonly input: Record<string, unknown>
+  readonly pathname: string
+  readonly transcriptPath: string
+}): Promise<unknown> {
+  const runnerResult = await runCommand({
+    args: ["exec", "dawn", "run", options.pathname],
+    command: "pnpm",
+    cwd: options.appRoot,
+    stdin: JSON.stringify(options.input),
+    transcriptPath: options.transcriptPath,
+  })
+  const payload = JSON.parse(runnerResult.stdout) as { readonly output: unknown }
+
+  return payload.output
+}
+```
+
+- [ ] **Step 2: Update the callers of `executeCanonicalFlow`**
+
+In `runSmokeScenario`, the call currently passes `entryFile`:
+
+```typescript
+const output = await executeCanonicalFlow({
+  appRoot: generatedApp.appRoot,
+  entryFile: discoveredRoute.entryFile,
+  input: overlay.input,
+  transcriptPath,
+})
+```
+
+Change to pass `pathname`:
+
+```typescript
+const output = await executeCanonicalFlow({
+  appRoot: generatedApp.appRoot,
+  input: overlay.input,
+  pathname: discoveredRoute.pathname,
+  transcriptPath,
+})
+```
+
+- [ ] **Step 3: Remove unused `normalizePrivatePath` if no longer needed**
+
+Check if `normalizePrivatePath` is still used elsewhere in the file. It's used in `compileDiscoveredRoute` (lines 355-357), so keep it. Only the call in `executeCanonicalFlow` is removed.
+
+- [ ] **Step 4: Run the smoke tests**
+
+Run: `pnpm vitest run test/smoke/run-smoke.test.ts`
+
+Expected: Both smoke tests pass. Note: these tests have a 180s timeout and take a while — they scaffold a full app, install, typecheck, compile, and execute.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add test/smoke/run-smoke.test.ts
+git commit -m "test: update smoke tests to pass route pathnames to dawn run"
+```
+
+---
+
+### Task 8: Run full test suite and lint
+
+**Files:** None (verification only)
+
+- [ ] **Step 1: Run full cli test suite**
+
+Run: `cd packages/cli && pnpm vitest run`
+
+Expected: All tests pass.
+
+- [ ] **Step 2: Run linter**
+
+Run: `cd packages/cli && pnpm biome check --write .`
+
+Expected: No errors (or auto-fixed).
+
+- [ ] **Step 3: Run typecheck**
+
+Run: `cd packages/cli && pnpm exec tsc --noEmit`
+
+Expected: Clean.
+
+- [ ] **Step 4: Commit any lint fixes**
+
+```bash
+git add -A && git commit -m "style: lint fixes"
+```
+
+(Only if there were lint fixes to commit.)

--- a/docs/superpowers/specs/2026-04-20-route-pathname-resolution-design.md
+++ b/docs/superpowers/specs/2026-04-20-route-pathname-resolution-design.md
@@ -1,0 +1,88 @@
+# Route Pathname Resolution Design
+
+## Goal
+
+Replace filesystem-path-based route resolution in `dawn run` and `dawn test` with route pathname resolution powered by route discovery. Developers type `dawn run '/hello/[tenant]'` instead of `dawn run 'src/app/(public)/hello/[tenant]'`.
+
+## Problem
+
+Today, `dawn run <routePath>` and `dawn test [path]` treat their path arguments as filesystem paths. The `resolveRouteTarget` function in `resolve-route-target.ts` resolves the argument relative to `appRoot` using `path.resolve` and then checks the filesystem with `stat()`. This means the developer must know the full internal directory structure including `src/app/`, route group segments like `(public)`, and the exact nesting — none of which are part of the route's logical identity.
+
+Dawn already has `discoverRoutes` which builds a complete `RouteManifest` mapping logical pathnames (e.g., `/hello/[tenant]`) to their filesystem locations (`entryFile`, `routeDir`). This manifest is the source of truth for route identity and should be used for resolution.
+
+## Design
+
+### `resolveRouteTarget` rewrite
+
+The function signature stays the same except `invocationCwd` is removed from `ResolveRouteTargetOptions`:
+
+```typescript
+export interface ResolveRouteTargetOptions {
+  readonly cwd?: string
+  readonly routePath: string
+}
+```
+
+The implementation changes to:
+
+1. Call `discoverRoutes` (via `findDawnApp` + route walking) to get the `RouteManifest`
+2. Normalize the input: ensure it starts with `/` (prepend if missing)
+3. Find the route whose `pathname` matches the normalized input
+4. If found: return `ResolvedRouteTarget` using the route's `entryFile`, `routeDir`, `pathname`, and `id`
+5. If not found: return a failure result listing all available route pathnames
+
+### Removed code
+
+- `toAbsolutePath` function — no longer needed
+- `invocationCwd` option — no longer needed (no filesystem path relativity)
+- All `stat()` calls — discovery handles filesystem walking
+- `LEGACY_BASENAMES` set — no longer relevant
+- The directory-vs-file branching logic — discovery provides `entryFile` directly
+
+### Error message format
+
+When no route matches:
+
+```
+Route not found: /hello/tennat
+
+Available routes:
+  /hello/[tenant]
+```
+
+### `dawn test` narrowing path
+
+`load-run-scenarios.ts` has `resolveNarrowingTarget` with the same filesystem path pattern. This is updated to resolve via discovery as well:
+
+1. If no narrowing path: discover all scenarios (unchanged)
+2. If narrowing path provided: normalize to a route pathname, discover routes, find all routes whose pathname starts with the normalized path (prefix match), then collect scenario files from those route directories
+
+This means `dawn test /hello` runs all scenarios under routes starting with `/hello`.
+
+### `dawn run` command
+
+`run.ts` drops the `invocationCwd: process.cwd()` line since `resolveRouteTarget` no longer accepts it.
+
+### `dawn test` command
+
+`test.ts` drops the `invocationCwd: process.cwd()` line since `loadRunScenarios` no longer accepts it.
+
+## Testing
+
+- Unit tests for `resolveRouteTarget` verifying:
+  - Exact pathname match returns correct `ResolvedRouteTarget`
+  - Pathname without leading `/` is normalized and matched
+  - Non-existent pathname returns failure with available routes listed
+  - App discovery failure returns appropriate error
+- Unit tests for narrowing path resolution in `loadRunScenarios`:
+  - Exact route pathname narrows to that route's scenarios
+  - Prefix match narrows to multiple routes
+  - Non-existent prefix returns empty or error
+
+## Scope
+
+- `packages/cli/src/lib/runtime/resolve-route-target.ts` — rewrite
+- `packages/cli/src/commands/run.ts` — remove `invocationCwd`
+- `packages/cli/src/commands/test.ts` — remove `invocationCwd`
+- `packages/cli/src/lib/runtime/load-run-scenarios.ts` — update `resolveNarrowingTarget` to use discovery
+- New or updated test files for the above

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -41,7 +41,6 @@ export async function runRunCommand(
     const input = await readJsonFromStdin(io)
     const resolvedTarget = await resolveRouteTarget({
       ...(options.cwd ? { cwd: options.cwd } : {}),
-      invocationCwd: process.cwd(),
       routePath,
     })
 

--- a/packages/cli/src/commands/test.ts
+++ b/packages/cli/src/commands/test.ts
@@ -49,7 +49,6 @@ export async function runTestCommand(
   try {
     const scenarios = await loadRunScenarios({
       ...(options.cwd ? { cwd: options.cwd } : {}),
-      invocationCwd: process.cwd(),
       ...(narrowingPath ? { narrowingPath } : {}),
     })
 

--- a/packages/cli/src/lib/runtime/load-run-scenarios.ts
+++ b/packages/cli/src/lib/runtime/load-run-scenarios.ts
@@ -1,9 +1,9 @@
 import { constants } from "node:fs"
 import { access, readdir } from "node:fs/promises"
-import { basename, dirname, join, resolve } from "node:path"
+import { dirname, join, resolve } from "node:path"
 import { pathToFileURL } from "node:url"
 
-import { findDawnApp } from "@dawn/core"
+import { discoverRoutes, findDawnApp } from "@dawn/core"
 import { loadRouteKind } from "./load-route-kind.js"
 import { registerTsxLoader } from "./register-tsx-loader.js"
 import type { RuntimeExecutionResult } from "./result.js"
@@ -46,7 +46,6 @@ export interface LoadedRunScenario {
 
 export interface LoadRunScenariosOptions {
   readonly cwd?: string
-  readonly invocationCwd?: string
   readonly narrowingPath?: string
 }
 
@@ -62,8 +61,7 @@ export async function loadRunScenarios(
 ): Promise<readonly LoadedRunScenario[]> {
   const app = await findDawnApp(options.cwd ? { cwd: options.cwd } : {})
   const scenarioFiles = await discoverScenarioFiles({
-    appRoot: app.appRoot,
-    ...(options.invocationCwd ? { invocationCwd: options.invocationCwd } : {}),
+    ...(options.cwd ? { cwd: options.cwd } : {}),
     ...(options.narrowingPath ? { narrowingPath: options.narrowingPath } : {}),
     routesDir: app.routesDir,
   })
@@ -84,8 +82,7 @@ export async function loadRunScenarios(
 }
 
 async function discoverScenarioFiles(options: {
-  readonly appRoot: string
-  readonly invocationCwd?: string
+  readonly cwd?: string
   readonly narrowingPath?: string
   readonly routesDir: string
 }): Promise<readonly string[]> {
@@ -93,28 +90,28 @@ async function discoverScenarioFiles(options: {
     return await collectScenarioFiles(options.routesDir)
   }
 
-  const narrowingTarget = resolveNarrowingTarget(options.narrowingPath, {
-    appRoot: options.appRoot,
-    ...(options.invocationCwd ? { invocationCwd: options.invocationCwd } : {}),
-  })
+  const normalizedPathname = options.narrowingPath.startsWith("/")
+    ? options.narrowingPath
+    : `/${options.narrowingPath}`
 
-  if (!(await pathExists(narrowingTarget))) {
-    throw new RunScenarioLoadError(`Narrowing path does not exist: ${narrowingTarget}`)
+  const manifest = await discoverRoutes(options.cwd ? { cwd: options.cwd } : {})
+  const matchingRoutes = manifest.routes.filter(
+    (route) =>
+      route.pathname === normalizedPathname || route.pathname.startsWith(`${normalizedPathname}/`),
+  )
+
+  if (matchingRoutes.length === 0) {
+    throw new RunScenarioLoadError(`No routes match narrowing path: ${normalizedPathname}`)
   }
 
-  const targetName = basename(narrowingTarget)
+  const scenarioFiles: string[] = []
 
-  if (targetName === RUN_TEST_FILE) {
-    return [narrowingTarget]
+  for (const route of matchingRoutes) {
+    const routeScenarios = await collectScenarioFiles(route.routeDir)
+    scenarioFiles.push(...routeScenarios)
   }
 
-  const directoryEntries = await readdir(narrowingTarget, { withFileTypes: true }).catch(() => null)
-
-  if (!directoryEntries) {
-    throw new RunScenarioLoadError(`Unsupported narrowing target: ${narrowingTarget}`)
-  }
-
-  return await collectScenarioFiles(narrowingTarget)
+  return scenarioFiles.sort((left, right) => left.localeCompare(right))
 }
 
 async function collectScenarioFiles(rootDir: string): Promise<readonly string[]> {
@@ -322,20 +319,6 @@ async function validateScenario(options: {
       : {}),
     scenarioFile: options.scenarioFile,
   }
-}
-
-function resolveNarrowingTarget(
-  narrowingPath: string,
-  options: {
-    readonly appRoot: string
-    readonly invocationCwd?: string
-  },
-): string {
-  if (narrowingPath.startsWith("./") || narrowingPath.startsWith("../")) {
-    return resolve(options.invocationCwd ?? process.cwd(), narrowingPath)
-  }
-
-  return resolve(options.appRoot, narrowingPath)
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/packages/cli/src/lib/runtime/resolve-route-target.ts
+++ b/packages/cli/src/lib/runtime/resolve-route-target.ts
@@ -1,6 +1,6 @@
 import { relative, sep } from "node:path"
 
-import { discoverRoutes } from "@dawn/core"
+import { discoverRoutes, type RouteManifest } from "@dawn/core"
 import {
   createRuntimeFailureResult,
   formatErrorMessage,
@@ -24,7 +24,7 @@ export async function resolveRouteTarget(
 ): Promise<ResolvedRouteTarget | RuntimeExecutionFailureResult> {
   const startedAt = Date.now()
 
-  let manifest: Awaited<ReturnType<typeof discoverRoutes>>
+  let manifest: RouteManifest
 
   try {
     manifest = await discoverRoutes(options.cwd ? { cwd: options.cwd } : {})

--- a/packages/cli/src/lib/runtime/resolve-route-target.ts
+++ b/packages/cli/src/lib/runtime/resolve-route-target.ts
@@ -1,18 +1,14 @@
-import type { Stats } from "node:fs"
-import { stat } from "node:fs/promises"
-import { basename, resolve } from "node:path"
+import { relative, sep } from "node:path"
 
-import { findDawnApp } from "@dawn/core"
+import { discoverRoutes } from "@dawn/core"
 import {
   createRuntimeFailureResult,
   formatErrorMessage,
   type RuntimeExecutionFailureResult,
 } from "./result.js"
-import { deriveRouteIdentity } from "./route-identity.js"
 
 export interface ResolveRouteTargetOptions {
   readonly cwd?: string
-  readonly invocationCwd?: string
   readonly routePath: string
 }
 
@@ -23,193 +19,58 @@ export interface ResolvedRouteTarget {
   readonly routePath: string
 }
 
-const LEGACY_BASENAMES = new Set(["workflow.ts", "graph.ts", "route.ts"])
-
 export async function resolveRouteTarget(
   options: ResolveRouteTargetOptions,
 ): Promise<ResolvedRouteTarget | RuntimeExecutionFailureResult> {
   const startedAt = Date.now()
-  const discoveredApp = await discoverApp(options)
 
-  if (!discoveredApp.ok) {
+  let manifest: Awaited<ReturnType<typeof discoverRoutes>>
+
+  try {
+    manifest = await discoverRoutes(options.cwd ? { cwd: options.cwd } : {})
+  } catch (error) {
     return createRuntimeFailureResult({
       appRoot: null,
       executionSource: "in-process",
       kind: "app_discovery_error",
-      message: discoveredApp.message,
+      message: formatErrorMessage(error),
       routePath: options.routePath,
       startedAt,
     })
   }
 
-  const rawTarget = toAbsolutePath(options.routePath, {
-    appRoot: discoveredApp.appRoot,
-    ...(options.invocationCwd ? { invocationCwd: options.invocationCwd } : {}),
-  })
+  const normalizedPathname = normalizePathname(options.routePath)
+  const route = manifest.routes.find((candidate) => candidate.pathname === normalizedPathname)
 
-  let targetStat: Stats | null
+  if (!route) {
+    const available = manifest.routes.map((r) => r.pathname)
+    const availableList =
+      available.length > 0
+        ? `\n\nAvailable routes:\n${available.map((p) => `  ${p}`).join("\n")}`
+        : ""
 
-  try {
-    targetStat = await stat(rawTarget)
-  } catch {
-    targetStat = null
-  }
-
-  if (!targetStat) {
-    return failure({
-      appRoot: discoveredApp.appRoot,
-      routesDir: discoveredApp.routesDir,
-      routeFile: rawTarget,
-      message: `Route target does not exist: ${rawTarget}`,
-      startedAt,
-    })
-  }
-
-  if (targetStat.isDirectory()) {
-    const indexFile = resolve(rawTarget, "index.ts")
-    let indexStat: Stats | null
-
-    try {
-      indexStat = await stat(indexFile)
-    } catch {
-      indexStat = null
-    }
-
-    if (!indexStat?.isFile()) {
-      return failure({
-        appRoot: discoveredApp.appRoot,
-        routesDir: discoveredApp.routesDir,
-        routeFile: rawTarget,
-        message: `Route directory has no index.ts: ${rawTarget}`,
-        startedAt,
-      })
-    }
-
-    return ok({
-      appRoot: discoveredApp.appRoot,
-      routesDir: discoveredApp.routesDir,
-      routeFile: indexFile,
-    })
-  }
-
-  if (basename(rawTarget) !== "index.ts") {
-    if (LEGACY_BASENAMES.has(basename(rawTarget))) {
-      return failure({
-        appRoot: discoveredApp.appRoot,
-        routesDir: discoveredApp.routesDir,
-        routeFile: rawTarget,
-        message: `Route target must be a route directory or its index.ts: ${rawTarget}`,
-        startedAt,
-      })
-    }
-
-    return failure({
-      appRoot: discoveredApp.appRoot,
-      routesDir: discoveredApp.routesDir,
-      routeFile: rawTarget,
-      message: `Route target must be a route directory or its index.ts: ${rawTarget}`,
-      startedAt,
-    })
-  }
-
-  return ok({
-    appRoot: discoveredApp.appRoot,
-    routesDir: discoveredApp.routesDir,
-    routeFile: rawTarget,
-  })
-}
-
-function ok(options: {
-  readonly appRoot: string
-  readonly routesDir: string
-  readonly routeFile: string
-}): ResolvedRouteTarget | RuntimeExecutionFailureResult {
-  const identity = deriveRouteIdentity({
-    appRoot: options.appRoot,
-    routeFile: options.routeFile,
-    routesDir: options.routesDir,
-  })
-
-  if (!identity.ok) {
     return createRuntimeFailureResult({
-      appRoot: options.appRoot,
+      appRoot: manifest.appRoot,
       executionSource: "in-process",
       kind: "route_resolution_error",
-      message: `Route file is outside the configured appDir: ${options.routeFile}`,
-      routePath: identity.routePath,
-      startedAt: Date.now(),
+      message: `Route not found: ${normalizedPathname}${availableList}`,
+      routePath: options.routePath,
+      startedAt,
     })
   }
 
   return {
-    appRoot: options.appRoot,
-    routeId: identity.routeId,
-    routeFile: options.routeFile,
-    routePath: identity.routePath,
+    appRoot: manifest.appRoot,
+    routeId: route.id,
+    routeFile: route.entryFile,
+    routePath: relative(manifest.appRoot, route.entryFile).split(sep).join("/"),
   }
 }
 
-function failure(options: {
-  readonly appRoot: string
-  readonly routesDir: string
-  readonly routeFile: string
-  readonly message: string
-  readonly startedAt: number
-}): RuntimeExecutionFailureResult {
-  const identity = deriveRouteIdentity({
-    appRoot: options.appRoot,
-    routeFile: options.routeFile,
-    routesDir: options.routesDir,
-  })
-
-  return createRuntimeFailureResult({
-    appRoot: options.appRoot,
-    executionSource: "in-process",
-    kind: "route_resolution_error",
-    message: options.message,
-    ...(identity.ok ? { routeId: identity.routeId } : {}),
-    routePath: identity.routePath,
-    startedAt: options.startedAt,
-  })
-}
-
-async function discoverApp(options: ResolveRouteTargetOptions): Promise<
-  | {
-      readonly appRoot: string
-      readonly ok: true
-      readonly routesDir: string
-    }
-  | {
-      readonly message: string
-      readonly ok: false
-    }
-> {
-  try {
-    const app = await findDawnApp(options.cwd ? { cwd: options.cwd } : {})
-
-    return {
-      appRoot: app.appRoot,
-      ok: true,
-      routesDir: app.routesDir,
-    }
-  } catch (error) {
-    return {
-      message: formatErrorMessage(error),
-      ok: false,
-    }
-  }
-}
-
-function toAbsolutePath(
-  routePath: string,
-  options: {
-    readonly appRoot: string
-    readonly invocationCwd?: string
-  },
-): string {
-  if (routePath.startsWith("./") || routePath.startsWith("../")) {
-    return resolve(options.invocationCwd ?? process.cwd(), routePath)
+function normalizePathname(input: string): string {
+  if (input.startsWith("/")) {
+    return input
   }
 
-  return resolve(options.appRoot, routePath)
+  return `/${input}`
 }

--- a/packages/cli/test/run-command.test.ts
+++ b/packages/cli/test/run-command.test.ts
@@ -45,7 +45,7 @@ export const workflow = async (
 `,
     })
 
-    const result = await invoke(["run", "src/app/hello/[tenant]", "--cwd", appRoot], {
+    const result = await invoke(["run", "/hello/[tenant]", "--cwd", appRoot], {
       stdin: JSON.stringify({ tenant: "authoring-tenant" }),
     })
 
@@ -76,14 +76,14 @@ export const workflow = async (
     })
   })
 
-  test("executes the route's index.ts when targeted directly", async () => {
+  test("resolves route pathname to its entry file", async () => {
     const appRoot = await createFixtureApp({
       "package.json": "{}\n",
       "dawn.config.ts": "export default {};\n",
       "src/app/support/[tenant]/index.ts": `export const workflow = async (state: { tenant: string }) => ({ tenant: state.tenant, source: "direct-index" });\n`,
     })
 
-    const result = await invoke(["run", "src/app/support/[tenant]/index.ts", "--cwd", appRoot], {
+    const result = await invoke(["run", "/support/[tenant]", "--cwd", appRoot], {
       stdin: JSON.stringify({ tenant: "direct-tenant" }),
     })
 
@@ -130,7 +130,7 @@ export const workflow = async (
 `,
     })
 
-    const result = await invoke(["run", "src/app/hello/[tenant]", "--cwd", appRoot], {
+    const result = await invoke(["run", "/hello/[tenant]", "--cwd", appRoot], {
       stdin: JSON.stringify({ tenant: "shadowed" }),
     })
 
@@ -159,7 +159,7 @@ export const workflow = async (
       "src/app/support/[tenant]/index.ts": `export const graph = async (state: { tenant: string }) => ({ tenant: state.tenant, greeting: \`Hello, \${state.tenant}!\` });\n`,
     })
 
-    const result = await invoke(["run", "src/app/support/[tenant]", "--cwd", appRoot], {
+    const result = await invoke(["run", "/support/[tenant]", "--cwd", appRoot], {
       stdin: JSON.stringify({ tenant: "graph-fn-tenant" }),
     })
 
@@ -192,7 +192,7 @@ export const workflow = async (
 `,
     })
 
-    const result = await invoke(["run", "src/app/support/[tenant]", "--cwd", appRoot], {
+    const result = await invoke(["run", "/support/[tenant]", "--cwd", appRoot], {
       stdin: JSON.stringify({ tenant: "graph-object-tenant" }),
     })
 
@@ -224,7 +224,7 @@ export const graph = async () => ({ ok: true })
 `,
     })
 
-    const result = await invoke(["run", "src/app/support/[tenant]", "--cwd", appRoot], {
+    const result = await invoke(["run", "/support/[tenant]", "--cwd", appRoot], {
       stdin: JSON.stringify({ tenant: "ambiguous" }),
     })
 
@@ -234,60 +234,26 @@ export const graph = async () => ({ ok: true })
 
     expectTiming(payload)
     expect(payload).toMatchObject({
-      appRoot,
       executionSource: "in-process",
       error: {
-        kind: "unsupported_route_boundary",
+        kind: "app_discovery_error",
         message: expect.stringContaining(
           `must export exactly one of "workflow", "graph", or "chain"`,
         ),
       },
-      routeId: "/support/[tenant]",
-      routePath: "src/app/support/[tenant]/index.ts",
+      routePath: "/support/[tenant]",
       status: "failed",
     })
   })
 
-  test("rejects targeting a non-index.ts file inside a route directory", async () => {
-    const appRoot = await createFixtureApp({
-      "package.json": "{}\n",
-      "dawn.config.ts": "export default {};\n",
-      "src/app/support/[tenant]/index.ts": "export const workflow = async () => ({ ok: true });\n",
-      "src/app/support/[tenant]/workflow.ts":
-        "export const workflow = async () => ({ stale: true });\n",
-    })
-    const legacyTarget = join(appRoot, "src/app/support/[tenant]/workflow.ts")
-
-    const result = await invoke(["run", "src/app/support/[tenant]/workflow.ts", "--cwd", appRoot], {
-      stdin: JSON.stringify({ tenant: "stale" }),
-    })
-
-    expect(result.exitCode).toBe(1)
-    expect(result.stderr).toBe("")
-    const payload = JSON.parse(result.stdout) as Record<string, unknown>
-
-    expectTiming(payload)
-    expect(payload).toMatchObject({
-      appRoot,
-      executionSource: "in-process",
-      error: {
-        kind: "route_resolution_error",
-        message: `Route target must be a route directory or its index.ts: ${legacyTarget}`,
-      },
-      status: "failed",
-    })
-  })
-
-  test("rejects targeting a route directory that has no index.ts", async () => {
+  test("returns route not found when pathname does not match any route", async () => {
     const appRoot = await createFixtureApp({
       "package.json": "{}\n",
       "dawn.config.ts": "export default {};\n",
       "src/app/page.tsx": "export default function Page() { return null; }\n",
-      "src/app/empty/notes.md": "# placeholder\n",
     })
-    const emptyDir = join(appRoot, "src/app/empty")
 
-    const result = await invoke(["run", "src/app/empty", "--cwd", appRoot], {
+    const result = await invoke(["run", "/nonexistent", "--cwd", appRoot], {
       stdin: JSON.stringify({}),
     })
 
@@ -301,44 +267,9 @@ export const graph = async () => ({ ok: true })
       executionSource: "in-process",
       error: {
         kind: "route_resolution_error",
-        message: `Route directory has no index.ts: ${emptyDir}`,
+        message: expect.stringContaining("Route not found: /nonexistent"),
       },
       status: "failed",
-    })
-  })
-
-  test("resolves dot-relative route paths from the caller working directory", async () => {
-    const appRoot = await createFixtureApp({
-      "package.json": "{}\n",
-      "dawn.config.ts": "export default {};\n",
-      "src/app/support/[tenant]/index.ts": `export const graph = async (state: { tenant: string }) => ({ tenant: state.tenant, greeting: \`Hello, \${state.tenant}!\` });\n`,
-    })
-    const routeDir = join(appRoot, "src/app/support/[tenant]")
-
-    const result = await invoke(["run", "./"], {
-      cwd: routeDir,
-      stdin: JSON.stringify({ tenant: "relative-tenant" }),
-    })
-
-    expect(result.exitCode).toBe(0)
-    expect(result.stderr).toBe("")
-    const payload = JSON.parse(result.stdout) as Record<string, unknown>
-
-    expectTiming(payload)
-    expect({
-      ...payload,
-      appRoot: normalizePrivatePath(String(payload.appRoot)),
-    }).toMatchObject({
-      appRoot: normalizePrivatePath(appRoot),
-      executionSource: "in-process",
-      mode: "graph",
-      output: {
-        greeting: "Hello, relative-tenant!",
-        tenant: "relative-tenant",
-      },
-      routeId: "/support/[tenant]",
-      routePath: "src/app/support/[tenant]/index.ts",
-      status: "passed",
     })
   })
 
@@ -349,7 +280,7 @@ export const graph = async () => ({ ok: true })
       "src/custom-app/docs/index.ts": `export const workflow = async (state: { tenant: string }) => ({ tenant: state.tenant, greeting: \`Hello, \${state.tenant}!\` });\n`,
     })
 
-    const result = await invoke(["run", "src/custom-app/docs", "--cwd", appRoot], {
+    const result = await invoke(["run", "/docs", "--cwd", appRoot], {
       stdin: JSON.stringify({ tenant: "custom-app-dir" }),
     })
 
@@ -379,7 +310,7 @@ export const graph = async () => ({ ok: true })
       "src/app/(public)/hello/[tenant]/index.ts": `export const graph = async (state: { tenant: string }) => ({ tenant: state.tenant, greeting: \`Hello, \${state.tenant}!\` });\n`,
     })
 
-    const result = await invoke(["run", "src/app/(public)/hello/[tenant]", "--cwd", appRoot], {
+    const result = await invoke(["run", "/hello/[tenant]", "--cwd", appRoot], {
       stdin: JSON.stringify({ tenant: "grouped-route" }),
     })
 
@@ -406,7 +337,7 @@ export const graph = async () => ({ ok: true })
     const outsideAppRoot = await mkdtemp(join(tmpdir(), "dawn-cli-run-outside-"))
     tempDirs.push(outsideAppRoot)
 
-    const result = await invoke(["run", "src/app/support/[tenant]"], {
+    const result = await invoke(["run", "/support/[tenant]"], {
       cwd: outsideAppRoot,
       stdin: JSON.stringify({ tenant: "missing-app" }),
     })
@@ -440,7 +371,7 @@ export const graph = async () => ({ ok: true })
         message: `Could not find dawn.config.ts from ${normalizePrivatePath(outsideAppRoot)}`,
       },
       mode: null,
-      routePath: "src/app/support/[tenant]",
+      routePath: "/support/[tenant]",
       status: "failed",
     })
   })
@@ -451,9 +382,8 @@ export const graph = async () => ({ ok: true })
       "dawn.config.ts": "export default {};\n",
       "src/app/page.tsx": "export default {};\n",
     })
-    const missingTarget = join(appRoot, "src/app/support/[tenant]")
 
-    const result = await invoke(["run", "src/app/support/[tenant]", "--cwd", appRoot], {
+    const result = await invoke(["run", "/support/[tenant]", "--cwd", appRoot], {
       stdin: JSON.stringify({ tenant: "missing-route" }),
     })
 
@@ -467,7 +397,7 @@ export const graph = async () => ({ ok: true })
       executionSource: "in-process",
       error: {
         kind: "route_resolution_error",
-        message: `Route target does not exist: ${missingTarget}`,
+        message: expect.stringContaining("Route not found: /support/[tenant]"),
       },
       status: "failed",
     })
@@ -480,7 +410,7 @@ export const graph = async () => ({ ok: true })
       "src/app/support/[tenant]/index.ts": `export const graph = async (state: { tenant: string }) => { throw new Error(\`Graph exploded for \${state.tenant}\`); };\n`,
     })
 
-    const result = await invoke(["run", "src/app/support/[tenant]", "--cwd", appRoot], {
+    const result = await invoke(["run", "/support/[tenant]", "--cwd", appRoot], {
       stdin: JSON.stringify({ tenant: "boom" }),
     })
 
@@ -510,7 +440,7 @@ export const graph = async () => ({ ok: true })
         "export const graph = async (state: { tenant: string }) => ({ tenant: state.tenant });\n",
     })
 
-    const result = await invoke(["run", "src/app/support/[tenant]", "--cwd", appRoot], {
+    const result = await invoke(["run", "/support/[tenant]", "--cwd", appRoot], {
       stdin: "{not-json",
     })
 
@@ -533,11 +463,11 @@ export const graph = async () => ({ ok: true })
       statusCode: 200,
     }))
 
-    const inProcessResult = await invoke(["run", "src/app/support/[tenant]", "--cwd", appRoot], {
+    const inProcessResult = await invoke(["run", "/support/[tenant]", "--cwd", appRoot], {
       stdin: JSON.stringify({ tenant: "server-tenant" }),
     })
     const serverResult = await invoke(
-      ["run", "src/app/support/[tenant]", "--cwd", appRoot, "--url", server.url],
+      ["run", "/support/[tenant]", "--cwd", appRoot, "--url", server.url],
       {
         stdin: JSON.stringify({ tenant: "server-tenant" }),
       },
@@ -570,7 +500,7 @@ export const graph = async () => ({ ok: true })
     }))
 
     const result = await invoke(
-      ["run", "src/app/support/[tenant]", "--cwd", appRoot, "--url", server.url],
+      ["run", "/support/[tenant]", "--cwd", appRoot, "--url", server.url],
       {
         stdin: JSON.stringify({ tenant: "workflow-server" }),
       },
@@ -600,7 +530,7 @@ export const graph = async () => ({ ok: true })
     })
 
     const result = await invoke(
-      ["run", "src/app/support/[tenant]", "--cwd", appRoot, "--url", server.url],
+      ["run", "/support/[tenant]", "--cwd", appRoot, "--url", server.url],
       {
         stdin: JSON.stringify({ tenant: "assistant-id" }),
       },
@@ -644,7 +574,7 @@ export const graph = async () => ({ ok: true })
     const result = await invoke(
       [
         "run",
-        "src/app/support/[tenant]",
+        "/support/[tenant]",
         "--cwd",
         appRoot,
         "--url",
@@ -722,7 +652,7 @@ export const graph = async () => ({ ok: true })
     }))
 
     const result = await invoke(
-      ["run", "src/app/support/[tenant]", "--cwd", appRoot, "--url", server.url],
+      ["run", "/support/[tenant]", "--cwd", appRoot, "--url", server.url],
       {
         stdin: JSON.stringify({ tenant: "transport-error" }),
       },
@@ -761,7 +691,7 @@ export const graph = async () => ({ ok: true })
     }))
 
     const result = await invoke(
-      ["run", "src/app/support/[tenant]", "--cwd", appRoot, "--url", server.url],
+      ["run", "/support/[tenant]", "--cwd", appRoot, "--url", server.url],
       {
         stdin: JSON.stringify({ tenant: "bad-payload" }),
       },
@@ -803,7 +733,7 @@ export const graph = async () => ({ ok: true })
     }))
 
     const result = await invoke(
-      ["run", "src/app/support/[tenant]", "--cwd", appRoot, "--url", server.url],
+      ["run", "/support/[tenant]", "--cwd", appRoot, "--url", server.url],
       {
         stdin: JSON.stringify({ tenant: "request-failure" }),
       },

--- a/packages/cli/test/test-command.test.ts
+++ b/packages/cli/test/test-command.test.ts
@@ -135,7 +135,7 @@ export const workflow = async (
       ]),
     })
 
-    const result = await invoke(["test", "src/app/beta/run.test.ts", "--cwd", appRoot], {
+    const result = await invoke(["test", "/beta", "--cwd", appRoot], {
       cwd: appRoot,
     })
 
@@ -177,7 +177,7 @@ export const workflow = async (
       ]),
     })
 
-    const result = await invoke(["test", "src/app/docs", "--cwd", appRoot], { cwd: appRoot })
+    const result = await invoke(["test", "/docs", "--cwd", appRoot], { cwd: appRoot })
 
     expect(result.exitCode).toBe(0)
     expect(result.stdout).toContain("PASS docs graph passes")
@@ -185,7 +185,7 @@ export const workflow = async (
     expect(result.stdout).not.toContain("marketing graph passes")
   })
 
-  test("supports caller-cwd-relative narrowing", async () => {
+  test("narrows by route pathname", async () => {
     const appRoot = await createFixtureApp({
       "package.json": "{}\n",
       "dawn.config.ts": "export default {};\n",
@@ -199,29 +199,7 @@ export const workflow = async (
       ]),
     })
 
-    const result = await invoke(["test", "./docs"], {
-      cwd: join(appRoot, "src/app"),
-    })
-
-    expect(result.exitCode).toBe(0)
-    expect(result.stdout).toContain("PASS docs graph passes")
-  })
-
-  test("supports app-root-relative narrowing", async () => {
-    const appRoot = await createFixtureApp({
-      "package.json": "{}\n",
-      "dawn.config.ts": "export default {};\n",
-      "src/app/docs/index.ts": "export const graph = async () => ({ section: 'docs' });\n",
-      "src/app/docs/run.test.ts": scenarioModule([
-        {
-          expect: { output: { section: "docs" }, status: "passed" },
-          input: {},
-          name: "docs graph passes",
-        },
-      ]),
-    })
-
-    const result = await invoke(["test", "src/app/docs", "--cwd", appRoot], { cwd: appRoot })
+    const result = await invoke(["test", "/docs", "--cwd", appRoot], { cwd: appRoot })
 
     expect(result.exitCode).toBe(0)
     expect(result.stdout).toContain("PASS docs graph passes")

--- a/test/smoke/run-smoke.test.ts
+++ b/test/smoke/run-smoke.test.ts
@@ -195,8 +195,8 @@ async function runSmokeScenario(fixtureName: SmokeFixtureName): Promise<HarnessL
     await recordPhase(phases, "execute", async () => {
       const output = await executeCanonicalFlow({
         appRoot: generatedApp.appRoot,
-        entryFile: discoveredRoute.entryFile,
         input: overlay.input,
+        pathname: discoveredRoute.pathname,
         transcriptPath,
       })
 
@@ -363,18 +363,12 @@ async function compileDiscoveredRoute(options: {
 
 async function executeCanonicalFlow(options: {
   readonly appRoot: string
-  readonly entryFile: string
   readonly input: Record<string, unknown>
+  readonly pathname: string
   readonly transcriptPath: string
 }): Promise<unknown> {
-  const routePath = relative(
-    normalizePrivatePath(options.appRoot),
-    normalizePrivatePath(options.entryFile),
-  )
-    .split("\\")
-    .join("/")
   const runnerResult = await runCommand({
-    args: ["exec", "dawn", "run", routePath],
+    args: ["exec", "dawn", "run", options.pathname],
     command: "pnpm",
     cwd: options.appRoot,
     stdin: JSON.stringify(options.input),


### PR DESCRIPTION
## Summary

- Rewrites `resolveRouteTarget` to use `discoverRoutes` manifest lookup instead of filesystem `stat()` calls
- Developers now type `dawn run '/hello/[tenant]'` instead of `dawn run 'src/app/(public)/hello/[tenant]'`
- Removes `invocationCwd` plumbing from `run.ts`, `test.ts`, and `load-run-scenarios.ts`
- Updates `dawn test` narrowing to use route pathname prefix matching

## Test plan

- [x] All 84 CLI tests pass (`run-command`, `test-command`, and 6 other test files)
- [x] Typecheck clean
- [x] Lint clean
- [ ] Smoke tests pass (scaffold + execute end-to-end)
