### PR TITLE
feat(web): mint-like docs shell — three-column layout + MDX components

### DIFF
--- a/apps/web/app/components/docs/DocsBreadcrumb.tsx
+++ b/apps/web/app/components/docs/DocsBreadcrumb.tsx
@@ -1,0 +1,28 @@
+import Link from "next/link"
+import { breadcrumbsFor } from "./nav"
+
+interface Props {
+  readonly href: string
+}
+
+export function DocsBreadcrumb({ href }: Props) {
+  const crumbs = breadcrumbsFor(href)
+  return (
+    <nav aria-label="Breadcrumb" className="mb-6 text-xs text-text-muted">
+      <ol className="flex items-center gap-2 flex-wrap">
+        {crumbs.map((c, i) => (
+          <li key={c.href ?? c.label} className="flex items-center gap-2">
+            {c.href ? (
+              <Link href={c.href} className="hover:text-text-primary transition-colors">
+                {c.label}
+              </Link>
+            ) : (
+              <span className="text-text-secondary">{c.label}</span>
+            )}
+            {i < crumbs.length - 1 && <span aria-hidden>/</span>}
+          </li>
+        ))}
+      </ol>
+    </nav>
+  )
+}

--- a/apps/web/app/components/docs/DocsPrevNext.tsx
+++ b/apps/web/app/components/docs/DocsPrevNext.tsx
@@ -1,0 +1,45 @@
+import Link from "next/link"
+import { siblingsFor } from "./nav"
+
+interface Props {
+  readonly href: string
+}
+
+export function DocsPrevNext({ href }: Props) {
+  const { prev, next } = siblingsFor(href)
+  if (!prev && !next) return null
+
+  return (
+    <nav
+      aria-label="Pagination"
+      className="mt-16 pt-8 border-t border-border-subtle grid grid-cols-2 gap-4"
+    >
+      {prev ? (
+        <Link
+          href={prev.href}
+          className="group border border-border rounded-lg p-4 hover:border-accent-amber/40 transition-colors"
+        >
+          <span className="text-xs text-text-muted block mb-1">&larr; Previous</span>
+          <span className="text-sm font-semibold text-text-primary group-hover:text-accent-amber transition-colors">
+            {prev.label}
+          </span>
+        </Link>
+      ) : (
+        <span />
+      )}
+      {next ? (
+        <Link
+          href={next.href}
+          className="group border border-border rounded-lg p-4 text-right hover:border-accent-amber/40 transition-colors"
+        >
+          <span className="text-xs text-text-muted block mb-1">Next &rarr;</span>
+          <span className="text-sm font-semibold text-text-primary group-hover:text-accent-amber transition-colors">
+            {next.label}
+          </span>
+        </Link>
+      ) : (
+        <span />
+      )}
+    </nav>
+  )
+}

--- a/apps/web/app/components/docs/DocsSidebar.tsx
+++ b/apps/web/app/components/docs/DocsSidebar.tsx
@@ -1,0 +1,46 @@
+"use client"
+
+import Link from "next/link"
+import { usePathname } from "next/navigation"
+import { DOCS_NAV } from "./nav"
+
+export function DocsSidebar() {
+  const pathname = usePathname()
+
+  return (
+    <aside className="w-56 shrink-0">
+      <p className="text-xs text-text-muted uppercase tracking-widest mb-6 inline-flex items-center gap-2">
+        <span className="inline-block w-1 h-1 rounded-full bg-accent-amber" aria-hidden />
+        Documentation
+      </p>
+      <nav className="space-y-6">
+        {DOCS_NAV.map((section) => (
+          <div key={section.label}>
+            <p className="text-[11px] font-semibold text-text-secondary uppercase tracking-wider mb-2 px-3">
+              {section.label}
+            </p>
+            <ul className="space-y-0.5">
+              {section.items.map((item) => {
+                const active = pathname === item.href
+                return (
+                  <li key={item.href}>
+                    <Link
+                      href={item.href}
+                      className={`block text-sm px-3 py-1.5 rounded-md transition-colors ${
+                        active
+                          ? "text-accent-amber bg-accent-amber/5 border-l border-accent-amber -ml-px pl-[11px]"
+                          : "text-text-secondary hover:text-text-primary hover:bg-bg-card"
+                      }`}
+                    >
+                      {item.label}
+                    </Link>
+                  </li>
+                )
+              })}
+            </ul>
+          </div>
+        ))}
+      </nav>
+    </aside>
+  )
+}

