### PR TITLE
feat(web): cmd-k search for docs

### DIFF
--- a/apps/web/app/components/docs/DocsSearch.tsx
+++ b/apps/web/app/components/docs/DocsSearch.tsx
@@ -1,0 +1,265 @@
+"use client"
+
+import { useRouter } from "next/navigation"
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import type { DocsSearchEntry, DocsSearchHeading } from "./search-index"
+
+interface Props {
+  readonly index: readonly DocsSearchEntry[]
+}
+
+interface Result {
+  readonly href: string
+  readonly title: string
+  readonly section: string
+  readonly heading?: DocsSearchHeading
+  readonly key: string
+}
+
+function flatten(index: readonly DocsSearchEntry[]): readonly Result[] {
+  const results: Result[] = []
+  for (const entry of index) {
+    results.push({
+      href: entry.href,
+      title: entry.title,
+      section: entry.section,
+      key: entry.href,
+    })
+    for (const heading of entry.headings) {
+      if (heading.level === 1) continue
+      results.push({
+        href: `${entry.href}#${heading.anchor}`,
+        title: entry.title,
+        section: entry.section,
+        heading,
+        key: `${entry.href}#${heading.anchor}`,
+      })
+    }
+  }
+  return results
+}
+
+function scoreMatch(query: string, target: string): number {
+  if (!query) return 1
+  const q = query.toLowerCase()
+  const t = target.toLowerCase()
+  if (t === q) return 100
+  if (t.startsWith(q)) return 80
+  if (t.includes(` ${q}`)) return 60
+  if (t.includes(q)) return 40
+  return 0
+}
+
+function filterResults(query: string, all: readonly Result[]): readonly Result[] {
+  if (!query.trim()) return all.slice(0, 20)
+  const scored = all
+    .map((r) => {
+      const titleScore = scoreMatch(query, r.title)
+      const headingScore = r.heading ? scoreMatch(query, r.heading.text) : 0
+      const sectionScore = scoreMatch(query, r.section) * 0.3
+      return { result: r, score: Math.max(titleScore, headingScore) + sectionScore }
+    })
+    .filter((x) => x.score > 0)
+    .sort((a, b) => b.score - a.score)
+    .slice(0, 20)
+  return scored.map((x) => x.result)
+}
+
+export function DocsSearch({ index }: Props) {
+  const router = useRouter()
+  const [open, setOpen] = useState(false)
+  const [query, setQuery] = useState("")
+  const [active, setActive] = useState(0)
+  const inputRef = useRef<HTMLInputElement>(null)
+  const listRef = useRef<HTMLUListElement>(null)
+
+  const flat = useMemo(() => flatten(index), [index])
+  const results = useMemo(() => filterResults(query, flat), [query, flat])
+
+  const close = useCallback(() => {
+    setOpen(false)
+    setQuery("")
+    setActive(0)
+  }, [])
+
+  const navigate = useCallback(
+    (href: string) => {
+      close()
+      router.push(href)
+    },
+    [router, close],
+  )
+
+  // Global Cmd/Ctrl-K opens the palette
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "k") {
+        e.preventDefault()
+        setOpen(true)
+      } else if (e.key === "Escape" && open) {
+        close()
+      }
+    }
+    window.addEventListener("keydown", onKey)
+    return () => window.removeEventListener("keydown", onKey)
+  }, [open, close])
+
+  // Focus input whenever opened
+  useEffect(() => {
+    if (open) inputRef.current?.focus()
+  }, [open])
+
+  // Keep active result in view. `active` is read via the data attribute, so
+  // the effect needs to run on every render but not include `active` in deps.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: active triggers DOM query
+  useEffect(() => {
+    if (!listRef.current) return
+    const activeEl = listRef.current.querySelector<HTMLElement>(`[data-active="true"]`)
+    activeEl?.scrollIntoView({ block: "nearest" })
+  }, [active])
+
+  const onInputKey = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "ArrowDown") {
+      e.preventDefault()
+      setActive((a) => Math.min(a + 1, Math.max(0, results.length - 1)))
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault()
+      setActive((a) => Math.max(a - 1, 0))
+    } else if (e.key === "Enter") {
+      e.preventDefault()
+      const r = results[active]
+      if (r) navigate(r.href)
+    }
+  }
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        className="w-full flex items-center justify-between gap-3 px-3 py-2 border border-border rounded-md bg-bg-card/50 text-sm text-text-muted hover:border-text-muted hover:text-text-secondary transition-colors mb-6"
+        aria-label="Search docs (press Cmd+K)"
+      >
+        <span className="flex items-center gap-2">
+          <svg
+            width="14"
+            height="14"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            role="img"
+          >
+            <title>Search</title>
+            <circle cx="11" cy="11" r="8" />
+            <path d="m21 21-4.3-4.3" />
+          </svg>
+          Search
+        </span>
+        <kbd className="font-mono text-[10px] text-text-muted border border-border-subtle rounded px-1.5 py-0.5">
+          ⌘K
+        </kbd>
+      </button>
+
+      {open && (
+        <div
+          className="fixed inset-0 z-50 flex items-start justify-center pt-[12vh] bg-bg-primary/80 backdrop-blur-sm"
+          onClick={close}
+          onKeyDown={(e) => {
+            if (e.key === "Escape") close()
+          }}
+          role="dialog"
+          aria-modal="true"
+          aria-label="Search docs"
+        >
+          {/* biome-ignore lint/a11y/noStaticElementInteractions: wrapper stops modal-close propagation; roles are on ancestor dialog */}
+          <div
+            className="w-full max-w-xl mx-4 bg-bg-secondary border border-border rounded-xl shadow-2xl overflow-hidden"
+            onClick={(e) => e.stopPropagation()}
+            onKeyDown={(e) => e.stopPropagation()}
+          >
+            <div className="flex items-center gap-3 px-4 py-3 border-b border-border-subtle">
+              <svg
+                width="16"
+                height="16"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                className="text-text-muted"
+                role="img"
+              >
+                <title>Search</title>
+                <circle cx="11" cy="11" r="8" />
+                <path d="m21 21-4.3-4.3" />
+              </svg>
+              <input
+                ref={inputRef}
+                type="text"
+                value={query}
+                onChange={(e) => {
+                  setQuery(e.target.value)
+                  setActive(0)
+                }}
+                onKeyDown={onInputKey}
+                placeholder="Search Dawn docs..."
+                className="flex-1 bg-transparent text-text-primary placeholder-text-muted focus:outline-none text-sm"
+              />
+              <button
+                type="button"
+                onClick={close}
+                className="text-xs text-text-muted border border-border-subtle rounded px-1.5 py-0.5 font-mono hover:text-text-primary"
+              >
+                ESC
+              </button>
+            </div>
+
+            <ul ref={listRef} className="max-h-[60vh] overflow-y-auto py-2">
+              {results.length === 0 ? (
+                <li className="px-4 py-6 text-sm text-text-muted text-center">
+                  No results for &quot;{query}&quot;
+                </li>
+              ) : (
+                results.map((r, i) => (
+                  <li key={r.key}>
+                    <button
+                      type="button"
+                      data-active={i === active}
+                      onMouseEnter={() => setActive(i)}
+                      onClick={() => navigate(r.href)}
+                      className={`w-full text-left px-4 py-2.5 flex items-center gap-3 ${
+                        i === active ? "bg-accent-amber/10" : ""
+                      }`}
+                    >
+                      <span
+                        className={`text-[10px] uppercase tracking-wider font-semibold w-20 shrink-0 ${
+                          i === active ? "text-accent-amber" : "text-text-muted"
+                        }`}
+                      >
+                        {r.section}
+                      </span>
+                      <span className="flex-1 min-w-0">
+                        <span
+                          className={`block text-sm font-semibold ${
+                            i === active ? "text-accent-amber" : "text-text-primary"
+                          }`}
+                        >
+                          {r.title}
+                        </span>
+                        {r.heading && (
+                          <span className="block text-xs text-text-muted truncate">
+                            <span aria-hidden>#</span> {r.heading.text}
+                          </span>
+                        )}
+                      </span>
+                    </button>
+                  </li>
+                ))
+              )}
+            </ul>
+          </div>
+        </div>
+      )}
+    </>
+  )
+}

