### PR TITLE
feat(web): stats strip + architecture section

### DIFF
--- a/apps/web/app/components/landing/ArchitectureSection.tsx
+++ b/apps/web/app/components/landing/ArchitectureSection.tsx
@@ -1,0 +1,140 @@
+interface Layer {
+  readonly label: string
+  readonly items: readonly string[]
+  readonly accent: "neutral" | "dawn" | "ecosystem"
+}
+
+const LAYERS: readonly Layer[] = [
+  {
+    label: "You",
+    items: ["Routes", "Tools", "State", "Tests"],
+    accent: "neutral",
+  },
+  {
+    label: "Dawn",
+    items: ["Conventions", "Type inference", "Dev server", "CLI", "Deployment protocol"],
+    accent: "dawn",
+  },
+  {
+    label: "LangChain",
+    items: ["LangGraph runtime", "LangGraph Platform", "LangSmith Assistants"],
+    accent: "ecosystem",
+  },
+]
+
+function Connector() {
+  return (
+    <div aria-hidden className="flex justify-center">
+      <div className="w-px h-6 bg-gradient-to-b from-border via-border to-transparent" />
+    </div>
+  )
+}
+
+function LayerCard({ layer }: { layer: Layer }) {
+  const isDawn = layer.accent === "dawn"
+  const isEcosystem = layer.accent === "ecosystem"
+  const borderClass = isDawn
+    ? "border-accent-amber/40"
+    : isEcosystem
+      ? "border-accent-green/25"
+      : "border-border"
+  const labelClass = isDawn
+    ? "text-accent-amber"
+    : isEcosystem
+      ? "text-accent-green"
+      : "text-text-primary"
+
+  return (
+    <div className={`relative bg-bg-card border rounded-xl p-6 overflow-hidden ${borderClass}`}>
+      {/* Illuminated glow for the Dawn layer — this is the piece that was missing */}
+      {isDawn && (
+        <div
+          aria-hidden
+          className="pointer-events-none absolute inset-0 rounded-xl opacity-80"
+          style={{
+            background:
+              "radial-gradient(ellipse 80% 60% at 50% 50%, rgba(245,158,11,0.08), transparent 70%)",
+          }}
+        />
+      )}
+      {/* Soft green tint for the ecosystem layer */}
+      {isEcosystem && (
+        <div
+          aria-hidden
+          className="pointer-events-none absolute inset-x-0 bottom-0 h-20 rounded-b-xl opacity-50"
+          style={{
+            background:
+              "radial-gradient(ellipse 80% 100% at 50% 100%, rgba(0,166,126,0.12), transparent 70%)",
+          }}
+        />
+      )}
+      <div className="relative flex flex-col md:flex-row md:items-center gap-4 md:gap-8">
+        <div className="md:w-40 shrink-0">
+          <p
+            className={`font-display text-2xl md:text-3xl font-semibold tracking-tight ${labelClass}`}
+            style={{ fontVariationSettings: "'opsz' 144, 'SOFT' 50" }}
+          >
+            {layer.label}
+          </p>
+          {isDawn && (
+            <p className="text-[10px] uppercase tracking-widest text-accent-amber/80 mt-1">
+              The missing layer
+            </p>
+          )}
+        </div>
+        <ul className="flex flex-wrap gap-x-4 gap-y-1.5 text-sm font-mono text-text-secondary">
+          {layer.items.map((item, i) => (
+            <li key={item} className="flex items-center gap-4">
+              <span>{item}</span>
+              {i < layer.items.length - 1 && (
+                <span aria-hidden className="text-text-dim">
+                  ·
+                </span>
+              )}
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  )
+}
+
+export function ArchitectureSection() {
+  return (
+    <section className="relative py-20 px-8 border-t border-border-subtle">
+      <div className="text-center max-w-2xl mx-auto mb-12">
+        <p className="text-text-muted text-xs uppercase tracking-widest mb-3 inline-flex items-center gap-2">
+          <span className="inline-block w-1 h-1 rounded-full bg-accent-amber" aria-hidden />
+          The Architecture
+        </p>
+        <h2
+          className="font-display text-4xl md:text-5xl font-semibold text-text-primary leading-[1.1] tracking-tight text-balance"
+          style={{ fontVariationSettings: "'opsz' 144, 'SOFT' 50" }}
+        >
+          Between your code and LangChain.
+        </h2>
+        <p className="text-text-secondary mt-4 leading-7">
+          Dawn is the conventions layer &mdash; everything you&apos;d build by hand, we built in the
+          open.
+        </p>
+      </div>
+
+      <div className="max-w-3xl mx-auto">
+        {LAYERS.map((layer, i) => (
+          <div key={layer.label}>
+            <LayerCard layer={layer} />
+            {i < LAYERS.length - 1 && <Connector />}
+          </div>
+        ))}
+      </div>
+
+      <div className="max-w-2xl mx-auto mt-10 text-center">
+        <p className="text-sm text-text-muted leading-relaxed">
+          <span className="text-text-primary">You</span> write the agent logic.{" "}
+          <span className="text-accent-amber">Dawn</span> writes the framework.{" "}
+          <span className="text-accent-green">LangChain</span> runs the runtime.
+        </p>
+      </div>
+    </section>
+  )
+}

--- a/apps/web/app/components/landing/StatsStrip.tsx
+++ b/apps/web/app/components/landing/StatsStrip.tsx
@@ -1,0 +1,46 @@
+const stats = [
+  {
+    value: "0",
+    label: "Zod schemas",
+    detail: "Tool types inferred from your function signatures",
+  },
+  {
+    value: "<30s",
+    label: "Scaffold to run",
+    detail: "npx create-dawn-app → dawn run",
+  },
+  {
+    value: "Native",
+    label: "LangGraph Platform",
+    detail: "Dev server speaks the deployment protocol",
+  },
+  {
+    value: "OSS",
+    label: "MIT-licensed",
+    detail: "Source available on GitHub",
+  },
+]
+
+export function StatsStrip() {
+  return (
+    <section className="relative px-8 py-12" style={{ background: "#020617" }}>
+      <div className="max-w-5xl mx-auto grid grid-cols-2 md:grid-cols-4 gap-4">
+        {stats.map((stat) => (
+          <div
+            key={stat.label}
+            className="relative bg-bg-card/60 border border-border rounded-xl px-5 py-6 text-center backdrop-blur-sm"
+          >
+            <div
+              className="font-mono font-semibold text-3xl md:text-4xl text-accent-amber leading-none mb-2"
+              style={{ fontFeatureSettings: "'tnum'" }}
+            >
+              {stat.value}
+            </div>
+            <div className="text-sm font-semibold text-text-primary">{stat.label}</div>
+            <div className="text-xs text-text-muted mt-1 leading-relaxed">{stat.detail}</div>
+          </div>
+        ))}
+      </div>
+    </section>
+  )
+}

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,3 +1,4 @@
+import { ArchitectureSection } from "./components/landing/ArchitectureSection"
 import { CodeExample } from "./components/landing/CodeExample"
 import { ComparisonTable } from "./components/landing/ComparisonTable"
 import { CtaSection } from "./components/landing/CtaSection"
@@ -9,15 +10,18 @@ import { HowItWorks } from "./components/landing/HowItWorks"
 import { LandingAmbient } from "./components/landing/LandingAmbient"
 import { ProblemSection } from "./components/landing/ProblemSection"
 import { SolutionSection } from "./components/landing/SolutionSection"
+import { StatsStrip } from "./components/landing/StatsStrip"
 
 export default function HomePage() {
   return (
     <div className="relative isolate">
       <LandingAmbient />
       <HeroSection />
+      <StatsStrip />
       <ProblemSection />
       <ComparisonTable />
       <SolutionSection />
+      <ArchitectureSection />
       <CodeExample />
       <DeploySection />
       <FeatureGrid />


### PR DESCRIPTION
## Summary

Two credibility/content moves from the earlier landing-page brainstorm.

### StatsStrip (between Hero and Problem)

Four glass-backed cards over a flat navy band that continues the hero→problem bleed seamlessly. Amber mono numerals anchor four specific claims:

- **0** Zod schemas — Tool types inferred from your function signatures
- **<30s** Scaffold to run — \`npx create-dawn-app\` → \`dawn run\`
- **Native** LangGraph Platform — Dev server speaks the deployment protocol
- **OSS** MIT-licensed — Source available on GitHub

Functions as the credibility strip right after the hero, before the reader enters the Problem narrative.

### ArchitectureSection (between Solution and CodeExample)

Three stacked layer cards showing where Dawn lives in the LangChain stack. Amber-illuminated middle layer explicitly labeled **\"THE MISSING LAYER\"** crystallizes the meta-framework claim.

- **You** — Routes · Tools · State · Tests (neutral)
- **Dawn** — Conventions · Type inference · Dev server · CLI · Deployment protocol (amber border + amber radial glow)
- **LangChain** — LangGraph runtime · LangGraph Platform · LangSmith Assistants (green-tinted border + soft green halo)

Thin vertical connectors between layers reinforce the stack. Closing color-coded line: \"You write the agent logic. Dawn writes the framework. LangChain runs the runtime.\"

Placed between Solution (three pillars) and CodeExample so the reader moves from \"what Dawn gives you\" → \"where Dawn lives\" → \"what the code looks like.\"

## Test plan

- [x] \`pnpm --filter @dawnai.org/web typecheck\` passes
- [x] \`pnpm --filter @dawnai.org/web lint\` passes
- [x] \`pnpm --filter @dawnai.org/web build\` succeeds
- [x] Stats strip renders after hero with seamless navy bleed
- [x] Architecture section renders between Solution and CodeExample
- [x] Amber middle layer reads as \"THE MISSING LAYER\" with illuminated glow
