### PR TITLE
feat(web): expand docs content — 7 new pages + MDX polish

### DIFF
--- a/apps/web/app/components/docs/DocsPage.tsx
+++ b/apps/web/app/components/docs/DocsPage.tsx
@@ -1,0 +1,43 @@
+import type { ComponentType } from "react"
+import { getPrompt, type PromptSlug } from "../../../content/prompts"
+import { CopyPromptButton } from "../CopyPromptButton"
+import { DocsBreadcrumb } from "./DocsBreadcrumb"
+import { DocsPrevNext } from "./DocsPrevNext"
+
+interface Props {
+  readonly href: string
+  readonly Content: ComponentType
+  readonly promptSlug?: PromptSlug
+  readonly promptPitch?: string
+}
+
+export function DocsPage({ href, Content, promptSlug, promptPitch }: Props) {
+  const prompt = promptSlug ? getPrompt(promptSlug) : null
+
+  return (
+    <>
+      <DocsBreadcrumb href={href} />
+      <article className="prose-dawn">
+        {prompt && (
+          <div className="mb-8 p-4 border border-border rounded-lg bg-bg-card/50 flex items-start gap-4">
+            <div className="flex-1 min-w-0">
+              <p className="text-sm font-semibold text-text-primary mb-1">
+                Skip ahead — hand this to your coding agent
+              </p>
+              <p className="text-sm text-text-muted leading-relaxed">
+                {promptPitch ?? prompt.description}
+              </p>
+            </div>
+            <CopyPromptButton
+              prompt={prompt.body}
+              label={`Copy ${prompt.slug} prompt`}
+              variant="docs"
+            />
+          </div>
+        )}
+        <Content />
+      </article>
+      <DocsPrevNext href={href} />
+    </>
+  )
+}

--- a/apps/web/app/components/docs/nav.ts
+++ b/apps/web/app/components/docs/nav.ts
@@ -13,6 +13,26 @@ export const DOCS_NAV: readonly DocsNavSection[] = [
     label: "Start",
     items: [{ label: "Getting Started", href: "/docs/getting-started" }],
   },
+  {
+    label: "Core Concepts",
+    items: [
+      { label: "Routes", href: "/docs/routes" },
+      { label: "Tools", href: "/docs/tools" },
+      { label: "State", href: "/docs/state" },
+    ],
+  },
+  {
+    label: "Workflow",
+    items: [
+      { label: "Testing", href: "/docs/testing" },
+      { label: "Dev Server", href: "/docs/dev-server" },
+      { label: "Deployment", href: "/docs/deployment" },
+    ],
+  },
+  {
+    label: "Reference",
+    items: [{ label: "CLI", href: "/docs/cli" }],
+  },
 ]
 
 // Flat ordered list of pages — used for prev/next navigation.

--- a/apps/web/app/docs/cli/page.tsx
+++ b/apps/web/app/docs/cli/page.tsx
@@ -1,0 +1,9 @@
+import type { Metadata } from "next"
+import Content from "../../../content/docs/cli.mdx"
+import { DocsPage } from "../../components/docs/DocsPage"
+
+export const metadata: Metadata = { title: "CLI Reference" }
+
+export default function Page() {
+  return <DocsPage href="/docs/cli" Content={Content} />
+}

--- a/apps/web/app/docs/deployment/page.tsx
+++ b/apps/web/app/docs/deployment/page.tsx
@@ -1,0 +1,9 @@
+import type { Metadata } from "next"
+import Content from "../../../content/docs/deployment.mdx"
+import { DocsPage } from "../../components/docs/DocsPage"
+
+export const metadata: Metadata = { title: "Deployment" }
+
+export default function Page() {
+  return <DocsPage href="/docs/deployment" Content={Content} promptSlug="deploy" />
+}

--- a/apps/web/app/docs/dev-server/page.tsx
+++ b/apps/web/app/docs/dev-server/page.tsx
@@ -1,0 +1,9 @@
+import type { Metadata } from "next"
+import Content from "../../../content/docs/dev-server.mdx"
+import { DocsPage } from "../../components/docs/DocsPage"
+
+export const metadata: Metadata = { title: "Dev Server" }
+
+export default function Page() {
+  return <DocsPage href="/docs/dev-server" Content={Content} />
+}

--- a/apps/web/app/docs/getting-started/page.tsx
+++ b/apps/web/app/docs/getting-started/page.tsx
@@ -1,41 +1,18 @@
 import type { Metadata } from "next"
 import GettingStarted from "../../../content/docs/getting-started.mdx"
-import { getPrompt } from "../../../content/prompts"
-import { CopyPromptButton } from "../../components/CopyPromptButton"
-import { DocsBreadcrumb } from "../../components/docs/DocsBreadcrumb"
-import { DocsPrevNext } from "../../components/docs/DocsPrevNext"
+import { DocsPage } from "../../components/docs/DocsPage"
 
 export const metadata: Metadata = {
   title: "Getting Started",
 }
 
