### PR TITLE
feat(web): polish, footer expansion, mobile sweep

### DIFF
--- a/apps/web/app/components/Footer.tsx
+++ b/apps/web/app/components/Footer.tsx
@@ -1,28 +1,179 @@
+import Link from "next/link"
+
+interface LinkItem {
+  readonly label: string
+  readonly href: string
+  readonly external?: boolean
+}
+
+interface Column {
+  readonly heading: string
+  readonly items: readonly LinkItem[]
+}
+
+const COLUMNS: readonly Column[] = [
+  {
+    heading: "Docs",
+    items: [
+      { label: "Getting Started", href: "/docs/getting-started" },
+      { label: "Routes", href: "/docs/routes" },
+      { label: "Tools", href: "/docs/tools" },
+      { label: "State", href: "/docs/state" },
+      { label: "Testing", href: "/docs/testing" },
+      { label: "Dev Server", href: "/docs/dev-server" },
+      { label: "Deployment", href: "/docs/deployment" },
+      { label: "CLI", href: "/docs/cli" },
+    ],
+  },
+  {
+    heading: "For Agents",
+    items: [
+      { label: "llms.txt", href: "/llms.txt", external: true },
+      { label: "llms-full.txt", href: "/llms-full.txt", external: true },
+      { label: "AGENTS.md", href: "/AGENTS.md", external: true },
+      { label: "CLAUDE.md", href: "/CLAUDE.md", external: true },
+      { label: "Scaffold prompt", href: "/prompts/scaffold", external: true },
+      { label: "Add a tool", href: "/prompts/add-a-tool", external: true },
+      { label: "Write a route", href: "/prompts/write-a-route", external: true },
+      { label: "Write a test", href: "/prompts/write-a-test", external: true },
+      { label: "Deploy", href: "/prompts/deploy", external: true },
+    ],
+  },
+  {
+    heading: "Ecosystem",
+    items: [
+      { label: "LangChain", href: "https://langchain.com", external: true },
+      { label: "LangGraph", href: "https://www.langchain.com/langgraph", external: true },
+      { label: "LangSmith", href: "https://smith.langchain.com", external: true },
+      { label: "TypeScript", href: "https://www.typescriptlang.org", external: true },
+      { label: "Vite", href: "https://vitejs.dev", external: true },
+    ],
+  },
+  {
+    heading: "Source",
+    items: [
+      { label: "GitHub", href: "https://github.com/cacheplane/dawnai", external: true },
+      { label: "npm", href: "https://www.npmjs.com/org/dawnai.org", external: true },
+      {
+        label: "MIT License",
+        href: "https://github.com/cacheplane/dawnai/blob/main/LICENSE",
+        external: true,
+      },
+    ],
+  },
+]
+
+function FooterLink({ label, href, external }: LinkItem) {
+  const className =
+    "text-sm text-text-secondary hover:text-accent-amber transition-colors block py-0.5"
+  if (external) {
+    return (
+      <a href={href} target="_blank" rel="noopener noreferrer" className={className}>
+        {label}
+      </a>
+    )
+  }
+  return (
+    <Link href={href} className={className}>
+      {label}
+    </Link>
+  )
+}
+
+function GitHubIcon() {
+  return (
+    <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor" role="img" aria-hidden>
+      <title>GitHub</title>
+      <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z" />
+    </svg>
+  )
+}
+
+function NpmIcon() {
+  return (
+    <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor" role="img" aria-hidden>
+      <title>npm</title>
+      <path d="M0 0v16h16V0H0zm13 13h-2.5V5.5H8V13H3V3h10v10z" />
+    </svg>
+  )
+}
+
 export function Footer() {
   return (
-    <footer className="flex justify-between items-center px-8 py-6 border-t border-border-subtle text-xs text-text-dim">
-      <span>dawn</span>
-      <nav className="flex gap-4">
-        <a href="/docs/getting-started" className="hover:text-text-secondary transition-colors">
-          Docs
-        </a>
-        <a
-          href="https://github.com/anthropics/dawn"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="hover:text-text-secondary transition-colors"
-        >
-          GitHub
-        </a>
-        <a
-          href="https://www.npmjs.com/org/dawn"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="hover:text-text-secondary transition-colors"
-        >
-          npm
-        </a>
-      </nav>
+    <footer
+      className="relative px-8 pt-16 pb-10 mt-12 border-t border-border-subtle"
+      style={{
+        background:
+          "linear-gradient(to bottom, transparent 0%, rgba(2,6,23,0.4) 50%, #020617 100%)",
+      }}
+    >
+      {/* Subtle starfield echo — closes the cosmic loop one final time */}
+      <div
+        aria-hidden
+        className="pointer-events-none absolute inset-x-0 top-0 h-32 opacity-30 bg-no-repeat bg-top"
+        style={{
+          backgroundImage: "url('/backgrounds/dawn-stars.svg')",
+          backgroundSize: "100% auto",
+        }}
+      />
+
+      <div className="relative max-w-6xl mx-auto">
+        <div className="grid grid-cols-2 md:grid-cols-6 gap-10 md:gap-8">
+          {/* Brand block — spans 2 cols on desktop, full width on mobile */}
+          <div className="col-span-2 md:col-span-2">
+            <Link
+              href="/"
+              className="font-display font-semibold text-2xl text-text-primary inline-block"
+              style={{
+                fontVariationSettings: "'opsz' 144, 'SOFT' 50",
+                letterSpacing: "-0.02em",
+              }}
+            >
+              dawn
+            </Link>
+            <p className="text-sm text-text-muted mt-3 leading-relaxed max-w-[36ch]">
+              The App Router for AI agents. A TypeScript-first meta-framework for LangChain.
+            </p>
+            <div className="flex items-center gap-3 mt-5">
+              <a
+                href="https://github.com/cacheplane/dawnai"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center justify-center w-10 h-10 rounded-md border border-border text-text-muted hover:text-accent-amber hover:border-accent-amber/40 transition-colors"
+                aria-label="GitHub"
+              >
+                <GitHubIcon />
+              </a>
+              <a
+                href="https://www.npmjs.com/org/dawnai.org"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center justify-center w-10 h-10 rounded-md border border-border text-text-muted hover:text-accent-amber hover:border-accent-amber/40 transition-colors"
+                aria-label="npm"
+              >
+                <NpmIcon />
+              </a>
+            </div>
+          </div>
+
+          {/* Link columns */}
+          {COLUMNS.map((col) => (
+            <div key={col.heading} className="flex flex-col gap-1">
+              <p className="text-[11px] font-semibold uppercase tracking-widest text-accent-amber mb-2">
+                {col.heading}
+              </p>
+              {col.items.map((item) => (
+                <FooterLink key={item.label} {...item} />
+              ))}
+            </div>
+          ))}
+        </div>
+
+        {/* Bottom bar */}
+        <div className="mt-12 pt-6 border-t border-border-subtle text-xs text-text-muted text-center md:text-left">
+          {`© ${new Date().getFullYear()} Dawn · MIT-licensed · Built on the LangChain ecosystem`}
+        </div>
+      </div>
     </footer>
   )
 }

