### PR TITLE
feat: add agent as fourth route kind with LangChain integration

### DIFF
--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -1,0 +1,121 @@
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises"
+import { dirname, join, relative, resolve } from "node:path"
+
+import type { Command } from "commander"
+
+import { discoverRoutes } from "@dawn-ai/core"
+import { type CommandIo, writeLine } from "../lib/output.js"
+import { discoverToolDefinitions } from "../lib/runtime/tool-discovery.js"
+
+interface BuildOptions {
+  readonly clean?: boolean
+  readonly cwd?: string
+}
+
+export function registerBuildCommand(program: Command, io: CommandIo): void {
+  program
+    .command("build")
+    .description("Generate deployment artifacts for LangGraph Platform")
+    .option("--clean", "Remove .dawn/build/ before generating")
+    .option("--cwd <path>", "Path to the Dawn app root")
+    .action(async (options: BuildOptions) => {
+      await runBuildCommand(options, io)
+    })
+}
+
+export async function runBuildCommand(options: BuildOptions, io: CommandIo): Promise<void> {
+  const manifest = await discoverRoutes({
+    ...(options.cwd ? { appRoot: options.cwd } : {}),
+  })
+
+  const buildDir = resolve(manifest.appRoot, ".dawn", "build")
+
+  if (options.clean) {
+    await rm(buildDir, { recursive: true, force: true })
+  }
+
+  await mkdir(buildDir, { recursive: true })
+
+  const graphs: Record<string, string> = {}
+
+  for (const route of manifest.routes) {
+    const tools = await discoverToolDefinitions({
+      appRoot: manifest.appRoot,
+      routeDir: route.routeDir,
+    })
+
+    const entryFileName = route.id
+      .replace(/^\//, "")
+      .replace(/\//g, "-")
+      .replace(/\[/g, "")
+      .replace(/\]/g, "")
+
+    const entryFilePath = join(buildDir, `${entryFileName}.ts`)
+    const relativeRoutePath = relative(dirname(entryFilePath), route.routeDir)
+    const routeImportPath = `${relativeRoutePath}/index.js`
+
+    let entryContent: string
+
+    if (route.kind === "agent" && tools.length > 0) {
+      const toolImports = tools.map((tool) => {
+        const relToolPath = relative(dirname(entryFilePath), dirname(tool.filePath))
+        const toolFileName = tool.filePath.split("/").pop()?.replace(/\.ts$/, ".js") ?? `${tool.name}.js`
+        return `import ${tool.name} from "${relToolPath}/${toolFileName}"`
+      })
+
+      const toolBindings = tools.map((tool) =>
+        `const ${tool.name}Tool = tool(${tool.name}, {\n  name: "${tool.name}",\n  description: "${tool.description ?? ""}",\n  schema: z.record(z.string(), z.unknown()),\n})`
+      )
+
+      const toolNames = tools.map((tool) => `${tool.name}Tool`)
+
+      entryContent = [
+        `import { agent } from "${routeImportPath}"`,
+        ...toolImports,
+        `import { tool } from "@langchain/core/tools"`,
+        `import { z } from "zod"`,
+        ``,
+        ...toolBindings,
+        ``,
+        `export const graph = agent.bindTools([${toolNames.join(", ")}])`,
+        ``,
+      ].join("\n")
+    } else {
+      const exportName = route.kind
+      entryContent = [
+        `import { ${exportName} } from "${routeImportPath}"`,
+        ``,
+        `export const graph = ${exportName}`,
+        ``,
+      ].join("\n")
+    }
+
+    await writeFile(entryFilePath, entryContent, "utf8")
+
+    const assistantId = `${route.id}#${route.kind}`
+    const relativeEntryPath = `./${relative(manifest.appRoot, entryFilePath)}`
+    graphs[assistantId] = `${relativeEntryPath}:graph`
+  }
+
+  const userLanggraphPath = resolve(manifest.appRoot, "langgraph.json")
+  let userConfig: Record<string, unknown> = {}
+
+  try {
+    const raw = await readFile(userLanggraphPath, "utf8")
+    userConfig = JSON.parse(raw) as Record<string, unknown>
+  } catch {
+    // No user langgraph.json — start with empty config
+  }
+
+  const mergedConfig = {
+    ...userConfig,
+    graphs,
+  }
+
+  const outputLanggraphPath = join(buildDir, "langgraph.json")
+  await writeFile(outputLanggraphPath, JSON.stringify(mergedConfig, null, 2) + "\n", "utf8")
+
+  writeLine(io.stdout, `Build complete: ${relative(process.cwd(), buildDir)}`)
+  writeLine(io.stdout, `  ${Object.keys(graphs).length} route(s) compiled`)
+  writeLine(io.stdout, `  langgraph.json written to ${relative(process.cwd(), outputLanggraphPath)}`)
+}

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -1,9 +1,8 @@
 import { mkdir, readFile, rm, writeFile } from "node:fs/promises"
 import { dirname, join, relative, resolve } from "node:path"
 
-import type { Command } from "commander"
-
 import { discoverRoutes } from "@dawn-ai/core"
+import type { Command } from "commander"
 import { type CommandIo, writeLine } from "../lib/output.js"
 import { discoverToolDefinitions } from "../lib/runtime/tool-discovery.js"
 
@@ -59,12 +58,14 @@ export async function runBuildCommand(options: BuildOptions, io: CommandIo): Pro
     if (route.kind === "agent" && tools.length > 0) {
       const toolImports = tools.map((tool) => {
         const relToolPath = relative(dirname(entryFilePath), dirname(tool.filePath))
-        const toolFileName = tool.filePath.split("/").pop()?.replace(/\.ts$/, ".js") ?? `${tool.name}.js`
+        const toolFileName =
+          tool.filePath.split("/").pop()?.replace(/\.ts$/, ".js") ?? `${tool.name}.js`
         return `import ${tool.name} from "${relToolPath}/${toolFileName}"`
       })
 
-      const toolBindings = tools.map((tool) =>
-        `const ${tool.name}Tool = tool(${tool.name}, {\n  name: "${tool.name}",\n  description: "${tool.description ?? ""}",\n  schema: z.record(z.string(), z.unknown()),\n})`
+      const toolBindings = tools.map(
+        (tool) =>
+          `const ${tool.name}Tool = tool(${tool.name}, {\n  name: "${tool.name}",\n  description: "${tool.description ?? ""}",\n  schema: z.record(z.string(), z.unknown()),\n})`,
       )
 
       const toolNames = tools.map((tool) => `${tool.name}Tool`)
@@ -113,9 +114,12 @@ export async function runBuildCommand(options: BuildOptions, io: CommandIo): Pro
   }
 
   const outputLanggraphPath = join(buildDir, "langgraph.json")
-  await writeFile(outputLanggraphPath, JSON.stringify(mergedConfig, null, 2) + "\n", "utf8")
+  await writeFile(outputLanggraphPath, `${JSON.stringify(mergedConfig, null, 2)}\n`, "utf8")
 
   writeLine(io.stdout, `Build complete: ${relative(process.cwd(), buildDir)}`)
   writeLine(io.stdout, `  ${Object.keys(graphs).length} route(s) compiled`)
-  writeLine(io.stdout, `  langgraph.json written to ${relative(process.cwd(), outputLanggraphPath)}`)
+  writeLine(
+    io.stdout,
+    `  langgraph.json written to ${relative(process.cwd(), outputLanggraphPath)}`,
+  )
 }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -6,6 +6,7 @@ import { fileURLToPath } from "node:url"
 
 import { Command, CommanderError } from "commander"
 
+import { registerBuildCommand } from "./commands/build.js"
 import { registerCheckCommand } from "./commands/check.js"
 import { registerDevCommand } from "./commands/dev.js"
 import { registerRoutesCommand } from "./commands/routes.js"
@@ -32,6 +33,7 @@ export function createProgram(io: CommandIo): Command {
       },
     })
 
