### PR TITLE
feat: TypeScript DX improvements — codegen schemas, state convention, model IDs

### DIFF
--- a/docs/superpowers/plans/2026-05-01-dx-improvements.md
+++ b/docs/superpowers/plans/2026-05-01-dx-improvements.md
@@ -1,0 +1,2079 @@
+# Dawn TypeScript DX Improvements Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Improve Dawn's TypeScript DX with per-provider model IDs, auto-generated JSON Schema for tools (so LLMs know what args to pass), type manifests for IDE visibility, convention-based agent state, and utility type exports.
+
+**Architecture:** Expand the existing typegen pipeline in `@dawn-ai/core` to emit JSON Schema + JSDoc descriptions alongside the current type strings. Add state discovery convention (`state.ts` + `reducers/` folder) wired through the LangChain adapter. SDK stays zero-dep with only types and interfaces.
+
+**Tech Stack:** TypeScript compiler API (existing), Standard Schema v1 interface, zod (consumer-side), LangChain `@langchain/langgraph` (adapter layer)
+
+---
+
+## File Structure
+
+### New Files
+
+| File | Responsibility |
+|------|---------------|
+| `packages/sdk/src/known-model-ids.ts` | Per-provider model ID types |
+| `packages/sdk/src/types.ts` | `Prettify<T>` utility type |
+| `packages/sdk/src/route-types.ts` | Empty `RouteToolMap` / `RouteStateMap` interfaces for augmentation |
+| `packages/core/src/typegen/extract-tool-schema.ts` | Generate JSON Schema from TS types + JSDoc |
+| `packages/core/src/typegen/render-state-types.ts` | Render state type manifest |
+| `packages/core/src/state/resolve-state-fields.ts` | Resolve state schema defaults → infer reducers |
+| `packages/cli/src/lib/runtime/state-discovery.ts` | Discover `state.ts` + `reducers/` folder |
+| `packages/langchain/src/state-adapter.ts` | Map resolved fields → LangChain AnnotationRoot |
+| `packages/sdk/test/known-model-ids.test.ts` | Model ID type tests |
+| `packages/core/test/extract-tool-schema.test.ts` | JSON Schema generation tests |
+| `packages/core/test/resolve-state-fields.test.ts` | State field resolution tests |
+| `packages/core/test/render-state-types.test.ts` | State type manifest rendering tests |
+| `packages/cli/test/state-discovery.test.ts` | State discovery tests |
+| `packages/langchain/test/state-adapter.test.ts` | State adapter tests |
+
+### Modified Files
+
+| File | Change |
+|------|--------|
+| `packages/sdk/src/agent.ts` | Remove `KnownModelId`, import from `known-model-ids.ts` |
+| `packages/sdk/src/index.ts` | Add new exports |
+| `packages/core/src/types.ts` | Add `ExtractedToolSchema`, `ResolvedStateField` interfaces |
+| `packages/core/src/typegen/extract-tool-types.ts` | Add JSDoc extraction |
+| `packages/core/src/index.ts` | Export new modules |
+| `packages/langchain/src/agent-adapter.ts` | Accept optional state, pass to `createReactAgent` |
+| `packages/cli/src/lib/runtime/execute-route.ts` | Discover state, pass to agent adapter |
+| `packages/cli/src/lib/runtime/tool-discovery.ts` | Inject generated schema when available |
+| `packages/devkit/templates/app-basic/.dawn/dawn.generated.d.ts` | Add state types |
+
+---
+
+### Task 1: Per-Provider Model IDs
+
+**Files:**
+- Create: `packages/sdk/src/known-model-ids.ts`
+- Modify: `packages/sdk/src/agent.ts`
+- Modify: `packages/sdk/src/index.ts`
+- Test: `packages/sdk/test/known-model-ids.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/sdk/test/known-model-ids.test.ts`:
+
+```typescript
+import type { AnthropicModelId, GoogleModelId, KnownModelId, OpenAiModelId } from "@dawn-ai/sdk"
+import { agent } from "@dawn-ai/sdk"
+import { describe, expect, expectTypeOf, test } from "vitest"
+
+describe("KnownModelId", () => {
+  test("accepts OpenAI model IDs", () => {
+    const descriptor = agent({ model: "gpt-5.5", systemPrompt: "test" })
+    expect(descriptor.model).toBe("gpt-5.5")
+  })
+
+  test("accepts Anthropic model IDs", () => {
+    const descriptor = agent({ model: "claude-opus-4-7", systemPrompt: "test" })
+    expect(descriptor.model).toBe("claude-opus-4-7")
+  })
+
+  test("accepts Google model IDs", () => {
+    const descriptor = agent({ model: "gemini-2.5-pro", systemPrompt: "test" })
+    expect(descriptor.model).toBe("gemini-2.5-pro")
+  })
+
+  test("accepts arbitrary string via (string & {})", () => {
+    const descriptor = agent({ model: "my-custom-model", systemPrompt: "test" })
+    expect(descriptor.model).toBe("my-custom-model")
+  })
+
+  test("per-provider types are subtypes of KnownModelId", () => {
+    expectTypeOf<OpenAiModelId>().toMatchTypeOf<KnownModelId>()
+    expectTypeOf<AnthropicModelId>().toMatchTypeOf<KnownModelId>()
+    expectTypeOf<GoogleModelId>().toMatchTypeOf<KnownModelId>()
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd packages/sdk && npx vitest run test/known-model-ids.test.ts`
+Expected: FAIL — `OpenAiModelId`, `AnthropicModelId`, `GoogleModelId` not exported
+
+- [ ] **Step 3: Create `known-model-ids.ts`**
+
+Create `packages/sdk/src/known-model-ids.ts`:
+
+```typescript
+export type OpenAiModelId =
+  // GPT-5.x series
+  | "gpt-5.5"
+  | "gpt-5.5-pro"
+  | "gpt-5.4"
+  | "gpt-5.4-pro"
+  | "gpt-5-mini"
+  // GPT-4.1 series
+  | "gpt-4.1"
+  | "gpt-4.1-mini"
+  | "gpt-4.1-nano"
+  // GPT-4o series
+  | "gpt-4o"
+  | "gpt-4o-mini"
+  // Reasoning
+  | "o3"
+  | "o3-mini"
+  | "o4-mini"
+
+export type AnthropicModelId =
+  | "claude-opus-4-7"
+  | "claude-sonnet-4-6"
+  | "claude-haiku-4-5-20251001"
+
+export type GoogleModelId =
+  | "gemini-3-pro-preview"
+  | "gemini-3-flash-preview"
+  | "gemini-2.5-pro"
+  | "gemini-2.5-flash"
+  | "gemini-2.5-flash-lite"
+
+export type KnownModelId =
+  | OpenAiModelId
+  | AnthropicModelId
+  | GoogleModelId
+  | (string & {})
+```
+
+- [ ] **Step 4: Update `agent.ts` to import from new file**
+
+Modify `packages/sdk/src/agent.ts` — remove lines 11-19 (the inline `KnownModelId` type) and add import:
+
+```typescript
+import type { KnownModelId } from "./known-model-ids.js"
+```
+
+Keep the rest of the file unchanged.
+
+- [ ] **Step 5: Update barrel exports**
+
+Modify `packages/sdk/src/index.ts` — add the new exports:
+
+```typescript
+export type { AgentConfig, DawnAgent } from "./agent.js"
+export { agent, isDawnAgent } from "./agent.js"
+export type { BackendAdapter } from "./backend-adapter.js"
+export type {
+  AnthropicModelId,
+  GoogleModelId,
+  KnownModelId,
+  OpenAiModelId,
+} from "./known-model-ids.js"
+export type { RouteConfig, RouteKind } from "./route-config.js"
+export type { RuntimeContext, RuntimeTool, ToolRegistry } from "./runtime-context.js"
+```
+
+Note: `KnownModelId` moves from `./agent.js` to `./known-model-ids.js` export.
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `cd packages/sdk && npx vitest run`
+Expected: ALL PASS (both existing `agent.test.ts` and new `known-model-ids.test.ts`)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/sdk/src/known-model-ids.ts packages/sdk/src/agent.ts packages/sdk/src/index.ts packages/sdk/test/known-model-ids.test.ts
+git commit -m "feat(sdk): per-provider model IDs with updated models"
+```
+
+---
+
+### Task 2: Utility Types and Export Cleanup
+
+**Files:**
+- Create: `packages/sdk/src/types.ts`
+- Create: `packages/sdk/src/route-types.ts`
+- Modify: `packages/sdk/src/index.ts`
+- Test: `packages/sdk/test/types.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/sdk/test/types.test.ts`:
+
+```typescript
+import type { Prettify, RouteStateMap, RouteToolMap } from "@dawn-ai/sdk"
+import { describe, expectTypeOf, test } from "vitest"
+
+describe("Prettify<T>", () => {
+  test("resolves intersection types into flat object", () => {
+    type A = { a: string } & { b: number }
+    type Result = Prettify<A>
+    expectTypeOf<Result>().toEqualTypeOf<{ a: string; b: number }>()
+  })
+
+  test("preserves optional properties", () => {
+    type A = { a: string; b?: number }
+    type Result = Prettify<A>
+    expectTypeOf<Result>().toEqualTypeOf<{ a: string; b?: number }>()
+  })
+})
+
+describe("RouteToolMap", () => {
+  test("is an empty interface by default", () => {
+    expectTypeOf<RouteToolMap>().toEqualTypeOf<{}>()
+  })
+})
+
+describe("RouteStateMap", () => {
+  test("is an empty interface by default", () => {
+    expectTypeOf<RouteStateMap>().toEqualTypeOf<{}>()
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd packages/sdk && npx vitest run test/types.test.ts`
+Expected: FAIL — `Prettify`, `RouteToolMap`, `RouteStateMap` not exported
+
+- [ ] **Step 3: Create `types.ts`**
+
+Create `packages/sdk/src/types.ts`:
+
+```typescript
+/**
+ * Resolves complex intersection/mapped types into a flat object shape.
+ * Makes IDE hovers show the actual resolved type instead of type algebra.
+ */
+export type Prettify<T> = { [K in keyof T]: T[K] } & {}
+```
+
+- [ ] **Step 4: Create `route-types.ts`**
+
+Create `packages/sdk/src/route-types.ts`:
+
+```typescript
+/**
+ * Open interface for codegen to augment with per-route tool type information.
+ * Populated by `.dawn/generated/route-tools.d.ts` at build time.
+ */
+export interface RouteToolMap {}
+
+/**
+ * Open interface for codegen to augment with per-route state type information.
+ * Populated by `.dawn/generated/route-state.d.ts` at build time.
+ */
+export interface RouteStateMap {}
+```
+
+- [ ] **Step 5: Update barrel exports**
+
+Modify `packages/sdk/src/index.ts` — add new exports (maintaining biome alphabetical order):
+
+```typescript
+export type { AgentConfig, DawnAgent } from "./agent.js"
+export { agent, isDawnAgent } from "./agent.js"
+export type { BackendAdapter } from "./backend-adapter.js"
+export type {
+  AnthropicModelId,
+  GoogleModelId,
+  KnownModelId,
+  OpenAiModelId,
+} from "./known-model-ids.js"
+export type { RouteConfig, RouteKind } from "./route-config.js"
+export type { RouteStateMap, RouteToolMap } from "./route-types.js"
+export type { RuntimeContext, RuntimeTool, ToolRegistry } from "./runtime-context.js"
+export type { Prettify } from "./types.js"
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `cd packages/sdk && npx vitest run`
+Expected: ALL PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/sdk/src/types.ts packages/sdk/src/route-types.ts packages/sdk/src/index.ts packages/sdk/test/types.test.ts
+git commit -m "feat(sdk): add Prettify utility type and RouteToolMap/RouteStateMap interfaces"
+```
+
+---
+
+### Task 3: Extract Tool JSON Schema from TypeScript Types
+
+**Files:**
+- Create: `packages/core/src/typegen/extract-tool-schema.ts`
+- Modify: `packages/core/src/types.ts`
+- Modify: `packages/core/src/index.ts`
+- Test: `packages/core/test/extract-tool-schema.test.ts`
+
+- [ ] **Step 1: Add `ExtractedToolSchema` interface to types**
+
+Modify `packages/core/src/types.ts` — add after `ExtractedToolType`:
+
+```typescript
+export interface JsonSchemaProperty {
+  readonly type: string
+  readonly description?: string
+  readonly items?: JsonSchemaProperty
+  readonly properties?: Record<string, JsonSchemaProperty>
+  readonly required?: readonly string[]
+  readonly additionalProperties?: boolean
+  readonly enum?: readonly string[]
+}
+
+export interface ExtractedToolSchema {
+  readonly name: string
+  readonly description: string
+  readonly parameters: {
+    readonly type: "object"
+    readonly properties: Record<string, JsonSchemaProperty>
+    readonly required: readonly string[]
+    readonly additionalProperties: false
+  }
+}
+
+export interface RouteToolSchemas {
+  readonly pathname: string
+  readonly tools: readonly ExtractedToolSchema[]
+}
+```
+
+- [ ] **Step 2: Write the failing test**
+
+Create `packages/core/test/extract-tool-schema.test.ts`:
+
+```typescript
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { afterEach, beforeEach, describe, expect, test } from "vitest"
+
+import { extractToolSchemasForRoute } from "../src/typegen/extract-tool-schema"
+
+let tempDir: string
+
+beforeEach(() => {
+  tempDir = mkdtempSync(join(tmpdir(), "dawn-tool-schema-"))
+})
+
+afterEach(() => {
+  rmSync(tempDir, { recursive: true, force: true })
+})
+
+function writeToolFile(dir: string, name: string, content: string): void {
+  const toolsDir = join(dir, "tools")
+  mkdirSync(toolsDir, { recursive: true })
+  writeFileSync(join(toolsDir, `${name}.ts`), content)
+}
+
+describe("extractToolSchemasForRoute", () => {
+  test("extracts JSON Schema from typed tool with JSDoc", async () => {
+    const routeDir = join(tempDir, "route")
+    writeToolFile(
+      routeDir,
+      "greet",
+      `
+/**
+ * Greets the tenant and returns their plan info.
+ */
+export default async (input: {
+  /** The tenant organization ID */
+  readonly tenant: string
+}) => {
+  return { name: input.tenant, plan: "starter" }
+}
+`,
+    )
+
+    const result = await extractToolSchemasForRoute({
+      routeDir,
+      sharedToolsDir: undefined,
+    })
+
+    expect(result).toEqual([
+      {
+        name: "greet",
+        description: "Greets the tenant and returns their plan info.",
+        parameters: {
+          type: "object",
+          properties: {
+            tenant: { type: "string", description: "The tenant organization ID" },
+          },
+          required: ["tenant"],
+          additionalProperties: false,
+        },
+      },
+    ])
+  })
+
+  test("maps number, boolean, and array types", async () => {
+    const routeDir = join(tempDir, "route")
+    writeToolFile(
+      routeDir,
+      "search",
+      `
+/**
+ * Searches for items.
+ */
+export default async (input: {
+  /** Search query */
+  query: string
+  /** Max results to return */
+  limit: number
+  /** Include archived items */
+  includeArchived: boolean
+  /** Tags to filter by */
+  tags: string[]
+}) => {
+  return { results: [] }
+}
+`,
+    )
+
+    const result = await extractToolSchemasForRoute({
+      routeDir,
+      sharedToolsDir: undefined,
+    })
+
+    expect(result[0]?.parameters.properties).toEqual({
+      query: { type: "string", description: "Search query" },
+      limit: { type: "number", description: "Max results to return" },
+      includeArchived: { type: "boolean", description: "Include archived items" },
+      tags: {
+        type: "array",
+        items: { type: "string" },
+        description: "Tags to filter by",
+      },
+    })
+    expect(result[0]?.parameters.required).toEqual([
+      "query",
+      "limit",
+      "includeArchived",
+      "tags",
+    ])
+  })
+
+  test("handles optional properties", async () => {
+    const routeDir = join(tempDir, "route")
+    writeToolFile(
+      routeDir,
+      "fetch",
+      `
+/** Fetches data. */
+export default async (input: {
+  url: string
+  timeout?: number
+}) => {
+  return {}
+}
+`,
+    )
+
+    const result = await extractToolSchemasForRoute({
+      routeDir,
+      sharedToolsDir: undefined,
+    })
+
+    expect(result[0]?.parameters.required).toEqual(["url"])
+    expect(result[0]?.parameters.properties.timeout).toEqual({ type: "number" })
+  })
+
+  test("handles string literal unions as enum", async () => {
+    const routeDir = join(tempDir, "route")
+    writeToolFile(
+      routeDir,
+      "sort",
+      `
+/** Sorts items. */
+export default async (input: {
+  /** Sort direction */
+  order: "asc" | "desc"
+}) => {
+  return {}
+}
+`,
+    )
+
+    const result = await extractToolSchemasForRoute({
+      routeDir,
+      sharedToolsDir: undefined,
+    })
+
+    expect(result[0]?.parameters.properties.order).toEqual({
+      type: "string",
+      enum: ["asc", "desc"],
+      description: "Sort direction",
+    })
+  })
+
+  test("returns empty description when no JSDoc present", async () => {
+    const routeDir = join(tempDir, "route")
+    writeToolFile(
+      routeDir,
+      "ping",
+      `
+export default async (input: { host: string }) => {
+  return { ok: true }
+}
+`,
+    )
+
+    const result = await extractToolSchemasForRoute({
+      routeDir,
+      sharedToolsDir: undefined,
+    })
+
+    expect(result[0]?.description).toBe("")
+    expect(result[0]?.parameters.properties.host).toEqual({ type: "string" })
+  })
+
+  test("handles no-parameter tools", async () => {
+    const routeDir = join(tempDir, "route")
+    writeToolFile(
+      routeDir,
+      "health",
+      `
+/** Returns health status. */
+export default async () => {
+  return { ok: true }
+}
+`,
+    )
+
+    const result = await extractToolSchemasForRoute({
+      routeDir,
+      sharedToolsDir: undefined,
+    })
+
+    expect(result[0]).toEqual({
+      name: "health",
+      description: "Returns health status.",
+      parameters: {
+        type: "object",
+        properties: {},
+        required: [],
+        additionalProperties: false,
+      },
+    })
+  })
+})
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `cd packages/core && npx vitest run test/extract-tool-schema.test.ts`
+Expected: FAIL — module not found
+
+- [ ] **Step 4: Implement `extract-tool-schema.ts`**
+
+Create `packages/core/src/typegen/extract-tool-schema.ts`:
+
+```typescript
+import { existsSync, readdirSync } from "node:fs"
+import { join } from "node:path"
+import ts from "typescript"
+
+import type { ExtractedToolSchema, JsonSchemaProperty } from "../types.js"
+
+export interface ExtractToolSchemasOptions {
+  readonly routeDir: string
+  readonly sharedToolsDir: string | undefined
+}
+
+export async function extractToolSchemasForRoute(
+  options: ExtractToolSchemasOptions,
+): Promise<readonly ExtractedToolSchema[]> {
+  const routeToolFiles = discoverToolFiles(join(options.routeDir, "tools"))
+  const sharedToolFiles = options.sharedToolsDir
+    ? discoverToolFiles(join(options.sharedToolsDir, "tools"))
+    : new Map<string, string>()
+
+  const merged = new Map<string, string>(sharedToolFiles)
+  for (const [name, filePath] of routeToolFiles) {
+    merged.set(name, filePath)
+  }
+
+  if (merged.size === 0) return []
+
+  const allFilePaths = [...merged.values()]
+  const compilerOptions: ts.CompilerOptions = {
+    target: ts.ScriptTarget.ES2022,
+    module: ts.ModuleKind.ESNext,
+    moduleResolution: ts.ModuleResolutionKind.Bundler,
+    strict: true,
+    noEmit: true,
+    lib: ["lib.es2022.d.ts"],
+  }
+
+  const program = ts.createProgram(allFilePaths, compilerOptions)
+  const checker = program.getTypeChecker()
+
+  const results: ExtractedToolSchema[] = []
+
+  for (const [name, filePath] of merged) {
+    const sourceFile = program.getSourceFile(filePath)
+    if (!sourceFile) continue
+
+    const moduleSymbol = checker.getSymbolAtLocation(sourceFile)
+    if (!moduleSymbol) continue
+
+    const exports = checker.getExportsOfModule(moduleSymbol)
+    const defaultExport = exports.find((e) => e.escapedName === "default")
+    if (!defaultExport) continue
+
+    const description = extractJsDoc(defaultExport, checker)
+    const exportType = checker.getTypeOfSymbolAtLocation(defaultExport, sourceFile)
+    const signatures = checker.getSignaturesOfType(exportType, ts.SignatureKind.Call)
+    if (signatures.length === 0) continue
+
+    const signature = signatures[0]
+    if (!signature) continue
+    const params = signature.getParameters()
+
+    if (params.length === 0) {
+      results.push({
+        name,
+        description,
+        parameters: {
+          type: "object",
+          properties: {},
+          required: [],
+          additionalProperties: false,
+        },
+      })
+      continue
+    }
+
+    const firstParam = params[0]
+    if (!firstParam) continue
+    const paramType = checker.getTypeOfSymbolAtLocation(firstParam, sourceFile)
+    const { properties, required } = extractObjectSchema(paramType, checker)
+
+    results.push({
+      name,
+      description,
+      parameters: {
+        type: "object",
+        properties,
+        required,
+        additionalProperties: false,
+      },
+    })
+  }
+
+  results.sort((a, b) => a.name.localeCompare(b.name))
+  return results
+}
+
+function extractJsDoc(symbol: ts.Symbol, checker: ts.TypeChecker): string {
+  const docs = symbol.getDocumentationComment(checker)
+  return docs.map((d) => d.text).join("").trim()
+}
+
+function extractObjectSchema(
+  type: ts.Type,
+  checker: ts.TypeChecker,
+): { properties: Record<string, JsonSchemaProperty>; required: string[] } {
+  const properties: Record<string, JsonSchemaProperty> = {}
+  const required: string[] = []
+
+  for (const prop of type.getProperties()) {
+    const propType = checker.getTypeOfSymbolAtLocation(
+      prop,
+      prop.valueDeclaration ?? prop.declarations?.[0] ?? ({} as ts.Node),
+    )
+
+    const description = extractJsDoc(prop, checker)
+    const schema = typeToJsonSchema(propType, checker)
+
+    if (description) {
+      schema.description = description
+    }
+
+    properties[prop.getName()] = schema
+
+    const isOptional = (prop.flags & ts.SymbolFlags.Optional) !== 0
+    if (!isOptional) {
+      required.push(prop.getName())
+    }
+  }
+
+  return { properties, required }
+}
+
+function typeToJsonSchema(type: ts.Type, checker: ts.TypeChecker): JsonSchemaProperty {
+  // String literal union → enum
+  if (type.isUnion()) {
+    const allStringLiterals = type.types.every((t) => t.isStringLiteral())
+    if (allStringLiterals) {
+      return {
+        type: "string",
+        enum: type.types.map((t) => (t as ts.StringLiteralType).value),
+      }
+    }
+  }
+
+  // Primitive types
+  if (type.flags & ts.TypeFlags.String) return { type: "string" }
+  if (type.flags & ts.TypeFlags.Number) return { type: "number" }
+  if (type.flags & ts.TypeFlags.Boolean) return { type: "boolean" }
+  if (type.flags & ts.TypeFlags.BooleanLiteral) return { type: "boolean" }
+
+  // Array type
+  if (checker.isArrayType(type)) {
+    const typeArgs = (type as ts.TypeReference).typeArguments
+    const itemType = typeArgs?.[0]
+    return {
+      type: "array",
+      items: itemType ? typeToJsonSchema(itemType, checker) : { type: "string" },
+    }
+  }
+
+  // Object type (nested)
+  if (type.flags & ts.TypeFlags.Object && type.getProperties().length > 0) {
+    const { properties, required } = extractObjectSchema(type, checker)
+    return {
+      type: "object",
+      properties,
+      required,
+      additionalProperties: false,
+    }
+  }
+
+  // Fallback
+  return { type: "string" }
+}
+
+function discoverToolFiles(toolsDir: string): Map<string, string> {
+  const files = new Map<string, string>()
+  if (!existsSync(toolsDir)) return files
+
+  const entries = readdirSync(toolsDir)
+  for (const entry of entries) {
+    if (!entry.endsWith(".ts")) continue
+    if (entry.endsWith(".d.ts")) continue
+    const name = entry.replace(/\.ts$/, "")
+    files.set(name, join(toolsDir, entry))
+  }
+
+  return files
+}
+```
+
+- [ ] **Step 5: Export from core barrel**
+
+Modify `packages/core/src/index.ts` — add:
+
+```typescript
+export type { ExtractToolSchemasOptions } from "./typegen/extract-tool-schema.js"
+export { extractToolSchemasForRoute } from "./typegen/extract-tool-schema.js"
+```
+
+Also add to the type exports block:
+
+```typescript
+export type {
+  // ... existing types ...
+  ExtractedToolSchema,
+  JsonSchemaProperty,
+  RouteToolSchemas,
+} from "./types.js"
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `cd packages/core && npx vitest run test/extract-tool-schema.test.ts`
+Expected: ALL PASS
+
+- [ ] **Step 7: Run full core test suite**
+
+Run: `cd packages/core && npx vitest run`
+Expected: ALL PASS
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add packages/core/src/typegen/extract-tool-schema.ts packages/core/src/types.ts packages/core/src/index.ts packages/core/test/extract-tool-schema.test.ts
+git commit -m "feat(core): extract JSON Schema from tool function signatures and JSDoc"
+```
+
+---
+
+### Task 4: Extract JSDoc from Existing Tool Type Extractor
+
+**Files:**
+- Modify: `packages/core/src/typegen/extract-tool-types.ts`
+- Modify: `packages/core/src/types.ts`
+- Modify: `packages/core/test/extract-tool-types.test.ts`
+
+- [ ] **Step 1: Add `description` field to `ExtractedToolType`**
+
+Modify `packages/core/src/types.ts` — update `ExtractedToolType`:
+
+```typescript
+export interface ExtractedToolType {
+  readonly name: string
+  readonly description: string
+  readonly inputType: string
+  readonly outputType: string
+}
+```
+
+- [ ] **Step 2: Write the failing test**
+
+Add to `packages/core/test/extract-tool-types.test.ts`:
+
+```typescript
+test("extracts JSDoc description from tool function", async () => {
+  const routeDir = join(tempDir, "route")
+  writeToolFile(
+    routeDir,
+    "greet",
+    `
+/**
+ * Greets the user by name.
+ */
+export default async function greet(input: { name: string }): Promise<{ message: string }> {
+  return { message: "hello " + input.name }
+}
+`,
+  )
+
+  const result = await extractToolTypesForRoute({
+    routeDir,
+    sharedToolsDir: undefined,
+  })
+
+  expect(result[0]?.description).toBe("Greets the user by name.")
+})
+
+test("returns empty description when no JSDoc", async () => {
+  const routeDir = join(tempDir, "route")
+  writeToolFile(
+    routeDir,
+    "ping",
+    `
+export default async function ping(): Promise<{ pong: boolean }> {
+  return { pong: true }
+}
+`,
+  )
+
+  const result = await extractToolTypesForRoute({
+    routeDir,
+    sharedToolsDir: undefined,
+  })
+
+  expect(result[0]?.description).toBe("")
+})
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `cd packages/core && npx vitest run test/extract-tool-types.test.ts`
+Expected: FAIL — `description` is `undefined`, not a string
+
+- [ ] **Step 4: Add JSDoc extraction to `extract-tool-types.ts`**
+
+Modify `packages/core/src/typegen/extract-tool-types.ts` — add helper and update result:
+
+After the `unwrapPromise` function, add:
+
+```typescript
+function extractJsDoc(symbol: ts.Symbol, checker: ts.TypeChecker): string {
+  const docs = symbol.getDocumentationComment(checker)
+  return docs.map((d) => d.text).join("").trim()
+}
+```
+
+In the main loop, after `if (!defaultExport) continue`, add:
+
+```typescript
+const description = extractJsDoc(defaultExport, checker)
+```
+
+Update the `results.push` call to include `description`:
+
+```typescript
+results.push({
+  name,
+  description,
+  inputType,
+  outputType: checker.typeToString(outputType),
+})
+```
+
+- [ ] **Step 5: Update existing test expectations**
+
+The existing tests in `extract-tool-types.test.ts` now need to include `description: ""` in their expected values. Update each `expect(result).toEqual(...)` to include the `description` field:
+
+```typescript
+// Example — update the first test:
+expect(result).toEqual([
+  {
+    name: "greet",
+    description: "",
+    inputType: "{ name: string; }",
+    outputType: "{ message: string; }",
+  },
+])
+```
+
+Apply the same pattern to all existing test expectations (add `description: ""` to each).
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `cd packages/core && npx vitest run test/extract-tool-types.test.ts`
+Expected: ALL PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/core/src/typegen/extract-tool-types.ts packages/core/src/types.ts packages/core/test/extract-tool-types.test.ts
+git commit -m "feat(core): extract JSDoc description from tool functions"
+```
+
+---
+
+### Task 5: State Field Resolution (Standard Schema Interface)
+
+**Files:**
+- Create: `packages/core/src/state/resolve-state-fields.ts`
+- Modify: `packages/core/src/types.ts`
+- Modify: `packages/core/src/index.ts`
+- Test: `packages/core/test/resolve-state-fields.test.ts`
+
+- [ ] **Step 1: Add state types to `types.ts`**
+
+Modify `packages/core/src/types.ts` — add:
+
+```typescript
+export type StateFieldReducer = "append" | "replace"
+
+export interface ResolvedStateField {
+  readonly name: string
+  readonly reducer: StateFieldReducer | ((current: unknown, incoming: unknown) => unknown)
+  readonly default: unknown
+}
+```
+
+- [ ] **Step 2: Write the failing test**
+
+Create `packages/core/test/resolve-state-fields.test.ts`:
+
+```typescript
+import { describe, expect, test } from "vitest"
+
+import { resolveStateFields } from "../src/state/resolve-state-fields"
+
+describe("resolveStateFields", () => {
+  test("infers append reducer for array defaults", () => {
+    const defaults = new Map<string, unknown>([
+      ["results", []],
+      ["tags", ["initial"]],
+    ])
+
+    const result = resolveStateFields({ defaults, reducerOverrides: new Map() })
+
+    expect(result).toEqual([
+      { name: "results", reducer: "append", default: [] },
+      { name: "tags", reducer: "append", default: ["initial"] },
+    ])
+  })
+
+  test("infers replace reducer for scalar defaults", () => {
+    const defaults = new Map<string, unknown>([
+      ["context", ""],
+      ["confidence", 0],
+      ["active", true],
+    ])
+
+    const result = resolveStateFields({ defaults, reducerOverrides: new Map() })
+
+    expect(result).toEqual([
+      { name: "active", reducer: "replace", default: true },
+      { name: "confidence", reducer: "replace", default: 0 },
+      { name: "context", reducer: "replace", default: "" },
+    ])
+  })
+
+  test("reducer overrides take precedence", () => {
+    const customReducer = (current: string[], incoming: string[]) => incoming
+    const defaults = new Map<string, unknown>([["results", []]])
+    const reducerOverrides = new Map<string, (current: unknown, incoming: unknown) => unknown>([
+      ["results", customReducer],
+    ])
+
+    const result = resolveStateFields({ defaults, reducerOverrides })
+
+    expect(result).toEqual([{ name: "results", reducer: customReducer, default: [] }])
+  })
+
+  test("infers replace for null and undefined defaults", () => {
+    const defaults = new Map<string, unknown>([
+      ["data", null],
+      ["meta", undefined],
+    ])
+
+    const result = resolveStateFields({ defaults, reducerOverrides: new Map() })
+
+    expect(result).toEqual([
+      { name: "data", reducer: "replace", default: null },
+      { name: "meta", reducer: "replace", default: undefined },
+    ])
+  })
+
+  test("sorts fields alphabetically by name", () => {
+    const defaults = new Map<string, unknown>([
+      ["zeta", "z"],
+      ["alpha", "a"],
+    ])
+
+    const result = resolveStateFields({ defaults, reducerOverrides: new Map() })
+
+    expect(result[0]?.name).toBe("alpha")
+    expect(result[1]?.name).toBe("zeta")
+  })
+})
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `cd packages/core && npx vitest run test/resolve-state-fields.test.ts`
+Expected: FAIL — module not found
+
+- [ ] **Step 4: Implement `resolve-state-fields.ts`**
+
+Create `packages/core/src/state/resolve-state-fields.ts`:
+
+```typescript
+import type { ResolvedStateField } from "../types.js"
+
+export interface ResolveStateFieldsOptions {
+  readonly defaults: ReadonlyMap<string, unknown>
+  readonly reducerOverrides: ReadonlyMap<
+    string,
+    (current: unknown, incoming: unknown) => unknown
+  >
+}
+
+export function resolveStateFields(options: ResolveStateFieldsOptions): readonly ResolvedStateField[] {
+  const results: ResolvedStateField[] = []
+
+  for (const [name, defaultValue] of options.defaults) {
+    const override = options.reducerOverrides.get(name)
+
+    if (override) {
+      results.push({ name, reducer: override, default: defaultValue })
+    } else {
+      const reducer = Array.isArray(defaultValue) ? "append" : "replace"
+      results.push({ name, reducer, default: defaultValue })
+    }
+  }
+
+  results.sort((a, b) => a.name.localeCompare(b.name))
+  return results
+}
+```
+
+- [ ] **Step 5: Export from core barrel**
+
+Modify `packages/core/src/index.ts` — add:
+
+```typescript
+export { resolveStateFields } from "./state/resolve-state-fields.js"
+export type { ResolveStateFieldsOptions } from "./state/resolve-state-fields.js"
+```
+
+Add to type exports:
+
+```typescript
+export type {
+  // ... existing ...
+  ResolvedStateField,
+  StateFieldReducer,
+} from "./types.js"
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `cd packages/core && npx vitest run test/resolve-state-fields.test.ts`
+Expected: ALL PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/core/src/state/resolve-state-fields.ts packages/core/src/types.ts packages/core/src/index.ts packages/core/test/resolve-state-fields.test.ts
+git commit -m "feat(core): resolve state field reducers from defaults via convention"
+```
+
+---
+
+### Task 6: State Discovery (CLI Runtime)
+
+**Files:**
+- Create: `packages/cli/src/lib/runtime/state-discovery.ts`
+- Test: `packages/cli/test/state-discovery.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/cli/test/state-discovery.test.ts`:
+
+```typescript
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { afterEach, beforeEach, describe, expect, test } from "vitest"
+
+import { discoverStateDefinition } from "../src/lib/runtime/state-discovery"
+
+let tempDir: string
+
+beforeEach(() => {
+  tempDir = mkdtempSync(join(tmpdir(), "dawn-state-disc-"))
+})
+
+afterEach(() => {
+  rmSync(tempDir, { recursive: true, force: true })
+})
+
+describe("discoverStateDefinition", () => {
+  test("returns null when no state.ts exists", async () => {
+    const routeDir = join(tempDir, "route")
+    mkdirSync(routeDir, { recursive: true })
+
+    const result = await discoverStateDefinition({ routeDir })
+    expect(result).toBeNull()
+  })
+
+  test("discovers state.ts and extracts defaults", async () => {
+    const routeDir = join(tempDir, "route")
+    mkdirSync(routeDir, { recursive: true })
+    writeFileSync(
+      join(routeDir, "state.ts"),
+      `
+import { z } from "zod"
+export default z.object({
+  context: z.string().default(""),
+  results: z.array(z.string()).default([]),
+})
+`,
+    )
+
+    const result = await discoverStateDefinition({ routeDir })
+
+    expect(result).not.toBeNull()
+    expect(result!.defaults.get("context")).toBe("")
+    expect(result!.defaults.get("results")).toEqual([])
+  })
+
+  test("discovers reducer overrides from reducers/ folder", async () => {
+    const routeDir = join(tempDir, "route")
+    const reducersDir = join(routeDir, "reducers")
+    mkdirSync(reducersDir, { recursive: true })
+    writeFileSync(
+      join(routeDir, "state.ts"),
+      `
+import { z } from "zod"
+export default z.object({
+  tags: z.array(z.string()).default([]),
+})
+`,
+    )
+    writeFileSync(
+      join(reducersDir, "tags.ts"),
+      `
+export default (current: string[], incoming: string[]) => incoming
+`,
+    )
+
+    const result = await discoverStateDefinition({ routeDir })
+
+    expect(result).not.toBeNull()
+    expect(result!.reducerOverrides.has("tags")).toBe(true)
+    const reducer = result!.reducerOverrides.get("tags")!
+    expect(reducer(["a"], ["b"])).toEqual(["b"])
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd packages/cli && npx vitest run test/state-discovery.test.ts`
+Expected: FAIL — module not found
+
+- [ ] **Step 3: Implement `state-discovery.ts`**
+
+Create `packages/cli/src/lib/runtime/state-discovery.ts`:
+
+```typescript
+import { existsSync, readdirSync } from "node:fs"
+import { basename, join } from "node:path"
+import { pathToFileURL } from "node:url"
+
+import { registerTsxLoader } from "./register-tsx-loader.js"
+
+export interface DiscoveredStateDefinition {
+  readonly defaults: Map<string, unknown>
+  readonly reducerOverrides: Map<string, (current: unknown, incoming: unknown) => unknown>
+}
+
+export async function discoverStateDefinition(options: {
+  readonly routeDir: string
+}): Promise<DiscoveredStateDefinition | null> {
+  const stateFile = join(options.routeDir, "state.ts")
+  if (!existsSync(stateFile)) return null
+
+  await registerTsxLoader()
+
+  const stateModule = (await import(pathToFileURL(stateFile).href)) as {
+    readonly default?: unknown
+  }
+  const schema = stateModule.default
+  if (!schema || typeof schema !== "object") return null
+
+  const defaults = extractDefaults(schema)
+  if (!defaults) return null
+
+  const reducerOverrides = await discoverReducerOverrides(options.routeDir)
+
+  return { defaults, reducerOverrides }
+}
+
+function extractDefaults(schema: unknown): Map<string, unknown> | null {
+  // Standard Schema v1 check: schema has ~standard property
+  if (!isStandardSchema(schema)) {
+    // Fallback: try to get defaults via zod-compatible .parse({}) pattern
+    if (hasParseMethod(schema)) {
+      try {
+        const parsed = schema.parse({})
+        if (typeof parsed === "object" && parsed !== null) {
+          return new Map(Object.entries(parsed))
+        }
+      } catch {
+        return null
+      }
+    }
+    return null
+  }
+
+  // Use Standard Schema validate with empty object to extract defaults
+  const result = schema["~standard"].validate({})
+  if ("issues" in result) return null
+  if (typeof result.value !== "object" || result.value === null) return null
+
+  return new Map(Object.entries(result.value as Record<string, unknown>))
+}
+
+function isStandardSchema(
+  value: unknown,
+): value is { "~standard": { validate: (input: unknown) => { value?: unknown; issues?: unknown } } } {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "~standard" in value &&
+    typeof (value as Record<string, unknown>)["~standard"] === "object"
+  )
+}
+
+function hasParseMethod(value: unknown): value is { parse: (input: unknown) => unknown } {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "parse" in value &&
+    typeof (value as Record<string, unknown>).parse === "function"
+  )
+}
+
+async function discoverReducerOverrides(
+  routeDir: string,
+): Promise<Map<string, (current: unknown, incoming: unknown) => unknown>> {
+  const reducersDir = join(routeDir, "reducers")
+  const overrides = new Map<string, (current: unknown, incoming: unknown) => unknown>()
+
+  if (!existsSync(reducersDir)) return overrides
+
+  const entries = readdirSync(reducersDir)
+  for (const entry of entries) {
+    if (!entry.endsWith(".ts")) continue
+    if (entry.endsWith(".d.ts")) continue
+
+    const fieldName = basename(entry, ".ts")
+    const filePath = join(reducersDir, entry)
+    const mod = (await import(pathToFileURL(filePath).href)) as { readonly default?: unknown }
+
+    if (typeof mod.default === "function") {
+      overrides.set(fieldName, mod.default as (current: unknown, incoming: unknown) => unknown)
+    }
+  }
+
+  return overrides
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd packages/cli && npx vitest run test/state-discovery.test.ts`
+Expected: ALL PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/cli/src/lib/runtime/state-discovery.ts packages/cli/test/state-discovery.test.ts
+git commit -m "feat(cli): discover state.ts and reducers/ folder conventions"
+```
+
+---
+
+### Task 7: State Adapter (LangChain)
+
+**Files:**
+- Create: `packages/langchain/src/state-adapter.ts`
+- Modify: `packages/langchain/src/index.ts`
+- Test: `packages/langchain/test/state-adapter.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/langchain/test/state-adapter.test.ts`:
+
+```typescript
+import type { ResolvedStateField } from "@dawn-ai/core"
+import { describe, expect, test } from "vitest"
+
+import { materializeStateSchema } from "../src/state-adapter"
+
+describe("materializeStateSchema", () => {
+  test("produces an annotation root with messages + custom fields", () => {
+    const fields: ResolvedStateField[] = [
+      { name: "context", reducer: "replace", default: "" },
+      { name: "results", reducer: "append", default: [] },
+    ]
+
+    const annotation = materializeStateSchema(fields)
+
+    // AnnotationRoot has a .spec property
+    expect(annotation).toBeDefined()
+    expect(annotation.spec).toBeDefined()
+    // Messages are always included
+    expect("messages" in annotation.spec).toBe(true)
+    // Custom fields are included
+    expect("context" in annotation.spec).toBe(true)
+    expect("results" in annotation.spec).toBe(true)
+  })
+
+  test("replace reducer uses last-write-wins semantics", () => {
+    const fields: ResolvedStateField[] = [
+      { name: "status", reducer: "replace", default: "idle" },
+    ]
+
+    const annotation = materializeStateSchema(fields)
+    const statusSpec = annotation.spec.status
+
+    // Access the reducer via the annotation's internal structure
+    expect(statusSpec).toBeDefined()
+  })
+
+  test("append reducer accumulates arrays", () => {
+    const fields: ResolvedStateField[] = [
+      { name: "items", reducer: "append", default: [] },
+    ]
+
+    const annotation = materializeStateSchema(fields)
+    expect(annotation.spec.items).toBeDefined()
+  })
+
+  test("custom function reducer is passed through", () => {
+    const customReducer = (current: unknown, incoming: unknown) => incoming
+    const fields: ResolvedStateField[] = [
+      { name: "data", reducer: customReducer, default: null },
+    ]
+
+    const annotation = materializeStateSchema(fields)
+    expect(annotation.spec.data).toBeDefined()
+  })
+
+  test("returns annotation with empty fields when no custom state", () => {
+    const annotation = materializeStateSchema([])
+
+    expect(annotation.spec).toBeDefined()
+    expect("messages" in annotation.spec).toBe(true)
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd packages/langchain && npx vitest run test/state-adapter.test.ts`
+Expected: FAIL — module not found
+
+- [ ] **Step 3: Implement `state-adapter.ts`**
+
+Create `packages/langchain/src/state-adapter.ts`:
+
+```typescript
+import type { ResolvedStateField } from "@dawn-ai/core"
+import { Annotation, MessagesAnnotation } from "@langchain/langgraph"
+import type { AnnotationRoot } from "@langchain/langgraph"
+
+export function materializeStateSchema(
+  fields: readonly ResolvedStateField[],
+): AnnotationRoot<any> {
+  const spec: Record<string, any> = {
+    ...MessagesAnnotation.spec,
+  }
+
+  for (const field of fields) {
+    if (typeof field.reducer === "function") {
+      spec[field.name] = Annotation({
+        reducer: field.reducer as (left: unknown, right: unknown) => unknown,
+        default: () => field.default,
+      })
+    } else if (field.reducer === "append") {
+      spec[field.name] = Annotation({
+        reducer: (prev: unknown[], next: unknown[]) => [
+          ...(prev ?? []),
+          ...(Array.isArray(next) ? next : [next]),
+        ],
+        default: () => (field.default ?? []) as unknown[],
+      })
+    } else {
+      spec[field.name] = Annotation({
+        reducer: (_: unknown, next: unknown) => next,
+        default: () => field.default,
+      })
+    }
+  }
+
+  return Annotation.Root(spec)
+}
+```
+
+- [ ] **Step 4: Export from langchain barrel**
+
+Modify `packages/langchain/src/index.ts` — add:
+
+```typescript
+export { materializeStateSchema } from "./state-adapter.js"
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cd packages/langchain && npx vitest run test/state-adapter.test.ts`
+Expected: ALL PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/langchain/src/state-adapter.ts packages/langchain/src/index.ts packages/langchain/test/state-adapter.test.ts
+git commit -m "feat(langchain): materialize Dawn state fields into LangChain AnnotationRoot"
+```
+
+---
+
+### Task 8: Wire State Through Agent Execution
+
+**Files:**
+- Modify: `packages/langchain/src/agent-adapter.ts`
+- Modify: `packages/cli/src/lib/runtime/execute-route.ts`
+
+- [ ] **Step 1: Update `materializeAgent` to accept state fields**
+
+Modify `packages/langchain/src/agent-adapter.ts`:
+
+Add import at top:
+
+```typescript
+import type { ResolvedStateField } from "@dawn-ai/core"
+import { materializeStateSchema } from "./state-adapter.js"
+```
+
+Update `materializeAgent` signature and body:
+
+```typescript
+async function materializeAgent(
+  descriptor: DawnAgent,
+  tools: readonly DawnToolDefinition[],
+  stateFields?: readonly ResolvedStateField[],
+): Promise<AgentLike> {
+  const cached = materializedAgents.get(descriptor)
+  if (cached) {
+    return cached
+  }
+
+  const { createReactAgent } = await import("@langchain/langgraph/prebuilt")
+  const { ChatOpenAI } = await import("@langchain/openai")
+
+  const langchainTools = tools.map((tool) => convertToolToLangChain(tool))
+
+  const llm = new ChatOpenAI({
+    model: descriptor.model,
+  })
+
+  const agentOptions: Record<string, unknown> = {
+    llm,
+    tools: langchainTools,
+    prompt: descriptor.systemPrompt,
+  }
+
+  if (stateFields && stateFields.length > 0) {
+    agentOptions.stateSchema = materializeStateSchema(stateFields)
+  }
+
+  const compiled = createReactAgent(agentOptions)
+
+  materializedAgents.set(descriptor, compiled as unknown as AgentLike)
+  return compiled as unknown as AgentLike
+}
+```
+
+Update `executeAgent` to accept and pass state fields:
+
+```typescript
+export async function executeAgent(options: {
+  readonly entry: unknown
+  readonly input: unknown
+  readonly routeParamNames: readonly string[]
+  readonly signal: AbortSignal
+  readonly stateFields?: readonly ResolvedStateField[]
+  readonly tools: readonly DawnToolDefinition[]
+}): Promise<unknown> {
+```
+
+And in the `isDawnAgent` branch:
+
+```typescript
+if (isDawnAgent(options.entry)) {
+  const materializedAgent = await materializeAgent(options.entry, options.tools, options.stateFields)
+  const messages = [new HumanMessage(formatAgentMessage(agentInput))]
+  return await materializedAgent.invoke({ messages }, config)
+}
+```
+
+- [ ] **Step 2: Update `execute-route.ts` to discover and pass state**
+
+Modify `packages/cli/src/lib/runtime/execute-route.ts`:
+
+Add import:
+
+```typescript
+import { resolveStateFields } from "@dawn-ai/core"
+import { discoverStateDefinition } from "./state-discovery.js"
+```
+
+In `executeRouteAtResolvedPath` (the function that calls `executeAgent`), after tool discovery and before the agent invocation, add state discovery:
+
+```typescript
+// Discover state (only for agent routes)
+let stateFields: readonly ResolvedStateField[] | undefined
+if (routeModule.kind === "agent") {
+  const stateDefinition = await discoverStateDefinition({ routeDir })
+  if (stateDefinition) {
+    stateFields = resolveStateFields({
+      defaults: stateDefinition.defaults,
+      reducerOverrides: stateDefinition.reducerOverrides,
+    })
+  }
+}
+```
+
+Pass `stateFields` to `executeAgent`:
+
+```typescript
+return await executeAgent({
+  entry: routeModule.entry,
+  input: options.input,
+  routeParamNames,
+  signal,
+  stateFields,
+  tools,
+})
+```
+
+- [ ] **Step 3: Run full test suite**
+
+Run: `cd packages/cli && npx vitest run && cd ../langchain && npx vitest run`
+Expected: ALL PASS (existing tests still pass since stateFields is optional)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/langchain/src/agent-adapter.ts packages/cli/src/lib/runtime/execute-route.ts
+git commit -m "feat: wire state discovery through agent execution pipeline"
+```
+
+---
+
+### Task 9: Inject Generated Schema into Tool Discovery
+
+**Files:**
+- Modify: `packages/cli/src/lib/runtime/tool-discovery.ts`
+- Modify: `packages/cli/src/lib/runtime/execute-route.ts`
+
+- [ ] **Step 1: Add schema injection to tool discovery**
+
+Modify `packages/cli/src/lib/runtime/tool-discovery.ts` — add a function to merge generated schemas:
+
+```typescript
+export function injectGeneratedSchemas(
+  tools: readonly DiscoveredToolDefinition[],
+  generatedSchemas: Record<string, unknown>,
+): readonly DiscoveredToolDefinition[] {
+  return tools.map((tool) => {
+    // User-exported schema takes priority
+    if (tool.schema) return tool
+
+    const generated = generatedSchemas[tool.name]
+    if (!generated) return tool
+
+    return { ...tool, schema: generated }
+  })
+}
+```
+
+- [ ] **Step 2: Load generated schemas in execute-route**
+
+In `packages/cli/src/lib/runtime/execute-route.ts`, after tool discovery, attempt to load generated schemas:
+
+```typescript
+import { existsSync, readFileSync } from "node:fs"
+import { join } from "node:path"
+import { injectGeneratedSchemas } from "./tool-discovery.js"
+```
+
+After `discoverToolDefinitions`:
+
+```typescript
+// Inject codegen-generated schemas (for tools without explicit schema exports)
+const schemaManifestPath = join(appRoot, ".dawn", "routes", routeId, "tools.json")
+let discoveredTools = tools
+if (existsSync(schemaManifestPath)) {
+  try {
+    const manifest = JSON.parse(readFileSync(schemaManifestPath, "utf-8"))
+    discoveredTools = injectGeneratedSchemas(tools, manifest)
+  } catch {
+    // Fall through — generated schema is best-effort
+  }
+}
+```
+
+- [ ] **Step 3: Run tests**
+
+Run: `cd packages/cli && npx vitest run`
+Expected: ALL PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/cli/src/lib/runtime/tool-discovery.ts packages/cli/src/lib/runtime/execute-route.ts
+git commit -m "feat(cli): inject codegen-generated JSON Schema into tool definitions"
+```
+
+---
+
+### Task 10: Render State Type Manifest
+
+**Files:**
+- Create: `packages/core/src/typegen/render-state-types.ts`
+- Modify: `packages/core/src/index.ts`
+- Test: `packages/core/test/render-state-types.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/core/test/render-state-types.test.ts`:
+
+```typescript
+import { describe, expect, test } from "vitest"
+
+import { renderStateTypes } from "../src/typegen/render-state-types"
+
+describe("renderStateTypes", () => {
+  test("renders empty interface when no routes have state", () => {
+    const result = renderStateTypes([])
+    expect(result).toContain("export interface DawnRouteState {}")
+  })
+
+  test("renders state type for a route", () => {
+    const result = renderStateTypes([
+      {
+        pathname: "/hello/[tenant]",
+        fields: [
+          { name: "context", type: "string" },
+          { name: "confidence", type: "number" },
+          { name: "results", type: "string[]" },
+        ],
+      },
+    ])
+
+    expect(result).toContain('"/hello/[tenant]"')
+    expect(result).toContain("context: string")
+    expect(result).toContain("confidence: number")
+    expect(result).toContain("results: string[]")
+  })
+
+  test("renders RouteState utility type", () => {
+    const result = renderStateTypes([])
+    expect(result).toContain("export type RouteState<P extends DawnRoutePath> = DawnRouteState[P]")
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd packages/core && npx vitest run test/render-state-types.test.ts`
+Expected: FAIL — module not found
+
+- [ ] **Step 3: Implement `render-state-types.ts`**
+
+Create `packages/core/src/typegen/render-state-types.ts`:
+
+```typescript
+export interface RouteStateFields {
+  readonly pathname: string
+  readonly fields: readonly { readonly name: string; readonly type: string }[]
+}
+
+export function renderStateTypes(routeStates: readonly RouteStateFields[]): string {
+  const routeStateType = "  export type RouteState<P extends DawnRoutePath> = DawnRouteState[P];"
+
+  if (routeStates.length === 0) {
+    return ["  export interface DawnRouteState {}", "", routeStateType, ""].join("\n")
+  }
+
+  const routeLines: string[] = []
+  for (const route of routeStates) {
+    routeLines.push(`    ${JSON.stringify(route.pathname)}: {`)
+    for (const field of route.fields) {
+      routeLines.push(`      readonly ${field.name}: ${field.type};`)
+    }
+    routeLines.push("    };")
+  }
+
+  return [
+    "  export interface DawnRouteState {",
+    ...routeLines,
+    "  }",
+    "",
+    routeStateType,
+    "",
+  ].join("\n")
+}
+```
+
+- [ ] **Step 4: Export from core barrel**
+
+Modify `packages/core/src/index.ts` — add:
+
+```typescript
+export type { RouteStateFields } from "./typegen/render-state-types.js"
+export { renderStateTypes } from "./typegen/render-state-types.js"
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cd packages/core && npx vitest run test/render-state-types.test.ts`
+Expected: ALL PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/core/src/typegen/render-state-types.ts packages/core/src/index.ts packages/core/test/render-state-types.test.ts
+git commit -m "feat(core): render state type manifest for codegen"
+```
+
+---
+
+### Task 11: Update Template with State Example
+
+**Files:**
+- Create: `packages/devkit/templates/app-basic/src/app/(public)/hello/[tenant]/state.ts`
+- Modify: `packages/devkit/templates/app-basic/.dawn/dawn.generated.d.ts`
+- Modify: `packages/devkit/templates/app-basic/package.json.template`
+
+- [ ] **Step 1: Create state.ts in template**
+
+Create `packages/devkit/templates/app-basic/src/app/(public)/hello/[tenant]/state.ts`:
+
+```typescript
+import { z } from "zod"
+
+export default z.object({
+  /** Accumulated context from tool call results */
+  context: z.string().default(""),
+})
+```
+
+- [ ] **Step 2: Update generated types to include state**
+
+Modify `packages/devkit/templates/app-basic/.dawn/dawn.generated.d.ts`:
+
+```typescript
+declare module "dawn:routes" {
+  export type DawnRoutePath = "/hello/[tenant]";
+
+  export interface DawnRouteParams {
+  "/hello/[tenant]": { tenant: string };
+  }
+
+  export interface DawnRouteTools {
+    "/hello/[tenant]": {
+      readonly greet: (input: { readonly tenant: string; }) => Promise<{ name: string; plan: string; }>;
+    };
+  }
+
+  export type RouteTools<P extends DawnRoutePath> = DawnRouteTools[P];
+
+  export interface DawnRouteState {
+    "/hello/[tenant]": {
+      readonly context: string;
+    };
+  }
+
+  export type RouteState<P extends DawnRoutePath> = DawnRouteState[P];
+}
+```
+
+- [ ] **Step 3: Add zod to template dependencies**
+
+Modify `packages/devkit/templates/app-basic/package.json.template` — add `zod` to dependencies:
+
+```json
+"zod": "^3.24.0"
+```
+
+- [ ] **Step 4: Run framework harness tests**
+
+Run: `pnpm test --filter @dawn-ai/devkit`
+Expected: ALL PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/devkit/templates/app-basic/src/app/\(public\)/hello/\[tenant\]/state.ts packages/devkit/templates/app-basic/.dawn/dawn.generated.d.ts packages/devkit/templates/app-basic/package.json.template
+git commit -m "feat(devkit): add state.ts to basic template with zod schema"
+```
+
+---
+
+### Task 12: Consolidate NormalizedRouteModule
+
+**Files:**
+- Modify: `packages/core/src/types.ts`
+- Modify: `packages/core/src/index.ts`
+- Modify: `packages/cli/src/lib/runtime/load-route-kind.ts`
+
+- [ ] **Step 1: Add canonical type to core**
+
+Modify `packages/core/src/types.ts` — add:
+
+```typescript
+export interface NormalizedRouteModule {
+  readonly kind: RouteKind
+  readonly entry: unknown
+  readonly config: Record<string, unknown>
+}
+```
+
+- [ ] **Step 2: Export from core barrel**
+
+Modify `packages/core/src/index.ts` — add to the type exports:
+
+```typescript
+export type { NormalizedRouteModule } from "./types.js"
+```
+
+- [ ] **Step 3: Update CLI to import from core**
+
+Modify `packages/cli/src/lib/runtime/load-route-kind.ts`:
+
+Remove the local `NormalizedRouteModule` interface definition (lines 8-12) and add import:
+
+```typescript
+import type { NormalizedRouteModule } from "@dawn-ai/core"
+```
+
+- [ ] **Step 4: Run CLI tests**
+
+Run: `cd packages/cli && npx vitest run`
+Expected: ALL PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/core/src/types.ts packages/core/src/index.ts packages/cli/src/lib/runtime/load-route-kind.ts
+git commit -m "refactor: consolidate NormalizedRouteModule into @dawn-ai/core"
+```
+
+---
+
+### Task 13: Update pack-check and CI Validation
+
+**Files:**
+- Modify: `scripts/pack-check.mjs`
+
+- [ ] **Step 1: Update pack-check for new SDK files**
+
+Modify `scripts/pack-check.mjs` — add the new SDK files to the expected dist entries:
+
+Add to the SDK expected files list:
+
+```javascript
+"dist/known-model-ids.js",
+"dist/known-model-ids.d.ts",
+"dist/types.js",
+"dist/types.d.ts",
+"dist/route-types.js",
+"dist/route-types.d.ts",
+```
+
+And for core, add:
+
+```javascript
+"dist/typegen/extract-tool-schema.js",
+"dist/typegen/extract-tool-schema.d.ts",
+"dist/typegen/render-state-types.js",
+"dist/typegen/render-state-types.d.ts",
+"dist/state/resolve-state-fields.js",
+"dist/state/resolve-state-fields.d.ts",
+```
+
+- [ ] **Step 2: Run pack-check**
+
+Run: `node scripts/pack-check.mjs`
+Expected: PASS
+
+- [ ] **Step 3: Run full CI locally**
+
+Run: `pnpm build && pnpm typecheck && pnpm test`
+Expected: ALL PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add scripts/pack-check.mjs
+git commit -m "chore: update pack-check for new SDK and core dist files"
+```
+
+---
+
+### Task 14: Integration Test — Full Pipeline
+
+**Files:**
+- Create: `test/integration/dx-improvements.test.ts`
+
+- [ ] **Step 1: Write integration test**
+
+Create `test/integration/dx-improvements.test.ts`:
+
+```typescript
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { afterEach, beforeEach, describe, expect, test } from "vitest"
+
+import { extractToolSchemasForRoute, extractToolTypesForRoute } from "@dawn-ai/core"
+
+let tempDir: string
+
+beforeEach(() => {
+  tempDir = mkdtempSync(join(tmpdir(), "dawn-dx-integration-"))
+})
+
+afterEach(() => {
+  rmSync(tempDir, { recursive: true, force: true })
+})
+
+describe("DX improvements integration", () => {
+  test("tool schema generation produces valid JSON Schema for LLM", async () => {
+    const routeDir = join(tempDir, "route")
+    const toolsDir = join(routeDir, "tools")
+    mkdirSync(toolsDir, { recursive: true })
+
+    writeFileSync(
+      join(toolsDir, "search.ts"),
+      `
+/**
+ * Searches the knowledge base for relevant documents.
+ */
+export default async (input: {
+  /** The search query string */
+  query: string
+  /** Maximum number of results */
+  limit?: number
+  /** Filter by category */
+  category: "docs" | "code" | "issues"
+}) => {
+  return { results: [], total: 0 }
+}
+`,
+    )
+
+    const schemas = await extractToolSchemasForRoute({
+      routeDir,
+      sharedToolsDir: undefined,
+    })
+
+    expect(schemas).toHaveLength(1)
+    const schema = schemas[0]!
+
+    expect(schema.name).toBe("search")
+    expect(schema.description).toBe("Searches the knowledge base for relevant documents.")
+    expect(schema.parameters.type).toBe("object")
+    expect(schema.parameters.additionalProperties).toBe(false)
+    expect(schema.parameters.properties.query).toEqual({
+      type: "string",
+      description: "The search query string",
+    })
+    expect(schema.parameters.properties.limit).toEqual({
+      type: "number",
+      description: "Maximum number of results",
+    })
+    expect(schema.parameters.properties.category).toEqual({
+      type: "string",
+      enum: ["docs", "code", "issues"],
+      description: "Filter by category",
+    })
+    expect(schema.parameters.required).toEqual(["query", "category"])
+  })
+
+  test("type extraction and schema extraction produce consistent results", async () => {
+    const routeDir = join(tempDir, "route")
+    const toolsDir = join(routeDir, "tools")
+    mkdirSync(toolsDir, { recursive: true })
+
+    writeFileSync(
+      join(toolsDir, "greet.ts"),
+      `
+/** Greets someone. */
+export default async (input: { name: string }) => {
+  return { message: "hello" }
+}
+`,
+    )
+
+    const types = await extractToolTypesForRoute({
+      routeDir,
+      sharedToolsDir: undefined,
+    })
+    const schemas = await extractToolSchemasForRoute({
+      routeDir,
+      sharedToolsDir: undefined,
+    })
+
+    expect(types).toHaveLength(1)
+    expect(schemas).toHaveLength(1)
+    expect(types[0]!.name).toBe(schemas[0]!.name)
+    expect(types[0]!.description).toBe(schemas[0]!.description)
+  })
+})
+```
+
+- [ ] **Step 2: Run integration test**
+
+Run: `npx vitest run test/integration/dx-improvements.test.ts`
+Expected: ALL PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add test/integration/dx-improvements.test.ts
+git commit -m "test: add integration test for DX improvements pipeline"
+```

--- a/docs/superpowers/specs/2026-05-01-dx-improvements-design.md
+++ b/docs/superpowers/specs/2026-05-01-dx-improvements-design.md
@@ -1,0 +1,346 @@
+# Dawn TypeScript DX Improvements Design
+
+## Problem
+
+Dawn's TypeScript developer experience has several gaps that reduce type safety and degrade the LLM's ability to use tools effectively:
+
+1. **Stale model IDs** — `KnownModelId` lists outdated models, giving wrong autocomplete suggestions
+2. **Tools invisible to the LLM** — without a user-exported zod schema, tools get `z.record(z.string(), z.unknown())` as their parameter schema, so the LLM has no information about what arguments to pass
+3. **Tools invisible to TypeScript** — tool types are erased to `unknown` at the discovery boundary; no type safety flows downstream
+4. **No state convention** — agents that need state beyond messages must directly use LangChain's `AnnotationRoot`, leaking framework internals
+5. **Missing utility types** — no `Prettify<T>`, `RuntimeTool` not exported, duplicated internal types
+
+## Goal
+
+Improve Dawn's TypeScript DX by:
+
+1. Updating model IDs with per-provider grouping and current models
+2. Auto-generating JSON Schema from tool function signatures + JSDoc (codegen) so the LLM gets proper parameter descriptions with zero user effort
+3. Auto-generating a type manifest so the IDE sees tool signatures and state shapes
+4. Providing a convention-based state system using Standard Schema (zod/valibot/arktype) with filesystem-discovered reducers
+5. Adding utility types and cleaning up exports
+
+## Design
+
+### 1. Per-Provider Model IDs
+
+Replace the flat `KnownModelId` union with grouped per-provider types in `packages/sdk/src/known-model-ids.ts`:
+
+```typescript
+export type OpenAiModelId =
+  // GPT-5.x series
+  | "gpt-5.5"
+  | "gpt-5.5-pro"
+  | "gpt-5.4"
+  | "gpt-5.4-pro"
+  | "gpt-5-mini"
+  // GPT-4.1 series
+  | "gpt-4.1"
+  | "gpt-4.1-mini"
+  | "gpt-4.1-nano"
+  // GPT-4o series
+  | "gpt-4o"
+  | "gpt-4o-mini"
+  // Reasoning
+  | "o3"
+  | "o3-mini"
+  | "o4-mini"
+
+export type AnthropicModelId =
+  | "claude-opus-4-7"
+  | "claude-sonnet-4-6"
+  | "claude-haiku-4-5-20251001"
+
+export type GoogleModelId =
+  | "gemini-3-pro-preview"
+  | "gemini-3-flash-preview"
+  | "gemini-2.5-pro"
+  | "gemini-2.5-flash"
+  | "gemini-2.5-flash-lite"
+
+export type KnownModelId =
+  | OpenAiModelId
+  | AnthropicModelId
+  | GoogleModelId
+  | (string & {})
+```
+
+The `(string & {})` pattern gives autocomplete for known models while allowing any string. Users type `"claude-"` and see only Anthropic models.
+
+### 2. Codegen Tool Schema Generation
+
+Expand the existing `extractToolTypesForRoute` (in `@dawn-ai/core`) to produce JSON Schema from tool function signatures and JSDoc comments. This schema is provided to the LLM at runtime so it knows what arguments tools accept.
+
+#### What the user writes (unchanged from today):
+
+```typescript
+// tools/greet.ts
+
+/**
+ * Greets the tenant and returns their plan info.
+ */
+export default async (input: {
+  /** The tenant organization ID */
+  readonly tenant: string
+}) => {
+  return { name: input.tenant, plan: "starter" }
+}
+```
+
+#### What codegen produces:
+
+```json
+{
+  "greet": {
+    "description": "Greets the tenant and returns their plan info.",
+    "parameters": {
+      "type": "object",
+      "properties": {
+        "tenant": { "type": "string", "description": "The tenant organization ID" }
+      },
+      "required": ["tenant"],
+      "additionalProperties": false
+    }
+  }
+}
+```
+
+#### JSDoc extraction:
+
+- Function-level JSDoc → tool `description`
+- Inline property JSDoc (`/** ... */`) → property `description` in JSON Schema
+- Uses `symbol.getDocumentationComment(checker)` from the TypeScript compiler API
+
+#### TypeScript type → JSON Schema mapping:
+
+| TS Type | JSON Schema |
+|---------|-------------|
+| `string` | `{ "type": "string" }` |
+| `number` | `{ "type": "number" }` |
+| `boolean` | `{ "type": "boolean" }` |
+| `string[]` | `{ "type": "array", "items": { "type": "string" } }` |
+| `{ key: T }` | `{ "type": "object", "properties": {...} }` |
+| `"literal"` | `{ "type": "string", "enum": ["literal"] }` |
+| `A \| B` (string union) | `{ "type": "string", "enum": ["A", "B"] }` |
+| `readonly` modifier | stripped (no JSON Schema equivalent) |
+| optional property | omitted from `required` array |
+
+#### Schema priority at runtime:
+
+1. User-exported `schema` (zod object) → wins (explicit override, already supported today)
+2. Codegen-generated JSON Schema → default (new)
+3. `z.record(z.string(), z.unknown())` → last resort (only if codegen didn't run)
+
+#### Pipeline:
+
+- `dawn build` runs typegen → produces `.dawn/routes/<routeId>/tools.json`
+- `dawn dev` watches tool files → regenerates on change
+- At request time, runtime loads the manifest and injects the generated schema into `DiscoveredToolDefinition`
+- `convertToolToLangChain` already uses `schema` if present → LLM gets proper JSON Schema
+
+### 3. Codegen Type Manifest
+
+Alongside the JSON Schema (for LLM), codegen emits a `.d.ts` that gives the TypeScript type system visibility into tool and state signatures via module augmentation.
+
+#### Generated output:
+
+```typescript
+// .dawn/generated/route-tools.d.ts
+declare module "@dawn-ai/sdk" {
+  interface RouteToolMap {
+    "/hello/[tenant]": {
+      greet: (input: { readonly tenant: string }) => Promise<{ name: string; plan: string }>
+    }
+  }
+}
+```
+
+```typescript
+// .dawn/generated/route-state.d.ts
+declare module "@dawn-ai/sdk" {
+  interface RouteStateMap {
+    "/hello/[tenant]": {
+      context: string
+      confidence: number
+      results: string[]
+    }
+  }
+}
+```
+
+#### SDK provides empty interfaces for augmentation:
+
+```typescript
+// packages/sdk/src/route-types.ts
+export interface RouteToolMap {}
+export interface RouteStateMap {}
+```
+
+#### How it integrates:
+
+- `dawn dev` / `dawn build` emits files to `.dawn/generated/`
+- The generated directory is gitignored
+- Project's `tsconfig.json` includes `.dawn/generated/` (via `include` or `/// <reference>`)
+- IDE sees augmented types automatically after `dawn dev` starts
+
+### 4. Convention-Based Agent State
+
+#### Filesystem convention:
+
+```
+src/app/(public)/hello/[tenant]/
+  index.ts              ← agent({ model, systemPrompt })
+  state.ts              ← Standard Schema export (optional)
+  reducers/             ← custom reducer overrides (optional)
+    results.ts
+  tools/
+    greet.ts
+```
+
+#### State definition (`state.ts`):
+
+Users export a Standard Schema (zod, valibot, arktype — anything implementing Standard Schema v1):
+
+```typescript
+// state.ts
+import { z } from "zod"
+
+export default z.object({
+  /** Accumulated context from tool calls */
+  context: z.string().default(""),
+  /** Confidence score */
+  confidence: z.number().default(0),
+  /** Research results collected across tool calls */
+  results: z.array(z.string()).default([]),
+})
+```
+
+#### Reducer conventions:
+
+Dawn infers reducers from default values — no runtime inspection of schema library internals:
+
+- `Array.isArray(defaultValue)` → **append** reducer (accumulate across tool calls)
+- Everything else → **replace** reducer (last value wins)
+- Messages → always present, always append (implicit, never user-defined)
+
+Dawn codes against the Standard Schema v1 interface only. No vendor-specific inspection of zod `.shape`, valibot `.entries`, or any other internal API.
+
+#### Reducer overrides (`reducers/` folder):
+
+For edge cases where convention is wrong (e.g., an array that should replace):
+
+```typescript
+// reducers/results.ts — override: replace instead of append
+export default (current: string[], incoming: string[]) => incoming
+```
+
+Convention:
+- Filename matches state field name
+- Default export is `(current: T, incoming: T) => T`
+- If no file exists → inferred from default value
+
+#### Discovery and adapter flow:
+
+1. Discovery: check for `state.ts` adjacent to route `index.ts` → import, validate Standard Schema
+2. Extract defaults from schema → infer reducers
+3. Discover `reducers/` folder → load override functions
+4. Adapter: map resolved fields → LangChain `AnnotationRoot`
+5. Pass to `createReactAgent({ stateSchema: annotation })`
+
+#### Adapter mapping (`@dawn-ai/langchain`):
+
+```typescript
+// packages/langchain/src/state-adapter.ts
+import { Annotation, MessagesAnnotation } from "@langchain/langgraph"
+
+export function materializeStateSchema(
+  fields: readonly ResolvedStateField[],
+): AnnotationRoot<any> {
+  const spec: Record<string, any> = {
+    ...MessagesAnnotation.spec,
+  }
+
+  for (const field of fields) {
+    if (typeof field.reducer === "function") {
+      spec[field.name] = Annotation({
+        reducer: field.reducer,
+        default: () => field.default,
+      })
+    } else if (field.reducer === "append") {
+      spec[field.name] = Annotation({
+        reducer: (prev: unknown[], next: unknown[]) => [...prev, ...next],
+        default: () => field.default ?? [],
+      })
+    } else {
+      spec[field.name] = Annotation({
+        reducer: (_: unknown, next: unknown) => next,
+        default: () => field.default,
+      })
+    }
+  }
+
+  return Annotation.Root(spec)
+}
+```
+
+#### What the user never does:
+
+- Import LangChain annotations
+- Write reducer config objects
+- Define messages (always implicit)
+- Wire state to the agent (auto-discovered)
+
+### 5. Utility Types and Export Cleanup
+
+**A. `Prettify<T>` utility:**
+
+```typescript
+// packages/sdk/src/types.ts
+export type Prettify<T> = { [K in keyof T]: T[K] } & {}
+```
+
+Makes IDE hovers show resolved shapes instead of intersection noise.
+
+**B. Export `RuntimeTool` from SDK barrel** — consumers can reference it for typing tool registries.
+
+**C. Consolidate `NormalizedRouteModule`** — single source of truth in `@dawn-ai/core`, re-exported by cli.
+
+## What Changes
+
+| Package | Changes |
+|---------|---------|
+| `@dawn-ai/sdk` | Per-provider model IDs, `Prettify<T>`, `RouteToolMap`/`RouteStateMap` interfaces, export `RuntimeTool` |
+| `@dawn-ai/core` | Expand typegen: JSON Schema generation + JSDoc extraction + type manifest emission, state field resolution (Standard Schema v1 interface), consolidate `NormalizedRouteModule` |
+| `@dawn-ai/langchain` | `materializeStateSchema()` maps resolved fields → AnnotationRoot, update `materializeAgent` to accept state |
+| `@dawn-ai/cli` | Discover `state.ts` + `reducers/` folder, load and pass to adapter, write `.dawn/` generated output, inject generated schema into tool definitions at runtime |
+| `@dawn-ai/devkit` | Update templates to show stateful agent example, add `state.ts` to template |
+
+## What Does NOT Change
+
+- Tool files — still plain default-exported functions
+- Tool auto-discovery — still filesystem-based
+- `agent()` API signature — same (model + systemPrompt), state is auto-wired by convention
+- `dawn build` output format — still generates compiled entries
+- Existing stateless agents — zero changes needed
+- Other route kinds (`chain`, `graph`, `workflow`) — unaffected
+
+## Dependencies
+
+- `@dawn-ai/sdk` gains zero new dependencies (utility types and interfaces only)
+- `@dawn-ai/core` already depends on `typescript` for typegen; no new deps
+- `@dawn-ai/langchain` already depends on `@langchain/langgraph`; no new deps
+- `@dawn-ai/cli` already depends on `@dawn-ai/core`; no new deps
+- Standard Schema v1 is an interface — no package dependency required
+
+## Generated Output Structure
+
+```
+.dawn/                          (gitignored)
+  generated/
+    route-tools.d.ts            RouteToolMap module augmentation
+    route-state.d.ts            RouteStateMap module augmentation
+  routes/
+    hello-[tenant]/
+      tools.json                JSON Schema per tool (fed to LLM at runtime)
+      state.json                Field definitions + reducers + defaults
+```

--- a/packages/cli/src/lib/runtime/execute-route.ts
+++ b/packages/cli/src/lib/runtime/execute-route.ts
@@ -1,4 +1,5 @@
-import { isAbsolute, resolve } from "node:path"
+import { existsSync, readFileSync } from "node:fs"
+import { isAbsolute, join, resolve } from "node:path"
 
 import { type ResolvedStateField, findDawnApp, resolveStateFields } from "@dawn-ai/core"
 import { executeAgent } from "@dawn-ai/langchain"
@@ -13,7 +14,7 @@ import {
 } from "./result.js"
 import { deriveRouteIdentity } from "./route-identity.js"
 import { discoverStateDefinition } from "./state-discovery.js"
-import { discoverToolDefinitions } from "./tool-discovery.js"
+import { discoverToolDefinitions, injectGeneratedSchemas } from "./tool-discovery.js"
 import { fileExists } from "./utils.js"
 
 export interface ExecuteRouteOptions {
@@ -116,10 +117,26 @@ async function executeRouteAtResolvedPath(options: {
     const normalized = await normalizeRouteModule(options.routeFile)
     mode = normalized.kind
 
-    const tools = await discoverToolDefinitions({
+    const discoveredTools = await discoverToolDefinitions({
       appRoot: options.appRoot,
       routeDir,
     })
+
+    // Inject codegen-generated schemas for tools without explicit schema exports
+    const routeId = options.routeId.replace(/^\//, "").replace(/\//g, "-") || "index"
+    const schemaManifestPath = join(options.appRoot, ".dawn", "routes", routeId, "tools.json")
+    let tools = discoveredTools
+    if (existsSync(schemaManifestPath)) {
+      try {
+        const manifest = JSON.parse(readFileSync(schemaManifestPath, "utf-8")) as Record<
+          string,
+          unknown
+        >
+        tools = injectGeneratedSchemas(discoveredTools, manifest)
+      } catch {
+        // Generated schema is best-effort — fall through on parse errors
+      }
+    }
 
     let stateFields: readonly ResolvedStateField[] | undefined
     if (normalized.kind === "agent") {

--- a/packages/cli/src/lib/runtime/execute-route.ts
+++ b/packages/cli/src/lib/runtime/execute-route.ts
@@ -1,6 +1,6 @@
 import { isAbsolute, resolve } from "node:path"
 
-import { findDawnApp } from "@dawn-ai/core"
+import { type ResolvedStateField, findDawnApp, resolveStateFields } from "@dawn-ai/core"
 import { executeAgent } from "@dawn-ai/langchain"
 import { createDawnContext } from "./dawn-context.js"
 import { normalizeRouteModule } from "./load-route-kind.js"
@@ -12,6 +12,7 @@ import {
   type RuntimeExecutionResult,
 } from "./result.js"
 import { deriveRouteIdentity } from "./route-identity.js"
+import { discoverStateDefinition } from "./state-discovery.js"
 import { discoverToolDefinitions } from "./tool-discovery.js"
 import { fileExists } from "./utils.js"
 
@@ -120,6 +121,17 @@ async function executeRouteAtResolvedPath(options: {
       routeDir,
     })
 
+    let stateFields: readonly ResolvedStateField[] | undefined
+    if (normalized.kind === "agent") {
+      const stateDefinition = await discoverStateDefinition({ routeDir })
+      if (stateDefinition) {
+        stateFields = resolveStateFields({
+          defaults: stateDefinition.defaults,
+          reducerOverrides: stateDefinition.reducerOverrides,
+        })
+      }
+    }
+
     const context = createDawnContext({
       tools,
       ...(options.signal ? { signal: options.signal } : {}),
@@ -127,6 +139,7 @@ async function executeRouteAtResolvedPath(options: {
 
     const output = await invokeEntry(normalized.kind, normalized.entry, options.input, context, {
       routeId: options.routeId,
+      ...(stateFields ? { stateFields } : {}),
       tools,
       ...(options.signal ? { signal: options.signal } : {}),
     })
@@ -165,6 +178,7 @@ async function invokeEntry(
   agentContext?: {
     readonly routeId: string
     readonly signal?: AbortSignal
+    readonly stateFields?: readonly ResolvedStateField[]
     readonly tools: ReadonlyArray<{
       readonly description?: string
       readonly name: string
@@ -183,6 +197,7 @@ async function invokeEntry(
       input,
       routeParamNames,
       signal: agentContext?.signal ?? new AbortController().signal,
+      ...(agentContext?.stateFields ? { stateFields: agentContext.stateFields } : {}),
       tools: agentContext?.tools ?? [],
     })
   }

--- a/packages/cli/src/lib/runtime/load-route-kind.ts
+++ b/packages/cli/src/lib/runtime/load-route-kind.ts
@@ -3,13 +3,11 @@ import { pathToFileURL } from "node:url"
 import type { RouteKind } from "@dawn-ai/sdk"
 import { isDawnAgent } from "@dawn-ai/sdk"
 
+import type { NormalizedRouteModule } from "@dawn-ai/core"
+
 import { registerTsxLoader } from "./register-tsx-loader.js"
 
-export interface NormalizedRouteModule {
-  readonly kind: RouteKind
-  readonly entry: unknown
-  readonly config: Record<string, unknown>
-}
+export type { NormalizedRouteModule } from "@dawn-ai/core"
 
 export async function loadRouteKind(routeFile: string): Promise<RouteKind> {
   const normalized = await normalizeRouteModule(routeFile)

--- a/packages/cli/src/lib/runtime/state-discovery.ts
+++ b/packages/cli/src/lib/runtime/state-discovery.ts
@@ -1,0 +1,101 @@
+import { existsSync, readdirSync } from "node:fs"
+import { basename, join } from "node:path"
+import { pathToFileURL } from "node:url"
+
+import { registerTsxLoader } from "./register-tsx-loader.js"
+
+export interface DiscoveredStateDefinition {
+  readonly defaults: Map<string, unknown>
+  readonly reducerOverrides: Map<string, (current: unknown, incoming: unknown) => unknown>
+}
+
+export async function discoverStateDefinition(options: {
+  readonly routeDir: string
+}): Promise<DiscoveredStateDefinition | null> {
+  const stateFile = join(options.routeDir, "state.ts")
+  if (!existsSync(stateFile)) return null
+
+  await registerTsxLoader()
+
+  const stateModule = (await import(pathToFileURL(stateFile).href)) as {
+    readonly default?: unknown
+  }
+  const schema = stateModule.default
+  if (!schema || typeof schema !== "object") return null
+
+  const defaults = extractDefaults(schema)
+  if (!defaults) return null
+
+  const reducerOverrides = await discoverReducerOverrides(options.routeDir)
+
+  return { defaults, reducerOverrides }
+}
+
+function extractDefaults(schema: unknown): Map<string, unknown> | null {
+  // Standard Schema v1 check
+  if (isStandardSchema(schema)) {
+    const result = schema["~standard"].validate({})
+    if ("issues" in result && result.issues) return null
+    if (typeof result.value !== "object" || result.value === null) return null
+    return new Map(Object.entries(result.value as Record<string, unknown>))
+  }
+
+  // Fallback: zod-compatible .parse()
+  if (hasParseMethod(schema)) {
+    try {
+      const parsed = schema.parse({})
+      if (typeof parsed === "object" && parsed !== null) {
+        return new Map(Object.entries(parsed))
+      }
+    } catch {
+      return null
+    }
+  }
+
+  return null
+}
+
+function isStandardSchema(
+  value: unknown,
+): value is { "~standard": { validate: (input: unknown) => { value?: unknown; issues?: unknown[] } } } {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "~standard" in value &&
+    typeof (value as Record<string, unknown>)["~standard"] === "object"
+  )
+}
+
+function hasParseMethod(value: unknown): value is { parse: (input: unknown) => unknown } {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "parse" in value &&
+    typeof (value as Record<string, unknown>).parse === "function"
+  )
+}
+
+async function discoverReducerOverrides(
+  routeDir: string,
+): Promise<Map<string, (current: unknown, incoming: unknown) => unknown>> {
+  const reducersDir = join(routeDir, "reducers")
+  const overrides = new Map<string, (current: unknown, incoming: unknown) => unknown>()
+
+  if (!existsSync(reducersDir)) return overrides
+
+  const entries = readdirSync(reducersDir)
+  for (const entry of entries) {
+    if (!entry.endsWith(".ts")) continue
+    if (entry.endsWith(".d.ts")) continue
+
+    const fieldName = basename(entry, ".ts")
+    const filePath = join(reducersDir, entry)
+    const mod = (await import(pathToFileURL(filePath).href)) as { readonly default?: unknown }
+
+    if (typeof mod.default === "function") {
+      overrides.set(fieldName, mod.default as (current: unknown, incoming: unknown) => unknown)
+    }
+  }
+
+  return overrides
+}

--- a/packages/cli/src/lib/runtime/tool-discovery.ts
+++ b/packages/cli/src/lib/runtime/tool-discovery.ts
@@ -84,6 +84,21 @@ async function loadToolScope(options: {
   return discovered
 }
 
+export function injectGeneratedSchemas(
+  tools: readonly DiscoveredToolDefinition[],
+  generatedSchemas: Record<string, unknown>,
+): readonly DiscoveredToolDefinition[] {
+  return tools.map((tool) => {
+    // User-exported schema takes priority
+    if (tool.schema) return tool
+
+    const generated = generatedSchemas[tool.name]
+    if (!generated) return tool
+
+    return { ...tool, schema: generated }
+  })
+}
+
 async function loadToolDefinition(
   filePath: string,
   scope: ToolScope,

--- a/packages/cli/test/state-discovery.test.ts
+++ b/packages/cli/test/state-discovery.test.ts
@@ -1,0 +1,142 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { afterEach, beforeEach, describe, expect, test } from "vitest"
+
+import { discoverStateDefinition } from "../src/lib/runtime/state-discovery"
+
+let tempDir: string
+
+beforeEach(() => {
+  tempDir = mkdtempSync(join(tmpdir(), "dawn-state-disc-"))
+})
+
+afterEach(() => {
+  rmSync(tempDir, { recursive: true, force: true })
+})
+
+describe("discoverStateDefinition", () => {
+  test("returns null when no state.ts exists", async () => {
+    const routeDir = join(tempDir, "route")
+    mkdirSync(routeDir, { recursive: true })
+
+    const result = await discoverStateDefinition({ routeDir })
+    expect(result).toBeNull()
+  })
+
+  test("discovers state.ts with Standard Schema interface", async () => {
+    const routeDir = join(tempDir, "route")
+    mkdirSync(routeDir, { recursive: true })
+    writeFileSync(
+      join(routeDir, "state.ts"),
+      `
+const schema = {
+  "~standard": {
+    version: 1,
+    vendor: "test",
+    validate: (input: unknown) => ({
+      value: { context: "", results: [] as string[] },
+    }),
+  },
+}
+export default schema
+`,
+    )
+
+    const result = await discoverStateDefinition({ routeDir })
+
+    expect(result).not.toBeNull()
+    expect(result!.defaults.get("context")).toBe("")
+    expect(result!.defaults.get("results")).toEqual([])
+  })
+
+  test("discovers state.ts with .parse() fallback", async () => {
+    const routeDir = join(tempDir, "route")
+    mkdirSync(routeDir, { recursive: true })
+    writeFileSync(
+      join(routeDir, "state.ts"),
+      `
+const schema = {
+  parse: (input: unknown) => ({
+    count: 0,
+    items: [] as string[],
+  }),
+}
+export default schema
+`,
+    )
+
+    const result = await discoverStateDefinition({ routeDir })
+
+    expect(result).not.toBeNull()
+    expect(result!.defaults.get("count")).toBe(0)
+    expect(result!.defaults.get("items")).toEqual([])
+  })
+
+  test("discovers reducer overrides from reducers/ folder", async () => {
+    const routeDir = join(tempDir, "route")
+    const reducersDir = join(routeDir, "reducers")
+    mkdirSync(reducersDir, { recursive: true })
+    writeFileSync(
+      join(routeDir, "state.ts"),
+      `
+const schema = {
+  "~standard": {
+    version: 1,
+    vendor: "test",
+    validate: (input: unknown) => ({ value: { tags: [] as string[] } }),
+  },
+}
+export default schema
+`,
+    )
+    writeFileSync(
+      join(reducersDir, "tags.ts"),
+      `
+export default (current: string[], incoming: string[]) => incoming
+`,
+    )
+
+    const result = await discoverStateDefinition({ routeDir })
+
+    expect(result).not.toBeNull()
+    expect(result!.reducerOverrides.has("tags")).toBe(true)
+    const reducer = result!.reducerOverrides.get("tags")!
+    expect(reducer(["a"], ["b"])).toEqual(["b"])
+  })
+
+  test("returns null when default export is not an object", async () => {
+    const routeDir = join(tempDir, "route")
+    mkdirSync(routeDir, { recursive: true })
+    writeFileSync(
+      join(routeDir, "state.ts"),
+      `export default "not a schema"`,
+    )
+
+    const result = await discoverStateDefinition({ routeDir })
+    expect(result).toBeNull()
+  })
+
+  test("returns empty reducerOverrides when no reducers/ folder", async () => {
+    const routeDir = join(tempDir, "route")
+    mkdirSync(routeDir, { recursive: true })
+    writeFileSync(
+      join(routeDir, "state.ts"),
+      `
+const schema = {
+  "~standard": {
+    version: 1,
+    vendor: "test",
+    validate: (input: unknown) => ({ value: { x: 1 } }),
+  },
+}
+export default schema
+`,
+    )
+
+    const result = await discoverStateDefinition({ routeDir })
+
+    expect(result).not.toBeNull()
+    expect(result!.reducerOverrides.size).toBe(0)
+  })
+})

--- a/packages/cli/test/state-discovery.test.ts
+++ b/packages/cli/test/state-discovery.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { afterEach, beforeEach, describe, expect, test } from "vitest"
 
-import { discoverStateDefinition } from "../src/lib/runtime/state-discovery"
+import { discoverStateDefinition } from "../src/lib/runtime/state-discovery.js"
 
 let tempDir: string
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -26,6 +26,7 @@ export type {
   JsonSchemaProperty,
   LoadDawnConfigOptions,
   LoadedDawnConfig,
+  NormalizedRouteModule,
   ResolvedStateField,
   RouteDefinition,
   RouteKind,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -14,6 +14,8 @@ export type { ExtractToolTypesOptions } from "./typegen/extract-tool-types.js"
 export { extractToolTypesForRoute } from "./typegen/extract-tool-types.js"
 export { renderDawnTypes, renderRouteTypes } from "./typegen/render-route-types.js"
 export { renderToolTypes } from "./typegen/render-tool-types.js"
+export type { RouteStateFields } from "./typegen/render-state-types.js"
+export { renderStateTypes } from "./typegen/render-state-types.js"
 export type {
   DawnConfig,
   DiscoveredDawnApp,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,5 +1,7 @@
 export { loadDawnConfig } from "./config.js"
 export { discoverRoutes } from "./discovery/discover-routes.js"
+export type { ResolveStateFieldsOptions } from "./state/resolve-state-fields.js"
+export { resolveStateFields } from "./state/resolve-state-fields.js"
 export { assertDawnRoutesDir, findDawnApp } from "./discovery/find-dawn-app.js"
 export {
   isPrivateSegment,
@@ -22,10 +24,12 @@ export type {
   JsonSchemaProperty,
   LoadDawnConfigOptions,
   LoadedDawnConfig,
+  ResolvedStateField,
   RouteDefinition,
   RouteKind,
   RouteManifest,
   RouteSegment,
   RouteToolSchemas,
   RouteToolTypes,
+  StateFieldReducer,
 } from "./types.js"

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -6,6 +6,8 @@ export {
   isRouteGroupSegment,
   toRouteSegments,
 } from "./discovery/route-segments.js"
+export type { ExtractToolSchemasOptions } from "./typegen/extract-tool-schema.js"
+export { extractToolSchemasForRoute } from "./typegen/extract-tool-schema.js"
 export type { ExtractToolTypesOptions } from "./typegen/extract-tool-types.js"
 export { extractToolTypesForRoute } from "./typegen/extract-tool-types.js"
 export { renderDawnTypes, renderRouteTypes } from "./typegen/render-route-types.js"
@@ -14,13 +16,16 @@ export type {
   DawnConfig,
   DiscoveredDawnApp,
   DiscoverRoutesOptions,
+  ExtractedToolSchema,
   ExtractedToolType,
   FindDawnAppOptions,
+  JsonSchemaProperty,
   LoadDawnConfigOptions,
   LoadedDawnConfig,
   RouteDefinition,
   RouteKind,
   RouteManifest,
   RouteSegment,
+  RouteToolSchemas,
   RouteToolTypes,
 } from "./types.js"

--- a/packages/core/src/state/resolve-state-fields.ts
+++ b/packages/core/src/state/resolve-state-fields.ts
@@ -1,0 +1,27 @@
+import type { ResolvedStateField } from "../types.js"
+
+export interface ResolveStateFieldsOptions {
+  readonly defaults: ReadonlyMap<string, unknown>
+  readonly reducerOverrides: ReadonlyMap<
+    string,
+    (current: unknown, incoming: unknown) => unknown
+  >
+}
+
+export function resolveStateFields(options: ResolveStateFieldsOptions): readonly ResolvedStateField[] {
+  const results: ResolvedStateField[] = []
+
+  for (const [name, defaultValue] of options.defaults) {
+    const override = options.reducerOverrides.get(name)
+
+    if (override) {
+      results.push({ name, reducer: override, default: defaultValue })
+    } else {
+      const reducer = Array.isArray(defaultValue) ? "append" : "replace"
+      results.push({ name, reducer, default: defaultValue })
+    }
+  }
+
+  results.sort((a, b) => a.name.localeCompare(b.name))
+  return results
+}

--- a/packages/core/src/typegen/extract-tool-schema.ts
+++ b/packages/core/src/typegen/extract-tool-schema.ts
@@ -136,11 +136,19 @@ function tsTypeToJsonSchema(
   type: ts.Type,
   checker: ts.TypeChecker,
 ): { type: string; description?: string; items?: JsonSchemaProperty; enum?: string[] } {
-  // String literal union → enum
+  // Strip undefined from unions (optional properties resolve as T | undefined)
   if (type.isUnion()) {
-    const allStringLiterals = type.types.every((t) => t.isStringLiteral())
-    if (allStringLiterals) {
-      const enumValues = type.types.map((t) => (t as ts.StringLiteralType).value)
+    const nonUndefined = type.types.filter(
+      (t) => !(t.flags & ts.TypeFlags.Undefined),
+    )
+    if (nonUndefined.length === 1 && nonUndefined[0]) {
+      return tsTypeToJsonSchema(nonUndefined[0], checker)
+    }
+
+    // String literal union → enum
+    const allStringLiterals = nonUndefined.every((t) => t.isStringLiteral())
+    if (allStringLiterals && nonUndefined.length > 0) {
+      const enumValues = nonUndefined.map((t) => (t as ts.StringLiteralType).value)
       return { type: "string", enum: enumValues }
     }
   }

--- a/packages/core/src/typegen/extract-tool-schema.ts
+++ b/packages/core/src/typegen/extract-tool-schema.ts
@@ -1,0 +1,181 @@
+import { existsSync, readdirSync } from "node:fs"
+import { join } from "node:path"
+import ts from "typescript"
+
+import type { ExtractedToolSchema, JsonSchemaProperty } from "../types.js"
+
+export interface ExtractToolSchemasOptions {
+  readonly routeDir: string
+  readonly sharedToolsDir: string | undefined
+}
+
+export async function extractToolSchemasForRoute(
+  options: ExtractToolSchemasOptions,
+): Promise<readonly ExtractedToolSchema[]> {
+  const routeToolFiles = discoverToolFiles(join(options.routeDir, "tools"))
+  const sharedToolFiles = options.sharedToolsDir
+    ? discoverToolFiles(join(options.sharedToolsDir, "tools"))
+    : new Map<string, string>()
+
+  // Merge: route-local tools shadow shared tools
+  const merged = new Map<string, string>(sharedToolFiles)
+  for (const [name, filePath] of routeToolFiles) {
+    merged.set(name, filePath)
+  }
+
+  if (merged.size === 0) return []
+
+  const allFilePaths = [...merged.values()]
+  const compilerOptions: ts.CompilerOptions = {
+    target: ts.ScriptTarget.ES2022,
+    module: ts.ModuleKind.ESNext,
+    moduleResolution: ts.ModuleResolutionKind.Bundler,
+    strict: true,
+    noEmit: true,
+    lib: ["lib.es2022.d.ts"],
+  }
+
+  const program = ts.createProgram(allFilePaths, compilerOptions)
+  const checker = program.getTypeChecker()
+
+  const results: ExtractedToolSchema[] = []
+
+  for (const [name, filePath] of merged) {
+    const sourceFile = program.getSourceFile(filePath)
+    if (!sourceFile) continue
+
+    const moduleSymbol = checker.getSymbolAtLocation(sourceFile)
+    if (!moduleSymbol) continue
+
+    const exports = checker.getExportsOfModule(moduleSymbol)
+    const defaultExport = exports.find((e) => e.escapedName === "default")
+    if (!defaultExport) continue
+
+    const exportType = checker.getTypeOfSymbolAtLocation(defaultExport, sourceFile)
+    const signatures = checker.getSignaturesOfType(exportType, ts.SignatureKind.Call)
+    if (signatures.length === 0) continue
+
+    const signature = signatures[0]
+    if (!signature) continue
+
+    // Extract tool description from JSDoc
+    const description = ts.displayPartsToString(
+      defaultExport.getDocumentationComment(checker),
+    )
+
+    const params = signature.getParameters()
+    if (params.length === 0) {
+      results.push({
+        name,
+        description,
+        parameters: {
+          type: "object",
+          properties: {},
+          required: [],
+          additionalProperties: false,
+        },
+      })
+      continue
+    }
+
+    const firstParam = params[0]
+    if (!firstParam) continue
+    const paramType = checker.getTypeOfSymbolAtLocation(firstParam, sourceFile)
+
+    const properties: Record<string, JsonSchemaProperty> = {}
+    const required: string[] = []
+
+    for (const prop of paramType.getProperties()) {
+      const propName = prop.getName()
+      const propType = checker.getTypeOfSymbolAtLocation(prop, sourceFile)
+      const schema = tsTypeToJsonSchema(propType, checker)
+
+      // Extract property JSDoc description
+      const propDoc = ts.displayPartsToString(
+        prop.getDocumentationComment(checker),
+      )
+      if (propDoc) {
+        schema.description = propDoc
+      }
+
+      properties[propName] = schema
+
+      // Check if property is optional
+      const declarations = prop.getDeclarations()
+      const isOptional =
+        declarations !== undefined &&
+        declarations.length > 0 &&
+        declarations.some(
+          (d) =>
+            ts.isPropertySignature(d) &&
+            d.questionToken !== undefined,
+        )
+
+      if (!isOptional) {
+        required.push(propName)
+      }
+    }
+
+    results.push({
+      name,
+      description,
+      parameters: {
+        type: "object",
+        properties,
+        required,
+        additionalProperties: false,
+      },
+    })
+  }
+
+  results.sort((a, b) => a.name.localeCompare(b.name))
+  return results
+}
+
+function tsTypeToJsonSchema(
+  type: ts.Type,
+  checker: ts.TypeChecker,
+): { type: string; description?: string; items?: JsonSchemaProperty; enum?: string[] } {
+  // String literal union → enum
+  if (type.isUnion()) {
+    const allStringLiterals = type.types.every((t) => t.isStringLiteral())
+    if (allStringLiterals) {
+      const enumValues = type.types.map((t) => (t as ts.StringLiteralType).value)
+      return { type: "string", enum: enumValues }
+    }
+  }
+
+  // Array type
+  if (checker.isArrayType(type)) {
+    const typeArgs = (type as ts.TypeReference).typeArguments
+    const elementType = typeArgs && typeArgs.length > 0 && typeArgs[0]
+    const items = elementType
+      ? tsTypeToJsonSchema(elementType, checker)
+      : { type: "string" }
+    return { type: "array", items }
+  }
+
+  const typeString = checker.typeToString(type)
+
+  if (typeString === "string") return { type: "string" }
+  if (typeString === "number") return { type: "number" }
+  if (typeString === "boolean") return { type: "boolean" }
+
+  // Fallback to string for unknown types
+  return { type: "string" }
+}
+
+function discoverToolFiles(toolsDir: string): Map<string, string> {
+  const files = new Map<string, string>()
+  if (!existsSync(toolsDir)) return files
+
+  const entries = readdirSync(toolsDir)
+  for (const entry of entries) {
+    if (!entry.endsWith(".ts")) continue
+    if (entry.endsWith(".d.ts")) continue
+    const name = entry.replace(/\.ts$/, "")
+    files.set(name, join(toolsDir, entry))
+  }
+
+  return files
+}

--- a/packages/core/src/typegen/extract-tool-types.ts
+++ b/packages/core/src/typegen/extract-tool-types.ts
@@ -72,7 +72,10 @@ export async function extractToolTypesForRoute(
     const returnType = checker.getReturnTypeOfSignature(signature)
     const outputType = unwrapPromise(returnType)
 
+    const description = extractJsDoc(defaultExport, checker)
+
     results.push({
+      description,
       name,
       inputType,
       outputType: checker.typeToString(outputType),
@@ -81,6 +84,11 @@ export async function extractToolTypesForRoute(
 
   results.sort((a, b) => a.name.localeCompare(b.name))
   return results
+}
+
+function extractJsDoc(symbol: ts.Symbol, checker: ts.TypeChecker): string {
+  const docs = symbol.getDocumentationComment(checker)
+  return docs.map((d) => d.text).join("").trim()
 }
 
 function unwrapPromise(type: ts.Type): ts.Type {

--- a/packages/core/src/typegen/render-state-types.ts
+++ b/packages/core/src/typegen/render-state-types.ts
@@ -1,0 +1,30 @@
+export interface RouteStateFields {
+  readonly pathname: string
+  readonly fields: readonly { readonly name: string; readonly type: string }[]
+}
+
+export function renderStateTypes(routeStates: readonly RouteStateFields[]): string {
+  const routeStateType = "  export type RouteState<P extends DawnRoutePath> = DawnRouteState[P];"
+
+  if (routeStates.length === 0) {
+    return ["  export interface DawnRouteState {}", "", routeStateType, ""].join("\n")
+  }
+
+  const routeLines: string[] = []
+  for (const route of routeStates) {
+    routeLines.push(`    ${JSON.stringify(route.pathname)}: {`)
+    for (const field of route.fields) {
+      routeLines.push(`      readonly ${field.name}: ${field.type};`)
+    }
+    routeLines.push("    };")
+  }
+
+  return [
+    "  export interface DawnRouteState {",
+    ...routeLines,
+    "  }",
+    "",
+    routeStateType,
+    "",
+  ].join("\n")
+}

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -68,3 +68,29 @@ export interface RouteToolTypes {
   readonly pathname: string
   readonly tools: readonly ExtractedToolType[]
 }
+
+export interface JsonSchemaProperty {
+  readonly type: string
+  readonly description?: string
+  readonly items?: JsonSchemaProperty
+  readonly properties?: Record<string, JsonSchemaProperty>
+  readonly required?: readonly string[]
+  readonly additionalProperties?: boolean
+  readonly enum?: readonly string[]
+}
+
+export interface ExtractedToolSchema {
+  readonly name: string
+  readonly description: string
+  readonly parameters: {
+    readonly type: "object"
+    readonly properties: Record<string, JsonSchemaProperty>
+    readonly required: readonly string[]
+    readonly additionalProperties: false
+  }
+}
+
+export interface RouteToolSchemas {
+  readonly pathname: string
+  readonly tools: readonly ExtractedToolSchema[]
+}

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -31,6 +31,12 @@ export interface RouteManifest {
   readonly routes: RouteDefinition[]
 }
 
+export interface NormalizedRouteModule {
+  readonly kind: RouteKind
+  readonly entry: unknown
+  readonly config: Record<string, unknown>
+}
+
 export interface LoadDawnConfigOptions {
   readonly appRoot: string
 }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -95,3 +95,11 @@ export interface RouteToolSchemas {
   readonly pathname: string
   readonly tools: readonly ExtractedToolSchema[]
 }
+
+export type StateFieldReducer = "append" | "replace"
+
+export interface ResolvedStateField {
+  readonly name: string
+  readonly reducer: StateFieldReducer | ((current: unknown, incoming: unknown) => unknown)
+  readonly default: unknown
+}

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -59,6 +59,7 @@ export interface DiscoverRoutesOptions {
 }
 
 export interface ExtractedToolType {
+  readonly description: string
   readonly name: string
   readonly inputType: string
   readonly outputType: string

--- a/packages/core/test/extract-tool-schema.test.ts
+++ b/packages/core/test/extract-tool-schema.test.ts
@@ -1,0 +1,283 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { afterEach, beforeEach, describe, expect, test } from "vitest"
+
+import { extractToolSchemasForRoute } from "../src/typegen/extract-tool-schema"
+
+let tempDir: string
+
+beforeEach(() => {
+  tempDir = mkdtempSync(join(tmpdir(), "dawn-extract-schema-"))
+})
+
+afterEach(() => {
+  rmSync(tempDir, { recursive: true, force: true })
+})
+
+function writeToolFile(dir: string, name: string, content: string): void {
+  const toolsDir = join(dir, "tools")
+  mkdirSync(toolsDir, { recursive: true })
+  writeFileSync(join(toolsDir, `${name}.ts`), content)
+}
+
+describe("extractToolSchemasForRoute", () => {
+  test("extracts full JSON Schema with JSDoc descriptions", async () => {
+    const routeDir = join(tempDir, "route")
+    writeToolFile(
+      routeDir,
+      "greet",
+      `
+/** Greets a user by name */
+export default async function greet(input: {
+  /** The user's name */
+  name: string
+  /** Optional greeting prefix */
+  prefix?: string
+}): Promise<{ message: string }> {
+  return { message: (input.prefix ?? "Hello") + " " + input.name }
+}
+`,
+    )
+
+    const result = await extractToolSchemasForRoute({
+      routeDir,
+      sharedToolsDir: undefined,
+    })
+
+    expect(result).toEqual([
+      {
+        name: "greet",
+        description: "Greets a user by name",
+        parameters: {
+          type: "object",
+          properties: {
+            name: { type: "string", description: "The user's name" },
+            prefix: { type: "string", description: "Optional greeting prefix" },
+          },
+          required: ["name"],
+          additionalProperties: false,
+        },
+      },
+    ])
+  })
+
+  test("maps number, boolean, and array types correctly", async () => {
+    const routeDir = join(tempDir, "route")
+    writeToolFile(
+      routeDir,
+      "process",
+      `
+/** Processes data */
+export default async function process(input: {
+  count: number
+  enabled: boolean
+  tags: string[]
+}): Promise<{ ok: boolean }> {
+  return { ok: true }
+}
+`,
+    )
+
+    const result = await extractToolSchemasForRoute({
+      routeDir,
+      sharedToolsDir: undefined,
+    })
+
+    expect(result).toEqual([
+      {
+        name: "process",
+        description: "Processes data",
+        parameters: {
+          type: "object",
+          properties: {
+            count: { type: "number" },
+            enabled: { type: "boolean" },
+            tags: { type: "array", items: { type: "string" } },
+          },
+          required: ["count", "enabled", "tags"],
+          additionalProperties: false,
+        },
+      },
+    ])
+  })
+
+  test("optional properties are omitted from required", async () => {
+    const routeDir = join(tempDir, "route")
+    writeToolFile(
+      routeDir,
+      "search",
+      `
+/** Searches items */
+export default async function search(input: {
+  query: string
+  limit?: number
+  offset?: number
+}): Promise<{ results: string[] }> {
+  return { results: [] }
+}
+`,
+    )
+
+    const result = await extractToolSchemasForRoute({
+      routeDir,
+      sharedToolsDir: undefined,
+    })
+
+    expect(result[0]?.parameters.required).toEqual(["query"])
+  })
+
+  test("string literal unions map to enum", async () => {
+    const routeDir = join(tempDir, "route")
+    writeToolFile(
+      routeDir,
+      "sort",
+      `
+/** Sorts items */
+export default async function sort(input: {
+  direction: "asc" | "desc"
+}): Promise<{ ok: boolean }> {
+  return { ok: true }
+}
+`,
+    )
+
+    const result = await extractToolSchemasForRoute({
+      routeDir,
+      sharedToolsDir: undefined,
+    })
+
+    expect(result[0]?.parameters.properties.direction).toEqual({
+      type: "string",
+      enum: ["asc", "desc"],
+    })
+  })
+
+  test("no JSDoc gives empty description string and no description key on properties", async () => {
+    const routeDir = join(tempDir, "route")
+    writeToolFile(
+      routeDir,
+      "plain",
+      `
+export default async function plain(input: {
+  value: string
+}): Promise<{ ok: boolean }> {
+  return { ok: true }
+}
+`,
+    )
+
+    const result = await extractToolSchemasForRoute({
+      routeDir,
+      sharedToolsDir: undefined,
+    })
+
+    expect(result[0]?.description).toBe("")
+    expect(result[0]?.parameters.properties.value).toEqual({ type: "string" })
+    expect("description" in (result[0]?.parameters.properties.value ?? {})).toBe(
+      false,
+    )
+  })
+
+  test("no-parameter tools get empty properties and required", async () => {
+    const routeDir = join(tempDir, "route")
+    writeToolFile(
+      routeDir,
+      "ping",
+      `
+/** Health check */
+export default async function ping(): Promise<{ pong: boolean }> {
+  return { pong: true }
+}
+`,
+    )
+
+    const result = await extractToolSchemasForRoute({
+      routeDir,
+      sharedToolsDir: undefined,
+    })
+
+    expect(result).toEqual([
+      {
+        name: "ping",
+        description: "Health check",
+        parameters: {
+          type: "object",
+          properties: {},
+          required: [],
+          additionalProperties: false,
+        },
+      },
+    ])
+  })
+
+  test("route-local tools shadow shared tools", async () => {
+    const routeDir = join(tempDir, "route")
+    const sharedDir = join(tempDir, "shared")
+
+    writeToolFile(
+      routeDir,
+      "lookup",
+      `
+/** Local lookup */
+export default async function lookup(input: { id: number }): Promise<{ found: boolean }> {
+  return { found: true }
+}
+`,
+    )
+    writeToolFile(
+      sharedDir,
+      "lookup",
+      `
+/** Shared lookup */
+export default async function lookup(input: { query: string }): Promise<{ found: boolean }> {
+  return { found: true }
+}
+`,
+    )
+
+    const result = await extractToolSchemasForRoute({
+      routeDir,
+      sharedToolsDir: sharedDir,
+    })
+
+    expect(result).toHaveLength(1)
+    expect(result[0]?.description).toBe("Local lookup")
+    expect(result[0]?.parameters.properties.id).toEqual({ type: "number" })
+  })
+
+  test("merges shared and route-local tools", async () => {
+    const routeDir = join(tempDir, "route")
+    const sharedDir = join(tempDir, "shared")
+
+    writeToolFile(
+      routeDir,
+      "local-tool",
+      `
+/** A local tool */
+export default async function localTool(input: { x: string }): Promise<{ y: string }> {
+  return { y: input.x }
+}
+`,
+    )
+    writeToolFile(
+      sharedDir,
+      "shared-tool",
+      `
+/** A shared tool */
+export default async function sharedTool(input: { a: number }): Promise<{ b: number }> {
+  return { b: input.a }
+}
+`,
+    )
+
+    const result = await extractToolSchemasForRoute({
+      routeDir,
+      sharedToolsDir: sharedDir,
+    })
+
+    expect(result).toHaveLength(2)
+    expect(result[0]?.name).toBe("local-tool")
+    expect(result[1]?.name).toBe("shared-tool")
+  })
+})

--- a/packages/core/test/extract-tool-types.test.ts
+++ b/packages/core/test/extract-tool-types.test.ts
@@ -41,6 +41,7 @@ export default async function greet(input: { name: string }): Promise<{ message:
 
     expect(result).toEqual([
       {
+        description: "",
         name: "greet",
         inputType: "{ name: string; }",
         outputType: "{ message: string; }",
@@ -110,6 +111,7 @@ export default async function flexible(input: unknown): Promise<{ done: boolean 
 
     expect(result).toEqual([
       {
+        description: "",
         name: "flexible",
         inputType: "unknown",
         outputType: "{ done: boolean; }",
@@ -136,6 +138,7 @@ export default async function ping(): Promise<{ pong: boolean }> {
 
     expect(result).toEqual([
       {
+        description: "",
         name: "ping",
         inputType: "void",
         outputType: "{ pong: boolean; }",
@@ -173,6 +176,7 @@ export default async function lookup(input: { query: string }): Promise<{ shared
 
     expect(result).toEqual([
       {
+        description: "",
         name: "lookup",
         inputType: "{ id: number; }",
         outputType: "{ local: true; }",
@@ -211,6 +215,49 @@ export default async function sharedTool(input: { a: number }): Promise<{ b: num
     expect(result).toHaveLength(2)
     expect(result[0]?.name).toBe("local-tool")
     expect(result[1]?.name).toBe("shared-tool")
+  })
+
+  test("extracts JSDoc description from tool function", async () => {
+    const routeDir = join(tempDir, "route")
+    writeToolFile(
+      routeDir,
+      "greet",
+      `
+/**
+ * Greets the user by name.
+ */
+export default async function greet(input: { name: string }): Promise<{ message: string }> {
+  return { message: "hello " + input.name }
+}
+`,
+    )
+
+    const result = await extractToolTypesForRoute({
+      routeDir,
+      sharedToolsDir: undefined,
+    })
+
+    expect(result[0]?.description).toBe("Greets the user by name.")
+  })
+
+  test("returns empty description when no JSDoc", async () => {
+    const routeDir = join(tempDir, "route")
+    writeToolFile(
+      routeDir,
+      "ping",
+      `
+export default async function ping(): Promise<{ pong: boolean }> {
+  return { pong: true }
+}
+`,
+    )
+
+    const result = await extractToolTypesForRoute({
+      routeDir,
+      sharedToolsDir: undefined,
+    })
+
+    expect(result[0]?.description).toBe("")
   })
 
   test("skips .d.ts files", async () => {

--- a/packages/core/test/integration-dx-improvements.test.ts
+++ b/packages/core/test/integration-dx-improvements.test.ts
@@ -1,0 +1,101 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { afterEach, beforeEach, describe, expect, test } from "vitest"
+
+import { extractToolSchemasForRoute } from "../src/typegen/extract-tool-schema"
+import { extractToolTypesForRoute } from "../src/typegen/extract-tool-types"
+
+let tempDir: string
+
+beforeEach(() => {
+  tempDir = mkdtempSync(join(tmpdir(), "dawn-dx-integration-"))
+})
+
+afterEach(() => {
+  rmSync(tempDir, { recursive: true, force: true })
+})
+
+describe("DX improvements integration", () => {
+  test("tool schema generation produces valid JSON Schema for LLM", async () => {
+    const routeDir = join(tempDir, "route")
+    const toolsDir = join(routeDir, "tools")
+    mkdirSync(toolsDir, { recursive: true })
+
+    writeFileSync(
+      join(toolsDir, "search.ts"),
+      `
+/**
+ * Searches the knowledge base for relevant documents.
+ */
+export default async function search(input: {
+  /** The search query string */
+  query: string
+  /** Maximum number of results */
+  limit?: string
+  /** Filter by category */
+  category: "docs" | "code" | "issues"
+}): Promise<{ results: unknown[]; total: number }> {
+  return { results: [], total: 0 }
+}
+`,
+    )
+
+    const schemas = await extractToolSchemasForRoute({
+      routeDir,
+      sharedToolsDir: undefined,
+    })
+
+    expect(schemas).toHaveLength(1)
+    const schema = schemas[0]!
+
+    expect(schema.name).toBe("search")
+    expect(schema.description).toBe("Searches the knowledge base for relevant documents.")
+    expect(schema.parameters.type).toBe("object")
+    expect(schema.parameters.additionalProperties).toBe(false)
+    expect(schema.parameters.properties.query).toEqual({
+      type: "string",
+      description: "The search query string",
+    })
+    expect(schema.parameters.properties.limit).toEqual({
+      type: "string",
+      description: "Maximum number of results",
+    })
+    expect(schema.parameters.properties.category).toEqual({
+      type: "string",
+      enum: ["docs", "code", "issues"],
+      description: "Filter by category",
+    })
+    expect(schema.parameters.required).toEqual(["query", "category"])
+  })
+
+  test("type extraction and schema extraction produce consistent results", async () => {
+    const routeDir = join(tempDir, "route")
+    const toolsDir = join(routeDir, "tools")
+    mkdirSync(toolsDir, { recursive: true })
+
+    writeFileSync(
+      join(toolsDir, "greet.ts"),
+      `
+/** Greets someone. */
+export default async function greet(input: { name: string }): Promise<{ message: string }> {
+  return { message: "hello" }
+}
+`,
+    )
+
+    const types = await extractToolTypesForRoute({
+      routeDir,
+      sharedToolsDir: undefined,
+    })
+    const schemas = await extractToolSchemasForRoute({
+      routeDir,
+      sharedToolsDir: undefined,
+    })
+
+    expect(types).toHaveLength(1)
+    expect(schemas).toHaveLength(1)
+    expect(types[0]!.name).toBe(schemas[0]!.name)
+    expect(types[0]!.description).toBe(schemas[0]!.description)
+  })
+})

--- a/packages/core/test/integration-dx-improvements.test.ts
+++ b/packages/core/test/integration-dx-improvements.test.ts
@@ -28,14 +28,14 @@ describe("DX improvements integration", () => {
 /**
  * Searches the knowledge base for relevant documents.
  */
-export default async function search(input: {
+export default async (input: {
   /** The search query string */
   query: string
   /** Maximum number of results */
-  limit?: string
+  limit?: number
   /** Filter by category */
   category: "docs" | "code" | "issues"
-}): Promise<{ results: unknown[]; total: number }> {
+}) => {
   return { results: [], total: 0 }
 }
 `,
@@ -58,7 +58,7 @@ export default async function search(input: {
       description: "The search query string",
     })
     expect(schema.parameters.properties.limit).toEqual({
-      type: "string",
+      type: "number",
       description: "Maximum number of results",
     })
     expect(schema.parameters.properties.category).toEqual({
@@ -78,7 +78,7 @@ export default async function search(input: {
       join(toolsDir, "greet.ts"),
       `
 /** Greets someone. */
-export default async function greet(input: { name: string }): Promise<{ message: string }> {
+export default async (input: { name: string }) => {
   return { message: "hello" }
 }
 `,

--- a/packages/core/test/render-state-types.test.ts
+++ b/packages/core/test/render-state-types.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from "vitest"
+
+import { renderStateTypes } from "../src/typegen/render-state-types"
+
+describe("renderStateTypes", () => {
+  test("renders empty interface when no routes have state", () => {
+    const result = renderStateTypes([])
+    expect(result).toContain("export interface DawnRouteState {}")
+    expect(result).toContain("export type RouteState<P extends DawnRoutePath> = DawnRouteState[P]")
+  })
+
+  test("renders state fields for a route", () => {
+    const result = renderStateTypes([
+      {
+        pathname: "/hello/[tenant]",
+        fields: [
+          { name: "context", type: "string" },
+          { name: "confidence", type: "number" },
+          { name: "results", type: "string[]" },
+        ],
+      },
+    ])
+
+    expect(result).toContain('"/hello/[tenant]"')
+    expect(result).toContain("readonly context: string;")
+    expect(result).toContain("readonly confidence: number;")
+    expect(result).toContain("readonly results: string[];")
+  })
+
+  test("renders multiple routes", () => {
+    const result = renderStateTypes([
+      {
+        pathname: "/a",
+        fields: [{ name: "x", type: "string" }],
+      },
+      {
+        pathname: "/b",
+        fields: [{ name: "y", type: "number" }],
+      },
+    ])
+
+    expect(result).toContain('"/a"')
+    expect(result).toContain('"/b"')
+    expect(result).toContain("readonly x: string;")
+    expect(result).toContain("readonly y: number;")
+  })
+
+  test("renders RouteState utility type", () => {
+    const result = renderStateTypes([
+      { pathname: "/test", fields: [{ name: "v", type: "boolean" }] },
+    ])
+    expect(result).toContain("export type RouteState<P extends DawnRoutePath> = DawnRouteState[P]")
+  })
+})

--- a/packages/core/test/resolve-state-fields.test.ts
+++ b/packages/core/test/resolve-state-fields.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from "vitest"
+
+import { resolveStateFields } from "../src/state/resolve-state-fields"
+
+describe("resolveStateFields", () => {
+  test("infers append reducer for array defaults", () => {
+    const defaults = new Map<string, unknown>([
+      ["results", []],
+      ["tags", ["initial"]],
+    ])
+
+    const result = resolveStateFields({ defaults, reducerOverrides: new Map() })
+
+    expect(result).toEqual([
+      { name: "results", reducer: "append", default: [] },
+      { name: "tags", reducer: "append", default: ["initial"] },
+    ])
+  })
+
+  test("infers replace reducer for scalar defaults", () => {
+    const defaults = new Map<string, unknown>([
+      ["context", ""],
+      ["confidence", 0],
+      ["active", true],
+    ])
+
+    const result = resolveStateFields({ defaults, reducerOverrides: new Map() })
+
+    expect(result).toEqual([
+      { name: "active", reducer: "replace", default: true },
+      { name: "confidence", reducer: "replace", default: 0 },
+      { name: "context", reducer: "replace", default: "" },
+    ])
+  })
+
+  test("reducer overrides take precedence", () => {
+    const customReducer = (current: string[], incoming: string[]) => incoming
+    const defaults = new Map<string, unknown>([["results", []]])
+    const reducerOverrides = new Map<string, (current: unknown, incoming: unknown) => unknown>([
+      ["results", customReducer as (current: unknown, incoming: unknown) => unknown],
+    ])
+
+    const result = resolveStateFields({ defaults, reducerOverrides })
+
+    expect(result).toEqual([{ name: "results", reducer: customReducer, default: [] }])
+  })
+
+  test("infers replace for null and undefined defaults", () => {
+    const defaults = new Map<string, unknown>([
+      ["data", null],
+      ["meta", undefined],
+    ])
+
+    const result = resolveStateFields({ defaults, reducerOverrides: new Map() })
+
+    expect(result).toEqual([
+      { name: "data", reducer: "replace", default: null },
+      { name: "meta", reducer: "replace", default: undefined },
+    ])
+  })
+
+  test("sorts fields alphabetically by name", () => {
+    const defaults = new Map<string, unknown>([
+      ["zeta", "z"],
+      ["alpha", "a"],
+    ])
+
+    const result = resolveStateFields({ defaults, reducerOverrides: new Map() })
+
+    expect(result[0]?.name).toBe("alpha")
+    expect(result[1]?.name).toBe("zeta")
+  })
+})

--- a/packages/devkit/templates/app-basic/.dawn/dawn.generated.d.ts
+++ b/packages/devkit/templates/app-basic/.dawn/dawn.generated.d.ts
@@ -12,4 +12,12 @@ declare module "dawn:routes" {
   }
 
   export type RouteTools<P extends DawnRoutePath> = DawnRouteTools[P];
+
+  export interface DawnRouteState {
+    "/hello/[tenant]": {
+      readonly context: string;
+    };
+  }
+
+  export type RouteState<P extends DawnRoutePath> = DawnRouteState[P];
 }

--- a/packages/devkit/templates/app-basic/package.json.template
+++ b/packages/devkit/templates/app-basic/package.json.template
@@ -11,7 +11,8 @@
     "@dawn-ai/core": "{{dawnCoreSpecifier}}",
     "@dawn-ai/cli": "{{dawnCliSpecifier}}",
     "@dawn-ai/langchain": "{{dawnLangchainSpecifier}}",
-    "@dawn-ai/sdk": "{{dawnSdkSpecifier}}"
+    "@dawn-ai/sdk": "{{dawnSdkSpecifier}}",
+    "zod": "^3.24.0"
   },
   "devDependencies": {
     "@dawn-ai/config-typescript": "{{dawnConfigTypescriptSpecifier}}",

--- a/packages/devkit/templates/app-basic/src/app/(public)/hello/[tenant]/state.ts
+++ b/packages/devkit/templates/app-basic/src/app/(public)/hello/[tenant]/state.ts
@@ -1,13 +1,6 @@
-export interface HelloInput {
-  readonly tenant: string
-}
+import { z } from "zod"
 
-export interface HelloOutput {
-  readonly greeting: string
-  readonly tenant: string
-}
-
-export interface HelloState {
-  greeting?: string
-  tenant: string
-}
+export default z.object({
+  /** Accumulated context from tool call results */
+  context: z.string().default(""),
+})

--- a/packages/langchain/src/agent-adapter.ts
+++ b/packages/langchain/src/agent-adapter.ts
@@ -1,6 +1,7 @@
 import type { DawnAgent } from "@dawn-ai/sdk"
 import { isDawnAgent } from "@dawn-ai/sdk"
 import { HumanMessage } from "@langchain/core/messages"
+import { type ResolvedStateField, materializeStateSchema } from "./state-adapter.js"
 import { convertToolToLangChain } from "./tool-converter.js"
 
 interface DawnToolDefinition {
@@ -33,6 +34,7 @@ const materializedAgents = new WeakMap<DawnAgent, AgentLike>()
 async function materializeAgent(
   descriptor: DawnAgent,
   tools: readonly DawnToolDefinition[],
+  stateFields?: readonly ResolvedStateField[],
 ): Promise<AgentLike> {
   const cached = materializedAgents.get(descriptor)
   if (cached) {
@@ -48,11 +50,17 @@ async function materializeAgent(
     model: descriptor.model,
   })
 
-  const compiled = createReactAgent({
+  const agentOptions: Record<string, unknown> = {
     llm,
     tools: langchainTools,
     prompt: descriptor.systemPrompt,
-  })
+  }
+
+  if (stateFields && stateFields.length > 0) {
+    agentOptions.stateSchema = materializeStateSchema(stateFields)
+  }
+
+  const compiled = createReactAgent(agentOptions as any)
 
   materializedAgents.set(descriptor, compiled as unknown as AgentLike)
   return compiled as unknown as AgentLike
@@ -63,6 +71,7 @@ export async function executeAgent(options: {
   readonly input: unknown
   readonly routeParamNames: readonly string[]
   readonly signal: AbortSignal
+  readonly stateFields?: readonly ResolvedStateField[]
   readonly tools: readonly DawnToolDefinition[]
 }): Promise<unknown> {
   const inputRecord = (options.input ?? {}) as Record<string, unknown>
@@ -87,7 +96,7 @@ export async function executeAgent(options: {
 
   // DawnAgent descriptor path — materialize on first use
   if (isDawnAgent(options.entry)) {
-    const materializedAgent = await materializeAgent(options.entry, options.tools)
+    const materializedAgent = await materializeAgent(options.entry, options.tools, options.stateFields)
     const messages = [new HumanMessage(formatAgentMessage(agentInput))]
     return await materializedAgent.invoke({ messages }, config)
   }

--- a/packages/langchain/src/index.ts
+++ b/packages/langchain/src/index.ts
@@ -1,4 +1,5 @@
 export { executeAgent } from "./agent-adapter.js"
 export { chainAdapter } from "./chain-adapter.js"
+export { materializeStateSchema } from "./state-adapter.js"
 export { convertToolToLangChain } from "./tool-converter.js"
 export { executeWithToolLoop } from "./tool-loop.js"

--- a/packages/langchain/src/state-adapter.ts
+++ b/packages/langchain/src/state-adapter.ts
@@ -35,5 +35,5 @@ export function materializeStateSchema(
     }
   }
 
-  return Annotation.Root(spec)
+  return Annotation.Root(spec as any)
 }

--- a/packages/langchain/src/state-adapter.ts
+++ b/packages/langchain/src/state-adapter.ts
@@ -1,0 +1,39 @@
+import { Annotation, MessagesAnnotation } from "@langchain/langgraph"
+
+export interface ResolvedStateField {
+  readonly name: string
+  readonly reducer: "append" | "replace" | ((current: unknown, incoming: unknown) => unknown)
+  readonly default: unknown
+}
+
+export function materializeStateSchema(
+  fields: readonly ResolvedStateField[],
+) {
+  const spec: Record<string, unknown> = {
+    ...MessagesAnnotation.spec,
+  }
+
+  for (const field of fields) {
+    if (typeof field.reducer === "function") {
+      spec[field.name] = Annotation({
+        reducer: field.reducer as (left: unknown, right: unknown) => unknown,
+        default: () => field.default,
+      })
+    } else if (field.reducer === "append") {
+      spec[field.name] = Annotation({
+        reducer: (prev: unknown[], next: unknown) => [
+          ...(prev ?? []),
+          ...(Array.isArray(next) ? next : [next]),
+        ],
+        default: () => (field.default ?? []) as unknown[],
+      })
+    } else {
+      spec[field.name] = Annotation({
+        reducer: (_: unknown, next: unknown) => next,
+        default: () => field.default,
+      })
+    }
+  }
+
+  return Annotation.Root(spec)
+}

--- a/packages/langchain/test/state-adapter.test.ts
+++ b/packages/langchain/test/state-adapter.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "vitest"
+
+import { materializeStateSchema } from "../src/state-adapter"
+
+describe("materializeStateSchema", () => {
+  test("produces an annotation root with messages + custom fields", () => {
+    const fields = [
+      { name: "context", reducer: "replace" as const, default: "" },
+      { name: "results", reducer: "append" as const, default: [] },
+    ]
+
+    const annotation = materializeStateSchema(fields)
+
+    expect(annotation).toBeDefined()
+    expect(annotation.spec).toBeDefined()
+    expect("messages" in annotation.spec).toBe(true)
+    expect("context" in annotation.spec).toBe(true)
+    expect("results" in annotation.spec).toBe(true)
+  })
+
+  test("returns annotation with messages when no custom fields", () => {
+    const annotation = materializeStateSchema([])
+
+    expect(annotation.spec).toBeDefined()
+    expect("messages" in annotation.spec).toBe(true)
+  })
+
+  test("handles custom function reducer", () => {
+    const customReducer = (current: unknown, incoming: unknown) => incoming
+    const fields = [
+      { name: "data", reducer: customReducer, default: null },
+    ]
+
+    const annotation = materializeStateSchema(fields)
+    expect(annotation.spec).toBeDefined()
+    expect("data" in annotation.spec).toBe(true)
+  })
+})

--- a/packages/sdk/src/agent.ts
+++ b/packages/sdk/src/agent.ts
@@ -8,15 +8,7 @@ export interface DawnAgent {
   readonly systemPrompt: string
 }
 
-export type KnownModelId =
-  | "gpt-4o"
-  | "gpt-4o-mini"
-  | "gpt-4.1"
-  | "gpt-4.1-mini"
-  | "gpt-4.1-nano"
-  | "claude-sonnet-4-20250514"
-  | "claude-haiku-4-20250414"
-  | (string & {})
+import type { KnownModelId } from "./known-model-ids.js"
 
 export interface AgentConfig {
   readonly model: KnownModelId

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -8,4 +8,6 @@ export type {
   OpenAiModelId,
 } from "./known-model-ids.js"
 export type { RouteConfig, RouteKind } from "./route-config.js"
+export type { RouteStateMap, RouteToolMap } from "./route-types.js"
 export type { RuntimeContext, RuntimeTool, ToolRegistry } from "./runtime-context.js"
+export type { Prettify } from "./types.js"

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -1,5 +1,11 @@
-export type { AgentConfig, DawnAgent, KnownModelId } from "./agent.js"
+export type { AgentConfig, DawnAgent } from "./agent.js"
 export { agent, isDawnAgent } from "./agent.js"
 export type { BackendAdapter } from "./backend-adapter.js"
+export type {
+  AnthropicModelId,
+  GoogleModelId,
+  KnownModelId,
+  OpenAiModelId,
+} from "./known-model-ids.js"
 export type { RouteConfig, RouteKind } from "./route-config.js"
 export type { RuntimeContext, RuntimeTool, ToolRegistry } from "./runtime-context.js"

--- a/packages/sdk/src/known-model-ids.ts
+++ b/packages/sdk/src/known-model-ids.ts
@@ -1,0 +1,36 @@
+export type OpenAiModelId =
+  // GPT-5.x series
+  | "gpt-5.5"
+  | "gpt-5.5-pro"
+  | "gpt-5.4"
+  | "gpt-5.4-pro"
+  | "gpt-5-mini"
+  // GPT-4.1 series
+  | "gpt-4.1"
+  | "gpt-4.1-mini"
+  | "gpt-4.1-nano"
+  // GPT-4o series
+  | "gpt-4o"
+  | "gpt-4o-mini"
+  // Reasoning
+  | "o3"
+  | "o3-mini"
+  | "o4-mini"
+
+export type AnthropicModelId =
+  | "claude-opus-4-7"
+  | "claude-sonnet-4-6"
+  | "claude-haiku-4-5-20251001"
+
+export type GoogleModelId =
+  | "gemini-3-pro-preview"
+  | "gemini-3-flash-preview"
+  | "gemini-2.5-pro"
+  | "gemini-2.5-flash"
+  | "gemini-2.5-flash-lite"
+
+export type KnownModelId =
+  | OpenAiModelId
+  | AnthropicModelId
+  | GoogleModelId
+  | (string & {})

--- a/packages/sdk/src/route-types.ts
+++ b/packages/sdk/src/route-types.ts
@@ -1,0 +1,11 @@
+/**
+ * Open interface for codegen to augment with per-route tool type information.
+ * Populated by `.dawn/generated/route-tools.d.ts` at build time.
+ */
+export interface RouteToolMap {}
+
+/**
+ * Open interface for codegen to augment with per-route state type information.
+ * Populated by `.dawn/generated/route-state.d.ts` at build time.
+ */
+export interface RouteStateMap {}

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -1,0 +1,5 @@
+/**
+ * Resolves complex intersection/mapped types into a flat object shape.
+ * Makes IDE hovers show the actual resolved type instead of type algebra.
+ */
+export type Prettify<T> = { [K in keyof T]: T[K] } & {}

--- a/packages/sdk/test/known-model-ids.test.ts
+++ b/packages/sdk/test/known-model-ids.test.ts
@@ -1,0 +1,31 @@
+import type { AnthropicModelId, GoogleModelId, KnownModelId, OpenAiModelId } from "@dawn-ai/sdk"
+import { agent } from "@dawn-ai/sdk"
+import { describe, expect, expectTypeOf, test } from "vitest"
+
+describe("KnownModelId", () => {
+  test("accepts OpenAI model IDs", () => {
+    const descriptor = agent({ model: "gpt-5.5", systemPrompt: "test" })
+    expect(descriptor.model).toBe("gpt-5.5")
+  })
+
+  test("accepts Anthropic model IDs", () => {
+    const descriptor = agent({ model: "claude-opus-4-7", systemPrompt: "test" })
+    expect(descriptor.model).toBe("claude-opus-4-7")
+  })
+
+  test("accepts Google model IDs", () => {
+    const descriptor = agent({ model: "gemini-2.5-pro", systemPrompt: "test" })
+    expect(descriptor.model).toBe("gemini-2.5-pro")
+  })
+
+  test("accepts arbitrary string via (string & {})", () => {
+    const descriptor = agent({ model: "my-custom-model", systemPrompt: "test" })
+    expect(descriptor.model).toBe("my-custom-model")
+  })
+
+  test("per-provider types are subtypes of KnownModelId", () => {
+    expectTypeOf<OpenAiModelId>().toMatchTypeOf<KnownModelId>()
+    expectTypeOf<AnthropicModelId>().toMatchTypeOf<KnownModelId>()
+    expectTypeOf<GoogleModelId>().toMatchTypeOf<KnownModelId>()
+  })
+})

--- a/packages/sdk/test/types.test.ts
+++ b/packages/sdk/test/types.test.ts
@@ -1,0 +1,28 @@
+import type { Prettify, RouteStateMap, RouteToolMap } from "@dawn-ai/sdk"
+import { describe, expectTypeOf, test } from "vitest"
+
+describe("Prettify<T>", () => {
+  test("resolves intersection types into flat object", () => {
+    type A = { a: string } & { b: number }
+    type Result = Prettify<A>
+    expectTypeOf<Result>().toEqualTypeOf<{ a: string; b: number }>()
+  })
+
+  test("preserves optional properties", () => {
+    type A = { a: string; b?: number }
+    type Result = Prettify<A>
+    expectTypeOf<Result>().toEqualTypeOf<{ a: string; b?: number }>()
+  })
+})
+
+describe("RouteToolMap", () => {
+  test("is an empty interface by default", () => {
+    expectTypeOf<RouteToolMap>().toEqualTypeOf<{}>()
+  })
+})
+
+describe("RouteStateMap", () => {
+  test("is an empty interface by default", () => {
+    expectTypeOf<RouteStateMap>().toEqualTypeOf<{}>()
+  })
+})

--- a/scripts/pack-check.mjs
+++ b/scripts/pack-check.mjs
@@ -10,7 +10,17 @@ const tempRoot = mkdtempSync(join(tmpdir(), "dawn-pack-check-"))
 const packages = [
   {
     dir: "packages/core",
-    expectedFiles: ["dist/index.js", "dist/index.d.ts", "README.md"],
+    expectedFiles: [
+      "dist/index.js",
+      "dist/index.d.ts",
+      "dist/typegen/extract-tool-schema.js",
+      "dist/typegen/extract-tool-schema.d.ts",
+      "dist/typegen/render-state-types.js",
+      "dist/typegen/render-state-types.d.ts",
+      "dist/state/resolve-state-fields.js",
+      "dist/state/resolve-state-fields.d.ts",
+      "README.md",
+    ],
     requiredFields: [
       "publishConfig.access",
       "repository",
@@ -48,6 +58,12 @@ const packages = [
       "dist/agent.d.ts",
       "dist/index.js",
       "dist/index.d.ts",
+      "dist/known-model-ids.js",
+      "dist/known-model-ids.d.ts",
+      "dist/types.js",
+      "dist/types.d.ts",
+      "dist/route-types.js",
+      "dist/route-types.d.ts",
       "package.json",
     ],
     requiredFields: [


### PR DESCRIPTION
## Summary

- **Per-provider model IDs** — `OpenAiModelId`, `AnthropicModelId`, `GoogleModelId` with current models (GPT-5.x, assistant 4.x, Gemini 3.x) plus `(string & {})` for autocomplete flexibility
- **Codegen JSON Schema from tool signatures** — uses TypeScript compiler API to extract parameter types and JSDoc descriptions, produces JSON Schema fed to the LLM at runtime with zero user effort
- **Convention-based agent state** — `state.ts` (Standard Schema v1) with reducer inference from defaults (array → append, scalar → replace), optional `reducers/` folder overrides, auto-wired through LangChain adapter
- **Utility types & exports** — `Prettify<T>`, `RouteToolMap`/`RouteStateMap` module augmentation interfaces, consolidated `NormalizedRouteModule`

## Test Plan

- [x] 177 tests passing (all packages)
- [x] Pack-check validates new dist files ship correctly
- [x] Integration test covers full schema generation pipeline (JSDoc extraction, type mapping, optional properties, string union enums)
- [ ] CI green on push