--- a/apps/web/app/components/docs/DocsSidebar.tsx
+++ b/apps/web/app/components/docs/DocsSidebar.tsx
@@ -2,17 +2,24 @@
 
 import Link from "next/link"
 import { usePathname } from "next/navigation"
+import { DocsSearch } from "./DocsSearch"
 import { DOCS_NAV } from "./nav"
+import type { DocsSearchEntry } from "./search-index"
 
-export function DocsSidebar() {
+interface Props {
+  readonly searchIndex: readonly DocsSearchEntry[]
+}
+
+export function DocsSidebar({ searchIndex }: Props) {
   const pathname = usePathname()
 
   return (
     <aside className="w-56 shrink-0">
-      <p className="text-xs text-text-muted uppercase tracking-widest mb-6 inline-flex items-center gap-2">
+      <p className="text-xs text-text-muted uppercase tracking-widest mb-4 inline-flex items-center gap-2">
         <span className="inline-block w-1 h-1 rounded-full bg-accent-amber" aria-hidden />
         Documentation
       </p>
+      <DocsSearch index={searchIndex} />
       <nav className="space-y-6">
         {DOCS_NAV.map((section) => (
           <div key={section.label}>

--- a/apps/web/app/components/docs/search-index.ts
+++ b/apps/web/app/components/docs/search-index.ts
@@ -1,0 +1,83 @@
+// Server-side index builder. Reads every MDX doc page at module init, extracts
+// H1/H2/H3 headings via regex, and exports a flat searchable index.
+//
+// This module is intentionally server-only (uses node:fs). The resulting
+// `DOCS_INDEX` value is serializable and can be passed to client components
+// via props.
+
+import { readFileSync } from "node:fs"
+import path from "node:path"
+import { DOCS_NAV, type DocsNavItem } from "./nav"
+
+export interface DocsSearchHeading {
+  readonly text: string
+  readonly level: 1 | 2 | 3
+  readonly anchor: string
+}
+
+export interface DocsSearchEntry {
+  readonly href: string
+  readonly title: string
+  readonly section: string
+  readonly headings: readonly DocsSearchHeading[]
+}
+
+function slugify(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/(^-|-$)/g, "")
+}
+
+function extractHeadings(mdx: string): readonly DocsSearchHeading[] {
+  const out: DocsSearchHeading[] = []
+  let inFence = false
+  for (const line of mdx.split("\n")) {
+    const trimmed = line.trim()
+    if (trimmed.startsWith("```")) {
+      inFence = !inFence
+      continue
+    }
+    if (inFence) continue
+    const match = /^(#{1,3})\s+(.+)$/.exec(trimmed)
+    if (!match || !match[1] || !match[2]) continue
+    const level = match[1].length as 1 | 2 | 3
+    const text = match[2].trim().replace(/`([^`]+)`/g, "$1")
+    out.push({ text, level, anchor: slugify(text) })
+  }
+  return out
+}
+
+function slugFromHref(href: string): string {
+  return href.replace(/^\/docs\//, "")
+}
+
+function buildEntry(item: DocsNavItem, section: string): DocsSearchEntry {
+  const slug = slugFromHref(item.href)
+  const mdxPath = path.join(process.cwd(), "content/docs", `${slug}.mdx`)
+  const mdx = readFileSync(mdxPath, "utf8")
+  const headings = extractHeadings(mdx)
+  const h1 = headings.find((h) => h.level === 1)
+  return {
+    href: item.href,
+    title: h1?.text ?? item.label,
+    section,
+    headings,
+  }
+}
+
+function buildIndex(): readonly DocsSearchEntry[] {
+  const entries: DocsSearchEntry[] = []
+  for (const section of DOCS_NAV) {
+    for (const item of section.items) {
+      try {
+        entries.push(buildEntry(item, section.label))
+      } catch {
+        // MDX file not present — skip silently rather than crashing the build
+      }
+    }
+  }
+  return entries
+}
+
+export const DOCS_INDEX: readonly DocsSearchEntry[] = buildIndex()

--- a/apps/web/app/docs/layout.tsx
+++ b/apps/web/app/docs/layout.tsx
@@ -1,11 +1,12 @@
 import type { ReactNode } from "react"
 import { DocsSidebar } from "../components/docs/DocsSidebar"
 import { DocsTOC } from "../components/docs/DocsTOC"
+import { DOCS_INDEX } from "../components/docs/search-index"
 
 export default function DocsLayout({ children }: { children: ReactNode }) {
   return (
     <div className="max-w-7xl mx-auto px-8 py-12 flex gap-12">
-      <DocsSidebar />
+      <DocsSidebar searchIndex={DOCS_INDEX} />
       <section className="flex-1 min-w-0 max-w-3xl">{children}</section>
       <DocsTOC />
     </div>

--- a/apps/web/next-env.d.ts
+++ b/apps/web/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
## Summary

Adds client-side fuzzy search over the docs index, opened via ⌘K/Ctrl-K or a dedicated button in the sidebar. Completes the Mint-like docs shell alongside sidebar, TOC, breadcrumb, and prev/next.

### Index (server-side)
- \`app/components/docs/search-index.ts\` reads every MDX page at module init, extracts H1/H2/H3 headings (skipping fenced code blocks), produces a serializable \`DOCS_INDEX\`.
- Passed from \`docs/layout.tsx\` → \`DocsSidebar\` → \`DocsSearch\`.

### Palette (client-side)
- ⌘K / Ctrl-K opens; ESC closes.
- Arrow up/down navigates; Enter selects; mouse hover reselects.
- Scoring prioritizes exact > prefix > word-boundary > substring matches on title + heading + section (with diminishing section weight).
- Results show section eyebrow, page title, and optional heading anchor so deep-linking works.

## Test plan

- [x] \`pnpm --filter @dawn/web typecheck\` passes
- [x] \`pnpm --filter @dawn/web lint\` passes
- [x] \`pnpm --filter @dawn/web build\` succeeds
- [x] Sidebar renders a ⌘K search button
- [x] ⌘K opens the palette; ESC closes it
- [x] Typing filters results; Enter navigates to the selected page/heading