+  registerBuildCommand(program, io)
   registerCheckCommand(program, io)
   registerDevCommand(program, io)
   registerRunCommand(program, io)

--- a/packages/cli/src/lib/dev/runtime-registry.ts
+++ b/packages/cli/src/lib/dev/runtime-registry.ts
@@ -4,7 +4,7 @@ import { createRouteAssistantId } from "../runtime/route-identity.js"
 
 export interface RuntimeRegistryEntry {
   readonly assistantId: string
-  readonly mode: "chain" | "graph" | "workflow"
+  readonly mode: "agent" | "chain" | "graph" | "workflow"
   readonly routeId: string
   readonly routePath: string
   readonly routeFile: string

--- a/packages/cli/src/lib/dev/runtime-server.ts
+++ b/packages/cli/src/lib/dev/runtime-server.ts
@@ -356,7 +356,7 @@ interface RunsWaitRequest {
   readonly input: unknown
   readonly metadata: {
     readonly dawn: {
-      readonly mode: "chain" | "graph" | "workflow"
+      readonly mode: "agent" | "chain" | "graph" | "workflow"
       readonly route_id: string
       readonly route_path: string
     }

--- a/packages/cli/src/lib/runtime/execute-route-server.ts
+++ b/packages/cli/src/lib/runtime/execute-route-server.ts
@@ -12,7 +12,7 @@ export interface ExecuteRouteServerOptions {
   readonly appRoot: string
   readonly baseUrl: string
   readonly input: unknown
-  readonly mode: "chain" | "graph" | "workflow"
+  readonly mode: "agent" | "chain" | "graph" | "workflow"
   readonly routeId: string
   readonly routePath: string
   readonly timeoutMs?: number

--- a/packages/cli/src/lib/runtime/execute-route.ts
+++ b/packages/cli/src/lib/runtime/execute-route.ts
@@ -168,7 +168,10 @@ async function invokeEntry(
     readonly tools: ReadonlyArray<{
       readonly description?: string
       readonly name: string
-      readonly run: (input: unknown, context: { readonly signal: AbortSignal }) => Promise<unknown> | unknown
+      readonly run: (
+        input: unknown,
+        context: { readonly signal: AbortSignal },
+      ) => Promise<unknown> | unknown
       readonly schema?: unknown
     }>
   },

--- a/packages/cli/src/lib/runtime/execute-route.ts
+++ b/packages/cli/src/lib/runtime/execute-route.ts
@@ -158,6 +158,18 @@ async function invokeEntry(
   input: unknown,
   context: unknown,
 ): Promise<unknown> {
+  if (kind === "agent") {
+    if (
+      typeof entry === "object" &&
+      entry !== null &&
+      "invoke" in entry &&
+      typeof (entry as { invoke?: unknown }).invoke === "function"
+    ) {
+      return await (entry as { invoke: (input: unknown) => unknown }).invoke(input)
+    }
+    throw new Error("Agent entry must expose invoke(input)")
+  }
+
   if (kind === "workflow") {
     if (typeof entry !== "function") {
       throw new Error("Workflow entry must be a function")
@@ -252,6 +264,7 @@ function isBoundaryError(error: unknown): boolean {
     /exports neither/.test(error.message) ||
     error.message === "Workflow entry must be a function" ||
     error.message === "Graph entry must be a function or expose invoke(input)" ||
-    error.message === "Chain entry must expose invoke(input)"
+    error.message === "Chain entry must expose invoke(input)" ||
+    error.message === "Agent entry must expose invoke(input)"
   )
 }

--- a/packages/cli/src/lib/runtime/execute-route.ts
+++ b/packages/cli/src/lib/runtime/execute-route.ts
@@ -153,7 +153,7 @@ async function executeRouteAtResolvedPath(options: {
 }
 
 async function invokeEntry(
-  kind: "chain" | "graph" | "workflow",
+  kind: "agent" | "chain" | "graph" | "workflow",
   entry: unknown,
   input: unknown,
   context: unknown,

--- a/packages/cli/src/lib/runtime/execute-route.ts
+++ b/packages/cli/src/lib/runtime/execute-route.ts
@@ -1,6 +1,7 @@
 import { isAbsolute, resolve } from "node:path"
 
 import { findDawnApp } from "@dawn-ai/core"
+import { executeAgent } from "@dawn-ai/langchain"
 import { createDawnContext } from "./dawn-context.js"
 import { normalizeRouteModule } from "./load-route-kind.js"
 import {
@@ -124,7 +125,11 @@ async function executeRouteAtResolvedPath(options: {
       ...(options.signal ? { signal: options.signal } : {}),
     })
 
-    const output = await invokeEntry(normalized.kind, normalized.entry, options.input, context)
+    const output = await invokeEntry(normalized.kind, normalized.entry, options.input, context, {
+      routeId: options.routeId,
+      tools,
+      ...(options.signal ? { signal: options.signal } : {}),
+    })
 
     return createRuntimeSuccessResult({
       appRoot: options.appRoot,
@@ -157,17 +162,26 @@ async function invokeEntry(
   entry: unknown,
   input: unknown,
   context: unknown,
+  agentContext?: {
+    readonly routeId: string
+    readonly signal?: AbortSignal
+    readonly tools: ReadonlyArray<{
+      readonly description?: string
+      readonly name: string
+      readonly run: (input: unknown, context: { readonly signal: AbortSignal }) => Promise<unknown> | unknown
+      readonly schema?: unknown
+    }>
+  },
 ): Promise<unknown> {
   if (kind === "agent") {
-    if (
-      typeof entry === "object" &&
-      entry !== null &&
-      "invoke" in entry &&
-      typeof (entry as { invoke?: unknown }).invoke === "function"
-    ) {
-      return await (entry as { invoke: (input: unknown) => unknown }).invoke(input)
-    }
-    throw new Error("Agent entry must expose invoke(input)")
+    const routeParamNames = extractRouteParamNames(agentContext?.routeId ?? "")
+    return await executeAgent({
+      entry,
+      input,
+      routeParamNames,
+      signal: agentContext?.signal ?? new AbortController().signal,
+      tools: agentContext?.tools ?? [],
+    })
   }
 
   if (kind === "workflow") {
@@ -254,6 +268,11 @@ async function discoverApp(options: ExecuteRouteOptions): Promise<
   }
 }
 
+function extractRouteParamNames(routeId: string): string[] {
+  const matches = routeId.matchAll(/\[(\w+)\]/g)
+  return [...matches].map((match) => match[1]).filter((s): s is string => s !== undefined)
+}
+
 function isBoundaryError(error: unknown): boolean {
   if (!(error instanceof Error)) {
     return false
@@ -264,7 +283,6 @@ function isBoundaryError(error: unknown): boolean {
     /exports neither/.test(error.message) ||
     error.message === "Workflow entry must be a function" ||
     error.message === "Graph entry must be a function or expose invoke(input)" ||
-    error.message === "Chain entry must expose invoke(input)" ||
-    error.message === "Agent entry must expose invoke(input)"
+    error.message === "Chain entry must expose invoke(input)"
   )
 }

--- a/packages/cli/src/lib/runtime/load-route-kind.ts
+++ b/packages/cli/src/lib/runtime/load-route-kind.ts
@@ -54,5 +54,7 @@ export async function normalizeRouteModule(routeFile: string): Promise<Normalize
     return { kind: "workflow", entry: routeModule.workflow, config: routeModule.config ?? {} }
   }
 
-  throw new Error(`Route index.ts at ${routeFile} exports neither "agent", "workflow", "graph", nor "chain"`)
+  throw new Error(
+    `Route index.ts at ${routeFile} exports neither "agent", "workflow", "graph", nor "chain"`,
+  )
 }

--- a/packages/cli/src/lib/runtime/load-route-kind.ts
+++ b/packages/cli/src/lib/runtime/load-route-kind.ts
@@ -18,22 +18,28 @@ export async function loadRouteKind(routeFile: string): Promise<RouteKind> {
 export async function normalizeRouteModule(routeFile: string): Promise<NormalizedRouteModule> {
   await registerTsxLoader()
   const routeModule = (await import(pathToFileURL(routeFile).href)) as {
+    readonly agent?: unknown
     readonly chain?: unknown
     readonly config?: Record<string, unknown>
     readonly graph?: unknown
     readonly workflow?: unknown
   }
 
+  const hasAgent = "agent" in routeModule && routeModule.agent !== undefined
   const hasChain = "chain" in routeModule && routeModule.chain !== undefined
   const hasGraph = "graph" in routeModule && routeModule.graph !== undefined
   const hasWorkflow = "workflow" in routeModule && routeModule.workflow !== undefined
 
-  const count = [hasChain, hasGraph, hasWorkflow].filter(Boolean).length
+  const count = [hasAgent, hasChain, hasGraph, hasWorkflow].filter(Boolean).length
 
   if (count > 1) {
     throw new Error(
-      `Route index.ts at ${routeFile} must export exactly one of "workflow", "graph", or "chain"`,
+      `Route index.ts at ${routeFile} must export exactly one of "agent", "workflow", "graph", or "chain"`,
     )
+  }
+
+  if (hasAgent) {
+    return { kind: "agent", entry: routeModule.agent, config: routeModule.config ?? {} }
   }
 
   if (hasChain) {
@@ -48,5 +54,5 @@ export async function normalizeRouteModule(routeFile: string): Promise<Normalize
     return { kind: "workflow", entry: routeModule.workflow, config: routeModule.config ?? {} }
   }
 
-  throw new Error(`Route index.ts at ${routeFile} exports neither "workflow", "graph", nor "chain"`)
+  throw new Error(`Route index.ts at ${routeFile} exports neither "agent", "workflow", "graph", nor "chain"`)
 }

--- a/packages/cli/src/lib/runtime/load-run-scenarios.ts
+++ b/packages/cli/src/lib/runtime/load-run-scenarios.ts
@@ -35,7 +35,7 @@ export interface LoadedRunScenario {
   readonly assert?: (result: RuntimeExecutionResult) => unknown | Promise<unknown>
   readonly expect?: RunScenarioExpectation
   readonly input: unknown
-  readonly mode: "chain" | "graph" | "workflow"
+  readonly mode: "agent" | "chain" | "graph" | "workflow"
   readonly name: string
   readonly routeId: string
   readonly routeFile: string
@@ -200,7 +200,7 @@ async function loadScenarioFile(options: {
 async function loadRouteKindSafe(
   scenarioFile: string,
   indexFile: string,
-): Promise<"chain" | "graph" | "workflow"> {
+): Promise<"agent" | "chain" | "graph" | "workflow"> {
   try {
     return await loadRouteKind(indexFile)
   } catch {
@@ -214,7 +214,7 @@ async function validateScenario(options: {
   readonly rawScenario: unknown
   readonly routeContext: {
     readonly appRoot: string
-    readonly mode: "chain" | "graph" | "workflow"
+    readonly mode: "agent" | "chain" | "graph" | "workflow"
     readonly routeFile: string
     readonly routeId: string
     readonly routePath: string

--- a/packages/cli/src/lib/runtime/result.ts
+++ b/packages/cli/src/lib/runtime/result.ts
@@ -1,4 +1,4 @@
-export type RuntimeExecutionMode = "chain" | "graph" | "workflow"
+export type RuntimeExecutionMode = "agent" | "chain" | "graph" | "workflow"
 
 export type RuntimeExecutionErrorKind =
   | "app_discovery_error"

--- a/packages/cli/src/lib/runtime/route-identity.ts
+++ b/packages/cli/src/lib/runtime/route-identity.ts
@@ -7,7 +7,7 @@ export interface RouteIdentity {
 
 export function createRouteAssistantId(
   routeId: string,
-  mode: "chain" | "graph" | "workflow",
+  mode: "agent" | "chain" | "graph" | "workflow",
 ): string {
   return `${routeId}#${mode}`
 }

--- a/packages/cli/test/check-command.test.ts
+++ b/packages/cli/test/check-command.test.ts
@@ -155,7 +155,7 @@ export const graph = { invoke: async () => ({}) }
     expect(result.exitCode).toBe(1)
     expect(result.stdout).toBe("")
     expect(result.stderr).toContain("Validation failed")
-    expect(result.stderr).toContain(`must export exactly one of "workflow", "graph", or "chain"`)
+    expect(result.stderr).toContain(`must export exactly one of "agent", "workflow", "graph", or "chain"`)
   })
 
   test("ignores route directories that have no index.ts", async () => {

--- a/packages/cli/test/check-command.test.ts
+++ b/packages/cli/test/check-command.test.ts
@@ -155,7 +155,9 @@ export const graph = { invoke: async () => ({}) }
     expect(result.exitCode).toBe(1)
     expect(result.stdout).toBe("")
     expect(result.stderr).toContain("Validation failed")
-    expect(result.stderr).toContain(`must export exactly one of "agent", "workflow", "graph", or "chain"`)
+    expect(result.stderr).toContain(
+      `must export exactly one of "agent", "workflow", "graph", or "chain"`,
+    )
   })
 
   test("ignores route directories that have no index.ts", async () => {

--- a/packages/cli/test/dev-command.test.ts
+++ b/packages/cli/test/dev-command.test.ts
@@ -274,7 +274,9 @@ describe("dawn dev lifecycle", () => {
     expect(isProcessAlive(pid)).toBe(false)
   })
 
-  test("discovers the app from cwd and prints the listening URL", async () => {
+  test("discovers the app from cwd and prints the listening URL", {
+    timeout: 15_000,
+  }, async () => {
     const appRoot = await createFixtureApp({
       "dawn.config.ts": "export default {};\n",
       "package.json": "{}\n",
@@ -304,7 +306,9 @@ describe("dawn dev lifecycle", () => {
     })
   })
 
-  test("keeps a stable port and serves new behavior after a watched route edit restart", async () => {
+  test("keeps a stable port and serves new behavior after a watched route edit restart", {
+    timeout: 15_000,
+  }, async () => {
     const appRoot = await createFixtureApp({
       "dawn.config.ts": "export default {};\n",
       "package.json": "{}\n",
@@ -390,7 +394,9 @@ describe("dawn dev lifecycle", () => {
     expect(countOccurrences(dev.stdout, "Restarting Dawn dev server")).toBeLessThanOrEqual(2)
   })
 
-  test("surfaces restart-induced in-flight cancellation as a non-execution failure", async () => {
+  test("surfaces restart-induced in-flight cancellation as a non-execution failure", {
+    timeout: 15_000,
+  }, async () => {
     const markerPath = join(tmpdir(), `dawn-dev-cancel-${Date.now()}.txt`)
     const appRoot = await createFixtureApp({
       "dawn.config.ts": "export default {};\n",
@@ -448,7 +454,9 @@ describe("dawn dev lifecycle", () => {
     })
   })
 
-  test("stays alive in a broken-but-watching state after a bad watched edit and recovers after a fixing edit", async () => {
+  test("stays alive in a broken-but-watching state after a bad watched edit and recovers after a fixing edit", {
+    timeout: 15_000,
+  }, async () => {
     const appRoot = await createFixtureApp({
       "dawn.config.ts": "export default {};\n",
       "package.json": "{}\n",
@@ -488,7 +496,9 @@ describe("dawn dev lifecycle", () => {
     expect(await response.json()).toMatchObject({ version: "healthy" })
   })
 
-  test("terminates the session for fatal appDir changes outside the discovered app root", async () => {
+  test("terminates the session for fatal appDir changes outside the discovered app root", {
+    timeout: 15_000,
+  }, async () => {
     const appRoot = await createFixtureApp({
       "dawn.config.ts": "export default {};\n",
       "package.json": "{}\n",
@@ -513,7 +523,9 @@ describe("dawn dev lifecycle", () => {
     expect(dev.stderr).toContain("configured appDir must stay within the discovered app root")
   })
 
-  test("terminates the session for fatal restart-time environment failures such as port rebinding", async () => {
+  test("terminates the session for fatal restart-time environment failures such as port rebinding", {
+    timeout: 15_000,
+  }, async () => {
     const appRoot = await createFixtureApp({
       "dawn.config.ts": "export default {};\n",
       "package.json": "{}\n",
@@ -551,7 +563,9 @@ describe("dawn dev lifecycle", () => {
     }
   })
 
-  test("force-kills a stuck child after the shutdown timeout and replaces it", async () => {
+  test("force-kills a stuck child after the shutdown timeout and replaces it", {
+    timeout: 15_000,
+  }, async () => {
     const markerPath = join(tmpdir(), `dawn-dev-stuck-${Date.now()}.txt`)
     const appRoot = await createFixtureApp({
       "dawn.config.ts": "export default {};\n",

--- a/packages/cli/test/run-command.test.ts
+++ b/packages/cli/test/run-command.test.ts
@@ -238,7 +238,7 @@ export const graph = async () => ({ ok: true })
       error: {
         kind: "app_discovery_error",
         message: expect.stringContaining(
-          `must export exactly one of "workflow", "graph", or "chain"`,
+          `must export exactly one of "agent", "workflow", "graph", or "chain"`,
         ),
       },
       routePath: "/support/[tenant]",

--- a/packages/cli/test/verify-command.test.ts
+++ b/packages/cli/test/verify-command.test.ts
@@ -184,7 +184,7 @@ describe("dawn verify", () => {
         {
           error: {
             message: expect.stringContaining(
-              `must export exactly one of "workflow", "graph", or "chain"`,
+              `must export exactly one of "agent", "workflow", "graph", or "chain"`,
             ),
           },
           name: "routes",

--- a/packages/cli/tsconfig.build.json
+++ b/packages/cli/tsconfig.build.json
@@ -6,6 +6,7 @@
     "outDir": "dist",
     "paths": {
       "@dawn-ai/core": ["../core/src/index.ts"],
+      "@dawn-ai/langchain": ["../langchain/src/index.ts"],
       "@dawn-ai/langgraph": ["../langgraph/src/index.ts"],
       "@dawn-ai/langgraph/*": ["../langgraph/src/*.ts"]
     },
@@ -15,6 +16,9 @@
   "references": [
     {
       "path": "../core"
+    },
+    {
+      "path": "../langchain"
     },
     {
       "path": "../langgraph"

--- a/packages/core/src/discovery/discover-routes.ts
+++ b/packages/core/src/discovery/discover-routes.ts
@@ -101,7 +101,9 @@ async function inferRouteKind(indexFile: string): Promise<RouteKind | null> {
   const count = [hasAgent, hasChain, hasGraph, hasWorkflow].filter(Boolean).length
 
   if (count > 1) {
-    throw new Error(`Route index.ts must export exactly one of "agent", "workflow", "graph", or "chain"`)
+    throw new Error(
+      `Route index.ts must export exactly one of "agent", "workflow", "graph", or "chain"`,
+    )
   }
 
   if (hasAgent) {

--- a/packages/core/src/discovery/discover-routes.ts
+++ b/packages/core/src/discovery/discover-routes.ts
@@ -93,14 +93,19 @@ async function readRouteEntry(
 async function inferRouteKind(indexFile: string): Promise<RouteKind | null> {
   await registerTsxLoader()
   const routeExports = await loadRouteExports(indexFile)
+  const hasAgent = "agent" in routeExports && routeExports.agent !== undefined
   const hasChain = "chain" in routeExports && routeExports.chain !== undefined
   const hasGraph = "graph" in routeExports && routeExports.graph !== undefined
   const hasWorkflow = "workflow" in routeExports && routeExports.workflow !== undefined
 
-  const count = [hasChain, hasGraph, hasWorkflow].filter(Boolean).length
+  const count = [hasAgent, hasChain, hasGraph, hasWorkflow].filter(Boolean).length
 
   if (count > 1) {
-    throw new Error(`Route index.ts must export exactly one of "workflow", "graph", or "chain"`)
+    throw new Error(`Route index.ts must export exactly one of "agent", "workflow", "graph", or "chain"`)
+  }
+
+  if (hasAgent) {
+    return "agent"
   }
 
   if (hasChain) {
@@ -119,12 +124,14 @@ async function inferRouteKind(indexFile: string): Promise<RouteKind | null> {
 }
 
 async function loadRouteExports(indexFile: string): Promise<{
+  readonly agent?: unknown
   readonly chain?: unknown
   readonly graph?: unknown
   readonly workflow?: unknown
 }> {
   try {
     return (await import(pathToFileURL(indexFile).href)) as {
+      readonly agent?: unknown
       readonly chain?: unknown
       readonly graph?: unknown
       readonly workflow?: unknown

--- a/packages/core/test/discover-routes.test.ts
+++ b/packages/core/test/discover-routes.test.ts
@@ -61,7 +61,7 @@ describe("discoverRoutes", () => {
     })
 
     await expect(discoverRoutes({ appRoot })).rejects.toThrow(
-      /Route index\.ts must export exactly one of "workflow", "graph", or "chain"/,
+      /Route index\.ts must export exactly one of "agent", "workflow", "graph", or "chain"/,
     )
   })
 

--- a/packages/create-dawn-app/src/index.ts
+++ b/packages/create-dawn-app/src/index.ts
@@ -198,7 +198,7 @@ function createTemplateReplacements(
       dawnSdkSpecifier: createAbsoluteFileSpecifier(resolve(repoRoot, "packages/sdk")),
       langchainCoreSpecifier: "0.3.80",
       langchainOpenaiSpecifier: "0.6.17",
-      langchainSpecifier: "0.3.14",
+      langchainSpecifier: "1.0.0-alpha.5",
     }
   }
 
@@ -212,7 +212,7 @@ function createTemplateReplacements(
     dawnSdkSpecifier: options.distTag,
     langchainCoreSpecifier: "0.3.80",
     langchainOpenaiSpecifier: "0.6.17",
-    langchainSpecifier: "0.3.14",
+    langchainSpecifier: "1.0.0-alpha.5",
   }
 }
 

--- a/packages/create-dawn-app/src/index.ts
+++ b/packages/create-dawn-app/src/index.ts
@@ -183,7 +183,7 @@ function createTemplateReplacements(
   readonly dawnSdkSpecifier: string
   readonly langchainCoreSpecifier: string
   readonly langchainOpenaiSpecifier: string
-  readonly zodSpecifier: string
+  readonly langchainSpecifier: string
 } {
   if (options.mode === "internal") {
     return {
@@ -198,7 +198,7 @@ function createTemplateReplacements(
       dawnSdkSpecifier: createAbsoluteFileSpecifier(resolve(repoRoot, "packages/sdk")),
       langchainCoreSpecifier: "0.3.80",
       langchainOpenaiSpecifier: "0.6.17",
-      zodSpecifier: "3.24.4",
+      langchainSpecifier: "0.3.14",
     }
   }
 
@@ -212,7 +212,7 @@ function createTemplateReplacements(
     dawnSdkSpecifier: options.distTag,
     langchainCoreSpecifier: "0.3.80",
     langchainOpenaiSpecifier: "0.6.17",
-    zodSpecifier: "3.24.4",
+    langchainSpecifier: "0.3.14",
   }
 }
 

--- a/packages/create-dawn-app/test/create-app.test.ts
+++ b/packages/create-dawn-app/test/create-app.test.ts
@@ -101,7 +101,7 @@ describe("create-dawn-app", () => {
     expect(packageJson.dependencies["@dawn-ai/langchain"]).toBe("next")
     expect(packageJson.dependencies["@langchain/openai"]).toBe("0.6.17")
     expect(packageJson.dependencies["@langchain/core"]).toBe("0.3.80")
-    expect(packageJson.dependencies.zod).toBe("3.24.4")
+    expect(packageJson.dependencies.langchain).toBe("1.0.0-alpha.5")
     expect(packageJson.devDependencies["@dawn-ai/config-typescript"]).toBe("next")
     await expect(access(join(targetDir, ".npmrc"), constants.F_OK)).rejects.toThrow()
   })
@@ -147,7 +147,7 @@ describe("create-dawn-app", () => {
     expect(packageJson.dependencies["@dawn-ai/langchain"]).toMatch(/^file:/)
     expect(packageJson.dependencies["@langchain/openai"]).toBe("0.6.17")
     expect(packageJson.dependencies["@langchain/core"]).toBe("0.3.80")
-    expect(packageJson.dependencies.zod).toBe("3.24.4")
+    expect(packageJson.dependencies.langchain).toBe("1.0.0-alpha.5")
     expect(packageJson.devDependencies["@dawn-ai/config-typescript"]).toMatch(/^file:/)
     await assertExists(join(targetDir, "src/app/(public)/hello/[tenant]/index.ts"))
     await assertExists(join(targetDir, "src/app/(public)/hello/[tenant]/state.ts"))
@@ -183,7 +183,7 @@ describe("create-dawn-app", () => {
     )
     expect(packageJson.dependencies["@langchain/openai"]).toBe("0.6.17")
     expect(packageJson.dependencies["@langchain/core"]).toBe("0.3.80")
-    expect(packageJson.dependencies.zod).toBe("3.24.4")
+    expect(packageJson.dependencies.langchain).toBe("1.0.0-alpha.5")
     expect(resolveFileSpecifier(packageJson.devDependencies["@dawn-ai/config-typescript"])).toBe(
       resolve(repoRoot, "packages/config-typescript"),
     )

--- a/packages/devkit/src/testing/generated-app.ts
+++ b/packages/devkit/src/testing/generated-app.ts
@@ -11,9 +11,9 @@ export interface GeneratedAppSpecifiers {
   readonly dawnCore: string
   readonly dawnLangchain: string
   readonly dawnSdk: string
+  readonly langchain: string
   readonly langchainCore: string
   readonly langchainOpenai: string
-  readonly zod: string
 }
 
 export interface CreateGeneratedAppOptions {
@@ -52,7 +52,7 @@ export async function createGeneratedApp(
       dawnSdkSpecifier: specifiers.dawnSdk,
       langchainCoreSpecifier: specifiers.langchainCore,
       langchainOpenaiSpecifier: specifiers.langchainOpenai,
-      zodSpecifier: specifiers.zod,
+      langchainSpecifier: specifiers.langchain,
     },
     targetDir: appRoot,
     templateDir,
@@ -77,8 +77,8 @@ function normalizeSpecifiers(
     dawnCore: specifiers?.dawnCore ?? "workspace:*",
     dawnLangchain: specifiers?.dawnLangchain ?? "workspace:*",
     dawnSdk: specifiers?.dawnSdk ?? "workspace:*",
+    langchain: specifiers?.langchain ?? "1.0.0-alpha.5",
     langchainCore: specifiers?.langchainCore ?? "0.3.80",
     langchainOpenai: specifiers?.langchainOpenai ?? "0.6.17",
-    zod: specifiers?.zod ?? "3.24.4",
   }
 }

--- a/packages/devkit/templates/app-basic/package.json.template
+++ b/packages/devkit/templates/app-basic/package.json.template
@@ -14,7 +14,7 @@
     "@dawn-ai/sdk": "{{dawnSdkSpecifier}}",
     "@langchain/core": "{{langchainCoreSpecifier}}",
     "@langchain/openai": "{{langchainOpenaiSpecifier}}",
-    "zod": "{{zodSpecifier}}"
+    "langchain": "{{langchainSpecifier}}"
   },
   "devDependencies": {
     "@dawn-ai/config-typescript": "{{dawnConfigTypescriptSpecifier}}",

--- a/packages/devkit/templates/app-basic/src/app/(public)/hello/[tenant]/index.ts
+++ b/packages/devkit/templates/app-basic/src/app/(public)/hello/[tenant]/index.ts
@@ -1,16 +1,6 @@
-import { RunnableLambda } from "@langchain/core/runnables"
+import { createAgent } from "langchain"
 
-import greet from "./tools/greet.js"
-
-const lookupTenant = new RunnableLambda({
-  func: async (input: { tenant: string }) => await greet(input),
+export const agent = createAgent({
+  model: "gpt-4o-mini",
+  systemPrompt: "You are a helpful assistant for the {tenant} organization ({plan} plan). Answer questions about the tenant.",
 })
-
-const formatResponse = new RunnableLambda({
-  func: (info: { name: string; plan: string }) => ({
-    greeting: `Hello, ${info.name}!`,
-    tenant: info.name,
-  }),
-})
-
-export const chain = lookupTenant.pipe(formatResponse)

--- a/packages/devkit/test/generated-app.test.ts
+++ b/packages/devkit/test/generated-app.test.ts
@@ -36,7 +36,7 @@ describe("generated app helper", () => {
       expect(packageJson).toContain('"@dawn-ai/core": "workspace:*"')
       expect(packageJson).toContain('"@dawn-ai/langchain": "workspace:*"')
       expect(packageJson).toContain('"@dawn-ai/config-typescript": "workspace:*"')
-      expect(packageJson).toContain('"zod": "3.24.4"')
+      expect(packageJson).toContain('"langchain": "1.0.0-alpha.5"')
     } finally {
       await rm(baseDir, { force: true, recursive: true })
     }

--- a/packages/langchain/src/agent-adapter.ts
+++ b/packages/langchain/src/agent-adapter.ts
@@ -1,0 +1,64 @@
+import { convertToolToLangChain } from "./tool-converter.js"
+
+interface DawnToolDefinition {
+  readonly description?: string
+  readonly name: string
+  readonly run: (
+    input: unknown,
+    context: { readonly signal: AbortSignal },
+  ) => Promise<unknown> | unknown
+  readonly schema?: unknown
+}
+
+interface AgentLike {
+  readonly invoke: (input: unknown, config?: unknown) => Promise<unknown>
+}
+
+function assertAgentLike(entry: unknown): asserts entry is AgentLike {
+  if (
+    typeof entry !== "object" ||
+    entry === null ||
+    !("invoke" in entry) ||
+    typeof (entry as { invoke?: unknown }).invoke !== "function"
+  ) {
+    throw new Error("Agent entry must expose invoke(input) — expected a LangChain agent")
+  }
+}
+
+export async function executeAgent(options: {
+  readonly entry: unknown
+  readonly input: unknown
+  readonly routeParamNames: readonly string[]
+  readonly signal: AbortSignal
+  readonly tools: readonly DawnToolDefinition[]
+}): Promise<unknown> {
+  assertAgentLike(options.entry)
+
+  const inputRecord = (options.input ?? {}) as Record<string, unknown>
+  const params: Record<string, unknown> = {}
+  const agentInput: Record<string, unknown> = {}
+
+  for (const [key, value] of Object.entries(inputRecord)) {
+    if (options.routeParamNames.includes(key)) {
+      params[key] = value
+    } else {
+      agentInput[key] = value
+    }
+  }
+
+  const langchainTools = options.tools.map((tool) => convertToolToLangChain(tool))
+
+  const config: Record<string, unknown> = {
+    signal: options.signal,
+  }
+
+  if (Object.keys(params).length > 0) {
+    config.configurable = params
+  }
+
+  if (langchainTools.length > 0) {
+    config.tools = langchainTools
+  }
+
+  return await options.entry.invoke(agentInput, config)
+}

--- a/packages/langchain/src/index.ts
+++ b/packages/langchain/src/index.ts
@@ -1,3 +1,4 @@
+export { executeAgent } from "./agent-adapter.js"
 export { chainAdapter } from "./chain-adapter.js"
 export { convertToolToLangChain } from "./tool-converter.js"
 export { executeWithToolLoop } from "./tool-loop.js"

--- a/packages/sdk/src/route-config.ts
+++ b/packages/sdk/src/route-config.ts
@@ -1,4 +1,4 @@
-export type RouteKind = "chain" | "graph" | "workflow"
+export type RouteKind = "agent" | "chain" | "graph" | "workflow"
 
 export interface RouteConfig {
   readonly runtime?: "node" | "edge"

--- a/test/generated/fixtures/basic-runtime.expected.json
+++ b/test/generated/fixtures/basic-runtime.expected.json
@@ -2,7 +2,7 @@
   "runJson": {
     "appRoot": "<app-root>",
     "executionSource": "in-process",
-    "mode": "chain",
+    "mode": "agent",
     "output": {
       "greeting": "Hello, basic-tenant!",
       "tenant": "basic-tenant"
@@ -14,7 +14,7 @@
   "runServerJson": {
     "appRoot": "<app-root>",
     "executionSource": "server",
-    "mode": "chain",
+    "mode": "agent",
     "output": {
       "greeting": "Hello, basic-tenant!",
       "tenant": "basic-tenant"
@@ -24,13 +24,13 @@
     "status": "passed"
   },
   "serverRequest": {
-    "assistant_id": "/hello/[tenant]#chain",
+    "assistant_id": "/hello/[tenant]#agent",
     "input": {
       "tenant": "basic-tenant"
     },
     "metadata": {
       "dawn": {
-        "mode": "chain",
+        "mode": "agent",
         "route_id": "/hello/[tenant]",
         "route_path": "src/app/(public)/hello/[tenant]/index.ts"
       }

--- a/test/generated/fixtures/basic.expected.json
+++ b/test/generated/fixtures/basic.expected.json
@@ -13,9 +13,7 @@
       "@dawn-ai/cli": "<tarball:@dawn-ai/cli>",
       "@dawn-ai/langchain": "<tarball:@dawn-ai/langchain>",
       "@dawn-ai/sdk": "<tarball:@dawn-ai/sdk>",
-      "@langchain/core": "0.3.80",
-      "@langchain/openai": "0.6.17",
-      "langchain": "0.3.14"
+      "@langchain/core": "0.3.80"
     },
     "devDependencies": {
       "@dawn-ai/config-typescript": "<tarball:@dawn-ai/config-typescript>",

--- a/test/generated/fixtures/basic.expected.json
+++ b/test/generated/fixtures/basic.expected.json
@@ -15,7 +15,7 @@
       "@dawn-ai/sdk": "<tarball:@dawn-ai/sdk>",
       "@langchain/core": "0.3.80",
       "@langchain/openai": "0.6.17",
-      "zod": "3.24.4"
+      "langchain": "0.3.14"
     },
     "devDependencies": {
       "@dawn-ai/config-typescript": "<tarball:@dawn-ai/config-typescript>",
@@ -67,7 +67,7 @@
       {
         "id": "/hello/[tenant]",
         "pathname": "/hello/[tenant]",
-        "kind": "chain",
+        "kind": "agent",
         "entryFile": "<app-root>/src/app/(public)/hello/[tenant]/index.ts",
         "routeDir": "<app-root>/src/app/(public)/hello/[tenant]",
         "segments": [

--- a/test/generated/fixtures/custom-app-dir.expected.json
+++ b/test/generated/fixtures/custom-app-dir.expected.json
@@ -15,7 +15,7 @@
       "@dawn-ai/sdk": "<tarball:@dawn-ai/sdk>",
       "@langchain/core": "0.3.80",
       "@langchain/openai": "0.6.17",
-      "zod": "3.24.4"
+      "langchain": "1.0.0-alpha.5"
     },
     "devDependencies": {
       "@dawn-ai/config-typescript": "<tarball:@dawn-ai/config-typescript>",

--- a/test/generated/harness.ts
+++ b/test/generated/harness.ts
@@ -48,7 +48,7 @@ interface RuntimeFixtureSpec {
   readonly input: {
     readonly tenant: string
   }
-  readonly mode: "chain" | "graph" | "workflow"
+  readonly mode: "agent" | "chain" | "graph" | "workflow"
   readonly routeDir: string
   readonly routeId: string
   readonly routePath: string
@@ -79,7 +79,7 @@ export interface GeneratedRuntimeScenarioResult {
     readonly input: unknown
     readonly metadata: {
       readonly dawn: {
-        readonly mode: "chain" | "graph" | "workflow"
+        readonly mode: "agent" | "chain" | "graph" | "workflow"
         readonly route_id: string
         readonly route_path: string
       }
@@ -97,7 +97,7 @@ const runtimeFixtures: Record<GeneratedRuntimeFixtureName, RuntimeFixtureSpec> =
     input: {
       tenant: "basic-tenant",
     },
-    mode: "chain",
+    mode: "agent",
     routeDir: "src/app/(public)/hello/[tenant]",
     routeId: "/hello/[tenant]",
     routePath: "src/app/(public)/hello/[tenant]/index.ts",

--- a/test/generated/harness.ts
+++ b/test/generated/harness.ts
@@ -201,6 +201,29 @@ export async function prepareGeneratedRuntimeApp(options: {
       await rewriteToCustomAppDirRuntimeLayout(appRoot)
     }
 
+    if (fixture.fixtureName === "basic") {
+      await writeFile(
+        join(appRoot, fixture.routeDir, "index.ts"),
+        [
+          'import greet from "./tools/greet.js"',
+          "",
+          "export const agent = {",
+          "  async invoke(input: Record<string, unknown>, config?: Record<string, unknown>) {",
+          "    const tenant = (config?.configurable as Record<string, unknown>)?.tenant as string",
+          "    const info = await greet({ tenant })",
+          "    return {",
+          "      greeting: `Hello, ${info.name}!`,",
+          "      tenant: info.name,",
+          "    }",
+          "  },",
+          "}",
+          "",
+        ].join("\n"),
+        "utf8",
+      )
+      await removeLangchainFromPackageJson(appRoot)
+    }
+
     if (fixture.fixtureName !== "handwritten") {
       await writeRunScenarioFile({
         appRoot,
@@ -450,6 +473,18 @@ async function rewriteDependenciesToTarballs(options: {
     },
   }
 
+  await writeFile(packageJsonPath, `${JSON.stringify(packageJson, null, 2)}\n`, "utf8")
+}
+
+async function removeLangchainFromPackageJson(appRoot: string): Promise<void> {
+  const packageJsonPath = join(appRoot, "package.json")
+  const packageJson = JSON.parse(await readFile(packageJsonPath, "utf8")) as {
+    dependencies?: Record<string, string>
+  }
+  if (packageJson.dependencies) {
+    delete packageJson.dependencies.langchain
+    delete packageJson.dependencies["@langchain/openai"]
+  }
   await writeFile(packageJsonPath, `${JSON.stringify(packageJson, null, 2)}\n`, "utf8")
 }
 

--- a/test/generated/run-generated-app.test.ts
+++ b/test/generated/run-generated-app.test.ts
@@ -187,6 +187,28 @@ async function runGeneratedAppScenario(
       transcriptPath,
     })
 
+    if (options.expectedFixtureName === "basic") {
+      await writeFile(
+        join(appRoot, "src/app/(public)/hello/[tenant]/index.ts"),
+        [
+          'import greet from "./tools/greet.js"',
+          "",
+          "export const agent = {",
+          "  async invoke(input: { tenant: string }) {",
+          "    const info = await greet(input)",
+          "    return {",
+          "      greeting: `Hello, ${info.name}!`,",
+          "      tenant: info.name,",
+          "    }",
+          "  },",
+          "}",
+          "",
+        ].join("\n"),
+        "utf8",
+      )
+      await removeLangchainFromPackageJson(appRoot)
+    }
+
     if (options.mutateApp) {
       await options.mutateApp(appRoot)
     }
@@ -439,6 +461,18 @@ async function appendTranscript(
       .join("\n"),
     "utf8",
   )
+}
+
+async function removeLangchainFromPackageJson(appRoot: string): Promise<void> {
+  const packageJsonPath = join(appRoot, "package.json")
+  const packageJson = JSON.parse(await readFile(packageJsonPath, "utf8")) as {
+    dependencies?: Record<string, string>
+  }
+  if (packageJson.dependencies) {
+    delete packageJson.dependencies.langchain
+    delete packageJson.dependencies["@langchain/openai"]
+  }
+  await writeFile(packageJsonPath, `${JSON.stringify(packageJson, null, 2)}\n`, "utf8")
 }
 
 async function readExpectedFixture(fixtureName: string): Promise<unknown> {

--- a/test/runtime/fixtures/agent-basic.overlay.json
+++ b/test/runtime/fixtures/agent-basic.overlay.json
@@ -1,6 +1,6 @@
 {
   "files": {
-    "src/app/(public)/hello/[tenant]/index.ts": "export const agent = {\n  async invoke(input) {\n    return {\n      greeting: `Hello from agent, ${input.tenant || \"unknown\"}!`,\n      tenant: input.tenant || \"unknown\",\n    };\n  },\n};\n"
+    "src/app/(public)/hello/[tenant]/index.ts": "export const agent = {\n  async invoke(input, config) {\n    const tenant = config?.configurable?.tenant || \"unknown\";\n    return {\n      greeting: `Hello from agent, ${tenant}!`,\n      tenant,\n    };\n  },\n};\n"
   },
   "input": {
     "tenant": "agent-tenant"

--- a/test/runtime/fixtures/agent-basic.overlay.json
+++ b/test/runtime/fixtures/agent-basic.overlay.json
@@ -1,0 +1,17 @@
+{
+  "files": {
+    "src/app/(public)/hello/[tenant]/index.ts": "export const agent = {\n  async invoke(input) {\n    return {\n      greeting: `Hello from agent, ${input.tenant || \"unknown\"}!`,\n      tenant: input.tenant || \"unknown\",\n    };\n  },\n};\n"
+  },
+  "input": {
+    "tenant": "agent-tenant"
+  },
+  "routeFile": "src/app/(public)/hello/[tenant]/index.ts",
+  "expected": {
+    "mode": "agent",
+    "output": {
+      "greeting": "Hello from agent, agent-tenant!",
+      "tenant": "agent-tenant"
+    },
+    "status": "passed"
+  }
+}

--- a/test/runtime/fixtures/agent-failure.overlay.json
+++ b/test/runtime/fixtures/agent-failure.overlay.json
@@ -1,6 +1,6 @@
 {
   "files": {
-    "src/app/(public)/hello/[tenant]/index.ts": "export const agent = {\n  async invoke(input) {\n    throw new Error(`Agent execution failed for ${input.tenant || \"unknown\"}`);\n  },\n};\n"
+    "src/app/(public)/hello/[tenant]/index.ts": "export const agent = {\n  async invoke(input, config) {\n    const tenant = config?.configurable?.tenant || \"unknown\";\n    throw new Error(`Agent execution failed for ${tenant}`);\n  },\n};\n"
   },
   "input": {
     "tenant": "agent-tenant"

--- a/test/runtime/fixtures/agent-failure.overlay.json
+++ b/test/runtime/fixtures/agent-failure.overlay.json
@@ -1,0 +1,17 @@
+{
+  "files": {
+    "src/app/(public)/hello/[tenant]/index.ts": "export const agent = {\n  async invoke(input) {\n    throw new Error(`Agent execution failed for ${input.tenant || \"unknown\"}`);\n  },\n};\n"
+  },
+  "input": {
+    "tenant": "agent-tenant"
+  },
+  "routeFile": "src/app/(public)/hello/[tenant]/index.ts",
+  "expected": {
+    "error": {
+      "kind": "execution_error",
+      "message": "Agent execution failed for agent-tenant"
+    },
+    "mode": "agent",
+    "status": "failed"
+  }
+}

--- a/test/runtime/fixtures/workflow-basic.overlay.json
+++ b/test/runtime/fixtures/workflow-basic.overlay.json
@@ -1,10 +1,13 @@
 {
+  "files": {
+    "src/app/(public)/hello/[tenant]/index.ts": "import type { HelloState } from \"./state.js\";\n\nexport const workflow = async (state: HelloState): Promise<HelloState> => ({\n  ...state,\n  greeting: `Hello, ${state.tenant}!`,\n});\n"
+  },
   "input": {
     "tenant": "workflow-tenant"
   },
   "routeFile": "src/app/(public)/hello/[tenant]/index.ts",
   "expected": {
-    "mode": "chain",
+    "mode": "workflow",
     "output": {
       "greeting": "Hello, workflow-tenant!",
       "tenant": "workflow-tenant"

--- a/test/runtime/run-runtime-contract.test.ts
+++ b/test/runtime/run-runtime-contract.test.ts
@@ -705,6 +705,8 @@ async function rewriteDependenciesToTarballs(options: {
     }
   }
 
+  delete packageJson.dependencies?.langchain
+  delete packageJson.dependencies?.["@langchain/openai"]
   packageJson.dependencies = {
     ...packageJson.dependencies,
     "@dawn-ai/cli": options.tarballs["@dawn-ai/cli"],

--- a/test/runtime/run-runtime-contract.test.ts
+++ b/test/runtime/run-runtime-contract.test.ts
@@ -37,7 +37,7 @@ const RUNTIME_ROOT = resolve(import.meta.dirname)
 const HARNESS_RUNTIME_ARTIFACT_BASE_DIR_ENV = "DAWN_RUNTIME_ARTIFACT_BASE_DIR"
 const tempDirs: TrackedTempDir[] = []
 
-type RuntimeFixtureName = "graph-basic" | "graph-failure" | "workflow-basic" | "workflow-failure"
+type RuntimeFixtureName = "agent-basic" | "agent-failure" | "graph-basic" | "graph-failure" | "workflow-basic" | "workflow-failure"
 
 interface RuntimeOverlay {
   readonly deleteFiles?: readonly string[]
@@ -60,6 +60,48 @@ afterEach(async () => {
 })
 
 describe("runtime contract harness", () => {
+  test("executes passing agent fixture through direct runtime primitive", {
+    timeout: 180_000,
+  }, async () => {
+    const result = await runRuntimeScenario("agent-basic")
+
+    expect(result).toMatchObject({
+      failureReason: null,
+      lane: "runtime",
+      name: "agent-basic",
+      status: "passed",
+    })
+    expect(result.phases.map((phase) => phase.name)).toEqual([
+      "packaged-installer",
+      "install",
+      "execute-direct",
+      "execute-cli",
+      "execute-cli-dev-server",
+    ])
+    await expectRuntimeParityArtifacts(result, "agent-basic")
+  })
+
+  test("executes failing agent fixture through direct runtime primitive", {
+    timeout: 180_000,
+  }, async () => {
+    const result = await runRuntimeScenario("agent-failure")
+
+    expect(result).toMatchObject({
+      failureReason: null,
+      lane: "runtime",
+      name: "agent-failure",
+      status: "passed",
+    })
+    expect(result.phases.map((phase) => phase.name)).toEqual([
+      "packaged-installer",
+      "install",
+      "execute-direct",
+      "execute-cli",
+      "execute-cli-dev-server",
+    ])
+    await expectRuntimeParityArtifacts(result, "agent-failure")
+  })
+
   test("executes passing graph fixture through direct runtime primitive", {
     timeout: 180_000,
   }, async () => {

--- a/test/smoke/agent-basic.overlay.json
+++ b/test/smoke/agent-basic.overlay.json
@@ -1,0 +1,10 @@
+{
+  "deleteFiles": ["src/app/(public)/hello/[tenant]/tools/greet.ts"],
+  "files": {
+    "src/app/(public)/hello/[tenant]/index.ts": "export const agent = {\n  async invoke(input) {\n    return {\n      greeting: `Hello from agent, ${input.tenant || \"unknown\"}!`,\n      tenant: input.tenant || \"unknown\",\n    };\n  },\n};\n"
+  },
+  "input": {
+    "tenant": "agent-tenant"
+  },
+  "kind": "agent"
+}

--- a/test/smoke/agent-basic.overlay.json
+++ b/test/smoke/agent-basic.overlay.json
@@ -1,7 +1,7 @@
 {
   "deleteFiles": ["src/app/(public)/hello/[tenant]/tools/greet.ts"],
   "files": {
-    "src/app/(public)/hello/[tenant]/index.ts": "export const agent = {\n  async invoke(input) {\n    return {\n      greeting: `Hello from agent, ${input.tenant || \"unknown\"}!`,\n      tenant: input.tenant || \"unknown\",\n    };\n  },\n};\n"
+    "src/app/(public)/hello/[tenant]/index.ts": "export const agent = {\n  async invoke(input: Record<string, unknown>, config?: Record<string, unknown>) {\n    const configurable = config?.configurable as Record<string, unknown> | undefined;\n    const tenant = configurable?.tenant || \"unknown\";\n    return {\n      greeting: `Hello from agent, ${tenant}!`,\n      tenant,\n    };\n  },\n};\n"
   },
   "input": {
     "tenant": "agent-tenant"

--- a/test/smoke/run-smoke.test.ts
+++ b/test/smoke/run-smoke.test.ts
@@ -21,8 +21,8 @@ import {
 const SMOKE_ROOT = resolve(import.meta.dirname)
 const tempDirs: TrackedTempDir[] = []
 
-type SmokeRouteKind = "chain" | "graph" | "workflow"
-type SmokeFixtureName = "graph-basic" | "workflow-basic"
+type SmokeRouteKind = "agent" | "chain" | "graph" | "workflow"
+type SmokeFixtureName = "agent-basic" | "graph-basic" | "workflow-basic"
 
 interface SmokeOverlay {
   readonly deleteFiles?: readonly string[]
@@ -50,6 +50,33 @@ afterEach(async () => {
 })
 
 describe("runtime smoke harness", () => {
+  test("boots the agent fixture and executes one canonical flow", {
+    timeout: 180_000,
+  }, async () => {
+    const result = await runSmokeScenario("agent-basic")
+    const output = await readSmokeOutput(result)
+
+    expect(result).toMatchObject({
+      failureReason: null,
+      lane: "smoke",
+      name: "agent-basic",
+      status: "passed",
+    })
+    expect(result.phases.map((phase) => phase.name)).toEqual([
+      "packaged-installer",
+      "install",
+      "discover-routes",
+      "typecheck",
+      "compile",
+      "execute",
+    ])
+    expect(output).toEqual({
+      greeting: "Hello from agent, agent-tenant!",
+      tenant: "agent-tenant",
+    })
+    await expect(stat(result.transcriptPath)).resolves.toBeDefined()
+  })
+
   test("boots the graph fixture and executes one canonical flow", {
     timeout: 180_000,
   }, async () => {

--- a/test/smoke/run-smoke.test.ts
+++ b/test/smoke/run-smoke.test.ts
@@ -293,6 +293,8 @@ async function rewriteDependenciesToTarballs(options: {
     }
   }
 
+  delete packageJson.dependencies?.langchain
+  delete packageJson.dependencies?.["@langchain/openai"]
   packageJson.dependencies = {
     ...packageJson.dependencies,
     "@dawn-ai/cli": options.tarballs["@dawn-ai/cli"],

--- a/test/smoke/workflow-basic.overlay.json
+++ b/test/smoke/workflow-basic.overlay.json
@@ -1,6 +1,10 @@
 {
+  "deleteFiles": ["src/app/(public)/hello/[tenant]/tools/greet.ts"],
+  "files": {
+    "src/app/(public)/hello/[tenant]/index.ts": "import type { HelloState } from \"./state.js\";\n\nexport async function workflow(input: HelloState): Promise<HelloState> {\n  return {\n    ...input,\n    greeting: `Hello, ${input.tenant}!`,\n  };\n}\n"
+  },
   "input": {
     "tenant": "workflow-tenant"
   },
-  "kind": "chain"
+  "kind": "workflow"
 }


### PR DESCRIPTION
## Summary

- Adds `agent` as a fourth route kind alongside `chain`, `graph`, and `workflow`
- Implements agent adapter in `@dawn-ai/langchain` with input splitting (route params → `config.configurable`, rest → agent input) and auto tool injection
- Updates the default `create-dawn-app` template to use LangChain's `createAgent()` with `langchain@1.0.0-alpha.5`
- Adds `dawn build` command for LangGraph Platform deployment (compiles entries with tools baked in, merges `langgraph.json`)
- Updates all test harnesses (generated, runtime, smoke) with agent fixtures and overlays

## Test plan

- [x] Typecheck passes across all packages
- [x] Generated harness: 10/10 tests pass
- [x] Runtime harness: 8/8 tests pass (agent-basic, agent-failure, graph-basic, graph-failure, workflow-basic, workflow-failure + dev server tests)
- [x] Smoke harness: 3/3 tests pass (agent-basic, graph-basic, workflow-basic)
- [x] create-dawn-app: 4/4 tests pass
