### PR TITLE
feat(web): ambient atmosphere + hero polish

### DIFF
--- a/apps/web/app/components/CopyCommand.tsx
+++ b/apps/web/app/components/CopyCommand.tsx
@@ -1,0 +1,70 @@
+"use client"
+
+import { useState } from "react"
+
+interface Props {
+  readonly command: string
+  readonly className?: string
+}
+
+export function CopyCommand({ command, className }: Props) {
+  const [copied, setCopied] = useState(false)
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(command)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 1800)
+    } catch {
+      // clipboard unavailable — silent no-op
+    }
+  }
+
+  return (
+    <div
+      className={`font-mono text-sm text-text-muted bg-bg-card inline-flex items-center gap-2 pl-4 pr-2 py-2 rounded-md border border-border ${
+        className ?? ""
+      }`}
+    >
+      <span>
+        <span className="text-accent-amber">$</span> {command}
+      </span>
+      <button
+        type="button"
+        onClick={handleCopy}
+        aria-label={copied ? "Copied" : `Copy command: ${command}`}
+        className="ml-1 p-1 rounded hover:bg-accent-amber/10 text-text-muted hover:text-accent-amber transition-colors"
+      >
+        {copied ? (
+          <svg
+            width="13"
+            height="13"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="3"
+            role="img"
+            className="text-accent-amber"
+          >
+            <title>Copied</title>
+            <polyline points="20 6 9 17 4 12" />
+          </svg>
+        ) : (
+          <svg
+            width="13"
+            height="13"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            role="img"
+          >
+            <title>Copy</title>
+            <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
+            <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+          </svg>
+        )}
+      </button>
+    </div>
+  )
+}

