### PR TITLE
feat: replace default template with LangChain chain implementation

### DIFF
--- a/docs/superpowers/plans/2026-04-30-langchain-starter-template.md
+++ b/docs/superpowers/plans/2026-04-30-langchain-starter-template.md
@@ -1,0 +1,380 @@
+# LangChain Starter Template Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the default `create-dawn-app` template with a working LangChain chain that uses `ChatOpenAI`, a prompt template, and a Dawn-discovered tool.
+
+**Architecture:** The `app-basic` template's route entry changes from exporting a `workflow` function (LangGraph pattern) to exporting an LCEL chain as default (LangChain pattern). The chain adapter in `@dawn-ai/langchain` handles tool execution via Dawn's built-in tool loop. Dependencies swap `@dawn-ai/langgraph` for `@dawn-ai/langchain` + `@langchain/openai` + `@langchain/core`.
+
+**Tech Stack:** TypeScript, LangChain (LCEL), `@langchain/openai`, `@dawn-ai/langchain` adapter, Dawn filesystem tool discovery
+
+---
+
+## File Structure
+
+| Path | Action | Responsibility |
+|------|--------|----------------|
+| `packages/devkit/templates/app-basic/src/app/(public)/hello/[tenant]/state.ts` | Modify | Define `HelloInput` and `HelloOutput` types |
+| `packages/devkit/templates/app-basic/src/app/(public)/hello/[tenant]/index.ts` | Modify | Export LCEL chain as default |
+| `packages/devkit/templates/app-basic/src/app/(public)/hello/[tenant]/tools/greet.ts` | Modify | Return richer structured data |
+| `packages/devkit/templates/app-basic/package.json.template` | Modify | Swap langgraph → langchain + openai deps |
+| `packages/devkit/templates/app-basic/.dawn/dawn.generated.d.ts` | Modify | Regenerate for new tool shape |
+| `packages/create-dawn-app/src/index.ts` | Modify | Add langchain specifiers, remove langgraph from template deps |
+| `packages/create-dawn-app/test/create-app.test.ts` | Modify | Update assertions from langgraph to langchain |
+
+---
+
+### Task 1: Update the template tool to return richer data
+
+**Files:**
+- Modify: `packages/devkit/templates/app-basic/src/app/(public)/hello/[tenant]/tools/greet.ts`
+
+- [ ] **Step 1: Replace the tool implementation**
+
+```ts
+/**
+ * Look up information about a tenant.
+ * @param tenant - The tenant identifier to look up
+ */
+export default async (input: { readonly tenant: string }) => {
+  return {
+    name: input.tenant,
+    greeting: `Welcome, ${input.tenant}!`,
+    plan: "starter",
+  }
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add packages/devkit/templates/app-basic/src/app/\(public\)/hello/\[tenant\]/tools/greet.ts
+git commit -m "feat(template): return richer structured data from greet tool"
+```
+
+---
+
+### Task 2: Update state types for chain input/output
+
+**Files:**
+- Modify: `packages/devkit/templates/app-basic/src/app/(public)/hello/[tenant]/state.ts`
+
+- [ ] **Step 1: Replace the state file with chain input/output types**
+
+```ts
+export interface HelloInput {
+  readonly tenant: string
+  readonly message: string
+}
+
+export interface HelloOutput {
+  readonly response: string
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add packages/devkit/templates/app-basic/src/app/\(public\)/hello/\[tenant\]/state.ts
+git commit -m "feat(template): define HelloInput and HelloOutput for chain route"
+```
+
+---
+
+### Task 3: Rewrite the route entry to export an LCEL chain
+
+**Files:**
+- Modify: `packages/devkit/templates/app-basic/src/app/(public)/hello/[tenant]/index.ts`
+
+- [ ] **Step 1: Replace the route entry with LCEL chain construction**
+
+Dawn discovers routes by looking for **named exports**: `chain`, `graph`, or `workflow`. The template must use `export const chain = ...` (not a default export).
+
+For chain routes, the runtime calls `entry.invoke(input)` directly without passing a tool context. The chain must be self-contained — import the greet tool directly and convert it to a LangChain tool at module level.
+
+```ts
+import { ChatPromptTemplate } from "@langchain/core/prompts"
+import { ChatOpenAI } from "@langchain/openai"
+import { convertToolToLangChain } from "@dawn-ai/langchain"
+
+import greet from "./tools/greet.js"
+
+const model = new ChatOpenAI({
+  modelName: "gpt-4o-mini",
+  temperature: 0,
+})
+
+const prompt = ChatPromptTemplate.fromMessages([
+  [
+    "system",
+    "You are a helpful assistant for the {tenant} organization. Use the available tools to look up tenant information before responding.",
+  ],
+  ["human", "{message}"],
+])
+
+const greetTool = convertToolToLangChain({
+  name: "greet",
+  description: "Look up information about a tenant",
+  run: greet,
+})
+
+export const chain = prompt.pipe(model.bindTools([greetTool]))
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add packages/devkit/templates/app-basic/src/app/\(public\)/hello/\[tenant\]/index.ts
+git commit -m "feat(template): export LCEL chain with tool use as named export"
+```
+
+---
+
+### Task 4: Update the generated types file
+
+**Files:**
+- Modify: `packages/devkit/templates/app-basic/.dawn/dawn.generated.d.ts`
+
+- [ ] **Step 1: Regenerate types to match new tool signature**
+
+```ts
+declare module "dawn:routes" {
+  export type DawnRoutePath = "/hello/[tenant]";
+
+  export interface DawnRouteParams {
+  "/hello/[tenant]": { tenant: string };
+  }
+
+  export interface DawnRouteTools {
+    "/hello/[tenant]": {
+      readonly greet: (input: { readonly tenant: string; }) => Promise<{ name: string; greeting: string; plan: string; }>;
+    };
+  }
+
+  export type RouteTools<P extends DawnRoutePath> = DawnRouteTools[P];
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add packages/devkit/templates/app-basic/.dawn/dawn.generated.d.ts
+git commit -m "feat(template): regenerate types for updated greet tool return shape"
+```
+
+---
+
+### Task 5: Update package.json.template dependencies
+
+**Files:**
+- Modify: `packages/devkit/templates/app-basic/package.json.template`
+
+- [ ] **Step 1: Replace the template with updated dependencies**
+
+```json
+{
+  "name": "{{appName}}",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "check": "dawn check",
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@dawn-ai/core": "{{dawnCoreSpecifier}}",
+    "@dawn-ai/cli": "{{dawnCliSpecifier}}",
+    "@dawn-ai/langchain": "{{dawnLangchainSpecifier}}",
+    "@dawn-ai/sdk": "{{dawnSdkSpecifier}}",
+    "@langchain/core": "{{langchainCoreSpecifier}}",
+    "@langchain/openai": "{{langchainOpenaiSpecifier}}"
+  },
+  "devDependencies": {
+    "@dawn-ai/config-typescript": "{{dawnConfigTypescriptSpecifier}}",
+    "@types/node": "25.6.0",
+    "typescript": "6.0.2"
+  }
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add packages/devkit/templates/app-basic/package.json.template
+git commit -m "feat(template): swap langgraph dep for langchain + openai + core"
+```
+
+---
+
+### Task 6: Update create-dawn-app replacement logic
+
+**Files:**
+- Modify: `packages/create-dawn-app/src/index.ts`
+
+- [ ] **Step 1: Add langchainCoreSpecifier and langchainOpenaiSpecifier to the replacement type and both mode branches**
+
+In `createTemplateReplacements`, update the return type to include the new specifiers and remove `dawnLanggraphSpecifier`:
+
+```ts
+function createTemplateReplacements(
+  appRoot: string,
+  options: CliOptions,
+): {
+  readonly appName: string
+  readonly dawnCliSpecifier: string
+  readonly dawnConfigTypescriptSpecifier: string
+  readonly dawnCoreSpecifier: string
+  readonly dawnLangchainSpecifier: string
+  readonly dawnLanggraphSpecifier: string
+  readonly dawnSdkSpecifier: string
+  readonly langchainCoreSpecifier: string
+  readonly langchainOpenaiSpecifier: string
+} {
+  if (options.mode === "internal") {
+    return {
+      appName: basename(appRoot),
+      dawnCliSpecifier: createAbsoluteFileSpecifier(resolve(repoRoot, "packages/cli")),
+      dawnConfigTypescriptSpecifier: createAbsoluteFileSpecifier(
+        resolve(repoRoot, "packages/config-typescript"),
+      ),
+      dawnCoreSpecifier: createAbsoluteFileSpecifier(resolve(repoRoot, "packages/core")),
+      dawnLangchainSpecifier: createAbsoluteFileSpecifier(resolve(repoRoot, "packages/langchain")),
+      dawnLanggraphSpecifier: createAbsoluteFileSpecifier(resolve(repoRoot, "packages/langgraph")),
+      dawnSdkSpecifier: createAbsoluteFileSpecifier(resolve(repoRoot, "packages/sdk")),
+      langchainCoreSpecifier: "0.3.80",
+      langchainOpenaiSpecifier: "0.6.17",
+    }
+  }
+
+  return {
+    appName: basename(appRoot),
+    dawnCliSpecifier: options.distTag,
+    dawnConfigTypescriptSpecifier: options.distTag,
+    dawnCoreSpecifier: options.distTag,
+    dawnLangchainSpecifier: options.distTag,
+    dawnLanggraphSpecifier: options.distTag,
+    dawnSdkSpecifier: options.distTag,
+    langchainCoreSpecifier: "0.3.80",
+    langchainOpenaiSpecifier: "0.6.17",
+  }
+}
+```
+
+Also update `applyInternalModePackageOverrides` to include overrides for `@dawn-ai/langchain` (already present via `dawnLangchainSpecifier`) but NOT for `@langchain/openai` or `@langchain/core` (third-party packages don't need file specifier overrides).
+
+- [ ] **Step 2: Run the create-dawn-app tests to verify**
+
+Run: `pnpm --filter create-dawn-app test`
+
+Expected: Tests should fail because assertions still reference `@dawn-ai/langgraph`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/create-dawn-app/src/index.ts
+git commit -m "feat(create-dawn-app): add langchain version specifiers to replacement map"
+```
+
+---
+
+### Task 7: Update create-dawn-app test assertions
+
+**Files:**
+- Modify: `packages/create-dawn-app/test/create-app.test.ts`
+
+- [ ] **Step 1: Replace all `@dawn-ai/langgraph` assertions with `@dawn-ai/langchain`**
+
+In the "scaffolds external mode" test, change:
+```ts
+expect(packageJson.dependencies["@dawn-ai/langgraph"]).not.toMatch(/^file:/)
+expect(packageJson.dependencies["@dawn-ai/langgraph"]).toBe("next")
+```
+to:
+```ts
+expect(packageJson.dependencies["@dawn-ai/langchain"]).not.toMatch(/^file:/)
+expect(packageJson.dependencies["@dawn-ai/langchain"]).toBe("next")
+expect(packageJson.dependencies["@langchain/openai"]).toBe("0.6.17")
+expect(packageJson.dependencies["@langchain/core"]).toBe("0.3.80")
+```
+
+In the "supports explicit internal dev scaffolding" test, change:
+```ts
+expect(packageJson.dependencies["@dawn-ai/langgraph"]).toMatch(/^file:/)
+```
+to:
+```ts
+expect(packageJson.dependencies["@dawn-ai/langchain"]).toMatch(/^file:/)
+expect(packageJson.dependencies["@langchain/openai"]).toBe("0.6.17")
+expect(packageJson.dependencies["@langchain/core"]).toBe("0.3.80")
+```
+
+In the "writes contributor-local package specifiers" test, change:
+```ts
+expect(resolveFileSpecifier(packageJson.dependencies["@dawn-ai/langgraph"])).toBe(
+  resolve(repoRoot, "packages/langgraph"),
+)
+```
+to:
+```ts
+expect(resolveFileSpecifier(packageJson.dependencies["@dawn-ai/langchain"])).toBe(
+  resolve(repoRoot, "packages/langchain"),
+)
+expect(packageJson.dependencies["@langchain/openai"]).toBe("0.6.17")
+expect(packageJson.dependencies["@langchain/core"]).toBe("0.3.80")
+```
+
+And update the overrides assertions similarly — change `@dawn-ai/langgraph` references to `@dawn-ai/langchain`:
+```ts
+expect(resolveFileSpecifier(packageJson.pnpm?.overrides?.["@dawn-ai/langgraph"] ?? "")).toBe(
+  resolve(repoRoot, "packages/langgraph"),
+)
+```
+to:
+```ts
+expect(resolveFileSpecifier(packageJson.pnpm?.overrides?.["@dawn-ai/langchain"] ?? "")).toBe(
+  resolve(repoRoot, "packages/langchain"),
+)
+```
+
+- [ ] **Step 2: Run the create-dawn-app tests**
+
+Run: `pnpm --filter create-dawn-app test`
+
+Expected: All 4 tests pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/create-dawn-app/test/create-app.test.ts
+git commit -m "test(create-dawn-app): update assertions from langgraph to langchain"
+```
+
+---
+
+### Task 8: Verify full test suite passes
+
+**Files:** None (verification only)
+
+- [ ] **Step 1: Run the full monorepo test suite**
+
+Run: `pnpm test`
+
+Expected: All packages pass. The CLI tests use inline `workflow` fixtures (not the template) so should be unaffected.
+
+- [ ] **Step 2: Run typecheck**
+
+Run: `pnpm typecheck`
+
+Expected: No type errors. The template files are not part of the monorepo typecheck (they lack a resolvable `node_modules`), but the `create-dawn-app` source and tests should pass.
+
+- [ ] **Step 3: If failures occur, fix them and commit the fixes**
+
+---
+
+## Notes for Implementer
+
+- **Named export `chain`**: Dawn discovers routes by looking for named exports (`chain`, `graph`, or `workflow`). Use `export const chain = ...`, NOT a default export.
+- **Tools are self-contained in chain routes**: For `chain` kind, the runtime calls `entry.invoke(input)` without passing tools. The chain must import and bind its own tools at module level.
+- **`dawnLanggraphSpecifier` kept in create-dawn-app**: The spec says to keep the replacement logic for future langgraph template use. Don't remove it from `createTemplateReplacements` — only remove the `@dawn-ai/langgraph` line from the `package.json.template`.
+- **`@langchain/openai` version**: Use `0.6.17` (latest 0.x, requires `@langchain/core >=0.3.68 <0.4.0`). Use `@langchain/core@0.3.80` (latest 0.3.x). These are pinned in the template, not dist-tag-driven, since they're third-party.
+- **No `AgentExecutor`**: The template exports `prompt.pipe(model.bindTools(tools))`. Dawn's chain adapter calls `invoke()` on this chain directly.

--- a/docs/superpowers/specs/2026-04-30-langchain-starter-template-design.md
+++ b/docs/superpowers/specs/2026-04-30-langchain-starter-template-design.md
@@ -1,0 +1,123 @@
+# LangChain Starter Template Design
+
+## Goal
+
+Replace the default `create-dawn-app` template with a working LangChain chain implementation that serves as a genuine starting point for developers building with Dawn and LangChain.
+
+## Context
+
+The current `app-basic` template exports a LangGraph `workflow` function with a greet tool. Dawn now has a mature `@dawn-ai/langchain` adapter supporting `chain` route kind with LCEL runnables, Dawn-owned tool conversion, and a ReAct tool execution loop. The template should showcase this path.
+
+Future templates for LangGraph and Deep Agents will follow. When they arrive, this template becomes `app-langchain` and the default becomes configurable. For now, it remains `app-basic`.
+
+## Route Structure
+
+```
+src/app/(public)/hello/[tenant]/
+  index.ts           — exports LCEL chain (route entry, kind: chain)
+  state.ts           — defines HelloInput and HelloOutput types
+  tools/greet.ts     — tool that looks up tenant info
+```
+
+### `state.ts`
+
+Defines structured input and output types for the chain:
+
+```ts
+export interface HelloInput {
+  readonly tenant: string
+  readonly message: string
+}
+
+export interface HelloOutput {
+  readonly response: string
+}
+```
+
+### `index.ts`
+
+Builds and exports an LCEL chain as the default export:
+
+1. Creates a `ChatOpenAI` instance (uses `OPENAI_API_KEY` from environment)
+2. Builds a `ChatPromptTemplate` with a system message establishing the assistant's role for the given tenant, and a human message placeholder
+3. Converts Dawn-discovered tools to LangChain tools via `convertTools()` from `@dawn-ai/langchain`
+4. Binds tools to the model
+5. Composes the chain: prompt → model-with-tools
+6. Exports the chain as default
+
+The chain adapter in `@dawn-ai/langchain` handles tool execution via Dawn's built-in tool loop — the template does not need to wire up `AgentExecutor` or manual tool calling.
+
+### `tools/greet.ts`
+
+A simple tool that returns tenant-specific information. Keeps the same default-export-function pattern Dawn uses for filesystem tool discovery:
+
+```ts
+/**
+ * Look up information about a tenant.
+ * @param tenant - The tenant identifier to look up
+ */
+export default async (input: { readonly tenant: string }) => {
+  return {
+    name: input.tenant,
+    greeting: `Welcome, ${input.tenant}!`,
+    plan: "starter",
+  }
+}
+```
+
+The tool has a real-ish shape (returns structured data beyond just a greeting) so developers can see where to plug in actual data sources.
+
+## Package Dependencies
+
+### Template `package.json.template` changes
+
+**Remove:**
+- `@dawn-ai/langgraph`
+
+**Add:**
+- `@dawn-ai/langchain`
+- `@langchain/openai`
+- `@langchain/core`
+
+**Keep:**
+- `@dawn-ai/core`
+- `@dawn-ai/cli`
+- `@dawn-ai/sdk`
+- `@dawn-ai/config-typescript` (devDependency)
+
+### Template replacement variables
+
+Add `dawnLangchainSpecifier` (already exists in `create-dawn-app/src/index.ts`).
+Remove `dawnLanggraphSpecifier` from the template (keep the replacement logic in create-dawn-app for future langgraph template use).
+
+Add `langchainOpenaiSpecifier` and `langchainCoreSpecifier` for pinned LangChain versions in external mode.
+
+## create-dawn-app Changes
+
+- Update `package.json.template` with new dependency list
+- Add LangChain version specifiers to the replacement map (pinned versions for external mode, `workspace:*` not applicable since these are third-party)
+- Internal mode: `@dawn-ai/langchain` uses file specifier like other Dawn packages; `@langchain/openai` and `@langchain/core` use published versions
+
+## Test Updates
+
+Existing tests in `packages/create-dawn-app/test/create-app.test.ts` assert on specific dependency names. These need updating:
+
+- Replace `@dawn-ai/langgraph` assertions with `@dawn-ai/langchain`
+- Add assertions for `@langchain/openai` and `@langchain/core` in dependencies
+- Update fixture expectations in `test/generated/fixtures/`
+
+Existing tests in `packages/cli/test/` that use the generated app fixture (`test/generated/fixtures/handwritten-runtime-app/`) need updating to use chain route kind instead of workflow.
+
+The `test/generated/fixtures/basic.expected.json` and `custom-app-dir.expected.json` route discovery fixtures should not need changes — they test route discovery, not route kind.
+
+## Dawn Generated Types
+
+The `.dawn/dawn.generated.d.ts` file in the template needs regeneration since the route structure changes (new tool parameter shape).
+
+## What This Does NOT Change
+
+- Route discovery mechanics (filesystem convention unchanged)
+- CLI commands (`verify`, `check`, `routes`, `typegen`, `run`, `dev`, `test`)
+- The `@dawn-ai/langchain` adapter itself (no changes needed)
+- The `@dawn-ai/sdk` contract
+- The `dawn.config.ts` format

--- a/packages/create-dawn-app/src/index.ts
+++ b/packages/create-dawn-app/src/index.ts
@@ -181,6 +181,8 @@ function createTemplateReplacements(
   readonly dawnLangchainSpecifier: string
   readonly dawnLanggraphSpecifier: string
   readonly dawnSdkSpecifier: string
+  readonly langchainCoreSpecifier: string
+  readonly langchainOpenaiSpecifier: string
 } {
   if (options.mode === "internal") {
     return {
@@ -193,6 +195,8 @@ function createTemplateReplacements(
       dawnLangchainSpecifier: createAbsoluteFileSpecifier(resolve(repoRoot, "packages/langchain")),
       dawnLanggraphSpecifier: createAbsoluteFileSpecifier(resolve(repoRoot, "packages/langgraph")),
       dawnSdkSpecifier: createAbsoluteFileSpecifier(resolve(repoRoot, "packages/sdk")),
+      langchainCoreSpecifier: "0.3.80",
+      langchainOpenaiSpecifier: "0.6.17",
     }
   }
 
@@ -204,6 +208,8 @@ function createTemplateReplacements(
     dawnLangchainSpecifier: options.distTag,
     dawnLanggraphSpecifier: options.distTag,
     dawnSdkSpecifier: options.distTag,
+    langchainCoreSpecifier: "0.3.80",
+    langchainOpenaiSpecifier: "0.6.17",
   }
 }
 

--- a/packages/create-dawn-app/src/index.ts
+++ b/packages/create-dawn-app/src/index.ts
@@ -234,7 +234,6 @@ async function applyInternalModePackageOverrides(
       "@dawn-ai/config-typescript": replacements.dawnConfigTypescriptSpecifier,
       "@dawn-ai/core": replacements.dawnCoreSpecifier,
       "@dawn-ai/langchain": replacements.dawnLangchainSpecifier,
-      "@dawn-ai/langgraph": replacements.dawnLanggraphSpecifier,
       "@dawn-ai/sdk": replacements.dawnSdkSpecifier,
     },
   }

--- a/packages/create-dawn-app/test/create-app.test.ts
+++ b/packages/create-dawn-app/test/create-app.test.ts
@@ -94,11 +94,13 @@ describe("create-dawn-app", () => {
     expect(packageJson.scripts.typecheck).toBe("tsc --noEmit")
     expect(packageJson.dependencies["@dawn-ai/core"]).not.toMatch(/^file:/)
     expect(packageJson.dependencies["@dawn-ai/cli"]).not.toMatch(/^file:/)
-    expect(packageJson.dependencies["@dawn-ai/langgraph"]).not.toMatch(/^file:/)
+    expect(packageJson.dependencies["@dawn-ai/langchain"]).not.toMatch(/^file:/)
     expect(packageJson.devDependencies["@dawn-ai/config-typescript"]).not.toMatch(/^file:/)
     expect(packageJson.dependencies["@dawn-ai/core"]).toBe("next")
     expect(packageJson.dependencies["@dawn-ai/cli"]).toBe("next")
-    expect(packageJson.dependencies["@dawn-ai/langgraph"]).toBe("next")
+    expect(packageJson.dependencies["@dawn-ai/langchain"]).toBe("next")
+    expect(packageJson.dependencies["@langchain/openai"]).toBe("0.6.17")
+    expect(packageJson.dependencies["@langchain/core"]).toBe("0.3.80")
     expect(packageJson.devDependencies["@dawn-ai/config-typescript"]).toBe("next")
     await expect(access(join(targetDir, ".npmrc"), constants.F_OK)).rejects.toThrow()
   })
@@ -141,7 +143,9 @@ describe("create-dawn-app", () => {
     expect(packageJson.scripts.build).toBe("tsc -p tsconfig.json")
     expect(packageJson.dependencies["@dawn-ai/core"]).toMatch(/^file:/)
     expect(packageJson.dependencies["@dawn-ai/cli"]).toMatch(/^file:/)
-    expect(packageJson.dependencies["@dawn-ai/langgraph"]).toMatch(/^file:/)
+    expect(packageJson.dependencies["@dawn-ai/langchain"]).toMatch(/^file:/)
+    expect(packageJson.dependencies["@langchain/openai"]).toBe("0.6.17")
+    expect(packageJson.dependencies["@langchain/core"]).toBe("0.3.80")
     expect(packageJson.devDependencies["@dawn-ai/config-typescript"]).toMatch(/^file:/)
     await assertExists(join(targetDir, "src/app/(public)/hello/[tenant]/index.ts"))
     await assertExists(join(targetDir, "src/app/(public)/hello/[tenant]/state.ts"))
@@ -172,9 +176,11 @@ describe("create-dawn-app", () => {
     expect(resolveFileSpecifier(packageJson.dependencies["@dawn-ai/cli"])).toBe(
       resolve(repoRoot, "packages/cli"),
     )
-    expect(resolveFileSpecifier(packageJson.dependencies["@dawn-ai/langgraph"])).toBe(
-      resolve(repoRoot, "packages/langgraph"),
+    expect(resolveFileSpecifier(packageJson.dependencies["@dawn-ai/langchain"])).toBe(
+      resolve(repoRoot, "packages/langchain"),
     )
+    expect(packageJson.dependencies["@langchain/openai"]).toBe("0.6.17")
+    expect(packageJson.dependencies["@langchain/core"]).toBe("0.3.80")
     expect(resolveFileSpecifier(packageJson.devDependencies["@dawn-ai/config-typescript"])).toBe(
       resolve(repoRoot, "packages/config-typescript"),
     )
@@ -184,8 +190,8 @@ describe("create-dawn-app", () => {
     expect(resolveFileSpecifier(packageJson.pnpm?.overrides?.["@dawn-ai/cli"] ?? "")).toBe(
       resolve(repoRoot, "packages/cli"),
     )
-    expect(resolveFileSpecifier(packageJson.pnpm?.overrides?.["@dawn-ai/langgraph"] ?? "")).toBe(
-      resolve(repoRoot, "packages/langgraph"),
+    expect(resolveFileSpecifier(packageJson.pnpm?.overrides?.["@dawn-ai/langchain"] ?? "")).toBe(
+      resolve(repoRoot, "packages/langchain"),
     )
     expect(
       resolveFileSpecifier(packageJson.pnpm?.overrides?.["@dawn-ai/config-typescript"] ?? ""),

--- a/packages/devkit/src/testing/generated-app.ts
+++ b/packages/devkit/src/testing/generated-app.ts
@@ -9,7 +9,10 @@ export interface GeneratedAppSpecifiers {
   readonly dawnCli: string
   readonly dawnConfigTypescript: string
   readonly dawnCore: string
-  readonly dawnLanggraph: string
+  readonly dawnLangchain: string
+  readonly dawnSdk: string
+  readonly langchainCore: string
+  readonly langchainOpenai: string
 }
 
 export interface CreateGeneratedAppOptions {
@@ -44,7 +47,10 @@ export async function createGeneratedApp(
       dawnCliSpecifier: specifiers.dawnCli,
       dawnConfigTypescriptSpecifier: specifiers.dawnConfigTypescript,
       dawnCoreSpecifier: specifiers.dawnCore,
-      dawnLanggraphSpecifier: specifiers.dawnLanggraph,
+      dawnLangchainSpecifier: specifiers.dawnLangchain,
+      dawnSdkSpecifier: specifiers.dawnSdk,
+      langchainCoreSpecifier: specifiers.langchainCore,
+      langchainOpenaiSpecifier: specifiers.langchainOpenai,
     },
     targetDir: appRoot,
     templateDir,
@@ -67,6 +73,9 @@ function normalizeSpecifiers(
     dawnCli: specifiers?.dawnCli ?? "workspace:*",
     dawnConfigTypescript: specifiers?.dawnConfigTypescript ?? "workspace:*",
     dawnCore: specifiers?.dawnCore ?? "workspace:*",
-    dawnLanggraph: specifiers?.dawnLanggraph ?? "workspace:*",
+    dawnLangchain: specifiers?.dawnLangchain ?? "workspace:*",
+    dawnSdk: specifiers?.dawnSdk ?? "workspace:*",
+    langchainCore: specifiers?.langchainCore ?? "0.3.80",
+    langchainOpenai: specifiers?.langchainOpenai ?? "0.6.17",
   }
 }

--- a/packages/devkit/templates/app-basic/.dawn/dawn.generated.d.ts
+++ b/packages/devkit/templates/app-basic/.dawn/dawn.generated.d.ts
@@ -7,7 +7,7 @@ declare module "dawn:routes" {
 
   export interface DawnRouteTools {
     "/hello/[tenant]": {
-      readonly greet: (input: { readonly tenant: string; }) => Promise<{ greeting: string; }>;
+      readonly greet: (input: { readonly tenant: string; }) => Promise<{ name: string; greeting: string; plan: string; }>;
     };
   }
 

--- a/packages/devkit/templates/app-basic/package.json.template
+++ b/packages/devkit/templates/app-basic/package.json.template
@@ -10,8 +10,10 @@
   "dependencies": {
     "@dawn-ai/core": "{{dawnCoreSpecifier}}",
     "@dawn-ai/cli": "{{dawnCliSpecifier}}",
-    "@dawn-ai/langgraph": "{{dawnLanggraphSpecifier}}",
-    "@dawn-ai/sdk": "{{dawnSdkSpecifier}}"
+    "@dawn-ai/langchain": "{{dawnLangchainSpecifier}}",
+    "@dawn-ai/sdk": "{{dawnSdkSpecifier}}",
+    "@langchain/core": "{{langchainCoreSpecifier}}",
+    "@langchain/openai": "{{langchainOpenaiSpecifier}}"
   },
   "devDependencies": {
     "@dawn-ai/config-typescript": "{{dawnConfigTypescriptSpecifier}}",

--- a/packages/devkit/templates/app-basic/src/app/(public)/hello/[tenant]/index.ts
+++ b/packages/devkit/templates/app-basic/src/app/(public)/hello/[tenant]/index.ts
@@ -1,16 +1,26 @@
-import type { RuntimeContext } from "@dawn-ai/sdk"
-import type { RouteTools } from "dawn:routes"
+import { ChatPromptTemplate } from "@langchain/core/prompts"
+import { ChatOpenAI } from "@langchain/openai"
+import { convertToolToLangChain } from "@dawn-ai/langchain"
 
-import type { HelloState } from "./state.js"
+import greet from "./tools/greet.js"
 
-export async function workflow(
-  state: HelloState,
-  context: RuntimeContext<RouteTools<"/hello/[tenant]">>,
-): Promise<HelloState> {
-  const result = await context.tools.greet({ tenant: state.tenant })
+const model = new ChatOpenAI({
+  modelName: "gpt-4o-mini",
+  temperature: 0,
+})
 
-  return {
-    ...state,
-    greeting: result.greeting,
-  }
-}
+const prompt = ChatPromptTemplate.fromMessages([
+  [
+    "system",
+    "You are a helpful assistant for the {tenant} organization. Use the available tools to look up tenant information before responding.",
+  ],
+  ["human", "{message}"],
+])
+
+const greetTool = convertToolToLangChain({
+  name: "greet",
+  description: "Look up information about a tenant",
+  run: greet,
+})
+
+export const chain = prompt.pipe(model.bindTools([greetTool]))

--- a/packages/devkit/templates/app-basic/src/app/(public)/hello/[tenant]/state.ts
+++ b/packages/devkit/templates/app-basic/src/app/(public)/hello/[tenant]/state.ts
@@ -1,4 +1,8 @@
-export interface HelloState {
-  readonly tenant: string;
-  readonly greeting?: string;
+export interface HelloInput {
+  readonly tenant: string
+  readonly message: string
+}
+
+export interface HelloOutput {
+  readonly response: string
 }

--- a/packages/devkit/templates/app-basic/src/app/(public)/hello/[tenant]/tools/greet.ts
+++ b/packages/devkit/templates/app-basic/src/app/(public)/hello/[tenant]/tools/greet.ts
@@ -1,3 +1,11 @@
+/**
+ * Look up information about a tenant.
+ * @param tenant - The tenant identifier to look up
+ */
 export default async (input: { readonly tenant: string }) => {
-  return { greeting: `Hello, ${input.tenant}!` }
+  return {
+    name: input.tenant,
+    greeting: `Welcome, ${input.tenant}!`,
+    plan: "starter",
+  }
 }

--- a/packages/devkit/test/generated-app.test.ts
+++ b/packages/devkit/test/generated-app.test.ts
@@ -34,7 +34,7 @@ describe("generated app helper", () => {
       expect(packageJson).toContain('"name": "sample-generated-app"')
       expect(packageJson).toContain('"@dawn-ai/cli": "workspace:*"')
       expect(packageJson).toContain('"@dawn-ai/core": "workspace:*"')
-      expect(packageJson).toContain('"@dawn-ai/langgraph": "workspace:*"')
+      expect(packageJson).toContain('"@dawn-ai/langchain": "workspace:*"')
       expect(packageJson).toContain('"@dawn-ai/config-typescript": "workspace:*"')
     } finally {
       await rm(baseDir, { force: true, recursive: true })

--- a/test/generated/fixtures/basic.expected.json
+++ b/test/generated/fixtures/basic.expected.json
@@ -11,8 +11,10 @@
     "dependencies": {
       "@dawn-ai/core": "<tarball:@dawn-ai/core>",
       "@dawn-ai/cli": "<tarball:@dawn-ai/cli>",
-      "@dawn-ai/langgraph": "<tarball:@dawn-ai/langgraph>",
-      "@dawn-ai/sdk": "<tarball:@dawn-ai/sdk>"
+      "@dawn-ai/langchain": "<tarball:@dawn-ai/langchain>",
+      "@dawn-ai/sdk": "<tarball:@dawn-ai/sdk>",
+      "@langchain/core": "0.3.80",
+      "@langchain/openai": "0.6.17"
     },
     "devDependencies": {
       "@dawn-ai/config-typescript": "<tarball:@dawn-ai/config-typescript>",
@@ -25,7 +27,6 @@
         "@dawn-ai/config-typescript": "<tarball:@dawn-ai/config-typescript>",
         "@dawn-ai/core": "<tarball:@dawn-ai/core>",
         "@dawn-ai/langchain": "<tarball:@dawn-ai/langchain>",
-        "@dawn-ai/langgraph": "<tarball:@dawn-ai/langgraph>",
         "@dawn-ai/sdk": "<tarball:@dawn-ai/sdk>"
       }
     }
@@ -48,7 +49,7 @@
       },
       {
         "name": "typegen",
-        "renderedBytes": 405,
+        "renderedBytes": 433,
         "status": "passed"
       }
     ],
@@ -65,7 +66,7 @@
       {
         "id": "/hello/[tenant]",
         "pathname": "/hello/[tenant]",
-        "kind": "workflow",
+        "kind": "chain",
         "entryFile": "<app-root>/src/app/(public)/hello/[tenant]/index.ts",
         "routeDir": "<app-root>/src/app/(public)/hello/[tenant]",
         "segments": [
@@ -82,5 +83,5 @@
       }
     ]
   },
-  "typegenOutput": "declare module \"dawn:routes\" {\n  export type DawnRoutePath = \"/hello/[tenant]\";\n\n  export interface DawnRouteParams {\n  \"/hello/[tenant]\": { tenant: string };\n  }\n\n  export interface DawnRouteTools {\n    \"/hello/[tenant]\": {\n      readonly greet: (input: { readonly tenant: string; }) => Promise<{ greeting: string; }>;\n    };\n  }\n\n  export type RouteTools<P extends DawnRoutePath> = DawnRouteTools[P];\n}\n"
+  "typegenOutput": "declare module \"dawn:routes\" {\n  export type DawnRoutePath = \"/hello/[tenant]\";\n\n  export interface DawnRouteParams {\n  \"/hello/[tenant]\": { tenant: string };\n  }\n\n  export interface DawnRouteTools {\n    \"/hello/[tenant]\": {\n      readonly greet: (input: { readonly tenant: string; }) => Promise<{ name: string; greeting: string; plan: string; }>;\n    };\n  }\n\n  export type RouteTools<P extends DawnRoutePath> = DawnRouteTools[P];\n}\n"
 }

--- a/test/generated/fixtures/custom-app-dir.expected.json
+++ b/test/generated/fixtures/custom-app-dir.expected.json
@@ -11,8 +11,10 @@
     "dependencies": {
       "@dawn-ai/core": "<tarball:@dawn-ai/core>",
       "@dawn-ai/cli": "<tarball:@dawn-ai/cli>",
-      "@dawn-ai/langgraph": "<tarball:@dawn-ai/langgraph>",
-      "@dawn-ai/sdk": "<tarball:@dawn-ai/sdk>"
+      "@dawn-ai/langchain": "<tarball:@dawn-ai/langchain>",
+      "@dawn-ai/sdk": "<tarball:@dawn-ai/sdk>",
+      "@langchain/core": "0.3.80",
+      "@langchain/openai": "0.6.17"
     },
     "devDependencies": {
       "@dawn-ai/config-typescript": "<tarball:@dawn-ai/config-typescript>",
@@ -25,7 +27,6 @@
         "@dawn-ai/config-typescript": "<tarball:@dawn-ai/config-typescript>",
         "@dawn-ai/core": "<tarball:@dawn-ai/core>",
         "@dawn-ai/langchain": "<tarball:@dawn-ai/langchain>",
-        "@dawn-ai/langgraph": "<tarball:@dawn-ai/langgraph>",
         "@dawn-ai/sdk": "<tarball:@dawn-ai/sdk>"
       }
     }

--- a/test/generated/run-generated-app.test.ts
+++ b/test/generated/run-generated-app.test.ts
@@ -272,7 +272,7 @@ async function rewriteDependenciesToTarballs(options: {
     ...packageJson.dependencies,
     "@dawn-ai/cli": options.tarballs.cli,
     "@dawn-ai/core": options.tarballs.core,
-    "@dawn-ai/langgraph": options.tarballs.langgraph,
+    "@dawn-ai/langchain": options.tarballs.langchain,
     "@dawn-ai/sdk": options.tarballs.sdk,
   }
   packageJson.devDependencies = {
@@ -287,7 +287,6 @@ async function rewriteDependenciesToTarballs(options: {
       "@dawn-ai/config-typescript": options.tarballs.configTypescript,
       "@dawn-ai/core": options.tarballs.core,
       "@dawn-ai/langchain": options.tarballs.langchain,
-      "@dawn-ai/langgraph": options.tarballs.langgraph,
       "@dawn-ai/sdk": options.tarballs.sdk,
     },
   }
@@ -479,7 +478,7 @@ async function createExpectedInternalFixture(
         ...expected.packageJson.dependencies,
         "@dawn-ai/cli": "<repo:@dawn-ai/cli>",
         "@dawn-ai/core": "<repo:@dawn-ai/core>",
-        "@dawn-ai/langgraph": "<repo:@dawn-ai/langgraph>",
+        "@dawn-ai/langchain": "<repo:@dawn-ai/langchain>",
         "@dawn-ai/sdk": "<repo:@dawn-ai/sdk>",
       },
       devDependencies: {
@@ -492,7 +491,6 @@ async function createExpectedInternalFixture(
           "@dawn-ai/config-typescript": "<repo:@dawn-ai/config-typescript>",
           "@dawn-ai/core": "<repo:@dawn-ai/core>",
           "@dawn-ai/langchain": "<repo:@dawn-ai/langchain>",
-          "@dawn-ai/langgraph": "<repo:@dawn-ai/langgraph>",
           "@dawn-ai/sdk": "<repo:@dawn-ai/sdk>",
         },
       },


### PR DESCRIPTION
## Summary

- Replace the `app-basic` template's `workflow` export with an LCEL `chain` export using `ChatOpenAI`, `ChatPromptTemplate`, and Dawn tool conversion
- Swap `@dawn-ai/langgraph` dependency for `@dawn-ai/langchain` + `@langchain/openai@0.6.17` + `@langchain/core@0.3.80`
- Update `create-dawn-app` replacement logic with new `langchainCoreSpecifier` and `langchainOpenaiSpecifier` template variables
- Update all test assertions, fixtures, and devkit `GeneratedAppSpecifiers` for the new template shape

## Test plan
- [x] All 135 unit tests pass (`pnpm test`)
- [x] Typecheck clean across all 10 packages (`pnpm typecheck`)
- [x] `create-dawn-app` external mode scaffolds with correct pinned versions
- [x] `create-dawn-app` internal mode scaffolds with file specifiers
- [x] Contributor-local package specifier assertions updated
- [ ] CI green