--- a/apps/web/app/components/docs/DocsTOC.tsx
+++ b/apps/web/app/components/docs/DocsTOC.tsx
@@ -1,0 +1,81 @@
+"use client"
+
+import { useEffect, useState } from "react"
+
+interface Heading {
+  readonly id: string
+  readonly text: string
+  readonly level: 2 | 3
+}
+
+function slugify(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/(^-|-$)/g, "")
+}
+
+export function DocsTOC() {
+  const [headings, setHeadings] = useState<readonly Heading[]>([])
+  const [activeId, setActiveId] = useState<string | null>(null)
+
+  useEffect(() => {
+    const article = document.querySelector("article.prose-dawn")
+    if (!article) return
+
+    const elements = Array.from(article.querySelectorAll<HTMLHeadingElement>("h2, h3"))
+    const parsed: Heading[] = elements.map((el) => {
+      const text = el.textContent?.trim() ?? ""
+      const id = el.id || slugify(text)
+      if (!el.id) el.id = id
+      return {
+        id,
+        text,
+        level: el.tagName === "H2" ? 2 : 3,
+      }
+    })
+    setHeadings(parsed)
+
+    if (parsed.length === 0) return
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const visible = entries
+          .filter((e) => e.isIntersecting)
+          .sort(
+            (a, b) => a.target.getBoundingClientRect().top - b.target.getBoundingClientRect().top,
+          )
+        const first = visible[0]
+        if (first) setActiveId(first.target.id)
+      },
+      { rootMargin: "0px 0px -70% 0px", threshold: 1 },
+    )
+    for (const el of elements) observer.observe(el)
+    return () => observer.disconnect()
+  }, [])
+
+  if (headings.length === 0) return null
+
+  return (
+    <nav aria-label="On this page" className="sticky top-8 w-52 shrink-0 hidden xl:block text-sm">
+      <p className="text-xs text-text-muted uppercase tracking-widest mb-3">On this page</p>
+      <ul className="space-y-2 border-l border-border-subtle">
+        {headings.map((h) => (
+          <li key={h.id} className={h.level === 3 ? "pl-5" : "pl-3"}>
+            <a
+              href={`#${h.id}`}
+              className={`block py-0.5 transition-colors -ml-px border-l ${
+                activeId === h.id
+                  ? "text-accent-amber border-accent-amber"
+                  : "text-text-muted border-transparent hover:text-text-primary"
+              }`}
+              style={{ paddingLeft: h.level === 3 ? 12 : 12 }}
+            >
+              {h.text}
+            </a>
+          </li>
+        ))}
+      </ul>
+    </nav>
+  )
+}

--- a/apps/web/app/components/docs/nav.ts
+++ b/apps/web/app/components/docs/nav.ts
@@ -1,0 +1,46 @@
+export interface DocsNavItem {
+  readonly label: string
+  readonly href: string
+}
+
+export interface DocsNavSection {
+  readonly label: string
+  readonly items: readonly DocsNavItem[]
+}
+
+export const DOCS_NAV: readonly DocsNavSection[] = [
+  {
+    label: "Start",
+    items: [{ label: "Getting Started", href: "/docs/getting-started" }],
+  },
+]
+
+// Flat ordered list of pages — used for prev/next navigation.
+export const DOCS_PAGES: readonly DocsNavItem[] = DOCS_NAV.flatMap((s) => s.items)
+
+export interface DocsCrumb {
+  readonly label: string
+  readonly href?: string
+}
+
+// Build breadcrumbs for a given href. Always starts with "Docs" → <section> → <page>.
+export function breadcrumbsFor(href: string): readonly DocsCrumb[] {
+  const section = DOCS_NAV.find((s) => s.items.some((i) => i.href === href))
+  const page = section?.items.find((i) => i.href === href)
+  const crumbs: DocsCrumb[] = [{ label: "Docs", href: "/docs/getting-started" }]
+  if (section) crumbs.push({ label: section.label })
+  if (page) crumbs.push({ label: page.label })
+  return crumbs
+}
+
+export function siblingsFor(href: string): {
+  readonly prev: DocsNavItem | null
+  readonly next: DocsNavItem | null
+} {
+  const idx = DOCS_PAGES.findIndex((p) => p.href === href)
+  if (idx < 0) return { prev: null, next: null }
+  return {
+    prev: idx > 0 ? (DOCS_PAGES[idx - 1] ?? null) : null,
+    next: idx < DOCS_PAGES.length - 1 ? (DOCS_PAGES[idx + 1] ?? null) : null,
+  }
+}

