### PR TITLE
test: fix framework verification fixtures for deps check

### DIFF
--- a/test/generated/fixtures/basic.expected.json
+++ b/test/generated/fixtures/basic.expected.json
@@ -51,12 +51,18 @@
         "name": "typegen",
         "renderedBytes": 415,
         "status": "passed"
+      },
+      {
+        "missingEnvVars": ["OPENAI_API_KEY"],
+        "missingPackages": ["@langchain/core", "@langchain/openai", "@langchain/langgraph"],
+        "name": "deps",
+        "status": "warning"
       }
     ],
     "counts": {
       "failed": 0,
-      "passed": 3,
-      "total": 3
+      "passed": 4,
+      "total": 4
     },
     "status": "passed"
   },

--- a/test/generated/fixtures/custom-app-dir.expected.json
+++ b/test/generated/fixtures/custom-app-dir.expected.json
@@ -51,12 +51,18 @@
         "name": "typegen",
         "renderedBytes": 279,
         "status": "passed"
+      },
+      {
+        "missingEnvVars": ["OPENAI_API_KEY"],
+        "missingPackages": [],
+        "name": "deps",
+        "status": "warning"
       }
     ],
     "counts": {
       "failed": 0,
-      "passed": 3,
-      "total": 3
+      "passed": 4,
+      "total": 4
     },
     "status": "passed"
   },

--- a/test/generated/fixtures/custom-app-dir.expected.json
+++ b/test/generated/fixtures/custom-app-dir.expected.json
@@ -54,7 +54,7 @@
       },
       {
         "missingEnvVars": ["OPENAI_API_KEY"],
-        "missingPackages": [],
+        "missingPackages": ["@langchain/core", "@langchain/openai", "@langchain/langgraph"],
         "name": "deps",
         "status": "warning"
       }


### PR DESCRIPTION
## Summary
- Add `missingPackages` (`@langchain/core`, `@langchain/openai`, `@langchain/langgraph`) to both `basic.expected.json` and `custom-app-dir.expected.json` fixtures
- Update fixture check counts from 3 to 4 (now includes the deps check added in the prior session)

The deps checker correctly reports these as missing since they are peer dependencies of `@dawn-ai/langchain`, not direct dependencies of the generated app.

Fixes the CI failure from PR #34 which was merged before CI completed.

## Test plan
- [x] All 225 unit tests pass locally
- [x] Framework verification harness (10 tests) passes locally