--- a/apps/web/app/components/Header.tsx
+++ b/apps/web/app/components/Header.tsx
@@ -18,7 +18,7 @@ export function Header() {
           Docs
         </Link>
         <a
-          href="https://github.com/anthropics/dawn"
+          href="https://github.com/cacheplane/dawnai"
           target="_blank"
           rel="noopener noreferrer"
           className="hover:text-text-primary transition-colors"
@@ -29,7 +29,7 @@ export function Header() {
           href="/docs/getting-started"
           className="bg-accent-amber text-bg-primary px-3 py-1.5 rounded-md font-semibold hover:bg-accent-amber-deep transition-colors"
         >
-          Get Started
+          Read the Docs
         </Link>
       </nav>
     </header>

--- a/apps/web/app/components/landing/ComparisonTable.tsx
+++ b/apps/web/app/components/landing/ComparisonTable.tsx
@@ -54,7 +54,7 @@ export function ComparisonTable() {
 
       <div className="max-w-[650px] mx-auto mt-10 border border-border rounded-lg overflow-hidden relative">
         {/* Header */}
-        <div className="grid grid-cols-[2fr_1fr_1fr] bg-bg-card px-5 py-3 text-xs text-text-secondary uppercase tracking-wide font-semibold">
+        <div className="grid grid-cols-[2fr_1fr_1fr] bg-bg-card px-3 sm:px-5 py-3 text-[10px] sm:text-xs text-text-secondary uppercase tracking-wide font-semibold">
           <span>Convention</span>
           <span className="text-center">Next.js</span>
           <span className="text-center text-accent-amber">Dawn</span>
@@ -64,17 +64,21 @@ export function ComparisonTable() {
         {rows.map((row, i) => (
           <div
             key={row.label}
-            className={`grid grid-cols-[2fr_1fr_1fr] px-5 py-2.5 text-sm border-t border-border-subtle ${
+            className={`grid grid-cols-[2fr_1fr_1fr] px-3 sm:px-5 py-2.5 text-xs sm:text-sm border-t border-border-subtle ${
               i % 2 === 1 ? "bg-bg-card/60" : ""
             }`}
           >
             <span className={`text-text-secondary ${row.dawnOnly ? "font-semibold" : ""}`}>
               {row.label}
             </span>
-            <span className="text-center text-text-muted font-mono text-xs">{row.nextjs}</span>
+            <span className="text-center text-text-muted font-mono text-[10px] sm:text-xs break-all sm:break-normal">
+              {row.nextjs}
+            </span>
             <span
-              className={`text-center font-mono text-xs ${
-                row.dawnOnly ? "text-accent-amber font-semibold text-sm" : "text-text-primary"
+              className={`text-center font-mono text-[10px] sm:text-xs break-all sm:break-normal ${
+                row.dawnOnly
+                  ? "text-accent-amber font-semibold text-xs sm:text-sm"
+                  : "text-text-primary"
               }`}
             >
               {row.dawn}

--- a/apps/web/app/components/landing/CtaSection.tsx
+++ b/apps/web/app/components/landing/CtaSection.tsx
@@ -31,7 +31,7 @@ export function CtaSection() {
           Get Started
         </Link>
         <a
-          href="https://github.com/anthropics/dawn"
+          href="https://github.com/cacheplane/dawnai"
           target="_blank"
           rel="noopener noreferrer"
           className="px-8 py-3 border border-border text-text-secondary rounded-md text-sm hover:border-text-muted hover:text-text-primary transition-colors"

--- a/apps/web/app/components/landing/DeploySection.tsx
+++ b/apps/web/app/components/landing/DeploySection.tsx
@@ -37,10 +37,10 @@ export function DeploySection() {
         </p>
       </div>
 
-      {/* Pipeline */}
-      <div className="max-w-[650px] mx-auto mt-10 flex items-center justify-center gap-0">
+      {/* Pipeline — stacked vertically on mobile, horizontal on md+ */}
+      <div className="max-w-[650px] mx-auto mt-10 flex flex-col md:flex-row items-center justify-center gap-0">
         {steps.map((step, i) => (
-          <div key={step.label} className="flex items-center">
+          <div key={step.label} className="flex flex-col md:flex-row items-center">
             <div className="text-center flex-1 min-w-[140px]">
               <div
                 className={`w-14 h-14 rounded-[10px] flex items-center justify-center mx-auto mb-3 ${
@@ -104,7 +104,14 @@ export function DeploySection() {
               </div>
             </div>
             {i < steps.length - 1 && (
-              <span className="text-accent-amber/50 text-2xl mb-8 mx-2">&rarr;</span>
+              <span className="text-accent-amber/50 text-2xl mx-2 my-2 md:my-0 md:mb-8 inline-flex">
+                <span className="md:hidden" aria-hidden>
+                  &darr;
+                </span>
+                <span className="hidden md:inline" aria-hidden>
+                  &rarr;
+                </span>
+              </span>
             )}
           </div>
         ))}


### PR DESCRIPTION
## Summary

Three-in-one polish PR.

### Footer expansion
- Brand block (dawn wordmark + tagline + GitHub/npm icons) plus four link columns: **Docs / For Agents / Ecosystem / Source**.
- \"For Agents\" column is distinctive to Dawn — surfaces \`llms.txt\`, \`AGENTS.md\`, \`assistant.md\`, and the five task prompts.
- Subtle starfield echo at the top closes the cosmic loop one final time.
- 2-col grid on mobile, 6-col on desktop (brand spans 2 cols).
- Inspired by angular-agent-framework's footer pattern, adapted to Dawn's warm-dark + amber aesthetic.

### Polish
- Header GitHub link: \`anthropics/dawn\` → \`cacheplane/dawnai\`.
- Renamed Header CTA pill from **\"Get Started\" → \"Read the Docs\"** to free \"Get Started\" semantics for the hero's actual install action (Copy prompt).
- CtaSection GitHub button URL fixed.

### Mobile sweep
- **DeploySection** 3-step pipeline now stacks vertically on mobile with downward arrows between steps; horizontal with rightward arrows on md+. The previous 3-steps-side-by-side layout was unreadable at 390px.
- **ComparisonTable**: tighter padding (\`px-3\` vs \`px-5\`) and smaller font (\`text-[10px]\`/\`text-xs\` vs \`text-xs\`/\`text-sm\`) on mobile, plus \`break-all\` word-wrap on the mono code cells so long values like \`dawn.generated.d.ts\` don't blow out the column.

## Test plan

- [x] \`pnpm --filter @dawnai.org/web typecheck\` passes
- [x] \`pnpm --filter @dawnai.org/web lint\` passes
- [x] \`pnpm --filter @dawnai.org/web build\` succeeds
- [x] Mobile (390px): footer renders 2x2 grid, ComparisonTable readable, DeploySection stacks vertically
- [x] Desktop: footer 6-col, ComparisonTable normal, DeploySection horizontal
- [x] Header link points to cacheplane/dawnai; CTA copy reads \"Read the Docs\"
