### PR TITLE
feat: enrich template chain with two-step LCEL pipeline

### DIFF
--- a/packages/devkit/templates/app-basic/.dawn/dawn.generated.d.ts
+++ b/packages/devkit/templates/app-basic/.dawn/dawn.generated.d.ts
@@ -7,7 +7,7 @@ declare module "dawn:routes" {
 
   export interface DawnRouteTools {
     "/hello/[tenant]": {
-      readonly greet: (input: { readonly tenant: string; }) => Promise<{ greeting: string; tenant: string; }>;
+      readonly greet: (input: { readonly tenant: string; }) => Promise<{ name: string; plan: string; }>;
     };
   }
 

--- a/packages/devkit/templates/app-basic/src/app/(public)/hello/[tenant]/index.ts
+++ b/packages/devkit/templates/app-basic/src/app/(public)/hello/[tenant]/index.ts
@@ -2,8 +2,15 @@ import { RunnableLambda } from "@langchain/core/runnables"
 
 import greet from "./tools/greet.js"
 
-export const chain = new RunnableLambda({
-  func: async (input: { tenant: string }) => {
-    return await greet(input)
-  },
+const lookupTenant = new RunnableLambda({
+  func: async (input: { tenant: string }) => await greet(input),
 })
+
+const formatResponse = new RunnableLambda({
+  func: (info: { name: string; plan: string }) => ({
+    greeting: `Hello, ${info.name}!`,
+    tenant: info.name,
+  }),
+})
+
+export const chain = lookupTenant.pipe(formatResponse)

--- a/packages/devkit/templates/app-basic/src/app/(public)/hello/[tenant]/tools/greet.ts
+++ b/packages/devkit/templates/app-basic/src/app/(public)/hello/[tenant]/tools/greet.ts
@@ -1,9 +1,9 @@
 /**
- * Look up information about a tenant and generate a greeting.
+ * Look up information about a tenant.
  */
 export default async (input: { readonly tenant: string }) => {
   return {
-    greeting: `Hello, ${input.tenant}!`,
-    tenant: input.tenant,
+    name: input.tenant,
+    plan: "starter",
   }
 }

--- a/test/generated/fixtures/basic.expected.json
+++ b/test/generated/fixtures/basic.expected.json
@@ -50,7 +50,7 @@
       },
       {
         "name": "typegen",
-        "renderedBytes": 421,
+        "renderedBytes": 415,
         "status": "passed"
       }
     ],
@@ -84,5 +84,5 @@
       }
     ]
   },
-  "typegenOutput": "declare module \"dawn:routes\" {\n  export type DawnRoutePath = \"/hello/[tenant]\";\n\n  export interface DawnRouteParams {\n  \"/hello/[tenant]\": { tenant: string };\n  }\n\n  export interface DawnRouteTools {\n    \"/hello/[tenant]\": {\n      readonly greet: (input: { readonly tenant: string; }) => Promise<{ greeting: string; tenant: string; }>;\n    };\n  }\n\n  export type RouteTools<P extends DawnRoutePath> = DawnRouteTools[P];\n}\n"
+  "typegenOutput": "declare module \"dawn:routes\" {\n  export type DawnRoutePath = \"/hello/[tenant]\";\n\n  export interface DawnRouteParams {\n  \"/hello/[tenant]\": { tenant: string };\n  }\n\n  export interface DawnRouteTools {\n    \"/hello/[tenant]\": {\n      readonly greet: (input: { readonly tenant: string; }) => Promise<{ name: string; plan: string; }>;\n    };\n  }\n\n  export type RouteTools<P extends DawnRoutePath> = DawnRouteTools[P];\n}\n"
 }


### PR DESCRIPTION
## Summary
- Split the template chain into a `lookupTenant` step and a `formatResponse` step to demonstrate LangChain's `.pipe()` composition
- Greet tool now returns raw tenant data (`{ name, plan }`), chain formats the greeting
- All harness fixtures updated (typegen output, renderedBytes)

## Test plan
- [x] 135 unit tests pass
- [x] Framework verification harness passes
- [x] Runtime verification harness passes
- [ ] Manual scaffold + verify in `~/tmp`
