### PR TITLE
feat: flow middleware context through to tools

### DIFF
--- a/packages/cli/src/lib/dev/runtime-server.ts
+++ b/packages/cli/src/lib/dev/runtime-server.ts
@@ -1,555 +1,502 @@
-import {
-	createServer,
-	type IncomingMessage,
-	type ServerResponse,
-} from "node:http";
-import type { AddressInfo } from "node:net";
-import type { DawnMiddleware, MiddlewareRequest } from "@dawn-ai/sdk";
-import {
-	executeResolvedRoute,
-	streamResolvedRoute,
-} from "../runtime/execute-route.js";
-import { type StreamChunk, toSseEvent } from "../runtime/stream-types.js";
-import { loadMiddleware, runMiddleware } from "./middleware.js";
-import {
-	createRuntimeRegistry,
-	type RuntimeRegistry,
-} from "./runtime-registry.js";
-import {
-	createExecutionErrorBody,
-	createRequestErrorBody,
-} from "./server-errors.js";
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http"
+import type { AddressInfo } from "node:net"
+import type { DawnMiddleware, MiddlewareRequest } from "@dawn-ai/sdk"
+import { executeResolvedRoute, streamResolvedRoute } from "../runtime/execute-route.js"
+import { type StreamChunk, toSseEvent } from "../runtime/stream-types.js"
+import { loadMiddleware, runMiddleware } from "./middleware.js"
+import { createRuntimeRegistry, type RuntimeRegistry } from "./runtime-registry.js"
+import { createExecutionErrorBody, createRequestErrorBody } from "./server-errors.js"
 
 export interface RuntimeServer {
-	readonly close: () => Promise<void>;
-	readonly url: string;
+  readonly close: () => Promise<void>
+  readonly url: string
 }
 
 export interface StartRuntimeServerOptions {
-	readonly appRoot: string;
-	readonly port?: number;
+  readonly appRoot: string
+  readonly port?: number
 }
 
 export async function startRuntimeServer(
-	options: StartRuntimeServerOptions,
+  options: StartRuntimeServerOptions,
 ): Promise<RuntimeServer> {
-	const registry = await createRuntimeRegistry(options.appRoot);
-	const middleware = await loadMiddleware(options.appRoot);
-	const state = {
-		acceptingRequests: true,
-		activeRequests: 0,
-		closed: false,
-	};
-	const shutdownController = new AbortController();
+  const registry = await createRuntimeRegistry(options.appRoot)
+  const middleware = await loadMiddleware(options.appRoot)
+  const state = {
+    acceptingRequests: true,
+    activeRequests: 0,
+    closed: false,
+  }
+  const shutdownController = new AbortController()
 
-	const server = createServer(async (request, response) => {
-		if (!state.acceptingRequests) {
-			sendJson(
-				response,
-				503,
-				createRequestErrorBody("Server is shutting down"),
-			);
-			return;
-		}
+  const server = createServer(async (request, response) => {
+    if (!state.acceptingRequests) {
+      sendJson(response, 503, createRequestErrorBody("Server is shutting down"))
+      return
+    }
 
-		state.activeRequests++;
-		try {
-			await handleRequest({
-				middleware,
-				registry,
-				request,
-				response,
-				signal: shutdownController.signal,
-			});
-		} catch (error) {
-			if (shutdownController.signal.aborted) {
-				sendJson(
-					response,
-					503,
-					createRequestErrorBody("Request canceled during server shutdown", {
-						error: error instanceof Error ? error.message : String(error),
-					}),
-				);
-				return;
-			}
+    state.activeRequests++
+    try {
+      await handleRequest({
+        middleware,
+        registry,
+        request,
+        response,
+        signal: shutdownController.signal,
+      })
+    } catch (error) {
+      if (shutdownController.signal.aborted) {
+        sendJson(
+          response,
+          503,
+          createRequestErrorBody("Request canceled during server shutdown", {
+            error: error instanceof Error ? error.message : String(error),
+          }),
+        )
+        return
+      }
 
-			sendJson(
-				response,
-				500,
-				createExecutionErrorBody("Unexpected runtime server failure"),
-			);
-		} finally {
-			state.activeRequests--;
-		}
-	});
+      sendJson(response, 500, createExecutionErrorBody("Unexpected runtime server failure"))
+    } finally {
+      state.activeRequests--
+    }
+  })
 
-	await listen(server, options.port);
+  await listen(server, options.port)
 
-	const address = server.address();
+  const address = server.address()
 
-	if (!address || typeof address === "string") {
-		throw new Error("Runtime server did not bind to a TCP address");
-	}
+  if (!address || typeof address === "string") {
+    throw new Error("Runtime server did not bind to a TCP address")
+  }
 
-	return {
-		close: async () => {
-			if (state.closed) {
-				return;
-			}
+  return {
+    close: async () => {
+      if (state.closed) {
+        return
+      }
 
-			state.acceptingRequests = false;
-			state.closed = true;
-			shutdownController.abort(new Error("Runtime server shutting down"));
+      state.acceptingRequests = false
+      state.closed = true
+      shutdownController.abort(new Error("Runtime server shutting down"))
 
-			await new Promise<void>((resolve, reject) => {
-				server.close((error) => {
-					if (error) {
-						reject(error);
-						return;
-					}
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => {
+          if (error) {
+            reject(error)
+            return
+          }
 
-					if (state.activeRequests === 0) {
-						resolve();
-						return;
-					}
+          if (state.activeRequests === 0) {
+            resolve()
+            return
+          }
 
-					const interval = setInterval(() => {
-						if (state.activeRequests > 0) {
-							return;
-						}
+          const interval = setInterval(() => {
+            if (state.activeRequests > 0) {
+              return
+            }
 
-						clearInterval(interval);
-						resolve();
-					}, 10);
-				});
-			});
-		},
-		url: `http://127.0.0.1:${(address as AddressInfo).port}`,
-	};
+            clearInterval(interval)
+            resolve()
+          }, 10)
+        })
+      })
+    },
+    url: `http://127.0.0.1:${(address as AddressInfo).port}`,
+  }
 }
 
 async function handleRequest(options: {
-	readonly middleware: DawnMiddleware | undefined;
-	readonly registry: RuntimeRegistry;
-	readonly request: IncomingMessage;
-	readonly response: ServerResponse;
-	readonly signal: AbortSignal;
+  readonly middleware: DawnMiddleware | undefined
+  readonly registry: RuntimeRegistry
+  readonly request: IncomingMessage
+  readonly response: ServerResponse
+  readonly signal: AbortSignal
 }): Promise<void> {
-	const { middleware, request, response, registry, signal } = options;
+  const { middleware, request, response, registry, signal } = options
 
-	if (request.method === "GET" && request.url === "/healthz") {
-		sendJson(response, 200, { status: "ready" });
-		return;
-	}
+  if (request.method === "GET" && request.url === "/healthz") {
+    sendJson(response, 200, { status: "ready" })
+    return
+  }
 
-	if (request.method === "POST" && request.url === "/runs/stream") {
-		await handleStreamRequest({
-			middleware,
-			registry,
-			request,
-			response,
-			signal,
-		});
-		return;
-	}
+  if (request.method === "POST" && request.url === "/runs/stream") {
+    await handleStreamRequest({
+      middleware,
+      registry,
+      request,
+      response,
+      signal,
+    })
+    return
+  }
 
-	if (request.method !== "POST" || request.url !== "/runs/wait") {
-		sendJson(response, 404, createRequestErrorBody("Not found"));
-		return;
-	}
+  if (request.method !== "POST" || request.url !== "/runs/wait") {
+    sendJson(response, 404, createRequestErrorBody("Not found"))
+    return
+  }
 
-	const rawBody = await readRequestBody(request);
-	const parsedBody = parseJson(rawBody);
+  const rawBody = await readRequestBody(request)
+  const parsedBody = parseJson(rawBody)
 
-	if (!parsedBody.ok) {
-		sendJson(response, 400, createRequestErrorBody("Malformed request body"));
-		return;
-	}
+  if (!parsedBody.ok) {
+    sendJson(response, 400, createRequestErrorBody("Malformed request body"))
+    return
+  }
 
-	const validatedBody = validateRunsWaitRequest(parsedBody.value);
+  const validatedBody = validateRunsWaitRequest(parsedBody.value)
 
-	if (!validatedBody.ok) {
-		sendJson(
-			response,
-			400,
-			createRequestErrorBody(validatedBody.message, validatedBody.details),
-		);
-		return;
-	}
+  if (!validatedBody.ok) {
+    sendJson(response, 400, createRequestErrorBody(validatedBody.message, validatedBody.details))
+    return
+  }
 
-	const route = registry.lookup(validatedBody.value.assistant_id);
+  const route = registry.lookup(validatedBody.value.assistant_id)
 
-	if (!route) {
-		sendJson(
-			response,
-			404,
-			createRequestErrorBody(
-				`Unknown assistant_id: ${validatedBody.value.assistant_id}`,
-			),
-		);
-		return;
-	}
+  if (!route) {
+    sendJson(
+      response,
+      404,
+      createRequestErrorBody(`Unknown assistant_id: ${validatedBody.value.assistant_id}`),
+    )
+    return
+  }
 
-	// Run middleware before execution
-	const mwRequest: MiddlewareRequest = {
-		assistantId: route.assistantId,
-		headers: parseHeaders(request),
-		method: request.method ?? "POST",
-		params: extractRouteParams(route.routeId, validatedBody.value.input),
-		routeId: route.routeId,
-		url: request.url ?? "/runs/wait",
-	};
-	const mwResult = await runMiddleware(middleware, mwRequest);
-	if (mwResult.action === "reject") {
-		sendJson(response, mwResult.status, mwResult.body);
-		return;
-	}
+  // Run middleware before execution
+  const mwRequest: MiddlewareRequest = {
+    assistantId: route.assistantId,
+    headers: parseHeaders(request),
+    method: request.method ?? "POST",
+    params: extractRouteParams(route.routeId, validatedBody.value.input),
+    routeId: route.routeId,
+    url: request.url ?? "/runs/wait",
+  }
+  const mwResult = await runMiddleware(middleware, mwRequest)
+  if (mwResult.action === "reject") {
+    sendJson(response, mwResult.status, mwResult.body)
+    return
+  }
 
-	if (
-		validatedBody.value.metadata.dawn.route_id !== route.routeId ||
-		validatedBody.value.metadata.dawn.route_path !== route.routePath ||
-		validatedBody.value.metadata.dawn.mode !== route.mode ||
-		validatedBody.value.assistant_id !== route.assistantId
-	) {
-		sendJson(
-			response,
-			400,
-			createRequestErrorBody(
-				"Request metadata does not match the registered route",
-				{
-					assistant_id: validatedBody.value.assistant_id,
-					expected: {
-						assistant_id: route.assistantId,
-						mode: route.mode,
-						route_id: route.routeId,
-						route_path: route.routePath,
-					},
-					received: validatedBody.value.metadata.dawn,
-				},
-			),
-		);
-		return;
-	}
+  if (
+    validatedBody.value.metadata.dawn.route_id !== route.routeId ||
+    validatedBody.value.metadata.dawn.route_path !== route.routePath ||
+    validatedBody.value.metadata.dawn.mode !== route.mode ||
+    validatedBody.value.assistant_id !== route.assistantId
+  ) {
+    sendJson(
+      response,
+      400,
+      createRequestErrorBody("Request metadata does not match the registered route", {
+        assistant_id: validatedBody.value.assistant_id,
+        expected: {
+          assistant_id: route.assistantId,
+          mode: route.mode,
+          route_id: route.routeId,
+          route_path: route.routePath,
+        },
+        received: validatedBody.value.metadata.dawn,
+      }),
+    )
+    return
+  }
 
-	const resultPromise = executeResolvedRoute({
-		appRoot: registry.appRoot,
-		input: validatedBody.value.input,
-		...(mwResult.context ? { middlewareContext: mwResult.context } : {}),
-		signal,
-		routeFile: route.routeFile,
-		routeId: route.routeId,
-		routePath: route.routePath,
-	});
-	const result = await raceRequestAgainstShutdown(resultPromise, signal);
+  const resultPromise = executeResolvedRoute({
+    appRoot: registry.appRoot,
+    input: validatedBody.value.input,
+    ...(mwResult.context ? { middlewareContext: mwResult.context } : {}),
+    signal,
+    routeFile: route.routeFile,
+    routeId: route.routeId,
+    routePath: route.routePath,
+  })
+  const result = await raceRequestAgainstShutdown(resultPromise, signal)
 
-	if (result === SHUTDOWN_ABORTED) {
-		sendJson(
-			response,
-			503,
-			createRequestErrorBody("Request canceled during server shutdown"),
-		);
-		return;
-	}
+  if (result === SHUTDOWN_ABORTED) {
+    sendJson(response, 503, createRequestErrorBody("Request canceled during server shutdown"))
+    return
+  }
 
-	if (result.status === "failed") {
-		if (signal.aborted) {
-			sendJson(
-				response,
-				503,
-				createRequestErrorBody("Request canceled during server shutdown", {
-					error: result.error.message,
-				}),
-			);
-			return;
-		}
+  if (result.status === "failed") {
+    if (signal.aborted) {
+      sendJson(
+        response,
+        503,
+        createRequestErrorBody("Request canceled during server shutdown", {
+          error: result.error.message,
+        }),
+      )
+      return
+    }
 
-		if (result.error.kind === "execution_error") {
-			sendJson(
-				response,
-				500,
-				createExecutionErrorBody(result.error.message, result.error.details),
-			);
-			return;
-		}
+    if (result.error.kind === "execution_error") {
+      sendJson(response, 500, createExecutionErrorBody(result.error.message, result.error.details))
+      return
+    }
 
-		sendJson(
-			response,
-			500,
-			createRequestErrorBody("Route execution failed before execution began", {
-				error: result.error,
-			}),
-		);
-		return;
-	}
+    sendJson(
+      response,
+      500,
+      createRequestErrorBody("Route execution failed before execution began", {
+        error: result.error,
+      }),
+    )
+    return
+  }
 
-	sendJson(response, 200, result.output);
+  sendJson(response, 200, result.output)
 }
 
 async function handleStreamRequest(options: {
-	readonly middleware: DawnMiddleware | undefined;
-	readonly registry: RuntimeRegistry;
-	readonly request: IncomingMessage;
-	readonly response: ServerResponse;
-	readonly signal: AbortSignal;
+  readonly middleware: DawnMiddleware | undefined
+  readonly registry: RuntimeRegistry
+  readonly request: IncomingMessage
+  readonly response: ServerResponse
+  readonly signal: AbortSignal
 }): Promise<void> {
-	const { middleware, request, response, registry, signal } = options;
+  const { middleware, request, response, registry, signal } = options
 
-	const rawBody = await readRequestBody(request);
-	const parsedBody = parseJson(rawBody);
+  const rawBody = await readRequestBody(request)
+  const parsedBody = parseJson(rawBody)
 
-	if (!parsedBody.ok) {
-		sendJson(response, 400, createRequestErrorBody("Malformed request body"));
-		return;
-	}
+  if (!parsedBody.ok) {
+    sendJson(response, 400, createRequestErrorBody("Malformed request body"))
+    return
+  }
 
-	const validatedBody = validateRunsWaitRequest(parsedBody.value);
+  const validatedBody = validateRunsWaitRequest(parsedBody.value)
 
-	if (!validatedBody.ok) {
-		sendJson(
-			response,
-			400,
-			createRequestErrorBody(validatedBody.message, validatedBody.details),
-		);
-		return;
-	}
+  if (!validatedBody.ok) {
+    sendJson(response, 400, createRequestErrorBody(validatedBody.message, validatedBody.details))
+    return
+  }
 
-	const route = registry.lookup(validatedBody.value.assistant_id);
+  const route = registry.lookup(validatedBody.value.assistant_id)
 
-	if (!route) {
-		sendJson(
-			response,
-			404,
-			createRequestErrorBody(
-				`Unknown assistant_id: ${validatedBody.value.assistant_id}`,
-			),
-		);
-		return;
-	}
+  if (!route) {
+    sendJson(
+      response,
+      404,
+      createRequestErrorBody(`Unknown assistant_id: ${validatedBody.value.assistant_id}`),
+    )
+    return
+  }
 
-	// Run middleware before streaming
-	const mwRequest: MiddlewareRequest = {
-		assistantId: route.assistantId,
-		headers: parseHeaders(request),
-		method: request.method ?? "POST",
-		params: extractRouteParams(route.routeId, validatedBody.value.input),
-		routeId: route.routeId,
-		url: request.url ?? "/runs/stream",
-	};
-	const mwResult = await runMiddleware(middleware, mwRequest);
-	if (mwResult.action === "reject") {
-		sendJson(response, mwResult.status, mwResult.body);
-		return;
-	}
+  // Run middleware before streaming
+  const mwRequest: MiddlewareRequest = {
+    assistantId: route.assistantId,
+    headers: parseHeaders(request),
+    method: request.method ?? "POST",
+    params: extractRouteParams(route.routeId, validatedBody.value.input),
+    routeId: route.routeId,
+    url: request.url ?? "/runs/stream",
+  }
+  const mwResult = await runMiddleware(middleware, mwRequest)
+  if (mwResult.action === "reject") {
+    sendJson(response, mwResult.status, mwResult.body)
+    return
+  }
 
-	response.writeHead(200, {
-		"content-type": "text/event-stream",
-		"cache-control": "no-cache",
-		connection: "keep-alive",
-	});
+  response.writeHead(200, {
+    "content-type": "text/event-stream",
+    "cache-control": "no-cache",
+    connection: "keep-alive",
+  })
 
-	try {
-		for await (const chunk of streamResolvedRoute({
-			appRoot: registry.appRoot,
-			input: validatedBody.value.input,
-			...(mwResult.context ? { middlewareContext: mwResult.context } : {}),
-			signal,
-			routeFile: route.routeFile,
-			routeId: route.routeId,
-			routePath: route.routePath,
-		})) {
-			response.write(toSseEvent(chunk));
-		}
-	} catch (error) {
-		const errorChunk: StreamChunk = {
-			type: "done",
-			output: { error: error instanceof Error ? error.message : String(error) },
-		};
-		response.write(toSseEvent(errorChunk));
-	}
+  try {
+    for await (const chunk of streamResolvedRoute({
+      appRoot: registry.appRoot,
+      input: validatedBody.value.input,
+      ...(mwResult.context ? { middlewareContext: mwResult.context } : {}),
+      signal,
+      routeFile: route.routeFile,
+      routeId: route.routeId,
+      routePath: route.routePath,
+    })) {
+      response.write(toSseEvent(chunk))
+    }
+  } catch (error) {
+    const errorChunk: StreamChunk = {
+      type: "done",
+      output: { error: error instanceof Error ? error.message : String(error) },
+    }
+    response.write(toSseEvent(errorChunk))
+  }
 
-	response.end();
+  response.end()
 }
 
-const SHUTDOWN_ABORTED = Symbol("shutdown-aborted");
+const SHUTDOWN_ABORTED = Symbol("shutdown-aborted")
 
 async function raceRequestAgainstShutdown<T>(
-	execution: Promise<T>,
-	signal: AbortSignal,
+  execution: Promise<T>,
+  signal: AbortSignal,
 ): Promise<T | typeof SHUTDOWN_ABORTED> {
-	if (signal.aborted) {
-		void execution.catch(() => undefined);
-		return SHUTDOWN_ABORTED;
-	}
+  if (signal.aborted) {
+    void execution.catch(() => undefined)
+    return SHUTDOWN_ABORTED
+  }
 
-	const shutdown = new Promise<typeof SHUTDOWN_ABORTED>((resolve) => {
-		const onAbort = () => {
-			signal.removeEventListener("abort", onAbort);
-			resolve(SHUTDOWN_ABORTED);
-		};
+  const shutdown = new Promise<typeof SHUTDOWN_ABORTED>((resolve) => {
+    const onAbort = () => {
+      signal.removeEventListener("abort", onAbort)
+      resolve(SHUTDOWN_ABORTED)
+    }
 
-		signal.addEventListener("abort", onAbort, { once: true });
-	});
+    signal.addEventListener("abort", onAbort, { once: true })
+  })
 
-	const result = await Promise.race([execution, shutdown]);
+  const result = await Promise.race([execution, shutdown])
 
-	if (result === SHUTDOWN_ABORTED) {
-		void execution.catch(() => undefined);
-	}
+  if (result === SHUTDOWN_ABORTED) {
+    void execution.catch(() => undefined)
+  }
 
-	return result;
+  return result
 }
 
 function validateRunsWaitRequest(value: unknown):
-	| { readonly ok: true; readonly value: RunsWaitRequest }
-	| {
-			readonly details?: Record<string, unknown>;
-			readonly message: string;
-			readonly ok: false;
-	  } {
-	if (!isRecord(value)) {
-		return { message: "Request body must be an object", ok: false };
-	}
+  | { readonly ok: true; readonly value: RunsWaitRequest }
+  | {
+      readonly details?: Record<string, unknown>
+      readonly message: string
+      readonly ok: false
+    } {
+  if (!isRecord(value)) {
+    return { message: "Request body must be an object", ok: false }
+  }
 
-	if (typeof value.assistant_id !== "string") {
-		return {
-			message: "Request body must include assistant_id as a string",
-			ok: false,
-		};
-	}
+  if (typeof value.assistant_id !== "string") {
+    return {
+      message: "Request body must include assistant_id as a string",
+      ok: false,
+    }
+  }
 
-	if (!isRecord(value.metadata) || !isRecord(value.metadata.dawn)) {
-		return { message: "Request body must include metadata.dawn", ok: false };
-	}
+  if (!isRecord(value.metadata) || !isRecord(value.metadata.dawn)) {
+    return { message: "Request body must include metadata.dawn", ok: false }
+  }
 
-	if (typeof value.metadata.dawn.mode !== "string") {
-		return {
-			message: "Request body must include metadata.dawn.mode as a string",
-			ok: false,
-		};
-	}
+  if (typeof value.metadata.dawn.mode !== "string") {
+    return {
+      message: "Request body must include metadata.dawn.mode as a string",
+      ok: false,
+    }
+  }
 
-	if (typeof value.metadata.dawn.route_id !== "string") {
-		return {
-			message: "Request body must include metadata.dawn.route_id as a string",
-			ok: false,
-		};
-	}
+  if (typeof value.metadata.dawn.route_id !== "string") {
+    return {
+      message: "Request body must include metadata.dawn.route_id as a string",
+      ok: false,
+    }
+  }
 
-	if (typeof value.metadata.dawn.route_path !== "string") {
-		return {
-			message: "Request body must include metadata.dawn.route_path as a string",
-			ok: false,
-		};
-	}
+  if (typeof value.metadata.dawn.route_path !== "string") {
+    return {
+      message: "Request body must include metadata.dawn.route_path as a string",
+      ok: false,
+    }
+  }
 
-	if (!Object.hasOwn(value, "input")) {
-		return { message: "Request body must include input", ok: false };
-	}
+  if (!Object.hasOwn(value, "input")) {
+    return { message: "Request body must include input", ok: false }
+  }
 
-	if (value.on_completion !== "delete") {
-		return {
-			message: "Request body must set on_completion to delete",
-			ok: false,
-		};
-	}
+  if (value.on_completion !== "delete") {
+    return {
+      message: "Request body must set on_completion to delete",
+      ok: false,
+    }
+  }
 
-	return {
-		ok: true as const,
-		value: value as unknown as RunsWaitRequest,
-	};
+  return {
+    ok: true as const,
+    value: value as unknown as RunsWaitRequest,
+  }
 }
 
 interface RunsWaitRequest {
-	readonly assistant_id: string;
-	readonly input: unknown;
-	readonly metadata: {
-		readonly dawn: {
-			readonly mode: "agent" | "chain" | "graph" | "workflow";
-			readonly route_id: string;
-			readonly route_path: string;
-		};
-	};
-	readonly on_completion: "delete";
+  readonly assistant_id: string
+  readonly input: unknown
+  readonly metadata: {
+    readonly dawn: {
+      readonly mode: "agent" | "chain" | "graph" | "workflow"
+      readonly route_id: string
+      readonly route_path: string
+    }
+  }
+  readonly on_completion: "delete"
 }
 
 function parseJson(
-	input: string,
+  input: string,
 ): { readonly ok: true; readonly value: unknown } | { readonly ok: false } {
-	try {
-		return {
-			ok: true,
-			value: JSON.parse(input),
-		};
-	} catch {
-		return { ok: false };
-	}
+  try {
+    return {
+      ok: true,
+      value: JSON.parse(input),
+    }
+  } catch {
+    return { ok: false }
+  }
 }
 
-function sendJson(
-	response: ServerResponse,
-	statusCode: number,
-	body: unknown,
-): void {
-	response.statusCode = statusCode;
-	response.setHeader("content-type", "application/json");
-	response.end(JSON.stringify(body));
+function sendJson(response: ServerResponse, statusCode: number, body: unknown): void {
+  response.statusCode = statusCode
+  response.setHeader("content-type", "application/json")
+  response.end(JSON.stringify(body))
 }
 
 async function readRequestBody(request: IncomingMessage): Promise<string> {
-	const chunks: Buffer[] = [];
+  const chunks: Buffer[] = []
 
-	for await (const chunk of request) {
-		chunks.push(typeof chunk === "string" ? Buffer.from(chunk) : chunk);
-	}
+  for await (const chunk of request) {
+    chunks.push(typeof chunk === "string" ? Buffer.from(chunk) : chunk)
+  }
 
-	return Buffer.concat(chunks).toString("utf8");
+  return Buffer.concat(chunks).toString("utf8")
 }
 
-async function listen(
-	server: ReturnType<typeof createServer>,
-	port?: number,
-): Promise<void> {
-	await new Promise<void>((resolve, reject) => {
-		server.once("error", reject);
-		server.listen(port ?? 0, "127.0.0.1", () => {
-			server.off("error", reject);
-			resolve();
-		});
-	});
+async function listen(server: ReturnType<typeof createServer>, port?: number): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject)
+    server.listen(port ?? 0, "127.0.0.1", () => {
+      server.off("error", reject)
+      resolve()
+    })
+  })
 }
 
 function parseHeaders(request: IncomingMessage): Record<string, string> {
-	const headers: Record<string, string> = {};
-	for (const [key, value] of Object.entries(request.headers)) {
-		if (typeof value === "string") {
-			headers[key] = value;
-		} else if (Array.isArray(value)) {
-			headers[key] = value.join(", ");
-		}
-	}
-	return headers;
+  const headers: Record<string, string> = {}
+  for (const [key, value] of Object.entries(request.headers)) {
+    if (typeof value === "string") {
+      headers[key] = value
+    } else if (Array.isArray(value)) {
+      headers[key] = value.join(", ")
+    }
+  }
+  return headers
 }
 
