### PR TITLE
feat(web): motion pass + logo wall + hero parallax experiment

### DIFF
--- a/apps/web/app/components/ScrollReveal.tsx
+++ b/apps/web/app/components/ScrollReveal.tsx
@@ -1,0 +1,74 @@
+"use client"
+
+import { type ReactNode, useEffect, useRef, useState } from "react"
+
+interface Props {
+  readonly children: ReactNode
+  readonly delayMs?: number
+  readonly distancePx?: number
+  readonly durationMs?: number
+}
+
+/**
+ * Fades and rises children when they scroll into view. Runs once per element
+ * via IntersectionObserver. Sections already visible on initial load render
+ * at full opacity with no transition — only off-screen sections get the reveal
+ * animation.
+ *
+ * Respects prefers-reduced-motion.
+ */
+export function ScrollReveal({ children, delayMs = 0, distancePx = 14, durationMs = 600 }: Props) {
+  const ref = useRef<HTMLDivElement>(null)
+  const [revealed, setRevealed] = useState(false)
+  const [mounted, setMounted] = useState(false)
+
+  useEffect(() => {
+    setMounted(true)
+    const el = ref.current
+    if (!el) return
+
+    // Respect reduced motion
+    if (window.matchMedia?.("(prefers-reduced-motion: reduce)").matches) {
+      setRevealed(true)
+      return
+    }
+
+    // If already in view on mount (e.g. above the fold), reveal without delay
+    const rect = el.getBoundingClientRect()
+    if (rect.top < window.innerHeight * 0.9) {
+      setRevealed(true)
+      return
+    }
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const entry = entries[0]
+        if (entry?.isIntersecting) {
+          setRevealed(true)
+          observer.disconnect()
+        }
+      },
+      { rootMargin: "0px 0px -10% 0px", threshold: 0.05 },
+    )
+    observer.observe(el)
+    return () => observer.disconnect()
+  }, [])
+
+  // Before mount, render at full opacity/transform so SSR output matches and
+  // there's no first-paint flash.
+  const active = !mounted || revealed
+
+  return (
+    <div
+      ref={ref}
+      style={{
+        opacity: active ? 1 : 0,
+        transform: active ? "translateY(0)" : `translateY(${distancePx}px)`,
+        transition: `opacity ${durationMs}ms ease-out ${delayMs}ms, transform ${durationMs}ms ease-out ${delayMs}ms`,
+        willChange: "opacity, transform",
+      }}
+    >
+      {children}
+    </div>
+  )
+}

--- a/apps/web/app/components/landing/HeroEarthParallax.tsx
+++ b/apps/web/app/components/landing/HeroEarthParallax.tsx
@@ -1,0 +1,69 @@
+"use client"
+
+import { useEffect, useRef, useState } from "react"
+
+/**
+ * Subtle scroll-linked parallax for the hero earth layer.
+ *
+ * The earth translates upward (the sun "rises" further) as the user scrolls
+ * past the hero. Max translation is capped at `maxRisePx`. Respects
+ * prefers-reduced-motion.
+ *
+ * EXPERIMENT: To undo, replace `<HeroEarthParallax />` in HeroSection with
+ * the original inline markup:
+ *
+ *   <div
+ *     aria-hidden
+ *     className="pointer-events-none absolute inset-x-0 bottom-0 -z-10 bg-no-repeat bg-bottom w-full"
+ *     style={{
+ *       backgroundImage: "url('/backgrounds/dawn-earth.svg')",
+ *       backgroundSize: "100% 100%",
+ *       aspectRatio: "1920 / 340",
+ *     }}
+ *   />
+ */
+export function HeroEarthParallax({ maxRisePx = 28 }: { maxRisePx?: number }) {
+  const [translateY, setTranslateY] = useState(0)
+  const rafRef = useRef<number | null>(null)
+
+  useEffect(() => {
+    if (window.matchMedia?.("(prefers-reduced-motion: reduce)").matches) return
+
+    const compute = () => {
+      // Scroll progress 0..1 across the first viewport height
+      const y = window.scrollY
+      const h = window.innerHeight
+      const progress = Math.max(0, Math.min(1, y / h))
+      setTranslateY(progress * maxRisePx)
+    }
+
+    const onScroll = () => {
+      if (rafRef.current != null) return
+      rafRef.current = requestAnimationFrame(() => {
+        rafRef.current = null
+        compute()
+      })
+    }
+
+    compute()
+    window.addEventListener("scroll", onScroll, { passive: true })
+    return () => {
+      window.removeEventListener("scroll", onScroll)
+      if (rafRef.current != null) cancelAnimationFrame(rafRef.current)
+    }
+  }, [maxRisePx])
+
+  return (
+    <div
+      aria-hidden
+      className="pointer-events-none absolute inset-x-0 bottom-0 -z-10 bg-no-repeat bg-bottom w-full"
+      style={{
+        backgroundImage: "url('/backgrounds/dawn-earth.svg')",
+        backgroundSize: "100% 100%",
+        aspectRatio: "1920 / 340",
+        transform: `translate3d(0, ${-translateY}px, 0)`,
+        willChange: "transform",
+      }}
+    />
+  )
+}