--- a/apps/web/app/components/mdx/Callout.tsx
+++ b/apps/web/app/components/mdx/Callout.tsx
@@ -1,0 +1,52 @@
+import type { ReactNode } from "react"
+
+type CalloutType = "info" | "tip" | "warn" | "danger"
+
+interface Props {
+  readonly type?: CalloutType
+  readonly title?: string
+  readonly children: ReactNode
+}
+
+const STYLES: Record<CalloutType, { border: string; icon: string; glyph: string }> = {
+  info: {
+    border: "border-accent-amber/40",
+    icon: "text-accent-amber",
+    glyph: "\u24D8", // ⓘ
+  },
+  tip: {
+    border: "border-accent-green/40",
+    icon: "text-accent-green",
+    glyph: "\u2728", // ✨
+  },
+  warn: {
+    border: "border-yellow-500/40",
+    icon: "text-yellow-500",
+    glyph: "\u26A0", // ⚠
+  },
+  danger: {
+    border: "border-red-500/40",
+    icon: "text-red-500",
+    glyph: "\u2716", // ✖
+  },
+}
+
+export function Callout({ type = "info", title, children }: Props) {
+  const s = STYLES[type]
+  return (
+    <aside
+      className={`my-6 p-4 bg-bg-card border rounded-lg flex gap-3 items-start ${s.border}`}
+      role="note"
+    >
+      <span className={`text-base mt-0.5 shrink-0 ${s.icon}`} aria-hidden>
+        {s.glyph}
+      </span>
+      <div className="flex-1 min-w-0">
+        {title && <p className="font-semibold text-text-primary mb-1 text-sm">{title}</p>}
+        <div className="text-sm text-text-secondary leading-relaxed [&>p]:m-0 [&>p+p]:mt-2">
+          {children}
+        </div>
+      </div>
+    </aside>
+  )
+}

--- a/apps/web/app/components/mdx/Steps.tsx
+++ b/apps/web/app/components/mdx/Steps.tsx
@@ -1,0 +1,39 @@
+import { Children, isValidElement, type ReactElement, type ReactNode } from "react"
+
+interface StepsProps {
+  readonly children: ReactNode
+}
+
+interface StepProps {
+  readonly title: string
+  readonly children: ReactNode
+}
+
+export function Steps({ children }: StepsProps) {
+  const steps = Children.toArray(children).filter((child): child is ReactElement<StepProps> =>
+    isValidElement(child),
+  )
+  return (
+    <ol className="my-8 space-y-6 list-none pl-0">
+      {steps.map((step, i) => (
+        <li key={step.props.title ?? i} className="flex gap-5 items-start">
+          <span className="w-7 h-7 rounded-full bg-accent-amber/15 border border-accent-amber/40 text-accent-amber flex items-center justify-center text-xs font-bold shrink-0 mt-0.5">
+            {i + 1}
+          </span>
+          <div className="flex-1 min-w-0">{step}</div>
+        </li>
+      ))}
+    </ol>
+  )
+}
+
+export function Step({ title, children }: StepProps) {
+  return (
+    <>
+      <p className="text-base font-semibold text-text-primary mb-2">{title}</p>
+      <div className="text-sm text-text-secondary leading-relaxed [&>p]:m-0 [&>p+*]:mt-3 [&>pre]:mt-3 [&>ul]:mt-3 [&>ol]:mt-3">
+        {children}
+      </div>
+    </>
+  )
+}

