### PR TITLE
feat(web): accelerate the sun — three-layer parallax with overflow fade

### DIFF
--- a/apps/web/app/components/landing/HeroEarthParallax.tsx
+++ b/apps/web/app/components/landing/HeroEarthParallax.tsx
@@ -3,38 +3,40 @@
 import { useEffect, useRef, useState } from "react"
 
 /**
- * Subtle scroll-linked parallax for the hero earth layer.
+ * Three-layer scroll-linked parallax for the hero sky + earth + sun.
  *
- * The earth translates upward (the sun "rises" further) as the user scrolls
- * past the hero. Max translation is capped at `maxRisePx`. Respects
- * prefers-reduced-motion.
+ * The effect: as the reader scrolls down, the stars drift slowly (far
+ * background), the earth rises at a medium rate (the horizon), and the sun
+ * bloom accelerates upward (cresting the horizon). Different rates = depth.
  *
- * EXPERIMENT: To undo, replace `<HeroEarthParallax />` in HeroSection with
- * the original inline markup:
+ * The full range is reached by the time the reader scrolls one viewport height.
+ * Respects prefers-reduced-motion.
  *
- *   <div
- *     aria-hidden
- *     className="pointer-events-none absolute inset-x-0 bottom-0 -z-10 bg-no-repeat bg-bottom w-full"
- *     style={{
- *       backgroundImage: "url('/backgrounds/dawn-earth.svg')",
- *       backgroundSize: "100% 100%",
- *       aspectRatio: "1920 / 340",
- *     }}
- *   />
+ * EXPERIMENT: To undo, replace `<HeroParallaxLayers />` in HeroSection with
+ * the original two inline divs (starfield + earth). The removal snippet is
+ * at the bottom of this file.
  */
-export function HeroEarthParallax({ maxRisePx = 28 }: { maxRisePx?: number }) {
-  const [translateY, setTranslateY] = useState(0)
+export function HeroParallaxLayers({
+  maxEarthRisePx = 90,
+  maxStarRisePx = 20,
+  maxSunRisePx = 160,
+}: {
+  maxEarthRisePx?: number
+  maxStarRisePx?: number
+  /** Accelerated rate for the sun bloom — outpaces the earth so the sun
+   *  reads as rising above the horizon, not dragging with the ground. */
+  maxSunRisePx?: number
+}) {
+  const [progress, setProgress] = useState(0)
   const rafRef = useRef<number | null>(null)
 
   useEffect(() => {
     if (window.matchMedia?.("(prefers-reduced-motion: reduce)").matches) return
 
     const compute = () => {
-      // Scroll progress 0..1 across the first viewport height
       const y = window.scrollY
       const h = window.innerHeight
-      const progress = Math.max(0, Math.min(1, y / h))
-      setTranslateY(progress * maxRisePx)
+      setProgress(Math.max(0, Math.min(1, y / h)))
     }
 
     const onScroll = () => {
@@ -51,19 +53,76 @@ export function HeroEarthParallax({ maxRisePx = 28 }: { maxRisePx?: number }) {
       window.removeEventListener("scroll", onScroll)
       if (rafRef.current != null) cancelAnimationFrame(rafRef.current)
     }
-  }, [maxRisePx])
+  }, [])
+
+  const earthY = progress * maxEarthRisePx
+  const starY = progress * maxStarRisePx
+  const sunY = progress * maxSunRisePx
 
   return (
-    <div
-      aria-hidden
-      className="pointer-events-none absolute inset-x-0 bottom-0 -z-10 bg-no-repeat bg-bottom w-full"
-      style={{
-        backgroundImage: "url('/backgrounds/dawn-earth.svg')",
-        backgroundSize: "100% 100%",
-        aspectRatio: "1920 / 340",
-        transform: `translate3d(0, ${-translateY}px, 0)`,
-        willChange: "transform",
-      }}
-    />
+    <>
+      {/* Starfield — drifts slowly (far background) */}
+      <div
+        aria-hidden
+        className="pointer-events-none absolute inset-0 -z-20 bg-no-repeat bg-top opacity-[0.85]"
+        style={{
+          backgroundImage: "url('/backgrounds/dawn-stars.svg')",
+          backgroundSize: "100% auto",
+          transform: `translate3d(0, ${-starY}px, 0)`,
+          willChange: "transform",
+        }}
+      />
+      {/* Earth — rises at medium rate (the horizon beneath the sun) */}
+      <div
+        aria-hidden
+        className="pointer-events-none absolute inset-x-0 bottom-0 -z-10 bg-no-repeat bg-bottom w-full"
+        style={{
+          backgroundImage: "url('/backgrounds/dawn-earth.svg')",
+          backgroundSize: "100% 100%",
+          aspectRatio: "1920 / 340",
+          transform: `translate3d(0, ${-earthY}px, 0)`,
+          willChange: "transform",
+        }}
+      />
+      {/* Sun bloom — accelerates upward FASTER than the earth, so the sun
+          appears to rise above the horizon. Container is oversized (800px
+          tall, anchored 320px below the hero) so the gradient's ellipse has
+          room to fade fully on all sides — no hard cutoff at the container
+          edge as the user scrolls. */}
+      <div
+        aria-hidden
+        className="pointer-events-none absolute inset-x-0 -z-[5] w-full h-[800px]"
+        style={{
+          bottom: "-320px",
+          background:
+            "radial-gradient(ellipse 30% 45% at 50% 50%, rgba(254,243,199,0.55) 0%, rgba(252,211,77,0.32) 28%, rgba(245,158,11,0.14) 58%, transparent 82%)",
+          transform: `translate3d(0, ${-sunY}px, 0)`,
+          willChange: "transform",
+        }}
+      />
+    </>
   )
 }
