### PR TITLE
feat: production readiness — deployment, retry, middleware

### DIFF
--- a/docs/superpowers/plans/2026-05-05-production-readiness.md
+++ b/docs/superpowers/plans/2026-05-05-production-readiness.md
@@ -1,0 +1,1373 @@
+# Production Readiness Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Redesign deployment config, retry, and middleware for production readiness with correct LangGraph Platform compatibility and clean DX.
+
+**Architecture:** Three independent features. (1) `dawn build` produces valid `langgraph.json` with `dependencies: ["."]` and `env: ".env"` for `langgraph deploy`. (2) Retry is invisible infrastructure with per-agent escape hatch via `retry` field on `AgentConfig`. (3) Middleware moves to SDK as `defineMiddleware`/`reject`/`allow` helpers with parsed `MiddlewareRequest` and context injection into tools.
+
+**Tech Stack:** TypeScript, Vitest, @dawn-ai/sdk, @dawn-ai/langchain, @dawn-ai/cli
+
+---
+
+### Task 1: Add `retry` field to `AgentConfig` in SDK
+
+**Files:**
+- Modify: `packages/sdk/src/agent.ts:13-16`
+- Modify: `packages/sdk/src/index.ts`
+- Test: `packages/sdk/test/agent.test.ts`
+
+- [ ] **Step 1: Write the failing test for retry config**
+
+In `packages/sdk/test/agent.test.ts`, add after the last test in the `describe("agent()")` block:
+
+```ts
+test("accepts optional retry config", () => {
+  const descriptor = agent({
+    model: "gpt-4o-mini",
+    systemPrompt: "You are helpful.",
+    retry: { maxAttempts: 5, baseDelay: 2000 },
+  })
+
+  expect(descriptor.model).toBe("gpt-4o-mini")
+  expect(descriptor.retry).toEqual({ maxAttempts: 5, baseDelay: 2000 })
+})
+
+test("retry defaults to undefined when not provided", () => {
+  const descriptor = agent({
+    model: "gpt-4o-mini",
+    systemPrompt: "Hello",
+  })
+
+  expect(descriptor.retry).toBeUndefined()
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /Users/blove/repos/dawn && pnpm vitest --run packages/sdk/test/agent.test.ts`
+Expected: FAIL — `retry` does not exist on `AgentConfig`
+
+- [ ] **Step 3: Add RetryConfig type and update AgentConfig and DawnAgent**
+
+In `packages/sdk/src/agent.ts`, replace the entire file with:
+
+```ts
+const DAWN_AGENT: unique symbol = Symbol.for("dawn.agent") as unknown as typeof DAWN_AGENT
+
+declare const brand: unique symbol
+
+export interface RetryConfig {
+  readonly maxAttempts?: number
+  readonly baseDelay?: number
+}
+
+export interface DawnAgent {
+  readonly [brand]: "DawnAgent"
+  readonly model: string
+  readonly retry?: RetryConfig
+  readonly systemPrompt: string
+}
+
+import type { KnownModelId } from "./known-model-ids.js"
+
+export interface AgentConfig {
+  readonly model: KnownModelId
+  readonly retry?: RetryConfig
+  readonly systemPrompt: string
+}
+
+export function agent(config: AgentConfig): DawnAgent {
+  return {
+    [DAWN_AGENT]: true,
+    model: config.model,
+    ...(config.retry ? { retry: config.retry } : {}),
+    systemPrompt: config.systemPrompt,
+  } as unknown as DawnAgent
+}
+
+export function isDawnAgent(value: unknown): value is DawnAgent {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    DAWN_AGENT in value &&
+    (value as Record<symbol, unknown>)[DAWN_AGENT] === true
+  )
+}
+```
+
+- [ ] **Step 4: Export RetryConfig from SDK index**
+
+In `packages/sdk/src/index.ts`, change the agent export line from:
+
+```ts
+export type { AgentConfig, DawnAgent } from "./agent.js"
+```
+
+to:
+
+```ts
+export type { AgentConfig, DawnAgent, RetryConfig } from "./agent.js"
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cd /Users/blove/repos/dawn && pnpm vitest --run packages/sdk/test/agent.test.ts`
+Expected: PASS — all tests including new retry config tests
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/sdk/src/agent.ts packages/sdk/src/index.ts packages/sdk/test/agent.test.ts
+git commit -m "feat(sdk): add optional retry config to AgentConfig"
+```
+
+---
+
+### Task 2: Wire per-agent retry config through agent-adapter
+
+**Files:**
+- Modify: `packages/langchain/src/agent-adapter.ts:35-69` (materializeAgent)
+- Modify: `packages/langchain/src/agent-adapter.ts:148-236` (streamFromRunnable)
+- Test: `packages/langchain/test/agent-adapter.test.ts` (create new)
+
+- [ ] **Step 1: Write the failing test for retry config passthrough**
+
+Create `packages/langchain/test/agent-adapter-retry.test.ts`:
+
+```ts
+import { describe, expect, test, vi } from "vitest"
+
+/**
+ * These tests verify that per-agent retry config is respected.
+ * We test the internal wiring by checking that withRetry receives
+ * the correct options from the agent descriptor.
+ */
+
+import { isRetryableError, withRetry } from "../src/retry.js"
+
+describe("per-agent retry config wiring", () => {
+  test("withRetry respects custom maxAttempts", async () => {
+    let attempts = 0
+    await expect(
+      withRetry(
+        async () => {
+          attempts++
+          throw new Error("503 Service Unavailable")
+        },
+        { baseDelayMs: 10, maxAttempts: 5 },
+      ),
+    ).rejects.toThrow("503 Service Unavailable")
+
+    expect(attempts).toBe(5)
+  })
+
+  test("withRetry respects custom baseDelayMs", async () => {
+    let attempts = 0
+    const start = Date.now()
+    await expect(
+      withRetry(
+        async () => {
+          attempts++
+          throw new Error("429 Too Many Requests")
+        },
+        { baseDelayMs: 10, maxAttempts: 2 },
+      ),
+    ).rejects.toThrow("429 Too Many Requests")
+
+    expect(attempts).toBe(2)
+    // With baseDelayMs=10, the delay should be very short
+    expect(Date.now() - start).toBeLessThan(1000)
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it passes (these test existing behavior)**
+
+Run: `cd /Users/blove/repos/dawn && pnpm vitest --run packages/langchain/test/agent-adapter-retry.test.ts`
+Expected: PASS — these verify existing withRetry behavior with custom options
+
+- [ ] **Step 3: Update materializeAgent to accept and forward retry config**
+
+In `packages/langchain/src/agent-adapter.ts`, update the `materializeAgent` function signature and the `streamFromRunnable` function to accept retry config.
+
+First, add the import at the top of the file (after existing imports):
+
+```ts
+import type { RetryConfig } from "@dawn-ai/sdk"
+```
+
+Then update the `AgentOptions` interface (around line 76) to add retry:
+
+```ts
+export interface AgentOptions {
+  readonly entry: unknown
+  readonly input: unknown
+  readonly retry?: RetryConfig
+  readonly routeParamNames: readonly string[]
+  readonly signal: AbortSignal
+  readonly stateFields?: readonly ResolvedStateField[]
+  readonly tools: readonly DawnToolDefinition[]
+}
+```
+
+Update `streamAgent` (around line 95) to pass retry config when materializing:
+
+In the DawnAgent descriptor path inside `streamAgent`, change:
+
+```ts
+  if (isDawnAgent(options.entry)) {
+    const materializedAgent = await materializeAgent(
+      options.entry,
+      options.tools,
+      options.stateFields,
+    )
+    yield* streamFromRunnable(materializedAgent, { messages }, config)
+    return
+  }
+```
+
+to:
+
+```ts
+  if (isDawnAgent(options.entry)) {
+    const materializedAgent = await materializeAgent(
+      options.entry,
+      options.tools,
+      options.stateFields,
+    )
+    const retryConfig = options.entry.retry
+    yield* streamFromRunnable(materializedAgent, { messages }, config, retryConfig)
+    return
+  }
+```
+
+Update the legacy path to also pass retry:
+
+```ts
+  yield* streamFromRunnable(options.entry, { messages }, config, options.retry)
+```
+
+Update `streamFromRunnable` signature (around line 148) to accept retry config:
+
+```ts
+async function* streamFromRunnable(
+  runnable: AgentLike,
+  input: unknown,
+  config: Record<string, unknown>,
+  retryConfig?: RetryConfig,
+): AsyncGenerator<AgentStreamChunk> {
+```
+
+In the `streamFromRunnable` fallback invoke path (around line 163), update the `withRetry` call to use per-agent config:
+
+```ts
+    const retryOptions: import("./retry.js").RetryOptions = {
+      ...(retryConfig?.maxAttempts ? { maxAttempts: retryConfig.maxAttempts } : {}),
+      ...(retryConfig?.baseDelay ? { baseDelayMs: retryConfig.baseDelay } : {}),
+      ...(signal ? { signal } : {}),
+    }
+    const result = await withRetry(
+      () => runnable.invoke(input, config),
+      Object.keys(retryOptions).length > 0 ? retryOptions : undefined,
+    )
+```
+
+In the streaming retry loop (around line 177), update the max attempts to use per-agent config:
+
+```ts
+  const maxStreamAttempts = retryConfig?.maxAttempts ?? 3
+```
+
+- [ ] **Step 4: Run all langchain tests**
+
+Run: `cd /Users/blove/repos/dawn && pnpm vitest --run packages/langchain/test/`
+Expected: PASS — all existing tests plus new retry wiring tests
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/langchain/src/agent-adapter.ts packages/langchain/test/agent-adapter-retry.test.ts
+git commit -m "feat(langchain): wire per-agent retry config through agent-adapter"
+```
+
+---
+
+### Task 3: Add middleware SDK exports (defineMiddleware, reject, allow)
+
+**Files:**
+- Create: `packages/sdk/src/middleware.ts`
+- Modify: `packages/sdk/src/index.ts`
+- Test: `packages/sdk/test/middleware.test.ts` (create new)
+
+- [ ] **Step 1: Write the failing test for middleware helpers**
+
+Create `packages/sdk/test/middleware.test.ts`:
+
+```ts
+import { describe, expect, test } from "vitest"
+import {
+  allow,
+  defineMiddleware,
+  reject,
+  type MiddlewareRequest,
+  type MiddlewareResult,
+} from "../src/middleware.js"
+
+describe("reject()", () => {
+  test("returns a reject result with status and body", () => {
+    const result = reject(401, { error: "Unauthorized" })
+    expect(result).toEqual({
+      action: "reject",
+      status: 401,
+      body: { error: "Unauthorized" },
+    })
+  })
+
+  test("body defaults to undefined", () => {
+    const result = reject(403)
+    expect(result).toEqual({
+      action: "reject",
+      status: 403,
+      body: undefined,
+    })
+  })
+})
+
+describe("allow()", () => {
+  test("returns a continue result with context", () => {
+    const result = allow({ userId: "user-1", orgId: "org-1" })
+    expect(result).toEqual({
+      action: "continue",
+      context: { userId: "user-1", orgId: "org-1" },
+    })
+  })
+
+  test("context defaults to undefined", () => {
+    const result = allow()
+    expect(result).toEqual({
+      action: "continue",
+      context: undefined,
+    })
+  })
+})
+
+describe("defineMiddleware()", () => {
+  test("returns the function as-is (type-safe identity wrapper)", () => {
+    const fn = async (req: MiddlewareRequest): Promise<MiddlewareResult> => {
+      return allow()
+    }
+
+    const middleware = defineMiddleware(fn)
+    expect(middleware).toBe(fn)
+  })
+
+  test("works with a sync function", () => {
+    const fn = (req: MiddlewareRequest): MiddlewareResult => {
+      return reject(401)
+    }
+
+    const middleware = defineMiddleware(fn)
+    expect(middleware).toBe(fn)
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /Users/blove/repos/dawn && pnpm vitest --run packages/sdk/test/middleware.test.ts`
+Expected: FAIL — module `../src/middleware.js` does not exist
+
+- [ ] **Step 3: Implement middleware types and helpers**
+
+Create `packages/sdk/src/middleware.ts`:
+
+```ts
+export interface MiddlewareRequest {
+  readonly assistantId: string
+  readonly headers: Readonly<Record<string, string>>
+  readonly method: string
+  readonly params: Readonly<Record<string, string>>
+  readonly routeId: string
+  readonly url: string
+}
+
+export interface ContinueResult {
+  readonly action: "continue"
+  readonly context?: Record<string, unknown>
+}
+
+export interface RejectResult {
+  readonly action: "reject"
+  readonly body?: unknown
+  readonly status: number
+}
+
+export type MiddlewareResult = ContinueResult | RejectResult
+
+export type DawnMiddleware = (
+  req: MiddlewareRequest,
+) => Promise<MiddlewareResult> | MiddlewareResult
+
+export function defineMiddleware(fn: DawnMiddleware): DawnMiddleware {
+  return fn
+}
+
+export function reject(status: number, body?: unknown): RejectResult {
+  return { action: "reject", body, status }
+}
+
+export function allow(context?: Record<string, unknown>): ContinueResult {
+  return { action: "continue", context }
+}
+```
+
+- [ ] **Step 4: Export middleware types and helpers from SDK index**
+
+In `packages/sdk/src/index.ts`, add these lines at the end:
+
+```ts
+export type {
+  ContinueResult,
+  DawnMiddleware,
+  MiddlewareRequest,
+  MiddlewareResult,
+  RejectResult,
+} from "./middleware.js"
+export { allow, defineMiddleware, reject } from "./middleware.js"
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cd /Users/blove/repos/dawn && pnpm vitest --run packages/sdk/test/middleware.test.ts`
+Expected: PASS — all middleware helper tests pass
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/sdk/src/middleware.ts packages/sdk/src/index.ts packages/sdk/test/middleware.test.ts
+git commit -m "feat(sdk): add defineMiddleware, reject, allow helpers"
+```
+
+---
+
+### Task 4: Rewrite CLI middleware to use SDK types
+
+**Files:**
+- Modify: `packages/cli/src/lib/dev/middleware.ts`
+- Modify: `packages/cli/test/middleware.test.ts`
+
+- [ ] **Step 1: Rewrite the middleware test to use SDK types**
+
+Replace the entire content of `packages/cli/test/middleware.test.ts`:
+
+```ts
+import { describe, expect, test } from "vitest"
+
+import type { DawnMiddleware, MiddlewareRequest } from "@dawn-ai/sdk"
+import { loadMiddleware, runMiddleware } from "../src/lib/dev/middleware.js"
+
+function createMockRequest(overrides?: Partial<MiddlewareRequest>): MiddlewareRequest {
+  return {
+    assistantId: "/hello/[tenant]#agent",
+    headers: {},
+    method: "POST",
+    params: {},
+    routeId: "/hello/[tenant]",
+    url: "/runs/wait",
+    ...overrides,
+  }
+}
+
+describe("runMiddleware", () => {
+  test("returns continue when middleware is undefined", async () => {
+    const result = await runMiddleware(undefined, createMockRequest())
+    expect(result.action).toBe("continue")
+  })
+
+  test("returns continue when middleware passes", async () => {
+    const mw: DawnMiddleware = async () => ({ action: "continue" })
+
+    const result = await runMiddleware(mw, createMockRequest())
+    expect(result.action).toBe("continue")
+  })
+
+  test("returns reject when middleware rejects", async () => {
+    const mw: DawnMiddleware = async () => ({
+      action: "reject",
+      status: 401,
+      body: { error: "Unauthorized" },
+    })
+
+    const result = await runMiddleware(mw, createMockRequest())
+    expect(result).toEqual({
+      action: "reject",
+      status: 401,
+      body: { error: "Unauthorized" },
+    })
+  })
+
+  test("passes context through on continue", async () => {
+    const mw: DawnMiddleware = async () => ({
+      action: "continue",
+      context: { userId: "user-1" },
+    })
+
+    const result = await runMiddleware(mw, createMockRequest())
+    expect(result).toEqual({
+      action: "continue",
+      context: { userId: "user-1" },
+    })
+  })
+
+  test("receives parsed request with headers and params", async () => {
+    let receivedReq: MiddlewareRequest | undefined
+
+    const mw: DawnMiddleware = async (req) => {
+      receivedReq = req
+      return { action: "continue" }
+    }
+
+    await runMiddleware(
+      mw,
+      createMockRequest({
+        headers: { authorization: "Bearer tok-123" },
+        params: { tenant: "acme" },
+        routeId: "/api/chat",
+      }),
+    )
+
+    expect(receivedReq?.headers.authorization).toBe("Bearer tok-123")
+    expect(receivedReq?.params.tenant).toBe("acme")
+    expect(receivedReq?.routeId).toBe("/api/chat")
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /Users/blove/repos/dawn && pnpm vitest --run packages/cli/test/middleware.test.ts`
+Expected: FAIL — `runMiddleware` signature no longer matches (single function vs array)
+
+- [ ] **Step 3: Rewrite the middleware module to use SDK types**
+
+Replace the entire content of `packages/cli/src/lib/dev/middleware.ts`:
+
+```ts
+import type { DawnMiddleware, MiddlewareRequest, MiddlewareResult } from "@dawn-ai/sdk"
+
+/**
+ * Load middleware from the app's middleware.ts file.
+ * Convention: src/middleware.ts exports a default function (using defineMiddleware).
+ */
+export async function loadMiddleware(appRoot: string): Promise<DawnMiddleware | undefined> {
+  const middlewarePaths = [
+    `${appRoot}/src/middleware.ts`,
+    `${appRoot}/src/middleware.js`,
+    `${appRoot}/middleware.ts`,
+    `${appRoot}/middleware.js`,
+  ]
+
+  for (const path of middlewarePaths) {
+    try {
+      const mod = await import(path)
+      const exported = mod.default ?? mod.middleware
+
+      if (typeof exported === "function") {
+        return exported as DawnMiddleware
+      }
+    } catch {
+      // File doesn't exist or can't be loaded — try next
+    }
+  }
+
+  return undefined
+}
+
+/**
+ * Run middleware. Returns continue (with optional context) or reject.
+ */
+export async function runMiddleware(
+  middleware: DawnMiddleware | undefined,
+  request: MiddlewareRequest,
+): Promise<MiddlewareResult> {
+  if (!middleware) {
+    return { action: "continue" }
+  }
+
+  return await middleware(request)
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd /Users/blove/repos/dawn && pnpm vitest --run packages/cli/test/middleware.test.ts`
+Expected: PASS — all middleware tests pass with new single-function model
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/cli/src/lib/dev/middleware.ts packages/cli/test/middleware.test.ts
+git commit -m "refactor(cli): rewrite middleware to use SDK types (single function model)"
+```
+
+---
+
+### Task 5: Update runtime-server to use new middleware API
+
+**Files:**
+- Modify: `packages/cli/src/lib/dev/runtime-server.ts:1-12` (imports)
+- Modify: `packages/cli/src/lib/dev/runtime-server.ts:25-30` (startRuntimeServer)
+- Modify: `packages/cli/src/lib/dev/runtime-server.ts:115-177` (handleRequest middleware block)
+- Modify: `packages/cli/src/lib/dev/runtime-server.ts:247-294` (handleStreamRequest middleware block)
+
+- [ ] **Step 1: Update imports in runtime-server**
+
+In `packages/cli/src/lib/dev/runtime-server.ts`, replace the middleware import (lines 6-11):
+
+```ts
+import {
+  type DawnMiddleware,
+  type MiddlewareContext,
+  loadMiddleware,
+  runMiddleware,
+} from "./middleware.js"
+```
+
+with:
+
+```ts
+import type { DawnMiddleware, MiddlewareRequest } from "@dawn-ai/sdk"
+import { loadMiddleware, runMiddleware } from "./middleware.js"
+```
+
+- [ ] **Step 2: Update startRuntimeServer to use single middleware**
+
+In `startRuntimeServer` (around line 29), change:
+
+```ts
+  const middlewares = await loadMiddleware(options.appRoot)
+```
+
+to:
+
+```ts
+  const middleware = await loadMiddleware(options.appRoot)
+```
+
+Then update all references in the function from `middlewares` to `middleware`. This means changing the `handleRequest` call (around line 45) from:
+
+```ts
+      await handleRequest({
+        middlewares,
+        registry,
+        request,
+        response,
+        signal: shutdownController.signal,
+      })
+```
+
+to:
+
+```ts
+      await handleRequest({
+        middleware,
+        registry,
+        request,
+        response,
+        signal: shutdownController.signal,
+      })
+```
+
+- [ ] **Step 3: Update handleRequest signature and middleware block**
+
+Update the `handleRequest` function signature (around line 115) from:
+
+```ts
+async function handleRequest(options: {
+  readonly middlewares: readonly DawnMiddleware[]
+  readonly registry: RuntimeRegistry
+  readonly request: IncomingMessage
+  readonly response: ServerResponse
+  readonly signal: AbortSignal
+}): Promise<void> {
+  const { middlewares, request, response, registry, signal } = options
+```
+
+to:
+
+```ts
+async function handleRequest(options: {
+  readonly middleware: DawnMiddleware | undefined
+  readonly registry: RuntimeRegistry
+  readonly request: IncomingMessage
+  readonly response: ServerResponse
+  readonly signal: AbortSignal
+}): Promise<void> {
+  const { middleware, request, response, registry, signal } = options
+```
+
+Replace the middleware execution block (around lines 166-177) from:
+
+```ts
+  // Run middleware before execution
+  if (middlewares.length > 0) {
+    const mwContext: MiddlewareContext = {
+      request,
+      routeId: route.routeId,
+      assistantId: route.assistantId,
+    }
+    const mwResult = await runMiddleware(middlewares, mwContext)
+    if (mwResult.action === "reject") {
+      sendJson(response, mwResult.status, mwResult.body)
+      return
+    }
+  }
+```
+
+to:
+
+```ts
+  // Run middleware before execution
+  const mwRequest: MiddlewareRequest = {
+    assistantId: route.assistantId,
+    headers: parseHeaders(request),
+    method: request.method ?? "POST",
+    params: extractRouteParams(route.routeId, validatedBody.value.input),
+    routeId: route.routeId,
+    url: request.url ?? "/runs/wait",
+  }
+  const mwResult = await runMiddleware(middleware, mwRequest)
+  if (mwResult.action === "reject") {
+    sendJson(response, mwResult.status, mwResult.body)
+    return
+  }
+```
+
+- [ ] **Step 4: Update handleStreamRequest similarly**
+
+Update the `handleStreamRequest` function signature (around line 247) from:
+
+```ts
+async function handleStreamRequest(options: {
+  readonly middlewares: readonly DawnMiddleware[]
+  readonly registry: RuntimeRegistry
+  readonly request: IncomingMessage
+  readonly response: ServerResponse
+  readonly signal: AbortSignal
+}): Promise<void> {
+  const { middlewares, request, response, registry, signal } = options
+```
+
+to:
+
+```ts
+async function handleStreamRequest(options: {
+  readonly middleware: DawnMiddleware | undefined
+  readonly registry: RuntimeRegistry
+  readonly request: IncomingMessage
+  readonly response: ServerResponse
+  readonly signal: AbortSignal
+}): Promise<void> {
+  const { middleware, request, response, registry, signal } = options
+```
+
+Replace the middleware execution block in `handleStreamRequest` (around lines 282-294) from:
+
+```ts
+  // Run middleware before streaming
+  if (middlewares.length > 0) {
+    const mwContext: MiddlewareContext = {
+      request,
+      routeId: route.routeId,
+      assistantId: route.assistantId,
+    }
+    const mwResult = await runMiddleware(middlewares, mwContext)
+    if (mwResult.action === "reject") {
+      sendJson(response, mwResult.status, mwResult.body)
+      return
+    }
+  }
+```
+
+to:
+
+```ts
+  // Run middleware before streaming
+  const mwRequest: MiddlewareRequest = {
+    assistantId: route.assistantId,
+    headers: parseHeaders(request),
+    method: request.method ?? "POST",
+    params: extractRouteParams(route.routeId, validatedBody.value.input),
+    routeId: route.routeId,
+    url: request.url ?? "/runs/stream",
+  }
+  const mwResult = await runMiddleware(middleware, mwRequest)
+  if (mwResult.action === "reject") {
+    sendJson(response, mwResult.status, mwResult.body)
+    return
+  }
+```
+
+Update the `handleStreamRequest` call in `handleRequest` (around line 130) from:
+
+```ts
+    await handleStreamRequest({ middlewares, registry, request, response, signal })
+```
+
+to:
+
+```ts
+    await handleStreamRequest({ middleware, registry, request, response, signal })
+```
+
+- [ ] **Step 5: Add helper functions at the bottom of runtime-server.ts**
+
+Add these helper functions before the closing of the file (before or after `isRecord`):
+
+```ts
+function parseHeaders(request: IncomingMessage): Record<string, string> {
+  const headers: Record<string, string> = {}
+  for (const [key, value] of Object.entries(request.headers)) {
+    if (typeof value === "string") {
+      headers[key] = value
+    } else if (Array.isArray(value)) {
+      headers[key] = value.join(", ")
+    }
+  }
+  return headers
+}
+
+function extractRouteParams(
+  routeId: string,
+  input: unknown,
+): Record<string, string> {
+  const params: Record<string, string> = {}
+  const matches = routeId.matchAll(/\[(\w+)\]/g)
+  const inputRecord = (typeof input === "object" && input !== null ? input : {}) as Record<
+    string,
+    unknown
+  >
+
+  for (const match of matches) {
+    const name = match[1]
+    if (name && name in inputRecord) {
+      params[name] = String(inputRecord[name])
+    }
+  }
+
+  return params
+}
+```
+
+- [ ] **Step 6: Run full CLI test suite**
+
+Run: `cd /Users/blove/repos/dawn && pnpm vitest --run packages/cli/test/`
+Expected: PASS — all tests including middleware tests
+
+- [ ] **Step 7: Run typecheck**
+
+Run: `cd /Users/blove/repos/dawn && pnpm typecheck`
+Expected: PASS — no type errors
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add packages/cli/src/lib/dev/runtime-server.ts
+git commit -m "refactor(cli): update runtime-server to new middleware API with parsed request"
+```
+
+---
+
+### Task 6: Rewrite deployment-config for correct langgraph.json format
+
+**Files:**
+- Modify: `packages/cli/src/lib/build/deployment-config.ts`
+- Modify: `packages/cli/test/deployment-config.test.ts`
+
+- [ ] **Step 1: Rewrite the deployment-config test**
+
+Replace the entire content of `packages/cli/test/deployment-config.test.ts`:
+
+```ts
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { afterEach, beforeEach, describe, expect, test } from "vitest"
+
+import {
+  extractDeploymentConfig,
+  type LangGraphConfig,
+} from "../src/lib/build/deployment-config.js"
+
+let tempDir: string
+
+beforeEach(() => {
+  tempDir = mkdtempSync(join(tmpdir(), "dawn-deploy-"))
+})
+
+afterEach(() => {
+  rmSync(tempDir, { recursive: true, force: true })
+})
+
+describe("extractDeploymentConfig", () => {
+  test("returns dependencies as ['.'] (project root path)", () => {
+    writeFileSync(
+      join(tempDir, "package.json"),
+      JSON.stringify({
+        dependencies: {
+          "@dawn-ai/cli": "0.1.6",
+          "@langchain/openai": "0.5.0",
+        },
+      }),
+    )
+
+    const config = extractDeploymentConfig(tempDir)
+
+    expect(config.dependencies).toEqual(["."])
+  })
+
+  test("returns env as path to .env file when .env exists", () => {
+    writeFileSync(join(tempDir, "package.json"), JSON.stringify({ dependencies: {} }))
+    writeFileSync(join(tempDir, ".env"), "OPENAI_API_KEY=sk-test\n")
+
+    const config = extractDeploymentConfig(tempDir)
+
+    expect(config.env).toBe(".env")
+  })
+
+  test("returns env as path to .env.example when it exists", () => {
+    writeFileSync(join(tempDir, "package.json"), JSON.stringify({ dependencies: {} }))
+    writeFileSync(join(tempDir, ".env.example"), "OPENAI_API_KEY=\n")
+
+    const config = extractDeploymentConfig(tempDir)
+
+    expect(config.env).toBe(".env.example")
+  })
+
+  test("prefers .env.example over .env", () => {
+    writeFileSync(join(tempDir, "package.json"), JSON.stringify({ dependencies: {} }))
+    writeFileSync(join(tempDir, ".env"), "OPENAI_API_KEY=real-key\nSECRET=value\n")
+    writeFileSync(join(tempDir, ".env.example"), "OPENAI_API_KEY=\n")
+
+    const config = extractDeploymentConfig(tempDir)
+
+    expect(config.env).toBe(".env.example")
+  })
+
+  test("returns env as .env when no env files exist (will be created)", () => {
+    writeFileSync(join(tempDir, "package.json"), JSON.stringify({ dependencies: {} }))
+
+    const config = extractDeploymentConfig(tempDir)
+
+    expect(config.env).toBe(".env")
+  })
+
+  test("returns node_version 22", () => {
+    writeFileSync(join(tempDir, "package.json"), JSON.stringify({ dependencies: {} }))
+
+    const config = extractDeploymentConfig(tempDir)
+
+    expect(config.node_version).toBe("22")
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /Users/blove/repos/dawn && pnpm vitest --run packages/cli/test/deployment-config.test.ts`
+Expected: FAIL — `dependencies` is `["@dawn-ai/cli@0.1.6", ...]` not `["."]`
+
+- [ ] **Step 3: Rewrite deployment-config.ts**
+
+Replace the entire content of `packages/cli/src/lib/build/deployment-config.ts`:
+
+```ts
+import { existsSync } from "node:fs"
+import { join } from "node:path"
+
+/**
+ * Configuration for LangGraph Platform deployment.
+ * Produces fields compatible with langgraph.json schema.
+ */
+
+export interface LangGraphConfig {
+  /** Paths to local directories/tarballs to install. Always ["."] for Dawn apps. */
+  readonly dependencies: readonly string[]
+  /** Path to env file relative to build output. */
+  readonly env: string
+  /** Node.js version. */
+  readonly node_version: string
+}
+
+export function extractDeploymentConfig(appRoot: string): LangGraphConfig {
+  return {
+    dependencies: ["."],
+    env: detectEnvFilePath(appRoot),
+    node_version: "22",
+  }
+}
+
+function detectEnvFilePath(appRoot: string): string {
+  // Prefer .env.example (canonical list of required vars, no secrets)
+  if (existsSync(join(appRoot, ".env.example"))) {
+    return ".env.example"
+  }
+
+  // Fall back to .env (may contain secrets — LangGraph Platform reads var names only)
+  return ".env"
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd /Users/blove/repos/dawn && pnpm vitest --run packages/cli/test/deployment-config.test.ts`
+Expected: PASS — all deployment config tests pass with corrected format
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/cli/src/lib/build/deployment-config.ts packages/cli/test/deployment-config.test.ts
+git commit -m "fix(cli): correct langgraph.json format — dependencies as paths, env as file path"
+```
+
+---
+
+### Task 7: Rewrite build command to produce correct langgraph.json (no Dockerfile)
+
+**Files:**
+- Modify: `packages/cli/src/commands/build.ts`
+
+- [ ] **Step 1: Rewrite the build command**
+
+Replace the entire content of `packages/cli/src/commands/build.ts`:
+
+```ts
+import { existsSync, readFileSync } from "node:fs"
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises"
+import { dirname, join, relative, resolve } from "node:path"
+
+import { discoverRoutes } from "@dawn-ai/core"
+import type { Command } from "commander"
+import { extractDeploymentConfig } from "../lib/build/deployment-config.js"
+import { type CommandIo, writeLine } from "../lib/output.js"
+import {
+  type DiscoveredToolDefinition,
+  discoverToolDefinitions,
+  injectGeneratedSchemas,
+} from "../lib/runtime/tool-discovery.js"
+import { runTypegen } from "../lib/typegen/run-typegen.js"
+
+interface BuildOptions {
+  readonly clean?: boolean
+  readonly cwd?: string
+}
+
+export function registerBuildCommand(program: Command, io: CommandIo): void {
+  program
+    .command("build")
+    .description("Generate deployment artifacts for LangGraph Platform")
+    .option("--clean", "Remove .dawn/build/ before generating")
+    .option("--cwd <path>", "Path to the Dawn app root")
+    .action(async (options: BuildOptions) => {
+      await runBuildCommand(options, io)
+    })
+}
+
+export async function runBuildCommand(options: BuildOptions, io: CommandIo): Promise<void> {
+  const manifest = await discoverRoutes({
+    ...(options.cwd ? { appRoot: options.cwd } : {}),
+  })
+
+  // Run typegen as pre-step to produce .dawn/routes/<id>/tools.json and .dawn/dawn.generated.d.ts
+  await runTypegen({ appRoot: manifest.appRoot, manifest })
+
+  const buildDir = resolve(manifest.appRoot, ".dawn", "build")
+
+  if (options.clean) {
+    await rm(buildDir, { recursive: true, force: true })
+  }
+
+  await mkdir(buildDir, { recursive: true })
+
+  const graphs: Record<string, string> = {}
+
+  for (const route of manifest.routes) {
+    const discoveredTools = await discoverToolDefinitions({
+      appRoot: manifest.appRoot,
+      routeDir: route.routeDir,
+    })
+
+    // Inject codegen-generated schemas (same as runtime path)
+    const routeSlug =
+      route.id.replace(/^\//, "").replace(/\//g, "-").replace(/\[/g, "").replace(/\]/g, "") ||
+      "index"
+    const schemaManifestPath = join(manifest.appRoot, ".dawn", "routes", routeSlug, "tools.json")
+    let tools = discoveredTools
+    if (existsSync(schemaManifestPath)) {
+      try {
+        const schemaManifest = JSON.parse(readFileSync(schemaManifestPath, "utf-8")) as Record<
+          string,
+          unknown
+        >
+        tools = injectGeneratedSchemas(discoveredTools, schemaManifest)
+      } catch {
+        // Best-effort — fall through on parse errors
+      }
+    }
+
+    const entryFilePath = join(buildDir, `${routeSlug}.ts`)
+    const relativeRoutePath = relative(dirname(entryFilePath), route.routeDir)
+    const routeImportPath = `${relativeRoutePath}/index.js`
+
+    let entryContent: string
+
+    if (route.kind === "agent" && tools.length > 0) {
+      const toolImports = tools.map((tool) => {
+        const relToolPath = relative(dirname(entryFilePath), dirname(tool.filePath))
+        const toolFileName =
+          tool.filePath.split("/").pop()?.replace(/\.ts$/, ".js") ?? `${tool.name}.js`
+        return `import ${tool.name} from "${relToolPath}/${toolFileName}"`
+      })
+
+      const toolBindings = tools.map((tool) => {
+        const description = tool.description ?? ""
+        const schema = toolSchemaToZodSource(tool)
+        return `const ${tool.name}Tool = tool(${tool.name}, {\n  name: "${tool.name}",\n  description: "${description}",\n  schema: ${schema},\n})`
+      })
+
+      const toolNames = tools.map((tool) => `${tool.name}Tool`)
+
+      entryContent = [
+        `import { agent } from "${routeImportPath}"`,
+        ...toolImports,
+        `import { tool } from "@langchain/core/tools"`,
+        `import { z } from "zod"`,
+        ``,
+        ...toolBindings,
+        ``,
+        `export const graph = agent.bindTools([${toolNames.join(", ")}])`,
+        ``,
+      ].join("\n")
+    } else {
+      const exportName = route.kind
+      entryContent = [
+        `import { ${exportName} } from "${routeImportPath}"`,
+        ``,
+        `export const graph = ${exportName}`,
+        ``,
+      ].join("\n")
+    }
+
+    await writeFile(entryFilePath, entryContent, "utf8")
+
+    const assistantId = `${route.id}#${route.kind}`
+    const relativeEntryPath = `./${relative(manifest.appRoot, entryFilePath)}`
+    graphs[assistantId] = `${relativeEntryPath}:graph`
+  }
+
+  const userLanggraphPath = resolve(manifest.appRoot, "langgraph.json")
+  let userConfig: Record<string, unknown> = {}
+
+  try {
+    const raw = await readFile(userLanggraphPath, "utf8")
+    userConfig = JSON.parse(raw) as Record<string, unknown>
+  } catch {
+    // No user langgraph.json — start with empty config
+  }
+
+  const deployment = extractDeploymentConfig(manifest.appRoot)
+
+  const mergedConfig = {
+    ...userConfig,
+    dependencies: deployment.dependencies,
+    env: deployment.env,
+    graphs,
+    node_version: deployment.node_version,
+  }
+
+  const outputLanggraphPath = join(buildDir, "langgraph.json")
+  await writeFile(outputLanggraphPath, `${JSON.stringify(mergedConfig, null, 2)}\n`, "utf8")
+
+  writeLine(io.stdout, `Build complete: ${relative(process.cwd(), buildDir)}`)
+  writeLine(io.stdout, `  ${Object.keys(graphs).length} route(s) compiled`)
+  writeLine(
+    io.stdout,
+    `  langgraph.json written to ${relative(process.cwd(), outputLanggraphPath)}`,
+  )
+}
+
+interface JsonSchemaProperty {
+  readonly type?: string
+  readonly items?: { readonly type?: string }
+}
+
+function toolSchemaToZodSource(tool: DiscoveredToolDefinition): string {
+  const schema = tool.schema as
+    | {
+        readonly type?: string
+        readonly properties?: Record<string, JsonSchemaProperty>
+        readonly required?: readonly string[]
+      }
+    | undefined
+
+  if (
+    !schema ||
+    typeof schema !== "object" ||
+    schema.type !== "object" ||
+    !schema.properties ||
+    Object.keys(schema.properties).length === 0
+  ) {
+    return "z.record(z.string(), z.unknown())"
+  }
+
+  const required = new Set(schema.required ?? [])
+  const fields = Object.entries(schema.properties).map(([key, prop]) => {
+    let zodType = jsonSchemaTypeToZod(prop)
+    if (!required.has(key)) {
+      zodType += ".optional()"
+    }
+    return `  ${key}: ${zodType}`
+  })
+
+  return `z.object({\n${fields.join(",\n")},\n})`
+}
+
+function jsonSchemaTypeToZod(prop: JsonSchemaProperty): string {
+  switch (prop.type) {
+    case "string":
+      return "z.string()"
+    case "number":
+    case "integer":
+      return "z.number()"
+    case "boolean":
+      return "z.boolean()"
+    case "array": {
+      const itemType = prop.items?.type
+      if (itemType === "string") return "z.array(z.string())"
+      if (itemType === "number" || itemType === "integer") return "z.array(z.number())"
+      if (itemType === "boolean") return "z.array(z.boolean())"
+      return "z.array(z.unknown())"
+    }
+    default:
+      return "z.unknown()"
+  }
+}
+```
+
+Key changes from the original:
+- Removed `generateDockerfile` import and Dockerfile generation
+- Changed `mergedConfig` to use correct field ordering (`dependencies`, `env`, `graphs`, `node_version`)
+- Removed Dockerfile output message
+
+- [ ] **Step 2: Run typecheck**
+
+Run: `cd /Users/blove/repos/dawn && pnpm typecheck`
+Expected: PASS — no type errors (generateDockerfile is no longer imported)
+
+- [ ] **Step 3: Run full CLI test suite**
+
+Run: `cd /Users/blove/repos/dawn && pnpm vitest --run packages/cli/test/`
+Expected: PASS — all tests pass
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/cli/src/commands/build.ts
+git commit -m "refactor(cli): remove Dockerfile generation, build produces langgraph.json only"
+```
+
+---
+
+### Task 8: Clean up old deployment-config exports and dead code
+
+**Files:**
+- Modify: `packages/cli/src/lib/build/deployment-config.ts` (remove generateDockerfile if still present)
+
+- [ ] **Step 1: Verify generateDockerfile is unused**
+
+Run: `cd /Users/blove/repos/dawn && grep -r "generateDockerfile" packages/`
+
+Expected: No matches (it was removed from build.ts in Task 7 and from deployment-config.ts in Task 6)
+
+- [ ] **Step 2: Verify old DeploymentConfig type is unused**
+
+Run: `cd /Users/blove/repos/dawn && grep -r "DeploymentConfig" packages/`
+
+Expected: No matches (replaced by `LangGraphConfig` in Task 6)
+
+- [ ] **Step 3: Run full test suite**
+
+Run: `cd /Users/blove/repos/dawn && pnpm test`
+Expected: PASS — all tests across all packages pass
+
+- [ ] **Step 4: Run typecheck**
+
+Run: `cd /Users/blove/repos/dawn && pnpm typecheck`
+Expected: PASS — no type errors
+
+- [ ] **Step 5: Commit (if any cleanup was needed)**
+
+```bash
+git add -A
+git commit -m "chore: clean up dead deployment config code"
+```
+
+---
+
+### Task 9: End-to-end validation
+
+**Files:**
+- None modified — validation only
+
+- [ ] **Step 1: Build SDK package**
+
+Run: `cd /Users/blove/repos/dawn && pnpm build`
+Expected: PASS — all packages build successfully
+
+- [ ] **Step 2: Run full test suite**
+
+Run: `cd /Users/blove/repos/dawn && pnpm test`
+Expected: PASS — all tests across all packages pass
+
+- [ ] **Step 3: Run typecheck**
+
+Run: `cd /Users/blove/repos/dawn && pnpm typecheck`
+Expected: PASS — no type errors
+
+- [ ] **Step 4: Run lint**
+
+Run: `cd /Users/blove/repos/dawn && pnpm lint`
+Expected: PASS — no lint errors
+
+- [ ] **Step 5: Verify SDK exports include new types**
+
+Run: `cd /Users/blove/repos/dawn && grep -A 5 "middleware" packages/sdk/src/index.ts`
+
+Expected output should show `defineMiddleware`, `reject`, `allow`, `MiddlewareRequest`, `MiddlewareResult`, `ContinueResult`, `RejectResult`, `DawnMiddleware` exports.
+
+Run: `cd /Users/blove/repos/dawn && grep "RetryConfig" packages/sdk/src/index.ts`
+
+Expected output should show `RetryConfig` in the agent type export line.
+
+- [ ] **Step 6: Verify langgraph.json format is correct**
+
+Inspect the deployment config test assertions to confirm:
+- `dependencies` is `["."]`
+- `env` is a file path string (`.env` or `.env.example`)
+- `node_version` is `"22"`
+
+These were validated in Task 6 tests. No additional action needed if tests pass.
+
+---
+
+## Deferred: Middleware Context Flow to Tools
+
+The spec describes middleware-injected context flowing into tool `context` parameters. This requires changes across the tool execution pipeline (`runtime-server.ts` → `executeResolvedRoute`/`streamResolvedRoute` → `agent-adapter.ts` → tool `run` callbacks). The current `RuntimeTool` signature is `(input) => output` with signal provided separately.
+
+This is deferred because:
+1. Middleware gating (reject/allow) works without context flow
+2. Context flow requires coordinated changes across 4+ files and multiple interfaces
+3. It deserves its own design pass to get the `context` parameter shape right
+
+The middleware infrastructure built in this plan is designed to support this — `allow({ userId, orgId })` returns context that can be threaded through once the plumbing exists.

--- a/docs/superpowers/specs/2026-05-05-production-readiness-design.md
+++ b/docs/superpowers/specs/2026-05-05-production-readiness-design.md
@@ -1,0 +1,275 @@
+# Production Readiness: Deployment, Retry, Middleware
+
+## Summary
+
+Three features to make Dawn production-ready for LangGraph Platform deployments:
+
+1. **Deployment Config** — `dawn build` produces valid `langgraph.json` for `langgraph deploy`
+2. **Retry/Resilience** — Invisible automatic retry of transient LLM errors with per-agent escape hatch
+3. **Middleware** — Global request middleware with context injection for auth and gating
+
+DX is the top priority. All three features should feel zero-config in the common case.
+
+---
+
+## 1. Deployment Config (`dawn build`)
+
+### Goal
+
+`dawn build` produces a valid project layout and `langgraph.json` compatible with `langgraph deploy` (LangSmith Cloud). The architecture supports future build targets (self-hosted Docker, Azure, AWS) without breaking changes.
+
+### Output Structure
+
+```
+.dawn/build/
+├── langgraph.json
+├── package.json
+├── src/
+│   └── graphs/        # compiled entry points per route
+└── ...
+```
+
+### `langgraph.json` Schema (corrected)
+
+```json
+{
+  "node_version": "22",
+  "dependencies": ["."],
+  "graphs": {
+    "hello/[tenant]#agent": "./src/graphs/hello_tenant.ts:default"
+  },
+  "env": ".env"
+}
+```
+
+Key points:
+- `dependencies`: Array of paths to local directories or tarballs. `["."]` means "install from project root's package.json". NOT `["pkg@version"]` strings.
+- `env`: Path to a `.env` file relative to the build output. NOT an array of variable names.
+- `graphs`: Maps assistant IDs to `"./path:exportName"` entries that Dawn generates during codegen.
+
+### Build Target Interface (internal)
+
+```ts
+interface BuildTarget {
+  readonly name: string
+  emit(context: BuildContext): Promise<void>
+}
+
+interface BuildContext {
+  readonly appRoot: string
+  readonly outputDir: string
+  readonly routes: readonly DiscoveredRoute[]
+  readonly packageJson: Record<string, unknown>
+}
+```
+
+Only `LangSmithTarget` ships today. The interface exists for future extensibility, not as user-facing API.
+
+### What Changes From Current Implementation
+
+| Current | Corrected |
+|---------|-----------|
+| `dependencies: ["pkg@version", ...]` | `dependencies: ["."]` |
+| `env: ["OPENAI_API_KEY", ...]` | `env: ".env"` |
+| Generates standalone Dockerfile | Generates `langgraph.json` (LangGraph CLI handles Docker) |
+| No build target abstraction | Internal `BuildTarget` interface |
+
+### User Workflow
+
+```bash
+dawn build                    # produces .dawn/build/ with langgraph.json
+cd .dawn/build
+langgraph deploy              # deploys to LangSmith Cloud
+# or
+langgraph build               # builds Docker image for self-hosting
+```
+
+---
+
+## 2. Retry/Resilience
+
+### Goal
+
+Dawn automatically retries transient LLM errors with sensible defaults. Zero configuration required. Per-agent escape hatch for edge cases.
+
+### Default Behavior (zero-config)
+
+| Setting | Default |
+|---------|---------|
+| Max attempts | 3 |
+| Base delay | 1000ms |
+| Backoff | Exponential with jitter |
+| Max delay | 10000ms |
+
+### Retryable Errors
+
+**Retried:**
+- 429 Too Many Requests / rate limit
+- 500, 502, 503 server errors
+- Network errors: ECONNRESET, ECONNREFUSED, ETIMEDOUT
+- OpenAI transient: "server is overloaded", "server_error"
+
+**NOT retried:**
+- 400 Bad Request
+- 401 Unauthorized, 403 Forbidden
+- Model not found, invalid API key
+- Validation errors
+
+### Streaming Behavior
+
+- If no chunks have been yielded to the client, retry the entire stream (up to max attempts)
+- Once any chunk has been yielded, do NOT retry (client has partial data — throw immediately)
+
+### Per-Agent Escape Hatch
+
+```ts
+// src/app/summarize/index.ts
+import { agent } from "@dawn-ai/sdk"
+
+export default agent({
+  model: "gpt-4o-mini",
+  systemPrompt: "Summarize the input.",
+  retry: { maxAttempts: 5, baseDelay: 2000 }
+})
+```
+
+`retry` is an optional field on `AgentConfig`:
+
+```ts
+interface RetryConfig {
+  readonly maxAttempts?: number   // default: 3
+  readonly baseDelay?: number    // default: 1000 (ms)
+}
+```
+
+### What Changes From Current Implementation
+
+The existing `retry.ts` and agent-adapter streaming retry logic are correct in behavior. Changes needed:
+
+- Add `retry?: RetryConfig` to `AgentConfig` in `@dawn-ai/sdk`
+- Wire per-agent config through `materializeAgent` → retry calls
+- No global config, no per-route config
+
+---
+
+## 3. Middleware
+
+### Goal
+
+Single global middleware file for request gating and context injection. Auth is the primary use case. Zero overhead when no middleware file exists.
+
+### Authoring Contract
+
+```ts
+// src/middleware.ts
+import { defineMiddleware, reject, allow } from "@dawn-ai/sdk"
+
+export default defineMiddleware(async (req) => {
+  const token = req.headers.authorization?.split(" ")[1]
+  if (!token) return reject(401, { error: "Unauthorized" })
+
+  const user = await verifyToken(token)
+  return allow({ userId: user.id, orgId: user.orgId })
+})
+```
+
+### Request Object
+
+```ts
+interface MiddlewareRequest {
+  readonly headers: Readonly<Record<string, string>>
+  readonly routeId: string        // e.g. "/hello/[tenant]"
+  readonly assistantId: string    // e.g. "/hello/[tenant]#agent"
+  readonly params: Readonly<Record<string, string>>  // parsed route params
+  readonly method: string
+  readonly url: string
+}
+```
+
+### Result Types
+
+```ts
+type MiddlewareResult = ContinueResult | RejectResult
+
+interface ContinueResult {
+  readonly action: "continue"
+  readonly context?: Record<string, unknown>
+}
+
+interface RejectResult {
+  readonly action: "reject"
+  readonly status: number
+  readonly body?: unknown
+}
+```
+
+### SDK Exports
+
+From `@dawn-ai/sdk`:
+
+- `defineMiddleware(fn: (req: MiddlewareRequest) => Promise<MiddlewareResult> | MiddlewareResult)` — type-safe wrapper
+- `reject(status: number, body?: unknown): RejectResult` — helper
+- `allow(context?: Record<string, unknown>): ContinueResult` — helper (avoids `continue` reserved word)
+
+### Context Flow
+
+Middleware-injected context merges into the tool execution `context` parameter:
+
+```ts
+// src/app/hello/tools/get-profile.ts
+import { tool } from "@dawn-ai/sdk"
+import { z } from "zod"
+
+export const getProfile = tool({
+  name: "get_profile",
+  schema: z.object({}),
+  run: async (input, context) => {
+    // context.userId — injected by middleware
+    // context.tenant — from route params [tenant]
+    return db.getProfile(context.userId)
+  }
+})
+```
+
+### Runtime Behavior
+
+- Middleware loaded once at server start via dynamic import of `src/middleware.ts`
+- Runs before route matching — rejection skips all route code
+- If no `src/middleware.ts` exists, middleware step is skipped (no overhead)
+- Middleware context merged with route params into tool context
+
+### What Changes From Current Implementation
+
+| Current | Corrected |
+|---------|-----------|
+| `DawnMiddleware` type in CLI package | `defineMiddleware` + helpers in SDK package |
+| Receives raw `IncomingMessage` | Receives parsed `MiddlewareRequest` |
+| `MiddlewareContext` has `request` field | No raw request exposure |
+| Array of middleware functions | Single middleware function |
+| `runMiddleware` chains array | Direct invocation of single function |
+| No context flow to tools | Context merges into tool `context` param |
+
+---
+
+## What We're NOT Doing
+
+- No per-route middleware (use `req.routeId` to branch internally)
+- No middleware chaining/composition (single function)
+- No request body parsing in middleware (runs pre-route)
+- No rewrite/redirect semantics
+- No global retry config in `dawn.config.ts`
+- No standalone Dockerfile generation (LangGraph CLI handles Docker)
+- No `dawn deploy` command (users run `langgraph deploy` directly)
+
+---
+
+## Migration From Current Implementation
+
+The existing code in `packages/langchain/src/retry.ts` and `packages/langchain/src/agent-adapter.ts` (retry logic) is mostly correct and can be kept. The following will be rewritten:
+
+1. `packages/cli/src/lib/build/deployment-config.ts` — rewrite to produce correct `langgraph.json`
+2. `packages/cli/src/commands/build.ts` — rewrite build command output
+3. `packages/cli/src/lib/dev/middleware.ts` — rewrite to single-function model with parsed request
+4. `packages/cli/src/lib/dev/runtime-server.ts` — update middleware integration
+5. `packages/sdk/src/agent.ts` — add `retry` field to `AgentConfig`
+6. `packages/sdk/src/index.ts` — export `defineMiddleware`, `reject`, `continue_`

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -4,10 +4,7 @@ import { dirname, join, relative, resolve } from "node:path"
 
 import { discoverRoutes } from "@dawn-ai/core"
 import type { Command } from "commander"
-import {
-  extractDeploymentConfig,
-  generateDockerfile,
-} from "../lib/build/deployment-config.js"
+import { extractDeploymentConfig } from "../lib/build/deployment-config.js"
 import { type CommandIo, writeLine } from "../lib/output.js"
 import {
   type DiscoveredToolDefinition,
@@ -147,17 +144,12 @@ export async function runBuildCommand(options: BuildOptions, io: CommandIo): Pro
   const outputLanggraphPath = join(buildDir, "langgraph.json")
   await writeFile(outputLanggraphPath, `${JSON.stringify(mergedConfig, null, 2)}\n`, "utf8")
 
-  // Generate Dockerfile for LangGraph Platform
-  const dockerfilePath = join(buildDir, "Dockerfile")
-  await writeFile(dockerfilePath, generateDockerfile(deployment.node_version), "utf8")
-
   writeLine(io.stdout, `Build complete: ${relative(process.cwd(), buildDir)}`)
   writeLine(io.stdout, `  ${Object.keys(graphs).length} route(s) compiled`)
   writeLine(
     io.stdout,
     `  langgraph.json written to ${relative(process.cwd(), outputLanggraphPath)}`,
   )
-  writeLine(io.stdout, `  Dockerfile written to ${relative(process.cwd(), dockerfilePath)}`)
 }
 
 interface JsonSchemaProperty {

--- a/packages/cli/src/commands/verify.ts
+++ b/packages/cli/src/commands/verify.ts
@@ -209,8 +209,7 @@ async function verifyApp(
 
   // Check dependencies and environment variables (advisory, not blocking)
   const depsResult = checkDependencies(app.appRoot)
-  const hasWarnings =
-    depsResult.missingPackages.length > 0 || depsResult.missingEnvVars.length > 0
+  const hasWarnings = depsResult.missingPackages.length > 0 || depsResult.missingEnvVars.length > 0
   checks.push({
     missingEnvVars: depsResult.missingEnvVars,
     missingPackages: depsResult.missingPackages,

--- a/packages/cli/src/lib/build/deployment-config.ts
+++ b/packages/cli/src/lib/build/deployment-config.ts
@@ -1,104 +1,34 @@
-import { existsSync, readFileSync } from "node:fs"
+import { existsSync } from "node:fs"
 import { join } from "node:path"
 
 /**
- * Extract deployment configuration from the app's package.json and .env file.
- * Used by `dawn build` to produce a complete langgraph.json for LangGraph Platform.
+ * Configuration for LangGraph Platform deployment.
+ * Produces fields compatible with langgraph.json schema.
  */
 
-export interface DeploymentConfig {
+export interface LangGraphConfig {
+  /** Paths to local directories/tarballs to install. Always ["."] for Dawn apps. */
   readonly dependencies: readonly string[]
-  readonly env: readonly string[]
+  /** Path to env file relative to build output. */
+  readonly env: string
+  /** Node.js version. */
   readonly node_version: string
 }
 
-/** Packages required at runtime for LangGraph Platform deployment */
-const RUNTIME_PACKAGES = [
-  "@langchain/core",
-  "@langchain/openai",
-  "@langchain/langgraph",
-  "@dawn-ai/sdk",
-  "@dawn-ai/langchain",
-  "@dawn-ai/core",
-  "@dawn-ai/cli",
-  "zod",
-] as const
-
-export function extractDeploymentConfig(appRoot: string): DeploymentConfig {
-  const dependencies = detectRuntimeDependencies(appRoot)
-  const env = detectEnvVars(appRoot)
-
+export function extractDeploymentConfig(appRoot: string): LangGraphConfig {
   return {
-    dependencies,
-    env,
+    dependencies: ["."],
+    env: detectEnvFilePath(appRoot),
     node_version: "22",
   }
 }
 
-function detectRuntimeDependencies(appRoot: string): string[] {
-  const packageJsonPath = join(appRoot, "package.json")
-
-  try {
-    const raw = readFileSync(packageJsonPath, "utf8")
-    const pkg = JSON.parse(raw) as {
-      dependencies?: Record<string, string>
-    }
-
-    if (!pkg.dependencies) {
-      return []
-    }
-
-    // Return all user dependencies (LangGraph Platform installs them)
-    return Object.entries(pkg.dependencies).map(([name, version]) => `${name}@${version}`)
-  } catch {
-    return []
-  }
-}
-
-function detectEnvVars(appRoot: string): string[] {
-  const envPath = join(appRoot, ".env")
-  const envExamplePath = join(appRoot, ".env.example")
-  const vars: Set<string> = new Set()
-
-  // Parse .env.example first (canonical list of required vars)
-  const exampleFile = existsSync(envExamplePath) ? envExamplePath : envPath
-
-  try {
-    const content = readFileSync(exampleFile, "utf8")
-    for (const line of content.split("\n")) {
-      const trimmed = line.trim()
-      if (trimmed.length === 0 || trimmed.startsWith("#")) continue
-      const eqIndex = trimmed.indexOf("=")
-      if (eqIndex === -1) continue
-      vars.add(trimmed.slice(0, eqIndex).trim())
-    }
-  } catch {
-    // No env file — return common defaults
+function detectEnvFilePath(appRoot: string): string {
+  // Prefer .env.example (canonical list of required vars, no secrets)
+  if (existsSync(join(appRoot, ".env.example"))) {
+    return ".env.example"
   }
 
-  // Always include these if not already present
-  if (vars.size === 0) {
-    vars.add("OPENAI_API_KEY")
-  }
-
-  return [...vars].sort()
-}
-
-export function generateDockerfile(nodeVersion: string): string {
-  return `FROM node:${nodeVersion}-slim
-
-WORKDIR /app
-
-COPY package.json package-lock.json* pnpm-lock.yaml* ./
-RUN corepack enable && \\
-    ([ -f pnpm-lock.yaml ] && pnpm install --frozen-lockfile --prod) || \\
-    ([ -f package-lock.json ] && npm ci --omit=dev) || \\
-    npm install --omit=dev
-
-COPY . .
-
-EXPOSE 8000
-
-CMD ["node", "--import", "tsx", "node_modules/.bin/dawn", "__dev-child", "--app-root", ".", "--port", "8000"]
-`
+  // Fall back to .env (may contain secrets — LangGraph Platform reads var names only)
+  return ".env"
 }

--- a/packages/cli/src/lib/dev/middleware.ts
+++ b/packages/cli/src/lib/dev/middleware.ts
@@ -1,28 +1,10 @@
-import type { IncomingMessage, ServerResponse } from "node:http"
+import type { DawnMiddleware, MiddlewareRequest, MiddlewareResult } from "@dawn-ai/sdk"
 
 /**
- * Dawn middleware hook — runs before route execution.
- * Return a response to short-circuit, or undefined to continue.
+ * Load middleware from the app's middleware.ts file.
+ * Convention: src/middleware.ts exports a default function (using defineMiddleware).
  */
-export interface DawnMiddleware {
-  (context: MiddlewareContext): Promise<MiddlewareResult> | MiddlewareResult
-}
-
-export interface MiddlewareContext {
-  readonly request: IncomingMessage
-  readonly routeId: string
-  readonly assistantId: string
-}
-
-export type MiddlewareResult =
-  | { readonly action: "continue"; readonly context?: Record<string, unknown> }
-  | { readonly action: "reject"; readonly status: number; readonly body: unknown }
-
-/**
- * Load middleware hooks from the app's middleware.ts file.
- * Convention: src/middleware.ts exports a default function or array.
- */
-export async function loadMiddleware(appRoot: string): Promise<readonly DawnMiddleware[]> {
+export async function loadMiddleware(appRoot: string): Promise<DawnMiddleware | undefined> {
   const middlewarePaths = [
     `${appRoot}/src/middleware.ts`,
     `${appRoot}/src/middleware.js`,
@@ -36,40 +18,26 @@ export async function loadMiddleware(appRoot: string): Promise<readonly DawnMidd
       const exported = mod.default ?? mod.middleware
 
       if (typeof exported === "function") {
-        return [exported as DawnMiddleware]
-      }
-
-      if (Array.isArray(exported)) {
-        return exported.filter((fn): fn is DawnMiddleware => typeof fn === "function")
+        return exported as DawnMiddleware
       }
     } catch {
       // File doesn't exist or can't be loaded — try next
     }
   }
 
-  return []
+  return undefined
 }
 
 /**
- * Run middleware chain. Returns the first rejection, or continue with merged context.
+ * Run middleware. Returns continue (with optional context) or reject.
  */
 export async function runMiddleware(
-  middlewares: readonly DawnMiddleware[],
-  context: MiddlewareContext,
+  middleware: DawnMiddleware | undefined,
+  request: MiddlewareRequest,
 ): Promise<MiddlewareResult> {
-  let mergedContext: Record<string, unknown> = {}
-
-  for (const mw of middlewares) {
-    const result = await mw(context)
-
-    if (result.action === "reject") {
-      return result
-    }
-
-    if (result.context) {
-      mergedContext = { ...mergedContext, ...result.context }
-    }
+  if (!middleware) {
+    return { action: "continue" }
   }
 
-  return { action: "continue", context: mergedContext }
+  return await middleware(request)
 }

--- a/packages/cli/src/lib/dev/runtime-server.ts
+++ b/packages/cli/src/lib/dev/runtime-server.ts
@@ -3,12 +3,8 @@ import type { AddressInfo } from "node:net"
 
 import { executeResolvedRoute, streamResolvedRoute } from "../runtime/execute-route.js"
 import { type StreamChunk, toSseEvent } from "../runtime/stream-types.js"
-import {
-  type DawnMiddleware,
-  type MiddlewareContext,
-  loadMiddleware,
-  runMiddleware,
-} from "./middleware.js"
+import type { DawnMiddleware, MiddlewareRequest } from "@dawn-ai/sdk"
+import { loadMiddleware, runMiddleware } from "./middleware.js"
 import { createRuntimeRegistry, type RuntimeRegistry } from "./runtime-registry.js"
 import { createExecutionErrorBody, createRequestErrorBody } from "./server-errors.js"
 
@@ -26,7 +22,7 @@ export async function startRuntimeServer(
   options: StartRuntimeServerOptions,
 ): Promise<RuntimeServer> {
   const registry = await createRuntimeRegistry(options.appRoot)
-  const middlewares = await loadMiddleware(options.appRoot)
+  const middleware = await loadMiddleware(options.appRoot)
   const state = {
     acceptingRequests: true,
     activeRequests: 0,
@@ -43,7 +39,7 @@ export async function startRuntimeServer(
     state.activeRequests++
     try {
       await handleRequest({
-        middlewares,
+        middleware,
         registry,
         request,
         response,
@@ -113,13 +109,13 @@ export async function startRuntimeServer(
 }
 
 async function handleRequest(options: {
-  readonly middlewares: readonly DawnMiddleware[]
+  readonly middleware: DawnMiddleware | undefined
   readonly registry: RuntimeRegistry
   readonly request: IncomingMessage
   readonly response: ServerResponse
   readonly signal: AbortSignal
 }): Promise<void> {
-  const { middlewares, request, response, registry, signal } = options
+  const { middleware, request, response, registry, signal } = options
 
   if (request.method === "GET" && request.url === "/healthz") {
     sendJson(response, 200, { status: "ready" })
@@ -127,7 +123,7 @@ async function handleRequest(options: {
   }
 
   if (request.method === "POST" && request.url === "/runs/stream") {
-    await handleStreamRequest({ middlewares, registry, request, response, signal })
+    await handleStreamRequest({ middleware, registry, request, response, signal })
     return
   }
 
@@ -163,17 +159,18 @@ async function handleRequest(options: {
   }
 
   // Run middleware before execution
-  if (middlewares.length > 0) {
-    const mwContext: MiddlewareContext = {
-      request,
-      routeId: route.routeId,
-      assistantId: route.assistantId,
-    }
-    const mwResult = await runMiddleware(middlewares, mwContext)
-    if (mwResult.action === "reject") {
-      sendJson(response, mwResult.status, mwResult.body)
-      return
-    }
+  const mwRequest: MiddlewareRequest = {
+    assistantId: route.assistantId,
+    headers: parseHeaders(request),
+    method: request.method ?? "POST",
+    params: extractRouteParams(route.routeId, validatedBody.value.input),
+    routeId: route.routeId,
+    url: request.url ?? "/runs/wait",
+  }
+  const mwResult = await runMiddleware(middleware, mwRequest)
+  if (mwResult.action === "reject") {
+    sendJson(response, mwResult.status, mwResult.body)
+    return
   }
 
   if (
@@ -245,13 +242,13 @@ async function handleRequest(options: {
 }
 
 async function handleStreamRequest(options: {
-  readonly middlewares: readonly DawnMiddleware[]
+  readonly middleware: DawnMiddleware | undefined
   readonly registry: RuntimeRegistry
   readonly request: IncomingMessage
   readonly response: ServerResponse
   readonly signal: AbortSignal
 }): Promise<void> {
-  const { middlewares, request, response, registry, signal } = options
+  const { middleware, request, response, registry, signal } = options
 
   const rawBody = await readRequestBody(request)
   const parsedBody = parseJson(rawBody)
@@ -280,17 +277,18 @@ async function handleStreamRequest(options: {
   }
 
   // Run middleware before streaming
-  if (middlewares.length > 0) {
-    const mwContext: MiddlewareContext = {
-      request,
-      routeId: route.routeId,
-      assistantId: route.assistantId,
-    }
-    const mwResult = await runMiddleware(middlewares, mwContext)
-    if (mwResult.action === "reject") {
-      sendJson(response, mwResult.status, mwResult.body)
-      return
-    }
+  const mwRequest: MiddlewareRequest = {
+    assistantId: route.assistantId,
+    headers: parseHeaders(request),
+    method: request.method ?? "POST",
+    params: extractRouteParams(route.routeId, validatedBody.value.input),
+    routeId: route.routeId,
+    url: request.url ?? "/runs/stream",
+  }
+  const mwResult = await runMiddleware(middleware, mwRequest)
+  if (mwResult.action === "reject") {
+    sendJson(response, mwResult.status, mwResult.body)
+    return
   }
 
   response.writeHead(200, {
@@ -443,6 +441,39 @@ async function listen(server: ReturnType<typeof createServer>, port?: number): P
       resolve()
     })
   })
+}
+
+function parseHeaders(request: IncomingMessage): Record<string, string> {
+  const headers: Record<string, string> = {}
+  for (const [key, value] of Object.entries(request.headers)) {
+    if (typeof value === "string") {
+      headers[key] = value
+    } else if (Array.isArray(value)) {
+      headers[key] = value.join(", ")
+    }
+  }
+  return headers
+}
+
+function extractRouteParams(
+  routeId: string,
+  input: unknown,
+): Record<string, string> {
+  const params: Record<string, string> = {}
+  const matches = routeId.matchAll(/\[(\w+)\]/g)
+  const inputRecord = (typeof input === "object" && input !== null ? input : {}) as Record<
+    string,
+    unknown
+  >
+
+  for (const match of matches) {
+    const name = match[1]
+    if (name && name in inputRecord) {
+      params[name] = String(inputRecord[name])
+    }
+  }
+
+  return params
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/packages/cli/src/lib/dev/runtime-server.ts
+++ b/packages/cli/src/lib/dev/runtime-server.ts
@@ -1,9 +1,8 @@
 import { createServer, type IncomingMessage, type ServerResponse } from "node:http"
 import type { AddressInfo } from "node:net"
-
+import type { DawnMiddleware, MiddlewareRequest } from "@dawn-ai/sdk"
 import { executeResolvedRoute, streamResolvedRoute } from "../runtime/execute-route.js"
 import { type StreamChunk, toSseEvent } from "../runtime/stream-types.js"
-import type { DawnMiddleware, MiddlewareRequest } from "@dawn-ai/sdk"
 import { loadMiddleware, runMiddleware } from "./middleware.js"
 import { createRuntimeRegistry, type RuntimeRegistry } from "./runtime-registry.js"
 import { createExecutionErrorBody, createRequestErrorBody } from "./server-errors.js"
@@ -455,10 +454,7 @@ function parseHeaders(request: IncomingMessage): Record<string, string> {
   return headers
 }
 
-function extractRouteParams(
-  routeId: string,
-  input: unknown,
-): Record<string, string> {
+function extractRouteParams(routeId: string, input: unknown): Record<string, string> {
   const params: Record<string, string> = {}
   const matches = routeId.matchAll(/\[(\w+)\]/g)
   const inputRecord = (typeof input === "object" && input !== null ? input : {}) as Record<

--- a/packages/cli/test/check-dependencies.test.ts
+++ b/packages/cli/test/check-dependencies.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { afterEach, beforeEach, describe, expect, test } from "vitest"

--- a/packages/cli/test/deployment-config.test.ts
+++ b/packages/cli/test/deployment-config.test.ts
@@ -1,12 +1,9 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { afterEach, beforeEach, describe, expect, test } from "vitest"
 
-import {
-  extractDeploymentConfig,
-  type LangGraphConfig,
-} from "../src/lib/build/deployment-config.js"
+import { extractDeploymentConfig } from "../src/lib/build/deployment-config.js"
 
 let tempDir: string
 

--- a/packages/cli/test/deployment-config.test.ts
+++ b/packages/cli/test/deployment-config.test.ts
@@ -5,7 +5,7 @@ import { afterEach, beforeEach, describe, expect, test } from "vitest"
 
 import {
   extractDeploymentConfig,
-  generateDockerfile,
+  type LangGraphConfig,
 } from "../src/lib/build/deployment-config.js"
 
 let tempDir: string
@@ -19,54 +19,56 @@ afterEach(() => {
 })
 
 describe("extractDeploymentConfig", () => {
-  test("extracts dependencies from package.json", () => {
+  test("returns dependencies as ['.'] (project root path)", () => {
     writeFileSync(
       join(tempDir, "package.json"),
       JSON.stringify({
         dependencies: {
           "@dawn-ai/cli": "0.1.6",
           "@langchain/openai": "0.5.0",
-          zod: "^3.24.0",
         },
       }),
     )
 
     const config = extractDeploymentConfig(tempDir)
 
-    expect(config.dependencies).toContain("@dawn-ai/cli@0.1.6")
-    expect(config.dependencies).toContain("@langchain/openai@0.5.0")
-    expect(config.dependencies).toContain("zod@^3.24.0")
+    expect(config.dependencies).toEqual(["."])
   })
 
-  test("extracts env vars from .env file", () => {
+  test("returns env as path to .env file when .env exists", () => {
     writeFileSync(join(tempDir, "package.json"), JSON.stringify({ dependencies: {} }))
-    writeFileSync(join(tempDir, ".env"), "OPENAI_API_KEY=sk-test\nLANGSMITH_API_KEY=lsv2_test\n")
+    writeFileSync(join(tempDir, ".env"), "OPENAI_API_KEY=sk-test\n")
 
     const config = extractDeploymentConfig(tempDir)
 
-    expect(config.env).toContain("OPENAI_API_KEY")
-    expect(config.env).toContain("LANGSMITH_API_KEY")
+    expect(config.env).toBe(".env")
   })
 
-  test("prefers .env.example for env schema", () => {
+  test("returns env as path to .env.example when it exists", () => {
+    writeFileSync(join(tempDir, "package.json"), JSON.stringify({ dependencies: {} }))
+    writeFileSync(join(tempDir, ".env.example"), "OPENAI_API_KEY=\n")
+
+    const config = extractDeploymentConfig(tempDir)
+
+    expect(config.env).toBe(".env.example")
+  })
+
+  test("prefers .env.example over .env", () => {
     writeFileSync(join(tempDir, "package.json"), JSON.stringify({ dependencies: {} }))
     writeFileSync(join(tempDir, ".env"), "OPENAI_API_KEY=real-key\nSECRET=value\n")
-    writeFileSync(join(tempDir, ".env.example"), "OPENAI_API_KEY=\nLANGSMITH_API_KEY=\n")
+    writeFileSync(join(tempDir, ".env.example"), "OPENAI_API_KEY=\n")
 
     const config = extractDeploymentConfig(tempDir)
 
-    expect(config.env).toContain("OPENAI_API_KEY")
-    expect(config.env).toContain("LANGSMITH_API_KEY")
-    // Should NOT include SECRET (only from .env.example)
-    expect(config.env).not.toContain("SECRET")
+    expect(config.env).toBe(".env.example")
   })
 
-  test("defaults OPENAI_API_KEY when no env file", () => {
+  test("returns env as .env when no env files exist (will be created)", () => {
     writeFileSync(join(tempDir, "package.json"), JSON.stringify({ dependencies: {} }))
 
     const config = extractDeploymentConfig(tempDir)
 
-    expect(config.env).toContain("OPENAI_API_KEY")
+    expect(config.env).toBe(".env")
   })
 
   test("returns node_version 22", () => {
@@ -75,17 +77,5 @@ describe("extractDeploymentConfig", () => {
     const config = extractDeploymentConfig(tempDir)
 
     expect(config.node_version).toBe("22")
-  })
-})
-
-describe("generateDockerfile", () => {
-  test("produces a valid Dockerfile", () => {
-    const dockerfile = generateDockerfile("22")
-
-    expect(dockerfile).toContain("FROM node:22-slim")
-    expect(dockerfile).toContain("WORKDIR /app")
-    expect(dockerfile).toContain("COPY package.json")
-    expect(dockerfile).toContain("EXPOSE 8000")
-    expect(dockerfile).toContain("dawn")
   })
 })

--- a/packages/cli/test/load-env.test.ts
+++ b/packages/cli/test/load-env.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { afterEach, beforeEach, describe, expect, test } from "vitest"
@@ -79,7 +79,7 @@ describe("loadEnvFile", () => {
 
     writeFileSync(
       join(tempDir, ".env"),
-      'TEST_DAWN_DOUBLE="quoted value"\nTEST_DAWN_SINGLE=\'single quoted\'\n',
+      "TEST_DAWN_DOUBLE=\"quoted value\"\nTEST_DAWN_SINGLE='single quoted'\n",
     )
 
     const count = loadEnvFile(tempDir)
@@ -118,7 +118,7 @@ describe("loadEnvFile", () => {
       "LANGSMITH_API_KEY=lsv2_test_key\nLANGCHAIN_TRACING_V2=false\n",
     )
 
-    const count = loadEnvFile(tempDir)
+    const _count = loadEnvFile(tempDir)
 
     expect(process.env.LANGCHAIN_TRACING_V2).toBe("false")
   })

--- a/packages/cli/test/middleware.test.ts
+++ b/packages/cli/test/middleware.test.ts
@@ -1,7 +1,6 @@
-import { describe, expect, test } from "vitest"
-
 import type { DawnMiddleware, MiddlewareRequest } from "@dawn-ai/sdk"
-import { loadMiddleware, runMiddleware } from "../src/lib/dev/middleware.js"
+import { describe, expect, test } from "vitest"
+import { runMiddleware } from "../src/lib/dev/middleware.js"
 
 function createMockRequest(overrides?: Partial<MiddlewareRequest>): MiddlewareRequest {
   return {

--- a/packages/cli/test/middleware.test.ts
+++ b/packages/cli/test/middleware.test.ts
@@ -1,42 +1,41 @@
-import type { IncomingMessage } from "node:http"
 import { describe, expect, test } from "vitest"
 
-import type { DawnMiddleware, MiddlewareContext } from "../src/lib/dev/middleware.js"
-import { runMiddleware } from "../src/lib/dev/middleware.js"
+import type { DawnMiddleware, MiddlewareRequest } from "@dawn-ai/sdk"
+import { loadMiddleware, runMiddleware } from "../src/lib/dev/middleware.js"
 
-function createMockContext(overrides?: Partial<MiddlewareContext>): MiddlewareContext {
+function createMockRequest(overrides?: Partial<MiddlewareRequest>): MiddlewareRequest {
   return {
-    request: {} as IncomingMessage,
-    routeId: "/hello/[tenant]",
     assistantId: "/hello/[tenant]#agent",
+    headers: {},
+    method: "POST",
+    params: {},
+    routeId: "/hello/[tenant]",
+    url: "/runs/wait",
     ...overrides,
   }
 }
 
 describe("runMiddleware", () => {
-  test("returns continue when no middleware", async () => {
-    const result = await runMiddleware([], createMockContext())
+  test("returns continue when middleware is undefined", async () => {
+    const result = await runMiddleware(undefined, createMockRequest())
     expect(result.action).toBe("continue")
   })
 
-  test("returns continue when all middleware passes", async () => {
-    const mw1: DawnMiddleware = async () => ({ action: "continue" })
-    const mw2: DawnMiddleware = async () => ({ action: "continue" })
+  test("returns continue when middleware passes", async () => {
+    const mw: DawnMiddleware = async () => ({ action: "continue" })
 
-    const result = await runMiddleware([mw1, mw2], createMockContext())
+    const result = await runMiddleware(mw, createMockRequest())
     expect(result.action).toBe("continue")
   })
 
-  test("returns reject on first rejection", async () => {
-    const mw1: DawnMiddleware = async () => ({ action: "continue" })
-    const mw2: DawnMiddleware = async () => ({
+  test("returns reject when middleware rejects", async () => {
+    const mw: DawnMiddleware = async () => ({
       action: "reject",
       status: 401,
       body: { error: "Unauthorized" },
     })
-    const mw3: DawnMiddleware = async () => ({ action: "continue" })
 
-    const result = await runMiddleware([mw1, mw2, mw3], createMockContext())
+    const result = await runMiddleware(mw, createMockRequest())
     expect(result).toEqual({
       action: "reject",
       status: 401,
@@ -44,33 +43,38 @@ describe("runMiddleware", () => {
     })
   })
 
-  test("merges context from multiple middleware", async () => {
-    const mw1: DawnMiddleware = async () => ({
+  test("passes context through on continue", async () => {
+    const mw: DawnMiddleware = async () => ({
       action: "continue",
       context: { userId: "user-1" },
     })
-    const mw2: DawnMiddleware = async () => ({
-      action: "continue",
-      context: { orgId: "org-1" },
-    })
 
-    const result = await runMiddleware([mw1, mw2], createMockContext())
+    const result = await runMiddleware(mw, createMockRequest())
     expect(result).toEqual({
       action: "continue",
-      context: { userId: "user-1", orgId: "org-1" },
+      context: { userId: "user-1" },
     })
   })
 
-  test("receives route context", async () => {
-    let receivedContext: MiddlewareContext | undefined
+  test("receives parsed request with headers and params", async () => {
+    let receivedReq: MiddlewareRequest | undefined
 
-    const mw: DawnMiddleware = async (ctx) => {
-      receivedContext = ctx
+    const mw: DawnMiddleware = async (req) => {
+      receivedReq = req
       return { action: "continue" }
     }
 
-    await runMiddleware([mw], createMockContext({ routeId: "/api/chat" }))
+    await runMiddleware(
+      mw,
+      createMockRequest({
+        headers: { authorization: "Bearer tok-123" },
+        params: { tenant: "acme" },
+        routeId: "/api/chat",
+      }),
+    )
 
-    expect(receivedContext?.routeId).toBe("/api/chat")
+    expect(receivedReq?.headers.authorization).toBe("Bearer tok-123")
+    expect(receivedReq?.params.tenant).toBe("acme")
+    expect(receivedReq?.routeId).toBe("/api/chat")
   })
 })

--- a/packages/langchain/src/agent-adapter.ts
+++ b/packages/langchain/src/agent-adapter.ts
@@ -1,4 +1,4 @@
-import type { DawnAgent } from "@dawn-ai/sdk"
+import type { DawnAgent, RetryConfig } from "@dawn-ai/sdk"
 import { isDawnAgent } from "@dawn-ai/sdk"
 import { HumanMessage } from "@langchain/core/messages"
 import { isRetryableError, withRetry } from "./retry.js"
@@ -76,6 +76,7 @@ export interface AgentStreamChunk {
 export interface AgentOptions {
   readonly entry: unknown
   readonly input: unknown
+  readonly retry?: RetryConfig
   readonly routeParamNames: readonly string[]
   readonly signal: AbortSignal
   readonly stateFields?: readonly ResolvedStateField[]
@@ -103,7 +104,8 @@ export async function* streamAgent(options: AgentOptions): AsyncGenerator<AgentS
       options.tools,
       options.stateFields,
     )
-    yield* streamFromRunnable(materializedAgent, { messages }, config)
+    const retryConfig = options.entry.retry
+    yield* streamFromRunnable(materializedAgent, { messages }, config, retryConfig)
     return
   }
 
@@ -115,7 +117,7 @@ export async function* streamAgent(options: AgentOptions): AsyncGenerator<AgentS
     config.tools = langchainTools
   }
 
-  yield* streamFromRunnable(options.entry, { messages }, config)
+  yield* streamFromRunnable(options.entry, { messages }, config, options.retry)
 }
 
 function prepareAgentCall(options: AgentOptions): {
@@ -149,6 +151,7 @@ async function* streamFromRunnable(
   runnable: AgentLike,
   input: unknown,
   config: Record<string, unknown>,
+  retryConfig?: RetryConfig,
 ): AsyncGenerator<AgentStreamChunk> {
   const streamable = runnable as AgentLike & {
     streamEvents?: (
@@ -160,9 +163,14 @@ async function* streamFromRunnable(
   if (typeof streamable.streamEvents !== "function") {
     // Fallback: invoke with retry and emit a single done event
     const signal = config.signal as AbortSignal | undefined
+    const retryOptions: import("./retry.js").RetryOptions = {
+      ...(retryConfig?.maxAttempts ? { maxAttempts: retryConfig.maxAttempts } : {}),
+      ...(retryConfig?.baseDelay ? { baseDelayMs: retryConfig.baseDelay } : {}),
+      ...(signal ? { signal } : {}),
+    }
     const result = await withRetry(
       () => runnable.invoke(input, config),
-      signal ? { signal } : undefined,
+      Object.keys(retryOptions).length > 0 ? retryOptions : undefined,
     )
     yield { type: "done", data: result }
     return
@@ -173,7 +181,7 @@ async function* streamFromRunnable(
   let lastStreamError: Error | undefined
 
   // Retry the entire stream if it fails before producing any output
-  const maxStreamAttempts = 3
+  const maxStreamAttempts = retryConfig?.maxAttempts ?? 3
   for (let attempt = 0; attempt < maxStreamAttempts; attempt++) {
     hasYielded = false
     lastStreamError = undefined

--- a/packages/langchain/src/index.ts
+++ b/packages/langchain/src/index.ts
@@ -1,7 +1,7 @@
 export type { AgentStreamChunk } from "./agent-adapter.js"
-export type { RetryOptions } from "./retry.js"
 export { executeAgent, streamAgent } from "./agent-adapter.js"
 export { chainAdapter } from "./chain-adapter.js"
+export type { RetryOptions } from "./retry.js"
 export { isRetryableError, withRetry } from "./retry.js"
 export { materializeStateSchema } from "./state-adapter.js"
 export { convertToolToLangChain } from "./tool-converter.js"

--- a/packages/langchain/test/agent-adapter-retry.test.ts
+++ b/packages/langchain/test/agent-adapter-retry.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test, vi } from "vitest"
+
+/**
+ * These tests verify that per-agent retry config is respected.
+ * We test the internal wiring by checking that withRetry receives
+ * the correct options from the agent descriptor.
+ */
+
+import { isRetryableError, withRetry } from "../src/retry.js"
+
+describe("per-agent retry config wiring", () => {
+  test("withRetry respects custom maxAttempts", async () => {
+    let attempts = 0
+    await expect(
+      withRetry(
+        async () => {
+          attempts++
+          throw new Error("503 Service Unavailable")
+        },
+        { baseDelayMs: 10, maxAttempts: 5 },
+      ),
+    ).rejects.toThrow("503 Service Unavailable")
+
+    expect(attempts).toBe(5)
+  })
+
+  test("withRetry respects custom baseDelayMs", async () => {
+    let attempts = 0
+    const start = Date.now()
+    await expect(
+      withRetry(
+        async () => {
+          attempts++
+          throw new Error("429 Too Many Requests")
+        },
+        { baseDelayMs: 10, maxAttempts: 2 },
+      ),
+    ).rejects.toThrow("429 Too Many Requests")
+
+    expect(attempts).toBe(2)
+    // With baseDelayMs=10, the delay should be very short
+    expect(Date.now() - start).toBeLessThan(1000)
+  })
+})

--- a/packages/langchain/test/agent-adapter-retry.test.ts
+++ b/packages/langchain/test/agent-adapter-retry.test.ts
@@ -1,12 +1,6 @@
-import { describe, expect, test, vi } from "vitest"
+import { describe, expect, test } from "vitest"
 
-/**
- * These tests verify that per-agent retry config is respected.
- * We test the internal wiring by checking that withRetry receives
- * the correct options from the agent descriptor.
- */
-
-import { isRetryableError, withRetry } from "../src/retry.js"
+import { withRetry } from "../src/retry.js"
 
 describe("per-agent retry config wiring", () => {
   test("withRetry respects custom maxAttempts", async () => {

--- a/packages/langchain/test/retry.test.ts
+++ b/packages/langchain/test/retry.test.ts
@@ -92,8 +92,8 @@ describe("withRetry", () => {
     const controller = new AbortController()
     controller.abort()
 
-    await expect(
-      withRetry(async () => "never", { signal: controller.signal }),
-    ).rejects.toThrow("Operation aborted")
+    await expect(withRetry(async () => "never", { signal: controller.signal })).rejects.toThrow(
+      "Operation aborted",
+    )
   })
 })

--- a/packages/sdk/src/agent.ts
+++ b/packages/sdk/src/agent.ts
@@ -2,9 +2,15 @@ const DAWN_AGENT: unique symbol = Symbol.for("dawn.agent") as unknown as typeof 
 
 declare const brand: unique symbol
 
+export interface RetryConfig {
+  readonly maxAttempts?: number
+  readonly baseDelay?: number
+}
+
 export interface DawnAgent {
   readonly [brand]: "DawnAgent"
   readonly model: string
+  readonly retry?: RetryConfig
   readonly systemPrompt: string
 }
 
@@ -12,6 +18,7 @@ import type { KnownModelId } from "./known-model-ids.js"
 
 export interface AgentConfig {
   readonly model: KnownModelId
+  readonly retry?: RetryConfig
   readonly systemPrompt: string
 }
 
@@ -19,6 +26,7 @@ export function agent(config: AgentConfig): DawnAgent {
   return {
     [DAWN_AGENT]: true,
     model: config.model,
+    ...(config.retry ? { retry: config.retry } : {}),
     systemPrompt: config.systemPrompt,
   } as unknown as DawnAgent
 }

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -1,4 +1,4 @@
-export type { AgentConfig, DawnAgent } from "./agent.js"
+export type { AgentConfig, DawnAgent, RetryConfig } from "./agent.js"
 export { agent, isDawnAgent } from "./agent.js"
 export type { BackendAdapter } from "./backend-adapter.js"
 export type {

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -11,3 +11,11 @@ export type { RouteConfig, RouteKind } from "./route-config.js"
 export type { RouteStateMap, RouteToolMap } from "./route-types.js"
 export type { RuntimeContext, RuntimeTool, ToolRegistry } from "./runtime-context.js"
 export type { Prettify } from "./types.js"
+export type {
+  ContinueResult,
+  DawnMiddleware,
+  MiddlewareRequest,
+  MiddlewareResult,
+  RejectResult,
+} from "./middleware.js"
+export { allow, defineMiddleware, reject } from "./middleware.js"

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -7,10 +7,6 @@ export type {
   KnownModelId,
   OpenAiModelId,
 } from "./known-model-ids.js"
-export type { RouteConfig, RouteKind } from "./route-config.js"
-export type { RouteStateMap, RouteToolMap } from "./route-types.js"
-export type { RuntimeContext, RuntimeTool, ToolRegistry } from "./runtime-context.js"
-export type { Prettify } from "./types.js"
 export type {
   ContinueResult,
   DawnMiddleware,
@@ -19,3 +15,7 @@ export type {
   RejectResult,
 } from "./middleware.js"
 export { allow, defineMiddleware, reject } from "./middleware.js"
+export type { RouteConfig, RouteKind } from "./route-config.js"
+export type { RouteStateMap, RouteToolMap } from "./route-types.js"
+export type { RuntimeContext, RuntimeTool, ToolRegistry } from "./runtime-context.js"
+export type { Prettify } from "./types.js"

--- a/packages/sdk/src/middleware.ts
+++ b/packages/sdk/src/middleware.ts
@@ -1,0 +1,43 @@
+export interface MiddlewareRequest {
+  readonly assistantId: string
+  readonly headers: Readonly<Record<string, string>>
+  readonly method: string
+  readonly params: Readonly<Record<string, string>>
+  readonly routeId: string
+  readonly url: string
+}
+
+export interface ContinueResult {
+  readonly action: "continue"
+  readonly context?: Record<string, unknown>
+}
+
+export interface RejectResult {
+  readonly action: "reject"
+  readonly body?: unknown
+  readonly status: number
+}
+
+export type MiddlewareResult = ContinueResult | RejectResult
+
+export type DawnMiddleware = (
+  req: MiddlewareRequest,
+) => Promise<MiddlewareResult> | MiddlewareResult
+
+export function defineMiddleware(fn: DawnMiddleware): DawnMiddleware {
+  return fn
+}
+
+export function reject(status: number, body?: unknown): RejectResult {
+  if (body !== undefined) {
+    return { action: "reject", body, status }
+  }
+  return { action: "reject", status }
+}
+
+export function allow(context?: Record<string, unknown>): ContinueResult {
+  if (context) {
+    return { action: "continue", context }
+  }
+  return { action: "continue" }
+}

--- a/packages/sdk/test/agent.test.ts
+++ b/packages/sdk/test/agent.test.ts
@@ -46,4 +46,24 @@ describe("agent()", () => {
     const descriptor = agent({ model: "gpt-4o", systemPrompt: "test" })
     expectTypeOf(descriptor).toMatchTypeOf<DawnAgent>()
   })
+
+  test("accepts optional retry config", () => {
+    const descriptor = agent({
+      model: "gpt-4o-mini",
+      systemPrompt: "You are helpful.",
+      retry: { maxAttempts: 5, baseDelay: 2000 },
+    })
+
+    expect(descriptor.model).toBe("gpt-4o-mini")
+    expect(descriptor.retry).toEqual({ maxAttempts: 5, baseDelay: 2000 })
+  })
+
+  test("retry defaults to undefined when not provided", () => {
+    const descriptor = agent({
+      model: "gpt-4o-mini",
+      systemPrompt: "Hello",
+    })
+
+    expect(descriptor.retry).toBeUndefined()
+  })
 })

--- a/packages/sdk/test/middleware.test.ts
+++ b/packages/sdk/test/middleware.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from "vitest"
+import {
+  allow,
+  defineMiddleware,
+  reject,
+  type MiddlewareRequest,
+  type MiddlewareResult,
+} from "../src/middleware.js"
+
+describe("reject()", () => {
+  test("returns a reject result with status and body", () => {
+    const result = reject(401, { error: "Unauthorized" })
+    expect(result).toEqual({
+      action: "reject",
+      status: 401,
+      body: { error: "Unauthorized" },
+    })
+  })
+
+  test("body defaults to undefined", () => {
+    const result = reject(403)
+    expect(result).toEqual({
+      action: "reject",
+      status: 403,
+      body: undefined,
+    })
+  })
+})
+
+describe("allow()", () => {
+  test("returns a continue result with context", () => {
+    const result = allow({ userId: "user-1", orgId: "org-1" })
+    expect(result).toEqual({
+      action: "continue",
+      context: { userId: "user-1", orgId: "org-1" },
+    })
+  })
+
+  test("context defaults to undefined", () => {
+    const result = allow()
+    expect(result).toEqual({
+      action: "continue",
+      context: undefined,
+    })
+  })
+})
+
+describe("defineMiddleware()", () => {
+  test("returns the function as-is (type-safe identity wrapper)", () => {
+    const fn = async (req: MiddlewareRequest): Promise<MiddlewareResult> => {
+      return allow()
+    }
+
+    const middleware = defineMiddleware(fn)
+    expect(middleware).toBe(fn)
+  })
+
+  test("works with a sync function", () => {
+    const fn = (req: MiddlewareRequest): MiddlewareResult => {
+      return reject(401)
+    }
+
+    const middleware = defineMiddleware(fn)
+    expect(middleware).toBe(fn)
+  })
+})

--- a/packages/sdk/test/middleware.test.ts
+++ b/packages/sdk/test/middleware.test.ts
@@ -2,9 +2,9 @@ import { describe, expect, test } from "vitest"
 import {
   allow,
   defineMiddleware,
-  reject,
   type MiddlewareRequest,
   type MiddlewareResult,
+  reject,
 } from "../src/middleware.js"
 
 describe("reject()", () => {
@@ -47,7 +47,7 @@ describe("allow()", () => {
 
 describe("defineMiddleware()", () => {
   test("returns the function as-is (type-safe identity wrapper)", () => {
-    const fn = async (req: MiddlewareRequest): Promise<MiddlewareResult> => {
+    const fn = async (_req: MiddlewareRequest): Promise<MiddlewareResult> => {
       return allow()
     }
 
@@ -56,7 +56,7 @@ describe("defineMiddleware()", () => {
   })
 
   test("works with a sync function", () => {
-    const fn = (req: MiddlewareRequest): MiddlewareResult => {
+    const fn = (_req: MiddlewareRequest): MiddlewareResult => {
       return reject(401)
     }
 


### PR DESCRIPTION
## Summary

- **Deployment config**: Corrected `langgraph.json` output — `dependencies: ["."]` (paths, not package@version), `env: ".env"` (file path, not var array), removed standalone Dockerfile generation (LangGraph CLI handles Docker)
- **Retry/resilience**: Added optional `retry` field to `AgentConfig` for per-agent retry customization; wired through agent-adapter with sensible defaults (3 attempts, exponential backoff, stream retry before first chunk)
- **Middleware**: New SDK authoring contract (`defineMiddleware`, `reject`, `allow`) with parsed `MiddlewareRequest` (headers, params, routeId); single-function model replacing array-based chaining; types moved from CLI to `@dawn-ai/sdk`

## Test plan
- [ ] 225 tests passing across 35 test files
- [ ] Typecheck clean (10 packages)
- [ ] Lint clean (11 packages)
- [ ] SDK exports: `RetryConfig`, `defineMiddleware`, `reject`, `allow`, `MiddlewareRequest`
- [ ] `langgraph.json` format validated: `dependencies: ["."]`, `env` as file path