-const scaffoldPrompt = getPrompt("scaffold")
-const HREF = "/docs/getting-started"
-
-export default function GettingStartedPage() {
+export default function Page() {
   return (
-    <>
-      <DocsBreadcrumb href={HREF} />
-      <article className="prose-dawn">
-        <div className="mb-8 p-4 border border-border rounded-lg bg-bg-card/50 flex items-start gap-4">
-          <div className="flex-1 min-w-0">
-            <p className="text-sm font-semibold text-text-primary mb-1">
-              Skip ahead — hand this to your coding agent
-            </p>
-            <p className="text-sm text-text-muted leading-relaxed">
-              Copy a prompt that instructs Claude Code, Cursor, or any coding agent to scaffold a
-              Dawn app and walk through the structure with you.
-            </p>
-          </div>
-          <CopyPromptButton
-            prompt={scaffoldPrompt.body}
-            label="Copy scaffold prompt"
-            variant="docs"
-          />
-        </div>
-        <GettingStarted />
-      </article>
-      <DocsPrevNext href={HREF} />
-    </>
+    <DocsPage
+      href="/docs/getting-started"
+      Content={GettingStarted}
+      promptSlug="scaffold"
+      promptPitch="Copy a prompt that instructs Claude Code, Cursor, or any coding agent to scaffold a Dawn app and walk through the structure with you."
+    />
   )
 }

--- a/apps/web/app/docs/routes/page.tsx
+++ b/apps/web/app/docs/routes/page.tsx
@@ -1,0 +1,9 @@
+import type { Metadata } from "next"
+import Content from "../../../content/docs/routes.mdx"
+import { DocsPage } from "../../components/docs/DocsPage"
+
+export const metadata: Metadata = { title: "Routes" }
+
+export default function Page() {
+  return <DocsPage href="/docs/routes" Content={Content} promptSlug="write-a-route" />
+}

--- a/apps/web/app/docs/state/page.tsx
+++ b/apps/web/app/docs/state/page.tsx
@@ -1,0 +1,9 @@
+import type { Metadata } from "next"
+import Content from "../../../content/docs/state.mdx"
+import { DocsPage } from "../../components/docs/DocsPage"
+
+export const metadata: Metadata = { title: "State" }
+
+export default function Page() {
+  return <DocsPage href="/docs/state" Content={Content} />
+}

--- a/apps/web/app/docs/testing/page.tsx
+++ b/apps/web/app/docs/testing/page.tsx
@@ -1,0 +1,9 @@
+import type { Metadata } from "next"
+import Content from "../../../content/docs/testing.mdx"
+import { DocsPage } from "../../components/docs/DocsPage"
+
+export const metadata: Metadata = { title: "Testing" }
+
+export default function Page() {
+  return <DocsPage href="/docs/testing" Content={Content} promptSlug="write-a-test" />
+}

--- a/apps/web/app/docs/tools/page.tsx
+++ b/apps/web/app/docs/tools/page.tsx
@@ -1,0 +1,9 @@
+import type { Metadata } from "next"
+import Content from "../../../content/docs/tools.mdx"
+import { DocsPage } from "../../components/docs/DocsPage"
+
+export const metadata: Metadata = { title: "Tools" }
+
+export default function Page() {
+  return <DocsPage href="/docs/tools" Content={Content} promptSlug="add-a-tool" />
+}

--- a/apps/web/app/llms-full.txt/route.ts
+++ b/apps/web/app/llms-full.txt/route.ts
@@ -5,7 +5,16 @@ import { PROMPTS } from "../../content/prompts"
 
 const CONTENT_ROOT = path.join(process.cwd(), "content")
 
-const DOCS_PAGES = [{ title: "Getting Started", path: "docs/getting-started.mdx" }]
+const DOCS_PAGES = [
+  { title: "Getting Started", path: "docs/getting-started.mdx" },
+  { title: "Routes", path: "docs/routes.mdx" },
+  { title: "Tools", path: "docs/tools.mdx" },
+  { title: "State", path: "docs/state.mdx" },
+  { title: "Testing", path: "docs/testing.mdx" },
+  { title: "Dev Server", path: "docs/dev-server.mdx" },
+  { title: "Deployment", path: "docs/deployment.mdx" },
+  { title: "CLI Reference", path: "docs/cli.mdx" },
+]
 
 const TEMPLATES = [
   { title: "AGENTS.md template", path: "templates/AGENTS.md" },

--- a/apps/web/content/docs/cli.mdx
+++ b/apps/web/content/docs/cli.mdx
@@ -1,0 +1,102 @@
+# CLI Reference
+
+Dawn ships a single `dawn` binary with six commands. Every command reads `dawn.config.ts` from the current working directory and operates on the app rooted there.
+
+## `dawn check`
+
+Validates the app structure and configuration.
+
+```
+dawn check
+```
+
+Checks:
+- `dawn.config.ts` exists and has only supported fields.
+- `package.json` exists.
+- Every route has exactly one of `workflow`, `graph`, or `chain` exported from `index.ts`.
+- Every route's `state.ts` exports a named state type.
+- No tool files have invalid shapes.
+
+Exits non-zero on any violation with a detailed message.
+
+## `dawn routes`
+
+Lists every route Dawn discovered and its computed pathname.
+
+```
+dawn routes
+```
+
+Output:
+
+```
+/hello/[tenant]   workflow   src/app/(public)/hello/[tenant]/index.ts
+/admin/users      graph      src/app/(internal)/admin/users/index.ts
+```
+
+Use this to confirm that route groups and dynamic segments are being parsed the way you expect.
+
+## `dawn typegen`
+
+Regenerates `dawn.generated.d.ts` from the current state of every tool file.
+
+```
+dawn typegen
+```
+
+<Callout type="info" title="Run automatically by dawn dev">
+  `dawn dev` runs `typegen` on every save. You only need to invoke it manually after a fresh clone, before CI, or after a tool signature change while the dev server isn't running.
+</Callout>
+
+## `dawn run`
+
+Executes a single route invocation with JSON stdin/stdout.
+
+```
+echo '{"tenant":"acme"}' | dawn run '/hello/[tenant]'
+```
+
+Flags:
+- `--url <url>` — run against a live dev server instead of the in-process runtime.
+- `--stream` — use the `/runs/stream` endpoint (requires `--url`) and pipe SSE events to stdout.
+
+<Callout type="tip" title="Quote the path">
+  Route paths contain `(`, `)`, `[`, and `]`. Always quote them in shell so they aren't expanded.
+</Callout>
+
+## `dawn test`
+
+Runs every colocated `run.test.ts` scenario in the app.
+
+```
+dawn test
+```
+
+Flags:
+- `--url <url>` — run against a live dev server.
+- `--filter <pattern>` — only run scenarios whose describe/test name matches.
+
+Exits non-zero on any failure with a diff per mismatched scenario. See [Testing](/docs/testing) for scenario authoring.
+
+## `dawn dev`
+
+Starts the local runtime — hot reload + LangGraph Platform protocol.
+
+```
+dawn dev --port 3001
+```
+
+Flags:
+- `--port <n>` — HTTP port (default 3000).
+- `--host <addr>` — bind address (default 127.0.0.1).
+
+See [Dev Server](/docs/dev-server) for the full protocol reference and architecture notes.
+
+## Exit codes
+
+| Code | Meaning |
+|---|---|
+| 0 | Success |
+| 1 | Validation failure (e.g. `dawn check`) or scenario failure (e.g. `dawn test`) |
+| 2 | Configuration error (missing `dawn.config.ts`, bad `appDir`) |
+| 3 | Internal error (bug — please file an issue) |

--- a/apps/web/content/docs/deployment.mdx
+++ b/apps/web/content/docs/deployment.mdx
@@ -1,0 +1,65 @@
+# Deployment
+
+Dawn itself is **not a deployment runtime**. It owns local development: `dawn dev`, `dawn run`, `dawn test`. Production runs on the **LangGraph Platform**, which Dawn's dev server already speaks natively. What runs locally runs in production without translation.
+
+## The deployment path
+
+<Steps>
+  <Step title="Verify locally">
+    ```
+    dawn check
+    dawn routes
+    dawn typegen
+    dawn test
+    ```
+
+    All four must pass. `dawn check` validates the app contract, `dawn routes` confirms discovery, `dawn typegen` regenerates ambient types, `dawn test` runs every scenario against the in-process runtime.
+  </Step>
+  <Step title="Confirm protocol parity">
+    Run your tests against a live dev server:
+
+    ```
+    dawn dev --port 3001 &
+    dawn test --url http://127.0.0.1:3001
+    ```
+
+    If in-process and live-server tests both pass, the same inputs will pass on LangGraph Platform.
+  </Step>
+  <Step title="Declare assistants">
+    Create a `langgraph.json` at the app root mapping Dawn's discovered routes to LangGraph assistants:
+
+    ```json
+    {
+      "graphs": {
+        "hello": "./src/app/(public)/hello/[tenant]/index.ts:workflow"
+      },
+      "env": ".env"
+    }
+    ```
+
+    Each entry binds an `assistant_id` (left side) to a route entry export (right side).
+  </Step>
+  <Step title="Push to your Platform-connected remote">
+    The LangGraph Platform builds the image and provisions assistants keyed by `assistant_id`. From there, your agents and harnesses can hit the deployed endpoints using the same protocol they already speak locally.
+  </Step>
+</Steps>
+
+## What Dawn does not do
+
+<Callout type="warn" title="Not a hosted platform">
+  Dawn does not provision infrastructure, manage secrets, or replace LangSmith. If you want a hosted runtime, use the LangGraph Platform. If you want observability, use LangSmith.
+</Callout>
+
+## Self-hosting
+
+If you can't or won't use the LangGraph Platform, you can self-host by wrapping Dawn's runtime in a Docker container that exposes the same protocol endpoints (`/runs/wait`, `/runs/stream`, `/assistants`). Dawn's dev server implementation (in `@dawn/cli`) is the reference — it's the same process you'd run in production, just without the file watcher.
+
+<Callout type="tip" title="Dev server as reference">
+  `dawn dev` running on port 3001 is functionally identical to a deployed Dawn runtime. Point your staging tests at a `dawn dev` instance and you'll catch 95% of deployment issues before you ship.
+</Callout>
+
+## Troubleshooting
+
+- **Tests pass in-process but fail live-server** — a tool or route isn't serializing cleanly. Check that inputs, outputs, and state are JSON-serializable (no Dates, Maps, classes).
+- **Assistant id not found** — the `langgraph.json` entry doesn't match what Dawn discovered. Run `dawn routes` to see the exact pathnames, then update the `graphs` mapping.
+- **Type inference drifted** — run `dawn typegen` locally and commit `dawn.generated.d.ts`. The Platform build uses the committed file.

--- a/apps/web/content/docs/dev-server.mdx
+++ b/apps/web/content/docs/dev-server.mdx
@@ -1,0 +1,82 @@
+# Dev Server
+
+`dawn dev` starts a local runtime that speaks the **LangGraph Platform protocol** natively. It hot-reloads routes and tools on every file save, and accepts the same `/runs/wait` and `/runs/stream` endpoints your production deployment will.
+
+## Starting the server
+
+```
+dawn dev
+```
+
+By default the server listens on port 3000. Override with `--port`:
+
+```
+dawn dev --port 3001
+```
+
+## Invoking a route
+
+With the server running in one terminal, you can hit it from another:
+
+```
+echo '{"tenant":"acme"}' | dawn run '/hello/[tenant]' --url http://127.0.0.1:3001
+```
+
+`dawn run` resolves the pathname to an `assistant_id`, POSTs to `/runs/wait`, and prints the result. This is the exact request path a production LangGraph Platform deployment would take.
+
+## Protocol endpoints
+
+<Tabs>
+  <Tab label="/runs/wait">
+    Synchronous run — blocks until the route completes, returns the final state.
+
+    ```
+    POST /runs/wait
+    Body: { assistant_id, input }
+    ```
+  </Tab>
+  <Tab label="/runs/stream">
+    Streaming run — returns an SSE stream of intermediate events as the route progresses.
+
+    ```
+    POST /runs/stream
+    Body: { assistant_id, input, stream_mode }
+    ```
+  </Tab>
+  <Tab label="/assistants">
+    Lists the assistants (routes) the server is serving.
+
+    ```
+    GET /assistants
+    ```
+  </Tab>
+</Tabs>
+
+## Hot reload
+
+When you save a route file, a tool, or a state file, the dev server:
+
+<Steps>
+  <Step title="Re-runs typegen">
+    Any tool signature changes are picked up and `dawn.generated.d.ts` is updated. Your IDE's TypeScript server sees the new types within seconds.
+  </Step>
+  <Step title="Restarts the child runtime">
+    Dawn uses a parent-child process architecture. The parent owns the HTTP server and file watcher; the child owns the route graph. On save, only the child restarts — in-flight requests complete before the swap.
+  </Step>
+  <Step title="Preserves assistant ids">
+    Assistants keep their stable ids across restarts, so any agent or harness holding an `assistant_id` continues to work without reconnection.
+  </Step>
+</Steps>
+
+<Callout type="info" title="Why this architecture">
+  Running the route runtime in a child process means the parent HTTP server is unaffected by a route's crash. The dev server stays up even when your code throws — you just see the error in the logs and save to retry.
+</Callout>
+
+## Logging
+
+Every request is logged to stdout with the pathname, assistant id, duration, and result status. Set `DEBUG=dawn:*` for verbose tracing of the parent/child handshake.
+
+## Next steps
+
+- [Testing](/docs/testing) — run scenarios against a live dev server
+- [Deployment](/docs/deployment) — ship the same runtime to LangGraph Platform

--- a/apps/web/content/docs/routes.mdx
+++ b/apps/web/content/docs/routes.mdx
@@ -1,0 +1,92 @@
+# Routes
+
+Routes are the unit of work in Dawn. A route is a directory under `src/app/` containing an `index.ts` that exports exactly one of three entry types: a `workflow` function, a LangGraph `graph`, or a LangChain `chain`.
+
+Routes are discovered by filesystem walk — **no registration, no config**.
+
+## Route entry
+
+Every route's `index.ts` exports one entry. The three choices are interchangeable: a given route picks whichever best matches the work.
+
+<Tabs>
+  <Tab label="workflow">
+    The most common entry. A plain async function that takes state + runtime context, returns new state.
+
+    ```ts
+    import type { RuntimeContext } from "@dawn/sdk"
+    import type { RouteTools } from "dawn:routes"
+    import type { HelloState } from "./state.js"
+
+    export async function workflow(
+      state: HelloState,
+      ctx: RuntimeContext<RouteTools<"/hello/[tenant]">>
+    ) {
+      const result = await ctx.tools.greet({ tenant: state.tenant })
+      return { ...state, greeting: result.greeting }
+    }
+    ```
+  </Tab>
+  <Tab label="graph">
+    A LangGraph graph instance. Use when the route is a genuine multi-node stateful graph.
+
+    ```ts
+    export const graph = /* LangGraph graph instance */
+    ```
+  </Tab>
+  <Tab label="chain">
+    A LangChain LCEL Runnable. Use for single-shot prompt chains.
+
+    ```ts
+    export const chain = /* LCEL runnable */
+    ```
+  </Tab>
+</Tabs>
+
+<Callout type="warn" title="Exactly one entry per route">
+  A single `index.ts` may export **only one** of `workflow`, `graph`, or `chain`. `dawn check` enforces this.
+</Callout>
+
+## Pathname rules
+
+The route's URL-style pathname is computed from its directory path, with two transformations:
+
+- **Route groups** — segments in parentheses like `(public)` are excluded from the pathname.
+- **Dynamic segments** — segments in brackets like `[tenant]` match any value and map to a state field of the same name.
+
+| Directory | Pathname |
+|---|---|
+| `src/app/(public)/hello/[tenant]/` | `/hello/[tenant]` |
+| `src/app/(internal)/admin/users/` | `/admin/users` |
+| `src/app/docs/[...slug]/` | `/docs/[...slug]` |
+
+Run `dawn routes` to list every route Dawn discovered and its computed pathname.
+
+## State
+
+Each route has a `state.ts` file that defines its state type:
+
+```ts
+// src/app/(public)/hello/[tenant]/state.ts
+export interface HelloState {
+  readonly tenant: string
+  readonly greeting?: string
+}
+```
+
+Dynamic segment names become state fields automatically. `[tenant]` → `state.tenant`.
+
+## Tools
+
+A route's `tools/` directory contains co-located tools. Tool types are inferred from source and made available on `ctx.tools` with full autocomplete. See [Tools](/docs/tools) for the full reference.
+
+## Running a route
+
+```
+dawn run '/hello/acme'
+```
+
+`dawn run` reads state from stdin (JSON), resolves the pathname to a route, invokes the entry, and writes the result to stdout.
+
+<Callout type="tip" title="Tip">
+  Quote the route path in your shell — route groups and dynamic segments contain `(`, `)`, and `[]` which shells expand.
+</Callout>

--- a/apps/web/content/docs/state.mdx
+++ b/apps/web/content/docs/state.mdx
@@ -1,0 +1,60 @@
+# State
+
+Every route has a state type declared in a colocated `state.ts` file. State is the contract between the caller, the route's entry, and any tools the entry invokes.
+
+## The shape
+
+```ts
+// src/app/(public)/hello/[tenant]/state.ts
+export interface HelloState {
+  readonly tenant: string
+  readonly greeting?: string
+}
+```
+
+`HelloState` is imported into `index.ts` and used as the first parameter of the `workflow` function (or the equivalent graph state type).
+
+```ts
+import type { HelloState } from "./state.js"
+
+export async function workflow(state: HelloState, ctx) {
+  // state.tenant is string
+  // state.greeting is string | undefined
+}
+```
+
+## Dynamic segments become state fields
+
+If your route's directory contains a dynamic segment like `[tenant]`, that segment's value is populated on the state field of the same name at runtime.
+
+```
+src/app/(public)/hello/[tenant]/  →  state.tenant populated from the pathname
+```
+
+<Callout type="info" title="Naming matters">
+  The dynamic segment name and the state field name must match exactly. Dawn wires them up by name, not by position.
+</Callout>
+
+## Rules
+
+<Steps>
+  <Step title="State must be JSON-serializable">
+    Dawn serializes state across runtime boundaries (dev server, scenario tests, LangGraph Platform). Use primitives, plain objects, arrays. No classes, no Dates, no Maps.
+  </Step>
+  <Step title="Prefer readonly">
+    Mark fields `readonly`. The entry function returns a new state object rather than mutating the input. This keeps scenario tests deterministic and LangGraph checkpoint-safe.
+  </Step>
+  <Step title="Outputs accumulate">
+    A workflow returns `{ ...state, newField }` — merging new outputs into the existing state. Fields added during the run are typed as optional (`greeting?: string`) so the caller isn't forced to provide them.
+  </Step>
+</Steps>
+
+## State flow
+
+```
+caller stdin  →  state  →  workflow/graph/chain  →  new state  →  stdout
+                              ↓
+                           ctx.tools
+```
+
+The state is the only thing that crosses the runtime boundary. Everything else — tool results, intermediate values — lives inside the entry for the duration of a single run.

--- a/apps/web/content/docs/testing.mdx
+++ b/apps/web/content/docs/testing.mdx
@@ -1,0 +1,81 @@
+# Testing
+
+Scenario tests are colocated with routes as `run.test.ts` files. Each scenario declares an input state and the expected output, and Dawn runs them against the real route runtime.
+
+## A minimal test
+
+```ts
+// src/app/(public)/hello/[tenant]/run.test.ts
+import { describe, test } from "@dawn/sdk/testing"
+
+describe("/hello/[tenant]", () => {
+  test("greets a tenant", {
+    input: { tenant: "acme" },
+    expected: { tenant: "acme", greeting: "Hello, acme!" },
+  })
+})
+```
+
+Run all scenarios:
+
+```
+dawn test
+```
+
+Dawn discovers every `run.test.ts` under `src/app/`, invokes the route for each scenario, and compares output deep-equal against `expected`.
+
+## Against a live dev server
+
+By default, tests run against the in-process route runtime. You can also point tests at a running `dawn dev` server to verify protocol parity:
+
+```
+dawn dev --port 3001 &
+dawn test --url http://127.0.0.1:3001
+```
+
+<Callout type="tip" title="Run both to confirm parity">
+  If the in-process run passes but the live-server run fails, something in your route doesn't survive the LangGraph Platform protocol. The live-server mode is how you catch this before deploy.
+</Callout>
+
+## Mocking tools
+
+For routes that call external APIs, databases, or LLMs, stub the tools per-scenario:
+
+```ts
+test("with mocked greet", {
+  input: { tenant: "acme" },
+  expected: { tenant: "acme", greeting: "Hi from mock!" },
+  tools: {
+    greet: async () => ({ greeting: "Hi from mock!" }),
+  },
+})
+```
+
+The mock signature must match the tool's inferred input/output shape. TypeScript checks this at compile time.
+
+## Rules
+
+<Steps>
+  <Step title="File location">
+    `run.test.ts` must live in the route's directory, not a sibling or nested folder. Dawn matches tests to routes by directory, not by name.
+  </Step>
+  <Step title="describe() matches the route">
+    The top-level `describe` block should pass the route's pathname. Dawn uses it to look up the correct route for the scenarios inside.
+  </Step>
+  <Step title="expected is deep-equal by default">
+    Dawn compares the returned state deep-equal against `expected`. Use `expected.eq`, `expected.contains`, or custom matchers for partial or fuzzy matching (see `@dawn/sdk/testing` for the full surface).
+  </Step>
+  <Step title="Keep scenarios focused">
+    One scenario = one claim about the route's behavior. If you're adding branches, add more scenarios — don't inflate a single one.
+  </Step>
+</Steps>
+
+## CI
+
+`dawn test` exits non-zero on any failure and outputs a diff per mismatched scenario. Wire it into your CI step after `dawn check` and `dawn typegen`:
+
+```yaml
+- run: pnpm exec dawn check
+- run: pnpm exec dawn typegen
+- run: pnpm exec dawn test
+```

--- a/apps/web/content/docs/tools.mdx
+++ b/apps/web/content/docs/tools.mdx
@@ -1,0 +1,79 @@
+# Tools
+
+Tools are the units of work a route's entry can invoke. They live in a `tools/` subdirectory inside a route, are discovered automatically, and have their types **inferred from source** — no Zod schemas, no manual type wiring.
+
+## A minimal tool
+
+```ts
+// src/app/(public)/hello/[tenant]/tools/greet.ts
+export default async (input: { readonly tenant: string }) => {
+  return { greeting: `Hello, ${input.tenant}!` }
+}
+```
+
+That's it. Dawn extracts the input and output types at build time using the TypeScript compiler API and writes them into `dawn.generated.d.ts`. The tool becomes available as `ctx.tools.greet` inside the route's entry, fully typed.
+
+<Callout type="info" title="No registration needed">
+  Every `.ts` file in a route's `tools/` directory is automatically discovered. Drop a file in, save, and the type appears in `ctx.tools` on the next `dawn typegen` or `dawn dev` reload.
+</Callout>
+
+## Invoking a tool
+
+```ts
+// in the route's index.ts
+export async function workflow(state, ctx) {
+  const result = await ctx.tools.greet({ tenant: state.tenant })
+  return { ...state, greeting: result.greeting }
+}
+```
+
+`ctx.tools.greet` has full IntelliSense — input shape, return shape, everything.
+
+## Input and output rules
+
+<Steps>
+  <Step title="Use a typed input parameter">
+    Annotate the input parameter with an inline type. This is what Dawn's compiler pass extracts.
+
+    ```ts
+    export default async (input: { readonly tenant: string; readonly limit?: number }) => { ... }
+    ```
+  </Step>
+  <Step title="Mark fields readonly">
+    `readonly` is preserved through type generation. Use it on every field — tool inputs are pure data, never mutated.
+  </Step>
+  <Step title="Keep inputs and outputs JSON-serializable">
+    Dawn serializes through the runtime boundary. Classes, Dates, Maps, functions — none of them survive. Use primitives, plain objects, and arrays.
+  </Step>
+  <Step title="Return a plain object">
+    Always return an object literal, not a primitive or array. Dawn's type inference handles shape-based returns cleanly; a bare `return someString` muddles the generated types.
+  </Step>
+</Steps>
+
+## The generated declaration
+
+Dawn writes a `dawn.generated.d.ts` file at your app root that looks roughly like:
+
+```ts
+declare module "dawn:routes" {
+  export type RouteTools<P> = DawnRouteTools[P]
+  // greet signature inferred from tools/greet.ts export
+}
+```
+
+<Callout type="warn" title="Don't edit this file">
+  `dawn.generated.d.ts` is regenerated on every `dawn typegen` and by the dev server on save. Your edits will be wiped.
+</Callout>
+
+Regenerate manually if needed:
+
+```
+dawn typegen
+```
+
+## Common patterns
+
+- **External API wrappers** — one tool per endpoint. Input shape mirrors the endpoint's parameters; output is the parsed response.
+- **Database reads** — input includes the filters; output is the record(s). Keep queries cheap — tools are meant to be fast.
+- **LLM calls** — input is the prompt variables; output is the parsed model response. Defer orchestration to the route entry.
+- **Pure transformations** — no side effects, just shape-to-shape mapping. Dawn's testing makes these trivial to verify.

--- a/apps/web/mdx-components.tsx
+++ b/apps/web/mdx-components.tsx
@@ -54,6 +54,30 @@ export function useMDXComponents(components: MDXComponents): MDXComponents {
     strong: ({ children }) => (
       <strong className="text-text-primary font-semibold">{children}</strong>
     ),
+    table: ({ children }) => (
+      <div className="my-6 overflow-x-auto border border-border rounded-lg">
+        <table className="w-full text-sm">{children}</table>
+      </div>
+    ),
+    thead: ({ children }) => <thead className="bg-bg-card">{children}</thead>,
+    tbody: ({ children }) => (
+      <tbody className="[&>tr]:border-t [&>tr]:border-border-subtle">{children}</tbody>
+    ),
+    tr: ({ children }) => <tr>{children}</tr>,
+    th: ({ children }) => (
+      <th className="text-left px-4 py-2 text-xs font-semibold text-text-secondary uppercase tracking-wide">
+        {children}
+      </th>
+    ),
+    td: ({ children }) => <td className="px-4 py-2 text-text-secondary align-top">{children}</td>,
+    a: ({ children, href }) => (
+      <a
+        href={href}
+        className="text-accent-amber hover:text-accent-amber-deep underline underline-offset-2 transition-colors"
+      >
+        {children}
+      </a>
+    ),
     ...components,
   }
 }

--- a/apps/web/next-env.d.ts
+++ b/apps/web/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -6,6 +6,11 @@ const nextConfig: NextConfig = {
   pageExtensions: ["ts", "tsx", "md", "mdx"],
 }
 
-const withMDX = createMDX({})
+const withMDX = createMDX({
+  options: {
+    // Turbopack requires serializable plugin references — pass as module-path strings
+    remarkPlugins: [["remark-gfm", {}]],
+  },
+})
 
 export default withMDX(nextConfig)

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -18,6 +18,7 @@
     "next": "16.2.3",
     "react": "19.2.0",
     "react-dom": "19.2.0",
+    "remark-gfm": "^4.0.1",
     "tailwindcss": "^4.2.4"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,9 @@ importers:
       react-dom:
         specifier: 19.2.0
         version: 19.2.0(react@19.2.0)
+      remark-gfm:
+        specifier: ^4.0.1
+        version: 4.0.1
       tailwindcss:
         specifier: ^4.2.4
         version: 4.2.4
@@ -1308,6 +1311,10 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  escape-string-regexp@5.0.0:
+    resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
+    engines: {node: '>=12'}
+
   esprima@4.0.1:
     resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
     engines: {node: '>=4'}
@@ -1591,8 +1598,32 @@ packages:
     resolution: {integrity: sha512-o5vL7aDWatOTX8LzaS1WMoaoxIiLRQJuIKKe2wAw6IeULDHaqbiqiggmx+pKvZDb1Sj+pE46Sn1T7lCqfFtg1Q==}
     engines: {node: '>=16'}
 
+  markdown-table@3.0.4:
+    resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
+
+  mdast-util-find-and-replace@3.0.2:
+    resolution: {integrity: sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==}
+
   mdast-util-from-markdown@2.0.3:
     resolution: {integrity: sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==}
+
+  mdast-util-gfm-autolink-literal@2.0.1:
+    resolution: {integrity: sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==}
+
+  mdast-util-gfm-footnote@2.1.0:
+    resolution: {integrity: sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==}
+
+  mdast-util-gfm-strikethrough@2.0.0:
+    resolution: {integrity: sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==}
+
+  mdast-util-gfm-table@2.0.0:
+    resolution: {integrity: sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==}
+
+  mdast-util-gfm-task-list-item@2.0.0:
+    resolution: {integrity: sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==}
+
+  mdast-util-gfm@3.1.0:
+    resolution: {integrity: sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==}
 
   mdast-util-mdx-expression@2.0.1:
     resolution: {integrity: sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==}
@@ -1624,6 +1655,27 @@ packages:
 
   micromark-core-commonmark@2.0.3:
     resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
+
+  micromark-extension-gfm-autolink-literal@2.1.0:
+    resolution: {integrity: sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==}
+
+  micromark-extension-gfm-footnote@2.1.0:
+    resolution: {integrity: sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==}
+
+  micromark-extension-gfm-strikethrough@2.1.0:
+    resolution: {integrity: sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==}
+
+  micromark-extension-gfm-table@2.1.1:
+    resolution: {integrity: sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==}
+
+  micromark-extension-gfm-tagfilter@2.0.0:
+    resolution: {integrity: sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==}
+
+  micromark-extension-gfm-task-list-item@2.1.0:
+    resolution: {integrity: sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==}
+
+  micromark-extension-gfm@3.0.0:
+    resolution: {integrity: sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==}
 
   micromark-extension-mdx-expression@3.0.1:
     resolution: {integrity: sha512-dD/ADLJ1AeMvSAKBwO22zG22N4ybhe7kFIZ3LsDI0GlsNr2A3KYxb0LdC1u5rj4Nw+CHKY0RVdnHX8vj8ejm4Q==}
@@ -1885,6 +1937,9 @@ packages:
   rehype-recma@1.0.0:
     resolution: {integrity: sha512-lqA4rGUf1JmacCNWWZx0Wv1dHqMwxzsDWYMTowuplHF3xH0N/MmrZ/G3BDZnzAkRmxDadujCjaKM2hqYdCBOGw==}
 
+  remark-gfm@4.0.1:
+    resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
+
   remark-mdx@3.1.1:
     resolution: {integrity: sha512-Pjj2IYlUY3+D8x00UJsIOg5BEvfMyeI+2uLPn9VO9Wg4MEtN/VTIq2NEJQfde9PnX15KgtHyl9S0BcTnWrIuWg==}
 
@@ -1893,6 +1948,9 @@ packages:
 
   remark-rehype@11.1.2:
     resolution: {integrity: sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==}
+
+  remark-stringify@11.0.0:
+    resolution: {integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==}
 
   resolve-from@5.0.0:
     resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
@@ -3172,6 +3230,8 @@ snapshots:
       '@esbuild/win32-ia32': 0.27.7
       '@esbuild/win32-x64': 0.27.7
 
+  escape-string-regexp@5.0.0: {}
+
   esprima@4.0.1: {}
 
   estree-util-attach-comments@3.0.0:
@@ -3451,6 +3511,15 @@ snapshots:
 
   markdown-extensions@2.0.0: {}
 
+  markdown-table@3.0.4: {}
+
+  mdast-util-find-and-replace@3.0.2:
+    dependencies:
+      '@types/mdast': 4.0.4
+      escape-string-regexp: 5.0.0
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
+
   mdast-util-from-markdown@2.0.3:
     dependencies:
       '@types/mdast': 4.0.4
@@ -3465,6 +3534,63 @@ snapshots:
       micromark-util-symbol: 2.0.1
       micromark-util-types: 2.0.2
       unist-util-stringify-position: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-autolink-literal@2.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      ccount: 2.0.1
+      devlop: 1.1.0
+      mdast-util-find-and-replace: 3.0.2
+      micromark-util-character: 2.1.1
+
+  mdast-util-gfm-footnote@2.1.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+      micromark-util-normalize-identifier: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-strikethrough@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-table@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      markdown-table: 3.0.4
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-task-list-item@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm@3.1.0:
+    dependencies:
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-gfm-autolink-literal: 2.0.1
+      mdast-util-gfm-footnote: 2.1.0
+      mdast-util-gfm-strikethrough: 2.0.0
+      mdast-util-gfm-table: 2.0.0
+      mdast-util-gfm-task-list-item: 2.0.0
+      mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
@@ -3569,6 +3695,64 @@ snapshots:
       micromark-util-resolve-all: 2.0.1
       micromark-util-subtokenize: 2.1.0
       micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-autolink-literal@2.1.0:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-footnote@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-strikethrough@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-chunked: 2.0.1
+      micromark-util-classify-character: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-table@2.1.1:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-tagfilter@2.0.0:
+    dependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-task-list-item@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm@3.0.0:
+    dependencies:
+      micromark-extension-gfm-autolink-literal: 2.1.0
+      micromark-extension-gfm-footnote: 2.1.0
+      micromark-extension-gfm-strikethrough: 2.1.0
+      micromark-extension-gfm-table: 2.1.1
+      micromark-extension-gfm-tagfilter: 2.0.0
+      micromark-extension-gfm-task-list-item: 2.1.0
+      micromark-util-combine-extensions: 2.0.1
       micromark-util-types: 2.0.2
 
   micromark-extension-mdx-expression@3.0.1:
@@ -3941,6 +4125,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  remark-gfm@4.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-gfm: 3.1.0
+      micromark-extension-gfm: 3.0.0
+      remark-parse: 11.0.0
+      remark-stringify: 11.0.0
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
   remark-mdx@3.1.1:
     dependencies:
       mdast-util-mdx: 3.0.0
@@ -3964,6 +4159,12 @@ snapshots:
       mdast-util-to-hast: 13.2.1
       unified: 11.0.5
       vfile: 6.0.3
+
+  remark-stringify@11.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-to-markdown: 2.1.2
+      unified: 11.0.5
 
   resolve-from@5.0.0: {}
 


### PR DESCRIPTION
## Summary

Writes the core Dawn documentation. Seven new pages, all using the MDX component library from [dawnai#7](https://github.com/cacheplane/dawnai/pull/7).

### Nav structure

Reorganizes the sidebar into four grouped sections:

| Section | Pages |
|---|---|
| Start | Getting Started |
| Core Concepts | Routes · Tools · State |
| Workflow | Testing · Dev Server · Deployment |
| Reference | CLI |

### Content

Each page uses \`<Tabs>\`, \`<Steps>\`, \`<Callout>\` where the shape fits:

- **Routes** — entry types as tabs (\`workflow\` / \`graph\` / \`chain\`), pathname rules as a table, a warn-Callout on the single-entry constraint.
- **Tools** — steps for input/output rules, warn-Callout about \`dawn.generated.d.ts\`.
- **State** — rules as steps, flow diagram as ASCII.
- **Testing** — scenarios example, mocking patterns, rules as steps, tip-Callout on protocol parity.
- **Dev Server** — protocol endpoints as tabs, hot-reload architecture as steps.
- **Deployment** — full deployment path as steps, warn-Callout on "not a hosted platform", self-hosting notes.
- **CLI Reference** — one section per command with flags and examples, exit-code table.

### Supporting changes

- \`remark-gfm\` added so markdown tables parse. Uses Turbopack-compatible \`[["remark-gfm", {}]]\` serializable syntax.
- \`mdx-components.tsx\` gains \`table\`/\`thead\`/\`tbody\`/\`tr\`/\`th\`/\`td\`/\`a\` overrides — bordered layout with warm-bg-card headers, amber anchors.
- New \`DocsPage\` component collapses the per-page boilerplate (breadcrumb + optional prompt card + content + prev/next) into a single wrapper.
- \`llms-full.txt\` concatenates all 8 docs pages so coding agents see the full picture.

### Pages that surface Copy-prompt cards

| Page | Prompt |
|---|---|
| Getting Started | scaffold |
| Routes | write-a-route |
| Tools | add-a-tool |
| Testing | write-a-test |
| Deployment | deploy |

## Test plan

- [x] \`pnpm --filter @dawn/web typecheck\` passes
- [x] \`pnpm --filter @dawn/web lint\` passes
- [x] \`pnpm --filter @dawn/web build\` — all 8 docs pages prerender as static
- [x] Sidebar shows 4 grouped sections with proper active state
- [x] Tables render with proper border/header styling
- [x] \`<Tabs>\` on Routes page switches between workflow/graph/chain
- [x] \`<Steps>\` on Deployment page renders with amber numbered circles
- [x] Prev/Next now appears (siblings exist)