+
+/* --- UNDO SNIPPET ----------------------------------------------------------
+Replace <HeroParallaxLayers /> in HeroSection.tsx with the two original divs
+to remove the parallax experiment entirely:
+
+  <div
+    aria-hidden
+    className="pointer-events-none absolute inset-0 -z-20 bg-no-repeat bg-top opacity-[0.85]"
+    style={{
+      backgroundImage: "url('/backgrounds/dawn-stars.svg')",
+      backgroundSize: "100% auto",
+    }}
+  />
+  <div
+    aria-hidden
+    className="pointer-events-none absolute inset-x-0 bottom-0 -z-10 bg-no-repeat bg-bottom w-full"
+    style={{
+      backgroundImage: "url('/backgrounds/dawn-earth.svg')",
+      backgroundSize: "100% 100%",
+      aspectRatio: "1920 / 340",
+    }}
+  />
+--------------------------------------------------------------------------- */

--- a/apps/web/app/components/landing/HeroSection.tsx
+++ b/apps/web/app/components/landing/HeroSection.tsx
@@ -1,30 +1,22 @@
 import { getPrompt } from "../../../content/prompts"
 import { CopyCommand } from "../CopyCommand"
 import { CopyPromptButton } from "../CopyPromptButton"
-import { HeroEarthParallax } from "./HeroEarthParallax"
+import { HeroParallaxLayers } from "./HeroEarthParallax"
 
 const scaffoldPrompt = getPrompt("scaffold")
 
 export function HeroSection() {
   return (
     <section
-      className="relative pt-24 pb-56 text-center overflow-hidden isolate"
+      className="relative pt-24 pb-56 text-center isolate"
       style={{
         background:
           "linear-gradient(to bottom, var(--color-bg-primary) 0%, var(--color-bg-primary) 55%, #020617 100%)",
       }}
     >
-      {/* Starfield — the distant cosmos, scattered throughout the upper hero */}
-      <div
-        aria-hidden
-        className="pointer-events-none absolute inset-0 -z-20 bg-no-repeat bg-top opacity-[0.85]"
-        style={{
-          backgroundImage: "url('/backgrounds/dawn-stars.svg')",
-          backgroundSize: "100% auto",
-        }}
-      />
-      {/* Earth — curvature pinned to the very bottom, with scroll-linked parallax lift. */}
-      <HeroEarthParallax />
+      {/* Starfield (slow drift) + earth (medium lift) + sun bloom (accelerated).
+          Sun bloom extends below the hero and bleeds into StatsStrip's transparent top. */}
+      <HeroParallaxLayers />
       {/* Ecosystem badge */}
       <div className="relative inline-flex items-center gap-2 px-3.5 py-1.5 border border-border rounded-full text-xs text-text-secondary mb-6">
         <span className="text-text-muted">Built for the</span>

--- a/apps/web/app/components/landing/StatsStrip.tsx
+++ b/apps/web/app/components/landing/StatsStrip.tsx
@@ -23,7 +23,12 @@ const stats = [
 
 export function StatsStrip() {
   return (
-    <section className="relative px-8 py-12" style={{ background: "#020617" }}>
+    <section
+      className="relative px-8 py-12"
+      style={{
+        background: "linear-gradient(to bottom, transparent 0%, rgba(2,6,23,0.6) 30%, #020617 70%)",
+      }}
+    >
       <div className="max-w-5xl mx-auto grid grid-cols-2 md:grid-cols-4 gap-4">
         {stats.map((stat) => (
           <div


### PR DESCRIPTION
## Summary

Refines the hero parallax experiment:

- **Three layers with distinct rise rates:** stars drift slowly (20px max, far background), earth lifts medium (90px max, horizon), **sun bloom accelerates** (160px max, cresting the horizon). The 8× differential between sun and stars reads as real depth.
- **Sun bloom separated** from the earth SVG as a CSS radial-gradient layer so it can have its own parallax rate. Brightest at the horizon level, fades upward into cosmic dark and downward past the hero.
- **Removed \`overflow-hidden\`** from the hero so the sun bloom can extend below the section boundary. **\`StatsStrip\` background** now fades from transparent at top to navy at 70%, letting the sun's warmth bleed gracefully into the stats band instead of being hard-cut at the section edge.

Scroll the live page — the sun should now read as actively rising above a horizon that's also rising (but slower), above a starfield that barely moves at all.

## Test plan

- [x] \`pnpm --filter @dawnai.org/web typecheck\` passes
- [x] \`pnpm --filter @dawnai.org/web lint\` passes
- [x] At scroll 0: sun bloom sits at horizon; earth full-width
- [x] At scroll 600: stars -12px, earth -55px, sun bloom -97px (measured)
- [x] Bottom of sun bloom fades smoothly into StatsStrip — no hard cutoff
- [x] Respects prefers-reduced-motion