-function extractRouteParams(
-	routeId: string,
-	input: unknown,
-): Record<string, string> {
-	const params: Record<string, string> = {};
-	const matches = routeId.matchAll(/\[(\w+)\]/g);
-	const inputRecord = (
-		typeof input === "object" && input !== null ? input : {}
-	) as Record<string, unknown>;
+function extractRouteParams(routeId: string, input: unknown): Record<string, string> {
+  const params: Record<string, string> = {}
+  const matches = routeId.matchAll(/\[(\w+)\]/g)
+  const inputRecord = (typeof input === "object" && input !== null ? input : {}) as Record<
+    string,
+    unknown
+  >
 
-	for (const match of matches) {
-		const name = match[1];
-		if (name && name in inputRecord) {
-			params[name] = String(inputRecord[name]);
-		}
-	}
+  for (const match of matches) {
+    const name = match[1]
+    if (name && name in inputRecord) {
+      params[name] = String(inputRecord[name])
+    }
+  }
 
-	return params;
+  return params
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
-	return typeof value === "object" && value !== null;
+  return typeof value === "object" && value !== null
 }

--- a/packages/cli/src/lib/dev/runtime-server.ts
+++ b/packages/cli/src/lib/dev/runtime-server.ts
@@ -1,477 +1,555 @@
-import { createServer, type IncomingMessage, type ServerResponse } from "node:http"
-import type { AddressInfo } from "node:net"
-import type { DawnMiddleware, MiddlewareRequest } from "@dawn-ai/sdk"
-import { executeResolvedRoute, streamResolvedRoute } from "../runtime/execute-route.js"
-import { type StreamChunk, toSseEvent } from "../runtime/stream-types.js"
-import { loadMiddleware, runMiddleware } from "./middleware.js"
-import { createRuntimeRegistry, type RuntimeRegistry } from "./runtime-registry.js"
-import { createExecutionErrorBody, createRequestErrorBody } from "./server-errors.js"
+import {
+	createServer,
+	type IncomingMessage,
+	type ServerResponse,
+} from "node:http";
+import type { AddressInfo } from "node:net";
+import type { DawnMiddleware, MiddlewareRequest } from "@dawn-ai/sdk";
+import {
+	executeResolvedRoute,
+	streamResolvedRoute,
+} from "../runtime/execute-route.js";
+import { type StreamChunk, toSseEvent } from "../runtime/stream-types.js";
+import { loadMiddleware, runMiddleware } from "./middleware.js";
+import {
+	createRuntimeRegistry,
+	type RuntimeRegistry,
+} from "./runtime-registry.js";
+import {
+	createExecutionErrorBody,
+	createRequestErrorBody,
+} from "./server-errors.js";
 
 export interface RuntimeServer {
-  readonly close: () => Promise<void>
-  readonly url: string
+	readonly close: () => Promise<void>;
+	readonly url: string;
 }
 
 export interface StartRuntimeServerOptions {
-  readonly appRoot: string
-  readonly port?: number
+	readonly appRoot: string;
+	readonly port?: number;
 }
 
 export async function startRuntimeServer(
-  options: StartRuntimeServerOptions,
+	options: StartRuntimeServerOptions,
 ): Promise<RuntimeServer> {
-  const registry = await createRuntimeRegistry(options.appRoot)
-  const middleware = await loadMiddleware(options.appRoot)
-  const state = {
-    acceptingRequests: true,
-    activeRequests: 0,
-    closed: false,
-  }
-  const shutdownController = new AbortController()
+	const registry = await createRuntimeRegistry(options.appRoot);
+	const middleware = await loadMiddleware(options.appRoot);
+	const state = {
+		acceptingRequests: true,
+		activeRequests: 0,
+		closed: false,
+	};
+	const shutdownController = new AbortController();
 
-  const server = createServer(async (request, response) => {
-    if (!state.acceptingRequests) {
-      sendJson(response, 503, createRequestErrorBody("Server is shutting down"))
-      return
-    }
+	const server = createServer(async (request, response) => {
+		if (!state.acceptingRequests) {
+			sendJson(
+				response,
+				503,
+				createRequestErrorBody("Server is shutting down"),
+			);
+			return;
+		}
 
-    state.activeRequests++
-    try {
-      await handleRequest({
-        middleware,
-        registry,
-        request,
-        response,
-        signal: shutdownController.signal,
-      })
-    } catch (error) {
-      if (shutdownController.signal.aborted) {
-        sendJson(
-          response,
-          503,
-          createRequestErrorBody("Request canceled during server shutdown", {
-            error: error instanceof Error ? error.message : String(error),
-          }),
-        )
-        return
-      }
+		state.activeRequests++;
+		try {
+			await handleRequest({
+				middleware,
+				registry,
+				request,
+				response,
+				signal: shutdownController.signal,
+			});
+		} catch (error) {
+			if (shutdownController.signal.aborted) {
+				sendJson(
+					response,
+					503,
+					createRequestErrorBody("Request canceled during server shutdown", {
+						error: error instanceof Error ? error.message : String(error),
+					}),
+				);
+				return;
+			}
 
-      sendJson(response, 500, createExecutionErrorBody("Unexpected runtime server failure"))
-    } finally {
-      state.activeRequests--
-    }
-  })
+			sendJson(
+				response,
+				500,
+				createExecutionErrorBody("Unexpected runtime server failure"),
+			);
+		} finally {
+			state.activeRequests--;
+		}
+	});
 
-  await listen(server, options.port)
+	await listen(server, options.port);
 
-  const address = server.address()
+	const address = server.address();
 
-  if (!address || typeof address === "string") {
-    throw new Error("Runtime server did not bind to a TCP address")
-  }
+	if (!address || typeof address === "string") {
+		throw new Error("Runtime server did not bind to a TCP address");
+	}
 
-  return {
-    close: async () => {
-      if (state.closed) {
-        return
-      }
+	return {
+		close: async () => {
+			if (state.closed) {
+				return;
+			}
 
-      state.acceptingRequests = false
-      state.closed = true
-      shutdownController.abort(new Error("Runtime server shutting down"))
+			state.acceptingRequests = false;
+			state.closed = true;
+			shutdownController.abort(new Error("Runtime server shutting down"));
 
-      await new Promise<void>((resolve, reject) => {
-        server.close((error) => {
-          if (error) {
-            reject(error)
-            return
-          }
+			await new Promise<void>((resolve, reject) => {
+				server.close((error) => {
+					if (error) {
+						reject(error);
+						return;
+					}
 
-          if (state.activeRequests === 0) {
-            resolve()
-            return
-          }
+					if (state.activeRequests === 0) {
+						resolve();
+						return;
+					}
 
-          const interval = setInterval(() => {
-            if (state.activeRequests > 0) {
-              return
-            }
+					const interval = setInterval(() => {
+						if (state.activeRequests > 0) {
+							return;
+						}
 
-            clearInterval(interval)
-            resolve()
-          }, 10)
-        })
-      })
-    },
-    url: `http://127.0.0.1:${(address as AddressInfo).port}`,
-  }
+						clearInterval(interval);
+						resolve();
+					}, 10);
+				});
+			});
+		},
+		url: `http://127.0.0.1:${(address as AddressInfo).port}`,
+	};
 }
 
 async function handleRequest(options: {
-  readonly middleware: DawnMiddleware | undefined
-  readonly registry: RuntimeRegistry
-  readonly request: IncomingMessage
-  readonly response: ServerResponse
-  readonly signal: AbortSignal
+	readonly middleware: DawnMiddleware | undefined;
+	readonly registry: RuntimeRegistry;
+	readonly request: IncomingMessage;
+	readonly response: ServerResponse;
+	readonly signal: AbortSignal;
 }): Promise<void> {
-  const { middleware, request, response, registry, signal } = options
+	const { middleware, request, response, registry, signal } = options;
 
-  if (request.method === "GET" && request.url === "/healthz") {
-    sendJson(response, 200, { status: "ready" })
-    return
-  }
+	if (request.method === "GET" && request.url === "/healthz") {
+		sendJson(response, 200, { status: "ready" });
+		return;
+	}
 
-  if (request.method === "POST" && request.url === "/runs/stream") {
-    await handleStreamRequest({ middleware, registry, request, response, signal })
-    return
-  }
+	if (request.method === "POST" && request.url === "/runs/stream") {
+		await handleStreamRequest({
+			middleware,
+			registry,
+			request,
+			response,
+			signal,
+		});
+		return;
+	}
 
-  if (request.method !== "POST" || request.url !== "/runs/wait") {
-    sendJson(response, 404, createRequestErrorBody("Not found"))
-    return
-  }
+	if (request.method !== "POST" || request.url !== "/runs/wait") {
+		sendJson(response, 404, createRequestErrorBody("Not found"));
+		return;
+	}
 
-  const rawBody = await readRequestBody(request)
-  const parsedBody = parseJson(rawBody)
+	const rawBody = await readRequestBody(request);
+	const parsedBody = parseJson(rawBody);
 
-  if (!parsedBody.ok) {
-    sendJson(response, 400, createRequestErrorBody("Malformed request body"))
-    return
-  }
+	if (!parsedBody.ok) {
+		sendJson(response, 400, createRequestErrorBody("Malformed request body"));
+		return;
+	}
 
-  const validatedBody = validateRunsWaitRequest(parsedBody.value)
+	const validatedBody = validateRunsWaitRequest(parsedBody.value);
 
-  if (!validatedBody.ok) {
-    sendJson(response, 400, createRequestErrorBody(validatedBody.message, validatedBody.details))
-    return
-  }
+	if (!validatedBody.ok) {
+		sendJson(
+			response,
+			400,
+			createRequestErrorBody(validatedBody.message, validatedBody.details),
+		);
+		return;
+	}
 
-  const route = registry.lookup(validatedBody.value.assistant_id)
+	const route = registry.lookup(validatedBody.value.assistant_id);
 
-  if (!route) {
-    sendJson(
-      response,
-      404,
-      createRequestErrorBody(`Unknown assistant_id: ${validatedBody.value.assistant_id}`),
-    )
-    return
-  }
+	if (!route) {
+		sendJson(
+			response,
+			404,
+			createRequestErrorBody(
+				`Unknown assistant_id: ${validatedBody.value.assistant_id}`,
+			),
+		);
+		return;
+	}
 
-  // Run middleware before execution
-  const mwRequest: MiddlewareRequest = {
-    assistantId: route.assistantId,
-    headers: parseHeaders(request),
-    method: request.method ?? "POST",
-    params: extractRouteParams(route.routeId, validatedBody.value.input),
-    routeId: route.routeId,
-    url: request.url ?? "/runs/wait",
-  }
-  const mwResult = await runMiddleware(middleware, mwRequest)
-  if (mwResult.action === "reject") {
-    sendJson(response, mwResult.status, mwResult.body)
-    return
-  }
+	// Run middleware before execution
+	const mwRequest: MiddlewareRequest = {
+		assistantId: route.assistantId,
+		headers: parseHeaders(request),
+		method: request.method ?? "POST",
+		params: extractRouteParams(route.routeId, validatedBody.value.input),
+		routeId: route.routeId,
+		url: request.url ?? "/runs/wait",
+	};
+	const mwResult = await runMiddleware(middleware, mwRequest);
+	if (mwResult.action === "reject") {
+		sendJson(response, mwResult.status, mwResult.body);
+		return;
+	}
 
-  if (
-    validatedBody.value.metadata.dawn.route_id !== route.routeId ||
-    validatedBody.value.metadata.dawn.route_path !== route.routePath ||
-    validatedBody.value.metadata.dawn.mode !== route.mode ||
-    validatedBody.value.assistant_id !== route.assistantId
-  ) {
-    sendJson(
-      response,
-      400,
-      createRequestErrorBody("Request metadata does not match the registered route", {
-        assistant_id: validatedBody.value.assistant_id,
-        expected: {
-          assistant_id: route.assistantId,
-          mode: route.mode,
-          route_id: route.routeId,
-          route_path: route.routePath,
-        },
-        received: validatedBody.value.metadata.dawn,
-      }),
-    )
-    return
-  }
+	if (
+		validatedBody.value.metadata.dawn.route_id !== route.routeId ||
+		validatedBody.value.metadata.dawn.route_path !== route.routePath ||
+		validatedBody.value.metadata.dawn.mode !== route.mode ||
+		validatedBody.value.assistant_id !== route.assistantId
+	) {
+		sendJson(
+			response,
+			400,
+			createRequestErrorBody(
+				"Request metadata does not match the registered route",
+				{
+					assistant_id: validatedBody.value.assistant_id,
+					expected: {
+						assistant_id: route.assistantId,
+						mode: route.mode,
+						route_id: route.routeId,
+						route_path: route.routePath,
+					},
+					received: validatedBody.value.metadata.dawn,
+				},
+			),
+		);
+		return;
+	}
 
-  const resultPromise = executeResolvedRoute({
-    appRoot: registry.appRoot,
-    input: validatedBody.value.input,
-    signal,
-    routeFile: route.routeFile,
-    routeId: route.routeId,
-    routePath: route.routePath,
-  })
-  const result = await raceRequestAgainstShutdown(resultPromise, signal)
+	const resultPromise = executeResolvedRoute({
+		appRoot: registry.appRoot,
+		input: validatedBody.value.input,
+		...(mwResult.context ? { middlewareContext: mwResult.context } : {}),
+		signal,
+		routeFile: route.routeFile,
+		routeId: route.routeId,
+		routePath: route.routePath,
+	});
+	const result = await raceRequestAgainstShutdown(resultPromise, signal);
 
-  if (result === SHUTDOWN_ABORTED) {
-    sendJson(response, 503, createRequestErrorBody("Request canceled during server shutdown"))
-    return
-  }
+	if (result === SHUTDOWN_ABORTED) {
+		sendJson(
+			response,
+			503,
+			createRequestErrorBody("Request canceled during server shutdown"),
+		);
+		return;
+	}
 
-  if (result.status === "failed") {
-    if (signal.aborted) {
-      sendJson(
-        response,
-        503,
-        createRequestErrorBody("Request canceled during server shutdown", {
-          error: result.error.message,
-        }),
-      )
-      return
-    }
+	if (result.status === "failed") {
+		if (signal.aborted) {
+			sendJson(
+				response,
+				503,
+				createRequestErrorBody("Request canceled during server shutdown", {
+					error: result.error.message,
+				}),
+			);
+			return;
+		}
 
-    if (result.error.kind === "execution_error") {
-      sendJson(response, 500, createExecutionErrorBody(result.error.message, result.error.details))
-      return
-    }
+		if (result.error.kind === "execution_error") {
+			sendJson(
+				response,
+				500,
+				createExecutionErrorBody(result.error.message, result.error.details),
+			);
+			return;
+		}
 
-    sendJson(
-      response,
-      500,
-      createRequestErrorBody("Route execution failed before execution began", {
-        error: result.error,
-      }),
-    )
-    return
-  }
+		sendJson(
+			response,
+			500,
+			createRequestErrorBody("Route execution failed before execution began", {
+				error: result.error,
+			}),
+		);
+		return;
+	}
 
-  sendJson(response, 200, result.output)
+	sendJson(response, 200, result.output);
 }
 
 async function handleStreamRequest(options: {
-  readonly middleware: DawnMiddleware | undefined
-  readonly registry: RuntimeRegistry
-  readonly request: IncomingMessage
-  readonly response: ServerResponse
-  readonly signal: AbortSignal
+	readonly middleware: DawnMiddleware | undefined;
+	readonly registry: RuntimeRegistry;
+	readonly request: IncomingMessage;
+	readonly response: ServerResponse;
+	readonly signal: AbortSignal;
 }): Promise<void> {
-  const { middleware, request, response, registry, signal } = options
+	const { middleware, request, response, registry, signal } = options;
 
-  const rawBody = await readRequestBody(request)
-  const parsedBody = parseJson(rawBody)
+	const rawBody = await readRequestBody(request);
+	const parsedBody = parseJson(rawBody);
 
-  if (!parsedBody.ok) {
-    sendJson(response, 400, createRequestErrorBody("Malformed request body"))
-    return
-  }
+	if (!parsedBody.ok) {
+		sendJson(response, 400, createRequestErrorBody("Malformed request body"));
+		return;
+	}
 
-  const validatedBody = validateRunsWaitRequest(parsedBody.value)
+	const validatedBody = validateRunsWaitRequest(parsedBody.value);
 
-  if (!validatedBody.ok) {
-    sendJson(response, 400, createRequestErrorBody(validatedBody.message, validatedBody.details))
-    return
-  }
+	if (!validatedBody.ok) {
+		sendJson(
+			response,
+			400,
+			createRequestErrorBody(validatedBody.message, validatedBody.details),
+		);
+		return;
+	}
 
-  const route = registry.lookup(validatedBody.value.assistant_id)
+	const route = registry.lookup(validatedBody.value.assistant_id);
 
-  if (!route) {
-    sendJson(
-      response,
-      404,
-      createRequestErrorBody(`Unknown assistant_id: ${validatedBody.value.assistant_id}`),
-    )
-    return
-  }
+	if (!route) {
+		sendJson(
+			response,
+			404,
+			createRequestErrorBody(
+				`Unknown assistant_id: ${validatedBody.value.assistant_id}`,
+			),
+		);
+		return;
+	}
 
-  // Run middleware before streaming
-  const mwRequest: MiddlewareRequest = {
-    assistantId: route.assistantId,
-    headers: parseHeaders(request),
-    method: request.method ?? "POST",
-    params: extractRouteParams(route.routeId, validatedBody.value.input),
-    routeId: route.routeId,
-    url: request.url ?? "/runs/stream",
-  }
-  const mwResult = await runMiddleware(middleware, mwRequest)
-  if (mwResult.action === "reject") {
-    sendJson(response, mwResult.status, mwResult.body)
-    return
-  }
+	// Run middleware before streaming
+	const mwRequest: MiddlewareRequest = {
+		assistantId: route.assistantId,
+		headers: parseHeaders(request),
+		method: request.method ?? "POST",
+		params: extractRouteParams(route.routeId, validatedBody.value.input),
+		routeId: route.routeId,
+		url: request.url ?? "/runs/stream",
+	};
+	const mwResult = await runMiddleware(middleware, mwRequest);
+	if (mwResult.action === "reject") {
+		sendJson(response, mwResult.status, mwResult.body);
+		return;
+	}
 
-  response.writeHead(200, {
-    "content-type": "text/event-stream",
-    "cache-control": "no-cache",
-    connection: "keep-alive",
-  })
+	response.writeHead(200, {
+		"content-type": "text/event-stream",
+		"cache-control": "no-cache",
+		connection: "keep-alive",
+	});
 
-  try {
-    for await (const chunk of streamResolvedRoute({
-      appRoot: registry.appRoot,
-      input: validatedBody.value.input,
-      signal,
-      routeFile: route.routeFile,
-      routeId: route.routeId,
-      routePath: route.routePath,
-    })) {
-      response.write(toSseEvent(chunk))
-    }
-  } catch (error) {
-    const errorChunk: StreamChunk = {
-      type: "done",
-      output: { error: error instanceof Error ? error.message : String(error) },
-    }
-    response.write(toSseEvent(errorChunk))
-  }
+	try {
+		for await (const chunk of streamResolvedRoute({
+			appRoot: registry.appRoot,
+			input: validatedBody.value.input,
+			...(mwResult.context ? { middlewareContext: mwResult.context } : {}),
+			signal,
+			routeFile: route.routeFile,
+			routeId: route.routeId,
+			routePath: route.routePath,
+		})) {
+			response.write(toSseEvent(chunk));
+		}
+	} catch (error) {
+		const errorChunk: StreamChunk = {
+			type: "done",
+			output: { error: error instanceof Error ? error.message : String(error) },
+		};
+		response.write(toSseEvent(errorChunk));
+	}
 
-  response.end()
+	response.end();
 }
 
-const SHUTDOWN_ABORTED = Symbol("shutdown-aborted")
+const SHUTDOWN_ABORTED = Symbol("shutdown-aborted");
 
 async function raceRequestAgainstShutdown<T>(
-  execution: Promise<T>,
-  signal: AbortSignal,
+	execution: Promise<T>,
+	signal: AbortSignal,
 ): Promise<T | typeof SHUTDOWN_ABORTED> {
-  if (signal.aborted) {
-    void execution.catch(() => undefined)
-    return SHUTDOWN_ABORTED
-  }
+	if (signal.aborted) {
+		void execution.catch(() => undefined);
+		return SHUTDOWN_ABORTED;
+	}
 
-  const shutdown = new Promise<typeof SHUTDOWN_ABORTED>((resolve) => {
-    const onAbort = () => {
-      signal.removeEventListener("abort", onAbort)
-      resolve(SHUTDOWN_ABORTED)
-    }
+	const shutdown = new Promise<typeof SHUTDOWN_ABORTED>((resolve) => {
+		const onAbort = () => {
+			signal.removeEventListener("abort", onAbort);
+			resolve(SHUTDOWN_ABORTED);
+		};
 
-    signal.addEventListener("abort", onAbort, { once: true })
-  })
+		signal.addEventListener("abort", onAbort, { once: true });
+	});
 
-  const result = await Promise.race([execution, shutdown])
+	const result = await Promise.race([execution, shutdown]);
 
-  if (result === SHUTDOWN_ABORTED) {
-    void execution.catch(() => undefined)
-  }
+	if (result === SHUTDOWN_ABORTED) {
+		void execution.catch(() => undefined);
+	}
 
-  return result
+	return result;
 }
 
-function validateRunsWaitRequest(
-  value: unknown,
-):
-  | { readonly ok: true; readonly value: RunsWaitRequest }
-  | { readonly details?: Record<string, unknown>; readonly message: string; readonly ok: false } {
-  if (!isRecord(value)) {
-    return { message: "Request body must be an object", ok: false }
-  }
+function validateRunsWaitRequest(value: unknown):
+	| { readonly ok: true; readonly value: RunsWaitRequest }
+	| {
+			readonly details?: Record<string, unknown>;
+			readonly message: string;
+			readonly ok: false;
+	  } {
+	if (!isRecord(value)) {
+		return { message: "Request body must be an object", ok: false };
+	}
 
-  if (typeof value.assistant_id !== "string") {
-    return { message: "Request body must include assistant_id as a string", ok: false }
-  }
+	if (typeof value.assistant_id !== "string") {
+		return {
+			message: "Request body must include assistant_id as a string",
+			ok: false,
+		};
+	}
 
-  if (!isRecord(value.metadata) || !isRecord(value.metadata.dawn)) {
-    return { message: "Request body must include metadata.dawn", ok: false }
-  }
+	if (!isRecord(value.metadata) || !isRecord(value.metadata.dawn)) {
+		return { message: "Request body must include metadata.dawn", ok: false };
+	}
 
-  if (typeof value.metadata.dawn.mode !== "string") {
-    return { message: "Request body must include metadata.dawn.mode as a string", ok: false }
-  }
+	if (typeof value.metadata.dawn.mode !== "string") {
+		return {
+			message: "Request body must include metadata.dawn.mode as a string",
+			ok: false,
+		};
+	}
 
-  if (typeof value.metadata.dawn.route_id !== "string") {
-    return { message: "Request body must include metadata.dawn.route_id as a string", ok: false }
-  }
+	if (typeof value.metadata.dawn.route_id !== "string") {
+		return {
+			message: "Request body must include metadata.dawn.route_id as a string",
+			ok: false,
+		};
+	}
 
-  if (typeof value.metadata.dawn.route_path !== "string") {
-    return { message: "Request body must include metadata.dawn.route_path as a string", ok: false }
-  }
+	if (typeof value.metadata.dawn.route_path !== "string") {
+		return {
+			message: "Request body must include metadata.dawn.route_path as a string",
+			ok: false,
+		};
+	}
 
-  if (!Object.hasOwn(value, "input")) {
-    return { message: "Request body must include input", ok: false }
-  }
+	if (!Object.hasOwn(value, "input")) {
+		return { message: "Request body must include input", ok: false };
+	}
 
-  if (value.on_completion !== "delete") {
-    return { message: "Request body must set on_completion to delete", ok: false }
-  }
+	if (value.on_completion !== "delete") {
+		return {
+			message: "Request body must set on_completion to delete",
+			ok: false,
+		};
+	}
 
-  return {
-    ok: true as const,
-    value: value as unknown as RunsWaitRequest,
-  }
+	return {
+		ok: true as const,
+		value: value as unknown as RunsWaitRequest,
+	};
 }
 
 interface RunsWaitRequest {
-  readonly assistant_id: string
-  readonly input: unknown
-  readonly metadata: {
-    readonly dawn: {
-      readonly mode: "agent" | "chain" | "graph" | "workflow"
-      readonly route_id: string
-      readonly route_path: string
-    }
-  }
-  readonly on_completion: "delete"
+	readonly assistant_id: string;
+	readonly input: unknown;
+	readonly metadata: {
+		readonly dawn: {
+			readonly mode: "agent" | "chain" | "graph" | "workflow";
+			readonly route_id: string;
+			readonly route_path: string;
+		};
+	};
+	readonly on_completion: "delete";
 }
 
 function parseJson(
-  input: string,
+	input: string,
 ): { readonly ok: true; readonly value: unknown } | { readonly ok: false } {
-  try {
-    return {
-      ok: true,
-      value: JSON.parse(input),
-    }
-  } catch {
-    return { ok: false }
-  }
+	try {
+		return {
+			ok: true,
+			value: JSON.parse(input),
+		};
+	} catch {
+		return { ok: false };
+	}
 }
 
-function sendJson(response: ServerResponse, statusCode: number, body: unknown): void {
-  response.statusCode = statusCode
-  response.setHeader("content-type", "application/json")
-  response.end(JSON.stringify(body))
+function sendJson(
+	response: ServerResponse,
+	statusCode: number,
+	body: unknown,
+): void {
+	response.statusCode = statusCode;
+	response.setHeader("content-type", "application/json");
+	response.end(JSON.stringify(body));
 }
 
 async function readRequestBody(request: IncomingMessage): Promise<string> {
-  const chunks: Buffer[] = []
+	const chunks: Buffer[] = [];
 
-  for await (const chunk of request) {
-    chunks.push(typeof chunk === "string" ? Buffer.from(chunk) : chunk)
-  }
+	for await (const chunk of request) {
+		chunks.push(typeof chunk === "string" ? Buffer.from(chunk) : chunk);
+	}
 
-  return Buffer.concat(chunks).toString("utf8")
+	return Buffer.concat(chunks).toString("utf8");
 }
 
-async function listen(server: ReturnType<typeof createServer>, port?: number): Promise<void> {
-  await new Promise<void>((resolve, reject) => {
-    server.once("error", reject)
-    server.listen(port ?? 0, "127.0.0.1", () => {
-      server.off("error", reject)
-      resolve()
-    })
-  })
+async function listen(
+	server: ReturnType<typeof createServer>,
+	port?: number,
+): Promise<void> {
+	await new Promise<void>((resolve, reject) => {
+		server.once("error", reject);
+		server.listen(port ?? 0, "127.0.0.1", () => {
+			server.off("error", reject);
+			resolve();
+		});
+	});
 }
 
 function parseHeaders(request: IncomingMessage): Record<string, string> {
-  const headers: Record<string, string> = {}
-  for (const [key, value] of Object.entries(request.headers)) {
-    if (typeof value === "string") {
-      headers[key] = value
-    } else if (Array.isArray(value)) {
-      headers[key] = value.join(", ")
-    }
-  }
-  return headers
+	const headers: Record<string, string> = {};
+	for (const [key, value] of Object.entries(request.headers)) {
+		if (typeof value === "string") {
+			headers[key] = value;
+		} else if (Array.isArray(value)) {
+			headers[key] = value.join(", ");
+		}
+	}
+	return headers;
 }
 
-function extractRouteParams(routeId: string, input: unknown): Record<string, string> {
-  const params: Record<string, string> = {}
-  const matches = routeId.matchAll(/\[(\w+)\]/g)
-  const inputRecord = (typeof input === "object" && input !== null ? input : {}) as Record<
-    string,
-    unknown
-  >
+function extractRouteParams(
+	routeId: string,
+	input: unknown,
+): Record<string, string> {
+	const params: Record<string, string> = {};
+	const matches = routeId.matchAll(/\[(\w+)\]/g);
+	const inputRecord = (
+		typeof input === "object" && input !== null ? input : {}
+	) as Record<string, unknown>;
 
-  for (const match of matches) {
-    const name = match[1]
-    if (name && name in inputRecord) {
-      params[name] = String(inputRecord[name])
-    }
-  }
+	for (const match of matches) {
+		const name = match[1];
+		if (name && name in inputRecord) {
+			params[name] = String(inputRecord[name]);
+		}
+	}
 
-  return params
+	return params;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null
+	return typeof value === "object" && value !== null;
 }

--- a/packages/cli/src/lib/runtime/dawn-context.ts
+++ b/packages/cli/src/lib/runtime/dawn-context.ts
@@ -1,24 +1,32 @@
-import type { DiscoveredToolDefinition } from "./tool-discovery.js"
+import type { DiscoveredToolDefinition } from "./tool-discovery.js";
 
 export interface DawnRouteContext {
-  readonly signal: AbortSignal
-  readonly tools: Record<string, (input: unknown) => Promise<unknown>>
+	readonly middleware?: Readonly<Record<string, unknown>>;
+	readonly signal: AbortSignal;
+	readonly tools: Record<string, (input: unknown) => Promise<unknown>>;
 }
 
 export function createDawnContext(options: {
-  readonly signal?: AbortSignal
-  readonly tools: readonly DiscoveredToolDefinition[]
+	readonly middleware?: Readonly<Record<string, unknown>>;
+	readonly signal?: AbortSignal;
+	readonly tools: readonly DiscoveredToolDefinition[];
 }): DawnRouteContext {
-  const signal = options.signal ?? new AbortController().signal
-  const tools = Object.fromEntries(
-    options.tools.map((tool) => [
-      tool.name,
-      async (input: unknown) => await tool.run(input, { signal }),
-    ]),
-  )
+	const signal = options.signal ?? new AbortController().signal;
+	const middleware = options.middleware;
+	const tools = Object.fromEntries(
+		options.tools.map((tool) => [
+			tool.name,
+			async (input: unknown) =>
+				await tool.run(input, {
+					...(middleware ? { middleware } : {}),
+					signal,
+				}),
+		]),
+	);
 
-  return {
-    signal,
-    tools,
-  }
+	const context: DawnRouteContext = { signal, tools };
+	if (middleware) {
+		return { ...context, middleware };
+	}
+	return context;
 }

--- a/packages/cli/src/lib/runtime/dawn-context.ts
+++ b/packages/cli/src/lib/runtime/dawn-context.ts
@@ -1,32 +1,32 @@
-import type { DiscoveredToolDefinition } from "./tool-discovery.js";
+import type { DiscoveredToolDefinition } from "./tool-discovery.js"
 
 export interface DawnRouteContext {
-	readonly middleware?: Readonly<Record<string, unknown>>;
-	readonly signal: AbortSignal;
-	readonly tools: Record<string, (input: unknown) => Promise<unknown>>;
+  readonly middleware?: Readonly<Record<string, unknown>>
+  readonly signal: AbortSignal
+  readonly tools: Record<string, (input: unknown) => Promise<unknown>>
 }
 
 export function createDawnContext(options: {
-	readonly middleware?: Readonly<Record<string, unknown>>;
-	readonly signal?: AbortSignal;
-	readonly tools: readonly DiscoveredToolDefinition[];
+  readonly middleware?: Readonly<Record<string, unknown>>
+  readonly signal?: AbortSignal
+  readonly tools: readonly DiscoveredToolDefinition[]
 }): DawnRouteContext {
-	const signal = options.signal ?? new AbortController().signal;
-	const middleware = options.middleware;
-	const tools = Object.fromEntries(
-		options.tools.map((tool) => [
-			tool.name,
-			async (input: unknown) =>
-				await tool.run(input, {
-					...(middleware ? { middleware } : {}),
-					signal,
-				}),
-		]),
-	);
+  const signal = options.signal ?? new AbortController().signal
+  const middleware = options.middleware
+  const tools = Object.fromEntries(
+    options.tools.map((tool) => [
+      tool.name,
+      async (input: unknown) =>
+        await tool.run(input, {
+          ...(middleware ? { middleware } : {}),
+          signal,
+        }),
+    ]),
+  )
 
-	const context: DawnRouteContext = { signal, tools };
-	if (middleware) {
-		return { ...context, middleware };
-	}
-	return context;
+  const context: DawnRouteContext = { signal, tools }
+  if (middleware) {
+    return { ...context, middleware }
+  }
+  return context
 }

--- a/packages/cli/src/lib/runtime/execute-route.ts
+++ b/packages/cli/src/lib/runtime/execute-route.ts
@@ -1,485 +1,444 @@
-import { existsSync, readFileSync } from "node:fs";
-import { isAbsolute, join, resolve } from "node:path";
+import { existsSync, readFileSync } from "node:fs"
+import { isAbsolute, join, resolve } from "node:path"
 
+import { findDawnApp, type ResolvedStateField, resolveStateFields } from "@dawn-ai/core"
+import { executeAgent, streamAgent } from "@dawn-ai/langchain"
+import { createDawnContext } from "./dawn-context.js"
+import { normalizeRouteModule } from "./load-route-kind.js"
 import {
-	findDawnApp,
-	type ResolvedStateField,
-	resolveStateFields,
-} from "@dawn-ai/core";
-import { executeAgent, streamAgent } from "@dawn-ai/langchain";
-import { createDawnContext } from "./dawn-context.js";
-import { normalizeRouteModule } from "./load-route-kind.js";
+  createRuntimeFailureResult,
+  createRuntimeSuccessResult,
+  formatErrorMessage,
+  type RuntimeExecutionMode,
+  type RuntimeExecutionResult,
+} from "./result.js"
+import { deriveRouteIdentity } from "./route-identity.js"
+import { discoverStateDefinition } from "./state-discovery.js"
+import type { StreamChunk } from "./stream-types.js"
 import {
-	createRuntimeFailureResult,
-	createRuntimeSuccessResult,
-	formatErrorMessage,
-	type RuntimeExecutionMode,
-	type RuntimeExecutionResult,
-} from "./result.js";
-import { deriveRouteIdentity } from "./route-identity.js";
-import { discoverStateDefinition } from "./state-discovery.js";
-import type { StreamChunk } from "./stream-types.js";
-import {
-	type DiscoveredToolDefinition,
-	discoverToolDefinitions,
-	injectGeneratedSchemas,
-} from "./tool-discovery.js";
-import { fileExists } from "./utils.js";
+  type DiscoveredToolDefinition,
+  discoverToolDefinitions,
+  injectGeneratedSchemas,
+} from "./tool-discovery.js"
+import { fileExists } from "./utils.js"
 
 export interface ExecuteRouteOptions {
-	readonly appRoot?: string;
-	readonly cwd?: string;
-	readonly input: unknown;
-	readonly routeFile: string;
-	readonly signal?: AbortSignal;
+  readonly appRoot?: string
+  readonly cwd?: string
+  readonly input: unknown
+  readonly routeFile: string
+  readonly signal?: AbortSignal
 }
 
-export async function executeRoute(
-	options: ExecuteRouteOptions,
-): Promise<RuntimeExecutionResult> {
-	const startedAt = Date.now();
-	const discoveredApp = await discoverApp(options);
+export async function executeRoute(options: ExecuteRouteOptions): Promise<RuntimeExecutionResult> {
+  const startedAt = Date.now()
+  const discoveredApp = await discoverApp(options)
 
-	if (!discoveredApp.ok) {
-		return createRuntimeFailureResult({
-			appRoot: null,
-			executionSource: "in-process",
-			kind: "app_discovery_error",
-			message: discoveredApp.message,
-			routePath: options.routeFile,
-			startedAt,
-		});
-	}
+  if (!discoveredApp.ok) {
+    return createRuntimeFailureResult({
+      appRoot: null,
+      executionSource: "in-process",
+      kind: "app_discovery_error",
+      message: discoveredApp.message,
+      routePath: options.routeFile,
+      startedAt,
+    })
+  }
 
-	const appRoot = discoveredApp.appRoot;
-	const routeFile = resolveRouteFile({
-		appRoot,
-		routeFile: options.routeFile,
-		...(options.cwd ? { cwd: options.cwd } : {}),
-	});
+  const appRoot = discoveredApp.appRoot
+  const routeFile = resolveRouteFile({
+    appRoot,
+    routeFile: options.routeFile,
+    ...(options.cwd ? { cwd: options.cwd } : {}),
+  })
 
-	const identity = deriveRouteIdentity({
-		appRoot,
-		routeFile,
-		routesDir: discoveredApp.routesDir,
-	});
+  const identity = deriveRouteIdentity({
+    appRoot,
+    routeFile,
+    routesDir: discoveredApp.routesDir,
+  })
 
-	if (!identity.ok) {
-		return createRuntimeFailureResult({
-			appRoot,
-			executionSource: "in-process",
-			kind: "route_resolution_error",
-			message: `Route file is outside the configured appDir: ${routeFile}`,
-			routePath: identity.routePath,
-			startedAt,
-		});
-	}
+  if (!identity.ok) {
+    return createRuntimeFailureResult({
+      appRoot,
+      executionSource: "in-process",
+      kind: "route_resolution_error",
+      message: `Route file is outside the configured appDir: ${routeFile}`,
+      routePath: identity.routePath,
+      startedAt,
+    })
+  }
 
-	if (!(await fileExists(routeFile))) {
-		return createRuntimeFailureResult({
-			appRoot,
-			executionSource: "in-process",
-			kind: "route_resolution_error",
-			message: `Route file does not exist: ${routeFile}`,
-			routeId: identity.routeId,
-			routePath: identity.routePath,
-			startedAt,
-		});
-	}
+  if (!(await fileExists(routeFile))) {
+    return createRuntimeFailureResult({
+      appRoot,
+      executionSource: "in-process",
+      kind: "route_resolution_error",
+      message: `Route file does not exist: ${routeFile}`,
+      routeId: identity.routeId,
+      routePath: identity.routePath,
+      startedAt,
+    })
+  }
 
-	return await executeRouteAtResolvedPath({
-		appRoot,
-		input: options.input,
-		routeFile,
-		routeId: identity.routeId,
-		routePath: identity.routePath,
-		...(options.signal ? { signal: options.signal } : {}),
-		startedAt,
-	});
+  return await executeRouteAtResolvedPath({
+    appRoot,
+    input: options.input,
+    routeFile,
+    routeId: identity.routeId,
+    routePath: identity.routePath,
+    ...(options.signal ? { signal: options.signal } : {}),
+    startedAt,
+  })
 }
 
 export async function executeResolvedRoute(options: {
-	readonly appRoot: string;
-	readonly input: unknown;
-	readonly middlewareContext?: Readonly<Record<string, unknown>>;
-	readonly routeFile: string;
-	readonly routeId: string;
-	readonly routePath: string;
-	readonly signal?: AbortSignal;
+  readonly appRoot: string
+  readonly input: unknown
+  readonly middlewareContext?: Readonly<Record<string, unknown>>
+  readonly routeFile: string
+  readonly routeId: string
+  readonly routePath: string
+  readonly signal?: AbortSignal
 }): Promise<RuntimeExecutionResult> {
-	return await executeRouteAtResolvedPath({
-		...options,
-		startedAt: Date.now(),
-	});
+  return await executeRouteAtResolvedPath({
+    ...options,
+    startedAt: Date.now(),
+  })
 }
 
 export async function* streamResolvedRoute(options: {
-	readonly appRoot: string;
-	readonly input: unknown;
-	readonly middlewareContext?: Readonly<Record<string, unknown>>;
-	readonly routeFile: string;
-	readonly routeId: string;
-	readonly routePath: string;
-	readonly signal?: AbortSignal;
+  readonly appRoot: string
+  readonly input: unknown
+  readonly middlewareContext?: Readonly<Record<string, unknown>>
+  readonly routeFile: string
+  readonly routeId: string
+  readonly routePath: string
+  readonly signal?: AbortSignal
 }): AsyncGenerator<StreamChunk> {
-	const prepared = await prepareRouteExecution(options);
+  const prepared = await prepareRouteExecution(options)
 
-	if (!prepared.ok) {
-		yield { type: "done", output: { error: prepared.message } };
-		return;
-	}
+  if (!prepared.ok) {
+    yield { type: "done", output: { error: prepared.message } }
+    return
+  }
 
-	const { normalized, tools, stateFields } = prepared;
+  const { normalized, tools, stateFields } = prepared
 
-	if (normalized.kind !== "agent") {
-		// Non-agent routes don't support incremental streaming — execute and emit done
-		const context = createDawnContext({
-			...(options.middlewareContext
-				? { middleware: options.middlewareContext }
-				: {}),
-			tools,
-			...(options.signal ? { signal: options.signal } : {}),
-		});
-		const output = await invokeEntry(
-			normalized.kind,
-			normalized.entry,
-			options.input,
-			context,
-		);
-		yield { type: "done", output };
-		return;
-	}
+  if (normalized.kind !== "agent") {
+    // Non-agent routes don't support incremental streaming — execute and emit done
+    const context = createDawnContext({
+      ...(options.middlewareContext ? { middleware: options.middlewareContext } : {}),
+      tools,
+      ...(options.signal ? { signal: options.signal } : {}),
+    })
+    const output = await invokeEntry(normalized.kind, normalized.entry, options.input, context)
+    yield { type: "done", output }
+    return
+  }
 
-	const routeParamNames = extractRouteParamNames(options.routeId);
+  const routeParamNames = extractRouteParamNames(options.routeId)
 
-	for await (const chunk of streamAgent({
-		entry: normalized.entry,
-		input: options.input,
-		...(options.middlewareContext
-			? { middlewareContext: options.middlewareContext }
-			: {}),
-		routeParamNames,
-		signal: options.signal ?? new AbortController().signal,
-		...(stateFields ? { stateFields } : {}),
-		tools,
-	})) {
-		switch (chunk.type) {
-			case "token":
-				yield { type: "chunk", data: chunk.data };
-				break;
-			case "tool_call": {
-				const tc = chunk.data as { name: string; input: unknown };
-				yield { type: "tool_call", name: tc.name, input: tc.input };
-				break;
-			}
-			case "tool_result": {
-				const tr = chunk.data as { name: string; output: unknown };
-				yield { type: "tool_result", name: tr.name, output: tr.output };
-				break;
-			}
-			case "done":
-				yield { type: "done", output: chunk.data };
-				break;
-		}
-	}
+  for await (const chunk of streamAgent({
+    entry: normalized.entry,
+    input: options.input,
+    ...(options.middlewareContext ? { middlewareContext: options.middlewareContext } : {}),
+    routeParamNames,
+    signal: options.signal ?? new AbortController().signal,
+    ...(stateFields ? { stateFields } : {}),
+    tools,
+  })) {
+    switch (chunk.type) {
+      case "token":
+        yield { type: "chunk", data: chunk.data }
+        break
+      case "tool_call": {
+        const tc = chunk.data as { name: string; input: unknown }
+        yield { type: "tool_call", name: tc.name, input: tc.input }
+        break
+      }
+      case "tool_result": {
+        const tr = chunk.data as { name: string; output: unknown }
+        yield { type: "tool_result", name: tr.name, output: tr.output }
+        break
+      }
+      case "done":
+        yield { type: "done", output: chunk.data }
+        break
+    }
+  }
 }
 
 interface PreparedRoute {
-	readonly normalized: {
-		readonly kind: "agent" | "chain" | "graph" | "workflow";
-		readonly entry: unknown;
-	};
-	readonly ok: true;
-	readonly stateFields: readonly ResolvedStateField[] | undefined;
-	readonly tools: readonly DiscoveredToolDefinition[];
+  readonly normalized: {
+    readonly kind: "agent" | "chain" | "graph" | "workflow"
+    readonly entry: unknown
+  }
+  readonly ok: true
+  readonly stateFields: readonly ResolvedStateField[] | undefined
+  readonly tools: readonly DiscoveredToolDefinition[]
 }
 
 interface PreparedRouteError {
-	readonly message: string;
-	readonly ok: false;
+  readonly message: string
+  readonly ok: false
 }
 
 async function prepareRouteExecution(options: {
-	readonly appRoot: string;
-	readonly routeFile: string;
-	readonly routeId: string;
+  readonly appRoot: string
+  readonly routeFile: string
+  readonly routeId: string
 }): Promise<PreparedRoute | PreparedRouteError> {
-	const routeDir = resolve(options.routeFile, "..");
+  const routeDir = resolve(options.routeFile, "..")
 
-	const normalized = await normalizeRouteModule(options.routeFile);
+  const normalized = await normalizeRouteModule(options.routeFile)
 
-	const discoveredTools = await discoverToolDefinitions({
-		appRoot: options.appRoot,
-		routeDir,
-	});
+  const discoveredTools = await discoverToolDefinitions({
+    appRoot: options.appRoot,
+    routeDir,
+  })
 
-	// Inject codegen-generated schemas for tools without explicit schema exports
-	const routeId =
-		options.routeId
-			.replace(/^\//, "")
-			.replace(/\//g, "-")
-			.replace(/\[/g, "")
-			.replace(/\]/g, "") || "index";
-	const schemaManifestPath = join(
-		options.appRoot,
-		".dawn",
-		"routes",
-		routeId,
-		"tools.json",
-	);
-	let tools = discoveredTools;
-	if (existsSync(schemaManifestPath)) {
-		try {
-			const manifest = JSON.parse(
-				readFileSync(schemaManifestPath, "utf-8"),
-			) as Record<string, unknown>;
-			tools = injectGeneratedSchemas(discoveredTools, manifest);
-		} catch {
-			// Generated schema is best-effort — fall through on parse errors
-		}
-	}
+  // Inject codegen-generated schemas for tools without explicit schema exports
+  const routeId =
+    options.routeId.replace(/^\//, "").replace(/\//g, "-").replace(/\[/g, "").replace(/\]/g, "") ||
+    "index"
+  const schemaManifestPath = join(options.appRoot, ".dawn", "routes", routeId, "tools.json")
+  let tools = discoveredTools
+  if (existsSync(schemaManifestPath)) {
+    try {
+      const manifest = JSON.parse(readFileSync(schemaManifestPath, "utf-8")) as Record<
+        string,
+        unknown
+      >
+      tools = injectGeneratedSchemas(discoveredTools, manifest)
+    } catch {
+      // Generated schema is best-effort — fall through on parse errors
+    }
+  }
 
-	let stateFields: readonly ResolvedStateField[] | undefined;
-	if (normalized.kind === "agent") {
-		const stateDefinition = await discoverStateDefinition({ routeDir });
-		if (stateDefinition) {
-			stateFields = resolveStateFields({
-				defaults: stateDefinition.defaults,
-				reducerOverrides: stateDefinition.reducerOverrides,
-			});
-		}
-	}
+  let stateFields: readonly ResolvedStateField[] | undefined
+  if (normalized.kind === "agent") {
+    const stateDefinition = await discoverStateDefinition({ routeDir })
+    if (stateDefinition) {
+      stateFields = resolveStateFields({
+        defaults: stateDefinition.defaults,
+        reducerOverrides: stateDefinition.reducerOverrides,
+      })
+    }
+  }
 
-	return { normalized, ok: true, stateFields, tools };
+  return { normalized, ok: true, stateFields, tools }
 }
 
 async function executeRouteAtResolvedPath(options: {
-	readonly appRoot: string;
-	readonly input: unknown;
-	readonly middlewareContext?: Readonly<Record<string, unknown>>;
-	readonly routeFile: string;
-	readonly routeId: string;
-	readonly routePath: string;
-	readonly signal?: AbortSignal;
-	readonly startedAt: number;
+  readonly appRoot: string
+  readonly input: unknown
+  readonly middlewareContext?: Readonly<Record<string, unknown>>
+  readonly routeFile: string
+  readonly routeId: string
+  readonly routePath: string
+  readonly signal?: AbortSignal
+  readonly startedAt: number
 }): Promise<RuntimeExecutionResult> {
-	let mode: RuntimeExecutionMode | null = null;
+  let mode: RuntimeExecutionMode | null = null
 
-	try {
-		const prepared = await prepareRouteExecution(options);
+  try {
+    const prepared = await prepareRouteExecution(options)
 
-		if (!prepared.ok) {
-			return createRuntimeFailureResult({
-				appRoot: options.appRoot,
-				executionSource: "in-process",
-				kind: "execution_error",
-				message: prepared.message,
-				mode,
-				routeId: options.routeId,
-				routePath: options.routePath,
-				startedAt: options.startedAt,
-			});
-		}
+    if (!prepared.ok) {
+      return createRuntimeFailureResult({
+        appRoot: options.appRoot,
+        executionSource: "in-process",
+        kind: "execution_error",
+        message: prepared.message,
+        mode,
+        routeId: options.routeId,
+        routePath: options.routePath,
+        startedAt: options.startedAt,
+      })
+    }
 
-		const { normalized, tools, stateFields } = prepared;
-		mode = normalized.kind;
+    const { normalized, tools, stateFields } = prepared
+    mode = normalized.kind
 
-		const context = createDawnContext({
-			...(options.middlewareContext
-				? { middleware: options.middlewareContext }
-				: {}),
-			tools,
-			...(options.signal ? { signal: options.signal } : {}),
-		});
+    const context = createDawnContext({
+      ...(options.middlewareContext ? { middleware: options.middlewareContext } : {}),
+      tools,
+      ...(options.signal ? { signal: options.signal } : {}),
+    })
 
-		const output = await invokeEntry(
-			normalized.kind,
-			normalized.entry,
-			options.input,
-			context,
-			{
-				...(options.middlewareContext
-					? { middlewareContext: options.middlewareContext }
-					: {}),
-				routeId: options.routeId,
-				...(stateFields ? { stateFields } : {}),
-				tools,
-				...(options.signal ? { signal: options.signal } : {}),
-			},
-		);
+    const output = await invokeEntry(normalized.kind, normalized.entry, options.input, context, {
+      ...(options.middlewareContext ? { middlewareContext: options.middlewareContext } : {}),
+      routeId: options.routeId,
+      ...(stateFields ? { stateFields } : {}),
+      tools,
+      ...(options.signal ? { signal: options.signal } : {}),
+    })
 
-		return createRuntimeSuccessResult({
-			appRoot: options.appRoot,
-			executionSource: "in-process",
-			mode: normalized.kind,
-			output,
-			routeId: options.routeId,
-			routePath: options.routePath,
-			startedAt: options.startedAt,
-		});
-	} catch (error) {
-		const kind = isBoundaryError(error)
-			? "unsupported_route_boundary"
-			: "execution_error";
-		const message = formatErrorMessage(error);
+    return createRuntimeSuccessResult({
+      appRoot: options.appRoot,
+      executionSource: "in-process",
+      mode: normalized.kind,
+      output,
+      routeId: options.routeId,
+      routePath: options.routePath,
+      startedAt: options.startedAt,
+    })
+  } catch (error) {
+    const kind = isBoundaryError(error) ? "unsupported_route_boundary" : "execution_error"
+    const message = formatErrorMessage(error)
 
-		return createRuntimeFailureResult({
-			appRoot: options.appRoot,
-			executionSource: "in-process",
-			kind,
-			message,
-			mode,
-			routeId: options.routeId,
-			routePath: options.routePath,
-			startedAt: options.startedAt,
-		});
-	}
+    return createRuntimeFailureResult({
+      appRoot: options.appRoot,
+      executionSource: "in-process",
+      kind,
+      message,
+      mode,
+      routeId: options.routeId,
+      routePath: options.routePath,
+      startedAt: options.startedAt,
+    })
+  }
 }
 
 async function invokeEntry(
-	kind: "agent" | "chain" | "graph" | "workflow",
-	entry: unknown,
-	input: unknown,
-	context: unknown,
-	agentContext?: {
-		readonly middlewareContext?: Readonly<Record<string, unknown>>;
-		readonly routeId: string;
-		readonly signal?: AbortSignal;
-		readonly stateFields?: readonly ResolvedStateField[];
-		readonly tools: ReadonlyArray<{
-			readonly description?: string;
-			readonly name: string;
-			readonly run: (
-				input: unknown,
-				context: {
-					readonly middleware?: Readonly<Record<string, unknown>>;
-					readonly signal: AbortSignal;
-				},
-			) => Promise<unknown> | unknown;
-			readonly schema?: unknown;
-		}>;
-	},
+  kind: "agent" | "chain" | "graph" | "workflow",
+  entry: unknown,
+  input: unknown,
+  context: unknown,
+  agentContext?: {
+    readonly middlewareContext?: Readonly<Record<string, unknown>>
+    readonly routeId: string
+    readonly signal?: AbortSignal
+    readonly stateFields?: readonly ResolvedStateField[]
+    readonly tools: ReadonlyArray<{
+      readonly description?: string
+      readonly name: string
+      readonly run: (
+        input: unknown,
+        context: {
+          readonly middleware?: Readonly<Record<string, unknown>>
+          readonly signal: AbortSignal
+        },
+      ) => Promise<unknown> | unknown
+      readonly schema?: unknown
+    }>
+  },
 ): Promise<unknown> {
-	if (kind === "agent") {
-		const routeParamNames = extractRouteParamNames(agentContext?.routeId ?? "");
-		return await executeAgent({
-			entry,
-			input,
-			...(agentContext?.middlewareContext
-				? { middlewareContext: agentContext.middlewareContext }
-				: {}),
-			routeParamNames,
-			signal: agentContext?.signal ?? new AbortController().signal,
-			...(agentContext?.stateFields
-				? { stateFields: agentContext.stateFields }
-				: {}),
-			tools: agentContext?.tools ?? [],
-		});
-	}
+  if (kind === "agent") {
+    const routeParamNames = extractRouteParamNames(agentContext?.routeId ?? "")
+    return await executeAgent({
+      entry,
+      input,
+      ...(agentContext?.middlewareContext
+        ? { middlewareContext: agentContext.middlewareContext }
+        : {}),
+      routeParamNames,
+      signal: agentContext?.signal ?? new AbortController().signal,
+      ...(agentContext?.stateFields ? { stateFields: agentContext.stateFields } : {}),
+      tools: agentContext?.tools ?? [],
+    })
+  }
 
-	if (kind === "workflow") {
-		if (typeof entry !== "function") {
-			throw new Error("Workflow entry must be a function");
-		}
-		return await entry(input, context);
-	}
+  if (kind === "workflow") {
+    if (typeof entry !== "function") {
+      throw new Error("Workflow entry must be a function")
+    }
+    return await entry(input, context)
+  }
 
-	if (kind === "chain") {
-		if (
-			typeof entry === "object" &&
-			entry !== null &&
-			"invoke" in entry &&
-			typeof (entry as { invoke?: unknown }).invoke === "function"
-		) {
-			return await (entry as { invoke: (input: unknown) => unknown }).invoke(
-				input,
-			);
-		}
-		throw new Error("Chain entry must expose invoke(input)");
-	}
+  if (kind === "chain") {
+    if (
+      typeof entry === "object" &&
+      entry !== null &&
+      "invoke" in entry &&
+      typeof (entry as { invoke?: unknown }).invoke === "function"
+    ) {
+      return await (entry as { invoke: (input: unknown) => unknown }).invoke(input)
+    }
+    throw new Error("Chain entry must expose invoke(input)")
+  }
 
-	if (typeof entry === "function") {
-		return await entry(input, context);
-	}
+  if (typeof entry === "function") {
+    return await entry(input, context)
+  }
 
-	if (
-		typeof entry === "object" &&
-		entry !== null &&
-		"invoke" in entry &&
-		typeof (entry as { invoke?: unknown }).invoke === "function"
-	) {
-		return await (
-			entry as { invoke: (input: unknown, context: unknown) => unknown }
-		).invoke(input, context);
-	}
+  if (
+    typeof entry === "object" &&
+    entry !== null &&
+    "invoke" in entry &&
+    typeof (entry as { invoke?: unknown }).invoke === "function"
+  ) {
+    return await (entry as { invoke: (input: unknown, context: unknown) => unknown }).invoke(
+      input,
+      context,
+    )
+  }
 
-	throw new Error("Graph entry must be a function or expose invoke(input)");
+  throw new Error("Graph entry must be a function or expose invoke(input)")
 }
 
 function resolveRouteFile(options: {
-	readonly appRoot: string;
-	readonly cwd?: string;
-	readonly routeFile: string;
+  readonly appRoot: string
+  readonly cwd?: string
+  readonly routeFile: string
 }): string {
-	if (isAbsolute(options.routeFile)) {
-		return resolve(options.routeFile);
-	}
+  if (isAbsolute(options.routeFile)) {
+    return resolve(options.routeFile)
+  }
 
-	if (options.routeFile.startsWith(".") || options.routeFile.startsWith("..")) {
-		return resolve(options.cwd ?? process.cwd(), options.routeFile);
-	}
+  if (options.routeFile.startsWith(".") || options.routeFile.startsWith("..")) {
+    return resolve(options.cwd ?? process.cwd(), options.routeFile)
+  }
 
-	return resolve(options.appRoot, options.routeFile);
+  return resolve(options.appRoot, options.routeFile)
 }
 
 async function discoverApp(options: ExecuteRouteOptions): Promise<
-	| {
-			readonly appRoot: string;
-			readonly ok: true;
-			readonly routesDir: string;
-	  }
-	| {
-			readonly message: string;
-			readonly ok: false;
-	  }
+  | {
+      readonly appRoot: string
+      readonly ok: true
+      readonly routesDir: string
+    }
+  | {
+      readonly message: string
+      readonly ok: false
+    }
 > {
-	try {
-		const app = await findDawnApp({
-			...(options.appRoot ? { appRoot: options.appRoot } : {}),
-			...(options.cwd ? { cwd: options.cwd } : {}),
-		});
+  try {
+    const app = await findDawnApp({
+      ...(options.appRoot ? { appRoot: options.appRoot } : {}),
+      ...(options.cwd ? { cwd: options.cwd } : {}),
+    })
 
-		return {
-			appRoot: app.appRoot,
-			ok: true,
-			routesDir: app.routesDir,
-		};
-	} catch (error) {
-		return {
-			message: formatErrorMessage(error),
-			ok: false,
-		};
-	}
+    return {
+      appRoot: app.appRoot,
+      ok: true,
+      routesDir: app.routesDir,
+    }
+  } catch (error) {
+    return {
+      message: formatErrorMessage(error),
+      ok: false,
+    }
+  }
 }
 
 function extractRouteParamNames(routeId: string): string[] {
-	const matches = routeId.matchAll(/\[(\w+)\]/g);
-	return [...matches]
-		.map((match) => match[1])
-		.filter((s): s is string => s !== undefined);
+  const matches = routeId.matchAll(/\[(\w+)\]/g)
+  return [...matches].map((match) => match[1]).filter((s): s is string => s !== undefined)
 }
 
 function isBoundaryError(error: unknown): boolean {
-	if (!(error instanceof Error)) {
-		return false;
-	}
+  if (!(error instanceof Error)) {
+    return false
+  }
 
-	return (
-		/must export exactly one of/.test(error.message) ||
-		/exports neither/.test(error.message) ||
-		error.message === "Workflow entry must be a function" ||
-		error.message ===
-			"Graph entry must be a function or expose invoke(input)" ||
-		error.message === "Chain entry must expose invoke(input)"
-	);
+  return (
+    /must export exactly one of/.test(error.message) ||
+    /exports neither/.test(error.message) ||
+    error.message === "Workflow entry must be a function" ||
+    error.message === "Graph entry must be a function or expose invoke(input)" ||
+    error.message === "Chain entry must expose invoke(input)"
+  )
 }

--- a/packages/cli/src/lib/runtime/execute-route.ts
+++ b/packages/cli/src/lib/runtime/execute-route.ts
@@ -1,430 +1,485 @@
-import { existsSync, readFileSync } from "node:fs"
-import { isAbsolute, join, resolve } from "node:path"
+import { existsSync, readFileSync } from "node:fs";
+import { isAbsolute, join, resolve } from "node:path";
 
-import { findDawnApp, type ResolvedStateField, resolveStateFields } from "@dawn-ai/core"
-import { executeAgent, streamAgent } from "@dawn-ai/langchain"
-import { createDawnContext } from "./dawn-context.js"
-import { normalizeRouteModule } from "./load-route-kind.js"
 import {
-  createRuntimeFailureResult,
-  createRuntimeSuccessResult,
-  formatErrorMessage,
-  type RuntimeExecutionMode,
-  type RuntimeExecutionResult,
-} from "./result.js"
-import { deriveRouteIdentity } from "./route-identity.js"
-import { discoverStateDefinition } from "./state-discovery.js"
-import type { StreamChunk } from "./stream-types.js"
+	findDawnApp,
+	type ResolvedStateField,
+	resolveStateFields,
+} from "@dawn-ai/core";
+import { executeAgent, streamAgent } from "@dawn-ai/langchain";
+import { createDawnContext } from "./dawn-context.js";
+import { normalizeRouteModule } from "./load-route-kind.js";
 import {
-  type DiscoveredToolDefinition,
-  discoverToolDefinitions,
-  injectGeneratedSchemas,
-} from "./tool-discovery.js"
-import { fileExists } from "./utils.js"
+	createRuntimeFailureResult,
+	createRuntimeSuccessResult,
+	formatErrorMessage,
+	type RuntimeExecutionMode,
+	type RuntimeExecutionResult,
+} from "./result.js";
+import { deriveRouteIdentity } from "./route-identity.js";
+import { discoverStateDefinition } from "./state-discovery.js";
+import type { StreamChunk } from "./stream-types.js";
+import {
+	type DiscoveredToolDefinition,
+	discoverToolDefinitions,
+	injectGeneratedSchemas,
+} from "./tool-discovery.js";
+import { fileExists } from "./utils.js";
 
 export interface ExecuteRouteOptions {
-  readonly appRoot?: string
-  readonly cwd?: string
-  readonly input: unknown
-  readonly routeFile: string
-  readonly signal?: AbortSignal
+	readonly appRoot?: string;
+	readonly cwd?: string;
+	readonly input: unknown;
+	readonly routeFile: string;
+	readonly signal?: AbortSignal;
 }
 
-export async function executeRoute(options: ExecuteRouteOptions): Promise<RuntimeExecutionResult> {
-  const startedAt = Date.now()
-  const discoveredApp = await discoverApp(options)
+export async function executeRoute(
+	options: ExecuteRouteOptions,
+): Promise<RuntimeExecutionResult> {
+	const startedAt = Date.now();
+	const discoveredApp = await discoverApp(options);
 
-  if (!discoveredApp.ok) {
-    return createRuntimeFailureResult({
-      appRoot: null,
-      executionSource: "in-process",
-      kind: "app_discovery_error",
-      message: discoveredApp.message,
-      routePath: options.routeFile,
-      startedAt,
-    })
-  }
+	if (!discoveredApp.ok) {
+		return createRuntimeFailureResult({
+			appRoot: null,
+			executionSource: "in-process",
+			kind: "app_discovery_error",
+			message: discoveredApp.message,
+			routePath: options.routeFile,
+			startedAt,
+		});
+	}
 
-  const appRoot = discoveredApp.appRoot
-  const routeFile = resolveRouteFile({
-    appRoot,
-    routeFile: options.routeFile,
-    ...(options.cwd ? { cwd: options.cwd } : {}),
-  })
+	const appRoot = discoveredApp.appRoot;
+	const routeFile = resolveRouteFile({
+		appRoot,
+		routeFile: options.routeFile,
+		...(options.cwd ? { cwd: options.cwd } : {}),
+	});
 
-  const identity = deriveRouteIdentity({
-    appRoot,
-    routeFile,
-    routesDir: discoveredApp.routesDir,
-  })
+	const identity = deriveRouteIdentity({
+		appRoot,
+		routeFile,
+		routesDir: discoveredApp.routesDir,
+	});
 
-  if (!identity.ok) {
-    return createRuntimeFailureResult({
-      appRoot,
-      executionSource: "in-process",
-      kind: "route_resolution_error",
-      message: `Route file is outside the configured appDir: ${routeFile}`,
-      routePath: identity.routePath,
-      startedAt,
-    })
-  }
+	if (!identity.ok) {
+		return createRuntimeFailureResult({
+			appRoot,
+			executionSource: "in-process",
+			kind: "route_resolution_error",
+			message: `Route file is outside the configured appDir: ${routeFile}`,
+			routePath: identity.routePath,
+			startedAt,
+		});
+	}
 
-  if (!(await fileExists(routeFile))) {
-    return createRuntimeFailureResult({
-      appRoot,
-      executionSource: "in-process",
-      kind: "route_resolution_error",
-      message: `Route file does not exist: ${routeFile}`,
-      routeId: identity.routeId,
-      routePath: identity.routePath,
-      startedAt,
-    })
-  }
+	if (!(await fileExists(routeFile))) {
+		return createRuntimeFailureResult({
+			appRoot,
+			executionSource: "in-process",
+			kind: "route_resolution_error",
+			message: `Route file does not exist: ${routeFile}`,
+			routeId: identity.routeId,
+			routePath: identity.routePath,
+			startedAt,
+		});
+	}
 
-  return await executeRouteAtResolvedPath({
-    appRoot,
-    input: options.input,
-    routeFile,
-    routeId: identity.routeId,
-    routePath: identity.routePath,
-    ...(options.signal ? { signal: options.signal } : {}),
-    startedAt,
-  })
+	return await executeRouteAtResolvedPath({
+		appRoot,
+		input: options.input,
+		routeFile,
+		routeId: identity.routeId,
+		routePath: identity.routePath,
+		...(options.signal ? { signal: options.signal } : {}),
+		startedAt,
+	});
 }
 
 export async function executeResolvedRoute(options: {
-  readonly appRoot: string
-  readonly input: unknown
-  readonly routeFile: string
-  readonly routeId: string
-  readonly routePath: string
-  readonly signal?: AbortSignal
+	readonly appRoot: string;
+	readonly input: unknown;
+	readonly middlewareContext?: Readonly<Record<string, unknown>>;
+	readonly routeFile: string;
+	readonly routeId: string;
+	readonly routePath: string;
+	readonly signal?: AbortSignal;
 }): Promise<RuntimeExecutionResult> {
-  return await executeRouteAtResolvedPath({
-    ...options,
-    startedAt: Date.now(),
-  })
+	return await executeRouteAtResolvedPath({
+		...options,
+		startedAt: Date.now(),
+	});
 }
 
 export async function* streamResolvedRoute(options: {
-  readonly appRoot: string
-  readonly input: unknown
-  readonly routeFile: string
-  readonly routeId: string
-  readonly routePath: string
-  readonly signal?: AbortSignal
+	readonly appRoot: string;
+	readonly input: unknown;
+	readonly middlewareContext?: Readonly<Record<string, unknown>>;
+	readonly routeFile: string;
+	readonly routeId: string;
+	readonly routePath: string;
+	readonly signal?: AbortSignal;
 }): AsyncGenerator<StreamChunk> {
-  const prepared = await prepareRouteExecution(options)
+	const prepared = await prepareRouteExecution(options);
 
-  if (!prepared.ok) {
-    yield { type: "done", output: { error: prepared.message } }
-    return
-  }
+	if (!prepared.ok) {
+		yield { type: "done", output: { error: prepared.message } };
+		return;
+	}
 
-  const { normalized, tools, stateFields } = prepared
+	const { normalized, tools, stateFields } = prepared;
 
-  if (normalized.kind !== "agent") {
-    // Non-agent routes don't support incremental streaming — execute and emit done
-    const context = createDawnContext({
-      tools,
-      ...(options.signal ? { signal: options.signal } : {}),
-    })
-    const output = await invokeEntry(normalized.kind, normalized.entry, options.input, context)
-    yield { type: "done", output }
-    return
-  }
+	if (normalized.kind !== "agent") {
+		// Non-agent routes don't support incremental streaming — execute and emit done
+		const context = createDawnContext({
+			...(options.middlewareContext
+				? { middleware: options.middlewareContext }
+				: {}),
+			tools,
+			...(options.signal ? { signal: options.signal } : {}),
+		});
+		const output = await invokeEntry(
+			normalized.kind,
+			normalized.entry,
+			options.input,
+			context,
+		);
+		yield { type: "done", output };
+		return;
+	}
 
-  const routeParamNames = extractRouteParamNames(options.routeId)
+	const routeParamNames = extractRouteParamNames(options.routeId);
 
-  for await (const chunk of streamAgent({
-    entry: normalized.entry,
-    input: options.input,
-    routeParamNames,
-    signal: options.signal ?? new AbortController().signal,
-    ...(stateFields ? { stateFields } : {}),
-    tools,
-  })) {
-    switch (chunk.type) {
-      case "token":
-        yield { type: "chunk", data: chunk.data }
-        break
-      case "tool_call": {
-        const tc = chunk.data as { name: string; input: unknown }
-        yield { type: "tool_call", name: tc.name, input: tc.input }
-        break
-      }
-      case "tool_result": {
-        const tr = chunk.data as { name: string; output: unknown }
-        yield { type: "tool_result", name: tr.name, output: tr.output }
-        break
-      }
-      case "done":
-        yield { type: "done", output: chunk.data }
-        break
-    }
-  }
+	for await (const chunk of streamAgent({
+		entry: normalized.entry,
+		input: options.input,
+		...(options.middlewareContext
+			? { middlewareContext: options.middlewareContext }
+			: {}),
+		routeParamNames,
+		signal: options.signal ?? new AbortController().signal,
+		...(stateFields ? { stateFields } : {}),
+		tools,
+	})) {
+		switch (chunk.type) {
+			case "token":
+				yield { type: "chunk", data: chunk.data };
+				break;
+			case "tool_call": {
+				const tc = chunk.data as { name: string; input: unknown };
+				yield { type: "tool_call", name: tc.name, input: tc.input };
+				break;
+			}
+			case "tool_result": {
+				const tr = chunk.data as { name: string; output: unknown };
+				yield { type: "tool_result", name: tr.name, output: tr.output };
+				break;
+			}
+			case "done":
+				yield { type: "done", output: chunk.data };
+				break;
+		}
+	}
 }
 
 interface PreparedRoute {
-  readonly normalized: {
-    readonly kind: "agent" | "chain" | "graph" | "workflow"
-    readonly entry: unknown
-  }
-  readonly ok: true
-  readonly stateFields: readonly ResolvedStateField[] | undefined
-  readonly tools: readonly DiscoveredToolDefinition[]
+	readonly normalized: {
+		readonly kind: "agent" | "chain" | "graph" | "workflow";
+		readonly entry: unknown;
+	};
+	readonly ok: true;
+	readonly stateFields: readonly ResolvedStateField[] | undefined;
+	readonly tools: readonly DiscoveredToolDefinition[];
 }
 
 interface PreparedRouteError {
-  readonly message: string
-  readonly ok: false
+	readonly message: string;
+	readonly ok: false;
 }
 
 async function prepareRouteExecution(options: {
-  readonly appRoot: string
-  readonly routeFile: string
-  readonly routeId: string
+	readonly appRoot: string;
+	readonly routeFile: string;
+	readonly routeId: string;
 }): Promise<PreparedRoute | PreparedRouteError> {
-  const routeDir = resolve(options.routeFile, "..")
+	const routeDir = resolve(options.routeFile, "..");
 
-  const normalized = await normalizeRouteModule(options.routeFile)
+	const normalized = await normalizeRouteModule(options.routeFile);
 
-  const discoveredTools = await discoverToolDefinitions({
-    appRoot: options.appRoot,
-    routeDir,
-  })
+	const discoveredTools = await discoverToolDefinitions({
+		appRoot: options.appRoot,
+		routeDir,
+	});
 
-  // Inject codegen-generated schemas for tools without explicit schema exports
-  const routeId =
-    options.routeId.replace(/^\//, "").replace(/\//g, "-").replace(/\[/g, "").replace(/\]/g, "") ||
-    "index"
-  const schemaManifestPath = join(options.appRoot, ".dawn", "routes", routeId, "tools.json")
-  let tools = discoveredTools
-  if (existsSync(schemaManifestPath)) {
-    try {
-      const manifest = JSON.parse(readFileSync(schemaManifestPath, "utf-8")) as Record<
-        string,
-        unknown
-      >
-      tools = injectGeneratedSchemas(discoveredTools, manifest)
-    } catch {
-      // Generated schema is best-effort — fall through on parse errors
-    }
-  }
+	// Inject codegen-generated schemas for tools without explicit schema exports
+	const routeId =
+		options.routeId
+			.replace(/^\//, "")
+			.replace(/\//g, "-")
+			.replace(/\[/g, "")
+			.replace(/\]/g, "") || "index";
+	const schemaManifestPath = join(
+		options.appRoot,
+		".dawn",
+		"routes",
+		routeId,
+		"tools.json",
+	);
+	let tools = discoveredTools;
+	if (existsSync(schemaManifestPath)) {
+		try {
+			const manifest = JSON.parse(
+				readFileSync(schemaManifestPath, "utf-8"),
+			) as Record<string, unknown>;
+			tools = injectGeneratedSchemas(discoveredTools, manifest);
+		} catch {
+			// Generated schema is best-effort — fall through on parse errors
+		}
+	}
 
-  let stateFields: readonly ResolvedStateField[] | undefined
-  if (normalized.kind === "agent") {
-    const stateDefinition = await discoverStateDefinition({ routeDir })
-    if (stateDefinition) {
-      stateFields = resolveStateFields({
-        defaults: stateDefinition.defaults,
-        reducerOverrides: stateDefinition.reducerOverrides,
-      })
-    }
-  }
+	let stateFields: readonly ResolvedStateField[] | undefined;
+	if (normalized.kind === "agent") {
+		const stateDefinition = await discoverStateDefinition({ routeDir });
+		if (stateDefinition) {
+			stateFields = resolveStateFields({
+				defaults: stateDefinition.defaults,
+				reducerOverrides: stateDefinition.reducerOverrides,
+			});
+		}
+	}
 
-  return { normalized, ok: true, stateFields, tools }
+	return { normalized, ok: true, stateFields, tools };
 }
 
 async function executeRouteAtResolvedPath(options: {
-  readonly appRoot: string
-  readonly input: unknown
-  readonly routeFile: string
-  readonly routeId: string
-  readonly routePath: string
-  readonly signal?: AbortSignal
-  readonly startedAt: number
+	readonly appRoot: string;
+	readonly input: unknown;
+	readonly middlewareContext?: Readonly<Record<string, unknown>>;
+	readonly routeFile: string;
+	readonly routeId: string;
+	readonly routePath: string;
+	readonly signal?: AbortSignal;
+	readonly startedAt: number;
 }): Promise<RuntimeExecutionResult> {
-  let mode: RuntimeExecutionMode | null = null
+	let mode: RuntimeExecutionMode | null = null;
 
-  try {
-    const prepared = await prepareRouteExecution(options)
+	try {
+		const prepared = await prepareRouteExecution(options);
 
-    if (!prepared.ok) {
-      return createRuntimeFailureResult({
-        appRoot: options.appRoot,
-        executionSource: "in-process",
-        kind: "execution_error",
-        message: prepared.message,
-        mode,
-        routeId: options.routeId,
-        routePath: options.routePath,
-        startedAt: options.startedAt,
-      })
-    }
+		if (!prepared.ok) {
+			return createRuntimeFailureResult({
+				appRoot: options.appRoot,
+				executionSource: "in-process",
+				kind: "execution_error",
+				message: prepared.message,
+				mode,
+				routeId: options.routeId,
+				routePath: options.routePath,
+				startedAt: options.startedAt,
+			});
+		}
 
-    const { normalized, tools, stateFields } = prepared
-    mode = normalized.kind
+		const { normalized, tools, stateFields } = prepared;
+		mode = normalized.kind;
 
-    const context = createDawnContext({
-      tools,
-      ...(options.signal ? { signal: options.signal } : {}),
-    })
+		const context = createDawnContext({
+			...(options.middlewareContext
+				? { middleware: options.middlewareContext }
+				: {}),
+			tools,
+			...(options.signal ? { signal: options.signal } : {}),
+		});
 
-    const output = await invokeEntry(normalized.kind, normalized.entry, options.input, context, {
-      routeId: options.routeId,
-      ...(stateFields ? { stateFields } : {}),
-      tools,
-      ...(options.signal ? { signal: options.signal } : {}),
-    })
+		const output = await invokeEntry(
+			normalized.kind,
+			normalized.entry,
+			options.input,
+			context,
+			{
+				...(options.middlewareContext
+					? { middlewareContext: options.middlewareContext }
+					: {}),
+				routeId: options.routeId,
+				...(stateFields ? { stateFields } : {}),
+				tools,
+				...(options.signal ? { signal: options.signal } : {}),
+			},
+		);
 
-    return createRuntimeSuccessResult({
-      appRoot: options.appRoot,
-      executionSource: "in-process",
-      mode: normalized.kind,
-      output,
-      routeId: options.routeId,
-      routePath: options.routePath,
-      startedAt: options.startedAt,
-    })
-  } catch (error) {
-    const kind = isBoundaryError(error) ? "unsupported_route_boundary" : "execution_error"
-    const message = formatErrorMessage(error)
+		return createRuntimeSuccessResult({
+			appRoot: options.appRoot,
+			executionSource: "in-process",
+			mode: normalized.kind,
+			output,
+			routeId: options.routeId,
+			routePath: options.routePath,
+			startedAt: options.startedAt,
+		});
+	} catch (error) {
+		const kind = isBoundaryError(error)
+			? "unsupported_route_boundary"
+			: "execution_error";
+		const message = formatErrorMessage(error);
 
-    return createRuntimeFailureResult({
-      appRoot: options.appRoot,
-      executionSource: "in-process",
-      kind,
-      message,
-      mode,
-      routeId: options.routeId,
-      routePath: options.routePath,
-      startedAt: options.startedAt,
-    })
-  }
+		return createRuntimeFailureResult({
+			appRoot: options.appRoot,
+			executionSource: "in-process",
+			kind,
+			message,
+			mode,
+			routeId: options.routeId,
+			routePath: options.routePath,
+			startedAt: options.startedAt,
+		});
+	}
 }
 
 async function invokeEntry(
-  kind: "agent" | "chain" | "graph" | "workflow",
-  entry: unknown,
-  input: unknown,
-  context: unknown,
-  agentContext?: {
-    readonly routeId: string
-    readonly signal?: AbortSignal
-    readonly stateFields?: readonly ResolvedStateField[]
-    readonly tools: ReadonlyArray<{
-      readonly description?: string
-      readonly name: string
-      readonly run: (
-        input: unknown,
-        context: { readonly signal: AbortSignal },
-      ) => Promise<unknown> | unknown
-      readonly schema?: unknown
-    }>
-  },
+	kind: "agent" | "chain" | "graph" | "workflow",
+	entry: unknown,
+	input: unknown,
+	context: unknown,
+	agentContext?: {
+		readonly middlewareContext?: Readonly<Record<string, unknown>>;
+		readonly routeId: string;
+		readonly signal?: AbortSignal;
+		readonly stateFields?: readonly ResolvedStateField[];
+		readonly tools: ReadonlyArray<{
+			readonly description?: string;
+			readonly name: string;
+			readonly run: (
+				input: unknown,
+				context: {
+					readonly middleware?: Readonly<Record<string, unknown>>;
+					readonly signal: AbortSignal;
+				},
+			) => Promise<unknown> | unknown;
+			readonly schema?: unknown;
+		}>;
+	},
 ): Promise<unknown> {
-  if (kind === "agent") {
-    const routeParamNames = extractRouteParamNames(agentContext?.routeId ?? "")
-    return await executeAgent({
-      entry,
-      input,
-      routeParamNames,
-      signal: agentContext?.signal ?? new AbortController().signal,
-      ...(agentContext?.stateFields ? { stateFields: agentContext.stateFields } : {}),
-      tools: agentContext?.tools ?? [],
-    })
-  }
+	if (kind === "agent") {
+		const routeParamNames = extractRouteParamNames(agentContext?.routeId ?? "");
+		return await executeAgent({
+			entry,
+			input,
+			...(agentContext?.middlewareContext
+				? { middlewareContext: agentContext.middlewareContext }
+				: {}),
+			routeParamNames,
+			signal: agentContext?.signal ?? new AbortController().signal,
+			...(agentContext?.stateFields
+				? { stateFields: agentContext.stateFields }
+				: {}),
+			tools: agentContext?.tools ?? [],
+		});
+	}
 
-  if (kind === "workflow") {
-    if (typeof entry !== "function") {
-      throw new Error("Workflow entry must be a function")
-    }
-    return await entry(input, context)
-  }
+	if (kind === "workflow") {
+		if (typeof entry !== "function") {
+			throw new Error("Workflow entry must be a function");
+		}
+		return await entry(input, context);
+	}
 
-  if (kind === "chain") {
-    if (
-      typeof entry === "object" &&
-      entry !== null &&
-      "invoke" in entry &&
-      typeof (entry as { invoke?: unknown }).invoke === "function"
-    ) {
-      return await (entry as { invoke: (input: unknown) => unknown }).invoke(input)
-    }
-    throw new Error("Chain entry must expose invoke(input)")
-  }
+	if (kind === "chain") {
+		if (
+			typeof entry === "object" &&
+			entry !== null &&
+			"invoke" in entry &&
+			typeof (entry as { invoke?: unknown }).invoke === "function"
+		) {
+			return await (entry as { invoke: (input: unknown) => unknown }).invoke(
+				input,
+			);
+		}
+		throw new Error("Chain entry must expose invoke(input)");
+	}
 
-  if (typeof entry === "function") {
-    return await entry(input, context)
-  }
+	if (typeof entry === "function") {
+		return await entry(input, context);
+	}
 
-  if (
-    typeof entry === "object" &&
-    entry !== null &&
-    "invoke" in entry &&
-    typeof (entry as { invoke?: unknown }).invoke === "function"
-  ) {
-    return await (entry as { invoke: (input: unknown, context: unknown) => unknown }).invoke(
-      input,
-      context,
-    )
-  }
+	if (
+		typeof entry === "object" &&
+		entry !== null &&
+		"invoke" in entry &&
+		typeof (entry as { invoke?: unknown }).invoke === "function"
+	) {
+		return await (
+			entry as { invoke: (input: unknown, context: unknown) => unknown }
+		).invoke(input, context);
+	}
 
-  throw new Error("Graph entry must be a function or expose invoke(input)")
+	throw new Error("Graph entry must be a function or expose invoke(input)");
 }
 
 function resolveRouteFile(options: {
-  readonly appRoot: string
-  readonly cwd?: string
-  readonly routeFile: string
+	readonly appRoot: string;
+	readonly cwd?: string;
+	readonly routeFile: string;
 }): string {
-  if (isAbsolute(options.routeFile)) {
-    return resolve(options.routeFile)
-  }
+	if (isAbsolute(options.routeFile)) {
+		return resolve(options.routeFile);
+	}
 
-  if (options.routeFile.startsWith(".") || options.routeFile.startsWith("..")) {
-    return resolve(options.cwd ?? process.cwd(), options.routeFile)
-  }
+	if (options.routeFile.startsWith(".") || options.routeFile.startsWith("..")) {
+		return resolve(options.cwd ?? process.cwd(), options.routeFile);
+	}
 
-  return resolve(options.appRoot, options.routeFile)
+	return resolve(options.appRoot, options.routeFile);
 }
 
 async function discoverApp(options: ExecuteRouteOptions): Promise<
-  | {
-      readonly appRoot: string
-      readonly ok: true
-      readonly routesDir: string
-    }
-  | {
-      readonly message: string
-      readonly ok: false
-    }
+	| {
+			readonly appRoot: string;
+			readonly ok: true;
+			readonly routesDir: string;
+	  }
+	| {
+			readonly message: string;
+			readonly ok: false;
+	  }
 > {
-  try {
-    const app = await findDawnApp({
-      ...(options.appRoot ? { appRoot: options.appRoot } : {}),
-      ...(options.cwd ? { cwd: options.cwd } : {}),
-    })
+	try {
+		const app = await findDawnApp({
+			...(options.appRoot ? { appRoot: options.appRoot } : {}),
+			...(options.cwd ? { cwd: options.cwd } : {}),
+		});
 
-    return {
-      appRoot: app.appRoot,
-      ok: true,
-      routesDir: app.routesDir,
-    }
-  } catch (error) {
-    return {
-      message: formatErrorMessage(error),
-      ok: false,
-    }
-  }
+		return {
+			appRoot: app.appRoot,
+			ok: true,
+			routesDir: app.routesDir,
+		};
+	} catch (error) {
+		return {
+			message: formatErrorMessage(error),
+			ok: false,
+		};
+	}
 }
 
 function extractRouteParamNames(routeId: string): string[] {
-  const matches = routeId.matchAll(/\[(\w+)\]/g)
-  return [...matches].map((match) => match[1]).filter((s): s is string => s !== undefined)
+	const matches = routeId.matchAll(/\[(\w+)\]/g);
+	return [...matches]
+		.map((match) => match[1])
+		.filter((s): s is string => s !== undefined);
 }
 
 function isBoundaryError(error: unknown): boolean {
-  if (!(error instanceof Error)) {
-    return false
-  }
+	if (!(error instanceof Error)) {
+		return false;
+	}
 
-  return (
-    /must export exactly one of/.test(error.message) ||
-    /exports neither/.test(error.message) ||
-    error.message === "Workflow entry must be a function" ||
-    error.message === "Graph entry must be a function or expose invoke(input)" ||
-    error.message === "Chain entry must expose invoke(input)"
-  )
+	return (
+		/must export exactly one of/.test(error.message) ||
+		/exports neither/.test(error.message) ||
+		error.message === "Workflow entry must be a function" ||
+		error.message ===
+			"Graph entry must be a function or expose invoke(input)" ||
+		error.message === "Chain entry must expose invoke(input)"
+	);
 }

--- a/packages/cli/src/lib/runtime/tool-discovery.ts
+++ b/packages/cli/src/lib/runtime/tool-discovery.ts
@@ -1,150 +1,169 @@
-import { readdir } from "node:fs/promises"
-import { basename, join } from "node:path"
-import { pathToFileURL } from "node:url"
+import { readdir } from "node:fs/promises";
+import { basename, join } from "node:path";
+import { pathToFileURL } from "node:url";
 
-import { registerTsxLoader } from "./register-tsx-loader.js"
-import { isRecord } from "./utils.js"
+import { registerTsxLoader } from "./register-tsx-loader.js";
+import { isRecord } from "./utils.js";
 
-type ToolScope = "route-local" | "shared"
+type ToolScope = "route-local" | "shared";
 
 export interface DiscoveredToolDefinition {
-  readonly description?: string
-  readonly filePath: string
-  readonly name: string
-  readonly run: (
-    input: unknown,
-    context: { readonly signal: AbortSignal },
-  ) => Promise<unknown> | unknown
-  readonly schema?: unknown
-  readonly scope: ToolScope
+	readonly description?: string;
+	readonly filePath: string;
+	readonly name: string;
+	readonly run: (
+		input: unknown,
+		context: {
+			readonly middleware?: Readonly<Record<string, unknown>>;
+			readonly signal: AbortSignal;
+		},
+	) => Promise<unknown> | unknown;
+	readonly schema?: unknown;
+	readonly scope: ToolScope;
 }
 
 export async function discoverToolDefinitions(options: {
-  readonly appRoot: string
-  readonly routeDir: string
+	readonly appRoot: string;
+	readonly routeDir: string;
 }): Promise<readonly DiscoveredToolDefinition[]> {
-  await registerTsxLoader()
+	await registerTsxLoader();
 
-  const sharedTools = await loadToolScope({
-    directory: join(options.appRoot, "src", "tools"),
-    scope: "shared",
-  })
-  const routeLocalTools = await loadToolScope({
-    directory: join(options.routeDir, "tools"),
-    scope: "route-local",
-  })
+	const sharedTools = await loadToolScope({
+		directory: join(options.appRoot, "src", "tools"),
+		scope: "shared",
+	});
+	const routeLocalTools = await loadToolScope({
+		directory: join(options.routeDir, "tools"),
+		scope: "route-local",
+	});
 
-  const discovered = new Map<string, DiscoveredToolDefinition>()
+	const discovered = new Map<string, DiscoveredToolDefinition>();
 
-  for (const tool of sharedTools) {
-    discovered.set(tool.name, tool)
-  }
+	for (const tool of sharedTools) {
+		discovered.set(tool.name, tool);
+	}
 
-  for (const tool of routeLocalTools) {
-    discovered.set(tool.name, tool)
-  }
+	for (const tool of routeLocalTools) {
+		discovered.set(tool.name, tool);
+	}
 
-  return [...discovered.values()]
+	return [...discovered.values()];
 }
 
 async function loadToolScope(options: {
-  readonly directory: string
-  readonly scope: ToolScope
+	readonly directory: string;
+	readonly scope: ToolScope;
 }): Promise<readonly DiscoveredToolDefinition[]> {
-  const entries = await readdir(options.directory, { withFileTypes: true }).catch(() => null)
+	const entries = await readdir(options.directory, {
+		withFileTypes: true,
+	}).catch(() => null);
 
-  if (!entries) {
-    return []
-  }
+	if (!entries) {
+		return [];
+	}
 
-  const files = entries
-    .filter(
-      (entry) => entry.isFile() && entry.name.endsWith(".ts") && !entry.name.endsWith(".d.ts"),
-    )
-    .map((entry) => join(options.directory, entry.name))
-    .sort((left, right) => left.localeCompare(right))
+	const files = entries
+		.filter(
+			(entry) =>
+				entry.isFile() &&
+				entry.name.endsWith(".ts") &&
+				!entry.name.endsWith(".d.ts"),
+		)
+		.map((entry) => join(options.directory, entry.name))
+		.sort((left, right) => left.localeCompare(right));
 
-  const discovered: DiscoveredToolDefinition[] = []
-  const byName = new Map<string, string>()
+	const discovered: DiscoveredToolDefinition[] = [];
+	const byName = new Map<string, string>();
 
-  for (const filePath of files) {
-    const tool = await loadToolDefinition(filePath, options.scope)
-    const existingFile = byName.get(tool.name)
+	for (const filePath of files) {
+		const tool = await loadToolDefinition(filePath, options.scope);
+		const existingFile = byName.get(tool.name);
 
-    if (existingFile) {
-      throw new Error(
-        `Duplicate ${options.scope} Dawn tool name "${tool.name}" detected at ${existingFile} and ${filePath}`,
-      )
-    }
+		if (existingFile) {
+			throw new Error(
+				`Duplicate ${options.scope} Dawn tool name "${tool.name}" detected at ${existingFile} and ${filePath}`,
+			);
+		}
 
-    byName.set(tool.name, filePath)
-    discovered.push(tool)
-  }
+		byName.set(tool.name, filePath);
+		discovered.push(tool);
+	}
 
-  return discovered
+	return discovered;
 }
 
 export function injectGeneratedSchemas(
-  tools: readonly DiscoveredToolDefinition[],
-  generatedSchemas: Record<string, unknown>,
+	tools: readonly DiscoveredToolDefinition[],
+	generatedSchemas: Record<string, unknown>,
 ): readonly DiscoveredToolDefinition[] {
-  return tools.map((tool) => {
-    // User-exported schema takes priority
-    if (tool.schema) return tool
+	return tools.map((tool) => {
+		// User-exported schema takes priority
+		if (tool.schema) return tool;
 
-    const generated = generatedSchemas[tool.name]
-    if (!generated || typeof generated !== "object") return tool
+		const generated = generatedSchemas[tool.name];
+		if (!generated || typeof generated !== "object") return tool;
 
-    const entry = generated as { description?: string; parameters?: unknown }
-    const description =
-      !tool.description && typeof entry.description === "string"
-        ? entry.description
-        : tool.description
-    const schema =
-      entry.parameters && typeof entry.parameters === "object" ? entry.parameters : undefined
+		const entry = generated as { description?: string; parameters?: unknown };
+		const description =
+			!tool.description && typeof entry.description === "string"
+				? entry.description
+				: tool.description;
+		const schema =
+			entry.parameters && typeof entry.parameters === "object"
+				? entry.parameters
+				: undefined;
 
-    if (!description && !schema) return tool
+		if (!description && !schema) return tool;
 
-    return { ...tool, ...(description ? { description } : {}), ...(schema ? { schema } : {}) }
-  })
+		return {
+			...tool,
+			...(description ? { description } : {}),
+			...(schema ? { schema } : {}),
+		};
+	});
 }
 
 async function loadToolDefinition(
-  filePath: string,
-  scope: ToolScope,
+	filePath: string,
+	scope: ToolScope,
 ): Promise<DiscoveredToolDefinition> {
-  const toolModule = (await import(`${pathToFileURL(filePath).href}?t=${Date.now()}`)) as {
-    readonly default?: unknown
-    readonly description?: unknown
-    readonly schema?: unknown
-  }
-  const definition = toolModule.default
-  const name = basename(filePath, ".ts")
-  const description =
-    typeof toolModule.description === "string" ? toolModule.description : undefined
-  const schema = toolModule.schema !== undefined ? toolModule.schema : undefined
+	const toolModule = (await import(
+		`${pathToFileURL(filePath).href}?t=${Date.now()}`
+	)) as {
+		readonly default?: unknown;
+		readonly description?: unknown;
+		readonly schema?: unknown;
+	};
+	const definition = toolModule.default;
+	const name = basename(filePath, ".ts");
+	const description =
+		typeof toolModule.description === "string"
+			? toolModule.description
+			: undefined;
+	const schema =
+		toolModule.schema !== undefined ? toolModule.schema : undefined;
 
-  if (typeof definition === "function") {
-    return {
-      ...(description ? { description } : {}),
-      ...(schema ? { schema } : {}),
-      filePath,
-      name,
-      run: definition as DiscoveredToolDefinition["run"],
-      scope,
-    }
-  }
+	if (typeof definition === "function") {
+		return {
+			...(description ? { description } : {}),
+			...(schema ? { schema } : {}),
+			filePath,
+			name,
+			run: definition as DiscoveredToolDefinition["run"],
+			scope,
+		};
+	}
 
-  if (isRecord(definition) && typeof definition.run === "function") {
-    return {
-      ...(description ? { description } : {}),
-      ...(schema ? { schema } : {}),
-      filePath,
-      name,
-      run: definition.run as DiscoveredToolDefinition["run"],
-      scope,
-    }
-  }
+	if (isRecord(definition) && typeof definition.run === "function") {
+		return {
+			...(description ? { description } : {}),
+			...(schema ? { schema } : {}),
+			filePath,
+			name,
+			run: definition.run as DiscoveredToolDefinition["run"],
+			scope,
+		};
+	}
 
-  throw new Error(`Tool file ${filePath} must default export a function`)
+	throw new Error(`Tool file ${filePath} must default export a function`);
 }

--- a/packages/cli/src/lib/runtime/tool-discovery.ts
+++ b/packages/cli/src/lib/runtime/tool-discovery.ts
@@ -1,169 +1,159 @@
-import { readdir } from "node:fs/promises";
-import { basename, join } from "node:path";
-import { pathToFileURL } from "node:url";
+import { readdir } from "node:fs/promises"
+import { basename, join } from "node:path"
+import { pathToFileURL } from "node:url"
 
-import { registerTsxLoader } from "./register-tsx-loader.js";
-import { isRecord } from "./utils.js";
+import { registerTsxLoader } from "./register-tsx-loader.js"
+import { isRecord } from "./utils.js"
 
-type ToolScope = "route-local" | "shared";
+type ToolScope = "route-local" | "shared"
 
 export interface DiscoveredToolDefinition {
-	readonly description?: string;
-	readonly filePath: string;
-	readonly name: string;
-	readonly run: (
-		input: unknown,
-		context: {
-			readonly middleware?: Readonly<Record<string, unknown>>;
-			readonly signal: AbortSignal;
-		},
-	) => Promise<unknown> | unknown;
-	readonly schema?: unknown;
-	readonly scope: ToolScope;
+  readonly description?: string
+  readonly filePath: string
+  readonly name: string
+  readonly run: (
+    input: unknown,
+    context: {
+      readonly middleware?: Readonly<Record<string, unknown>>
+      readonly signal: AbortSignal
+    },
+  ) => Promise<unknown> | unknown
+  readonly schema?: unknown
+  readonly scope: ToolScope
 }
 
 export async function discoverToolDefinitions(options: {
-	readonly appRoot: string;
-	readonly routeDir: string;
+  readonly appRoot: string
+  readonly routeDir: string
 }): Promise<readonly DiscoveredToolDefinition[]> {
-	await registerTsxLoader();
+  await registerTsxLoader()
 
-	const sharedTools = await loadToolScope({
-		directory: join(options.appRoot, "src", "tools"),
-		scope: "shared",
-	});
-	const routeLocalTools = await loadToolScope({
-		directory: join(options.routeDir, "tools"),
-		scope: "route-local",
-	});
+  const sharedTools = await loadToolScope({
+    directory: join(options.appRoot, "src", "tools"),
+    scope: "shared",
+  })
+  const routeLocalTools = await loadToolScope({
+    directory: join(options.routeDir, "tools"),
+    scope: "route-local",
+  })
 
-	const discovered = new Map<string, DiscoveredToolDefinition>();
+  const discovered = new Map<string, DiscoveredToolDefinition>()
 
-	for (const tool of sharedTools) {
-		discovered.set(tool.name, tool);
-	}
+  for (const tool of sharedTools) {
+    discovered.set(tool.name, tool)
+  }
 
-	for (const tool of routeLocalTools) {
-		discovered.set(tool.name, tool);
-	}
+  for (const tool of routeLocalTools) {
+    discovered.set(tool.name, tool)
+  }
 
-	return [...discovered.values()];
+  return [...discovered.values()]
 }
 
 async function loadToolScope(options: {
-	readonly directory: string;
-	readonly scope: ToolScope;
+  readonly directory: string
+  readonly scope: ToolScope
 }): Promise<readonly DiscoveredToolDefinition[]> {
-	const entries = await readdir(options.directory, {
-		withFileTypes: true,
-	}).catch(() => null);
+  const entries = await readdir(options.directory, {
+    withFileTypes: true,
+  }).catch(() => null)
 
-	if (!entries) {
-		return [];
-	}
+  if (!entries) {
+    return []
+  }
 
-	const files = entries
-		.filter(
-			(entry) =>
-				entry.isFile() &&
-				entry.name.endsWith(".ts") &&
-				!entry.name.endsWith(".d.ts"),
-		)
-		.map((entry) => join(options.directory, entry.name))
-		.sort((left, right) => left.localeCompare(right));
+  const files = entries
+    .filter(
+      (entry) => entry.isFile() && entry.name.endsWith(".ts") && !entry.name.endsWith(".d.ts"),
+    )
+    .map((entry) => join(options.directory, entry.name))
+    .sort((left, right) => left.localeCompare(right))
 
-	const discovered: DiscoveredToolDefinition[] = [];
-	const byName = new Map<string, string>();
+  const discovered: DiscoveredToolDefinition[] = []
+  const byName = new Map<string, string>()
 
-	for (const filePath of files) {
-		const tool = await loadToolDefinition(filePath, options.scope);
-		const existingFile = byName.get(tool.name);
+  for (const filePath of files) {
+    const tool = await loadToolDefinition(filePath, options.scope)
+    const existingFile = byName.get(tool.name)
 
-		if (existingFile) {
-			throw new Error(
-				`Duplicate ${options.scope} Dawn tool name "${tool.name}" detected at ${existingFile} and ${filePath}`,
-			);
-		}
+    if (existingFile) {
+      throw new Error(
+        `Duplicate ${options.scope} Dawn tool name "${tool.name}" detected at ${existingFile} and ${filePath}`,
+      )
+    }
 
-		byName.set(tool.name, filePath);
-		discovered.push(tool);
-	}
+    byName.set(tool.name, filePath)
+    discovered.push(tool)
+  }
 
-	return discovered;
+  return discovered
 }
 
 export function injectGeneratedSchemas(
-	tools: readonly DiscoveredToolDefinition[],
-	generatedSchemas: Record<string, unknown>,
+  tools: readonly DiscoveredToolDefinition[],
+  generatedSchemas: Record<string, unknown>,
 ): readonly DiscoveredToolDefinition[] {
-	return tools.map((tool) => {
-		// User-exported schema takes priority
-		if (tool.schema) return tool;
+  return tools.map((tool) => {
+    // User-exported schema takes priority
+    if (tool.schema) return tool
 
-		const generated = generatedSchemas[tool.name];
-		if (!generated || typeof generated !== "object") return tool;
+    const generated = generatedSchemas[tool.name]
+    if (!generated || typeof generated !== "object") return tool
 
-		const entry = generated as { description?: string; parameters?: unknown };
-		const description =
-			!tool.description && typeof entry.description === "string"
-				? entry.description
-				: tool.description;
-		const schema =
-			entry.parameters && typeof entry.parameters === "object"
-				? entry.parameters
-				: undefined;
+    const entry = generated as { description?: string; parameters?: unknown }
+    const description =
+      !tool.description && typeof entry.description === "string"
+        ? entry.description
+        : tool.description
+    const schema =
+      entry.parameters && typeof entry.parameters === "object" ? entry.parameters : undefined
 
-		if (!description && !schema) return tool;
+    if (!description && !schema) return tool
 
-		return {
-			...tool,
-			...(description ? { description } : {}),
-			...(schema ? { schema } : {}),
-		};
-	});
+    return {
+      ...tool,
+      ...(description ? { description } : {}),
+      ...(schema ? { schema } : {}),
+    }
+  })
 }
 
 async function loadToolDefinition(
-	filePath: string,
-	scope: ToolScope,
+  filePath: string,
+  scope: ToolScope,
 ): Promise<DiscoveredToolDefinition> {
-	const toolModule = (await import(
-		`${pathToFileURL(filePath).href}?t=${Date.now()}`
-	)) as {
-		readonly default?: unknown;
-		readonly description?: unknown;
-		readonly schema?: unknown;
-	};
-	const definition = toolModule.default;
-	const name = basename(filePath, ".ts");
-	const description =
-		typeof toolModule.description === "string"
-			? toolModule.description
-			: undefined;
-	const schema =
-		toolModule.schema !== undefined ? toolModule.schema : undefined;
+  const toolModule = (await import(`${pathToFileURL(filePath).href}?t=${Date.now()}`)) as {
+    readonly default?: unknown
+    readonly description?: unknown
+    readonly schema?: unknown
+  }
+  const definition = toolModule.default
+  const name = basename(filePath, ".ts")
+  const description =
+    typeof toolModule.description === "string" ? toolModule.description : undefined
+  const schema = toolModule.schema !== undefined ? toolModule.schema : undefined
 
-	if (typeof definition === "function") {
-		return {
-			...(description ? { description } : {}),
-			...(schema ? { schema } : {}),
-			filePath,
-			name,
-			run: definition as DiscoveredToolDefinition["run"],
-			scope,
-		};
-	}
+  if (typeof definition === "function") {
+    return {
+      ...(description ? { description } : {}),
+      ...(schema ? { schema } : {}),
+      filePath,
+      name,
+      run: definition as DiscoveredToolDefinition["run"],
+      scope,
+    }
+  }
 
-	if (isRecord(definition) && typeof definition.run === "function") {
-		return {
-			...(description ? { description } : {}),
-			...(schema ? { schema } : {}),
-			filePath,
-			name,
-			run: definition.run as DiscoveredToolDefinition["run"],
-			scope,
-		};
-	}
+  if (isRecord(definition) && typeof definition.run === "function") {
+    return {
+      ...(description ? { description } : {}),
+      ...(schema ? { schema } : {}),
+      filePath,
+      name,
+      run: definition.run as DiscoveredToolDefinition["run"],
+      scope,
+    }
+  }
 
-	throw new Error(`Tool file ${filePath} must default export a function`);
+  throw new Error(`Tool file ${filePath} must default export a function`)
 }

--- a/packages/langchain/src/agent-adapter.ts
+++ b/packages/langchain/src/agent-adapter.ts
@@ -1,329 +1,307 @@
-import type { DawnAgent, RetryConfig } from "@dawn-ai/sdk";
-import { isDawnAgent } from "@dawn-ai/sdk";
-import { HumanMessage } from "@langchain/core/messages";
-import { isRetryableError, withRetry } from "./retry.js";
-import {
-	materializeStateSchema,
-	type ResolvedStateField,
-} from "./state-adapter.js";
-import { convertToolToLangChain } from "./tool-converter.js";
+import type { DawnAgent, RetryConfig } from "@dawn-ai/sdk"
+import { isDawnAgent } from "@dawn-ai/sdk"
+import { HumanMessage } from "@langchain/core/messages"
+import { isRetryableError, withRetry } from "./retry.js"
+import { materializeStateSchema, type ResolvedStateField } from "./state-adapter.js"
+import { convertToolToLangChain } from "./tool-converter.js"
 
 interface DawnToolDefinition {
-	readonly description?: string;
-	readonly name: string;
-	readonly run: (
-		input: unknown,
-		context: {
-			readonly middleware?: Readonly<Record<string, unknown>>;
-			readonly signal: AbortSignal;
-		},
-	) => Promise<unknown> | unknown;
-	readonly schema?: unknown;
+  readonly description?: string
+  readonly name: string
+  readonly run: (
+    input: unknown,
+    context: {
+      readonly middleware?: Readonly<Record<string, unknown>>
+      readonly signal: AbortSignal
+    },
+  ) => Promise<unknown> | unknown
+  readonly schema?: unknown
 }
 
 interface AgentLike {
-	readonly invoke: (input: unknown, config?: unknown) => Promise<unknown>;
+  readonly invoke: (input: unknown, config?: unknown) => Promise<unknown>
 }
 
 function assertAgentLike(entry: unknown): asserts entry is AgentLike {
-	if (
-		typeof entry !== "object" ||
-		entry === null ||
-		!("invoke" in entry) ||
-		typeof (entry as { invoke?: unknown }).invoke !== "function"
-	) {
-		throw new Error(
-			"Agent entry must expose invoke(input) — expected a LangChain agent",
-		);
-	}
+  if (
+    typeof entry !== "object" ||
+    entry === null ||
+    !("invoke" in entry) ||
+    typeof (entry as { invoke?: unknown }).invoke !== "function"
+  ) {
+    throw new Error("Agent entry must expose invoke(input) — expected a LangChain agent")
+  }
 }
 
-const materializedAgents = new WeakMap<DawnAgent, AgentLike>();
+const materializedAgents = new WeakMap<DawnAgent, AgentLike>()
 
 async function materializeAgent(
-	descriptor: DawnAgent,
-	tools: readonly DawnToolDefinition[],
-	stateFields?: readonly ResolvedStateField[],
-	middlewareContext?: Readonly<Record<string, unknown>>,
+  descriptor: DawnAgent,
+  tools: readonly DawnToolDefinition[],
+  stateFields?: readonly ResolvedStateField[],
+  middlewareContext?: Readonly<Record<string, unknown>>,
 ): Promise<AgentLike> {
-	const cached = materializedAgents.get(descriptor);
-	if (cached) {
-		return cached;
-	}
+  const cached = materializedAgents.get(descriptor)
+  if (cached) {
+    return cached
+  }
 
-	const { createReactAgent } = await import("@langchain/langgraph/prebuilt");
-	const { ChatOpenAI } = await import("@langchain/openai");
+  const { createReactAgent } = await import("@langchain/langgraph/prebuilt")
+  const { ChatOpenAI } = await import("@langchain/openai")
 
-	const langchainTools = tools.map((tool) =>
-		convertToolToLangChain(tool, middlewareContext),
-	);
+  const langchainTools = tools.map((tool) => convertToolToLangChain(tool, middlewareContext))
 
-	const llm = new ChatOpenAI({
-		model: descriptor.model,
-	});
+  const llm = new ChatOpenAI({
+    model: descriptor.model,
+  })
 
-	const agentOptions: Record<string, unknown> = {
-		llm,
-		tools: langchainTools,
-		prompt: descriptor.systemPrompt,
-	};
+  const agentOptions: Record<string, unknown> = {
+    llm,
+    tools: langchainTools,
+    prompt: descriptor.systemPrompt,
+  }
 
-	if (stateFields && stateFields.length > 0) {
-		agentOptions.stateSchema = materializeStateSchema(stateFields);
-	}
+  if (stateFields && stateFields.length > 0) {
+    agentOptions.stateSchema = materializeStateSchema(stateFields)
+  }
 
-	// biome-ignore lint/suspicious/noExplicitAny: dynamically-built options don't satisfy strict StateDefinition type
-	const compiled = createReactAgent(agentOptions as any);
+  // biome-ignore lint/suspicious/noExplicitAny: dynamically-built options don't satisfy strict StateDefinition type
+  const compiled = createReactAgent(agentOptions as any)
 
-	materializedAgents.set(descriptor, compiled as unknown as AgentLike);
-	return compiled as unknown as AgentLike;
+  materializedAgents.set(descriptor, compiled as unknown as AgentLike)
+  return compiled as unknown as AgentLike
 }
 
 export interface AgentStreamChunk {
-	readonly type: "token" | "tool_call" | "tool_result" | "done";
-	readonly data: unknown;
+  readonly type: "token" | "tool_call" | "tool_result" | "done"
+  readonly data: unknown
 }
 
 export interface AgentOptions {
-	readonly entry: unknown;
-	readonly input: unknown;
-	readonly middlewareContext?: Readonly<Record<string, unknown>>;
-	readonly retry?: RetryConfig;
-	readonly routeParamNames: readonly string[];
-	readonly signal: AbortSignal;
-	readonly stateFields?: readonly ResolvedStateField[];
-	readonly tools: readonly DawnToolDefinition[];
+  readonly entry: unknown
+  readonly input: unknown
+  readonly middlewareContext?: Readonly<Record<string, unknown>>
+  readonly retry?: RetryConfig
+  readonly routeParamNames: readonly string[]
+  readonly signal: AbortSignal
+  readonly stateFields?: readonly ResolvedStateField[]
+  readonly tools: readonly DawnToolDefinition[]
 }
 
 export async function executeAgent(options: AgentOptions): Promise<unknown> {
-	let result: unknown;
-	for await (const chunk of streamAgent(options)) {
-		if (chunk.type === "done") {
-			result = chunk.data;
-		}
-	}
-	return result;
+  let result: unknown
+  for await (const chunk of streamAgent(options)) {
+    if (chunk.type === "done") {
+      result = chunk.data
+    }
+  }
+  return result
 }
 
-export async function* streamAgent(
-	options: AgentOptions,
-): AsyncGenerator<AgentStreamChunk> {
-	const { agentInput, config } = prepareAgentCall(options);
-	const messages = extractMessages(agentInput);
+export async function* streamAgent(options: AgentOptions): AsyncGenerator<AgentStreamChunk> {
+  const { agentInput, config } = prepareAgentCall(options)
+  const messages = extractMessages(agentInput)
 
-	// DawnAgent descriptor path — materialize on first use
-	if (isDawnAgent(options.entry)) {
-		const materializedAgent = await materializeAgent(
-			options.entry,
-			options.tools,
-			options.stateFields,
-			options.middlewareContext,
-		);
-		const retryConfig = options.entry.retry;
-		yield* streamFromRunnable(
-			materializedAgent,
-			{ messages },
-			config,
-			retryConfig,
-		);
-		return;
-	}
+  // DawnAgent descriptor path — materialize on first use
+  if (isDawnAgent(options.entry)) {
+    const materializedAgent = await materializeAgent(
+      options.entry,
+      options.tools,
+      options.stateFields,
+      options.middlewareContext,
+    )
+    const retryConfig = options.entry.retry
+    yield* streamFromRunnable(materializedAgent, { messages }, config, retryConfig)
+    return
+  }
 
-	// Legacy path — raw Runnable with .invoke()
-	assertAgentLike(options.entry);
+  // Legacy path — raw Runnable with .invoke()
+  assertAgentLike(options.entry)
 
-	const langchainTools = options.tools.map((tool) =>
-		convertToolToLangChain(tool, options.middlewareContext),
-	);
-	if (langchainTools.length > 0) {
-		config.tools = langchainTools;
-	}
+  const langchainTools = options.tools.map((tool) =>
+    convertToolToLangChain(tool, options.middlewareContext),
+  )
+  if (langchainTools.length > 0) {
+    config.tools = langchainTools
+  }
 
-	yield* streamFromRunnable(options.entry, { messages }, config, options.retry);
+  yield* streamFromRunnable(options.entry, { messages }, config, options.retry)
 }
 
 function prepareAgentCall(options: AgentOptions): {
-	agentInput: Record<string, unknown>;
-	config: Record<string, unknown>;
+  agentInput: Record<string, unknown>
+  config: Record<string, unknown>
 } {
-	const inputRecord = (options.input ?? {}) as Record<string, unknown>;
-	const params: Record<string, unknown> = {};
-	const agentInput: Record<string, unknown> = {};
+  const inputRecord = (options.input ?? {}) as Record<string, unknown>
+  const params: Record<string, unknown> = {}
+  const agentInput: Record<string, unknown> = {}
 
-	for (const [key, value] of Object.entries(inputRecord)) {
-		if (options.routeParamNames.includes(key)) {
-			params[key] = value;
-		} else {
-			agentInput[key] = value;
-		}
-	}
+  for (const [key, value] of Object.entries(inputRecord)) {
+    if (options.routeParamNames.includes(key)) {
+      params[key] = value
+    } else {
+      agentInput[key] = value
+    }
+  }
 
-	const config: Record<string, unknown> = {
-		signal: options.signal,
-	};
+  const config: Record<string, unknown> = {
+    signal: options.signal,
+  }
 
-	if (Object.keys(params).length > 0) {
-		config.configurable = params;
-	}
+  if (Object.keys(params).length > 0) {
+    config.configurable = params
+  }
 
-	return { agentInput, config };
+  return { agentInput, config }
 }
 
 async function* streamFromRunnable(
-	runnable: AgentLike,
-	input: unknown,
-	config: Record<string, unknown>,
-	retryConfig?: RetryConfig,
+  runnable: AgentLike,
+  input: unknown,
+  config: Record<string, unknown>,
+  retryConfig?: RetryConfig,
 ): AsyncGenerator<AgentStreamChunk> {
-	const streamable = runnable as AgentLike & {
-		streamEvents?: (
-			input: unknown,
-			options: Record<string, unknown>,
-		) => AsyncIterable<{
-			event: string;
-			data: { chunk?: unknown; output?: unknown };
-			name: string;
-		}>;
-	};
+  const streamable = runnable as AgentLike & {
+    streamEvents?: (
+      input: unknown,
+      options: Record<string, unknown>,
+    ) => AsyncIterable<{
+      event: string
+      data: { chunk?: unknown; output?: unknown }
+      name: string
+    }>
+  }
 
-	if (typeof streamable.streamEvents !== "function") {
-		// Fallback: invoke with retry and emit a single done event
-		const signal = config.signal as AbortSignal | undefined;
-		const retryOptions: import("./retry.js").RetryOptions = {
-			...(retryConfig?.maxAttempts
-				? { maxAttempts: retryConfig.maxAttempts }
-				: {}),
-			...(retryConfig?.baseDelay ? { baseDelayMs: retryConfig.baseDelay } : {}),
-			...(signal ? { signal } : {}),
-		};
-		const result = await withRetry(
-			() => runnable.invoke(input, config),
-			Object.keys(retryOptions).length > 0 ? retryOptions : undefined,
-		);
-		yield { type: "done", data: result };
-		return;
-	}
+  if (typeof streamable.streamEvents !== "function") {
+    // Fallback: invoke with retry and emit a single done event
+    const signal = config.signal as AbortSignal | undefined
+    const retryOptions: import("./retry.js").RetryOptions = {
+      ...(retryConfig?.maxAttempts ? { maxAttempts: retryConfig.maxAttempts } : {}),
+      ...(retryConfig?.baseDelay ? { baseDelayMs: retryConfig.baseDelay } : {}),
+      ...(signal ? { signal } : {}),
+    }
+    const result = await withRetry(
+      () => runnable.invoke(input, config),
+      Object.keys(retryOptions).length > 0 ? retryOptions : undefined,
+    )
+    yield { type: "done", data: result }
+    return
+  }
 
-	let finalOutput: unknown;
-	let hasYielded = false;
-	let lastStreamError: Error | undefined;
+  let finalOutput: unknown
+  let hasYielded = false
+  let lastStreamError: Error | undefined
 
-	// Retry the entire stream if it fails before producing any output
-	const maxStreamAttempts = retryConfig?.maxAttempts ?? 3;
-	for (let attempt = 0; attempt < maxStreamAttempts; attempt++) {
-		hasYielded = false;
-		lastStreamError = undefined;
-		finalOutput = undefined;
+  // Retry the entire stream if it fails before producing any output
+  const maxStreamAttempts = retryConfig?.maxAttempts ?? 3
+  for (let attempt = 0; attempt < maxStreamAttempts; attempt++) {
+    hasYielded = false
+    lastStreamError = undefined
+    finalOutput = undefined
 
-		try {
-			for await (const event of streamable.streamEvents(input, {
-				...config,
-				version: "v2",
-			})) {
-				switch (event.event) {
-					case "on_chat_model_stream": {
-						const content = (event.data.chunk as { content?: unknown })
-							?.content;
-						if (content && typeof content === "string" && content.length > 0) {
-							hasYielded = true;
-							yield { type: "token" as const, data: content };
-						}
-						break;
-					}
-					case "on_tool_start": {
-						hasYielded = true;
-						yield {
-							type: "tool_call" as const,
-							data: {
-								name: event.name,
-								input: event.data.chunk ?? event.data.output,
-							},
-						};
-						break;
-					}
-					case "on_tool_end": {
-						hasYielded = true;
-						yield {
-							type: "tool_result" as const,
-							data: { name: event.name, output: event.data.output },
-						};
-						break;
-					}
-					case "on_chain_end": {
-						if (event.name === "LangGraph") {
-							finalOutput = event.data.output;
-						}
-						break;
-					}
-				}
-			}
+    try {
+      for await (const event of streamable.streamEvents(input, {
+        ...config,
+        version: "v2",
+      })) {
+        switch (event.event) {
+          case "on_chat_model_stream": {
+            const content = (event.data.chunk as { content?: unknown })?.content
+            if (content && typeof content === "string" && content.length > 0) {
+              hasYielded = true
+              yield { type: "token" as const, data: content }
+            }
+            break
+          }
+          case "on_tool_start": {
+            hasYielded = true
+            yield {
+              type: "tool_call" as const,
+              data: {
+                name: event.name,
+                input: event.data.chunk ?? event.data.output,
+              },
+            }
+            break
+          }
+          case "on_tool_end": {
+            hasYielded = true
+            yield {
+              type: "tool_result" as const,
+              data: { name: event.name, output: event.data.output },
+            }
+            break
+          }
+          case "on_chain_end": {
+            if (event.name === "LangGraph") {
+              finalOutput = event.data.output
+            }
+            break
+          }
+        }
+      }
 
-			// Stream completed successfully
-			break;
-		} catch (error) {
-			lastStreamError =
-				error instanceof Error ? error : new Error(String(error));
+      // Stream completed successfully
+      break
+    } catch (error) {
+      lastStreamError = error instanceof Error ? error : new Error(String(error))
 
-			// If we already yielded chunks, we can't retry (client has partial data)
-			// Or if the error isn't retryable, rethrow immediately
-			if (
-				hasYielded ||
-				!isRetryableError(error) ||
-				attempt === maxStreamAttempts - 1
-			) {
-				throw lastStreamError;
-			}
+      // If we already yielded chunks, we can't retry (client has partial data)
+      // Or if the error isn't retryable, rethrow immediately
+      if (hasYielded || !isRetryableError(error) || attempt === maxStreamAttempts - 1) {
+        throw lastStreamError
+      }
 
-			// Backoff before retry
-			const delay = Math.min(1000 * 2 ** attempt + Math.random() * 500, 10_000);
-			await new Promise((resolve) => setTimeout(resolve, delay));
-		}
-	}
+      // Backoff before retry
+      const delay = Math.min(1000 * 2 ** attempt + Math.random() * 500, 10_000)
+      await new Promise((resolve) => setTimeout(resolve, delay))
+    }
+  }
 
-	yield { type: "done", data: finalOutput };
+  yield { type: "done", data: finalOutput }
 }
 
 interface InputMessage {
-	readonly role: string;
-	readonly content: string;
+  readonly role: string
+  readonly content: string
 }
 
 function isInputMessageArray(value: unknown): value is readonly InputMessage[] {
-	return (
-		Array.isArray(value) &&
-		value.length > 0 &&
-		value.every(
-			(item) =>
-				typeof item === "object" &&
-				item !== null &&
-				typeof (item as { role?: unknown }).role === "string" &&
-				typeof (item as { content?: unknown }).content === "string",
-		)
-	);
+  return (
+    Array.isArray(value) &&
+    value.length > 0 &&
+    value.every(
+      (item) =>
+        typeof item === "object" &&
+        item !== null &&
+        typeof (item as { role?: unknown }).role === "string" &&
+        typeof (item as { content?: unknown }).content === "string",
+    )
+  )
 }
 
 function extractMessages(input: Record<string, unknown>): HumanMessage[] {
-	// LangGraph protocol format: {messages: [{role, content}, ...]}
-	if (isInputMessageArray(input.messages)) {
-		return input.messages
-			.filter((msg) => msg.role === "user")
-			.map((msg) => new HumanMessage(msg.content));
-	}
+  // LangGraph protocol format: {messages: [{role, content}, ...]}
+  if (isInputMessageArray(input.messages)) {
+    return input.messages
+      .filter((msg) => msg.role === "user")
+      .map((msg) => new HumanMessage(msg.content))
+  }
 
-	// Legacy flat-object format: {key: value, ...}
-	return [new HumanMessage(formatAgentMessage(input))];
+  // Legacy flat-object format: {key: value, ...}
+  return [new HumanMessage(formatAgentMessage(input))]
 }
 
 function formatAgentMessage(input: Record<string, unknown>): string {
-	const entries = Object.entries(input);
+  const entries = Object.entries(input)
 
-	if (entries.length === 0) {
-		return "";
-	}
+  if (entries.length === 0) {
+    return ""
+  }
 
-	if (entries.length === 1) {
-		return String(entries[0]?.[1]);
-	}
+  if (entries.length === 1) {
+    return String(entries[0]?.[1])
+  }
 
-	return entries.map(([key, value]) => `${key}: ${String(value)}`).join("\n");
+  return entries.map(([key, value]) => `${key}: ${String(value)}`).join("\n")
 }

--- a/packages/langchain/src/agent-adapter.ts
+++ b/packages/langchain/src/agent-adapter.ts
@@ -1,289 +1,329 @@
-import type { DawnAgent, RetryConfig } from "@dawn-ai/sdk"
-import { isDawnAgent } from "@dawn-ai/sdk"
-import { HumanMessage } from "@langchain/core/messages"
-import { isRetryableError, withRetry } from "./retry.js"
-import { materializeStateSchema, type ResolvedStateField } from "./state-adapter.js"
-import { convertToolToLangChain } from "./tool-converter.js"
+import type { DawnAgent, RetryConfig } from "@dawn-ai/sdk";
+import { isDawnAgent } from "@dawn-ai/sdk";
+import { HumanMessage } from "@langchain/core/messages";
+import { isRetryableError, withRetry } from "./retry.js";
+import {
+	materializeStateSchema,
+	type ResolvedStateField,
+} from "./state-adapter.js";
+import { convertToolToLangChain } from "./tool-converter.js";
 
 interface DawnToolDefinition {
-  readonly description?: string
-  readonly name: string
-  readonly run: (
-    input: unknown,
-    context: { readonly signal: AbortSignal },
-  ) => Promise<unknown> | unknown
-  readonly schema?: unknown
+	readonly description?: string;
+	readonly name: string;
+	readonly run: (
+		input: unknown,
+		context: {
+			readonly middleware?: Readonly<Record<string, unknown>>;
+			readonly signal: AbortSignal;
+		},
+	) => Promise<unknown> | unknown;
+	readonly schema?: unknown;
 }
 
 interface AgentLike {
-  readonly invoke: (input: unknown, config?: unknown) => Promise<unknown>
+	readonly invoke: (input: unknown, config?: unknown) => Promise<unknown>;
 }
 
 function assertAgentLike(entry: unknown): asserts entry is AgentLike {
-  if (
-    typeof entry !== "object" ||
-    entry === null ||
-    !("invoke" in entry) ||
-    typeof (entry as { invoke?: unknown }).invoke !== "function"
-  ) {
-    throw new Error("Agent entry must expose invoke(input) — expected a LangChain agent")
-  }
+	if (
+		typeof entry !== "object" ||
+		entry === null ||
+		!("invoke" in entry) ||
+		typeof (entry as { invoke?: unknown }).invoke !== "function"
+	) {
+		throw new Error(
+			"Agent entry must expose invoke(input) — expected a LangChain agent",
+		);
+	}
 }
 
-const materializedAgents = new WeakMap<DawnAgent, AgentLike>()
+const materializedAgents = new WeakMap<DawnAgent, AgentLike>();
 
 async function materializeAgent(
-  descriptor: DawnAgent,
-  tools: readonly DawnToolDefinition[],
-  stateFields?: readonly ResolvedStateField[],
+	descriptor: DawnAgent,
+	tools: readonly DawnToolDefinition[],
+	stateFields?: readonly ResolvedStateField[],
+	middlewareContext?: Readonly<Record<string, unknown>>,
 ): Promise<AgentLike> {
-  const cached = materializedAgents.get(descriptor)
-  if (cached) {
-    return cached
-  }
+	const cached = materializedAgents.get(descriptor);
+	if (cached) {
+		return cached;
+	}
 
-  const { createReactAgent } = await import("@langchain/langgraph/prebuilt")
-  const { ChatOpenAI } = await import("@langchain/openai")
+	const { createReactAgent } = await import("@langchain/langgraph/prebuilt");
+	const { ChatOpenAI } = await import("@langchain/openai");
 
-  const langchainTools = tools.map((tool) => convertToolToLangChain(tool))
+	const langchainTools = tools.map((tool) =>
+		convertToolToLangChain(tool, middlewareContext),
+	);
 
-  const llm = new ChatOpenAI({
-    model: descriptor.model,
-  })
+	const llm = new ChatOpenAI({
+		model: descriptor.model,
+	});
 
-  const agentOptions: Record<string, unknown> = {
-    llm,
-    tools: langchainTools,
-    prompt: descriptor.systemPrompt,
-  }
+	const agentOptions: Record<string, unknown> = {
+		llm,
+		tools: langchainTools,
+		prompt: descriptor.systemPrompt,
+	};
 
-  if (stateFields && stateFields.length > 0) {
-    agentOptions.stateSchema = materializeStateSchema(stateFields)
-  }
+	if (stateFields && stateFields.length > 0) {
+		agentOptions.stateSchema = materializeStateSchema(stateFields);
+	}
 
-  // biome-ignore lint/suspicious/noExplicitAny: dynamically-built options don't satisfy strict StateDefinition type
-  const compiled = createReactAgent(agentOptions as any)
+	// biome-ignore lint/suspicious/noExplicitAny: dynamically-built options don't satisfy strict StateDefinition type
+	const compiled = createReactAgent(agentOptions as any);
 
-  materializedAgents.set(descriptor, compiled as unknown as AgentLike)
-  return compiled as unknown as AgentLike
+	materializedAgents.set(descriptor, compiled as unknown as AgentLike);
+	return compiled as unknown as AgentLike;
 }
 
 export interface AgentStreamChunk {
-  readonly type: "token" | "tool_call" | "tool_result" | "done"
-  readonly data: unknown
+	readonly type: "token" | "tool_call" | "tool_result" | "done";
+	readonly data: unknown;
 }
 
 export interface AgentOptions {
-  readonly entry: unknown
-  readonly input: unknown
-  readonly retry?: RetryConfig
-  readonly routeParamNames: readonly string[]
-  readonly signal: AbortSignal
-  readonly stateFields?: readonly ResolvedStateField[]
-  readonly tools: readonly DawnToolDefinition[]
+	readonly entry: unknown;
+	readonly input: unknown;
+	readonly middlewareContext?: Readonly<Record<string, unknown>>;
+	readonly retry?: RetryConfig;
+	readonly routeParamNames: readonly string[];
+	readonly signal: AbortSignal;
+	readonly stateFields?: readonly ResolvedStateField[];
+	readonly tools: readonly DawnToolDefinition[];
 }
 
 export async function executeAgent(options: AgentOptions): Promise<unknown> {
-  let result: unknown
-  for await (const chunk of streamAgent(options)) {
-    if (chunk.type === "done") {
-      result = chunk.data
-    }
-  }
-  return result
+	let result: unknown;
+	for await (const chunk of streamAgent(options)) {
+		if (chunk.type === "done") {
+			result = chunk.data;
+		}
+	}
+	return result;
 }
 
-export async function* streamAgent(options: AgentOptions): AsyncGenerator<AgentStreamChunk> {
-  const { agentInput, config } = prepareAgentCall(options)
-  const messages = extractMessages(agentInput)
+export async function* streamAgent(
+	options: AgentOptions,
+): AsyncGenerator<AgentStreamChunk> {
+	const { agentInput, config } = prepareAgentCall(options);
+	const messages = extractMessages(agentInput);
 
-  // DawnAgent descriptor path — materialize on first use
-  if (isDawnAgent(options.entry)) {
-    const materializedAgent = await materializeAgent(
-      options.entry,
-      options.tools,
-      options.stateFields,
-    )
-    const retryConfig = options.entry.retry
-    yield* streamFromRunnable(materializedAgent, { messages }, config, retryConfig)
-    return
-  }
+	// DawnAgent descriptor path — materialize on first use
+	if (isDawnAgent(options.entry)) {
+		const materializedAgent = await materializeAgent(
+			options.entry,
+			options.tools,
+			options.stateFields,
+			options.middlewareContext,
+		);
+		const retryConfig = options.entry.retry;
+		yield* streamFromRunnable(
+			materializedAgent,
+			{ messages },
+			config,
+			retryConfig,
+		);
+		return;
+	}
 
-  // Legacy path — raw Runnable with .invoke()
-  assertAgentLike(options.entry)
+	// Legacy path — raw Runnable with .invoke()
+	assertAgentLike(options.entry);
 
-  const langchainTools = options.tools.map((tool) => convertToolToLangChain(tool))
-  if (langchainTools.length > 0) {
-    config.tools = langchainTools
-  }
+	const langchainTools = options.tools.map((tool) =>
+		convertToolToLangChain(tool, options.middlewareContext),
+	);
+	if (langchainTools.length > 0) {
+		config.tools = langchainTools;
+	}
 
-  yield* streamFromRunnable(options.entry, { messages }, config, options.retry)
+	yield* streamFromRunnable(options.entry, { messages }, config, options.retry);
 }
 
 function prepareAgentCall(options: AgentOptions): {
-  agentInput: Record<string, unknown>
-  config: Record<string, unknown>
+	agentInput: Record<string, unknown>;
+	config: Record<string, unknown>;
 } {
-  const inputRecord = (options.input ?? {}) as Record<string, unknown>
-  const params: Record<string, unknown> = {}
-  const agentInput: Record<string, unknown> = {}
+	const inputRecord = (options.input ?? {}) as Record<string, unknown>;
+	const params: Record<string, unknown> = {};
+	const agentInput: Record<string, unknown> = {};
 
-  for (const [key, value] of Object.entries(inputRecord)) {
-    if (options.routeParamNames.includes(key)) {
-      params[key] = value
-    } else {
-      agentInput[key] = value
-    }
-  }
+	for (const [key, value] of Object.entries(inputRecord)) {
+		if (options.routeParamNames.includes(key)) {
+			params[key] = value;
+		} else {
+			agentInput[key] = value;
+		}
+	}
 
-  const config: Record<string, unknown> = {
-    signal: options.signal,
-  }
+	const config: Record<string, unknown> = {
+		signal: options.signal,
+	};
 
-  if (Object.keys(params).length > 0) {
-    config.configurable = params
-  }
+	if (Object.keys(params).length > 0) {
+		config.configurable = params;
+	}
 
-  return { agentInput, config }
+	return { agentInput, config };
 }
 
 async function* streamFromRunnable(
-  runnable: AgentLike,
-  input: unknown,
-  config: Record<string, unknown>,
-  retryConfig?: RetryConfig,
+	runnable: AgentLike,
+	input: unknown,
+	config: Record<string, unknown>,
+	retryConfig?: RetryConfig,
 ): AsyncGenerator<AgentStreamChunk> {
-  const streamable = runnable as AgentLike & {
-    streamEvents?: (
-      input: unknown,
-      options: Record<string, unknown>,
-    ) => AsyncIterable<{ event: string; data: { chunk?: unknown; output?: unknown }; name: string }>
-  }
+	const streamable = runnable as AgentLike & {
+		streamEvents?: (
+			input: unknown,
+			options: Record<string, unknown>,
+		) => AsyncIterable<{
+			event: string;
+			data: { chunk?: unknown; output?: unknown };
+			name: string;
+		}>;
+	};
 
-  if (typeof streamable.streamEvents !== "function") {
-    // Fallback: invoke with retry and emit a single done event
-    const signal = config.signal as AbortSignal | undefined
-    const retryOptions: import("./retry.js").RetryOptions = {
-      ...(retryConfig?.maxAttempts ? { maxAttempts: retryConfig.maxAttempts } : {}),
-      ...(retryConfig?.baseDelay ? { baseDelayMs: retryConfig.baseDelay } : {}),
-      ...(signal ? { signal } : {}),
-    }
-    const result = await withRetry(
-      () => runnable.invoke(input, config),
-      Object.keys(retryOptions).length > 0 ? retryOptions : undefined,
-    )
-    yield { type: "done", data: result }
-    return
-  }
+	if (typeof streamable.streamEvents !== "function") {
+		// Fallback: invoke with retry and emit a single done event
+		const signal = config.signal as AbortSignal | undefined;
+		const retryOptions: import("./retry.js").RetryOptions = {
+			...(retryConfig?.maxAttempts
+				? { maxAttempts: retryConfig.maxAttempts }
+				: {}),
+			...(retryConfig?.baseDelay ? { baseDelayMs: retryConfig.baseDelay } : {}),
+			...(signal ? { signal } : {}),
+		};
+		const result = await withRetry(
+			() => runnable.invoke(input, config),
+			Object.keys(retryOptions).length > 0 ? retryOptions : undefined,
+		);
+		yield { type: "done", data: result };
+		return;
+	}
 
-  let finalOutput: unknown
-  let hasYielded = false
-  let lastStreamError: Error | undefined
+	let finalOutput: unknown;
+	let hasYielded = false;
+	let lastStreamError: Error | undefined;
 
-  // Retry the entire stream if it fails before producing any output
-  const maxStreamAttempts = retryConfig?.maxAttempts ?? 3
-  for (let attempt = 0; attempt < maxStreamAttempts; attempt++) {
-    hasYielded = false
-    lastStreamError = undefined
-    finalOutput = undefined
+	// Retry the entire stream if it fails before producing any output
+	const maxStreamAttempts = retryConfig?.maxAttempts ?? 3;
+	for (let attempt = 0; attempt < maxStreamAttempts; attempt++) {
+		hasYielded = false;
+		lastStreamError = undefined;
+		finalOutput = undefined;
 
-    try {
-      for await (const event of streamable.streamEvents(input, { ...config, version: "v2" })) {
-        switch (event.event) {
-          case "on_chat_model_stream": {
-            const content = (event.data.chunk as { content?: unknown })?.content
-            if (content && typeof content === "string" && content.length > 0) {
-              hasYielded = true
-              yield { type: "token" as const, data: content }
-            }
-            break
-          }
-          case "on_tool_start": {
-            hasYielded = true
-            yield {
-              type: "tool_call" as const,
-              data: { name: event.name, input: event.data.chunk ?? event.data.output },
-            }
-            break
-          }
-          case "on_tool_end": {
-            hasYielded = true
-            yield {
-              type: "tool_result" as const,
-              data: { name: event.name, output: event.data.output },
-            }
-            break
-          }
-          case "on_chain_end": {
-            if (event.name === "LangGraph") {
-              finalOutput = event.data.output
-            }
-            break
-          }
-        }
-      }
+		try {
+			for await (const event of streamable.streamEvents(input, {
+				...config,
+				version: "v2",
+			})) {
+				switch (event.event) {
+					case "on_chat_model_stream": {
+						const content = (event.data.chunk as { content?: unknown })
+							?.content;
+						if (content && typeof content === "string" && content.length > 0) {
+							hasYielded = true;
+							yield { type: "token" as const, data: content };
+						}
+						break;
+					}
+					case "on_tool_start": {
+						hasYielded = true;
+						yield {
+							type: "tool_call" as const,
+							data: {
+								name: event.name,
+								input: event.data.chunk ?? event.data.output,
+							},
+						};
+						break;
+					}
+					case "on_tool_end": {
+						hasYielded = true;
+						yield {
+							type: "tool_result" as const,
+							data: { name: event.name, output: event.data.output },
+						};
+						break;
+					}
+					case "on_chain_end": {
+						if (event.name === "LangGraph") {
+							finalOutput = event.data.output;
+						}
+						break;
+					}
+				}
+			}
 
-      // Stream completed successfully
-      break
-    } catch (error) {
-      lastStreamError = error instanceof Error ? error : new Error(String(error))
+			// Stream completed successfully
+			break;
+		} catch (error) {
+			lastStreamError =
+				error instanceof Error ? error : new Error(String(error));
 
-      // If we already yielded chunks, we can't retry (client has partial data)
-      // Or if the error isn't retryable, rethrow immediately
-      if (hasYielded || !isRetryableError(error) || attempt === maxStreamAttempts - 1) {
-        throw lastStreamError
-      }
+			// If we already yielded chunks, we can't retry (client has partial data)
+			// Or if the error isn't retryable, rethrow immediately
+			if (
+				hasYielded ||
+				!isRetryableError(error) ||
+				attempt === maxStreamAttempts - 1
+			) {
+				throw lastStreamError;
+			}
 
-      // Backoff before retry
-      const delay = Math.min(1000 * 2 ** attempt + Math.random() * 500, 10_000)
-      await new Promise((resolve) => setTimeout(resolve, delay))
-    }
-  }
+			// Backoff before retry
+			const delay = Math.min(1000 * 2 ** attempt + Math.random() * 500, 10_000);
+			await new Promise((resolve) => setTimeout(resolve, delay));
+		}
+	}
 
-  yield { type: "done", data: finalOutput }
+	yield { type: "done", data: finalOutput };
 }
 
 interface InputMessage {
-  readonly role: string
-  readonly content: string
+	readonly role: string;
+	readonly content: string;
 }
 
 function isInputMessageArray(value: unknown): value is readonly InputMessage[] {
-  return (
-    Array.isArray(value) &&
-    value.length > 0 &&
-    value.every(
-      (item) =>
-        typeof item === "object" &&
-        item !== null &&
-        typeof (item as { role?: unknown }).role === "string" &&
-        typeof (item as { content?: unknown }).content === "string",
-    )
-  )
+	return (
+		Array.isArray(value) &&
+		value.length > 0 &&
+		value.every(
+			(item) =>
+				typeof item === "object" &&
+				item !== null &&
+				typeof (item as { role?: unknown }).role === "string" &&
+				typeof (item as { content?: unknown }).content === "string",
+		)
+	);
 }
 
 function extractMessages(input: Record<string, unknown>): HumanMessage[] {
-  // LangGraph protocol format: {messages: [{role, content}, ...]}
-  if (isInputMessageArray(input.messages)) {
-    return input.messages
-      .filter((msg) => msg.role === "user")
-      .map((msg) => new HumanMessage(msg.content))
-  }
+	// LangGraph protocol format: {messages: [{role, content}, ...]}
+	if (isInputMessageArray(input.messages)) {
+		return input.messages
+			.filter((msg) => msg.role === "user")
+			.map((msg) => new HumanMessage(msg.content));
+	}
 
-  // Legacy flat-object format: {key: value, ...}
-  return [new HumanMessage(formatAgentMessage(input))]
+	// Legacy flat-object format: {key: value, ...}
+	return [new HumanMessage(formatAgentMessage(input))];
 }
 
 function formatAgentMessage(input: Record<string, unknown>): string {
-  const entries = Object.entries(input)
+	const entries = Object.entries(input);
 
-  if (entries.length === 0) {
-    return ""
-  }
+	if (entries.length === 0) {
+		return "";
+	}
 
-  if (entries.length === 1) {
-    return String(entries[0]?.[1])
-  }
+	if (entries.length === 1) {
+		return String(entries[0]?.[1]);
+	}
 
-  return entries.map(([key, value]) => `${key}: ${String(value)}`).join("\n")
+	return entries.map(([key, value]) => `${key}: ${String(value)}`).join("\n");
 }

--- a/packages/langchain/src/tool-converter.ts
+++ b/packages/langchain/src/tool-converter.ts
@@ -1,115 +1,108 @@
-import { DynamicStructuredTool } from "@langchain/core/tools";
-import { z } from "zod";
+import { DynamicStructuredTool } from "@langchain/core/tools"
+import { z } from "zod"
 
 interface DawnToolDefinition {
-	readonly description?: string;
-	readonly name: string;
-	readonly run: (
-		input: unknown,
-		context: {
-			readonly middleware?: Readonly<Record<string, unknown>>;
-			readonly signal: AbortSignal;
-		},
-	) => Promise<unknown> | unknown;
-	readonly schema?: unknown;
+  readonly description?: string
+  readonly name: string
+  readonly run: (
+    input: unknown,
+    context: {
+      readonly middleware?: Readonly<Record<string, unknown>>
+      readonly signal: AbortSignal
+    },
+  ) => Promise<unknown> | unknown
+  readonly schema?: unknown
 }
 
 export function convertToolToLangChain(
-	tool: DawnToolDefinition,
-	middlewareContext?: Readonly<Record<string, unknown>>,
+  tool: DawnToolDefinition,
+  middlewareContext?: Readonly<Record<string, unknown>>,
 ): DynamicStructuredTool {
-	const schema = toZodSchema(tool.schema);
+  const schema = toZodSchema(tool.schema)
 
-	// Cast through unknown to bridge the dual-Zod version type incompatibility
-	// (package uses zod@3.24.4; @langchain/core uses zod@3.25.x — structurally identical at runtime)
-	return new DynamicStructuredTool({
-		name: tool.name,
-		description: tool.description ?? "",
-		schema: schema as unknown as z.ZodObject<z.ZodRawShape>,
-		func: async (input, _runManager, config) => {
-			const signal = config?.signal ?? new AbortController().signal;
-			const result = await tool.run(input, {
-				...(middlewareContext ? { middleware: middlewareContext } : {}),
-				signal,
-			});
-			return JSON.stringify(result);
-		},
-	}) as unknown as DynamicStructuredTool;
+  // Cast through unknown to bridge the dual-Zod version type incompatibility
+  // (package uses zod@3.24.4; @langchain/core uses zod@3.25.x — structurally identical at runtime)
+  return new DynamicStructuredTool({
+    name: tool.name,
+    description: tool.description ?? "",
+    schema: schema as unknown as z.ZodObject<z.ZodRawShape>,
+    func: async (input, _runManager, config) => {
+      const signal = config?.signal ?? new AbortController().signal
+      const result = await tool.run(input, {
+        ...(middlewareContext ? { middleware: middlewareContext } : {}),
+        signal,
+      })
+      return JSON.stringify(result)
+    },
+  }) as unknown as DynamicStructuredTool
 }
 
 function toZodSchema(value: unknown): z.ZodObject<z.ZodRawShape> {
-	if (isZodObject(value)) return value;
-	if (isJsonSchemaObject(value)) return jsonSchemaToZod(value);
-	return z.record(
-		z.string(),
-		z.unknown(),
-	) as unknown as z.ZodObject<z.ZodRawShape>;
+  if (isZodObject(value)) return value
+  if (isJsonSchemaObject(value)) return jsonSchemaToZod(value)
+  return z.record(z.string(), z.unknown()) as unknown as z.ZodObject<z.ZodRawShape>
 }
 
 function isZodObject(value: unknown): value is z.ZodObject<z.ZodRawShape> {
-	return (
-		typeof value === "object" &&
-		value !== null &&
-		"_def" in value &&
-		typeof (value as { _def?: { typeName?: unknown } })._def === "object" &&
-		(value as { _def: { typeName?: unknown } })._def !== null
-	);
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "_def" in value &&
+    typeof (value as { _def?: { typeName?: unknown } })._def === "object" &&
+    (value as { _def: { typeName?: unknown } })._def !== null
+  )
 }
 
 interface JsonSchemaObject {
-	readonly type: "object";
-	readonly properties?: Record<
-		string,
-		{ readonly type?: string; readonly items?: unknown }
-	>;
-	readonly required?: readonly string[];
+  readonly type: "object"
+  readonly properties?: Record<string, { readonly type?: string; readonly items?: unknown }>
+  readonly required?: readonly string[]
 }
 
 function isJsonSchemaObject(value: unknown): value is JsonSchemaObject {
-	return (
-		typeof value === "object" &&
-		value !== null &&
-		(value as { type?: unknown }).type === "object" &&
-		typeof (value as { properties?: unknown }).properties === "object"
-	);
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    (value as { type?: unknown }).type === "object" &&
+    typeof (value as { properties?: unknown }).properties === "object"
+  )
 }
 
 function jsonSchemaToZod(schema: JsonSchemaObject): z.ZodObject<z.ZodRawShape> {
-	const shape: z.ZodRawShape = {};
-	const required = new Set(schema.required ?? []);
+  const shape: z.ZodRawShape = {}
+  const required = new Set(schema.required ?? [])
 
-	for (const [key, prop] of Object.entries(schema.properties ?? {})) {
-		let field: z.ZodTypeAny = jsonSchemaFieldToZod(prop);
-		if (!required.has(key)) {
-			field = field.optional();
-		}
-		shape[key] = field;
-	}
+  for (const [key, prop] of Object.entries(schema.properties ?? {})) {
+    let field: z.ZodTypeAny = jsonSchemaFieldToZod(prop)
+    if (!required.has(key)) {
+      field = field.optional()
+    }
+    shape[key] = field
+  }
 
-	return z.object(shape);
+  return z.object(shape)
 }
 
 function jsonSchemaFieldToZod(prop: {
-	readonly type?: string;
-	readonly items?: unknown;
+  readonly type?: string
+  readonly items?: unknown
 }): z.ZodTypeAny {
-	switch (prop.type) {
-		case "string":
-			return z.string();
-		case "number":
-		case "integer":
-			return z.number();
-		case "boolean":
-			return z.boolean();
-		case "array": {
-			const items = prop.items as { readonly type?: string } | undefined;
-			if (items?.type === "string") return z.array(z.string());
-			if (items?.type === "number" || items?.type === "integer")
-				return z.array(z.number());
-			if (items?.type === "boolean") return z.array(z.boolean());
-			return z.array(z.unknown());
-		}
-		default:
-			return z.unknown();
-	}
+  switch (prop.type) {
+    case "string":
+      return z.string()
+    case "number":
+    case "integer":
+      return z.number()
+    case "boolean":
+      return z.boolean()
+    case "array": {
+      const items = prop.items as { readonly type?: string } | undefined
+      if (items?.type === "string") return z.array(z.string())
+      if (items?.type === "number" || items?.type === "integer") return z.array(z.number())
+      if (items?.type === "boolean") return z.array(z.boolean())
+      return z.array(z.unknown())
+    }
+    default:
+      return z.unknown()
+  }
 }

--- a/packages/langchain/src/tool-converter.ts
+++ b/packages/langchain/src/tool-converter.ts
@@ -1,99 +1,115 @@
-import { DynamicStructuredTool } from "@langchain/core/tools"
-import { z } from "zod"
+import { DynamicStructuredTool } from "@langchain/core/tools";
+import { z } from "zod";
 
 interface DawnToolDefinition {
-  readonly description?: string
-  readonly name: string
-  readonly run: (
-    input: unknown,
-    context: { readonly signal: AbortSignal },
-  ) => Promise<unknown> | unknown
-  readonly schema?: unknown
+	readonly description?: string;
+	readonly name: string;
+	readonly run: (
+		input: unknown,
+		context: {
+			readonly middleware?: Readonly<Record<string, unknown>>;
+			readonly signal: AbortSignal;
+		},
+	) => Promise<unknown> | unknown;
+	readonly schema?: unknown;
 }
 
-export function convertToolToLangChain(tool: DawnToolDefinition): DynamicStructuredTool {
-  const schema = toZodSchema(tool.schema)
+export function convertToolToLangChain(
+	tool: DawnToolDefinition,
+	middlewareContext?: Readonly<Record<string, unknown>>,
+): DynamicStructuredTool {
+	const schema = toZodSchema(tool.schema);
 
-  // Cast through unknown to bridge the dual-Zod version type incompatibility
-  // (package uses zod@3.24.4; @langchain/core uses zod@3.25.x — structurally identical at runtime)
-  return new DynamicStructuredTool({
-    name: tool.name,
-    description: tool.description ?? "",
-    schema: schema as unknown as z.ZodObject<z.ZodRawShape>,
-    func: async (input, _runManager, config) => {
-      const signal = config?.signal ?? new AbortController().signal
-      const result = await tool.run(input, { signal })
-      return JSON.stringify(result)
-    },
-  }) as unknown as DynamicStructuredTool
+	// Cast through unknown to bridge the dual-Zod version type incompatibility
+	// (package uses zod@3.24.4; @langchain/core uses zod@3.25.x — structurally identical at runtime)
+	return new DynamicStructuredTool({
+		name: tool.name,
+		description: tool.description ?? "",
+		schema: schema as unknown as z.ZodObject<z.ZodRawShape>,
+		func: async (input, _runManager, config) => {
+			const signal = config?.signal ?? new AbortController().signal;
+			const result = await tool.run(input, {
+				...(middlewareContext ? { middleware: middlewareContext } : {}),
+				signal,
+			});
+			return JSON.stringify(result);
+		},
+	}) as unknown as DynamicStructuredTool;
 }
 
 function toZodSchema(value: unknown): z.ZodObject<z.ZodRawShape> {
-  if (isZodObject(value)) return value
-  if (isJsonSchemaObject(value)) return jsonSchemaToZod(value)
-  return z.record(z.string(), z.unknown()) as unknown as z.ZodObject<z.ZodRawShape>
+	if (isZodObject(value)) return value;
+	if (isJsonSchemaObject(value)) return jsonSchemaToZod(value);
+	return z.record(
+		z.string(),
+		z.unknown(),
+	) as unknown as z.ZodObject<z.ZodRawShape>;
 }
 
 function isZodObject(value: unknown): value is z.ZodObject<z.ZodRawShape> {
-  return (
-    typeof value === "object" &&
-    value !== null &&
-    "_def" in value &&
-    typeof (value as { _def?: { typeName?: unknown } })._def === "object" &&
-    (value as { _def: { typeName?: unknown } })._def !== null
-  )
+	return (
+		typeof value === "object" &&
+		value !== null &&
+		"_def" in value &&
+		typeof (value as { _def?: { typeName?: unknown } })._def === "object" &&
+		(value as { _def: { typeName?: unknown } })._def !== null
+	);
 }
 
 interface JsonSchemaObject {
-  readonly type: "object"
-  readonly properties?: Record<string, { readonly type?: string; readonly items?: unknown }>
-  readonly required?: readonly string[]
+	readonly type: "object";
+	readonly properties?: Record<
+		string,
+		{ readonly type?: string; readonly items?: unknown }
+	>;
+	readonly required?: readonly string[];
 }
 
 function isJsonSchemaObject(value: unknown): value is JsonSchemaObject {
-  return (
-    typeof value === "object" &&
-    value !== null &&
-    (value as { type?: unknown }).type === "object" &&
-    typeof (value as { properties?: unknown }).properties === "object"
-  )
+	return (
+		typeof value === "object" &&
+		value !== null &&
+		(value as { type?: unknown }).type === "object" &&
+		typeof (value as { properties?: unknown }).properties === "object"
+	);
 }
 
 function jsonSchemaToZod(schema: JsonSchemaObject): z.ZodObject<z.ZodRawShape> {
-  const shape: z.ZodRawShape = {}
-  const required = new Set(schema.required ?? [])
+	const shape: z.ZodRawShape = {};
+	const required = new Set(schema.required ?? []);
 
-  for (const [key, prop] of Object.entries(schema.properties ?? {})) {
-    let field: z.ZodTypeAny = jsonSchemaFieldToZod(prop)
-    if (!required.has(key)) {
-      field = field.optional()
-    }
-    shape[key] = field
-  }
+	for (const [key, prop] of Object.entries(schema.properties ?? {})) {
+		let field: z.ZodTypeAny = jsonSchemaFieldToZod(prop);
+		if (!required.has(key)) {
+			field = field.optional();
+		}
+		shape[key] = field;
+	}
 
-  return z.object(shape)
+	return z.object(shape);
 }
 
 function jsonSchemaFieldToZod(prop: {
-  readonly type?: string
-  readonly items?: unknown
+	readonly type?: string;
+	readonly items?: unknown;
 }): z.ZodTypeAny {
-  switch (prop.type) {
-    case "string":
-      return z.string()
-    case "number":
-    case "integer":
-      return z.number()
-    case "boolean":
-      return z.boolean()
-    case "array": {
-      const items = prop.items as { readonly type?: string } | undefined
-      if (items?.type === "string") return z.array(z.string())
-      if (items?.type === "number" || items?.type === "integer") return z.array(z.number())
-      if (items?.type === "boolean") return z.array(z.boolean())
-      return z.array(z.unknown())
-    }
-    default:
-      return z.unknown()
-  }
+	switch (prop.type) {
+		case "string":
+			return z.string();
+		case "number":
+		case "integer":
+			return z.number();
+		case "boolean":
+			return z.boolean();
+		case "array": {
+			const items = prop.items as { readonly type?: string } | undefined;
+			if (items?.type === "string") return z.array(z.string());
+			if (items?.type === "number" || items?.type === "integer")
+				return z.array(z.number());
+			if (items?.type === "boolean") return z.array(z.boolean());
+			return z.array(z.unknown());
+		}
+		default:
+			return z.unknown();
+	}
 }

--- a/packages/langchain/src/tool-loop.ts
+++ b/packages/langchain/src/tool-loop.ts
@@ -1,77 +1,95 @@
-import { AIMessage, ToolMessage } from "@langchain/core/messages"
+import { AIMessage, ToolMessage } from "@langchain/core/messages";
 
-const DEFAULT_MAX_ITERATIONS = 10
+const DEFAULT_MAX_ITERATIONS = 10;
 
 interface ToolExecutor {
-  readonly name: string
-  readonly run: (
-    input: unknown,
-    context: { readonly signal: AbortSignal },
-  ) => Promise<unknown> | unknown
+	readonly name: string;
+	readonly run: (
+		input: unknown,
+		context: {
+			readonly middleware?: Readonly<Record<string, unknown>>;
+			readonly signal: AbortSignal;
+		},
+	) => Promise<unknown> | unknown;
 }
 
 export interface ExecuteWithToolLoopOptions {
-  readonly chain: { readonly invoke: (input: unknown) => Promise<unknown> }
-  readonly input: unknown
-  readonly tools: readonly ToolExecutor[]
-  readonly signal: AbortSignal
-  readonly maxIterations?: number
+	readonly chain: { readonly invoke: (input: unknown) => Promise<unknown> };
+	readonly input: unknown;
+	readonly middlewareContext?: Readonly<Record<string, unknown>>;
+	readonly tools: readonly ToolExecutor[];
+	readonly signal: AbortSignal;
+	readonly maxIterations?: number;
 }
 
-export async function executeWithToolLoop(options: ExecuteWithToolLoopOptions): Promise<unknown> {
-  const { chain, input, tools, signal, maxIterations = DEFAULT_MAX_ITERATIONS } = options
-  const toolMap = new Map(tools.map((t) => [t.name, t]))
-  let currentInput: unknown = input
+export async function executeWithToolLoop(
+	options: ExecuteWithToolLoopOptions,
+): Promise<unknown> {
+	const {
+		chain,
+		input,
+		middlewareContext,
+		tools,
+		signal,
+		maxIterations = DEFAULT_MAX_ITERATIONS,
+	} = options;
+	const toolMap = new Map(tools.map((t) => [t.name, t]));
+	let currentInput: unknown = input;
 
-  for (let i = 0; i < maxIterations; i++) {
-    const result = await chain.invoke(currentInput)
+	for (let i = 0; i < maxIterations; i++) {
+		const result = await chain.invoke(currentInput);
 
-    if (!isAIMessageWithToolCalls(result)) {
-      return result
-    }
+		if (!isAIMessageWithToolCalls(result)) {
+			return result;
+		}
 
-    const toolMessages = await Promise.all(
-      result.tool_calls.map(async (call) => {
-        const tool = toolMap.get(call.name)
-        if (!tool) {
-          return new ToolMessage({
-            content: JSON.stringify({ error: `Unknown tool: ${call.name}` }),
-            tool_call_id: call.id ?? "",
-          })
-        }
-        try {
-          const output = await tool.run(call.args, { signal })
-          return new ToolMessage({
-            content: JSON.stringify(output),
-            tool_call_id: call.id ?? "",
-          })
-        } catch (error) {
-          return new ToolMessage({
-            content: JSON.stringify({
-              error: error instanceof Error ? error.message : String(error),
-            }),
-            tool_call_id: call.id ?? "",
-          })
-        }
-      }),
-    )
+		const toolMessages = await Promise.all(
+			result.tool_calls.map(async (call) => {
+				const tool = toolMap.get(call.name);
+				if (!tool) {
+					return new ToolMessage({
+						content: JSON.stringify({ error: `Unknown tool: ${call.name}` }),
+						tool_call_id: call.id ?? "",
+					});
+				}
+				try {
+					const output = await tool.run(call.args, {
+						...(middlewareContext ? { middleware: middlewareContext } : {}),
+						signal,
+					});
+					return new ToolMessage({
+						content: JSON.stringify(output),
+						tool_call_id: call.id ?? "",
+					});
+				} catch (error) {
+					return new ToolMessage({
+						content: JSON.stringify({
+							error: error instanceof Error ? error.message : String(error),
+						}),
+						tool_call_id: call.id ?? "",
+					});
+				}
+			}),
+		);
 
-    currentInput = [
-      ...(Array.isArray(currentInput) ? (currentInput as unknown[]) : []),
-      result,
-      ...toolMessages,
-    ]
-  }
+		currentInput = [
+			...(Array.isArray(currentInput) ? (currentInput as unknown[]) : []),
+			result,
+			...toolMessages,
+		];
+	}
 
-  throw new Error(`Tool execution loop exceeded maximum ${maxIterations} iterations`)
+	throw new Error(
+		`Tool execution loop exceeded maximum ${maxIterations} iterations`,
+	);
 }
 
-function isAIMessageWithToolCalls(
-  value: unknown,
-): value is AIMessage & { tool_calls: readonly { id?: string; name: string; args: unknown }[] } {
-  return (
-    value instanceof AIMessage &&
-    Array.isArray((value as AIMessage & { tool_calls?: unknown }).tool_calls) &&
-    (value as AIMessage & { tool_calls: unknown[] }).tool_calls.length > 0
-  )
+function isAIMessageWithToolCalls(value: unknown): value is AIMessage & {
+	tool_calls: readonly { id?: string; name: string; args: unknown }[];
+} {
+	return (
+		value instanceof AIMessage &&
+		Array.isArray((value as AIMessage & { tool_calls?: unknown }).tool_calls) &&
+		(value as AIMessage & { tool_calls: unknown[] }).tool_calls.length > 0
+	);
 }

--- a/packages/langchain/src/tool-loop.ts
+++ b/packages/langchain/src/tool-loop.ts
@@ -1,95 +1,91 @@
-import { AIMessage, ToolMessage } from "@langchain/core/messages";
+import { AIMessage, ToolMessage } from "@langchain/core/messages"
 
-const DEFAULT_MAX_ITERATIONS = 10;
+const DEFAULT_MAX_ITERATIONS = 10
 
 interface ToolExecutor {
-	readonly name: string;
-	readonly run: (
-		input: unknown,
-		context: {
-			readonly middleware?: Readonly<Record<string, unknown>>;
-			readonly signal: AbortSignal;
-		},
-	) => Promise<unknown> | unknown;
+  readonly name: string
+  readonly run: (
+    input: unknown,
+    context: {
+      readonly middleware?: Readonly<Record<string, unknown>>
+      readonly signal: AbortSignal
+    },
+  ) => Promise<unknown> | unknown
 }
 
 export interface ExecuteWithToolLoopOptions {
-	readonly chain: { readonly invoke: (input: unknown) => Promise<unknown> };
-	readonly input: unknown;
-	readonly middlewareContext?: Readonly<Record<string, unknown>>;
-	readonly tools: readonly ToolExecutor[];
-	readonly signal: AbortSignal;
-	readonly maxIterations?: number;
+  readonly chain: { readonly invoke: (input: unknown) => Promise<unknown> }
+  readonly input: unknown
+  readonly middlewareContext?: Readonly<Record<string, unknown>>
+  readonly tools: readonly ToolExecutor[]
+  readonly signal: AbortSignal
+  readonly maxIterations?: number
 }
 
-export async function executeWithToolLoop(
-	options: ExecuteWithToolLoopOptions,
-): Promise<unknown> {
-	const {
-		chain,
-		input,
-		middlewareContext,
-		tools,
-		signal,
-		maxIterations = DEFAULT_MAX_ITERATIONS,
-	} = options;
-	const toolMap = new Map(tools.map((t) => [t.name, t]));
-	let currentInput: unknown = input;
+export async function executeWithToolLoop(options: ExecuteWithToolLoopOptions): Promise<unknown> {
+  const {
+    chain,
+    input,
+    middlewareContext,
+    tools,
+    signal,
+    maxIterations = DEFAULT_MAX_ITERATIONS,
+  } = options
+  const toolMap = new Map(tools.map((t) => [t.name, t]))
+  let currentInput: unknown = input
 
-	for (let i = 0; i < maxIterations; i++) {
-		const result = await chain.invoke(currentInput);
+  for (let i = 0; i < maxIterations; i++) {
+    const result = await chain.invoke(currentInput)
 
-		if (!isAIMessageWithToolCalls(result)) {
-			return result;
-		}
+    if (!isAIMessageWithToolCalls(result)) {
+      return result
+    }
 
-		const toolMessages = await Promise.all(
-			result.tool_calls.map(async (call) => {
-				const tool = toolMap.get(call.name);
-				if (!tool) {
-					return new ToolMessage({
-						content: JSON.stringify({ error: `Unknown tool: ${call.name}` }),
-						tool_call_id: call.id ?? "",
-					});
-				}
-				try {
-					const output = await tool.run(call.args, {
-						...(middlewareContext ? { middleware: middlewareContext } : {}),
-						signal,
-					});
-					return new ToolMessage({
-						content: JSON.stringify(output),
-						tool_call_id: call.id ?? "",
-					});
-				} catch (error) {
-					return new ToolMessage({
-						content: JSON.stringify({
-							error: error instanceof Error ? error.message : String(error),
-						}),
-						tool_call_id: call.id ?? "",
-					});
-				}
-			}),
-		);
+    const toolMessages = await Promise.all(
+      result.tool_calls.map(async (call) => {
+        const tool = toolMap.get(call.name)
+        if (!tool) {
+          return new ToolMessage({
+            content: JSON.stringify({ error: `Unknown tool: ${call.name}` }),
+            tool_call_id: call.id ?? "",
+          })
+        }
+        try {
+          const output = await tool.run(call.args, {
+            ...(middlewareContext ? { middleware: middlewareContext } : {}),
+            signal,
+          })
+          return new ToolMessage({
+            content: JSON.stringify(output),
+            tool_call_id: call.id ?? "",
+          })
+        } catch (error) {
+          return new ToolMessage({
+            content: JSON.stringify({
+              error: error instanceof Error ? error.message : String(error),
+            }),
+            tool_call_id: call.id ?? "",
+          })
+        }
+      }),
+    )
 
-		currentInput = [
-			...(Array.isArray(currentInput) ? (currentInput as unknown[]) : []),
-			result,
-			...toolMessages,
-		];
-	}
+    currentInput = [
+      ...(Array.isArray(currentInput) ? (currentInput as unknown[]) : []),
+      result,
+      ...toolMessages,
+    ]
+  }
 
-	throw new Error(
-		`Tool execution loop exceeded maximum ${maxIterations} iterations`,
-	);
+  throw new Error(`Tool execution loop exceeded maximum ${maxIterations} iterations`)
 }
 
 function isAIMessageWithToolCalls(value: unknown): value is AIMessage & {
-	tool_calls: readonly { id?: string; name: string; args: unknown }[];
+  tool_calls: readonly { id?: string; name: string; args: unknown }[]
 } {
-	return (
-		value instanceof AIMessage &&
-		Array.isArray((value as AIMessage & { tool_calls?: unknown }).tool_calls) &&
-		(value as AIMessage & { tool_calls: unknown[] }).tool_calls.length > 0
-	);
+  return (
+    value instanceof AIMessage &&
+    Array.isArray((value as AIMessage & { tool_calls?: unknown }).tool_calls) &&
+    (value as AIMessage & { tool_calls: unknown[] }).tool_calls.length > 0
+  )
 }


### PR DESCRIPTION
## Summary
- Thread middleware context from `allow({ userId, orgId })` through the entire execution pipeline to tool `run()` calls
- Tools now receive middleware context as `(input, { middleware, signal })` — the `middleware` property is the object passed to `allow()`
- Context flows: `runtime-server` → `executeResolvedRoute`/`streamResolvedRoute` → `createDawnContext` → `tool.run()`, and through `convertToolToLangChain` and `executeWithToolLoop` in `@dawn-ai/langchain`

## Test plan
- [x] All 225 tests pass
- [x] Build clean, typecheck clean, lint clean
- [x] `exactOptionalPropertyTypes` handled — middleware context conditionally spread to avoid `undefined` assignment