--- a/apps/web/app/components/landing/CodeExample.tsx
+++ b/apps/web/app/components/landing/CodeExample.tsx
@@ -1,6 +1,6 @@
 export function CodeExample() {
   return (
-    <section className="py-20 px-8 border-t border-border-subtle bg-bg-secondary">
+    <section className="py-20 px-8 border-t border-border-subtle bg-bg-secondary/50">
       <div className="text-center mb-10">
         <p className="text-text-muted text-xs uppercase tracking-widest mb-3 inline-flex items-center gap-2">
           <span className="inline-block w-1 h-1 rounded-full bg-accent-amber" aria-hidden />

--- a/apps/web/app/components/landing/ComparisonTable.tsx
+++ b/apps/web/app/components/landing/ComparisonTable.tsx
@@ -34,7 +34,7 @@ const rows: Array<{
 
 export function ComparisonTable() {
   return (
-    <section className="py-20 px-8 border-t border-border-subtle bg-bg-secondary">
+    <section className="py-20 px-8 border-t border-border-subtle bg-bg-secondary/50">
       <div className="text-center max-w-2xl mx-auto">
         <p className="text-text-muted text-xs uppercase tracking-widest mb-3 inline-flex items-center gap-2">
           <span className="inline-block w-1 h-1 rounded-full bg-accent-amber" aria-hidden />
@@ -53,12 +53,6 @@ export function ComparisonTable() {
       </div>
 
       <div className="max-w-[650px] mx-auto mt-10 border border-border rounded-lg overflow-hidden relative">
-        {/* The illuminated column — a hairline amber seam dividing Next.js from Dawn */}
-        <div
-          aria-hidden
-          className="pointer-events-none absolute top-0 bottom-0 w-px bg-gradient-to-b from-transparent via-accent-amber/60 to-transparent"
-          style={{ right: "calc((100% - 40px) / 4)" }}
-        />
         {/* Header */}
         <div className="grid grid-cols-[2fr_1fr_1fr] bg-bg-card px-5 py-3 text-xs text-text-secondary uppercase tracking-wide font-semibold">
           <span>Convention</span>

--- a/apps/web/app/components/landing/CtaSection.tsx
+++ b/apps/web/app/components/landing/CtaSection.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link"
+import { CopyCommand } from "../CopyCommand"
 
 export function CtaSection() {
   return (
@@ -39,8 +40,8 @@ export function CtaSection() {
         </a>
       </div>
 
-      <div className="mt-6 font-mono text-sm text-text-muted bg-bg-card inline-block px-5 py-2.5 rounded-md border border-border">
-        <span className="text-accent-amber">$</span> npx create-dawn-app my-agent
+      <div className="mt-6">
+        <CopyCommand command="npx create-dawn-app my-agent" />
       </div>
     </section>
   )

--- a/apps/web/app/components/landing/EcosystemSection.tsx
+++ b/apps/web/app/components/landing/EcosystemSection.tsx
@@ -18,7 +18,7 @@ const packages = [
 
 export function EcosystemSection() {
   return (
-    <section className="py-16 px-8 border-t border-border-subtle bg-bg-secondary">
+    <section className="py-16 px-8 border-t border-border-subtle bg-bg-secondary/50">
       <div className="text-center max-w-2xl mx-auto">
         <p className="text-text-muted text-xs uppercase tracking-widest mb-3 inline-flex items-center gap-2">
           <span className="inline-block w-1 h-1 rounded-full bg-accent-green" aria-hidden />

--- a/apps/web/app/components/landing/FeatureGrid.tsx
+++ b/apps/web/app/components/landing/FeatureGrid.tsx
@@ -27,7 +27,7 @@ const features = [
 
 export function FeatureGrid() {
   return (
-    <section className="py-20 px-8 border-t border-border-subtle bg-bg-secondary">
+    <section className="py-20 px-8 border-t border-border-subtle bg-bg-secondary/50">
       <div className="text-center mb-10">
         <h2
           className="font-display text-4xl md:text-5xl font-semibold text-text-primary tracking-tight"

--- a/apps/web/app/components/landing/HeroSection.tsx
+++ b/apps/web/app/components/landing/HeroSection.tsx
@@ -1,11 +1,12 @@
 import { getPrompt } from "../../../content/prompts"
+import { CopyCommand } from "../CopyCommand"
 import { CopyPromptButton } from "../CopyPromptButton"
 
 const scaffoldPrompt = getPrompt("scaffold")
 
 export function HeroSection() {
   return (
-    <section className="relative pt-24 pb-32 text-center overflow-hidden isolate">
+    <section className="relative pt-24 pb-56 text-center overflow-hidden isolate">
       {/* Starfield — the distant cosmos, scattered throughout the upper hero */}
       <div
         aria-hidden
@@ -72,8 +73,8 @@ export function HeroSection() {
         </a>
       </div>
 
-      <div className="relative mt-6 font-mono text-sm text-text-muted bg-bg-card inline-block px-4 py-2 rounded-md border border-border">
-        <span className="text-accent-amber">$</span> npx create-dawn-app my-agent
+      <div className="relative mt-6">
+        <CopyCommand command="npx create-dawn-app my-agent" />
       </div>
     </section>
   )

--- a/apps/web/app/components/landing/LandingAmbient.tsx
+++ b/apps/web/app/components/landing/LandingAmbient.tsx
@@ -1,0 +1,85 @@
+// Page-level ambient atmosphere for the landing. Three layers:
+//   1. Repeating starfield below the hero, so the cosmic dark continues all the way down.
+//   2. Color blobs anchored at scroll depths to give each narrative beat its own atmospheric tint.
+//   3. A faint amber dot grid masked to fade in/out, adding subtle technical texture.
+//
+// Sits behind everything on the landing (-z-40 → -z-30). Sections continue to render their own
+// backgrounds on top; the ambient bleeds through wherever section bg is dark or transparent.
+
+interface Blob {
+  readonly top: string
+  readonly side: "left" | "right" | "center"
+  readonly offset: string
+  readonly size: number
+  readonly color: string
+}
+
+const BLOBS: readonly Blob[] = [
+  // Pre-dawn deep violet behind the Problem section — "the cold before sunrise"
+  { top: "950px", side: "left", offset: "-180px", size: 640, color: "rgba(99, 102, 241, 0.10)" },
+  // Amber wash behind Comparison/Solution — "first warmth"
+  { top: "1900px", side: "right", offset: "-120px", size: 580, color: "rgba(245, 158, 11, 0.08)" },
+  // Soft peach behind CodeExample/Deploy — "morning sunlight catching the page"
+  { top: "3100px", side: "left", offset: "-100px", size: 520, color: "rgba(251, 146, 60, 0.07)" },
+  // Quiet amber under FeatureGrid/HowItWorks — keeping the warmth alive
+  { top: "4300px", side: "right", offset: "-160px", size: 600, color: "rgba(245, 158, 11, 0.06)" },
+  // Green halo behind Ecosystem — green's home, signaling the LangChain ecosystem moment
+  { top: "5400px", side: "center", offset: "-300px", size: 700, color: "rgba(0, 166, 126, 0.09)" },
+  // Final amber dawn at the CTA — closing the loop with the brightest warmth
+  { top: "6100px", side: "center", offset: "-250px", size: 600, color: "rgba(245, 158, 11, 0.10)" },
+]
+
+function blobStyle(blob: Blob): React.CSSProperties {
+  const positionStyle: React.CSSProperties = { top: blob.top }
+  if (blob.side === "left") positionStyle.left = blob.offset
+  if (blob.side === "right") positionStyle.right = blob.offset
+  if (blob.side === "center") {
+    positionStyle.left = "50%"
+    positionStyle.transform = `translateX(calc(-50% + ${blob.offset}))`
+  }
+  return {
+    ...positionStyle,
+    width: blob.size,
+    height: blob.size,
+    background: `radial-gradient(circle at center, ${blob.color}, transparent 70%)`,
+    filter: "blur(40px)",
+  }
+}
+
+export function LandingAmbient() {
+  return (
+    <div aria-hidden className="pointer-events-none absolute inset-0 -z-40 overflow-hidden">
+      {/* Repeating starfield below the hero — continues the cosmic dark */}
+      <div
+        className="absolute inset-x-0 top-[800px] bottom-0 opacity-[0.55] bg-repeat-y bg-top"
+        style={{
+          backgroundImage: "url('/backgrounds/dawn-stars.svg')",
+          backgroundSize: "100% 1200px",
+        }}
+      />
+
+      {/* Faint amber dot grid — technical texture, masked to fade at top/bottom */}
+      <div
+        className="absolute inset-x-0 top-[600px] bottom-0"
+        style={{
+          backgroundImage:
+            "radial-gradient(circle at center, rgba(245,158,11,0.07) 1px, transparent 1.4px)",
+          backgroundSize: "36px 36px",
+          maskImage:
+            "linear-gradient(to bottom, transparent 0%, black 8%, black 92%, transparent 100%)",
+          WebkitMaskImage:
+            "linear-gradient(to bottom, transparent 0%, black 8%, black 92%, transparent 100%)",
+        }}
+      />
+
+      {/* Section-anchored color blobs */}
+      {BLOBS.map((blob) => (
+        <div
+          key={`${blob.top}-${blob.side}`}
+          className="absolute rounded-full"
+          style={blobStyle(blob)}
+        />
+      ))}
+    </div>
+  )
+}

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -6,12 +6,14 @@ import { EcosystemSection } from "./components/landing/EcosystemSection"
 import { FeatureGrid } from "./components/landing/FeatureGrid"
 import { HeroSection } from "./components/landing/HeroSection"
 import { HowItWorks } from "./components/landing/HowItWorks"
+import { LandingAmbient } from "./components/landing/LandingAmbient"
 import { ProblemSection } from "./components/landing/ProblemSection"
 import { SolutionSection } from "./components/landing/SolutionSection"
 
 export default function HomePage() {
   return (
-    <>
+    <div className="relative isolate">
+      <LandingAmbient />
       <HeroSection />
       <ProblemSection />
       <ComparisonTable />
@@ -22,6 +24,6 @@ export default function HomePage() {
       <HowItWorks />
       <EcosystemSection />
       <CtaSection />
-    </>
+    </div>
   )
 }

--- a/apps/web/public/backgrounds/dawn-earth.svg
+++ b/apps/web/public/backgrounds/dawn-earth.svg
@@ -14,27 +14,31 @@
   <!-- Earth disc — the dark curvature, sitting low -->
   <circle cx="960" cy="5300" r="5100" fill="url(#earth-body)"/>
   <!-- City lights — a scatter of warm pinpricks on the dark nightside of earth -->
-  <g fill="#fbbf24" opacity="0.9">
-    <circle cx="540" cy="222" r="0.8"/>
-    <circle cx="610" cy="240" r="0.6"/>
-    <circle cx="690" cy="218" r="1.0"/>
-    <circle cx="760" cy="232" r="0.7"/>
-    <circle cx="830" cy="215" r="0.9"/>
-    <circle cx="910" cy="225" r="0.6"/>
-    <circle cx="990" cy="218" r="1.1"/>
-    <circle cx="1070" cy="230" r="0.7"/>
-    <circle cx="1150" cy="222" r="0.8"/>
-    <circle cx="1230" cy="228" r="0.6"/>
-    <circle cx="1310" cy="218" r="0.9"/>
-    <circle cx="1390" cy="234" r="0.7"/>
-  </g>
-  <g fill="#fde68a" opacity="0.6">
-    <circle cx="580" cy="248" r="0.5"/>
-    <circle cx="720" cy="252" r="0.5"/>
-    <circle cx="870" cy="246" r="0.5"/>
-    <circle cx="1020" cy="250" r="0.5"/>
-    <circle cx="1170" cy="248" r="0.5"/>
-    <circle cx="1330" cy="252" r="0.5"/>
+  <!-- Symmetric around cx=960. Mirrored pairs ensure no left/right optical bias. -->
+  <g filter="url(#city-glow)">
+    <g fill="#fcd34d" opacity="0.7">
+      <circle cx="540" cy="222" r="0.9"/>
+      <circle cx="1380" cy="222" r="0.9"/>
+      <circle cx="615" cy="240" r="0.7"/>
+      <circle cx="1305" cy="240" r="0.7"/>
+      <circle cx="690" cy="218" r="1.1"/>
+      <circle cx="1230" cy="218" r="1.1"/>
+      <circle cx="765" cy="232" r="0.8"/>
+      <circle cx="1155" cy="232" r="0.8"/>
+      <circle cx="840" cy="215" r="1.0"/>
+      <circle cx="1080" cy="215" r="1.0"/>
+      <circle cx="915" cy="225" r="0.7"/>
+      <circle cx="1005" cy="225" r="0.7"/>
+      <circle cx="960" cy="221" r="1.2"/>
+    </g>
+    <g fill="#fef3c7" opacity="0.45">
+      <circle cx="600" cy="248" r="0.55"/>
+      <circle cx="1320" cy="248" r="0.55"/>
+      <circle cx="740" cy="252" r="0.55"/>
+      <circle cx="1180" cy="252" r="0.55"/>
+      <circle cx="870" cy="246" r="0.55"/>
+      <circle cx="1050" cy="246" r="0.55"/>
+    </g>
   </g>
   <!-- Hair-thin bright edge at the terminator -->
   <g filter="url(#limb-blur-edge)">
@@ -42,7 +46,11 @@
   </g>
   <!-- Localized terminator bloom — where the sun is actually cresting, brightest at center -->
   <g filter="url(#terminator-bloom-blur)">
-    <ellipse cx="960" cy="210" rx="520" ry="40" fill="url(#terminator-bloom-fill)" opacity="0.95"/>
+    <ellipse cx="960" cy="210" rx="560" ry="44" fill="url(#terminator-bloom-fill)" opacity="1"/>
+  </g>
+  <!-- Sharp central anchor — the unmistakable peak the eye locks onto -->
+  <g filter="url(#terminator-peak-blur)">
+    <ellipse cx="960" cy="208" rx="120" ry="16" fill="url(#terminator-peak-fill)" opacity="1"/>
   </g>
   <defs>
     <filter id="limb-blur-outer" x="-4500" y="-100" width="10920" height="11000" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
@@ -60,11 +68,27 @@
     <filter id="terminator-bloom-blur" x="0" y="120" width="1920" height="200" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
       <feGaussianBlur stdDeviation="24"/>
     </filter>
-    <radialGradient id="terminator-bloom-fill" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(960 210) scale(520 40)">
-      <stop offset="0" stop-color="#fef3c7" stop-opacity="0.85"/>
-      <stop offset="0.3" stop-color="#fcd34d" stop-opacity="0.7"/>
-      <stop offset="0.6" stop-color="#f59e0b" stop-opacity="0.4"/>
+    <!-- City lights glow — pinpoints with a faint warm halo so they read as light sources without dominating -->
+    <filter id="city-glow" x="-50%" y="-50%" width="200%" height="200%" color-interpolation-filters="sRGB">
+      <feGaussianBlur stdDeviation="0.5" result="blur1"/>
+      <feMerge>
+        <feMergeNode in="blur1"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    <radialGradient id="terminator-bloom-fill" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(960 210) scale(560 44)">
+      <stop offset="0" stop-color="#fef3c7" stop-opacity="0.95"/>
+      <stop offset="0.3" stop-color="#fcd34d" stop-opacity="0.78"/>
+      <stop offset="0.6" stop-color="#f59e0b" stop-opacity="0.45"/>
       <stop offset="1" stop-color="#d97706" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="terminator-peak-blur" x="780" y="180" width="360" height="80" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feGaussianBlur stdDeviation="6"/>
+    </filter>
+    <radialGradient id="terminator-peak-fill" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(960 208) scale(120 16)">
+      <stop offset="0" stop-color="#ffffff" stop-opacity="0.95"/>
+      <stop offset="0.4" stop-color="#fef3c7" stop-opacity="0.8"/>
+      <stop offset="1" stop-color="#fcd34d" stop-opacity="0"/>
     </radialGradient>
     <!-- Outer atmosphere: pale periwinkle scattering upward -->
     <radialGradient id="atmosphere-outer" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(960 5420) scale(5340)">


### PR DESCRIPTION
## Summary

A polish pass on the landing page that lays the groundwork for richer ambient treatment. Inspired by angular-agent-framework's gradient-blob technique and Vercel's section-level atmospheric continuity.

### Ambient atmosphere — \`LandingAmbient\`

A new page-level layer that sits behind everything (\`-z-40\`) and provides:

- **Repeating starfield below the hero** — the cosmic dark from the hero now continues through the whole landing rather than cutting off at the first section border.
- **Faint amber dot grid** — masked to fade in/out at top/bottom; adds technical texture without visual noise.
- **Six section-anchored color blobs** at scroll depths, each giving its narrative beat an atmospheric tint:
  - Cool violet behind Problem (\"pre-dawn\")
  - Amber wash near Comparison/Solution (\"first warmth\")
  - Peach behind CodeExample/Deploy (\"morning sunlight\")
  - Quiet amber under FeatureGrid/HowItWorks
  - Green halo behind Ecosystem (green's only home)
  - Warm amber bloom at the CTA (closing the loop)

Alternating section bgs (\`bg-bg-secondary\`) lowered to 50% opacity so the ambient bleeds through.

### Hero polish

- City lights re-laid as symmetric mirrored pairs around center; the previous scatter was right-biased.
- City lights brighter with a soft warm halo (filter \`feGaussianBlur\` merge) — read as actual light sources, not pinpricks.
- Sharper, brighter terminator bloom peak — gives the eye a clear center anchor aligned with the headline.
- More breathing room between content and the earth (\`pb-32\` → \`pb-56\`).

### Comparison table

- Removed the amber column-divider seam; math was off (bisected the Dawn column) and user preferred no divider.

### Install command

- New \`<CopyCommand>\` component renders the inline install command with a small copy icon (hover amber, click copies). Used in hero and CTA.

## Test plan

- [x] \`pnpm --filter @dawn/web typecheck\` passes
- [x] \`pnpm --filter @dawn/web lint\` passes
- [x] \`pnpm --filter @dawn/web build\` succeeds
- [x] Hero composition: stars + earth + symmetric cities + sharp bloom + breathing room
- [x] Scroll through all sections: ambient blobs visible at each beat, dot grid faintly continuous
- [x] Comparison table: no divider, columns clean
- [x] Install command in hero & CTA: copy icon visible, click copies to clipboard
