### PR TITLE
feat: agent() typed API for zero-annotation DX

### DIFF
--- a/docs/superpowers/plans/2026-05-01-agent-typed-api.md
+++ b/docs/superpowers/plans/2026-05-01-agent-typed-api.md
@@ -1,0 +1,948 @@
+# `agent()` Typed API Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a lazy `agent()` descriptor function to `@dawn-ai/sdk` that eliminates LangChain type leakage and provides zero-annotation DX for Dawn agent routes.
+
+**Architecture:** The SDK exports a pure `agent()` factory that returns an opaque branded `DawnAgent` descriptor. Route discovery recognizes this descriptor via symbol check. The `@dawn-ai/langchain` adapter materializes the descriptor into a live LangChain agent at invocation time. The template switches from `createAgent` to `agent()`, dropping direct LangChain deps.
+
+**Tech Stack:** TypeScript 6.0, Vitest, pnpm workspace, `@langchain/core`, `@langchain/langgraph`
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|------|---------------|
+| `packages/sdk/src/agent.ts` (create) | `agent()`, `isDawnAgent()`, `DawnAgent`, `AgentConfig`, `KnownModelId` |
+| `packages/sdk/src/index.ts` (modify) | Re-export agent types and functions |
+| `packages/sdk/test/agent.test.ts` (create) | Unit tests for `agent()` and `isDawnAgent()` |
+| `packages/langchain/src/agent-adapter.ts` (modify) | Add `isDawnAgent` branch and `materializeAgent` |
+| `packages/langchain/test/agent-adapter.test.ts` (create) | Tests for descriptor materialization path |
+| `packages/core/src/discovery/discover-routes.ts` (modify) | Support `default` export detection for agents |
+| `packages/core/test/discover-routes.test.ts` (modify) | Add test for `export default agent({...})` route |
+| `packages/devkit/templates/app-basic/src/app/(public)/hello/[tenant]/index.ts` (modify) | Switch to `agent()` API |
+| `packages/devkit/templates/app-basic/package.json.template` (modify) | Remove direct langchain deps |
+| `packages/devkit/src/testing/generated-app.ts` (modify) | Remove langchain specifiers |
+
+---
+
+### Task 1: SDK — `agent()` function and `DawnAgent` type
+
+**Files:**
+- Create: `packages/sdk/src/agent.ts`
+- Modify: `packages/sdk/src/index.ts`
+- Create: `packages/sdk/test/agent.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `packages/sdk/test/agent.test.ts`:
+
+```typescript
+import { describe, expect, expectTypeOf, test } from "vitest"
+import { agent, isDawnAgent } from "@dawn-ai/sdk"
+import type { AgentConfig, DawnAgent, KnownModelId } from "@dawn-ai/sdk"
+
+describe("agent()", () => {
+  test("returns a DawnAgent descriptor with the provided config", () => {
+    const descriptor = agent({
+      model: "gpt-4o-mini",
+      systemPrompt: "You are helpful.",
+    })
+
+    expect(descriptor.model).toBe("gpt-4o-mini")
+    expect(descriptor.systemPrompt).toBe("You are helpful.")
+  })
+
+  test("descriptor is recognized by isDawnAgent", () => {
+    const descriptor = agent({
+      model: "gpt-4o-mini",
+      systemPrompt: "Hello",
+    })
+
+    expect(isDawnAgent(descriptor)).toBe(true)
+  })
+
+  test("isDawnAgent rejects plain objects", () => {
+    expect(isDawnAgent({})).toBe(false)
+    expect(isDawnAgent(null)).toBe(false)
+    expect(isDawnAgent(undefined)).toBe(false)
+    expect(isDawnAgent({ model: "gpt-4o", systemPrompt: "hi" })).toBe(false)
+  })
+
+  test("isDawnAgent rejects objects with invoke method (legacy agents)", () => {
+    expect(isDawnAgent({ invoke: async () => ({}) })).toBe(false)
+  })
+
+  test("KnownModelId provides autocomplete but accepts any string", () => {
+    const config: AgentConfig = {
+      model: "my-custom-model",
+      systemPrompt: "hi",
+    }
+    const descriptor = agent(config)
+    expect(descriptor.model).toBe("my-custom-model")
+  })
+
+  test("DawnAgent type is exported", () => {
+    const descriptor = agent({ model: "gpt-4o", systemPrompt: "test" })
+    expectTypeOf(descriptor).toMatchTypeOf<DawnAgent>()
+  })
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd packages/sdk && pnpm test -- --run agent.test.ts`
+Expected: FAIL — cannot resolve `agent` or `isDawnAgent` from `@dawn-ai/sdk`
+
+- [ ] **Step 3: Write the implementation**
+
+Create `packages/sdk/src/agent.ts`:
+
+```typescript
+const DAWN_AGENT: unique symbol = Symbol.for("dawn.agent") as unknown as typeof DAWN_AGENT
+
+declare const brand: unique symbol
+
+export interface DawnAgent {
+  readonly [brand]: "DawnAgent"
+  readonly model: string
+  readonly systemPrompt: string
+}
+
+export type KnownModelId =
+  | "gpt-4o"
+  | "gpt-4o-mini"
+  | "gpt-4.1"
+  | "gpt-4.1-mini"
+  | "gpt-4.1-nano"
+  | "claude-sonnet-4-20250514"
+  | "claude-haiku-4-20250414"
+  | (string & {})
+
+export interface AgentConfig {
+  readonly model: KnownModelId
+  readonly systemPrompt: string
+}
+
+export function agent(config: AgentConfig): DawnAgent {
+  return {
+    [DAWN_AGENT]: true,
+    model: config.model,
+    systemPrompt: config.systemPrompt,
+  } as unknown as DawnAgent
+}
+
+export function isDawnAgent(value: unknown): value is DawnAgent {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    DAWN_AGENT in value &&
+    (value as Record<symbol, unknown>)[DAWN_AGENT] === true
+  )
+}
+```
+
+Update `packages/sdk/src/index.ts` to add exports:
+
+```typescript
+export type { BackendAdapter } from "./backend-adapter.js"
+export type { RouteConfig, RouteKind } from "./route-config.js"
+export type { RuntimeContext, RuntimeTool, ToolRegistry } from "./runtime-context.js"
+export { agent, isDawnAgent } from "./agent.js"
+export type { AgentConfig, DawnAgent, KnownModelId } from "./agent.js"
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd packages/sdk && pnpm test -- --run agent.test.ts`
+Expected: PASS (all 6 tests)
+
+- [ ] **Step 5: Run typecheck**
+
+Run: `cd packages/sdk && pnpm typecheck`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/sdk/src/agent.ts packages/sdk/src/index.ts packages/sdk/test/agent.test.ts
+git commit -m "feat(sdk): add agent() descriptor function and isDawnAgent guard"
+```
+
+---
+
+### Task 2: LangChain adapter — handle `DawnAgent` descriptors
+
+**Files:**
+- Modify: `packages/langchain/src/agent-adapter.ts`
+- Modify: `packages/langchain/src/index.ts`
+- Create: `packages/langchain/test/agent-adapter.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `packages/langchain/test/agent-adapter.test.ts`:
+
+```typescript
+import { AIMessage } from "@langchain/core/messages"
+import { describe, expect, test, vi } from "vitest"
+import { agent } from "@dawn-ai/sdk"
+import { executeAgent } from "../src/agent-adapter.js"
+
+describe("executeAgent with DawnAgent descriptors", () => {
+  test("materializes a DawnAgent descriptor and invokes it", async () => {
+    const descriptor = agent({
+      model: "gpt-4o-mini",
+      systemPrompt: "You are helpful.",
+    })
+
+    const mockInvoke = vi.fn().mockResolvedValue(
+      new AIMessage({ content: "Hello!" }),
+    )
+
+    // Mock the materializeAgent path by intercepting createReactAgent
+    // We'll test that executeAgent recognizes the descriptor and doesn't
+    // throw "Agent entry must expose invoke(input)"
+    // For this unit test, we mock the materialization
+    const result = await executeAgent({
+      entry: descriptor,
+      input: { question: "hi" },
+      routeParamNames: [],
+      signal: new AbortController().signal,
+      tools: [],
+    }).catch((error: Error) => error)
+
+    // The descriptor should be recognized (not throw "must expose invoke")
+    // It will fail on materialization since we don't have a real LLM,
+    // but the error should NOT be "Agent entry must expose invoke(input)"
+    if (result instanceof Error) {
+      expect(result.message).not.toContain("must expose invoke")
+    }
+  })
+
+  test("legacy agent with invoke() still works", async () => {
+    const mockAgent = {
+      invoke: vi.fn().mockResolvedValue(new AIMessage({ content: "Legacy!" })),
+    }
+
+    const result = await executeAgent({
+      entry: mockAgent,
+      input: { question: "hi" },
+      routeParamNames: [],
+      signal: new AbortController().signal,
+      tools: [],
+    })
+
+    expect(mockAgent.invoke).toHaveBeenCalled()
+    expect((result as AIMessage).content).toBe("Legacy!")
+  })
+
+  test("route params are separated from agent input", async () => {
+    const mockAgent = {
+      invoke: vi.fn().mockResolvedValue(new AIMessage({ content: "ok" })),
+    }
+
+    await executeAgent({
+      entry: mockAgent,
+      input: { tenant: "acme", question: "hello" },
+      routeParamNames: ["tenant"],
+      signal: new AbortController().signal,
+      tools: [],
+    })
+
+    const [invokeInput, invokeConfig] = mockAgent.invoke.mock.calls[0]!
+    expect(invokeInput.messages[0].content).toBe("hello")
+    expect(invokeConfig.configurable).toEqual({ tenant: "acme" })
+  })
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd packages/langchain && pnpm test -- --run agent-adapter.test.ts`
+Expected: FAIL — `isDawnAgent` not imported, `executeAgent` still throws on non-invoke objects
+
+- [ ] **Step 3: Implement the DawnAgent branch in the adapter**
+
+Replace `packages/langchain/src/agent-adapter.ts` with:
+
+```typescript
+import { HumanMessage } from "@langchain/core/messages"
+import { isDawnAgent } from "@dawn-ai/sdk"
+import type { DawnAgent } from "@dawn-ai/sdk"
+import { convertToolToLangChain } from "./tool-converter.js"
+
+interface DawnToolDefinition {
+  readonly description?: string
+  readonly name: string
+  readonly run: (
+    input: unknown,
+    context: { readonly signal: AbortSignal },
+  ) => Promise<unknown> | unknown
+  readonly schema?: unknown
+}
+
+interface AgentLike {
+  readonly invoke: (input: unknown, config?: unknown) => Promise<unknown>
+}
+
+function assertAgentLike(entry: unknown): asserts entry is AgentLike {
+  if (
+    typeof entry !== "object" ||
+    entry === null ||
+    !("invoke" in entry) ||
+    typeof (entry as { invoke?: unknown }).invoke !== "function"
+  ) {
+    throw new Error("Agent entry must expose invoke(input) — expected a LangChain agent")
+  }
+}
+
+const materializedAgents = new WeakMap<DawnAgent, AgentLike>()
+
+async function materializeAgent(
+  descriptor: DawnAgent,
+  tools: readonly DawnToolDefinition[],
+): Promise<AgentLike> {
+  const cached = materializedAgents.get(descriptor)
+  if (cached) {
+    return cached
+  }
+
+  const { createReactAgent } = await import("@langchain/langgraph/prebuilt")
+  const { ChatOpenAI } = await import("@langchain/openai")
+
+  const langchainTools = tools.map((tool) => convertToolToLangChain(tool))
+
+  const llm = new ChatOpenAI({
+    model: descriptor.model,
+  })
+
+  const compiled = createReactAgent({
+    llm,
+    tools: langchainTools,
+    prompt: descriptor.systemPrompt,
+  })
+
+  materializedAgents.set(descriptor, compiled as unknown as AgentLike)
+  return compiled as unknown as AgentLike
+}
+
+export async function executeAgent(options: {
+  readonly entry: unknown
+  readonly input: unknown
+  readonly routeParamNames: readonly string[]
+  readonly signal: AbortSignal
+  readonly tools: readonly DawnToolDefinition[]
+}): Promise<unknown> {
+  const inputRecord = (options.input ?? {}) as Record<string, unknown>
+  const params: Record<string, unknown> = {}
+  const agentInput: Record<string, unknown> = {}
+
+  for (const [key, value] of Object.entries(inputRecord)) {
+    if (options.routeParamNames.includes(key)) {
+      params[key] = value
+    } else {
+      agentInput[key] = value
+    }
+  }
+
+  const config: Record<string, unknown> = {
+    signal: options.signal,
+  }
+
+  if (Object.keys(params).length > 0) {
+    config.configurable = params
+  }
+
+  // DawnAgent descriptor path — materialize on first use
+  if (isDawnAgent(options.entry)) {
+    const materializedAgent = await materializeAgent(options.entry, options.tools)
+    const messages = [new HumanMessage(formatAgentMessage(agentInput))]
+    return await materializedAgent.invoke({ messages }, config)
+  }
+
+  // Legacy path — raw Runnable with .invoke()
+  assertAgentLike(options.entry)
+
+  const langchainTools = options.tools.map((tool) => convertToolToLangChain(tool))
+  if (langchainTools.length > 0) {
+    config.tools = langchainTools
+  }
+
+  const messages = [new HumanMessage(formatAgentMessage(agentInput))]
+  return await options.entry.invoke({ messages }, config)
+}
+
+function formatAgentMessage(input: Record<string, unknown>): string {
+  const entries = Object.entries(input)
+
+  if (entries.length === 0) {
+    return ""
+  }
+
+  if (entries.length === 1) {
+    return String(entries[0]![1])
+  }
+
+  return entries.map(([key, value]) => `${key}: ${String(value)}`).join("\n")
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd packages/langchain && pnpm test -- --run agent-adapter.test.ts`
+Expected: PASS (all 3 tests)
+
+- [ ] **Step 5: Run full langchain test suite**
+
+Run: `cd packages/langchain && pnpm test`
+Expected: PASS (all existing tests still pass)
+
+- [ ] **Step 6: Run typecheck**
+
+Run: `cd packages/langchain && pnpm typecheck`
+Expected: PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/langchain/src/agent-adapter.ts packages/langchain/src/index.ts packages/langchain/test/agent-adapter.test.ts
+git commit -m "feat(langchain): materialize DawnAgent descriptors at invocation time"
+```
+
+---
+
+### Task 3: Route discovery — support `export default` for agent descriptors
+
+**Files:**
+- Modify: `packages/core/src/discovery/discover-routes.ts`
+- Modify: `packages/core/test/discover-routes.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `packages/core/test/discover-routes.test.ts`:
+
+```typescript
+it("discovers an agent route from export default agent()", async () => {
+  const appRoot = await writeApp({
+    "src/app/hello/index.ts": [
+      `import { agent } from "@dawn-ai/sdk"`,
+      `export default agent({ model: "gpt-4o-mini", systemPrompt: "hi" })`,
+    ].join("\n") + "\n",
+  })
+
+  const manifest = await discoverRoutes({ appRoot })
+
+  expect(manifest.routes).toHaveLength(1)
+  expect(manifest.routes[0]).toMatchObject({
+    pathname: "/hello",
+    kind: "agent",
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd packages/core && pnpm test -- --run discover-routes.test.ts`
+Expected: FAIL — the `export default` is not checked for `isDawnAgent`, so it returns `null` (no route)
+
+- [ ] **Step 3: Implement default export detection**
+
+In `packages/core/src/discovery/discover-routes.ts`, update the `loadRouteExports` return type and `inferRouteKind`:
+
+Add import at the top:
+```typescript
+import { isDawnAgent } from "@dawn-ai/sdk"
+```
+
+Update `inferRouteKind` to check the default export:
+
+```typescript
+async function inferRouteKind(indexFile: string): Promise<RouteKind | null> {
+  await registerTsxLoader()
+  const routeExports = await loadRouteExports(indexFile)
+
+  // Check default export for DawnAgent descriptor
+  if ("default" in routeExports && isDawnAgent(routeExports.default)) {
+    return "agent"
+  }
+
+  const hasAgent = "agent" in routeExports && routeExports.agent !== undefined
+  const hasChain = "chain" in routeExports && routeExports.chain !== undefined
+  const hasGraph = "graph" in routeExports && routeExports.graph !== undefined
+  const hasWorkflow = "workflow" in routeExports && routeExports.workflow !== undefined
+
+  const count = [hasAgent, hasChain, hasGraph, hasWorkflow].filter(Boolean).length
+
+  if (count > 1) {
+    throw new Error(
+      `Route index.ts must export exactly one of "agent", "workflow", "graph", or "chain"`,
+    )
+  }
+
+  if (hasAgent) {
+    return "agent"
+  }
+
+  if (hasChain) {
+    return "chain"
+  }
+
+  if (hasGraph) {
+    return "graph"
+  }
+
+  if (hasWorkflow) {
+    return "workflow"
+  }
+
+  return null
+}
+```
+
+Update `loadRouteExports` to also capture the `default` export:
+
+```typescript
+async function loadRouteExports(indexFile: string): Promise<{
+  readonly default?: unknown
+  readonly agent?: unknown
+  readonly chain?: unknown
+  readonly graph?: unknown
+  readonly workflow?: unknown
+}> {
+  try {
+    return (await import(pathToFileURL(indexFile).href)) as {
+      readonly default?: unknown
+      readonly agent?: unknown
+      readonly chain?: unknown
+      readonly graph?: unknown
+      readonly workflow?: unknown
+    }
+  } catch (cause) {
+    const reason = cause instanceof Error ? cause.message : String(cause)
+    throw new Error(`Failed to load route at ${indexFile}: ${reason}`, { cause })
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd packages/core && pnpm test -- --run discover-routes.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Run full core test suite**
+
+Run: `cd packages/core && pnpm test`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/core/src/discovery/discover-routes.ts packages/core/test/discover-routes.test.ts
+git commit -m "feat(core): detect export default agent() descriptors in route discovery"
+```
+
+---
+
+### Task 4: CLI runtime — support `export default` in `normalizeRouteModule`
+
+**Files:**
+- Modify: `packages/cli/src/lib/runtime/load-route-kind.ts`
+- Modify: `packages/cli/test/run-command.test.ts` (if needed for coverage)
+
+The CLI's `normalizeRouteModule` only checks named exports (`agent`, `chain`, etc.). It must also check `module.default` for `DawnAgent` descriptors.
+
+- [ ] **Step 1: Update `normalizeRouteModule` to handle default exports**
+
+In `packages/cli/src/lib/runtime/load-route-kind.ts`, add the `isDawnAgent` import and default export check:
+
+```typescript
+import { pathToFileURL } from "node:url"
+
+import type { RouteKind } from "@dawn-ai/sdk"
+import { isDawnAgent } from "@dawn-ai/sdk"
+
+import { registerTsxLoader } from "./register-tsx-loader.js"
+
+export interface NormalizedRouteModule {
+  readonly kind: RouteKind
+  readonly entry: unknown
+  readonly config: Record<string, unknown>
+}
+
+export async function loadRouteKind(routeFile: string): Promise<RouteKind> {
+  const normalized = await normalizeRouteModule(routeFile)
+  return normalized.kind
+}
+
+export async function normalizeRouteModule(routeFile: string): Promise<NormalizedRouteModule> {
+  await registerTsxLoader()
+  const routeModule = (await import(pathToFileURL(routeFile).href)) as {
+    readonly default?: unknown
+    readonly agent?: unknown
+    readonly chain?: unknown
+    readonly config?: Record<string, unknown>
+    readonly graph?: unknown
+    readonly workflow?: unknown
+  }
+
+  // Check default export for DawnAgent descriptor (preferred path)
+  if ("default" in routeModule && isDawnAgent(routeModule.default)) {
+    return { kind: "agent", entry: routeModule.default, config: routeModule.config ?? {} }
+  }
+
+  const hasAgent = "agent" in routeModule && routeModule.agent !== undefined
+  const hasChain = "chain" in routeModule && routeModule.chain !== undefined
+  const hasGraph = "graph" in routeModule && routeModule.graph !== undefined
+  const hasWorkflow = "workflow" in routeModule && routeModule.workflow !== undefined
+
+  const count = [hasAgent, hasChain, hasGraph, hasWorkflow].filter(Boolean).length
+
+  if (count > 1) {
+    throw new Error(
+      `Route index.ts at ${routeFile} must export exactly one of "agent", "workflow", "graph", or "chain"`,
+    )
+  }
+
+  if (hasAgent) {
+    return { kind: "agent", entry: routeModule.agent, config: routeModule.config ?? {} }
+  }
+
+  if (hasChain) {
+    return { kind: "chain", entry: routeModule.chain, config: routeModule.config ?? {} }
+  }
+
+  if (hasGraph) {
+    return { kind: "graph", entry: routeModule.graph, config: routeModule.config ?? {} }
+  }
+
+  if (hasWorkflow) {
+    return { kind: "workflow", entry: routeModule.workflow, config: routeModule.config ?? {} }
+  }
+
+  throw new Error(
+    `Route index.ts at ${routeFile} exports neither "agent", "workflow", "graph", nor "chain"`,
+  )
+}
+```
+
+- [ ] **Step 2: Run CLI tests**
+
+Run: `cd packages/cli && pnpm test`
+Expected: PASS
+
+- [ ] **Step 3: Run typecheck**
+
+Run: `cd packages/cli && pnpm typecheck`
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/cli/src/lib/runtime/load-route-kind.ts
+git commit -m "feat(cli): support export default agent() in route module normalization"
+```
+
+---
+
+### Task 5: Template — switch to `agent()` API
+
+**Files:**
+- Modify: `packages/devkit/templates/app-basic/src/app/(public)/hello/[tenant]/index.ts`
+- Modify: `packages/devkit/templates/app-basic/package.json.template`
+- Modify: `packages/devkit/src/testing/generated-app.ts`
+
+- [ ] **Step 1: Update the template route file**
+
+Replace `packages/devkit/templates/app-basic/src/app/(public)/hello/[tenant]/index.ts` with:
+
+```typescript
+import { agent } from "@dawn-ai/sdk"
+
+export default agent({
+  model: "gpt-4o-mini",
+  systemPrompt:
+    "You are a helpful assistant for the {tenant} organization. Answer questions about the tenant.",
+})
+```
+
+- [ ] **Step 2: Remove direct langchain deps from template package.json**
+
+Update `packages/devkit/templates/app-basic/package.json.template` — remove the three langchain lines:
+
+```json
+{
+  "name": "{{appName}}",
+  "private": true,
+  "type": "module",
+  "engines": {
+    "node": ">=22.12.0"
+  },
+  "dependencies": {
+    "@dawn-ai/core": "{{dawnCoreSpecifier}}",
+    "@dawn-ai/cli": "{{dawnCliSpecifier}}",
+    "@dawn-ai/langchain": "{{dawnLangchainSpecifier}}",
+    "@dawn-ai/sdk": "{{dawnSdkSpecifier}}"
+  },
+  "devDependencies": {
+    "@dawn-ai/config-typescript": "{{dawnConfigTypescriptSpecifier}}",
+    "@types/node": "25.6.0",
+    "typescript": "6.0.2"
+  },
+  "scripts": {
+    "check": "dawn check",
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc --noEmit"
+  }
+}
+```
+
+- [ ] **Step 3: Update `GeneratedAppSpecifiers` in testing helper**
+
+In `packages/devkit/src/testing/generated-app.ts`, remove the langchain specifier fields:
+
+Remove from `GeneratedAppSpecifiers`:
+```typescript
+export interface GeneratedAppSpecifiers {
+  readonly dawnCli: string
+  readonly dawnConfigTypescript: string
+  readonly dawnCore: string
+  readonly dawnLangchain: string
+  readonly dawnSdk: string
+}
+```
+
+Remove from `normalizeSpecifiers`:
+```typescript
+function normalizeSpecifiers(
+  specifiers: Partial<GeneratedAppSpecifiers> | undefined,
+): GeneratedAppSpecifiers {
+  return {
+    dawnCli: specifiers?.dawnCli ?? "workspace:*",
+    dawnConfigTypescript: specifiers?.dawnConfigTypescript ?? "workspace:*",
+    dawnCore: specifiers?.dawnCore ?? "workspace:*",
+    dawnLangchain: specifiers?.dawnLangchain ?? "workspace:*",
+    dawnSdk: specifiers?.dawnSdk ?? "workspace:*",
+  }
+}
+```
+
+Remove from `createGeneratedApp` replacements:
+```typescript
+replacements: {
+  appName: options.appName,
+  dawnCliSpecifier: specifiers.dawnCli,
+  dawnConfigTypescriptSpecifier: specifiers.dawnConfigTypescript,
+  dawnCoreSpecifier: specifiers.dawnCore,
+  dawnLangchainSpecifier: specifiers.dawnLangchain,
+  dawnSdkSpecifier: specifiers.dawnSdk,
+},
+```
+
+- [ ] **Step 4: Run devkit tests**
+
+Run: `cd packages/devkit && pnpm test`
+Expected: PASS
+
+- [ ] **Step 5: Run full workspace typecheck**
+
+Run: `pnpm -r typecheck`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/devkit/templates/app-basic/src/app/\(public\)/hello/\[tenant\]/index.ts \
+  packages/devkit/templates/app-basic/package.json.template \
+  packages/devkit/src/testing/generated-app.ts
+git commit -m "feat(devkit): switch template to agent() API, drop direct langchain deps"
+```
+
+---
+
+### Task 6: Add `@langchain/langgraph` and `@langchain/openai` as deps of `@dawn-ai/langchain`
+
+**Files:**
+- Modify: `packages/langchain/package.json`
+
+- [ ] **Step 1: Add the dependencies**
+
+The `materializeAgent` function dynamically imports `@langchain/langgraph/prebuilt` and `@langchain/openai`. These must be declared as dependencies (or peer dependencies) of `@dawn-ai/langchain`.
+
+Update `packages/langchain/package.json` to add:
+
+```json
+{
+  "dependencies": {
+    "@dawn-ai/sdk": "workspace:*",
+    "@langchain/langgraph": "^1.2.9",
+    "@langchain/openai": "^1.0.0-alpha.1"
+  },
+  "peerDependencies": {
+    "@langchain/core": ">=1.1.40"
+  }
+}
+```
+
+Note: bump `@langchain/core` peer dep minimum from `>=0.3.0` to `>=1.1.40` since that's what langgraph requires.
+
+- [ ] **Step 2: Install dependencies**
+
+Run: `pnpm install`
+Expected: Lockfile updates, no errors
+
+- [ ] **Step 3: Run langchain tests**
+
+Run: `cd packages/langchain && pnpm test`
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/langchain/package.json pnpm-lock.yaml
+git commit -m "feat(langchain): add langgraph and openai as dependencies for agent materialization"
+```
+
+---
+
+### Task 7: Integration test — full round-trip with mock LLM
+
+**Files:**
+- Create: `packages/langchain/test/agent-descriptor-integration.test.ts`
+
+- [ ] **Step 1: Write the integration test**
+
+Create `packages/langchain/test/agent-descriptor-integration.test.ts`:
+
+```typescript
+import { describe, expect, test, vi } from "vitest"
+import { agent } from "@dawn-ai/sdk"
+import { executeAgent } from "../src/agent-adapter.js"
+
+describe("agent() descriptor integration", () => {
+  test("DawnAgent descriptor is recognized and does not throw invoke error", async () => {
+    const descriptor = agent({
+      model: "gpt-4o-mini",
+      systemPrompt: "You are a test assistant.",
+    })
+
+    // Without a real LLM key, materialization will fail on ChatOpenAI creation
+    // or network call — but it should NOT fail with "must expose invoke(input)"
+    const error = await executeAgent({
+      entry: descriptor,
+      input: { question: "hi" },
+      routeParamNames: [],
+      signal: new AbortController().signal,
+      tools: [],
+    }).catch((e: Error) => e)
+
+    expect(error).toBeInstanceOf(Error)
+    expect((error as Error).message).not.toContain("must expose invoke")
+  })
+
+  test("DawnAgent with tools passes tools to materialized agent", async () => {
+    const descriptor = agent({
+      model: "gpt-4o-mini",
+      systemPrompt: "Use tools.",
+    })
+
+    const tools = [
+      {
+        name: "lookup",
+        description: "Look up data",
+        run: async (input: unknown) => ({ result: "found" }),
+      },
+    ]
+
+    // Will fail on LLM connection, but should get past tool conversion
+    const error = await executeAgent({
+      entry: descriptor,
+      input: { query: "test" },
+      routeParamNames: [],
+      signal: new AbortController().signal,
+      tools,
+    }).catch((e: Error) => e)
+
+    expect(error).toBeInstanceOf(Error)
+    expect((error as Error).message).not.toContain("must expose invoke")
+  })
+})
+```
+
+- [ ] **Step 2: Run integration test**
+
+Run: `cd packages/langchain && pnpm test -- --run agent-descriptor-integration.test.ts`
+Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/langchain/test/agent-descriptor-integration.test.ts
+git commit -m "test(langchain): add integration tests for DawnAgent descriptor materialization"
+```
+
+---
+
+### Task 8: Update smoke test overlays for new template
+
+**Files:**
+- Modify: `test/smoke/agent-basic.overlay.json` (if it references old template format)
+- Verify: All existing CI tests pass
+
+- [ ] **Step 1: Check existing smoke overlays**
+
+Run: `cat test/smoke/agent-basic.overlay.json`
+
+If the overlay still provides a mock agent via `export const agent = { invoke: ... }`, it should continue to work (legacy path). Verify no overlay references the old `createAgent` import.
+
+- [ ] **Step 2: Run full test suite**
+
+Run: `pnpm test`
+Expected: PASS across all packages
+
+- [ ] **Step 3: Run full typecheck**
+
+Run: `pnpm -r typecheck`
+Expected: PASS
+
+- [ ] **Step 4: Run biome lint**
+
+Run: `pnpm -r lint`
+Expected: PASS (no formatting issues)
+
+- [ ] **Step 5: Commit (if any overlay fixes needed)**
+
+```bash
+git add test/
+git commit -m "test: update smoke overlays for agent() template change"
+```
+
+---
+
+### Task 9: Delete unused `packages/sdk/src/tool.ts`
+
+**Files:**
+- Delete: `packages/sdk/src/tool.ts`
+
+- [ ] **Step 1: Verify file is empty/unused**
+
+Run: `cat packages/sdk/src/tool.ts && grep -r "tool.js\|from.*./tool" packages/sdk/src/`
+Expected: File is empty, no imports reference it
+
+- [ ] **Step 2: Remove the file**
+
+```bash
+rm packages/sdk/src/tool.ts
+```
+
+- [ ] **Step 3: Run tests and typecheck**
+
+Run: `cd packages/sdk && pnpm test && pnpm typecheck`
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add -u packages/sdk/src/tool.ts
+git commit -m "chore(sdk): remove empty tool.ts placeholder"
+```

--- a/docs/superpowers/specs/2026-05-01-agent-typed-api-design.md
+++ b/docs/superpowers/specs/2026-05-01-agent-typed-api-design.md
@@ -1,0 +1,178 @@
+# `agent()` Typed API Design
+
+## Problem
+
+When users write a Dawn agent route using LangChain's `createAgent()` directly, TypeScript cannot infer the return type without referencing deep internal types from `@langchain/langgraph`. This produces the error:
+
+> The inferred type of 'agent' cannot be named without a reference to 'AnnotationRoot'
+
+Users must add a manual type annotation (`const agent: Runnable = ...`) to suppress this — poor DX for a starter template.
+
+## Goal
+
+Provide a single `agent()` function in `@dawn-ai/sdk` that:
+
+1. Returns an opaque type Dawn controls — no third-party type leakage
+2. Requires zero type annotations from the user
+3. Provides model name autocomplete
+4. Is a lazy descriptor — no LLM SDK code runs at import time
+5. Works with Dawn's existing auto-discovered tools (no `tool()` wrapper needed)
+
+## Design
+
+### User-Facing API
+
+```typescript
+// src/app/(public)/hello/[tenant]/index.ts
+import { agent } from "@dawn-ai/sdk"
+
+export default agent({
+  model: "gpt-4o-mini",
+  systemPrompt: "You are a helpful assistant for {tenant}.",
+})
+```
+
+Tools remain unchanged — default-exported functions discovered from `tools/`:
+
+```typescript
+// src/app/(public)/hello/[tenant]/tools/greet.ts
+export default async (input: { readonly tenant: string }) => {
+  return { name: input.tenant, plan: "starter" }
+}
+```
+
+### Type Definition (in `@dawn-ai/sdk`)
+
+```typescript
+const DAWN_AGENT: unique symbol = Symbol.for("dawn.agent")
+
+export interface DawnAgent {
+  readonly [DAWN_AGENT]: true
+  readonly model: string
+  readonly systemPrompt: string
+}
+
+export interface AgentConfig {
+  readonly model: KnownModelId
+  readonly systemPrompt: string
+}
+
+export type KnownModelId =
+  | "gpt-4o"
+  | "gpt-4o-mini"
+  | "gpt-4.1"
+  | "gpt-4.1-mini"
+  | "gpt-4.1-nano"
+  | "claude-sonnet-4-20250514"
+  | "claude-haiku-4-20250414"
+  | (string & {})
+
+export function agent(config: AgentConfig): DawnAgent
+```
+
+Key type tricks:
+- `KnownModelId` uses the `(string & {})` pattern for autocomplete on known models while allowing any string
+- `DawnAgent` is branded with a symbol — opaque to consumers, recognizable to Dawn internals
+- No generics needed since tools are auto-discovered, not passed in
+
+### Runtime Implementation (in `@dawn-ai/sdk`)
+
+```typescript
+export function agent(config: AgentConfig): DawnAgent {
+  return {
+    [DAWN_AGENT]: true,
+    model: config.model,
+    systemPrompt: config.systemPrompt,
+  }
+}
+
+export function isDawnAgent(value: unknown): value is DawnAgent {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    DAWN_AGENT in value &&
+    (value as Record<symbol, unknown>)[DAWN_AGENT] === true
+  )
+}
+```
+
+### Adapter Changes (in `@dawn-ai/langchain`)
+
+The `executeAgent` function gains a branch for `DawnAgent` descriptors:
+
+```typescript
+export async function executeAgent(options: {
+  readonly entry: unknown  // DawnAgent | raw Runnable
+  readonly input: unknown
+  readonly routeParamNames: readonly string[]
+  readonly signal: AbortSignal
+  readonly tools: readonly DawnToolDefinition[]
+}): Promise<unknown> {
+  if (isDawnAgent(options.entry)) {
+    const materializedAgent = materializeAgent(options.entry, options.tools)
+    return await invokeAgent(materializedAgent, options)
+  }
+
+  // Fallback: raw Runnable with .invoke()
+  return await invokeLegacyAgent(options)
+}
+```
+
+`materializeAgent` calls LangChain's `createAgent` with the config from the descriptor plus the auto-discovered tools. It caches the compiled agent for subsequent invocations.
+
+### Route Discovery
+
+Discovery already imports route files and checks for named exports. The check becomes (in priority order):
+
+1. `export default` is a `DawnAgent` (check symbol) → kind is `"agent"` (preferred)
+2. `export const agent` is a `DawnAgent` (check symbol) → kind is `"agent"`
+3. `export const agent` is an object with `.invoke()` → kind is `"agent"` (legacy/escape-hatch)
+
+### Escape Hatch (Power Users)
+
+Users who want raw LangChain control can still do:
+
+```typescript
+import type { Runnable } from "@langchain/core/runnables"
+import { createAgent } from "langchain"
+
+export const agent: Runnable = createAgent({
+  model: "gpt-4o-mini",
+  tools: [/* manually wired tools */],
+})
+```
+
+This works because the adapter falls back to calling `.invoke()` directly on anything that isn't a `DawnAgent` descriptor.
+
+## What Changes
+
+| Component | Change |
+|-----------|--------|
+| `@dawn-ai/sdk` | Add `agent()`, `DawnAgent`, `isDawnAgent`, `KnownModelId` |
+| `@dawn-ai/langchain` | Add `materializeAgent`, update `executeAgent` to handle descriptors |
+| Template | Replace `import { createAgent } from "langchain"` with `import { agent } from "@dawn-ai/sdk"` |
+| `packages/devkit` | Update template `index.ts` and remove `langchain` from template deps |
+| Route discovery | Add `isDawnAgent` check alongside existing `.invoke()` check |
+
+## What Does NOT Change
+
+- Tool files — still plain default-exported functions
+- Tool auto-discovery — still filesystem-based
+- `dawn build` — still generates compiled entries
+- Other route kinds (`chain`, `graph`, `workflow`) — unaffected
+- Test overlays — mock agents still use plain `{ invoke() }` objects
+
+## Dependencies
+
+`@dawn-ai/sdk` gains zero new dependencies. The `agent()` function is pure data construction — no imports from LangChain, zod, or anything else.
+
+`@dawn-ai/langchain` already depends on `@langchain/core`. It gains a dependency on `@dawn-ai/sdk` (for `isDawnAgent`).
+
+## Template Dependency Simplification
+
+Today the template requires:
+- `langchain@1.0.0-alpha.5`
+- `@langchain/core@1.1.40`
+- `@langchain/openai@1.0.0-alpha.1`
+
+After this change, these become transitive deps of `@dawn-ai/langchain` (which the user already depends on). The template's `package.json` no longer lists them directly — Dawn owns the version coordination.

--- a/packages/cli/src/lib/runtime/load-route-kind.ts
+++ b/packages/cli/src/lib/runtime/load-route-kind.ts
@@ -1,6 +1,7 @@
 import { pathToFileURL } from "node:url"
 
 import type { RouteKind } from "@dawn-ai/sdk"
+import { isDawnAgent } from "@dawn-ai/sdk"
 
 import { registerTsxLoader } from "./register-tsx-loader.js"
 
@@ -21,8 +22,14 @@ export async function normalizeRouteModule(routeFile: string): Promise<Normalize
     readonly agent?: unknown
     readonly chain?: unknown
     readonly config?: Record<string, unknown>
+    readonly default?: unknown
     readonly graph?: unknown
     readonly workflow?: unknown
+  }
+
+  // Check default export for DawnAgent descriptor (preferred path)
+  if ("default" in routeModule && isDawnAgent(routeModule.default)) {
+    return { kind: "agent", entry: routeModule.default, config: routeModule.config ?? {} }
   }
 
   const hasAgent = "agent" in routeModule && routeModule.agent !== undefined

--- a/packages/core/src/discovery/discover-routes.ts
+++ b/packages/core/src/discovery/discover-routes.ts
@@ -2,6 +2,7 @@ import { readdir } from "node:fs/promises"
 import { join, relative, resolve, sep } from "node:path"
 import { pathToFileURL } from "node:url"
 import type { RouteKind } from "@dawn-ai/sdk"
+import { isDawnAgent } from "@dawn-ai/sdk"
 import type { DiscoverRoutesOptions, RouteDefinition, RouteManifest } from "../types.js"
 import { findDawnApp } from "./find-dawn-app.js"
 import { isPrivateSegment, isRouteGroupSegment, toRouteSegments } from "./route-segments.js"
@@ -93,6 +94,12 @@ async function readRouteEntry(
 async function inferRouteKind(indexFile: string): Promise<RouteKind | null> {
   await registerTsxLoader()
   const routeExports = await loadRouteExports(indexFile)
+
+  // Check default export for DawnAgent descriptor (preferred path)
+  if ("default" in routeExports && isDawnAgent(routeExports.default)) {
+    return "agent"
+  }
+
   const hasAgent = "agent" in routeExports && routeExports.agent !== undefined
   const hasChain = "chain" in routeExports && routeExports.chain !== undefined
   const hasGraph = "graph" in routeExports && routeExports.graph !== undefined
@@ -126,6 +133,7 @@ async function inferRouteKind(indexFile: string): Promise<RouteKind | null> {
 }
 
 async function loadRouteExports(indexFile: string): Promise<{
+  readonly default?: unknown
   readonly agent?: unknown
   readonly chain?: unknown
   readonly graph?: unknown
@@ -133,6 +141,7 @@ async function loadRouteExports(indexFile: string): Promise<{
 }> {
   try {
     return (await import(pathToFileURL(indexFile).href)) as {
+      readonly default?: unknown
       readonly agent?: unknown
       readonly chain?: unknown
       readonly graph?: unknown

--- a/packages/core/test/discover-routes.test.ts
+++ b/packages/core/test/discover-routes.test.ts
@@ -1,9 +1,12 @@
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises"
+import { mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
-import { join } from "node:path"
+import { join, resolve } from "node:path"
+import { fileURLToPath } from "node:url"
 import { afterEach, beforeEach, describe, expect, it } from "vitest"
 
 import { discoverRoutes } from "../src/index.js"
+
+const SDK_PATH = resolve(fileURLToPath(import.meta.url), "../../../sdk")
 
 let workspaceRoot: string
 
@@ -20,6 +23,10 @@ async function writeApp(files: Readonly<Record<string, string>>): Promise<string
 
   await writeFile(join(appRoot, "package.json"), `{}\n`, "utf8")
   await writeFile(join(appRoot, "dawn.config.ts"), `export default { appDir: "src/app" }\n`, "utf8")
+
+  // Symlink @dawn-ai/sdk so fixture files can import it
+  await mkdir(join(appRoot, "node_modules/@dawn-ai"), { recursive: true })
+  await symlink(SDK_PATH, join(appRoot, "node_modules/@dawn-ai/sdk"))
 
   for (const [relative, content] of Object.entries(files)) {
     const absolute = join(appRoot, relative)
@@ -117,5 +124,19 @@ describe("discoverRoutes", () => {
     })
 
     await expect(discoverRoutes({ appRoot })).rejects.toThrow(/Duplicate Dawn route pathname/)
+  })
+
+  it("discovers an agent route from export default agent()", async () => {
+    const appRoot = await writeApp({
+      "src/app/hello/index.ts": `import { agent } from "@dawn-ai/sdk"\nexport default agent({ model: "gpt-4o-mini", systemPrompt: "hi" })\n`,
+    })
+
+    const manifest = await discoverRoutes({ appRoot })
+
+    expect(manifest.routes).toHaveLength(1)
+    expect(manifest.routes[0]).toMatchObject({
+      pathname: "/hello",
+      kind: "agent",
+    })
   })
 })

--- a/packages/create-dawn-app/src/index.ts
+++ b/packages/create-dawn-app/src/index.ts
@@ -181,9 +181,6 @@ function createTemplateReplacements(
   readonly dawnLangchainSpecifier: string
   readonly dawnLanggraphSpecifier: string
   readonly dawnSdkSpecifier: string
-  readonly langchainCoreSpecifier: string
-  readonly langchainOpenaiSpecifier: string
-  readonly langchainSpecifier: string
 } {
   if (options.mode === "internal") {
     return {
@@ -196,9 +193,6 @@ function createTemplateReplacements(
       dawnLangchainSpecifier: createAbsoluteFileSpecifier(resolve(repoRoot, "packages/langchain")),
       dawnLanggraphSpecifier: createAbsoluteFileSpecifier(resolve(repoRoot, "packages/langgraph")),
       dawnSdkSpecifier: createAbsoluteFileSpecifier(resolve(repoRoot, "packages/sdk")),
-      langchainCoreSpecifier: "0.3.80",
-      langchainOpenaiSpecifier: "0.6.17",
-      langchainSpecifier: "1.0.0-alpha.5",
     }
   }
 
@@ -210,9 +204,6 @@ function createTemplateReplacements(
     dawnLangchainSpecifier: options.distTag,
     dawnLanggraphSpecifier: options.distTag,
     dawnSdkSpecifier: options.distTag,
-    langchainCoreSpecifier: "0.3.80",
-    langchainOpenaiSpecifier: "0.6.17",
-    langchainSpecifier: "1.0.0-alpha.5",
   }
 }
 

--- a/packages/create-dawn-app/test/create-app.test.ts
+++ b/packages/create-dawn-app/test/create-app.test.ts
@@ -99,9 +99,6 @@ describe("create-dawn-app", () => {
     expect(packageJson.dependencies["@dawn-ai/core"]).toBe("next")
     expect(packageJson.dependencies["@dawn-ai/cli"]).toBe("next")
     expect(packageJson.dependencies["@dawn-ai/langchain"]).toBe("next")
-    expect(packageJson.dependencies["@langchain/openai"]).toBe("0.6.17")
-    expect(packageJson.dependencies["@langchain/core"]).toBe("0.3.80")
-    expect(packageJson.dependencies.langchain).toBe("1.0.0-alpha.5")
     expect(packageJson.devDependencies["@dawn-ai/config-typescript"]).toBe("next")
     await expect(access(join(targetDir, ".npmrc"), constants.F_OK)).rejects.toThrow()
   })
@@ -145,9 +142,6 @@ describe("create-dawn-app", () => {
     expect(packageJson.dependencies["@dawn-ai/core"]).toMatch(/^file:/)
     expect(packageJson.dependencies["@dawn-ai/cli"]).toMatch(/^file:/)
     expect(packageJson.dependencies["@dawn-ai/langchain"]).toMatch(/^file:/)
-    expect(packageJson.dependencies["@langchain/openai"]).toBe("0.6.17")
-    expect(packageJson.dependencies["@langchain/core"]).toBe("0.3.80")
-    expect(packageJson.dependencies.langchain).toBe("1.0.0-alpha.5")
     expect(packageJson.devDependencies["@dawn-ai/config-typescript"]).toMatch(/^file:/)
     await assertExists(join(targetDir, "src/app/(public)/hello/[tenant]/index.ts"))
     await assertExists(join(targetDir, "src/app/(public)/hello/[tenant]/state.ts"))
@@ -181,9 +175,6 @@ describe("create-dawn-app", () => {
     expect(resolveFileSpecifier(packageJson.dependencies["@dawn-ai/langchain"])).toBe(
       resolve(repoRoot, "packages/langchain"),
     )
-    expect(packageJson.dependencies["@langchain/openai"]).toBe("0.6.17")
-    expect(packageJson.dependencies["@langchain/core"]).toBe("0.3.80")
-    expect(packageJson.dependencies.langchain).toBe("1.0.0-alpha.5")
     expect(resolveFileSpecifier(packageJson.devDependencies["@dawn-ai/config-typescript"])).toBe(
       resolve(repoRoot, "packages/config-typescript"),
     )

--- a/packages/devkit/src/testing/generated-app.ts
+++ b/packages/devkit/src/testing/generated-app.ts
@@ -11,9 +11,6 @@ export interface GeneratedAppSpecifiers {
   readonly dawnCore: string
   readonly dawnLangchain: string
   readonly dawnSdk: string
-  readonly langchain: string
-  readonly langchainCore: string
-  readonly langchainOpenai: string
 }
 
 export interface CreateGeneratedAppOptions {
@@ -50,9 +47,6 @@ export async function createGeneratedApp(
       dawnCoreSpecifier: specifiers.dawnCore,
       dawnLangchainSpecifier: specifiers.dawnLangchain,
       dawnSdkSpecifier: specifiers.dawnSdk,
-      langchainCoreSpecifier: specifiers.langchainCore,
-      langchainOpenaiSpecifier: specifiers.langchainOpenai,
-      langchainSpecifier: specifiers.langchain,
     },
     targetDir: appRoot,
     templateDir,
@@ -77,8 +71,5 @@ function normalizeSpecifiers(
     dawnCore: specifiers?.dawnCore ?? "workspace:*",
     dawnLangchain: specifiers?.dawnLangchain ?? "workspace:*",
     dawnSdk: specifiers?.dawnSdk ?? "workspace:*",
-    langchain: specifiers?.langchain ?? "1.0.0-alpha.5",
-    langchainCore: specifiers?.langchainCore ?? "0.3.80",
-    langchainOpenai: specifiers?.langchainOpenai ?? "0.6.17",
   }
 }

--- a/packages/devkit/templates/app-basic/package.json.template
+++ b/packages/devkit/templates/app-basic/package.json.template
@@ -11,10 +11,7 @@
     "@dawn-ai/core": "{{dawnCoreSpecifier}}",
     "@dawn-ai/cli": "{{dawnCliSpecifier}}",
     "@dawn-ai/langchain": "{{dawnLangchainSpecifier}}",
-    "@dawn-ai/sdk": "{{dawnSdkSpecifier}}",
-    "@langchain/core": "{{langchainCoreSpecifier}}",
-    "@langchain/openai": "{{langchainOpenaiSpecifier}}",
-    "langchain": "{{langchainSpecifier}}"
+    "@dawn-ai/sdk": "{{dawnSdkSpecifier}}"
   },
   "devDependencies": {
     "@dawn-ai/config-typescript": "{{dawnConfigTypescriptSpecifier}}",

--- a/packages/devkit/templates/app-basic/src/app/(public)/hello/[tenant]/index.ts
+++ b/packages/devkit/templates/app-basic/src/app/(public)/hello/[tenant]/index.ts
@@ -1,6 +1,7 @@
+import type { Runnable } from "@langchain/core/runnables"
 import { createAgent } from "langchain"
 
-export const agent = createAgent({
+export const agent: Runnable = createAgent({
   model: "gpt-4o-mini",
   systemPrompt:
     "You are a helpful assistant for the {tenant} organization. Answer questions about the tenant.",

--- a/packages/devkit/templates/app-basic/src/app/(public)/hello/[tenant]/index.ts
+++ b/packages/devkit/templates/app-basic/src/app/(public)/hello/[tenant]/index.ts
@@ -1,9 +1,7 @@
-import type { Runnable } from "@langchain/core/runnables"
-import { createAgent } from "langchain"
+import { agent } from "@dawn-ai/sdk"
 
-export const agent: Runnable = createAgent({
+export default agent({
   model: "gpt-4o-mini",
   systemPrompt:
     "You are a helpful assistant for the {tenant} organization. Answer questions about the tenant.",
-  tools: [],
 })

--- a/packages/devkit/test/generated-app.test.ts
+++ b/packages/devkit/test/generated-app.test.ts
@@ -35,8 +35,8 @@ describe("generated app helper", () => {
       expect(packageJson).toContain('"@dawn-ai/cli": "workspace:*"')
       expect(packageJson).toContain('"@dawn-ai/core": "workspace:*"')
       expect(packageJson).toContain('"@dawn-ai/langchain": "workspace:*"')
+      expect(packageJson).toContain('"@dawn-ai/sdk": "workspace:*"')
       expect(packageJson).toContain('"@dawn-ai/config-typescript": "workspace:*"')
-      expect(packageJson).toContain('"langchain": "1.0.0-alpha.5"')
     } finally {
       await rm(baseDir, { force: true, recursive: true })
     }

--- a/packages/langchain/package.json
+++ b/packages/langchain/package.json
@@ -36,7 +36,9 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@dawn-ai/sdk": "workspace:*"
+    "@dawn-ai/sdk": "workspace:*",
+    "@langchain/langgraph": "^0.2.71",
+    "@langchain/openai": "^0.3.17"
   },
   "peerDependencies": {
     "@langchain/core": ">=0.3.0"
@@ -44,6 +46,8 @@
   "devDependencies": {
     "@dawn-ai/config-typescript": "workspace:*",
     "@langchain/core": "0.3.62",
+    "@langchain/langgraph": "0.2.71",
+    "@langchain/openai": "0.3.17",
     "@types/node": "25.6.0",
     "zod": "3.24.4"
   }

--- a/packages/langchain/src/agent-adapter.ts
+++ b/packages/langchain/src/agent-adapter.ts
@@ -1,3 +1,5 @@
+import type { DawnAgent } from "@dawn-ai/sdk"
+import { isDawnAgent } from "@dawn-ai/sdk"
 import { HumanMessage } from "@langchain/core/messages"
 import { convertToolToLangChain } from "./tool-converter.js"
 
@@ -26,6 +28,36 @@ function assertAgentLike(entry: unknown): asserts entry is AgentLike {
   }
 }
 
+const materializedAgents = new WeakMap<DawnAgent, AgentLike>()
+
+async function materializeAgent(
+  descriptor: DawnAgent,
+  tools: readonly DawnToolDefinition[],
+): Promise<AgentLike> {
+  const cached = materializedAgents.get(descriptor)
+  if (cached) {
+    return cached
+  }
+
+  const { createReactAgent } = await import("@langchain/langgraph/prebuilt")
+  const { ChatOpenAI } = await import("@langchain/openai")
+
+  const langchainTools = tools.map((tool) => convertToolToLangChain(tool))
+
+  const llm = new ChatOpenAI({
+    model: descriptor.model,
+  })
+
+  const compiled = createReactAgent({
+    llm,
+    tools: langchainTools,
+    prompt: descriptor.systemPrompt,
+  })
+
+  materializedAgents.set(descriptor, compiled as unknown as AgentLike)
+  return compiled as unknown as AgentLike
+}
+
 export async function executeAgent(options: {
   readonly entry: unknown
   readonly input: unknown
@@ -33,8 +65,6 @@ export async function executeAgent(options: {
   readonly signal: AbortSignal
   readonly tools: readonly DawnToolDefinition[]
 }): Promise<unknown> {
-  assertAgentLike(options.entry)
-
   const inputRecord = (options.input ?? {}) as Record<string, unknown>
   const params: Record<string, unknown> = {}
   const agentInput: Record<string, unknown> = {}
@@ -47,8 +77,6 @@ export async function executeAgent(options: {
     }
   }
 
-  const langchainTools = options.tools.map((tool) => convertToolToLangChain(tool))
-
   const config: Record<string, unknown> = {
     signal: options.signal,
   }
@@ -57,12 +85,22 @@ export async function executeAgent(options: {
     config.configurable = params
   }
 
+  // DawnAgent descriptor path — materialize on first use
+  if (isDawnAgent(options.entry)) {
+    const materializedAgent = await materializeAgent(options.entry, options.tools)
+    const messages = [new HumanMessage(formatAgentMessage(agentInput))]
+    return await materializedAgent.invoke({ messages }, config)
+  }
+
+  // Legacy path — raw Runnable with .invoke()
+  assertAgentLike(options.entry)
+
+  const langchainTools = options.tools.map((tool) => convertToolToLangChain(tool))
   if (langchainTools.length > 0) {
     config.tools = langchainTools
   }
 
   const messages = [new HumanMessage(formatAgentMessage(agentInput))]
-
   return await options.entry.invoke({ messages }, config)
 }
 
@@ -74,7 +112,7 @@ function formatAgentMessage(input: Record<string, unknown>): string {
   }
 
   if (entries.length === 1) {
-    return String(entries[0]![1])
+    return String(entries[0]?.[1])
   }
 
   return entries.map(([key, value]) => `${key}: ${String(value)}`).join("\n")

--- a/packages/langchain/src/agent-adapter.ts
+++ b/packages/langchain/src/agent-adapter.ts
@@ -1,3 +1,4 @@
+import { HumanMessage } from "@langchain/core/messages"
 import { convertToolToLangChain } from "./tool-converter.js"
 
 interface DawnToolDefinition {
@@ -60,5 +61,21 @@ export async function executeAgent(options: {
     config.tools = langchainTools
   }
 
-  return await options.entry.invoke(agentInput, config)
+  const messages = [new HumanMessage(formatAgentMessage(agentInput))]
+
+  return await options.entry.invoke({ messages }, config)
+}
+
+function formatAgentMessage(input: Record<string, unknown>): string {
+  const entries = Object.entries(input)
+
+  if (entries.length === 0) {
+    return ""
+  }
+
+  if (entries.length === 1) {
+    return String(entries[0]![1])
+  }
+
+  return entries.map(([key, value]) => `${key}: ${String(value)}`).join("\n")
 }

--- a/packages/langchain/test/agent-adapter.test.ts
+++ b/packages/langchain/test/agent-adapter.test.ts
@@ -1,0 +1,63 @@
+import { agent } from "@dawn-ai/sdk"
+import { AIMessage } from "@langchain/core/messages"
+import { describe, expect, test, vi } from "vitest"
+import { executeAgent } from "../src/agent-adapter.js"
+
+describe("executeAgent with DawnAgent descriptors", () => {
+  test("DawnAgent descriptor is recognized and does not throw invoke error", async () => {
+    const descriptor = agent({
+      model: "gpt-4o-mini",
+      systemPrompt: "You are helpful.",
+    })
+
+    // Without a real LLM key, materialization will fail on ChatOpenAI/network
+    // but the error should NOT be "Agent entry must expose invoke(input)"
+    const error = await executeAgent({
+      entry: descriptor,
+      input: { question: "hi" },
+      routeParamNames: [],
+      signal: new AbortController().signal,
+      tools: [],
+    }).catch((e: Error) => e)
+
+    expect(error).toBeInstanceOf(Error)
+    expect((error as Error).message).not.toContain("must expose invoke")
+  })
+
+  test("legacy agent with invoke() still works", async () => {
+    const mockAgent = {
+      invoke: vi.fn().mockResolvedValue(new AIMessage({ content: "Legacy!" })),
+    }
+
+    const result = await executeAgent({
+      entry: mockAgent,
+      input: { question: "hi" },
+      routeParamNames: [],
+      signal: new AbortController().signal,
+      tools: [],
+    })
+
+    expect(mockAgent.invoke).toHaveBeenCalled()
+    expect((result as AIMessage).content).toBe("Legacy!")
+  })
+
+  test("route params are separated from agent input", async () => {
+    const mockAgent = {
+      invoke: vi.fn().mockResolvedValue(new AIMessage({ content: "ok" })),
+    }
+
+    await executeAgent({
+      entry: mockAgent,
+      input: { tenant: "acme", question: "hello" },
+      routeParamNames: ["tenant"],
+      signal: new AbortController().signal,
+      tools: [],
+    })
+
+    const call = mockAgent.invoke.mock.calls[0]
+    const invokeInput = call?.[0] as { messages: Array<{ content: string }> }
+    const invokeConfig = call?.[1] as { configurable?: Record<string, unknown> }
+    expect(invokeInput?.messages[0]?.content).toBe("hello")
+    expect(invokeConfig?.configurable).toEqual({ tenant: "acme" })
+  })
+})

--- a/packages/langchain/test/agent-descriptor-integration.test.ts
+++ b/packages/langchain/test/agent-descriptor-integration.test.ts
@@ -1,0 +1,52 @@
+import { agent } from "@dawn-ai/sdk"
+import { describe, expect, test } from "vitest"
+import { executeAgent } from "../src/agent-adapter.js"
+
+describe("agent() descriptor integration", () => {
+  test("DawnAgent descriptor is recognized and does not throw invoke error", async () => {
+    const descriptor = agent({
+      model: "gpt-4o-mini",
+      systemPrompt: "You are a test assistant.",
+    })
+
+    // Without a real LLM key, materialization will fail on ChatOpenAI creation
+    // or network call — but it should NOT fail with "must expose invoke(input)"
+    const error = await executeAgent({
+      entry: descriptor,
+      input: { question: "hi" },
+      routeParamNames: [],
+      signal: new AbortController().signal,
+      tools: [],
+    }).catch((e: Error) => e)
+
+    expect(error).toBeInstanceOf(Error)
+    expect((error as Error).message).not.toContain("must expose invoke")
+  })
+
+  test("DawnAgent with tools passes tools to materialized agent", async () => {
+    const descriptor = agent({
+      model: "gpt-4o-mini",
+      systemPrompt: "Use tools.",
+    })
+
+    const tools = [
+      {
+        name: "lookup",
+        description: "Look up data",
+        run: async (_input: unknown) => ({ result: "found" }),
+      },
+    ]
+
+    // Will fail on LLM connection, but should get past tool conversion
+    const error = await executeAgent({
+      entry: descriptor,
+      input: { query: "test" },
+      routeParamNames: [],
+      signal: new AbortController().signal,
+      tools,
+    }).catch((e: Error) => e)
+
+    expect(error).toBeInstanceOf(Error)
+    expect((error as Error).message).not.toContain("must expose invoke")
+  })
+})

--- a/packages/sdk/src/agent.ts
+++ b/packages/sdk/src/agent.ts
@@ -1,0 +1,41 @@
+const DAWN_AGENT: unique symbol = Symbol.for("dawn.agent") as unknown as typeof DAWN_AGENT
+
+declare const brand: unique symbol
+
+export interface DawnAgent {
+  readonly [brand]: "DawnAgent"
+  readonly model: string
+  readonly systemPrompt: string
+}
+
+export type KnownModelId =
+  | "gpt-4o"
+  | "gpt-4o-mini"
+  | "gpt-4.1"
+  | "gpt-4.1-mini"
+  | "gpt-4.1-nano"
+  | "claude-sonnet-4-20250514"
+  | "claude-haiku-4-20250414"
+  | (string & {})
+
+export interface AgentConfig {
+  readonly model: KnownModelId
+  readonly systemPrompt: string
+}
+
+export function agent(config: AgentConfig): DawnAgent {
+  return {
+    [DAWN_AGENT]: true,
+    model: config.model,
+    systemPrompt: config.systemPrompt,
+  } as unknown as DawnAgent
+}
+
+export function isDawnAgent(value: unknown): value is DawnAgent {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    DAWN_AGENT in value &&
+    (value as Record<symbol, unknown>)[DAWN_AGENT] === true
+  )
+}

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -1,3 +1,5 @@
+export type { AgentConfig, DawnAgent, KnownModelId } from "./agent.js"
+export { agent, isDawnAgent } from "./agent.js"
 export type { BackendAdapter } from "./backend-adapter.js"
 export type { RouteConfig, RouteKind } from "./route-config.js"
 export type { RuntimeContext, RuntimeTool, ToolRegistry } from "./runtime-context.js"

--- a/packages/sdk/test/agent.test.ts
+++ b/packages/sdk/test/agent.test.ts
@@ -1,0 +1,49 @@
+import type { AgentConfig, DawnAgent } from "@dawn-ai/sdk"
+import { agent, isDawnAgent } from "@dawn-ai/sdk"
+import { describe, expect, expectTypeOf, test } from "vitest"
+
+describe("agent()", () => {
+  test("returns a DawnAgent descriptor with the provided config", () => {
+    const descriptor = agent({
+      model: "gpt-4o-mini",
+      systemPrompt: "You are helpful.",
+    })
+
+    expect(descriptor.model).toBe("gpt-4o-mini")
+    expect(descriptor.systemPrompt).toBe("You are helpful.")
+  })
+
+  test("descriptor is recognized by isDawnAgent", () => {
+    const descriptor = agent({
+      model: "gpt-4o-mini",
+      systemPrompt: "Hello",
+    })
+
+    expect(isDawnAgent(descriptor)).toBe(true)
+  })
+
+  test("isDawnAgent rejects plain objects", () => {
+    expect(isDawnAgent({})).toBe(false)
+    expect(isDawnAgent(null)).toBe(false)
+    expect(isDawnAgent(undefined)).toBe(false)
+    expect(isDawnAgent({ model: "gpt-4o", systemPrompt: "hi" })).toBe(false)
+  })
+
+  test("isDawnAgent rejects objects with invoke method (legacy agents)", () => {
+    expect(isDawnAgent({ invoke: async () => ({}) })).toBe(false)
+  })
+
+  test("KnownModelId provides autocomplete but accepts any string", () => {
+    const config: AgentConfig = {
+      model: "my-custom-model",
+      systemPrompt: "hi",
+    }
+    const descriptor = agent(config)
+    expect(descriptor.model).toBe("my-custom-model")
+  })
+
+  test("DawnAgent type is exported", () => {
+    const descriptor = agent({ model: "gpt-4o", systemPrompt: "test" })
+    expectTypeOf(descriptor).toMatchTypeOf<DawnAgent>()
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,7 +105,7 @@ importers:
         version: link:../sdk
       '@langchain/core':
         specifier: 0.3.62
-        version: 0.3.62
+        version: 0.3.62(openai@4.104.0(zod@3.25.76))
       '@types/node':
         specifier: 25.6.0
         version: 25.6.0
@@ -170,13 +170,19 @@ importers:
       '@dawn-ai/sdk':
         specifier: workspace:*
         version: link:../sdk
+      '@langchain/langgraph':
+        specifier: ^0.2.71
+        version: 0.2.71(@langchain/core@0.3.62(openai@4.104.0(zod@3.24.4)))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(zod-to-json-schema@3.25.2(zod@3.24.4))
+      '@langchain/openai':
+        specifier: ^0.3.17
+        version: 0.3.17(@langchain/core@0.3.62(openai@4.104.0(zod@3.24.4)))
     devDependencies:
       '@dawn-ai/config-typescript':
         specifier: workspace:*
         version: link:../config-typescript
       '@langchain/core':
         specifier: 0.3.62
-        version: 0.3.62
+        version: 0.3.62(openai@4.104.0(zod@3.24.4))
       '@types/node':
         specifier: 25.6.0
         version: 25.6.0
@@ -697,6 +703,42 @@ packages:
     resolution: {integrity: sha512-GqRTcoUPnozGRMUcA6QkP7LHL/OvanGdB51Jgb0w7IIPDI3wFugxMHZ4gphnGDtxsD1tQY5ykyEpYNxFK8kl1w==}
     engines: {node: '>=18'}
 
+  '@langchain/langgraph-checkpoint@0.0.18':
+    resolution: {integrity: sha512-IS7zJj36VgY+4pf8ZjsVuUWef7oTwt1y9ylvwu0aLuOn1d0fg05Om9DLm3v2GZ2Df6bhLV1kfWAM0IAl9O5rQQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@langchain/core': '>=0.2.31 <0.4.0'
+
+  '@langchain/langgraph-sdk@0.0.112':
+    resolution: {integrity: sha512-/9W5HSWCqYgwma6EoOspL4BGYxGxeJP6lIquPSF4FA0JlKopaUv58ucZC3vAgdJyCgg6sorCIV/qg7SGpEcCLw==}
+    peerDependencies:
+      '@langchain/core': '>=0.2.31 <0.4.0'
+      react: ^18 || ^19
+      react-dom: ^18 || ^19
+    peerDependenciesMeta:
+      '@langchain/core':
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
+
+  '@langchain/langgraph@0.2.71':
+    resolution: {integrity: sha512-++p6NuU6aQX1aSrB+IDeXbnUCydb72HKiiQPgsGluWs1ZP61VTYydlEU6KPHHHp3JwROBzIbQHXY/G/ygHIrFg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@langchain/core': '>=0.2.36 <0.3.0 || >=0.3.40 < 0.4.0'
+      zod-to-json-schema: ^3.x
+    peerDependenciesMeta:
+      zod-to-json-schema:
+        optional: true
+
+  '@langchain/openai@0.3.17':
+    resolution: {integrity: sha512-uw4po32OKptVjq+CYHrumgbfh4NuD7LqyE+ZgqY9I/LrLc6bHLMc+sisHmI17vgek0K/yqtarI0alPJbzrwyag==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@langchain/core': '>=0.3.29 <0.4.0'
+
   '@manypkg/find-root@1.1.0':
     resolution: {integrity: sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA==}
 
@@ -1058,6 +1100,9 @@ packages:
   '@types/hast@3.0.4':
     resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
 
+  '@types/json-schema@7.0.15':
+    resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
+
   '@types/mdast@4.0.4':
     resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
 
@@ -1067,8 +1112,14 @@ packages:
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
+  '@types/node-fetch@2.6.13':
+    resolution: {integrity: sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==}
+
   '@types/node@12.20.55':
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
+
+  '@types/node@18.19.130':
+    resolution: {integrity: sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==}
 
   '@types/node@25.6.0':
     resolution: {integrity: sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==}
@@ -1125,6 +1176,10 @@ packages:
   '@vitest/utils@4.1.4':
     resolution: {integrity: sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw==}
 
+  abort-controller@3.0.0:
+    resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
+    engines: {node: '>=6.5'}
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -1134,6 +1189,10 @@ packages:
     resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
     engines: {node: '>=0.4.0'}
     hasBin: true
+
+  agentkeepalive@4.6.0:
+    resolution: {integrity: sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==}
+    engines: {node: '>= 8.0.0'}
 
   ansi-colors@4.1.3:
     resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
@@ -1169,6 +1228,9 @@ packages:
     resolution: {integrity: sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==}
     hasBin: true
 
+  asynckit@0.4.0:
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+
   bail@2.0.2:
     resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
 
@@ -1187,6 +1249,10 @@ packages:
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
+
+  call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
 
   camelcase@6.3.0:
     resolution: {integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==}
@@ -1234,6 +1300,10 @@ packages:
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
+  combined-stream@1.0.8:
+    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
+    engines: {node: '>= 0.8'}
+
   comma-separated-tokens@2.0.3:
     resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
 
@@ -1270,6 +1340,10 @@ packages:
   decode-named-character-reference@1.3.0:
     resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
 
+  delayed-stream@1.0.0:
+    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
+    engines: {node: '>=0.4.0'}
+
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
@@ -1289,6 +1363,10 @@ packages:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
     engines: {node: '>=8'}
 
+  dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
+
   enhanced-resolve@5.20.1:
     resolution: {integrity: sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==}
     engines: {node: '>=10.13.0'}
@@ -1297,8 +1375,24 @@ packages:
     resolution: {integrity: sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==}
     engines: {node: '>=8.6'}
 
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
   es-module-lexer@2.0.0:
     resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
+
+  es-object-atoms@1.1.1:
+    resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
+    engines: {node: '>= 0.4'}
+
+  es-set-tostringtag@2.1.0:
+    resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
+    engines: {node: '>= 0.4'}
 
   esast-util-from-estree@2.0.0:
     resolution: {integrity: sha512-4CyanoAudUSBAn5K13H4JhsMH6L9ZP7XbLVe/dKybkxMO7eDyLsT8UHl9TRNrU2Gr9nz+FovfSIjuXWJ81uVwQ==}
@@ -1341,6 +1435,10 @@ packages:
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
 
+  event-target-shim@5.0.1:
+    resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
+    engines: {node: '>=6'}
+
   eventemitter3@4.0.7:
     resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
 
@@ -1378,6 +1476,17 @@ packages:
     resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
     engines: {node: '>=8'}
 
+  form-data-encoder@1.7.2:
+    resolution: {integrity: sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==}
+
+  form-data@4.0.5:
+    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
+    engines: {node: '>= 6'}
+
+  formdata-node@4.4.1:
+    resolution: {integrity: sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==}
+    engines: {node: '>= 12.20'}
+
   fs-extra@7.0.1:
     resolution: {integrity: sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==}
     engines: {node: '>=6 <7 || >=8'}
@@ -1391,6 +1500,17 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
+
+  get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
+
   get-tsconfig@4.13.7:
     resolution: {integrity: sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==}
 
@@ -1402,12 +1522,28 @@ packages:
     resolution: {integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==}
     engines: {node: '>=10'}
 
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
+
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
+
+  has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
+  has-tostringtag@1.0.2:
+    resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.3:
+    resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
+    engines: {node: '>= 0.4'}
 
   hast-util-to-estree@3.1.3:
     resolution: {integrity: sha512-48+B/rJWAp0jamNbAAf9M7Uf//UVqAoMmgXhBdxTDJLGKY+LRnZ99qcG+Qjl5HfMpYNzS5v4EAwVEF34LeAj7w==}
@@ -1421,6 +1557,9 @@ packages:
   human-id@4.1.3:
     resolution: {integrity: sha512-tsYlhAYpjCKa//8rXZ9DqKEawhPoSytweBC2eNvcaDK+57RZLHGqNs3PZTQO6yekLFSuvA6AlnAfrw1uBvtb+Q==}
     hasBin: true
+
+  humanize-ms@1.2.1:
+    resolution: {integrity: sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==}
 
   iconv-lite@0.7.2:
     resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
@@ -1601,6 +1740,10 @@ packages:
   markdown-table@3.0.4:
     resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
 
+  math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
+
   mdast-util-find-and-replace@3.0.2:
     resolution: {integrity: sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==}
 
@@ -1762,6 +1905,14 @@ packages:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
 
+  mime-db@1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
+    engines: {node: '>= 0.6'}
+
   mri@1.2.0:
     resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
     engines: {node: '>=4'}
@@ -1799,8 +1950,34 @@ packages:
       sass:
         optional: true
 
+  node-domexception@1.0.0:
+    resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
+    engines: {node: '>=10.5.0'}
+    deprecated: Use your platform's native DOMException instead
+
+  node-fetch@2.7.0:
+    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
+
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+
+  openai@4.104.0:
+    resolution: {integrity: sha512-p99EFNsA/yX6UhVO93f5kJsDRLAg+CTA2RBqdHK4RtK8u5IJw32Hyb2dTGKbnnFmnuoBv5r7Z2CURI9sGZpSuA==}
+    hasBin: true
+    peerDependencies:
+      ws: ^8.18.0
+      zod: ^3.23.8
+    peerDependenciesMeta:
+      ws:
+        optional: true
+      zod:
+        optional: true
 
   outdent@0.5.0:
     resolution: {integrity: sha512-/jHxFIzoMXdqPzTaCpFzAAWhpkSjZPF4Vsn6jAfNpmbH/ymsmd7Qc6VE9BGn0L6YMj6uwpQLxCECpus4ukKS9Q==}
@@ -2103,6 +2280,9 @@ packages:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
 
+  tr46@0.0.3:
+    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
   trim-lines@3.0.1:
     resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
 
@@ -2130,6 +2310,9 @@ packages:
     resolution: {integrity: sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  undici-types@5.26.5:
+    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
 
   undici-types@7.19.2:
     resolution: {integrity: sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==}
@@ -2161,6 +2344,11 @@ packages:
 
   uuid@10.0.0:
     resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
+    hasBin: true
+
+  uuid@9.0.1:
+    resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   vfile-message@4.0.3:
@@ -2252,6 +2440,16 @@ packages:
         optional: true
       jsdom:
         optional: true
+
+  web-streams-polyfill@4.0.0-beta.3:
+    resolution: {integrity: sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==}
+    engines: {node: '>= 14'}
+
+  webidl-conversions@3.0.1:
+    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+
+  whatwg-url@5.0.0:
+    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
 
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
@@ -2680,14 +2878,14 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@langchain/core@0.3.62':
+  '@langchain/core@0.3.62(openai@4.104.0(zod@3.24.4))':
     dependencies:
       '@cfworker/json-schema': 4.1.1
       ansi-styles: 5.2.0
       camelcase: 6.3.0
       decamelize: 1.2.0
       js-tiktoken: 1.0.21
-      langsmith: 0.3.87
+      langsmith: 0.3.87(openai@4.104.0(zod@3.24.4))
       mustache: 4.2.0
       p-queue: 6.6.2
       p-retry: 4.6.2
@@ -2699,6 +2897,66 @@ snapshots:
       - '@opentelemetry/exporter-trace-otlp-proto'
       - '@opentelemetry/sdk-trace-base'
       - openai
+
+  '@langchain/core@0.3.62(openai@4.104.0(zod@3.25.76))':
+    dependencies:
+      '@cfworker/json-schema': 4.1.1
+      ansi-styles: 5.2.0
+      camelcase: 6.3.0
+      decamelize: 1.2.0
+      js-tiktoken: 1.0.21
+      langsmith: 0.3.87(openai@4.104.0(zod@3.25.76))
+      mustache: 4.2.0
+      p-queue: 6.6.2
+      p-retry: 4.6.2
+      uuid: 10.0.0
+      zod: 3.25.76
+      zod-to-json-schema: 3.25.2(zod@3.25.76)
+    transitivePeerDependencies:
+      - '@opentelemetry/api'
+      - '@opentelemetry/exporter-trace-otlp-proto'
+      - '@opentelemetry/sdk-trace-base'
+      - openai
+
+  '@langchain/langgraph-checkpoint@0.0.18(@langchain/core@0.3.62(openai@4.104.0(zod@3.24.4)))':
+    dependencies:
+      '@langchain/core': 0.3.62(openai@4.104.0(zod@3.24.4))
+      uuid: 10.0.0
+
+  '@langchain/langgraph-sdk@0.0.112(@langchain/core@0.3.62(openai@4.104.0(zod@3.24.4)))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      '@types/json-schema': 7.0.15
+      p-queue: 6.6.2
+      p-retry: 4.6.2
+      uuid: 9.0.1
+    optionalDependencies:
+      '@langchain/core': 0.3.62(openai@4.104.0(zod@3.24.4))
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
+
+  '@langchain/langgraph@0.2.71(@langchain/core@0.3.62(openai@4.104.0(zod@3.24.4)))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(zod-to-json-schema@3.25.2(zod@3.24.4))':
+    dependencies:
+      '@langchain/core': 0.3.62(openai@4.104.0(zod@3.24.4))
+      '@langchain/langgraph-checkpoint': 0.0.18(@langchain/core@0.3.62(openai@4.104.0(zod@3.24.4)))
+      '@langchain/langgraph-sdk': 0.0.112(@langchain/core@0.3.62(openai@4.104.0(zod@3.24.4)))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      uuid: 10.0.0
+      zod: 3.24.4
+    optionalDependencies:
+      zod-to-json-schema: 3.25.2(zod@3.24.4)
+    transitivePeerDependencies:
+      - react
+      - react-dom
+
+  '@langchain/openai@0.3.17(@langchain/core@0.3.62(openai@4.104.0(zod@3.24.4)))':
+    dependencies:
+      '@langchain/core': 0.3.62(openai@4.104.0(zod@3.24.4))
+      js-tiktoken: 1.0.21
+      openai: 4.104.0(zod@3.24.4)
+      zod: 3.24.4
+      zod-to-json-schema: 3.25.2(zod@3.24.4)
+    transitivePeerDependencies:
+      - encoding
+      - ws
 
   '@manypkg/find-root@1.1.0':
     dependencies:
@@ -2985,6 +3243,8 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
 
+  '@types/json-schema@7.0.15': {}
+
   '@types/mdast@4.0.4':
     dependencies:
       '@types/unist': 3.0.3
@@ -2993,7 +3253,16 @@ snapshots:
 
   '@types/ms@2.1.0': {}
 
+  '@types/node-fetch@2.6.13':
+    dependencies:
+      '@types/node': 25.6.0
+      form-data: 4.0.5
+
   '@types/node@12.20.55': {}
+
+  '@types/node@18.19.130':
+    dependencies:
+      undici-types: 5.26.5
 
   '@types/node@25.6.0':
     dependencies:
@@ -3058,11 +3327,19 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
+  abort-controller@3.0.0:
+    dependencies:
+      event-target-shim: 5.0.1
+
   acorn-jsx@5.3.2(acorn@8.16.0):
     dependencies:
       acorn: 8.16.0
 
   acorn@8.16.0: {}
+
+  agentkeepalive@4.6.0:
+    dependencies:
+      humanize-ms: 1.2.1
 
   ansi-colors@4.1.3: {}
 
@@ -3086,6 +3363,8 @@ snapshots:
 
   astring@1.9.0: {}
 
+  asynckit@0.4.0: {}
+
   bail@2.0.2: {}
 
   base64-js@1.5.1: {}
@@ -3099,6 +3378,11 @@ snapshots:
   braces@3.0.3:
     dependencies:
       fill-range: 7.1.1
+
+  call-bind-apply-helpers@1.0.2:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
 
   camelcase@6.3.0: {}
 
@@ -3133,6 +3417,10 @@ snapshots:
 
   color-name@1.1.4: {}
 
+  combined-stream@1.0.8:
+    dependencies:
+      delayed-stream: 1.0.0
+
   comma-separated-tokens@2.0.3: {}
 
   commander@14.0.3: {}
@@ -3161,6 +3449,8 @@ snapshots:
     dependencies:
       character-entities: 2.0.2
 
+  delayed-stream@1.0.0: {}
+
   dequal@2.0.3: {}
 
   detect-indent@6.1.0: {}
@@ -3175,6 +3465,12 @@ snapshots:
     dependencies:
       path-type: 4.0.0
 
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
   enhanced-resolve@5.20.1:
     dependencies:
       graceful-fs: 4.2.11
@@ -3185,7 +3481,22 @@ snapshots:
       ansi-colors: 4.1.3
       strip-ansi: 6.0.1
 
+  es-define-property@1.0.1: {}
+
+  es-errors@1.3.0: {}
+
   es-module-lexer@2.0.0: {}
+
+  es-object-atoms@1.1.1:
+    dependencies:
+      es-errors: 1.3.0
+
+  es-set-tostringtag@2.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      has-tostringtag: 1.0.2
+      hasown: 2.0.3
 
   esast-util-from-estree@2.0.0:
     dependencies:
@@ -3267,6 +3578,8 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.8
 
+  event-target-shim@5.0.1: {}
+
   eventemitter3@4.0.7: {}
 
   expect-type@1.3.0: {}
@@ -3300,6 +3613,21 @@ snapshots:
       locate-path: 5.0.0
       path-exists: 4.0.0
 
+  form-data-encoder@1.7.2: {}
+
+  form-data@4.0.5:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.3
+      mime-types: 2.1.35
+
+  formdata-node@4.4.1:
+    dependencies:
+      node-domexception: 1.0.0
+      web-streams-polyfill: 4.0.0-beta.3
+
   fs-extra@7.0.1:
     dependencies:
       graceful-fs: 4.2.11
@@ -3314,6 +3642,26 @@ snapshots:
 
   fsevents@2.3.3:
     optional: true
+
+  function-bind@1.1.2: {}
+
+  get-intrinsic@1.3.0:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.3
+      math-intrinsics: 1.1.0
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.1
 
   get-tsconfig@4.13.7:
     dependencies:
@@ -3332,9 +3680,21 @@ snapshots:
       merge2: 1.4.1
       slash: 3.0.0
 
+  gopd@1.2.0: {}
+
   graceful-fs@4.2.11: {}
 
   has-flag@4.0.0: {}
+
+  has-symbols@1.1.0: {}
+
+  has-tostringtag@1.0.2:
+    dependencies:
+      has-symbols: 1.1.0
+
+  hasown@2.0.3:
+    dependencies:
+      function-bind: 1.1.2
 
   hast-util-to-estree@3.1.3:
     dependencies:
@@ -3382,6 +3742,10 @@ snapshots:
       '@types/hast': 3.0.4
 
   human-id@4.1.3: {}
+
+  humanize-ms@1.2.1:
+    dependencies:
+      ms: 2.1.3
 
   iconv-lite@0.7.2:
     dependencies:
@@ -3439,7 +3803,7 @@ snapshots:
     optionalDependencies:
       graceful-fs: 4.2.11
 
-  langsmith@0.3.87:
+  langsmith@0.3.87(openai@4.104.0(zod@3.24.4)):
     dependencies:
       '@types/uuid': 10.0.0
       chalk: 4.1.2
@@ -3447,6 +3811,19 @@ snapshots:
       p-queue: 6.6.2
       semver: 7.7.4
       uuid: 10.0.0
+    optionalDependencies:
+      openai: 4.104.0(zod@3.24.4)
+
+  langsmith@0.3.87(openai@4.104.0(zod@3.25.76)):
+    dependencies:
+      '@types/uuid': 10.0.0
+      chalk: 4.1.2
+      console-table-printer: 2.15.0
+      p-queue: 6.6.2
+      semver: 7.7.4
+      uuid: 10.0.0
+    optionalDependencies:
+      openai: 4.104.0(zod@3.25.76)
 
   lightningcss-android-arm64@1.32.0:
     optional: true
@@ -3512,6 +3889,8 @@ snapshots:
   markdown-extensions@2.0.0: {}
 
   markdown-table@3.0.4: {}
+
+  math-intrinsics@1.1.0: {}
 
   mdast-util-find-and-replace@3.0.2:
     dependencies:
@@ -3947,6 +4326,12 @@ snapshots:
       braces: 3.0.3
       picomatch: 2.3.2
 
+  mime-db@1.52.0: {}
+
+  mime-types@2.1.35:
+    dependencies:
+      mime-db: 1.52.0
+
   mri@1.2.0: {}
 
   ms@2.1.3: {}
@@ -3979,7 +4364,42 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
+  node-domexception@1.0.0: {}
+
+  node-fetch@2.7.0:
+    dependencies:
+      whatwg-url: 5.0.0
+
   obug@2.1.1: {}
+
+  openai@4.104.0(zod@3.24.4):
+    dependencies:
+      '@types/node': 18.19.130
+      '@types/node-fetch': 2.6.13
+      abort-controller: 3.0.0
+      agentkeepalive: 4.6.0
+      form-data-encoder: 1.7.2
+      formdata-node: 4.4.1
+      node-fetch: 2.7.0
+    optionalDependencies:
+      zod: 3.24.4
+    transitivePeerDependencies:
+      - encoding
+
+  openai@4.104.0(zod@3.25.76):
+    dependencies:
+      '@types/node': 18.19.130
+      '@types/node-fetch': 2.6.13
+      abort-controller: 3.0.0
+      agentkeepalive: 4.6.0
+      form-data-encoder: 1.7.2
+      formdata-node: 4.4.1
+      node-fetch: 2.7.0
+    optionalDependencies:
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - encoding
+    optional: true
 
   outdent@0.5.0: {}
 
@@ -4321,6 +4741,8 @@ snapshots:
     dependencies:
       is-number: 7.0.0
 
+  tr46@0.0.3: {}
+
   trim-lines@3.0.1: {}
 
   trough@2.2.0: {}
@@ -4346,6 +4768,8 @@ snapshots:
   typescript@5.8.3: {}
 
   typescript@6.0.2: {}
+
+  undici-types@5.26.5: {}
 
   undici-types@7.19.2: {}
 
@@ -4389,6 +4813,8 @@ snapshots:
   universalify@0.1.2: {}
 
   uuid@10.0.0: {}
+
+  uuid@9.0.1: {}
 
   vfile-message@4.0.3:
     dependencies:
@@ -4441,6 +4867,15 @@ snapshots:
     transitivePeerDependencies:
       - msw
 
+  web-streams-polyfill@4.0.0-beta.3: {}
+
+  webidl-conversions@3.0.1: {}
+
+  whatwg-url@5.0.0:
+    dependencies:
+      tr46: 0.0.3
+      webidl-conversions: 3.0.1
+
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
@@ -4449,6 +4884,10 @@ snapshots:
     dependencies:
       siginfo: 2.0.0
       stackback: 0.0.2
+
+  zod-to-json-schema@3.25.2(zod@3.24.4):
+    dependencies:
+      zod: 3.24.4
 
   zod-to-json-schema@3.25.2(zod@3.25.76):
     dependencies:

--- a/scripts/pack-check.mjs
+++ b/scripts/pack-check.mjs
@@ -44,10 +44,10 @@ const packages = [
   {
     dir: "packages/sdk",
     expectedFiles: [
+      "dist/agent.js",
+      "dist/agent.d.ts",
       "dist/index.js",
       "dist/index.d.ts",
-      "dist/tool.js",
-      "dist/tool.d.ts",
       "package.json",
     ],
     requiredFields: [

--- a/test/generated/fixtures/basic.expected.json
+++ b/test/generated/fixtures/basic.expected.json
@@ -12,8 +12,7 @@
       "@dawn-ai/core": "<tarball:@dawn-ai/core>",
       "@dawn-ai/cli": "<tarball:@dawn-ai/cli>",
       "@dawn-ai/langchain": "<tarball:@dawn-ai/langchain>",
-      "@dawn-ai/sdk": "<tarball:@dawn-ai/sdk>",
-      "@langchain/core": "0.3.80"
+      "@dawn-ai/sdk": "<tarball:@dawn-ai/sdk>"
     },
     "devDependencies": {
       "@dawn-ai/config-typescript": "<tarball:@dawn-ai/config-typescript>",

--- a/test/generated/fixtures/custom-app-dir.expected.json
+++ b/test/generated/fixtures/custom-app-dir.expected.json
@@ -12,10 +12,7 @@
       "@dawn-ai/core": "<tarball:@dawn-ai/core>",
       "@dawn-ai/cli": "<tarball:@dawn-ai/cli>",
       "@dawn-ai/langchain": "<tarball:@dawn-ai/langchain>",
-      "@dawn-ai/sdk": "<tarball:@dawn-ai/sdk>",
-      "@langchain/core": "0.3.80",
-      "@langchain/openai": "0.6.17",
-      "langchain": "1.0.0-alpha.5"
+      "@dawn-ai/sdk": "<tarball:@dawn-ai/sdk>"
     },
     "devDependencies": {
       "@dawn-ai/config-typescript": "<tarball:@dawn-ai/config-typescript>",


### PR DESCRIPTION
## Summary

- Adds `agent()` lazy descriptor function to `@dawn-ai/sdk` — returns opaque branded `DawnAgent` type, no LangChain type leakage
- `@dawn-ai/langchain` materializes descriptors into live LangChain agents at invocation time (cached via WeakMap)
- Route discovery and CLI runtime support `export default agent({...})` pattern
- Template switches from `createAgent`/`Runnable` to `agent()`, dropping direct langchain/openai/core deps from user projects
- `create-dawn-app` scaffold output updated accordingly

## Test plan

- [x] 142 tests passing across all packages
- [x] SDK: agent(), isDawnAgent(), type exports verified
- [x] LangChain adapter: descriptor recognition, legacy fallback, route param separation
- [x] Core discovery: `export default agent()` detected as kind "agent"
- [x] CLI normalization: default export handled before named exports
- [x] DevKit: template generates correct package.json without langchain deps
- [x] Integration: descriptor passes tool conversion without "must expose invoke" error