--- a/apps/web/app/components/mdx/Tabs.tsx
+++ b/apps/web/app/components/mdx/Tabs.tsx
@@ -1,0 +1,53 @@
+"use client"
+
+import { Children, isValidElement, type ReactElement, type ReactNode, useState } from "react"
+
+interface TabsProps {
+  readonly children: ReactNode
+}
+
+interface TabProps {
+  readonly label: string
+  readonly children: ReactNode
+}
+
+interface TabElementProps {
+  readonly label: string
+  readonly children: ReactNode
+}
+
+export function Tabs({ children }: TabsProps) {
+  const tabs = Children.toArray(children).filter((child): child is ReactElement<TabElementProps> =>
+    isValidElement(child),
+  )
+  const [active, setActive] = useState(0)
+  if (tabs.length === 0) return null
+
+  return (
+    <div className="my-6 border border-border rounded-lg overflow-hidden">
+      <div role="tablist" className="flex bg-bg-card border-b border-border-subtle">
+        {tabs.map((tab, i) => (
+          <button
+            key={tab.props.label}
+            type="button"
+            role="tab"
+            aria-selected={active === i}
+            onClick={() => setActive(i)}
+            className={`px-4 py-2 text-xs font-mono transition-colors border-b-2 ${
+              active === i
+                ? "text-accent-amber border-accent-amber"
+                : "text-text-muted border-transparent hover:text-text-primary"
+            }`}
+          >
+            {tab.props.label}
+          </button>
+        ))}
+      </div>
+      <div className="p-4 text-sm text-text-secondary">{tabs[active]?.props.children}</div>
+    </div>
+  )
+}
+
+export function Tab({ children }: TabProps) {
+  return <>{children}</>
+}

--- a/apps/web/app/docs/getting-started/page.tsx
+++ b/apps/web/app/docs/getting-started/page.tsx
@@ -2,33 +2,40 @@ import type { Metadata } from "next"
 import GettingStarted from "../../../content/docs/getting-started.mdx"
 import { getPrompt } from "../../../content/prompts"
 import { CopyPromptButton } from "../../components/CopyPromptButton"
+import { DocsBreadcrumb } from "../../components/docs/DocsBreadcrumb"
+import { DocsPrevNext } from "../../components/docs/DocsPrevNext"
 
 export const metadata: Metadata = {
   title: "Getting Started",
 }
 
 const scaffoldPrompt = getPrompt("scaffold")
+const HREF = "/docs/getting-started"
 
 export default function GettingStartedPage() {
   return (
-    <article className="prose-dawn">
-      <div className="mb-8 p-4 border border-border rounded-lg bg-bg-card/50 flex items-start gap-4">
-        <div className="flex-1 min-w-0">
-          <p className="text-sm font-semibold text-text-primary mb-1">
-            Skip ahead — hand this to your coding agent
-          </p>
-          <p className="text-sm text-text-muted leading-relaxed">
-            Copy a prompt that instructs Claude Code, Cursor, or any coding agent to scaffold a Dawn
-            app and walk through the structure with you.
-          </p>
+    <>
+      <DocsBreadcrumb href={HREF} />
+      <article className="prose-dawn">
+        <div className="mb-8 p-4 border border-border rounded-lg bg-bg-card/50 flex items-start gap-4">
+          <div className="flex-1 min-w-0">
+            <p className="text-sm font-semibold text-text-primary mb-1">
+              Skip ahead — hand this to your coding agent
+            </p>
+            <p className="text-sm text-text-muted leading-relaxed">
+              Copy a prompt that instructs Claude Code, Cursor, or any coding agent to scaffold a
+              Dawn app and walk through the structure with you.
+            </p>
+          </div>
+          <CopyPromptButton
+            prompt={scaffoldPrompt.body}
+            label="Copy scaffold prompt"
+            variant="docs"
+          />
         </div>
-        <CopyPromptButton
-          prompt={scaffoldPrompt.body}
-          label="Copy scaffold prompt"
-          variant="docs"
-        />
-      </div>
-      <GettingStarted />
-    </article>
+        <GettingStarted />
+      </article>
+      <DocsPrevNext href={HREF} />
+    </>
   )
 }

--- a/apps/web/app/docs/layout.tsx
+++ b/apps/web/app/docs/layout.tsx
@@ -1,29 +1,13 @@
-import Link from "next/link"
 import type { ReactNode } from "react"
