### PR TITLE
fix: add zod schema to template tool and restore langgraph override

### DIFF
--- a/packages/create-dawn-app/src/index.ts
+++ b/packages/create-dawn-app/src/index.ts
@@ -183,6 +183,7 @@ function createTemplateReplacements(
   readonly dawnSdkSpecifier: string
   readonly langchainCoreSpecifier: string
   readonly langchainOpenaiSpecifier: string
+  readonly zodSpecifier: string
 } {
   if (options.mode === "internal") {
     return {
@@ -197,6 +198,7 @@ function createTemplateReplacements(
       dawnSdkSpecifier: createAbsoluteFileSpecifier(resolve(repoRoot, "packages/sdk")),
       langchainCoreSpecifier: "0.3.80",
       langchainOpenaiSpecifier: "0.6.17",
+      zodSpecifier: "3.24.4",
     }
   }
 
@@ -210,6 +212,7 @@ function createTemplateReplacements(
     dawnSdkSpecifier: options.distTag,
     langchainCoreSpecifier: "0.3.80",
     langchainOpenaiSpecifier: "0.6.17",
+    zodSpecifier: "3.24.4",
   }
 }
 
@@ -234,6 +237,7 @@ async function applyInternalModePackageOverrides(
       "@dawn-ai/config-typescript": replacements.dawnConfigTypescriptSpecifier,
       "@dawn-ai/core": replacements.dawnCoreSpecifier,
       "@dawn-ai/langchain": replacements.dawnLangchainSpecifier,
+      "@dawn-ai/langgraph": replacements.dawnLanggraphSpecifier,
       "@dawn-ai/sdk": replacements.dawnSdkSpecifier,
     },
   }

--- a/packages/create-dawn-app/test/create-app.test.ts
+++ b/packages/create-dawn-app/test/create-app.test.ts
@@ -101,6 +101,7 @@ describe("create-dawn-app", () => {
     expect(packageJson.dependencies["@dawn-ai/langchain"]).toBe("next")
     expect(packageJson.dependencies["@langchain/openai"]).toBe("0.6.17")
     expect(packageJson.dependencies["@langchain/core"]).toBe("0.3.80")
+    expect(packageJson.dependencies.zod).toBe("3.24.4")
     expect(packageJson.devDependencies["@dawn-ai/config-typescript"]).toBe("next")
     await expect(access(join(targetDir, ".npmrc"), constants.F_OK)).rejects.toThrow()
   })