--- a/apps/web/app/components/landing/HeroSection.tsx
+++ b/apps/web/app/components/landing/HeroSection.tsx
@@ -1,6 +1,7 @@
 import { getPrompt } from "../../../content/prompts"
 import { CopyCommand } from "../CopyCommand"
 import { CopyPromptButton } from "../CopyPromptButton"
+import { HeroEarthParallax } from "./HeroEarthParallax"
 
 const scaffoldPrompt = getPrompt("scaffold")
 
@@ -22,16 +23,8 @@ export function HeroSection() {
           backgroundSize: "100% auto",
         }}
       />
-      {/* Earth — curvature pinned to the very bottom, thin atmospheric dawn along the limb */}
-      <div
-        aria-hidden
-        className="pointer-events-none absolute inset-x-0 bottom-0 -z-10 bg-no-repeat bg-bottom w-full"
-        style={{
-          backgroundImage: "url('/backgrounds/dawn-earth.svg')",
-          backgroundSize: "100% 100%",
-          aspectRatio: "1920 / 340",
-        }}
-      />
+      {/* Earth — curvature pinned to the very bottom, with scroll-linked parallax lift. */}
+      <HeroEarthParallax />
       {/* Ecosystem badge */}
       <div className="relative inline-flex items-center gap-2 px-3.5 py-1.5 border border-border rounded-full text-xs text-text-secondary mb-6">
         <span className="text-text-muted">Built for the</span>