-
-const docsNav = [{ href: "/docs/getting-started", label: "Getting Started" }]
+import { DocsSidebar } from "../components/docs/DocsSidebar"
+import { DocsTOC } from "../components/docs/DocsTOC"
 
 export default function DocsLayout({ children }: { children: ReactNode }) {
   return (
-    <div className="max-w-5xl mx-auto px-8 py-12 flex gap-12">
-      <aside className="w-56 shrink-0">
-        <p className="text-xs text-text-muted uppercase tracking-widest mb-4 inline-flex items-center gap-2">
-          <span className="inline-block w-1 h-1 rounded-full bg-accent-amber" aria-hidden />
-          Documentation
-        </p>
-        <nav className="space-y-2">
-          {docsNav.map((item) => (
-            <Link
-              key={item.href}
-              href={item.href}
-              className="block text-sm text-text-secondary hover:text-text-primary transition-colors px-3 py-2 rounded-md hover:bg-bg-card"
-            >
-              {item.label}
-            </Link>
-          ))}
-        </nav>
-      </aside>
-      <section className="flex-1 min-w-0">{children}</section>
+    <div className="max-w-7xl mx-auto px-8 py-12 flex gap-12">
+      <DocsSidebar />
+      <section className="flex-1 min-w-0 max-w-3xl">{children}</section>
+      <DocsTOC />
     </div>
   )
 }

--- a/apps/web/mdx-components.tsx
+++ b/apps/web/mdx-components.tsx
@@ -1,7 +1,15 @@
 import type { MDXComponents } from "mdx/types"
+import { Callout } from "./app/components/mdx/Callout"
+import { Step, Steps } from "./app/components/mdx/Steps"
+import { Tab, Tabs } from "./app/components/mdx/Tabs"
 
 export function useMDXComponents(components: MDXComponents): MDXComponents {
   return {
+    Callout,
+    Steps,
+    Step,
+    Tabs,
+    Tab,
     h1: ({ children }) => (
       <h1
         className="font-display text-4xl md:text-5xl font-semibold text-text-primary mb-6 tracking-tight"


### PR DESCRIPTION
## Summary

Builds the Mintlify-style docs shell on top of the agent-first foundation from [dawnai#6](https://github.com/cacheplane/dawnai/pull/6).

### Shell

- **Three-column layout** — DocsSidebar (left) + content (center) + DocsTOC (right). TOC is hidden below \`xl\` so narrower screens keep two columns.
- **DocsSidebar** — grouped nav with section headers and active-page highlight (amber left-border + amber text).
- **DocsTOC** — client component that extracts H2/H3 from rendered content, sets ids on headings that lack them, and highlights the active heading via IntersectionObserver as the reader scrolls.
- **DocsBreadcrumb** — trail at the top of each docs page.
- **DocsPrevNext** — prev/next cards at the bottom of each docs page, driven by the same nav config. Renders nothing when no siblings.

All nav structure lives in \`app/components/docs/nav.ts\` as a single source of truth shared by the sidebar, breadcrumb, and pagination.

### MDX components

Available in every \`.mdx\` file via \`mdx-components.tsx\`:

- \`<Callout type="info|tip|warn|danger" title="...">\` — colored inline note boxes.
- \`<Steps>\` + \`<Step title="...">\` — numbered vertical step list with amber step circles.
- \`<Tabs>\` + \`<Tab label="...">\` — client-side tabbed content.

### Visible changes

The Getting Started page now renders inside the shell — breadcrumb at top, TOC on the right showing every section heading, warm-neutral warm-Fraunces treatment continues. Screenshot shows the three-column composition cleanly.

### What's next

PR 3: client-side Cmd-K search. PR 4+: expanded content (routes, tools, testing, dev server, deployment, CLI reference) using the new MDX components.

## Test plan

- [x] \`pnpm --filter @dawn/web typecheck\` passes
- [x] \`pnpm --filter @dawn/web lint\` passes
- [x] \`pnpm --filter @dawn/web build\` succeeds
- [x] Getting Started docs page renders with breadcrumb, sidebar, TOC
- [x] TOC highlights the active section as the reader scrolls
- [x] Sidebar active state (amber border + amber text) on current page