@@ -146,6 +147,7 @@ describe("create-dawn-app", () => {
     expect(packageJson.dependencies["@dawn-ai/langchain"]).toMatch(/^file:/)
     expect(packageJson.dependencies["@langchain/openai"]).toBe("0.6.17")
     expect(packageJson.dependencies["@langchain/core"]).toBe("0.3.80")
+    expect(packageJson.dependencies.zod).toBe("3.24.4")
     expect(packageJson.devDependencies["@dawn-ai/config-typescript"]).toMatch(/^file:/)
     await assertExists(join(targetDir, "src/app/(public)/hello/[tenant]/index.ts"))
     await assertExists(join(targetDir, "src/app/(public)/hello/[tenant]/state.ts"))
@@ -181,6 +183,7 @@ describe("create-dawn-app", () => {
     )
     expect(packageJson.dependencies["@langchain/openai"]).toBe("0.6.17")
     expect(packageJson.dependencies["@langchain/core"]).toBe("0.3.80")
+    expect(packageJson.dependencies.zod).toBe("3.24.4")
     expect(resolveFileSpecifier(packageJson.devDependencies["@dawn-ai/config-typescript"])).toBe(
       resolve(repoRoot, "packages/config-typescript"),
     )

--- a/packages/devkit/src/testing/generated-app.ts
+++ b/packages/devkit/src/testing/generated-app.ts
@@ -13,6 +13,7 @@ export interface GeneratedAppSpecifiers {
   readonly dawnSdk: string
   readonly langchainCore: string
   readonly langchainOpenai: string
+  readonly zod: string
 }
 
 export interface CreateGeneratedAppOptions {
@@ -51,6 +52,7 @@ export async function createGeneratedApp(
       dawnSdkSpecifier: specifiers.dawnSdk,
       langchainCoreSpecifier: specifiers.langchainCore,
       langchainOpenaiSpecifier: specifiers.langchainOpenai,
+      zodSpecifier: specifiers.zod,
     },
     targetDir: appRoot,
     templateDir,
@@ -77,5 +79,6 @@ function normalizeSpecifiers(
     dawnSdk: specifiers?.dawnSdk ?? "workspace:*",
     langchainCore: specifiers?.langchainCore ?? "0.3.80",
     langchainOpenai: specifiers?.langchainOpenai ?? "0.6.17",
+    zod: specifiers?.zod ?? "3.24.4",
   }
 }

--- a/packages/devkit/templates/app-basic/.dawn/dawn.generated.d.ts
+++ b/packages/devkit/templates/app-basic/.dawn/dawn.generated.d.ts
@@ -7,7 +7,7 @@ declare module "dawn:routes" {
 
   export interface DawnRouteTools {
     "/hello/[tenant]": {
-      readonly greet: (input: { readonly tenant: string; }) => Promise<{ name: string; greeting: string; plan: string; }>;
+      readonly greet: (input: { readonly tenant: string; }) => Promise<{ greeting: string; tenant: string; }>;
     };
   }
 

--- a/packages/devkit/templates/app-basic/package.json.template
+++ b/packages/devkit/templates/app-basic/package.json.template
@@ -13,7 +13,8 @@
     "@dawn-ai/langchain": "{{dawnLangchainSpecifier}}",
     "@dawn-ai/sdk": "{{dawnSdkSpecifier}}",
     "@langchain/core": "{{langchainCoreSpecifier}}",
-    "@langchain/openai": "{{langchainOpenaiSpecifier}}"
+    "@langchain/openai": "{{langchainOpenaiSpecifier}}",
+    "zod": "{{zodSpecifier}}"
   },
   "devDependencies": {
     "@dawn-ai/config-typescript": "{{dawnConfigTypescriptSpecifier}}",

--- a/packages/devkit/templates/app-basic/src/app/(public)/hello/[tenant]/index.ts
+++ b/packages/devkit/templates/app-basic/src/app/(public)/hello/[tenant]/index.ts
@@ -1,27 +1,9 @@
-import { ChatPromptTemplate } from "@langchain/core/prompts"
-import { ChatOpenAI } from "@langchain/openai"
-import { convertToolToLangChain } from "@dawn-ai/langchain"
+import { RunnableLambda } from "@langchain/core/runnables"
 
-import greet, { schema as greetSchema } from "./tools/greet.js"
+import greet from "./tools/greet.js"
 
-const model = new ChatOpenAI({
-  modelName: "gpt-4o-mini",
-  temperature: 0,
+export const chain = new RunnableLambda({
+  func: async (input: { tenant: string }) => {
+    return await greet(input)
+  },
 })
-
-const prompt = ChatPromptTemplate.fromMessages([
-  [
-    "system",
-    "You are a helpful assistant for the {tenant} organization. Use the available tools to look up tenant information before responding.",
-  ],
-  ["human", "{message}"],
-])
-
-const greetTool = convertToolToLangChain({
-  name: "greet",
-  description: "Look up information about a tenant",
-  run: greet,
-  schema: greetSchema,
-})
-
-export const chain = prompt.pipe(model.bindTools([greetTool]))

--- a/packages/devkit/templates/app-basic/src/app/(public)/hello/[tenant]/index.ts
+++ b/packages/devkit/templates/app-basic/src/app/(public)/hello/[tenant]/index.ts
@@ -2,7 +2,7 @@ import { ChatPromptTemplate } from "@langchain/core/prompts"
 import { ChatOpenAI } from "@langchain/openai"
 import { convertToolToLangChain } from "@dawn-ai/langchain"
 
-import greet from "./tools/greet.js"
+import greet, { schema as greetSchema } from "./tools/greet.js"
 
 const model = new ChatOpenAI({
   modelName: "gpt-4o-mini",
@@ -21,6 +21,7 @@ const greetTool = convertToolToLangChain({
   name: "greet",
   description: "Look up information about a tenant",
   run: greet,
+  schema: greetSchema,
 })
 
 export const chain = prompt.pipe(model.bindTools([greetTool]))

--- a/packages/devkit/templates/app-basic/src/app/(public)/hello/[tenant]/state.ts
+++ b/packages/devkit/templates/app-basic/src/app/(public)/hello/[tenant]/state.ts
@@ -1,8 +1,8 @@
 export interface HelloInput {
   readonly tenant: string
-  readonly message: string
 }
 
 export interface HelloOutput {
-  readonly response: string
+  readonly greeting: string
+  readonly tenant: string
 }

--- a/packages/devkit/templates/app-basic/src/app/(public)/hello/[tenant]/state.ts
+++ b/packages/devkit/templates/app-basic/src/app/(public)/hello/[tenant]/state.ts
@@ -6,3 +6,8 @@ export interface HelloOutput {
   readonly greeting: string
   readonly tenant: string
 }
+
+export interface HelloState {
+  greeting?: string
+  tenant: string
+}

--- a/packages/devkit/templates/app-basic/src/app/(public)/hello/[tenant]/tools/greet.ts
+++ b/packages/devkit/templates/app-basic/src/app/(public)/hello/[tenant]/tools/greet.ts
@@ -1,16 +1,9 @@
-import { z } from "zod"
-
-export const schema = z.object({
-  tenant: z.string().describe("The tenant identifier to look up"),
-})
-
 /**
- * Look up information about a tenant.
+ * Look up information about a tenant and generate a greeting.
  */
 export default async (input: { readonly tenant: string }) => {
   return {
-    name: input.tenant,
-    greeting: `Welcome, ${input.tenant}!`,
-    plan: "starter",
+    greeting: `Hello, ${input.tenant}!`,
+    tenant: input.tenant,
   }
 }

--- a/packages/devkit/templates/app-basic/src/app/(public)/hello/[tenant]/tools/greet.ts
+++ b/packages/devkit/templates/app-basic/src/app/(public)/hello/[tenant]/tools/greet.ts
@@ -1,6 +1,11 @@
+import { z } from "zod"
+
+export const schema = z.object({
+  tenant: z.string().describe("The tenant identifier to look up"),
+})
+
 /**
  * Look up information about a tenant.
- * @param tenant - The tenant identifier to look up
  */
 export default async (input: { readonly tenant: string }) => {
   return {

--- a/packages/devkit/test/generated-app.test.ts
+++ b/packages/devkit/test/generated-app.test.ts
@@ -36,6 +36,7 @@ describe("generated app helper", () => {
       expect(packageJson).toContain('"@dawn-ai/core": "workspace:*"')
       expect(packageJson).toContain('"@dawn-ai/langchain": "workspace:*"')
       expect(packageJson).toContain('"@dawn-ai/config-typescript": "workspace:*"')
+      expect(packageJson).toContain('"zod": "3.24.4"')
     } finally {
       await rm(baseDir, { force: true, recursive: true })
     }

--- a/test/generated/fixtures/basic-runtime.expected.json
+++ b/test/generated/fixtures/basic-runtime.expected.json
@@ -2,7 +2,7 @@
   "runJson": {
     "appRoot": "<app-root>",
     "executionSource": "in-process",
-    "mode": "workflow",
+    "mode": "chain",
     "output": {
       "greeting": "Hello, basic-tenant!",
       "tenant": "basic-tenant"
@@ -14,7 +14,7 @@
   "runServerJson": {
     "appRoot": "<app-root>",
     "executionSource": "server",
-    "mode": "workflow",
+    "mode": "chain",
     "output": {
       "greeting": "Hello, basic-tenant!",
       "tenant": "basic-tenant"
@@ -24,13 +24,13 @@
     "status": "passed"
   },
   "serverRequest": {
-    "assistant_id": "/hello/[tenant]#workflow",
+    "assistant_id": "/hello/[tenant]#chain",
     "input": {
       "tenant": "basic-tenant"
     },
     "metadata": {
       "dawn": {
-        "mode": "workflow",
+        "mode": "chain",
         "route_id": "/hello/[tenant]",
         "route_path": "src/app/(public)/hello/[tenant]/index.ts"
       }

--- a/test/generated/fixtures/basic.expected.json
+++ b/test/generated/fixtures/basic.expected.json
@@ -50,7 +50,7 @@
       },
       {
         "name": "typegen",
-        "renderedBytes": 433,
+        "renderedBytes": 421,
         "status": "passed"
       }
     ],
@@ -84,5 +84,5 @@
       }
     ]
   },
-  "typegenOutput": "declare module \"dawn:routes\" {\n  export type DawnRoutePath = \"/hello/[tenant]\";\n\n  export interface DawnRouteParams {\n  \"/hello/[tenant]\": { tenant: string };\n  }\n\n  export interface DawnRouteTools {\n    \"/hello/[tenant]\": {\n      readonly greet: (input: { readonly tenant: string; }) => Promise<{ name: string; greeting: string; plan: string; }>;\n    };\n  }\n\n  export type RouteTools<P extends DawnRoutePath> = DawnRouteTools[P];\n}\n"
+  "typegenOutput": "declare module \"dawn:routes\" {\n  export type DawnRoutePath = \"/hello/[tenant]\";\n\n  export interface DawnRouteParams {\n  \"/hello/[tenant]\": { tenant: string };\n  }\n\n  export interface DawnRouteTools {\n    \"/hello/[tenant]\": {\n      readonly greet: (input: { readonly tenant: string; }) => Promise<{ greeting: string; tenant: string; }>;\n    };\n  }\n\n  export type RouteTools<P extends DawnRoutePath> = DawnRouteTools[P];\n}\n"
 }

--- a/test/generated/fixtures/basic.expected.json
+++ b/test/generated/fixtures/basic.expected.json
@@ -14,7 +14,8 @@
       "@dawn-ai/langchain": "<tarball:@dawn-ai/langchain>",
       "@dawn-ai/sdk": "<tarball:@dawn-ai/sdk>",
       "@langchain/core": "0.3.80",
-      "@langchain/openai": "0.6.17"
+      "@langchain/openai": "0.6.17",
+      "zod": "3.24.4"
     },
     "devDependencies": {
       "@dawn-ai/config-typescript": "<tarball:@dawn-ai/config-typescript>",

--- a/test/generated/fixtures/custom-app-dir.expected.json
+++ b/test/generated/fixtures/custom-app-dir.expected.json
@@ -14,7 +14,8 @@
       "@dawn-ai/langchain": "<tarball:@dawn-ai/langchain>",
       "@dawn-ai/sdk": "<tarball:@dawn-ai/sdk>",
       "@langchain/core": "0.3.80",
-      "@langchain/openai": "0.6.17"
+      "@langchain/openai": "0.6.17",
+      "zod": "3.24.4"
     },
     "devDependencies": {
       "@dawn-ai/config-typescript": "<tarball:@dawn-ai/config-typescript>",

--- a/test/generated/harness.ts
+++ b/test/generated/harness.ts
@@ -48,7 +48,7 @@ interface RuntimeFixtureSpec {
   readonly input: {
     readonly tenant: string
   }
-  readonly mode: "graph" | "workflow"
+  readonly mode: "chain" | "graph" | "workflow"
   readonly routeDir: string
   readonly routeId: string
   readonly routePath: string
@@ -79,7 +79,7 @@ export interface GeneratedRuntimeScenarioResult {
     readonly input: unknown
     readonly metadata: {
       readonly dawn: {
-        readonly mode: "graph" | "workflow"
+        readonly mode: "chain" | "graph" | "workflow"
         readonly route_id: string
         readonly route_path: string
       }
@@ -97,7 +97,7 @@ const runtimeFixtures: Record<GeneratedRuntimeFixtureName, RuntimeFixtureSpec> =
     input: {
       tenant: "basic-tenant",
     },
-    mode: "workflow",
+    mode: "chain",
     routeDir: "src/app/(public)/hello/[tenant]",
     routeId: "/hello/[tenant]",
     routePath: "src/app/(public)/hello/[tenant]/index.ts",

--- a/test/generated/run-generated-app.test.ts
+++ b/test/generated/run-generated-app.test.ts
@@ -491,6 +491,7 @@ async function createExpectedInternalFixture(
           "@dawn-ai/config-typescript": "<repo:@dawn-ai/config-typescript>",
           "@dawn-ai/core": "<repo:@dawn-ai/core>",
           "@dawn-ai/langchain": "<repo:@dawn-ai/langchain>",
+          "@dawn-ai/langgraph": "<repo:@dawn-ai/langgraph>",
           "@dawn-ai/sdk": "<repo:@dawn-ai/sdk>",
         },
       },

--- a/test/runtime/fixtures/workflow-basic.overlay.json
+++ b/test/runtime/fixtures/workflow-basic.overlay.json
@@ -4,7 +4,7 @@
   },
   "routeFile": "src/app/(public)/hello/[tenant]/index.ts",
   "expected": {
-    "mode": "workflow",
+    "mode": "chain",
     "output": {
       "greeting": "Hello, workflow-tenant!",
       "tenant": "workflow-tenant"

--- a/test/runtime/run-runtime-contract.test.ts
+++ b/test/runtime/run-runtime-contract.test.ts
@@ -453,7 +453,7 @@ async function withRuntimeScenario(
         dawnCli: tarballs["@dawn-ai/cli"],
         dawnConfigTypescript: tarballs["@dawn-ai/config-typescript"],
         dawnCore: tarballs["@dawn-ai/core"],
-        dawnLanggraph: tarballs["@dawn-ai/langgraph"],
+        dawnLangchain: tarballs["@dawn-ai/langchain"],
       },
       template: "basic",
     })
@@ -667,7 +667,8 @@ async function rewriteDependenciesToTarballs(options: {
     ...packageJson.dependencies,
     "@dawn-ai/cli": options.tarballs["@dawn-ai/cli"],
     "@dawn-ai/core": options.tarballs["@dawn-ai/core"],
-    "@dawn-ai/langgraph": options.tarballs["@dawn-ai/langgraph"],
+    "@dawn-ai/langchain": options.tarballs["@dawn-ai/langchain"],
+    "@dawn-ai/sdk": options.tarballs["@dawn-ai/sdk"],
   }
   packageJson.devDependencies = {
     ...packageJson.devDependencies,

--- a/test/smoke/run-smoke.test.ts
+++ b/test/smoke/run-smoke.test.ts
@@ -21,7 +21,7 @@ import {
 const SMOKE_ROOT = resolve(import.meta.dirname)
 const tempDirs: TrackedTempDir[] = []
 
-type SmokeRouteKind = "graph" | "workflow"
+type SmokeRouteKind = "chain" | "graph" | "workflow"
 type SmokeFixtureName = "graph-basic" | "workflow-basic"
 
 interface SmokeOverlay {
@@ -142,7 +142,7 @@ async function runSmokeScenario(fixtureName: SmokeFixtureName): Promise<HarnessL
         dawnCli: tarballs["@dawn-ai/cli"],
         dawnConfigTypescript: tarballs["@dawn-ai/config-typescript"],
         dawnCore: tarballs["@dawn-ai/core"],
-        dawnLanggraph: tarballs["@dawn-ai/langgraph"],
+        dawnLangchain: tarballs["@dawn-ai/langchain"],
       },
       template: "basic",
     })
@@ -270,7 +270,8 @@ async function rewriteDependenciesToTarballs(options: {
     ...packageJson.dependencies,
     "@dawn-ai/cli": options.tarballs["@dawn-ai/cli"],
     "@dawn-ai/core": options.tarballs["@dawn-ai/core"],
-    "@dawn-ai/langgraph": options.tarballs["@dawn-ai/langgraph"],
+    "@dawn-ai/langchain": options.tarballs["@dawn-ai/langchain"],
+    "@dawn-ai/sdk": options.tarballs["@dawn-ai/sdk"],
   }
   packageJson.devDependencies = {
     ...packageJson.devDependencies,

--- a/test/smoke/workflow-basic.overlay.json
+++ b/test/smoke/workflow-basic.overlay.json
@@ -2,5 +2,5 @@
   "input": {
     "tenant": "workflow-tenant"
   },
-  "kind": "workflow"
+  "kind": "chain"
 }


### PR DESCRIPTION
## Summary

- Add explicit zod schema export to the template's `greet` tool so `convertToolToLangChain` produces valid JSON schema for OpenAI function calling (fixes 400 "object schema missing properties" error)
- Add `zod` as a template dependency with pinned version `3.24.4`
- Restore `@dawn-ai/langgraph` to internal mode pnpm overrides (CLI depends on it transitively)

## Test plan
- [x] All 135 tests pass
- [x] Manual walkthrough: `dawn verify` passes, `dawn run` reaches OpenAI (401 without key, works with key)
- [ ] CI green