--- a/apps/web/app/components/landing/LogoWall.tsx
+++ b/apps/web/app/components/landing/LogoWall.tsx
@@ -1,0 +1,128 @@
+interface Logo {
+  readonly name: string
+  readonly colorClass: string
+  readonly mark: React.ReactNode
+  readonly href?: string
+}
+
+function LangChainMark() {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      role="img"
+      aria-hidden
+    >
+      <title>LangChain</title>
+      <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
+      <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
+    </svg>
+  )
+}
+
+function TypeScriptMark() {
+  return (
+    <span
+      className="inline-flex items-center justify-center w-4 h-4 rounded-[3px] font-mono text-[9px] font-bold"
+      style={{ background: "currentColor" }}
+    >
+      <span className="text-bg-primary">TS</span>
+    </span>
+  )
+}
+
+function ViteMark() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" role="img" aria-hidden>
+      <title>Vite</title>
+      <path d="M2 2 L22 2 L12 22 Z" opacity="0.9" />
+    </svg>
+  )
+}
+
+function NodeMark() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" role="img" aria-hidden>
+      <title>Node.js</title>
+      <path d="M12 2 L22 8 L22 16 L12 22 L2 16 L2 8 Z" opacity="0.85" />
+    </svg>
+  )
+}
+
+function LangGraphMark() {
+  return (
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      role="img"
+      aria-hidden
+    >
+      <title>LangGraph</title>
+      <circle cx="5" cy="6" r="2" />
+      <circle cx="19" cy="6" r="2" />
+      <circle cx="12" cy="18" r="2" />
+      <path d="M7 6h10" />
+      <path d="M6 8l6 8" />
+      <path d="M18 8l-6 8" />
+    </svg>
+  )
+}
+
+function LangSmithMark() {
+  return (
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      role="img"
+      aria-hidden
+    >
+      <title>LangSmith</title>
+      <circle cx="11" cy="11" r="7" />
+      <path d="m21 21-4.3-4.3" />
+    </svg>
+  )
+}
+
+const LOGOS: readonly Logo[] = [
+  { name: "LangChain", colorClass: "text-accent-green", mark: <LangChainMark /> },
+  { name: "LangGraph", colorClass: "text-accent-green", mark: <LangGraphMark /> },
+  { name: "LangSmith", colorClass: "text-accent-green", mark: <LangSmithMark /> },
+  { name: "TypeScript", colorClass: "text-accent-blue", mark: <TypeScriptMark /> },
+  { name: "Vite", colorClass: "text-accent-purple", mark: <ViteMark /> },
+  { name: "Node.js", colorClass: "text-[#8cc84b]", mark: <NodeMark /> },
+]
+
+export function LogoWall() {
+  return (
+    <section className="relative px-8 py-10" style={{ background: "#020617" }}>
+      <div className="max-w-5xl mx-auto">
+        <p className="text-center text-xs uppercase tracking-widest text-text-muted mb-6">
+          Built on
+        </p>
+        <div className="flex flex-wrap items-center justify-center gap-x-10 gap-y-4">
+          {LOGOS.map((logo) => (
+            <span
+              key={logo.name}
+              className={`inline-flex items-center gap-2 text-sm font-semibold ${logo.colorClass} opacity-60 hover:opacity-100 transition-opacity`}
+            >
+              <span className="shrink-0">{logo.mark}</span>
+              {logo.name}
+            </span>
+          ))}
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -8,26 +8,49 @@ import { FeatureGrid } from "./components/landing/FeatureGrid"
 import { HeroSection } from "./components/landing/HeroSection"
 import { HowItWorks } from "./components/landing/HowItWorks"
 import { LandingAmbient } from "./components/landing/LandingAmbient"
+import { LogoWall } from "./components/landing/LogoWall"
 import { ProblemSection } from "./components/landing/ProblemSection"
 import { SolutionSection } from "./components/landing/SolutionSection"
 import { StatsStrip } from "./components/landing/StatsStrip"
+import { ScrollReveal } from "./components/ScrollReveal"
 
 export default function HomePage() {
   return (
     <div className="relative isolate">
       <LandingAmbient />
+      {/* Hero / Stats / Problem aren't wrapped — the seamless navy bleed across them
+          would break if their bgs faded in independently. Reveals begin at ComparisonTable. */}
       <HeroSection />
       <StatsStrip />
+      <LogoWall />
       <ProblemSection />
-      <ComparisonTable />
-      <SolutionSection />
-      <ArchitectureSection />
-      <CodeExample />
-      <DeploySection />
-      <FeatureGrid />
-      <HowItWorks />
-      <EcosystemSection />
-      <CtaSection />
+      <ScrollReveal>
+        <ComparisonTable />
+      </ScrollReveal>
+      <ScrollReveal>
+        <SolutionSection />
+      </ScrollReveal>
+      <ScrollReveal>
+        <ArchitectureSection />
+      </ScrollReveal>
+      <ScrollReveal>
+        <CodeExample />
+      </ScrollReveal>
+      <ScrollReveal>
+        <DeploySection />
+      </ScrollReveal>
+      <ScrollReveal>
+        <FeatureGrid />
+      </ScrollReveal>
+      <ScrollReveal>
+        <HowItWorks />
+      </ScrollReveal>
+      <ScrollReveal>
+        <EcosystemSection />
+      </ScrollReveal>
+      <ScrollReveal>
+        <CtaSection />
+      </ScrollReveal>
     </div>
   )
 }


### PR DESCRIPTION
## Summary

Three small additions to the landing.

### Motion pass — \`ScrollReveal\`
New client component that fades and rises children when they scroll into view via \`IntersectionObserver\`. Runs once per element. Sections visible on initial mount render at full opacity with no animation. Respects \`prefers-reduced-motion\`.

Applied from **ComparisonTable onward**. Hero / Stats / LogoWall / Problem are intentionally NOT wrapped — their seamless navy bleed would break if their bgs faded in independently.

### Logo wall — \`LogoWall\`
New section placed after \`StatsStrip\` on the same navy band. Six ecosystem brands shown with minimal inline-SVG marks + wordmarks at 60% opacity (hover 100%): **LangChain, LangGraph, LangSmith, TypeScript, Vite, Node.js**. Eyebrow: \"BUILT ON\".

### Hero parallax experiment — \`HeroEarthParallax\`
Subtle scroll-linked translate on the hero earth layer: the earth rises up to 28px as the user scrolls the first viewport height — suggesting the sun continuing to crest as you move down.

Implemented as a drop-in component that fully encapsulates the earth div. **Easy to undo** by replacing \`<HeroEarthParallax />\` in HeroSection with the original inline div (removal snippet included as a comment in \`HeroEarthParallax.tsx\`).

Uses \`requestAnimationFrame\`-throttled scroll handler. Respects \`prefers-reduced-motion\`.

## Test plan

- [x] \`pnpm --filter @dawnai.org/web typecheck\` passes
- [x] \`pnpm --filter @dawnai.org/web lint\` passes
- [x] \`pnpm --filter @dawnai.org/web build\` succeeds
- [x] Landing page loads: sections below fold fade + rise on scroll; above-fold sections render without animation
- [x] Logo wall renders on navy between Stats and Problem
- [x] Earth lifts subtly as scroll progresses; base position unchanged at scroll 0
