### PR TITLE
docs: docs review audit (PR 0 of 5)

### DIFF
--- a/docs/superpowers/audits/2026-05-06-docs-audit.md
+++ b/docs/superpowers/audits/2026-05-06-docs-audit.md
@@ -1,0 +1,49 @@
+# Dawn Docs Audit — 2026-05-06
+
+**Status:** in progress
+**Spec:** `docs/superpowers/specs/2026-05-06-docs-review-design.md`
+**Plan:** `docs/superpowers/plans/2026-05-06-docs-review.md`
+
+## Findings format
+
+Each finding uses this schema:
+
+```markdown
+### F-NNN: <one-line summary>
+- **Surface:** <surface>
+- **File:** <path:line if applicable>
+- **Type:** gap | misalignment | error | broken-example
+- **Severity:** critical | important | minor
+- **Description:** <what's wrong>
+- **Suggested fix:** <concrete change, or "needs design">
+```
+
+Findings are numbered globally across all sections (F-001, F-002, ...). Each subagent claims a contiguous range and announces it in its closing summary so the next subagent picks up from F-(N+1).
+
+## 1. Root README (`README.md`)
+
+_(pending — Task 2)_
+
+## 2. Website load-bearing pages (`getting-started.mdx`, `routes.mdx`, `tools.mdx`, `deployment.mdx`)
+
+_(pending — Task 3)_
+
+## 3. Website supporting pages (`state.mdx`, `cli.mdx`, `dev-server.mdx`, `testing.mdx`)
+
+_(pending — Task 4)_
+
+## 4. Templates (`AGENTS.md`, `CLAUDE.md`)
+
+_(pending — Task 5)_
+
+## 5. Public package READMEs (`@dawn-ai/sdk`, `@dawn-ai/cli`, `create-dawn-ai-app`)
+
+_(pending — Task 6)_
+
+## 6. Internal package READMEs (config-biome, config-typescript, core, devkit, langchain, langgraph, vite-plugin)
+
+_(pending — Task 7)_
+
+## Summary
+
+_(pending — populated at the findings cut after Tasks 2–7)_

--- a/docs/superpowers/audits/2026-05-06-docs-audit.md
+++ b/docs/superpowers/audits/2026-05-06-docs-audit.md
@@ -1,6 +1,6 @@
 # Dawn Docs Audit — 2026-05-06
 
-**Status:** in progress
+**Status:** complete
 **Spec:** `docs/superpowers/specs/2026-05-06-docs-review-design.md`
 **Plan:** `docs/superpowers/plans/2026-05-06-docs-review.md`
 **Last refresh:** 2026-05-07 — audit refreshed against main HEAD 7a96d3b (Add Dawn brand assets, PR #38). Affected sections: 1, 5, 6.
@@ -981,4 +981,28 @@ Internal READMEs findings: F-107 through F-113, plus F-115 (0 critical, 2 import
 
 ## Summary
 
-_(pending — populated at the findings cut after Tasks 2–7)_
+| Section | Critical | Important | Minor | Total |
+|---------|---------:|----------:|------:|------:|
+| 1. Root README                | 3  | 6  | 5  | 14  |
+| 2. Website load-bearing       | 12 | 10 | 4  | 26  |
+| 3. Website supporting         | 14 | 14 | 7  | 35  |
+| 4. Templates                  | 6  | 3  | 4  | 13  |
+| 5. Public package READMEs     | 4  | 10 | 5  | 19  |
+| 6. Internal package READMEs   | 0  | 2  | 6  | 8   |
+| **Total**                     | **39** | **45** | **31** | **115** |
+
+**In scope for fix PRs (PR A, B, C, D):** all critical + important findings = 84 total.
+
+**Deferred to follow-up issue:** 31 minor findings will be filed as a single GitHub issue after the fix PRs land.
+
+**Recategorization decisions:** none. The refresh against main HEAD 7a96d3b added two brand-asset minor findings (F-114, F-115) but did not invalidate or change the severity of any prior finding.
+
+**Notable cross-cutting observations:**
+
+- `testing.mdx` and `cli.mdx` (section 3) drifted heavily — testing.mdx imports a non-existent `@dawn-ai/sdk/testing` subpath; `cli.mdx` lists 3 of 8 commands and documents non-existent flags. Section 3 carries the largest individual-page issue density.
+- `deployment.mdx` (section 2) tells users to hand-write `langgraph.json` despite `dawn build` shipping that file with the correct format.
+- Templates (section 4) and several website docs entirely omit middleware (`defineMiddleware`, `reject`, `allow`) and the agent retry config — both first-class shipped surfaces.
+- Templates `AGENTS.md` and `CLAUDE.md` are byte-identical (F-075). PR B should canonicalize one as the source-of-truth (or document them as intentionally identical).
+- F-082 (`@dawn-ai/sdk/testing` import) is an escape-hatch candidate: the right fix depends on intent (delete the directive vs. add a `./testing` subpath export). PR B implementer must decide and call it out.
+
+**Next:** This report is the basis for PR 0 (lands the audit) followed by four fix PRs (B → A → C → D).

--- a/docs/superpowers/audits/2026-05-06-docs-audit.md
+++ b/docs/superpowers/audits/2026-05-06-docs-audit.md
@@ -3,6 +3,7 @@
 **Status:** in progress
 **Spec:** `docs/superpowers/specs/2026-05-06-docs-review-design.md`
 **Plan:** `docs/superpowers/plans/2026-05-06-docs-review.md`
+**Last refresh:** 2026-05-07 — audit refreshed against main HEAD 7a96d3b (Add Dawn brand assets, PR #38). Affected sections: 1, 5, 6.
 
 ## Findings format
 
@@ -24,7 +25,7 @@ Findings are numbered globally across all sections (F-001, F-002, ...). Each sub
 
 ### F-001: README opening sentence omits agent execution and tools — Dawn's primary capability
 - **Surface:** Root README
-- **File:** README.md:3
+- **File:** README.md:7
 - **Type:** misalignment
 - **Severity:** important
 - **Description:** The opening line describes Dawn as a framework for "filesystem-based route discovery, route validation, type generation, local route execution, and a local development runtime." This omits agent execution, route-local tool authoring, middleware, and `dawn build` for LangGraph Platform deployment artifacts — all currently shipping capabilities. The scaffold even ships an `agent()` route by default (see F-005), so describing Dawn purely as a route/runtime framework is misleading.
@@ -32,7 +33,7 @@ Findings are numbered globally across all sections (F-001, F-002, ...). Each sub
 
 ### F-002: "Status" section says Dawn is not a deployment runtime, but `dawn build` produces LangGraph Platform deployment artifacts
 - **Surface:** Root README
-- **File:** README.md:5-7
+- **File:** README.md:9-11
 - **Type:** misalignment
 - **Severity:** important
 - **Description:** The Status section asserts Dawn "is not a deployment runtime, not a LangSmith trace replacement, and not a hosted platform." This is technically still true (Dawn does not host or run production traffic), but it ignores the fact that `dawn build` (packages/cli/src/commands/build.ts) now exists specifically to emit `langgraph.json` + entry files for LangGraph Platform deployment. Readers will be confused when `dawn build` is missing from Commands and the Status disclaimer suggests deployment is out of scope.
@@ -40,7 +41,7 @@ Findings are numbered globally across all sections (F-001, F-002, ...). Each sub
 
 ### F-003: Quickstart `pnpm create dawn-app` invokes a non-existent npm package
 - **Surface:** Root README
-- **File:** README.md:14, 72
+- **File:** README.md:18, 76
 - **Type:** error
 - **Severity:** critical
 - **Description:** The README instructs users to run `pnpm create dawn-app my-dawn-app`. `pnpm create dawn-app` resolves to the npm package `create-dawn-app`, but the published package is `create-dawn-ai-app` (see packages/create-dawn-app/package.json line 2: `"name": "create-dawn-ai-app"`, and bin name `create-dawn-ai-app` on line 23). The Quickstart command will fail with a "package not found" error for any first-time user.
@@ -48,7 +49,7 @@ Findings are numbered globally across all sections (F-001, F-002, ...). Each sub
 
 ### F-004: Scaffold route example documents `workflow`/`graph` exports but actual scaffold exports `agent`
 - **Surface:** Root README
-- **File:** README.md:40-50
+- **File:** README.md:44-54
 - **Type:** misalignment
 - **Severity:** critical
 - **Description:** The App Contract section says a route's `index.ts` "exports either a `workflow` function or a `graph` function/object" and shows two snippets using those exports. But the basic template ships `index.ts` that does `export default agent({...})` (packages/devkit/templates/app-basic/src/app/(public)/hello/[tenant]/index.ts). The discovery layer (packages/core/src/discovery/discover-routes.ts) actually accepts four kinds: `agent`, `workflow`, `graph`, and `chain` (RouteKind in packages/sdk/src/route-config.ts:1). A user reading this section and then opening the scaffold would be very confused — the scaffolded route does not match either pattern shown.
@@ -56,7 +57,7 @@ Findings are numbered globally across all sections (F-001, F-002, ...). Each sub
 
 ### F-005: README under-claims scaffold contents — omits `state.ts` and the default `agent` export
 - **Surface:** Root README
-- **File:** README.md:58-61
+- **File:** README.md:62-65
 - **Type:** misalignment
 - **Severity:** important
 - **Description:** README says the basic scaffold ships `index.ts` and `tools/greet.ts`. The actual template (packages/devkit/templates/app-basic/) also ships `state.ts` (line 7 of the file listing). The README's own App Contract section even calls out that "Route directories may also include companion files such as `state.ts`," yet the scaffold listing omits it. Additionally the `index.ts` content is `export default agent({...})`, not the `workflow`/`graph` forms shown in the contract.
@@ -64,7 +65,7 @@ Findings are numbered globally across all sections (F-001, F-002, ...). Each sub
 
 ### F-006: Commands section omits `dawn build` and `dawn verify` — both shipping commands
 - **Surface:** Root README
-- **File:** README.md:63-105
+- **File:** README.md:67-109
 - **Type:** gap
 - **Severity:** important
 - **Description:** The Commands section documents `dawn check`, `dawn routes`, `dawn typegen`, `dawn run`, `dawn test`, and `dawn dev`. Two shipping commands are missing:
@@ -75,7 +76,7 @@ Findings are numbered globally across all sections (F-001, F-002, ...). Each sub
 
 ### F-007: Quickstart never mentions `dawn check`/`dawn typegen`/`dawn verify` despite Commands listing them
 - **Surface:** Root README
-- **File:** README.md:9-30
+- **File:** README.md:13-34
 - **Type:** gap
 - **Severity:** minor
 - **Description:** The Quickstart goes from `pnpm install` straight to `dawn run`. A first-time user will hit cryptic errors if `dawn typegen` has not been run (the scaffolded `.dawn/dawn.generated.d.ts` ships pre-generated, but any added route requires regeneration). At minimum a `pnpm exec dawn check` step would surface validation issues before invocation, and `pnpm exec dawn typegen` would set expectations.
@@ -95,7 +96,7 @@ Findings are numbered globally across all sections (F-001, F-002, ...). Each sub
 
 ### F-009: App Contract claims `appDir` is "the only supported config option today" — accurate but tonally fragile
 - **Surface:** Root README
-- **File:** README.md:38
+- **File:** README.md:42
 - **Type:** misalignment
 - **Severity:** minor
 - **Description:** The claim is currently true (packages/core/src/config.ts:90 only accepts `appDir`; the type at packages/core/src/types.ts:6 has `appDir?: string` as the only field). However the wording invites churn — every time a config option lands, this line needs editing. More importantly, it does not state the default value (`src/app`) inline, even though that default is documented one line earlier.
@@ -103,7 +104,7 @@ Findings are numbered globally across all sections (F-001, F-002, ...). Each sub
 
 ### F-010: Route directory "additional files" list says only `page.tsx` — omits `state.ts`, `run.test.ts`, and `tools/`
 - **Surface:** Root README
-- **File:** README.md:54-56
+- **File:** README.md:58-60
 - **Type:** misalignment
 - **Severity:** important
 - **Description:** The README lists `page.tsx for UI routes` as the only additional file, but two paragraphs earlier (line 52) it acknowledges `state.ts` and `tools/*.ts`. The `dawn test` command (line 95-97) further depends on `run.test.ts` colocated next to `index.ts`. The "additional files" list is contradicted by the rest of the same section.
@@ -111,7 +112,7 @@ Findings are numbered globally across all sections (F-001, F-002, ...). Each sub
 
 ### F-011: Packages section is missing `@dawn-ai/vite-plugin`
 - **Surface:** Root README
-- **File:** README.md:107-116
+- **File:** README.md:111-120
 - **Type:** gap
 - **Severity:** minor
 - **Description:** The Packages section enumerates eight packages. The workspace also ships `@dawn-ai/vite-plugin` (packages/vite-plugin/ exists in the tree). Whether this is "internal-only" or user-facing should be made explicit; right now it is silently absent.
@@ -127,13 +128,21 @@ Findings are numbered globally across all sections (F-001, F-002, ...). Each sub
 
 ### F-013: "Current Boundaries" repeats Status disclaimers without adding new information
 - **Surface:** Root README
-- **File:** README.md:118-124
+- **File:** README.md:122-128
 - **Type:** misalignment
 - **Severity:** minor
 - **Description:** Lines 118-124 restate "Dawn is not a deployment runtime" and "Dawn is not a LangSmith trace replacement" — both already stated in the Status section (lines 5-7). The third sentence ("starter template surface is intentionally small") is the only novel content. This duplication wastes readers' attention and amplifies the F-002 misalignment about deployment scope.
 - **Suggested fix:** Either fold Current Boundaries into a single revised Status block (with the deployment-artifact correction from F-002) or drop it.
 
-Root README findings: F-001 through F-013 (3 critical, 6 important, 4 minor).
+### F-114: Image header markup is inconsistent between the root README and the nine package READMEs
+- **Surface:** Root README (and all package READMEs)
+- **File:** README.md:1-3, packages/sdk/README.md:1-3, packages/cli/README.md:1-3, packages/core/README.md:1-3, packages/langchain/README.md:1-3, packages/langgraph/README.md:1-3, packages/vite-plugin/README.md:1-3, packages/devkit/README.md:1-3, packages/config-typescript/README.md:1-3, packages/config-biome/README.md:1-3, packages/create-dawn-app/README.md:1-3
+- **Type:** misalignment
+- **Severity:** minor
+- **Description:** PR #38 added a Dawn brand image header to the root README and to all nine package READMEs, but the markup diverges between root and packages. The root README uses `<p align="center">` with `width="360"` and a relative path `docs/brand/dawn-logo-horizontal-black-on-white.png`. The nine package READMEs use plain `<p>` (no `align`) with `width="180"` and an absolute `https://raw.githubusercontent.com/cacheplane/dawnai/main/...` URL. The visual result on GitHub differs (centered vs. left-aligned) and on npmjs.com only the absolute URL renders, so the chosen-style asymmetry is not just cosmetic — it affects how the brand surfaces on each channel.
+- **Suggested fix:** Decide on a single canonical header markup (e.g., always `<p align="center">` with the same width) and apply it uniformly. Keep the relative path for the root README (renders on GitHub) and the absolute path for package READMEs (renders on both GitHub and npmjs.com), but normalize the wrapping element and width across all ten files.
+
+Root README findings: F-001 through F-013, plus F-114 (3 critical, 6 important, 5 minor).
 
 ## 2. Website load-bearing pages (`getting-started.mdx`, `routes.mdx`, `tools.mdx`, `deployment.mdx`)
 
@@ -758,7 +767,7 @@ Templates findings: F-075 through F-087 (6 critical, 3 important, 4 minor).
 
 ### F-089: `@dawn-ai/sdk` README claims "pure type layer with no runtime dependencies" but the package now ships runtime helpers
 - **Surface:** Public package READMEs
-- **File:** packages/sdk/README.md:10
+- **File:** packages/sdk/README.md:14
 - **Type:** error
 - **Severity:** critical
 - **Description:** The README closes with "This package is a pure type layer with no runtime dependencies." That is wrong: `packages/sdk/src/index.ts` exports runtime values `agent`, `isDawnAgent` (from `./agent.js`) and `allow`, `defineMiddleware`, `reject` (from `./middleware.js`). These are real functions, not types. The README will mislead readers into thinking they cannot author agents or middleware via the SDK and that the import has zero runtime cost.
@@ -766,7 +775,7 @@ Templates findings: F-075 through F-087 (6 critical, 3 important, 4 minor).
 
 ### F-090: `@dawn-ai/sdk` README "Public surface" list is materially incomplete
 - **Surface:** Public package READMEs
-- **File:** packages/sdk/README.md:5-8
+- **File:** packages/sdk/README.md:9-12
 - **Type:** gap
 - **Severity:** important
 - **Description:** The README lists three exports (`RuntimeContext`, `RuntimeTool`/`ToolRegistry`, `RouteConfig`/`RouteKind`). The actual `packages/sdk/src/index.ts` re-exports many more, including `agent`, `AgentConfig`, `DawnAgent`, `RetryConfig`, `isDawnAgent`, `BackendAdapter`, `AnthropicModelId`/`GoogleModelId`/`OpenAiModelId`/`KnownModelId`, `ContinueResult`/`DawnMiddleware`/`MiddlewareRequest`/`MiddlewareResult`/`RejectResult`, `allow`/`defineMiddleware`/`reject`, `RouteStateMap`/`RouteToolMap`, and `Prettify`. Readers cannot discover the actual SDK surface from the README.
@@ -806,7 +815,7 @@ Templates findings: F-075 through F-087 (6 critical, 3 important, 4 minor).
 
 ### F-095: `@dawn-ai/cli` README's command list omits five of eight commands
 - **Surface:** Public package READMEs
-- **File:** packages/cli/README.md:5-8
+- **File:** packages/cli/README.md:9-12
 - **Type:** error
 - **Severity:** critical
 - **Description:** The README lists only `dawn check`, `dawn routes`, `dawn typegen`. The actual program (`packages/cli/src/index.ts:36-44`) registers eight user-facing commands: `build`, `check`, `dev`, `run`, `routes`, `test`, `typegen`, `verify` (plus an internal `dev-child`). Notably, `dawn dev` (the local development runtime) and `dawn build` (which produces LangGraph Platform deployment artifacts) are the two highest-leverage commands and are entirely absent.
@@ -814,7 +823,7 @@ Templates findings: F-075 through F-087 (6 critical, 3 important, 4 minor).
 
 ### F-096: `@dawn-ai/cli` README mischaracterizes the CLI as primarily a CI checker
 - **Surface:** Public package READMEs
-- **File:** packages/cli/README.md:3, 10
+- **File:** packages/cli/README.md:7, 14
 - **Type:** misalignment
 - **Severity:** important
 - **Description:** The opening describes the CLI as "validating Dawn apps, inspecting routes, and generating route types" and the closing line frames usage as "run Dawn app checks in CI and local development." This frames the CLI as a static-analysis/typegen tool, but `dawn dev` is the local runtime, `dawn run` executes routes locally, `dawn test` runs route tests, and `dawn build` produces deployment artifacts. The README undersells the CLI to the point of being misleading.
@@ -854,7 +863,7 @@ Templates findings: F-075 through F-087 (6 critical, 3 important, 4 minor).
 
 ### F-101: `create-dawn-app` README title and self-name disagree with the published package name
 - **Surface:** Public package READMEs
-- **File:** packages/create-dawn-app/README.md:1
+- **File:** packages/create-dawn-app/README.md:5
 - **Type:** error
 - **Severity:** critical
 - **Description:** The README's H1 is `# create-dawn-app`, but the package is published as `create-dawn-ai-app` (per `packages/create-dawn-app/package.json:2`, with bin name `create-dawn-ai-app` on line 23). The directory name `create-dawn-app` is internal-only — the public name on npm is `create-dawn-ai-app`. A reader on npmjs.com will see a title that does not match the package they're viewing, and any `npm init`/`pnpm create` example derived from the title will fail. This is the same class of bug as the root README's F-003.
@@ -894,7 +903,7 @@ Templates findings: F-075 through F-087 (6 critical, 3 important, 4 minor).
 
 ### F-106: `create-dawn-app` README understates available templates relative to roadmap, with no signal of what's coming
 - **Surface:** Public package READMEs
-- **File:** packages/create-dawn-app/README.md:5-6
+- **File:** packages/create-dawn-app/README.md:9-10
 - **Type:** gap
 - **Severity:** minor
 - **Description:** "Current template support: `basic`" is technically accurate today, but the README gives no indication of how to request additional templates, how to pass `--template`, or whether more are planned. For a scaffolder whose entire value prop is templates, this is a thin presentation.
@@ -960,7 +969,15 @@ Public READMEs findings: F-088 through F-106 (4 critical, 11 important, 4 minor)
 - **Description:** The README's "Public surface" elevates `extractJsDoc()`, `extractParameterType()`, and `generateZodSchema()` alongside `dawnToolSchemaPlugin()` and `transformToolSource()`. The first three are implementation details re-exported for testability — no consumer imports them in normal use, and listing them in a stub README implies they are part of the user-facing contract. This is the only README of the seven that exposes internal helpers this way, contributing to the F-108 inconsistency.
 - **Suggested fix:** Trim the public-surface list to `dawnToolSchemaPlugin()` (and optionally `transformToolSource()` if it is intentionally documented for advanced users). Move the JSDoc/type/Zod helpers to the website's internals page if they need documenting.
 
-Internal READMEs findings: F-107 through F-113 (0 critical, 2 important, 5 minor).
+### F-115: Package README image headers hardcode `cacheplane/dawnai@main` raw GitHub URL — durability and pre-publish risk
+- **Surface:** Public package READMEs and Internal package READMEs
+- **File:** packages/sdk/README.md:2, packages/cli/README.md:2, packages/create-dawn-app/README.md:2, packages/core/README.md:2, packages/langchain/README.md:2, packages/langgraph/README.md:2, packages/vite-plugin/README.md:2, packages/devkit/README.md:2, packages/config-typescript/README.md:2, packages/config-biome/README.md:2
+- **Type:** misalignment
+- **Severity:** minor
+- **Description:** All ten package READMEs reference the brand image via `https://raw.githubusercontent.com/cacheplane/dawnai/main/docs/brand/dawn-logo-horizontal-black-on-white.png`. Two consequences: (1) the URL only resolves once the brand asset has actually landed on `main` — for any package README that's published to npm before that commit propagates (or for a fork where the asset was never copied), the image renders broken; (2) the URL hardcodes both the GitHub org/repo (`cacheplane/dawnai`) and the branch (`main`), so any future repo rename, transfer, or default-branch change silently breaks the brand on every published package page. This is acceptable today (PR #38 lands the asset alongside the references) but it deserves a tracking note so future repo-rename work knows to search for `cacheplane/dawnai`.
+- **Suggested fix:** Either (a) leave as-is and document the coupling in CONTRIBUTORS.md so a repo rename triggers a sweep of `cacheplane/dawnai` references, or (b) bundle the image into each published package via `files`/`publishConfig` and reference `./logo.png` so the README is self-contained on npmjs.com. Option (b) is more durable but increases the published tarball size by ~30KB per package.
+
+Internal READMEs findings: F-107 through F-113, plus F-115 (0 critical, 2 important, 6 minor).
 
 ## Summary
 

--- a/docs/superpowers/audits/2026-05-06-docs-audit.md
+++ b/docs/superpowers/audits/2026-05-06-docs-audit.md
@@ -137,7 +137,222 @@ Root README findings: F-001 through F-013 (3 critical, 6 important, 4 minor).
 
 ## 2. Website load-bearing pages (`getting-started.mdx`, `routes.mdx`, `tools.mdx`, `deployment.mdx`)
 
-_(pending — Task 3)_
+### F-014: Getting Started uses `npx create-dawn-app` — package does not exist
+- **Surface:** Website (load-bearing)
+- **File:** apps/web/content/docs/getting-started.mdx:13
+- **Type:** error
+- **Severity:** critical
+- **Description:** The Scaffold step says `npx create-dawn-app my-agent`. `create-dawn-app` is unpublished; the published package is `create-dawn-ai-app` (packages/create-dawn-app/package.json line 2: `"name": "create-dawn-ai-app"`; bin name `create-dawn-ai-app` on line 23). First-time users will hit a "package not found" error. Same divergence as F-003 in the README.
+- **Suggested fix:** Replace with `npx create-dawn-ai-app my-agent` (or `pnpm create dawn-ai-app my-agent`). Align with whatever spelling PR A picks for the README.
+
+### F-015: Getting Started lists three route entry kinds — Dawn supports four (`agent` is missing and is the scaffold default)
+- **Surface:** Website (load-bearing)
+- **File:** apps/web/content/docs/getting-started.mdx:38-43
+- **Type:** misalignment
+- **Severity:** critical
+- **Description:** "Each route is a directory under `src/app/` with an `index.ts` that exports exactly one of: `workflow`, `graph`, `chain`." But `RouteKind` (packages/sdk/src/route-config.ts:1) is `"agent" | "chain" | "graph" | "workflow"`, and the discovery layer (packages/core/src/discovery/discover-routes.ts:112) explicitly accepts all four. The basic scaffold itself ships `export default agent({ model, systemPrompt })` (packages/devkit/templates/app-basic/src/app/(public)/hello/[tenant]/index.ts), so the Getting Started flow is internally inconsistent: the user scaffolds, then reads a paragraph that claims their scaffolded route shape doesn't exist.
+- **Suggested fix:** List all four kinds with `agent` first as the recommended/default. Reorder examples so the `agent({...})` form appears before the `workflow` form on this page.
+
+### F-016: Getting Started claims "the scaffolded app uses a workflow export" — actually scaffolds an `agent` default export
+- **Surface:** Website (load-bearing)
+- **File:** apps/web/content/docs/getting-started.mdx:44-58
+- **Type:** error
+- **Severity:** critical
+- **Description:** The page asserts the scaffold uses a `workflow` export and shows a sample `export async function workflow(state, ctx)` snippet. The actual basic template's `index.ts` is `export default agent({ model: "gpt-4o-mini", systemPrompt: "You are a helpful assistant for the {tenant} organization. Answer questions about the tenant." })`. There is no `workflow` function in the scaffold. A user opening the scaffolded `index.ts` after running through this page will see a completely different file from what is documented.
+- **Suggested fix:** Replace the snippet with the actual scaffolded `agent(...)` body, then point readers to the routes page for `workflow`/`graph`/`chain` alternatives.
+
+### F-017: Getting Started's run-output example shows a fake table and tenant resolution that the real `dawn run` does not produce
+- **Surface:** Website (load-bearing)
+- **File:** apps/web/content/docs/getting-started.mdx:77-88
+- **Type:** error
+- **Severity:** important
+- **Description:** Documented output is a multi-row table (`Route /hello/[tenant]`, `Mode workflow`, `Tenant acme`, `✓ { greeting: "Hello, acme!" }`). Actual `runRunCommand` (packages/cli/src/commands/run.ts:96-101) prints the result via `JSON.stringify(payload, null, 2)` after reading state from stdin. There is no row-formatted table, no "Mode" line, and no tenant echo. Worse, the snippet implies `dawn run '/hello/acme'` alone resolves the tenant — but the command reads JSON from stdin (run.ts:42, 82-94), so the user must pipe state in, e.g. `echo '{"tenant":"acme"}' | dawn run '/hello/acme'`. The shown invocation will actually receive `null` input.
+- **Suggested fix:** Show the real invocation form (pipe state via stdin) and the real JSON output. Either drop the pretty table or note it as an aspirational future format.
+
+### F-018: Getting Started never mentions `dawn typegen`, `dawn check`, `dawn verify`, or `dawn build`
+- **Surface:** Website (load-bearing)
+- **File:** apps/web/content/docs/getting-started.mdx (overall)
+- **Type:** gap
+- **Severity:** important
+- **Description:** The flow goes scaffold → write tool → `dawn run` → `dawn dev`. None of `dawn typegen` (regenerates `dawn.generated.d.ts`, mentioned later under tools), `dawn check` (validates app), `dawn verify` (4-check integrity gate), or `dawn build` (produces langgraph.json) appears. Several of these are needed before runs work cleanly, and `dawn build` is the only path to deployment.
+- **Suggested fix:** Add a "Validate the app" step between scaffold and run: `dawn check && dawn typegen` (or `dawn verify`). Add a closing "Ship to production" pointer to `dawn build` and the deployment page.
+
+### F-019: Getting Started "What's next" links to GitHub but not to other website docs
+- **Surface:** Website (load-bearing)
+- **File:** apps/web/content/docs/getting-started.mdx:100-104
+- **Type:** gap
+- **Severity:** important
+- **Description:** The closing section sends readers to the GitHub repo and "the template code in src/app/" but never links to `/docs/routes`, `/docs/tools`, `/docs/state`, `/docs/deployment`, `/docs/cli`, `/docs/dev-server`, or `/docs/testing`. Routes/tools/deployment are direct sequels of this page. Without internal cross-links, users have no obvious path forward inside the docs site.
+- **Suggested fix:** Replace or augment "What's next" with bullet links to `/docs/routes`, `/docs/tools`, `/docs/state`, and `/docs/deployment` at minimum.
+
+### F-020: Getting Started omits the `agent()` descriptor, `retry`, middleware (`defineMiddleware`, `reject`, `allow`)
+- **Surface:** Website (load-bearing)
+- **File:** apps/web/content/docs/getting-started.mdx (overall)
+- **Type:** gap
+- **Severity:** critical
+- **Description:** Per the audit context (2026-05-05/06), `agent({ model, systemPrompt, retry?: { maxAttempts, baseDelay } })`, `defineMiddleware`, `reject(status, body?)`, `allow(context?)`, and `MiddlewareRequest` are now exported from `@dawn-ai/sdk` (packages/sdk/src/index.ts:1-21, packages/sdk/src/agent.ts, packages/sdk/src/middleware.ts). The basic scaffold ships an `agent()` route by default, yet Getting Started never names this primitive. Users finishing the page have no model of what they just scaffolded.
+- **Suggested fix:** Add a short "Authoring an agent" section that introduces `agent({ model, systemPrompt })` with the optional `retry` shape, then a one-line pointer to a future middleware page.
+
+### F-021: Routes page lists three entry kinds — `agent` is missing
+- **Surface:** Website (load-bearing)
+- **File:** apps/web/content/docs/routes.mdx:3,11-43,46
+- **Type:** error
+- **Severity:** critical
+- **Description:** The opening sentence says routes export "exactly one of three entry types: a `workflow` function, a LangGraph `graph`, or a LangChain `chain`." The `<Tabs>` block exposes only those three. The Callout claims `dawn check` enforces "exactly one of `workflow`, `graph`, or `chain`." Reality: `RouteKind` is four kinds (packages/sdk/src/route-config.ts:1) and discoverRoutes accepts `agent | workflow | graph | chain` (packages/core/src/discovery/discover-routes.ts:112). The scaffold default is an `agent` route. `dawn check` will gladly accept `agent` exports.
+- **Suggested fix:** Lead the page with `agent` (since it is the scaffold default), then `workflow`, `graph`, `chain` as alternatives. Update the Callout to enumerate all four. Update the count in the opening line.
+
+### F-022: Routes page Callout says `dawn check` enforces single-entry rule — discovery throws, not check
+- **Surface:** Website (load-bearing)
+- **File:** apps/web/content/docs/routes.mdx:45-47
+- **Type:** misalignment
+- **Severity:** minor
+- **Description:** Callout: "A single `index.ts` may export only one of `workflow`, `graph`, or `chain`. `dawn check` enforces this." `dawn check` (packages/cli/src/commands/check.ts) just calls `discoverRoutes`, and the multi-export check is inside discovery (`packages/core/src/discovery/discover-routes.ts:108-113`), not check itself. `dawn run`, `dawn routes`, `dawn typegen`, `dawn build`, and `dawn verify` all surface the same error since they all call discovery. Wording is mostly harmless, but it under-claims where the rule lives.
+- **Suggested fix:** Reword: "Discovery enforces this — `dawn check`, `dawn routes`, `dawn build`, and friends all surface the violation." Also update to include `agent` after F-021.
+
+### F-023: Routes page state example uses a TypeScript `interface` — actual scaffold uses a default-exported Zod schema
+- **Surface:** Website (load-bearing)
+- **File:** apps/web/content/docs/routes.mdx:64-77
+- **Type:** error
+- **Severity:** critical
+- **Description:** The State section shows `export interface HelloState { readonly tenant: string; readonly greeting?: string }`. The actual scaffold's `state.ts` (packages/devkit/templates/app-basic/src/app/(public)/hello/[tenant]/state.ts) is `import { z } from "zod"; export default z.object({ context: z.string().default("") })`. The runtime state-discovery layer (packages/cli/src/lib/runtime/state-discovery.ts:11-30) imports `state.ts`'s default export and treats it as a schema with `extractDefaults`. A reader following the docs and writing an `interface` will produce a state.ts whose default-export-based discovery returns `null`, silently disabling state defaults. Same misalignment also implicit in getting-started.mdx:49 (the `HelloState` import).
+- **Suggested fix:** Replace with the Zod default-export form. Note that dynamic-segment fields (`[tenant]`) appear automatically in state and are not declared in `state.ts`. Cross-reference state.mdx (which is the canonical state page).
+
+### F-024: Routes page `dawn run` example omits stdin input, suggesting bare invocation works
+- **Surface:** Website (load-bearing)
+- **File:** apps/web/content/docs/routes.mdx:82-92
+- **Type:** error
+- **Severity:** important
+- **Description:** Says `dawn run '/hello/acme'` "reads state from stdin (JSON)" — that text is correct (run.ts:82-94) — but the example shows the command alone with no pipe and no example payload. Users who copy this verbatim will pass `null` as input and get either a typegen mismatch or an unexpected null-state result. Same issue manifests in getting-started.mdx (F-017).
+- **Suggested fix:** Show the working invocation: `echo '{"tenant":"acme"}' | dawn run '/hello/acme'` (or a heredoc). Mention that `[tenant]` resolves from the URL path *and* must match a state field per F-023.
+
+### F-025: Routes page never mentions `agent()` or middleware — the user-facing primitives shipped 2026-05-05/06
+- **Surface:** Website (load-bearing)
+- **File:** apps/web/content/docs/routes.mdx (overall)
+- **Type:** gap
+- **Severity:** critical
+- **Description:** This is the canonical routes page. It does not name `agent()`, `AgentConfig`, `RetryConfig`, `defineMiddleware`, `reject`, `allow`, or `MiddlewareRequest` — all currently exported from `@dawn-ai/sdk` (packages/sdk/src/index.ts) and recently added per the audit context. Since the scaffold default is `agent()`, an `agent` subsection on this page is mandatory.
+- **Suggested fix:** Add an `## Agents` subsection covering `agent({ model, systemPrompt, retry? })` with the `RetryConfig` shape (`maxAttempts`, `baseDelay`). Add a `## Middleware` subsection covering `defineMiddleware`, `reject(status, body?)`, `allow(context?)`, and the `MiddlewareRequest` shape (assistantId, headers, method, params, routeId, url).
+
+### F-026: Routes page does not link to `/docs/tools` (only inline reference) or to `/docs/state`, `/docs/cli`, `/docs/deployment`
+- **Surface:** Website (load-bearing)
+- **File:** apps/web/content/docs/routes.mdx:79-80
+- **Type:** gap
+- **Severity:** minor
+- **Description:** One inline link to `/docs/tools` exists. The routes page mentions state and `dawn run` but does not link to `/docs/state` or `/docs/cli`. Adjacent pages exist (apps/web/content/docs/state.mdx, cli.mdx) so the cross-links would resolve.
+- **Suggested fix:** Add cross-links to `/docs/state`, `/docs/cli` (for `dawn run`), and `/docs/deployment` at the bottom of the page.
+
+### F-027: Tools page documents tool input only — the second `(input, ctx)` arg shape (signal + middleware) is invisible
+- **Surface:** Website (load-bearing)
+- **File:** apps/web/content/docs/tools.mdx:6-12,22-30,33-51
+- **Type:** gap
+- **Severity:** critical
+- **Description:** The minimal tool example is `async (input: { ... }) => { ... }`. Per the audit context (2026-05-06), tools' second arg now has shape `{ middleware?: Readonly<Record<string, unknown>>, signal: AbortSignal }`. The runtime call sites confirm this: packages/cli/src/lib/runtime/dawn-context.ts:15-30 builds `{ signal, ...(middleware ? { middleware } : {}) }`; packages/langchain/src/tool-loop.ts:54 and packages/langchain/src/tool-converter.ts:31 pass that shape into `tool.run(input, {...})`. Tools authors that need cancellation or middleware-derived context have no way to discover this from the docs.
+- **Suggested fix:** Document the second-argument shape: `async (input, { signal, middleware }) => { ... }`. Note that `signal` is always present (`AbortSignal`) and `middleware` is `Readonly<Record<string, unknown>>` populated by `defineMiddleware`/`allow(context)`. Add a one-tool example using `signal` for cancellation.
+
+### F-028: Tools page "generated declaration" snippet is non-functional shorthand presented as real
+- **Surface:** Website (load-bearing)
+- **File:** apps/web/content/docs/tools.mdx:54-66
+- **Type:** misalignment
+- **Severity:** important
+- **Description:** Shows:
+  ```
+  declare module "dawn:routes" {
+    export type RouteTools<P> = DawnRouteTools[P]
+    // greet signature inferred from tools/greet.ts export
+  }
+  ```
+  `DawnRouteTools` is presented as if it were a real symbol, but the file is "roughly" what gets generated. Readers who try to import `DawnRouteTools` will fail. The actual generated file (renderDawnTypes in packages/core/src) emits a populated `RouteTools` map with concrete pathnames as keys. The current snippet is too lossy to be useful and too detailed to be obviously sketch.
+- **Suggested fix:** Either (a) show the real shape Dawn emits — e.g. `declare module "dawn:routes" { export type RouteTools<P extends keyof DawnRouteTypes> = DawnRouteTypes[P]["tools"] }` with a concrete entry — or (b) drop the code block and point users at running `dawn typegen` and reading their own `dawn.generated.d.ts`.
+
+### F-029: Tools page invocation example uses unannotated `state, ctx` — relies on the `workflow` form contradicted by Routes/Getting-Started fixes
+- **Surface:** Website (load-bearing)
+- **File:** apps/web/content/docs/tools.mdx:22-28
+- **Type:** misalignment
+- **Severity:** minor
+- **Description:** The "Invoking a tool" snippet shows `export async function workflow(state, ctx) { ... }` with no type annotations. In a strict TS config (every Dawn-generated app turns on strict), this would be `noImplicitAny` errors. The bigger problem: it is the `workflow` form, but per F-015/F-021 the recommended scaffold shape is `agent()`. Tool invocation from inside an `agent()` route happens via tool binding at build (packages/cli/src/commands/build.ts:80-106), not via `ctx.tools` in user code. The page never explains this branching.
+- **Suggested fix:** Add types to the snippet. Add a one-paragraph note: "Inside `workflow` and `graph` exports, tools are invoked through `ctx.tools.<name>(...)`. Inside `agent()` routes, Dawn binds the tools to the agent at `dawn build` time and the LLM invokes them — see Routes." Cross-link to /docs/routes.
+
+### F-030: Tools page never mentions `dawn typegen` outputs `.dawn/routes/<id>/tools.json` or interplay with `dawn dev` watcher
+- **Surface:** Website (load-bearing)
+- **File:** apps/web/content/docs/tools.mdx:14-18,68-72
+- **Type:** gap
+- **Severity:** minor
+- **Description:** The page says types appear "on the next `dawn typegen` or `dawn dev` reload." Accurate, but skipped: `dawn build` (packages/cli/src/commands/build.ts:60) consumes `tools.json` schemas, and the dev server invalidates per-route state on tool-file change. Authors debugging "my tool isn't appearing" would benefit from a note that the type pipeline produces both `.dawn/dawn.generated.d.ts` and per-route `.dawn/routes/<slug>/tools.json`.
+- **Suggested fix:** Add a sentence under "The generated declaration" explaining that typegen also writes per-route `tools.json` artifacts under `.dawn/routes/`, consumed by `dawn build` for LangGraph Platform deployment.
+
+### F-031: Deployment page tells users to hand-write `langgraph.json` — `dawn build` exists and produces it for them
+- **Surface:** Website (load-bearing)
+- **File:** apps/web/content/docs/deployment.mdx:28-41
+- **Type:** error
+- **Severity:** critical
+- **Description:** Step 3 instructs users to "Create a `langgraph.json` at the app root" by hand. But `dawn build` (packages/cli/src/commands/build.ts:32-153) writes `.dawn/build/langgraph.json` automatically with `graphs`, `dependencies: ["."]`, `env` (path string from extractDeploymentConfig — `.env.example` if present, else `.env`), and `node_version: "22"` (packages/cli/src/lib/build/deployment-config.ts:18-24). It also generates per-route entry files under `.dawn/build/<slug>.ts` and (for `agent` routes) handles tool binding via `agent.bindTools([...])` (build.ts:104). Telling users to hand-write the JSON in 2026 is a critical user-experience regression: they will produce something that misses the entry-file generation `dawn build` does for them.
+- **Suggested fix:** Replace Step 3 with `dawn build` (clean form `dawn build --clean`). Show a sample of the generated `.dawn/build/langgraph.json` so users know what to expect, and explain the merge behavior with a user-supplied root `langgraph.json` (build.ts:124-142 reads and shallow-merges).
+
+### F-032: Deployment page sample `langgraph.json` is missing `dependencies` and `node_version` — both required for LangGraph Platform
+- **Surface:** Website (load-bearing)
+- **File:** apps/web/content/docs/deployment.mdx:31-38
+- **Type:** error
+- **Severity:** critical
+- **Description:** The sample shows only `{ "graphs": ..., "env": ".env" }`. The real `dawn build` output (packages/cli/src/lib/build/deployment-config.ts:18-24, used at packages/cli/src/commands/build.ts:136-142) emits `dependencies: ["."]`, `env`, and `node_version: "22"`. LangGraph Platform requires `dependencies` and `node_version`. A user copying the documented sample will fail to build a deploy image. Also note that `env` resolves to `.env.example` when that file exists, not `.env` blindly (deployment-config.ts:26-34).
+- **Suggested fix:** Replace the sample with the actual `dawn build` output, including `dependencies: ["."]`, `env: ".env.example"` (or `.env`), and `node_version: "22"`. Cross-reference: F-031 (use `dawn build`), and the audit context's note that `dawn build` produces `langgraph.json` with `dependencies: ["."]` and `env` as a path.
+
+### F-033: Deployment page shows non-existent `dawn test --url` flag
+- **Surface:** Website (load-bearing)
+- **File:** apps/web/content/docs/deployment.mdx:21-24
+- **Type:** error
+- **Severity:** critical
+- **Description:** Step 2 says `dawn test --url http://127.0.0.1:3001`. `runTestCommand` (packages/cli/src/commands/test.ts:34-41) registers only `--cwd <path>`. There is no `--url` option on `dawn test`. The `--url` flag exists on `dawn run` (packages/cli/src/commands/run.ts:29) and scenario files can declare a `run.url` field (packages/cli/src/lib/runtime/load-run-scenarios.ts:278), but `dawn test --url` will fail with "unknown option" from commander. This breaks the documented protocol-parity step.
+- **Suggested fix:** Either (a) replace with `dawn run` examples that use `--url`, or (b) document scenario-level `run: { url }` configuration in the test file and how to point all scenarios at a live server. Until parity tooling exists for `dawn test`, mark this step as "use scenario-level `run.url`."
+
+### F-034: Deployment page does not enumerate `dawn verify`'s four checks (app, routes, typegen, deps)
+- **Surface:** Website (load-bearing)
+- **File:** apps/web/content/docs/deployment.mdx:7-16
+- **Type:** gap
+- **Severity:** important
+- **Description:** Step 1 lists four pre-deploy commands: `dawn check`, `dawn routes`, `dawn typegen`, `dawn test`. None is `dawn verify`. Per the audit context (2026-05-06), `dawn verify` runs four checks (app, routes, typegen, deps — packages/cli/src/commands/verify.ts:162-218) and is the canonical integrity gate. Re-running four shell commands manually duplicates what `dawn verify` does in one call, and importantly skips the `deps` check (missing packages, missing env vars) which is most relevant pre-deploy.
+- **Suggested fix:** Replace the four-command list in Step 1 with `dawn verify`, optionally followed by `dawn test` for scenarios. Mention that verify includes a deps check that is uniquely useful before a deploy.
+
+### F-035: Deployment page never mentions `dawn build` anywhere — the only path to a deployable artifact
+- **Surface:** Website (load-bearing)
+- **File:** apps/web/content/docs/deployment.mdx (overall)
+- **Type:** gap
+- **Severity:** critical
+- **Description:** `dawn build` does not appear once on the deployment page. It is the command that produces deployable artifacts (langgraph.json + per-route entry files). Self-hosting (lines 53-58) tells users to "wrap Dawn's runtime in a Docker container" — but the canonical container starts from `dawn build` output, not from `dawn dev`'s in-process server. Telling users to ship `dawn dev` in production is misleading and contradicts the build pipeline that exists today.
+- **Suggested fix:** Restructure the page around `dawn build` as the central command. Self-hosting section should reference the `.dawn/build/` directory and show how to feed it to a container build, not "ship dawn dev."
+
+### F-036: Deployment page assistant-id format is wrong — `dawn build` emits `<routeId>#<kind>`, not the route name
+- **Surface:** Website (load-bearing)
+- **File:** apps/web/content/docs/deployment.mdx:32-40,62-66
+- **Type:** error
+- **Severity:** important
+- **Description:** Sample maps `"hello"` → entry path. Then "Each entry binds an `assistant_id` (left side) to a route entry export (right side)." The actual `dawn build` output keys assistants as `${route.id}#${route.kind}` (packages/cli/src/commands/build.ts:119-121), e.g. `/hello/[tenant]#agent`. Troubleshooting says "the `langgraph.json` entry doesn't match what Dawn discovered. Run `dawn routes` to see the exact pathnames" — but `dawn routes` prints `<pathname> -> <entryFile>` (packages/cli/src/commands/routes.ts:33-35), not assistant ids. So users who copy the docs and key on a freeform name like `"hello"` will then debug-loop against `dawn routes` output that doesn't show assistant-id format either.
+- **Suggested fix:** Document the real assistant-id naming `<routeId>#<kind>`. Either show that as the key in the sample, or remove the sample entirely in favor of "run `dawn build` and inspect `.dawn/build/langgraph.json`." Update the troubleshooting bullet to point at `cat .dawn/build/langgraph.json` (or `dawn verify --json`) rather than `dawn routes`.
+
+### F-037: Deployment page Step 2 "live-server tests" claim implies dev server is identical to LangGraph Platform — true only at protocol level
+- **Surface:** Website (load-bearing)
+- **File:** apps/web/content/docs/deployment.mdx:18-26,57-59
+- **Type:** misalignment
+- **Severity:** important
+- **Description:** "If in-process and live-server tests both pass, the same inputs will pass on LangGraph Platform" — and the closing tip "`dawn dev` running on port 3001 is functionally identical to a deployed Dawn runtime" — overstate parity. Dev server (packages/cli/src/lib/dev/runtime-server.ts) only handles `/runs/wait` and `/runs/stream` (lines 124-135) and uses an in-process runtime registry (line 117). The deployed LangGraph Platform invokes the entry files generated by `dawn build` (built with `agent.bindTools(...)` for agent routes, build.ts:104), serialized through their Docker boundary, with platform-managed state stores. Tools that pass in dev because they share a process can fail in deploy due to serialization. F-031/F-035 amplify this — the dev-only path skips `dawn build`'s codegen entirely.
+- **Suggested fix:** Soften: "`dawn dev` exposes the same protocol endpoints as the deployed runtime — `runs/wait` and `runs/stream` — so request/response shape parity is guaranteed. Process boundaries, state persistence, and tool bindings are still re-materialized by `dawn build` for production." Then keep the JSON-serializability reminder.
+
+### F-038: Deployment page makes no reference to `defineMiddleware` / `MiddlewareRequest` — middleware is invisible end-to-end
+- **Surface:** Website (load-bearing)
+- **File:** apps/web/content/docs/deployment.mdx (overall)
+- **Type:** gap
+- **Severity:** important
+- **Description:** Middleware (packages/sdk/src/middleware.ts; runtime usage in packages/cli/src/lib/dev/runtime-server.ts:117,257) is a per-request authorization/context primitive that ships today. Deployment is exactly the moment a developer asks "how do I gate access in production?" — but the page never mentions middleware. Compounded by F-025 (routes.mdx omits it too), middleware is a dark feature.
+- **Suggested fix:** Add a brief "Per-route middleware" subsection pointing at `defineMiddleware`/`reject`/`allow` and noting that middleware runs identically in `dawn dev` and on LangGraph Platform.
+
+### F-039: Getting Started, Routes, Tools, and Deployment all assume "no Zod schemas" while the scaffold's `state.ts` ships Zod
+- **Surface:** Website (load-bearing)
+- **File:** apps/web/content/docs/tools.mdx:1-3, getting-started.mdx:73, routes.mdx:64-77
+- **Type:** misalignment
+- **Severity:** important
+- **Description:** Tools page opening: "no Zod schemas, no manual type wiring." Repeated at line 13: "No Zod schemas, no manual type declarations." Getting-started.mdx:73 echoes this. But the scaffolded `state.ts` (packages/devkit/templates/app-basic/src/app/(public)/hello/[tenant]/state.ts) is `z.object({...})`, and state-discovery (packages/cli/src/lib/runtime/state-discovery.ts) requires Zod schemas to extract defaults. The "no Zod" claim applies only to *tool inputs* via TS-compiler-API extraction, but reads as if Zod is absent system-wide. Users will be confused when state needs Zod but tools don't.
+- **Suggested fix:** Tighten the claim: "Tool input/output types are inferred from TypeScript source — no Zod schemas required for tools." Acknowledge that route state uses Zod (in state.mdx and a one-line note here).
+
+Load-bearing pages findings: F-014 through F-039 (12 critical, 10 important, 4 minor).
 
 ## 3. Website supporting pages (`state.mdx`, `cli.mdx`, `dev-server.mdx`, `testing.mdx`)
 

--- a/docs/superpowers/audits/2026-05-06-docs-audit.md
+++ b/docs/superpowers/audits/2026-05-06-docs-audit.md
@@ -748,7 +748,159 @@ Templates findings: F-075 through F-087 (6 critical, 3 important, 4 minor).
 
 ## 5. Public package READMEs (`@dawn-ai/sdk`, `@dawn-ai/cli`, `create-dawn-ai-app`)
 
-_(pending — Task 6)_
+### F-088: `@dawn-ai/sdk` README has no install instructions
+- **Surface:** Public package READMEs
+- **File:** packages/sdk/README.md
+- **Type:** gap
+- **Severity:** important
+- **Description:** The README never tells the reader how to install the package. The hybrid policy requires an install command (e.g., `npm install @dawn-ai/sdk` / `pnpm add @dawn-ai/sdk`) so the npmjs.com listing is actionable. Today the file jumps straight from a one-line description to a public-surface bullet list.
+- **Suggested fix:** Add an "Install" section with `npm install @dawn-ai/sdk` (and a pnpm/yarn equivalent), placed immediately after the overview paragraph.
+
+### F-089: `@dawn-ai/sdk` README claims "pure type layer with no runtime dependencies" but the package now ships runtime helpers
+- **Surface:** Public package READMEs
+- **File:** packages/sdk/README.md:10
+- **Type:** error
+- **Severity:** critical
+- **Description:** The README closes with "This package is a pure type layer with no runtime dependencies." That is wrong: `packages/sdk/src/index.ts` exports runtime values `agent`, `isDawnAgent` (from `./agent.js`) and `allow`, `defineMiddleware`, `reject` (from `./middleware.js`). These are real functions, not types. The README will mislead readers into thinking they cannot author agents or middleware via the SDK and that the import has zero runtime cost.
+- **Suggested fix:** Replace the "pure type layer" sentence with a description that the SDK ships both type primitives and small runtime helpers (`agent()`, `defineMiddleware()`, `allow()`, `reject()`, `isDawnAgent()`), and is the canonical entry point for authoring Dawn routes, agents, and middleware.
+
+### F-090: `@dawn-ai/sdk` README "Public surface" list is materially incomplete
+- **Surface:** Public package READMEs
+- **File:** packages/sdk/README.md:5-8
+- **Type:** gap
+- **Severity:** important
+- **Description:** The README lists three exports (`RuntimeContext`, `RuntimeTool`/`ToolRegistry`, `RouteConfig`/`RouteKind`). The actual `packages/sdk/src/index.ts` re-exports many more, including `agent`, `AgentConfig`, `DawnAgent`, `RetryConfig`, `isDawnAgent`, `BackendAdapter`, `AnthropicModelId`/`GoogleModelId`/`OpenAiModelId`/`KnownModelId`, `ContinueResult`/`DawnMiddleware`/`MiddlewareRequest`/`MiddlewareResult`/`RejectResult`, `allow`/`defineMiddleware`/`reject`, `RouteStateMap`/`RouteToolMap`, and `Prettify`. Readers cannot discover the actual SDK surface from the README.
+- **Suggested fix:** Restructure the README around the three public concept buckets — agents (`agent()`, `AgentConfig`, `DawnAgent`, `isDawnAgent`), middleware (`defineMiddleware`, `allow`, `reject`, `DawnMiddleware`), and route/runtime types (`RouteConfig`, `RouteKind`, `RuntimeContext`, `RuntimeTool`, `ToolRegistry`) — with a link out to the website for the full API.
+
+### F-091: `@dawn-ai/sdk` README contains no code example
+- **Surface:** Public package READMEs
+- **File:** packages/sdk/README.md
+- **Type:** gap
+- **Severity:** important
+- **Description:** The hybrid policy requires "most important APIs/commands shown briefly with a code example or two." The SDK README has zero code blocks. A reader landing on npmjs.com cannot tell what authoring a Dawn route looks like.
+- **Suggested fix:** Add one short example showing an `agent()` route export (matching the scaffold default) and one showing a `defineMiddleware()` usage, both as fenced TypeScript blocks.
+
+### F-092: `@dawn-ai/sdk` README has no link to the canonical docs site
+- **Surface:** Public package READMEs
+- **File:** packages/sdk/README.md
+- **Type:** gap
+- **Severity:** important
+- **Description:** The hybrid policy requires a link to `https://dawn-ai.org/docs/<page>` so the README on npmjs.com points readers to the full reference. The current SDK README has no outbound link at all.
+- **Suggested fix:** Add a "Learn more" / "Documentation" footer linking to `https://dawn-ai.org/docs/routes` (and `…/tools`, `…/state` as relevant) for the full reference.
+
+### F-093: `@dawn-ai/sdk` README does not state the Node engine requirement
+- **Surface:** Public package READMEs
+- **File:** packages/sdk/README.md
+- **Type:** gap
+- **Severity:** minor
+- **Description:** `packages/sdk/package.json` declares `"engines": { "node": ">=22.12.0" }`. The README does not mention this. Users who install on older Node versions will hit npm engine warnings without context.
+- **Suggested fix:** Add a one-line "Requires Node.js 22.12+" note alongside the install command.
+
+### F-094: `@dawn-ai/cli` README has no install instructions
+- **Surface:** Public package READMEs
+- **File:** packages/cli/README.md
+- **Type:** gap
+- **Severity:** important
+- **Description:** The README describes the CLI but never shows an install command. The closing line says "Install the package globally or use it as a project-local dependency" without telling the reader how. Hybrid policy requires an explicit install command (`npm install -D @dawn-ai/cli` or `npm install -g @dawn-ai/cli`) that matches the published package name.
+- **Suggested fix:** Add an "Install" section with both the project-local (`npm install -D @dawn-ai/cli`) and global (`npm install -g @dawn-ai/cli`) commands, plus pnpm equivalents.
+
+### F-095: `@dawn-ai/cli` README's command list omits five of eight commands
+- **Surface:** Public package READMEs
+- **File:** packages/cli/README.md:5-8
+- **Type:** error
+- **Severity:** critical
+- **Description:** The README lists only `dawn check`, `dawn routes`, `dawn typegen`. The actual program (`packages/cli/src/index.ts:36-44`) registers eight user-facing commands: `build`, `check`, `dev`, `run`, `routes`, `test`, `typegen`, `verify` (plus an internal `dev-child`). Notably, `dawn dev` (the local development runtime) and `dawn build` (which produces LangGraph Platform deployment artifacts) are the two highest-leverage commands and are entirely absent.
+- **Suggested fix:** Replace the three-bullet list with a complete table covering all eight commands (`build`, `check`, `dev`, `routes`, `run`, `test`, `typegen`, `verify`) with a one-line description of each. Cross-reference `packages/cli/src/commands/*.ts` for accurate descriptions.
+
+### F-096: `@dawn-ai/cli` README mischaracterizes the CLI as primarily a CI checker
+- **Surface:** Public package READMEs
+- **File:** packages/cli/README.md:3, 10
+- **Type:** misalignment
+- **Severity:** important
+- **Description:** The opening describes the CLI as "validating Dawn apps, inspecting routes, and generating route types" and the closing line frames usage as "run Dawn app checks in CI and local development." This frames the CLI as a static-analysis/typegen tool, but `dawn dev` is the local runtime, `dawn run` executes routes locally, `dawn test` runs route tests, and `dawn build` produces deployment artifacts. The README undersells the CLI to the point of being misleading.
+- **Suggested fix:** Reword the opening to: "The `dawn` command-line interface — local dev server, route execution, validation/typegen, and the build step that produces LangGraph Platform deployment artifacts." Update the closing to drop the "checks in CI" framing.
+
+### F-097: `@dawn-ai/cli` README contains no code example or usage snippet
+- **Surface:** Public package READMEs
+- **File:** packages/cli/README.md
+- **Type:** gap
+- **Severity:** important
+- **Description:** Hybrid policy requires "most important APIs/commands shown briefly with a code example or two." The CLI README has no shell snippets at all — not even `dawn --help` or a representative invocation like `dawn dev` / `dawn build`.
+- **Suggested fix:** Add a short "Usage" section with a couple of the most common invocations (`dawn dev`, `dawn check`, `dawn build`) shown as fenced shell blocks.
+
+### F-098: `@dawn-ai/cli` README has no link to the canonical docs site
+- **Surface:** Public package READMEs
+- **File:** packages/cli/README.md
+- **Type:** gap
+- **Severity:** important
+- **Description:** The README does not link to the website. Hybrid policy requires a pointer to `https://dawn-ai.org/docs/<page>` so npmjs.com readers can reach the full reference (e.g., `https://dawn-ai.org/docs/cli`).
+- **Suggested fix:** Add a "Learn more" footer linking to `https://dawn-ai.org/docs/cli` (and `…/getting-started`, `…/deployment` as relevant).
+
+### F-099: `@dawn-ai/cli` README does not state the Node engine requirement
+- **Surface:** Public package READMEs
+- **File:** packages/cli/README.md
+- **Type:** gap
+- **Severity:** minor
+- **Description:** `packages/cli/package.json` declares `"engines": { "node": ">=22.12.0" }`. The README does not mention this.
+- **Suggested fix:** Add a one-line "Requires Node.js 22.12+" note alongside the install command.
+
+### F-100: `@dawn-ai/cli` README does not mention the `dawn` binary name
+- **Surface:** Public package READMEs
+- **File:** packages/cli/README.md
+- **Type:** gap
+- **Severity:** minor
+- **Description:** The package is published as `@dawn-ai/cli` but the binary it installs is named `dawn` (per `packages/cli/package.json:23-25`). The README uses `dawn …` in command examples without ever stating that the package installs a `dawn` binary, which is mildly confusing for readers comparing the install name to the command name.
+- **Suggested fix:** Add a sentence near the install instructions: "Installs a `dawn` binary on your `PATH`."
+
+### F-101: `create-dawn-app` README title and self-name disagree with the published package name
+- **Surface:** Public package READMEs
+- **File:** packages/create-dawn-app/README.md:1
+- **Type:** error
+- **Severity:** critical
+- **Description:** The README's H1 is `# create-dawn-app`, but the package is published as `create-dawn-ai-app` (per `packages/create-dawn-app/package.json:2`, with bin name `create-dawn-ai-app` on line 23). The directory name `create-dawn-app` is internal-only — the public name on npm is `create-dawn-ai-app`. A reader on npmjs.com will see a title that does not match the package they're viewing, and any `npm init`/`pnpm create` example derived from the title will fail. This is the same class of bug as the root README's F-003.
+- **Suggested fix:** Change the H1 to `# create-dawn-ai-app` and use that name consistently throughout. Mention the directory/published-name divergence is intentional only if it helps; otherwise just use the published name.
+
+### F-102: `create-dawn-app` README has no install/usage command
+- **Surface:** Public package READMEs
+- **File:** packages/create-dawn-app/README.md
+- **Type:** gap
+- **Severity:** critical
+- **Description:** The README describes the scaffolder but never shows the canonical `npm create dawn-ai-app …` / `pnpm create dawn-ai-app …` invocation. This is the *only* thing a user needs from this README, and it is missing. (Compare with the root README, which uses `pnpm create dawn-app` — itself wrong per F-003 — but at least shows a command.)
+- **Suggested fix:** Add a "Usage" section showing `pnpm create dawn-ai-app my-app`, `npm create dawn-ai-app@latest my-app`, and `yarn create dawn-ai-app my-app` (or whichever subset the team supports), followed by the next-step `cd my-app && pnpm install && pnpm dawn dev` flow.
+
+### F-103: `create-dawn-app` README does not enumerate the scaffold's resulting structure or commands
+- **Surface:** Public package READMEs
+- **File:** packages/create-dawn-app/README.md
+- **Type:** gap
+- **Severity:** important
+- **Description:** The README mentions "Dawn's canonical `src/app` route layout" but doesn't show what the user gets — no example of the generated tree, no mention that the scaffold installs a working `agent()` route, no list of the npm scripts available in the generated `package.json` (e.g., `dawn dev`, `dawn check`, `dawn build`). Hybrid policy requires the most important surface shown briefly.
+- **Suggested fix:** Add a short "What you get" section listing the generated layout (e.g., `src/app/agent/index.ts`, scripts: `dawn dev`, `dawn check`, `dawn build`) with a tiny tree snippet.
+
+### F-104: `create-dawn-app` README has no link to the canonical docs site
+- **Surface:** Public package READMEs
+- **File:** packages/create-dawn-app/README.md
+- **Type:** gap
+- **Severity:** important
+- **Description:** No outbound link to `https://dawn-ai.org/docs/getting-started` (or equivalent), which is where a fresh user should land after running the scaffolder. Hybrid policy requires this pointer.
+- **Suggested fix:** Add a "Next steps" footer linking to `https://dawn-ai.org/docs/getting-started`.
+
+### F-105: `create-dawn-app` README does not state the Node engine requirement
+- **Surface:** Public package READMEs
+- **File:** packages/create-dawn-app/README.md
+- **Type:** gap
+- **Severity:** minor
+- **Description:** `packages/create-dawn-app/package.json` declares `"engines": { "node": ">=22.12.0" }` and the scaffolded apps inherit similar constraints. The README does not surface this, so users on older Node versions will hit obscure failures during scaffold.
+- **Suggested fix:** Add a one-line "Requires Node.js 22.12+" note alongside the usage commands.
+
+### F-106: `create-dawn-app` README understates available templates relative to roadmap, with no signal of what's coming
+- **Surface:** Public package READMEs
+- **File:** packages/create-dawn-app/README.md:5-6
+- **Type:** gap
+- **Severity:** minor
+- **Description:** "Current template support: `basic`" is technically accurate today, but the README gives no indication of how to request additional templates, how to pass `--template`, or whether more are planned. For a scaffolder whose entire value prop is templates, this is a thin presentation.
+- **Suggested fix:** If the CLI supports `--template <name>`, document the flag with the current accepted values. If not, drop the bullet and just say "Generates a working Dawn starter app with an `agent()` route."
+
+Public READMEs findings: F-088 through F-106 (4 critical, 11 important, 4 minor).
 
 ## 6. Internal package READMEs (config-biome, config-typescript, core, devkit, langchain, langgraph, vite-plugin)
 

--- a/docs/superpowers/audits/2026-05-06-docs-audit.md
+++ b/docs/superpowers/audits/2026-05-06-docs-audit.md
@@ -904,7 +904,63 @@ Public READMEs findings: F-088 through F-106 (4 critical, 11 important, 4 minor)
 
 ## 6. Internal package READMEs (config-biome, config-typescript, core, devkit, langchain, langgraph, vite-plugin)
 
-_(pending — Task 7)_
+### F-107: No internal package README points to https://dawn-ai.org (stub-with-pointer policy gap, all seven)
+- **Surface:** Internal package READMEs
+- **File:** packages/config-biome/README.md, packages/config-typescript/README.md, packages/core/README.md, packages/devkit/README.md, packages/langchain/README.md, packages/langgraph/README.md, packages/vite-plugin/README.md
+- **Type:** gap
+- **Severity:** important
+- **Description:** The hybrid docs policy specifies internal packages should be stub-with-pointer: a 5–10 line README naming the package, summarizing its purpose in one sentence, and pointing to the website for full docs. None of the seven internal-package READMEs include a link to https://dawn-ai.org (or a more specific page such as `https://dawn-ai.org/docs/internals/<pkg>`). Readers landing on the package on npm or GitHub have no path forward to canonical docs.
+- **Suggested fix:** Add a closing line to each internal README of the form `Full docs: https://dawn-ai.org` (or a more specific URL when one exists). Apply uniformly across all seven files so the stub-with-pointer template is consistent.
+
+### F-108: Internal READMEs use inconsistent body shapes (some have "Exports:", some "Public surface:", vite-plugin is materially longer)
+- **Surface:** Internal package READMEs
+- **File:** packages/config-biome/README.md, packages/config-typescript/README.md, packages/core/README.md, packages/devkit/README.md, packages/langchain/README.md, packages/langgraph/README.md, packages/vite-plugin/README.md
+- **Type:** misalignment
+- **Severity:** minor
+- **Description:** The seven READMEs nominally follow the same shape (title, one-line summary, bulleted list, closing remark) but use different section labels: `config-biome` and `config-typescript` use `Exports:` (subpath imports), while `core`, `devkit`, `langchain`, `langgraph`, `vite-plugin` use `Public surface:` (function/symbol names). `vite-plugin` is also noticeably longer (5 listed exports plus a longer closing sentence) than the others. The stub-with-pointer policy expects a single uniform template.
+- **Suggested fix:** Pick one label (recommend `Public surface:` for code packages, `Exports:` for config packages — or normalize to a single label) and trim `vite-plugin` to match the brevity of the others. Document the canonical template once (e.g., as a comment in CONTRIBUTORS.md or the docs spec) so future packages match.
+
+### F-109: `@dawn-ai/langchain` README lists wrong export names (`ChainAdapter`, `convertTools`, `toolLoop`) — none of these symbols exist
+- **Surface:** Internal package READMEs
+- **File:** packages/langchain/README.md
+- **Type:** error
+- **Severity:** important
+- **Description:** The README's "Public surface" lists `ChainAdapter`, `convertTools()`, and `toolLoop()`. None of these names match the actual exports from `packages/langchain/src/index.ts`, which exports `chainAdapter` (camelCase, not PascalCase), `convertToolToLangChain` (singular, different name), and `executeWithToolLoop` (different name). The README also entirely omits the agent surface (`executeAgent`, `streamAgent`, `AgentStreamChunk`), retry helpers (`withRetry`, `isRetryableError`, `RetryOptions`), and state-adapter (`materializeStateSchema`). A reader who copies the README's symbols will get import errors.
+- **Suggested fix:** Replace the bullet list with the actual exports: `chainAdapter`, `executeAgent` / `streamAgent`, `convertToolToLangChain`, `executeWithToolLoop`, `withRetry`, `materializeStateSchema`. Drop the editorial "no AgentExecutor dependency" note or move it to the website.
+
+### F-110: `@dawn-ai/devkit` README references `create-dawn-app` (non-existent npm name)
+- **Surface:** Internal package READMEs
+- **File:** packages/devkit/README.md
+- **Type:** error
+- **Severity:** minor
+- **Description:** The README says "packaged starter templates consumed by `create-dawn-app`". The published scaffolder package is `create-dawn-ai-app` (see `packages/create-dawn-app/package.json` line 2), the same divergence flagged in F-003. The directory is `packages/create-dawn-app/` but the npm name and bin are `create-dawn-ai-app`. The README leaves a reader unsure which name to install.
+- **Suggested fix:** Change the reference to `create-dawn-ai-app` (the published package name). Coordinate with the F-003 fix so the root README, CONTRIBUTORS.md, and devkit README all use one name.
+
+### F-111: `@dawn-ai/core` README "Public surface" omits typegen, state-fields, and route-segment exports
+- **Surface:** Internal package READMEs
+- **File:** packages/core/README.md
+- **Type:** gap
+- **Severity:** minor
+- **Description:** The README lists only `loadDawnConfig()`, `findDawnApp()`, `discoverRoutes()`, `renderRouteTypes()`. The actual `src/index.ts` also exports `extractToolTypesForRoute`, `extractToolSchemasForRoute`, `renderDawnTypes`, `renderStateTypes`, `renderToolTypes`, `resolveStateFields`, `assertDawnRoutesDir`, `isPrivateSegment`, `isRouteGroupSegment`, `toRouteSegments`, plus the bulk of Dawn's shared types (`DawnConfig`, `RouteManifest`, `RouteDefinition`, etc.). Internal consumers (`vite-plugin`, the CLI) rely on these. The README undersells what the package owns.
+- **Suggested fix:** Either (a) replace the curated list with one or two grouped bullets ("config loading, app discovery, route discovery, typegen renderers, state-field resolution") and let the website own the symbol list, or (b) expand the bullet list to include the typegen and state-field exports. Option (a) better fits the stub-with-pointer policy.
+
+### F-112: `@dawn-ai/langgraph` README "Public surface" omits `graphAdapter` and `workflowAdapter`
+- **Surface:** Internal package READMEs
+- **File:** packages/langgraph/README.md
+- **Type:** gap
+- **Severity:** minor
+- **Description:** The README lists `defineEntry()`, `normalizeRouteModule()`, and route module/config types. The actual `src/index.ts` also exports `graphAdapter` and `workflowAdapter` (the `BackendAdapter` implementations that make the package useful at runtime, paralleling `chainAdapter` in `@dawn-ai/langchain`). Without these, the README hides the package's actual integration surface.
+- **Suggested fix:** Add `graphAdapter` and `workflowAdapter` to the public-surface list (or, if going stub-with-pointer per F-108, summarize as "graph and workflow `BackendAdapter` implementations and the `defineEntry` helper" and link to the website).
+
+### F-113: `@dawn-ai/vite-plugin` README leaks internal helpers as public surface
+- **Surface:** Internal package READMEs
+- **File:** packages/vite-plugin/README.md
+- **Type:** misalignment
+- **Severity:** minor
+- **Description:** The README's "Public surface" elevates `extractJsDoc()`, `extractParameterType()`, and `generateZodSchema()` alongside `dawnToolSchemaPlugin()` and `transformToolSource()`. The first three are implementation details re-exported for testability — no consumer imports them in normal use, and listing them in a stub README implies they are part of the user-facing contract. This is the only README of the seven that exposes internal helpers this way, contributing to the F-108 inconsistency.
+- **Suggested fix:** Trim the public-surface list to `dawnToolSchemaPlugin()` (and optionally `transformToolSource()` if it is intentionally documented for advanced users). Move the JSDoc/type/Zod helpers to the website's internals page if they need documenting.
+
+Internal READMEs findings: F-107 through F-113 (0 critical, 2 important, 5 minor).
 
 ## Summary
 

--- a/docs/superpowers/audits/2026-05-06-docs-audit.md
+++ b/docs/superpowers/audits/2026-05-06-docs-audit.md
@@ -356,7 +356,287 @@ Load-bearing pages findings: F-014 through F-039 (12 critical, 10 important, 4 m
 
 ## 3. Website supporting pages (`state.mdx`, `cli.mdx`, `dev-server.mdx`, `testing.mdx`)
 
-_(pending — Task 4)_
+### F-040: state.mdx documents a TypeScript `interface` shape — actual scaffold uses a default-exported Zod schema
+- **Surface:** Website (supporting)
+- **File:** apps/web/content/docs/state.mdx:7-24
+- **Type:** error
+- **Severity:** critical
+- **Description:** The "shape" snippet shows `export interface HelloState { readonly tenant: string; readonly greeting?: string }` and then imports `HelloState` for use as the workflow's state-typed first parameter. The actual scaffold (packages/devkit/templates/app-basic/src/app/(public)/hello/[tenant]/state.ts) is `import { z } from "zod"; export default z.object({ context: z.string().default("") })`. State discovery (packages/cli/src/lib/runtime/state-discovery.ts:11-56) requires a default-exported Standard-Schema-compatible or Zod schema with a `.parse({})` shape — a TypeScript `interface` produces no runtime export, so `discoverStateDefinition` returns `null` and state defaults silently disappear. This is the same drift flagged in F-023 on routes.mdx but state.mdx is the canonical state page, so the misalignment is more severe here.
+- **Suggested fix:** Replace the snippet with the Zod default-export form: `import { z } from "zod"; export default z.object({ context: z.string().default("") })`. Show how the schema doubles as a runtime defaults provider (state-discovery extracts via `.parse({})`) and as a TS type via `z.infer<typeof state>`.
+
+### F-041: state.mdx never mentions Zod, Standard Schema, or `.default()` — the entire runtime contract is invisible
+- **Surface:** Website (supporting)
+- **File:** apps/web/content/docs/state.mdx (overall)
+- **Type:** gap
+- **Severity:** critical
+- **Description:** The page says "State is the contract between the caller, the route's entry, and any tools" but never explains how the contract is declared. Reality: `discoverStateDefinition` (packages/cli/src/lib/runtime/state-discovery.ts:34-56) accepts either a Standard-Schema-conformant value (via the `~standard.validate({})` slot) or a Zod-compatible `.parse({})` object. The scaffold uses Zod. The audit plan flags state.ts semantics as the load-bearing detail to verify, and the doc treats state as a TS-only concept.
+- **Suggested fix:** Rewrite the "shape" section around the Zod default-export form. Add a note on Standard Schema fallback for non-Zod schema libraries. Show the `z.infer<typeof state>` idiom for getting a TS type out of the schema.
+
+### F-042: state.mdx omits the `reducers/<field>.ts` override mechanism
+- **Surface:** Website (supporting)
+- **File:** apps/web/content/docs/state.mdx:38-50
+- **Type:** gap
+- **Severity:** important
+- **Description:** state-discovery.ts:78-103 imports any `reducers/<field>.ts` files inside a route directory and registers each default export as a custom reducer for that state field. The "Rules" Steps explain JSON-serializability, readonly, and accumulation, but never mention that reducers exist or that they let authors override the default merge behavior per field. Authors hitting accumulation issues have no doc surface to find this.
+- **Suggested fix:** Add a "Custom reducers" section showing `routeDir/reducers/<fieldName>.ts` exporting `(current, incoming) => merged` as the default. Note that the file basename must equal the state-field name. Cross-reference to a future reducers-deep-dive page.
+
+### F-043: state.mdx workflow snippet uses untyped `ctx` and the `workflow` form, contradicting agent-first scaffold
+- **Surface:** Website (supporting)
+- **File:** apps/web/content/docs/state.mdx:17-24
+- **Type:** misalignment
+- **Severity:** important
+- **Description:** Snippet: `export async function workflow(state: HelloState, ctx) { ... }`. The scaffold default is `export default agent({ model, systemPrompt })` (packages/devkit/templates/app-basic/src/app/(public)/hello/[tenant]/index.ts), and per F-015/F-016 in load-bearing pages, agent is now a first-class kind. `ctx` is also untyped (`noImplicitAny` would error in strict mode). Same misalignment thread as F-029.
+- **Suggested fix:** Add types (`ctx: RuntimeContext` from `@dawn-ai/sdk`). Add a sibling note that agent routes don't use a workflow signature — state still flows through the same Zod default export and is consumed by the LLM/tool-binding layer.
+
+### F-044: state.mdx "State flow" diagram says state goes "stdin → workflow → stdout" — no mention of HTTP, dev-server, or LangGraph protocol
+- **Surface:** Website (supporting)
+- **File:** apps/web/content/docs/state.mdx:52-60
+- **Type:** misalignment
+- **Severity:** minor
+- **Description:** The flow diagram implies state always crosses `dawn run`'s stdin/stdout boundary. In production, state crosses HTTP via `/runs/wait` and `/runs/stream` (packages/cli/src/lib/dev/runtime-server.ts:124-135), keyed by `assistant_id`, with dev/prod parity. The diagram is correct for `dawn run` only.
+- **Suggested fix:** Either generalize the boundary description ("state crosses the runtime boundary — stdin/stdout for `dawn run`, JSON over HTTP for `/runs/wait` and `/runs/stream`"), or drop the diagram and link to the dev-server protocol page.
+
+### F-045: state.mdx makes no reference to dynamic-segment merging into Zod state defaults
+- **Surface:** Website (supporting)
+- **File:** apps/web/content/docs/state.mdx:26-36
+- **Type:** gap
+- **Severity:** important
+- **Description:** "Naming matters" callout is correct on the wiring rule, but the scaffolded state.ts only declares `context`. The `tenant` field actually arrives at runtime from the URL pathname and is layered on top of the schema-derived defaults (resolveStateFields, packages/core/src/state-resolution). The page says "the dynamic segment is populated on the state field of the same name" but never notes that authors do NOT need to (and should not) declare `tenant` in their Zod schema — it's injected from the path. Authors copying the snippet from F-040's fix could double-declare and conflict.
+- **Suggested fix:** Add a sentence: "Dynamic-segment fields are injected from the URL path at runtime — they are not declared in the Zod schema. Schema fields cover the state your entry produces or the caller supplies." Show the scaffold pattern (`z.object({ context })`) alongside the `[tenant]` segment to make the split explicit.
+
+### F-046: cli.mdx opening claims "Dawn ships a single `dawn` binary with six commands" — the binary registers eight
+- **Surface:** Website (supporting)
+- **File:** apps/web/content/docs/cli.mdx:3
+- **Type:** error
+- **Severity:** critical
+- **Description:** The first paragraph asserts six commands. packages/cli/src/index.ts:36-44 registers eight user-facing commands: `build`, `check`, `dev`, `run`, `routes`, `test`, `typegen`, `verify`. The page documents only six (`check`, `routes`, `typegen`, `run`, `test`, `dev`). `dawn build` and `dawn verify` are entirely absent — both shipping commands per the audit context.
+- **Suggested fix:** Update the count to eight (or drop the count). Add `## dawn build` and `## dawn verify` sections (see F-047 and F-048).
+
+### F-047: cli.mdx is missing the `dawn build` reference entirely
+- **Surface:** Website (supporting)
+- **File:** apps/web/content/docs/cli.mdx (overall)
+- **Type:** gap
+- **Severity:** critical
+- **Description:** `dawn build` (packages/cli/src/commands/build.ts:21-30) is the only path to LangGraph Platform deployment artifacts. It accepts `--clean` and `--cwd <path>`, runs typegen as a pre-step, writes `.dawn/build/<routeSlug>.ts` entry files (with `agent.bindTools(...)` for agent routes), and emits `.dawn/build/langgraph.json` with `graphs`, `dependencies: ["."]`, `env`, and `node_version: "22"` (extractDeploymentConfig at packages/cli/src/lib/build/deployment-config.ts:18-24). None of this is in cli.mdx.
+- **Suggested fix:** Add a `## dawn build` section that documents `--clean` and `--cwd`, describes the artifact layout under `.dawn/build/`, and cross-links to deployment.mdx.
+
+### F-048: cli.mdx is missing the `dawn verify` reference entirely
+- **Surface:** Website (supporting)
+- **File:** apps/web/content/docs/cli.mdx (overall)
+- **Type:** gap
+- **Severity:** critical
+- **Description:** `dawn verify` (packages/cli/src/commands/verify.ts:88-97) runs four checks (`app`, `routes`, `typegen`, `deps`) with optional `--json`. Per the audit context it is the canonical integrity gate, and per F-034 deployment.mdx should reroute users to it. The CLI reference omits it entirely.
+- **Suggested fix:** Add a `## dawn verify` section documenting `--cwd`, `--json`, the four checks (including the deps check that surfaces missing packages and missing env vars), and the JSON output shape (`{ status, appRoot, checks, counts }`).
+
+### F-049: cli.mdx `dawn check` description over-claims — `state.ts` named-export rule and "no invalid tool shapes" rule are documented but not real
+- **Surface:** Website (supporting)
+- **File:** apps/web/content/docs/cli.mdx:13-18
+- **Type:** error
+- **Severity:** important
+- **Description:** The check list says it validates: (1) dawn.config.ts has only supported fields, (2) package.json exists, (3) every route exports exactly one of `workflow`/`graph`/`chain`, (4) every route's `state.ts` exports a named state type, (5) no tool files have invalid shapes. Reality (packages/cli/src/commands/check.ts:21-40): check calls `discoverRoutes` (which enforces app structure and the single-entry rule across `agent | workflow | graph | chain` — note `agent` missing from doc list, mirroring F-021) and then `discoverToolDefinitions` per route. There is no `state.ts` named-export check (state.ts uses a default Zod export; F-040). The "package.json exists" check happens during `findDawnApp`, not as a separate check call.
+- **Suggested fix:** Rewrite the bullet list to match reality: (a) dawn.config.ts loads, (b) app structure resolves via findDawnApp, (c) discoverRoutes returns successfully — single entry per route across `agent | workflow | graph | chain`, (d) discoverToolDefinitions parses each route's `tools/*.ts` without errors. Drop the `state.ts` named-export claim. Update the entry-kind enumeration to four kinds.
+
+### F-050: cli.mdx `dawn check` and `dawn routes` outputs do not match the real CLI
+- **Surface:** Website (supporting)
+- **File:** apps/web/content/docs/cli.mdx:22-37
+- **Type:** error
+- **Severity:** important
+- **Description:** `dawn routes` is documented to print `pathname  kind  entryFile` columns. The actual implementation (packages/cli/src/commands/routes.ts:31-35) prints `Discovered N Dawn routes in <appRoot>` followed by `<pathname> -> <entryFile>` (no kind column). It also accepts `--json` (line 16-17), which is not documented. `dawn check` similarly prints `Dawn app is valid: N routes discovered.` plus per-route `- <pathname> (<kind>)` lines (check.ts:32-35), which the doc never describes.
+- **Suggested fix:** Replace the `dawn routes` sample with the real `<pathname> -> <entryFile>` form, and document `--json`. Add a one-line description of `dawn check`'s output (route count + per-route kind line).
+
+### F-051: cli.mdx `dawn run` example uses `--stream` flag — flag does not exist
+- **Surface:** Website (supporting)
+- **File:** apps/web/content/docs/cli.mdx:60-61
+- **Type:** error
+- **Severity:** critical
+- **Description:** Documented flags include `--stream` "use the `/runs/stream` endpoint (requires `--url`)". `runRunCommand` (packages/cli/src/commands/run.ts:24-33) registers exactly two options: `--cwd <path>` and `--url <baseUrl>`. There is no `--stream` flag — invoking `dawn run --stream` will produce commander's "unknown option" error. The runtime server has a `/runs/stream` endpoint (runtime-server.ts:124-135), but the CLI does not surface it as a `dawn run` flag today.
+- **Suggested fix:** Either remove the `--stream` bullet, or document the actual streaming entry point (e.g., direct fetch of `/runs/stream`) — but do not advertise a CLI flag that does not exist.
+
+### F-052: cli.mdx `dawn run` flags omit `--cwd` (real flag) and use route ID `'/hello/[tenant]'` literally
+- **Surface:** Website (supporting)
+- **File:** apps/web/content/docs/cli.mdx:55-57,60-61
+- **Type:** misalignment
+- **Severity:** minor
+- **Description:** `--cwd <path>` is a real flag (run.ts:28) and should appear in the flags list. The example pipes `{"tenant":"acme"}` and runs `dawn run '/hello/[tenant]'` with the bracketed ID. resolveRouteTarget supports both pathname (`/hello/[tenant]`) and concrete (`/hello/acme`) forms, so the example is correct; but the cli.mdx tip on quoting (lines 63-65) only mentions `(`, `)`, `[`, `]` — readers may be unsure whether the ID should be the bracketed form or the concrete tenant.
+- **Suggested fix:** Add `--cwd <path>` to the flags list. Add a note that the route argument can be the parameterized ID (`/hello/[tenant]`) or the concrete pathname (`/hello/acme`); the input JSON's matching field supplies the dynamic segment value.
+
+### F-053: cli.mdx `dawn test` flags wrong — only `--cwd` exists; `--url` and `--filter` are documented but absent
+- **Surface:** Website (supporting)
+- **File:** apps/web/content/docs/cli.mdx:75-77
+- **Type:** error
+- **Severity:** critical
+- **Description:** Documented flags: `--url <url>` and `--filter <pattern>`. `runTestCommand` (packages/cli/src/commands/test.ts:34-42) registers only `--cwd <path>`. There is also a positional `[path]` narrowing argument. To run scenarios against a live server, scenario files must declare `run: { url }` per-scenario (load-run-scenarios.ts:269-279); there is no command-level `--url`. There is no filter flag at all. Same `dawn test --url` defect manifests in deployment.mdx F-033 and testing.mdx (see F-058).
+- **Suggested fix:** Replace flags list with `--cwd <path>` and the optional positional `[path]` narrowing argument. Cross-reference scenario-level `run: { url }` for live-server tests. Drop `--filter`.
+
+### F-054: cli.mdx `dawn dev` documents non-existent `--host` flag and wrong default port
+- **Surface:** Website (supporting)
+- **File:** apps/web/content/docs/cli.mdx:81-91
+- **Type:** error
+- **Severity:** important
+- **Description:** Documented flags: `--port <n>` (default 3000) and `--host <addr>` (default 127.0.0.1). `runDevCommand` (packages/cli/src/commands/dev.ts:9-17) registers only `--port <number>`. There is no `--host` flag — bind address is always `127.0.0.1` (runtime-server.ts:463 and dev-session.ts:33). Default port is **dynamically allocated** when `--port` is omitted (dev-session.ts:32, allocatePort()), not 3000.
+- **Suggested fix:** Drop the `--host` bullet. Reword `--port` as "HTTP port (default: dynamically allocated; pass `--port` for a stable address)." Mention the bind address is fixed at 127.0.0.1.
+
+### F-055: cli.mdx exit-code table claims 4 codes — actual surface uses 0/1/2 and indirectly Commander codes; "code 3 internal error" is unverified
+- **Surface:** Website (supporting)
+- **File:** apps/web/content/docs/cli.mdx:95-103
+- **Type:** misalignment
+- **Severity:** minor
+- **Description:** The table claims codes 0, 1, 2, and 3. The runtime (packages/cli/src/index.ts:49-71) returns 0 on success, propagates `error.exitCode` for `CliError`/`CommanderError`, and falls back to 1 for unknown errors. CliError defaults to exit code 1 (lib/output.ts), and explicit code-2 throws are scattered through commands (`dawn run` config errors, scenario-load failures). There is no documented code-3 path. The current table over-promises a stable error taxonomy that the code does not enforce.
+- **Suggested fix:** Either wire up explicit error codes in code (as a separate engineering task), or soften the table: "0 success; 1 validation/scenario failure; 2 configuration/runtime error; non-zero exit codes may be propagated unchanged from underlying tools." Drop the unverified `3` row until backed by code.
+
+### F-056: cli.mdx `dawn typegen` output description is incomplete — no mention of per-route `tools.json` artifacts
+- **Surface:** Website (supporting)
+- **File:** apps/web/content/docs/cli.mdx:39-49
+- **Type:** gap
+- **Severity:** minor
+- **Description:** The page says typegen "regenerates `dawn.generated.d.ts` from the current state of every tool file." Reality (packages/cli/src/commands/typegen.ts:21-33 and packages/cli/src/lib/typegen/run-typegen.ts): typegen also writes per-route `.dawn/routes/<slug>/tools.json` schema manifests consumed by `dawn build`'s codegen (build.ts:60-72). The completion message even reports `routeCount`, `toolSchemaCount`, and `stateRouteCount`. Mirrors F-030 in tools.mdx.
+- **Suggested fix:** Expand the description to "Regenerates `dawn.generated.d.ts` and per-route `.dawn/routes/<slug>/tools.json` schema manifests." Add a one-line mention that the success log reports route, tool-schema, and stateful-route counts.
+
+### F-057: dev-server.mdx documents `/assistants` endpoint — does not exist
+- **Surface:** Website (supporting)
+- **File:** apps/web/content/docs/dev-server.mdx:46-52
+- **Type:** error
+- **Severity:** critical
+- **Description:** The Tabs include a `/assistants` tab claiming `GET /assistants` "lists the assistants (routes) the server is serving." packages/cli/src/lib/dev/runtime-server.ts:119-138 only handles `GET /healthz`, `POST /runs/stream`, and `POST /runs/wait`. Anything else returns 404 (line 136). There is no list endpoint. Users following the docs to enumerate routes via HTTP will hit a 404.
+- **Suggested fix:** Drop the `/assistants` tab. If a list endpoint is desirable, file a follow-up issue. Cross-reference `dawn routes` (or `dawn routes --json`) for the list-routes use case.
+
+### F-058: dev-server.mdx omits `GET /healthz` — the only readiness endpoint
+- **Surface:** Website (supporting)
+- **File:** apps/web/content/docs/dev-server.mdx:27-53
+- **Type:** gap
+- **Severity:** important
+- **Description:** runtime-server.ts:119-122 implements `GET /healthz` returning `{ status: "ready" }` with HTTP 200. The dev-session uses it to detect readiness (health.ts:1-14, dev-session.ts:234). The doc never mentions `/healthz`, which is the only contract surface external orchestrators (Docker, k8s, CI) can rely on.
+- **Suggested fix:** Add a `/healthz` tab in the protocol section: `GET /healthz` returns `200 { "status": "ready" }` once the child runtime is up; non-200 means not-ready. Note that `dawn dev` itself uses this endpoint internally.
+
+### F-059: dev-server.mdx assistant_id description is wrong — claims `dawn run` resolves pathname, but the format is `<routeId>#<mode>`
+- **Surface:** Website (supporting)
+- **File:** apps/web/content/docs/dev-server.mdx:23-25,33-44,66-68
+- **Type:** error
+- **Severity:** critical
+- **Description:** The page says "`dawn run` resolves the pathname to an `assistant_id`, POSTs to `/runs/wait`, and prints the result." It never reveals the format. Real format (createRouteAssistantId at packages/cli/src/lib/runtime/route-identity.ts:8-13 and dawn build at build.ts:119): `${routeId}#${kind}` — e.g. `/hello/[tenant]#agent`. The lookup at runtime-server.ts:155 keys on this exact string, and runs/wait body validation requires `metadata.dawn.{mode, route_id, route_path}` to all match the registered route (lines 181-202). External clients building requests by hand have no way to derive the assistant_id from the docs. Mirrors F-036 in deployment.mdx.
+- **Suggested fix:** Document the format `<routeId>#<kind>` with a concrete example (`/hello/[tenant]#agent`). In the `/runs/wait` body, also document the required `metadata.dawn.{mode, route_id, route_path}` and `on_completion: "delete"` shape (validateRunsWaitRequest at runtime-server.ts:358-416).
+
+### F-060: dev-server.mdx `/runs/wait` body shape is incomplete — missing `metadata.dawn.{mode,route_id,route_path}` and `on_completion`
+- **Surface:** Website (supporting)
+- **File:** apps/web/content/docs/dev-server.mdx:33-37
+- **Type:** error
+- **Severity:** critical
+- **Description:** Documented body: `{ assistant_id, input }`. Reality (runtime-server.ts:358-416): the validator rejects any body that does not also include `metadata.dawn.mode` (string), `metadata.dawn.route_id` (string), `metadata.dawn.route_path` (string), and `on_completion: "delete"`. A naive client posting `{ assistant_id, input }` gets a 400 with "Request body must include metadata.dawn." `/runs/stream` shares the same validator (line 267).
+- **Suggested fix:** Document the full body shape with the four required envelope fields. Note that `metadata.dawn.{mode, route_id, route_path}` must match the values for the registered `assistant_id` or the server returns 400 with an `expected/received` diff.
+
+### F-061: dev-server.mdx `/runs/stream` body shape includes `stream_mode` — server ignores it
+- **Surface:** Website (supporting)
+- **File:** apps/web/content/docs/dev-server.mdx:41-44
+- **Type:** error
+- **Severity:** important
+- **Description:** Documented `/runs/stream` body: `{ assistant_id, input, stream_mode }`. The server validates the same RunsWait shape (runtime-server.ts:267) and never reads `stream_mode`. Conversely it ignores the documented `stream_mode` field but does require the same envelope (`metadata.dawn`, `on_completion`).
+- **Suggested fix:** Drop `stream_mode` from the documented body. Use the same body shape as `/runs/wait` (per F-060). Note that the response is SSE (`content-type: text/event-stream`).
+
+### F-062: dev-server.mdx hot-reload "Re-runs typegen" claim — typegen is debounced and only fires for tools/state file changes
+- **Surface:** Website (supporting)
+- **File:** apps/web/content/docs/dev-server.mdx:55-69
+- **Type:** misalignment
+- **Severity:** minor
+- **Description:** The page says "When you save a route file, a tool, or a state file, the dev server: re-runs typegen." Real behavior (dev-session.ts:173-203 and classify-change.ts): on file change, classifyChange returns either `"typegen"` (debounced 100ms typegen run) or another tag triggering a full child restart. Not every save runs typegen. Also "Restarts the child runtime ... in-flight requests complete before the swap" overstates: the child is `stop()`ed with a forced kill timeout (dev-session.ts:218-223) — in-flight requests are not guaranteed to complete.
+- **Suggested fix:** Tighten the Steps: "(1) Reclassifies the change — typegen-only changes (tool signatures, state schema) re-run typegen with a 100ms debounce; structural changes restart the child. (2) Restarts the child runtime — in-flight requests are given a brief grace window, then force-killed."
+
+### F-063: dev-server.mdx makes no mention of middleware — `src/middleware.ts` is the only place to wire auth/context per request
+- **Surface:** Website (supporting)
+- **File:** apps/web/content/docs/dev-server.mdx (overall)
+- **Type:** gap
+- **Severity:** important
+- **Description:** packages/cli/src/lib/dev/middleware.ts:7-29 looks for `src/middleware.ts` (or `middleware.ts`/`.js`) and runs it before every `/runs/wait` and `/runs/stream` request. The result either continues (with optional context) or rejects with a status. The dev-server doc never mentions this. Authors trying to gate access in dev have no doc surface to find it. Compounded by F-025 (routes.mdx) and F-038 (deployment.mdx) — middleware is undocumented end to end.
+- **Suggested fix:** Add a "Middleware" subsection: `src/middleware.ts` (default-exporting a `defineMiddleware(...)` function) runs before every `/runs/wait` and `/runs/stream` request. `MiddlewareRequest` shape: `{ assistantId, headers, method, params, routeId, url }`. Mention that creating a dedicated middleware page is **deferred to a follow-up issue (new page out of scope for this PR series)**.
+
+### F-064: dev-server.mdx says default port is 3000 — port is dynamically allocated when `--port` is omitted
+- **Surface:** Website (supporting)
+- **File:** apps/web/content/docs/dev-server.mdx:7-15
+- **Type:** error
+- **Severity:** important
+- **Description:** "By default the server listens on port 3000." dev-session.ts:32 calls `allocatePort()` (lines 330-358) which binds an ephemeral port via `server.listen(0, "127.0.0.1")`. The startup line `Dawn dev ready at ${this.url}` shows the actual chosen port. To get a stable port, the user must pass `--port`. Mirrors F-054.
+- **Suggested fix:** Reword to "By default the server binds an ephemeral localhost port (announced on stdout). Pass `--port <n>` for a stable port:".
+
+### F-065: dev-server.mdx tells readers to set `DEBUG=dawn:*` — no `debug` instrumentation exists in the dev path
+- **Surface:** Website (supporting)
+- **File:** apps/web/content/docs/dev-server.mdx:75-77
+- **Type:** error
+- **Severity:** minor
+- **Description:** "Set `DEBUG=dawn:*` for verbose tracing of the parent/child handshake." A grep across the dev-session, runtime-server, and dev-child modules shows no `debug` package usage and no `DAWN_*` debug env var consumption (only `DAWN_DEV_SHUTDOWN_TIMEOUT_MS` exists, dev-session.ts:360-369). The documented env var has no effect.
+- **Suggested fix:** Drop the `DEBUG=dawn:*` claim. Either replace with the real env vars (`DAWN_DEV_SHUTDOWN_TIMEOUT_MS`) or remove the whole logging note until structured logging is wired up.
+
+### F-066: testing.mdx imports `@dawn-ai/sdk/testing` — submodule does not exist
+- **Surface:** Website (supporting)
+- **File:** apps/web/content/docs/testing.mdx:9
+- **Type:** error
+- **Severity:** critical
+- **Description:** `import { describe, test } from "@dawn-ai/sdk/testing"`. packages/sdk/package.json `exports` only declares `"."` — there is no `./testing` subpath (the package re-exports types and middleware/agent helpers, none of which are testing primitives). The real testing helpers live at `@dawn-ai/cli/testing` (packages/cli/package.json declares `"./testing"`) and export `expectError`, `expectMeta`, `expectOutput` — not `describe`/`test`. The fixture at test/generated/fixtures/handwritten-runtime-app/.../run.test.ts:1 uses the correct path: `import { expectMeta, expectOutput } from "@dawn-ai/cli/testing"`.
+- **Suggested fix:** Replace with `import { expectMeta, expectOutput } from "@dawn-ai/cli/testing"` and remove the `describe`/`test` imports (they are not real). See F-067 for the actual scenario file shape.
+
+### F-067: testing.mdx scenario file shape is fictional — real scenarios are `export default [...]`, not `describe()`/`test()` blocks
+- **Surface:** Website (supporting)
+- **File:** apps/web/content/docs/testing.mdx:7-17,44-52
+- **Type:** error
+- **Severity:** critical
+- **Description:** The doc shows `describe("/hello/[tenant]", () => { test("greets a tenant", { input, expected }) })`. The real scenario file (validateScenario at packages/cli/src/lib/runtime/load-run-scenarios.ts:213-322 and the working fixture above) is `export default [{ name, input, expect: { status, output, meta }, run?, assert? }]` — a default-exported array of plain scenario records. There is no `describe`, no `test`, no top-level pathname binding (the route is inferred from file location, not from a `describe` argument). The "expected" key is also wrong — the real key is `expect` with required `status: "passed" | "failed"` and optional `output`, `meta`, `error`. `dawn test`'s declarative-expectation evaluator (test.ts:151-189) reads `expect.{status,output,meta,error}`, never `expected`.
+- **Suggested fix:** Replace the snippet wholesale with the real array form, e.g. `export default [{ name: "greets a tenant", input: { tenant: "acme" }, expect: { status: "passed", output: { tenant: "acme", greeting: "Hello, acme!" } } }]`. Document the full expectation shape: `status` (required), `output`, `meta` (`mode`, `routeId`, `routePath`, `executionSource`), `error` (`kind`, `message: string | { includes }`).
+
+### F-068: testing.mdx `dawn test --url` flag does not exist
+- **Surface:** Website (supporting)
+- **File:** apps/web/content/docs/testing.mdx:31-34
+- **Type:** error
+- **Severity:** critical
+- **Description:** "`dawn test --url http://127.0.0.1:3001`" — but `runTestCommand` (packages/cli/src/commands/test.ts:34-42) only registers `--cwd`. Live-server scenarios are configured per-scenario via the `run: { url }` field (load-run-scenarios.ts:269-279, scenario fixture's "handwritten server scenario" entry). Same defect as F-033 (deployment.mdx) and F-053 (cli.mdx).
+- **Suggested fix:** Replace with the real per-scenario form: `{ name, input, run: { url: "http://127.0.0.1:3001" }, expect: { ... } }`. Drop the command-level `--url` bullet; mention that scenarios opt in individually.
+
+### F-069: testing.mdx documents per-scenario `tools` mocking — feature does not exist
+- **Surface:** Website (supporting)
+- **File:** apps/web/content/docs/testing.mdx:40-54
+- **Type:** error
+- **Severity:** critical
+- **Description:** Snippet: `test("with mocked greet", { input, expected, tools: { greet: async () => ({ greeting: "Hi from mock!" }) } })`. The validator (load-run-scenarios.ts:213-322) accepts only `name`, `input`, `expect`, `assert`, and `run`; any other key is silently ignored. Tool mocking is not part of the scenario surface today. Authors copying this snippet will see their mock ignored and their assertion fail against the real tool's output.
+- **Suggested fix:** Either (a) drop the "Mocking tools" section entirely until the feature lands, or (b) document the actual workaround (a tool-internal stub gated by an env var, or constructing a custom `assert(result)` with `expectOutput`). Mark this section as a known gap and link to a follow-up issue.
+
+### F-070: testing.mdx "Rules" reference `expected.eq` / `expected.contains` matchers — none exist
+- **Surface:** Website (supporting)
+- **File:** apps/web/content/docs/testing.mdx:65-67
+- **Type:** error
+- **Severity:** important
+- **Description:** "Use `expected.eq`, `expected.contains`, or custom matchers for partial or fuzzy matching (see `@dawn-ai/sdk/testing` for the full surface)." `@dawn-ai/sdk/testing` does not exist (F-066), and the real `@dawn-ai/cli/testing` exports `expectError`, `expectMeta`, `expectOutput` — none of which is named `eq` or `contains`. `expectOutput` does deep-equal under the hood (assertions.ts) and there is no documented partial-match helper.
+- **Suggested fix:** Drop the `expected.eq`/`expected.contains` references. Replace with the real matchers and a one-line description of what each does. Show how `assert(result)` lets authors write custom matchers using `expectOutput`/`expectMeta` directly.
+
+### F-071: testing.mdx CI snippet omits `dawn verify` and the deps check, mirroring F-034
+- **Surface:** Website (supporting)
+- **File:** apps/web/content/docs/testing.mdx:75-81
+- **Type:** misalignment
+- **Severity:** minor
+- **Description:** The CI YAML runs `dawn check && dawn typegen && dawn test`. Per the audit context, `dawn verify` is the canonical integrity gate (covers app, routes, typegen, deps in one call — verify.ts:162-218). Replacing the three pre-test steps with `dawn verify` shortens CI configs and adds the deps check (missing packages / env vars) that the current sequence omits.
+- **Suggested fix:** Replace the first two YAML steps with `pnpm exec dawn verify` and keep `pnpm exec dawn test`. Mention that verify runs typegen and check internally.
+
+### F-072: testing.mdx never mentions `agent()` retry policies or middleware — both observable in scenario behavior
+- **Surface:** Website (supporting)
+- **File:** apps/web/content/docs/testing.mdx (overall)
+- **Type:** gap
+- **Severity:** important
+- **Description:** Per the audit context, `agent()` accepts `retry: { maxAttempts, baseDelay }` and middleware runs before route execution on `/runs/wait`/`/runs/stream`. Both shape what scenarios assert: a retry policy can change observable output on flaky tools, and middleware that calls `reject(...)` will surface as a failed scenario whose `expect.status` should be `"failed"`. The page never names either primitive.
+- **Suggested fix:** Add a short note on testing agent retries (use `expect.status: "failed"` + `expect.error` for exhausted-retry cases) and middleware (live-server scenarios via `run.url` exercise middleware; in-process scenarios bypass it). Note that creating a dedicated middleware page is **deferred to a follow-up issue (new page out of scope for this PR series)**.
+
+### F-073: No middleware page exists in apps/web/content/docs/ despite middleware shipping today
+- **Surface:** Website (supporting)
+- **File:** apps/web/content/docs/ (gap — page absent)
+- **Type:** gap
+- **Severity:** important
+- **Description:** packages/sdk/src/middleware.ts exports `defineMiddleware`, `reject`, `allow`, plus types `DawnMiddleware`, `MiddlewareRequest`, `MiddlewareResult`, `ContinueResult`, `RejectResult`. packages/cli/src/lib/dev/middleware.ts loads `src/middleware.ts` and runs it before every dev-server request. The website docs directory contains state, cli, dev-server, testing, getting-started, routes, tools, deployment — no middleware page. Cross-cutting findings (F-025, F-038, F-063, F-072) all flag the omission piecewise.
+- **Suggested fix:** Defer to follow-up issue (new page out of scope for this PR series). In the meantime, every existing page that touches request flow should mention `defineMiddleware` and link to `@dawn-ai/sdk` source until the page lands.
+
+### F-074: No `agent()` retry-config documentation page or section exists despite `RetryConfig` shipping
+- **Surface:** Website (supporting)
+- **File:** apps/web/content/docs/ (gap — coverage absent)
+- **Type:** gap
+- **Severity:** important
+- **Description:** `agent({ retry: { maxAttempts, baseDelay } })` ships from packages/sdk/src/agent.ts (per audit context); types are exported from `@dawn-ai/sdk` (`AgentConfig`, `RetryConfig`). No page covers the retry contract — semantics of `maxAttempts` (total attempts vs. retries-after-first), `baseDelay` units (ms vs. seconds), backoff shape (linear, exponential, jittered), or which errors are retried. The supporting pages, like the load-bearing pages, are silent.
+- **Suggested fix:** Defer a dedicated section to the eventual routes/agent expansion (out of scope here as a new page). At minimum, add a one-liner in routes.mdx (per F-025's fix) referencing the `retry` shape and link to the source until full docs land. Track as follow-up issue.
+
+Supporting pages findings: F-040 through F-074 (13 critical, 15 important, 7 minor).
 
 ## 4. Templates (`AGENTS.md`, `CLAUDE.md`)
 

--- a/docs/superpowers/audits/2026-05-06-docs-audit.md
+++ b/docs/superpowers/audits/2026-05-06-docs-audit.md
@@ -22,7 +22,118 @@ Findings are numbered globally across all sections (F-001, F-002, ...). Each sub
 
 ## 1. Root README (`README.md`)
 
-_(pending — Task 2)_
+### F-001: README opening sentence omits agent execution and tools — Dawn's primary capability
+- **Surface:** Root README
+- **File:** README.md:3
+- **Type:** misalignment
+- **Severity:** important
+- **Description:** The opening line describes Dawn as a framework for "filesystem-based route discovery, route validation, type generation, local route execution, and a local development runtime." This omits agent execution, route-local tool authoring, middleware, and `dawn build` for LangGraph Platform deployment artifacts — all currently shipping capabilities. The scaffold even ships an `agent()` route by default (see F-005), so describing Dawn purely as a route/runtime framework is misleading.
+- **Suggested fix:** Update the opening to mention agent authoring (`agent()` descriptor), route-local tools, middleware, and the `dawn build` deployment-artifact path alongside discovery/typegen/dev.
+
+### F-002: "Status" section says Dawn is not a deployment runtime, but `dawn build` produces LangGraph Platform deployment artifacts
+- **Surface:** Root README
+- **File:** README.md:5-7
+- **Type:** misalignment
+- **Severity:** important
+- **Description:** The Status section asserts Dawn "is not a deployment runtime, not a LangSmith trace replacement, and not a hosted platform." This is technically still true (Dawn does not host or run production traffic), but it ignores the fact that `dawn build` (packages/cli/src/commands/build.ts) now exists specifically to emit `langgraph.json` + entry files for LangGraph Platform deployment. Readers will be confused when `dawn build` is missing from Commands and the Status disclaimer suggests deployment is out of scope.
+- **Suggested fix:** Reword to "Dawn does not host or run production traffic. Dawn produces deployment artifacts (`dawn build`) for LangGraph Platform, which owns the runtime." Then add `dawn build` to the Commands section (see F-007).
+
+### F-003: Quickstart `pnpm create dawn-app` invokes a non-existent npm package
+- **Surface:** Root README
+- **File:** README.md:14, 72
+- **Type:** error
+- **Severity:** critical
+- **Description:** The README instructs users to run `pnpm create dawn-app my-dawn-app`. `pnpm create dawn-app` resolves to the npm package `create-dawn-app`, but the published package is `create-dawn-ai-app` (see packages/create-dawn-app/package.json line 2: `"name": "create-dawn-ai-app"`, and bin name `create-dawn-ai-app` on line 23). The Quickstart command will fail with a "package not found" error for any first-time user.
+- **Suggested fix:** Replace both occurrences with `pnpm create dawn-ai-app my-dawn-app`. Also align CONTRIBUTORS.md (line 56) which has the same divergence — flag for the contributor doc audit.
+
+### F-004: Scaffold route example documents `workflow`/`graph` exports but actual scaffold exports `agent`
+- **Surface:** Root README
+- **File:** README.md:40-50
+- **Type:** misalignment
+- **Severity:** critical
+- **Description:** The App Contract section says a route's `index.ts` "exports either a `workflow` function or a `graph` function/object" and shows two snippets using those exports. But the basic template ships `index.ts` that does `export default agent({...})` (packages/devkit/templates/app-basic/src/app/(public)/hello/[tenant]/index.ts). The discovery layer (packages/core/src/discovery/discover-routes.ts) actually accepts four kinds: `agent`, `workflow`, `graph`, and `chain` (RouteKind in packages/sdk/src/route-config.ts:1). A user reading this section and then opening the scaffold would be very confused — the scaffolded route does not match either pattern shown.
+- **Suggested fix:** Add `agent` (the recommended/default) and `chain` to the supported exports list. Show the `agent({ model, systemPrompt })` form first since it is the scaffold's default. Keep the `workflow`/`graph` snippets for users who need lower-level control.
+
+### F-005: README under-claims scaffold contents — omits `state.ts` and the default `agent` export
+- **Surface:** Root README
+- **File:** README.md:58-61
+- **Type:** misalignment
+- **Severity:** important
+- **Description:** README says the basic scaffold ships `index.ts` and `tools/greet.ts`. The actual template (packages/devkit/templates/app-basic/) also ships `state.ts` (line 7 of the file listing). The README's own App Contract section even calls out that "Route directories may also include companion files such as `state.ts`," yet the scaffold listing omits it. Additionally the `index.ts` content is `export default agent({...})`, not the `workflow`/`graph` forms shown in the contract.
+- **Suggested fix:** Add `src/app/(public)/hello/[tenant]/state.ts` to the bullet list. Optionally clarify that the scaffold uses an agent-style route (`export default agent(...)`).
+
+### F-006: Commands section omits `dawn build` and `dawn verify` — both shipping commands
+- **Surface:** Root README
+- **File:** README.md:63-105
+- **Type:** gap
+- **Severity:** important
+- **Description:** The Commands section documents `dawn check`, `dawn routes`, `dawn typegen`, `dawn run`, `dawn test`, and `dawn dev`. Two shipping commands are missing:
+  - `dawn build` (packages/cli/src/commands/build.ts) — produces LangGraph Platform deployment artifacts in `.dawn/build/` (langgraph.json + per-route entry files).
+  - `dawn verify` (packages/cli/src/commands/verify.ts) — runs four integrity checks (app, routes, typegen, deps) with optional `--json` output.
+  The CLI registers all eight commands in packages/cli/src/index.ts:36-44. The "user-first command set" framing on line 65 does not justify omitting `dawn build` (which is the only path to deployment) or `dawn verify` (which is the canonical integrity gate).
+- **Suggested fix:** Add `### dawn build` and `### dawn verify` sub-sections describing what each does. For `dawn build`, mention that it emits `langgraph.json` with `dependencies: ["."]` and the entry files referenced by `graphs`.
+
+### F-007: Quickstart never mentions `dawn check`/`dawn typegen`/`dawn verify` despite Commands listing them
+- **Surface:** Root README
+- **File:** README.md:9-30
+- **Type:** gap
+- **Severity:** minor
+- **Description:** The Quickstart goes from `pnpm install` straight to `dawn run`. A first-time user will hit cryptic errors if `dawn typegen` has not been run (the scaffolded `.dawn/dawn.generated.d.ts` ships pre-generated, but any added route requires regeneration). At minimum a `pnpm exec dawn check` step would surface validation issues before invocation, and `pnpm exec dawn typegen` would set expectations.
+- **Suggested fix:** Add a step between install and run: "Validate the app and generate types: `pnpm exec dawn check && pnpm exec dawn typegen`." Or fold this into a single `dawn verify` invocation once that command is documented.
+
+### F-008: README does not mention `agent()` descriptor, `retry`, middleware, or any new SDK surface
+- **Surface:** Root README
+- **File:** README.md (entire file, esp. App Contract and Packages)
+- **Type:** gap
+- **Severity:** critical
+- **Description:** Recent feature work (per the audit context, dated 2026-05-05/2026-05-06) added several user-facing primitives that are now exported from `@dawn-ai/sdk` (packages/sdk/src/index.ts):
+  - `agent()` descriptor with optional `retry: { maxAttempts, baseDelay }` (`AgentConfig`, `RetryConfig`, `DawnAgent`, `isDawnAgent`).
+  - `defineMiddleware`, `reject(status, body?)`, `allow(context?)`, plus types `DawnMiddleware`, `MiddlewareRequest`, `MiddlewareResult`, `ContinueResult`, `RejectResult`.
+  - Tools receive `middleware` context via `RuntimeContext`/`RuntimeTool`.
+  None of these appear in the README. The Packages section describes `@dawn-ai/sdk` only as "the backend-neutral author-facing contract: types, helpers, runtime context, and tool authoring," which technically covers them but gives the reader nothing concrete. Since `agent()` is the default scaffold's export, this is a critical gap.
+- **Suggested fix:** Add a short "Authoring agents" subsection under App Contract that shows `agent({ model, systemPrompt, retry: { maxAttempts, baseDelay } })`. Add a short "Middleware" subsection showing `defineMiddleware`, `reject`, and `allow` with a one-line description of `MiddlewareRequest`. Reference the website pages for full detail.
+
+### F-009: App Contract claims `appDir` is "the only supported config option today" — accurate but tonally fragile
+- **Surface:** Root README
+- **File:** README.md:38
+- **Type:** misalignment
+- **Severity:** minor
+- **Description:** The claim is currently true (packages/core/src/config.ts:90 only accepts `appDir`; the type at packages/core/src/types.ts:6 has `appDir?: string` as the only field). However the wording invites churn — every time a config option lands, this line needs editing. More importantly, it does not state the default value (`src/app`) inline, even though that default is documented one line earlier.
+- **Suggested fix:** Reword to "`appDir` is the only currently supported config option, and it defaults to `src/app`." Cross-link to the dawn.config.ts docs page if/when it exists.
+
+### F-010: Route directory "additional files" list says only `page.tsx` — omits `state.ts`, `run.test.ts`, and `tools/`
+- **Surface:** Root README
+- **File:** README.md:54-56
+- **Type:** misalignment
+- **Severity:** important
+- **Description:** The README lists `page.tsx for UI routes` as the only additional file, but two paragraphs earlier (line 52) it acknowledges `state.ts` and `tools/*.ts`. The `dawn test` command (line 95-97) further depends on `run.test.ts` colocated next to `index.ts`. The "additional files" list is contradicted by the rest of the same section.
+- **Suggested fix:** Expand the list to include `state.ts` (route state shape), `tools/*.ts` (route-local tools), `run.test.ts` (colocated scenarios), and `page.tsx` (UI). Mark each with one-line purpose.
+
+### F-011: Packages section is missing `@dawn-ai/vite-plugin`
+- **Surface:** Root README
+- **File:** README.md:107-116
+- **Type:** gap
+- **Severity:** minor
+- **Description:** The Packages section enumerates eight packages. The workspace also ships `@dawn-ai/vite-plugin` (packages/vite-plugin/ exists in the tree). Whether this is "internal-only" or user-facing should be made explicit; right now it is silently absent.
+- **Suggested fix:** Either add a one-line bullet for `@dawn-ai/vite-plugin` describing its role, or add a sentence noting that internal-only packages are documented in CONTRIBUTORS.md. Coordinate with the internal-package-READMEs audit task.
+
+### F-012: README does not link to website docs (getting-started, routes, tools, deployment)
+- **Surface:** Root README
+- **File:** README.md (overall)
+- **Type:** gap
+- **Severity:** important
+- **Description:** The README contains a Quickstart and one inline link to CONTRIBUTORS.md, but never points readers at the website docs that cover routes, tools, state, deployment, dev-server, testing, etc. (the audit plan references getting-started.mdx, routes.mdx, tools.mdx, deployment.mdx). For a meta-framework, the README should be a launching pad to deeper docs, not a self-contained tutorial.
+- **Suggested fix:** Add a "Documentation" section near the top (or replace the Quickstart's tail) with links to the canonical pages on the public docs site for routes, tools, state, deployment, dev server, and testing.
+
+### F-013: "Current Boundaries" repeats Status disclaimers without adding new information
+- **Surface:** Root README
+- **File:** README.md:118-124
+- **Type:** misalignment
+- **Severity:** minor
+- **Description:** Lines 118-124 restate "Dawn is not a deployment runtime" and "Dawn is not a LangSmith trace replacement" — both already stated in the Status section (lines 5-7). The third sentence ("starter template surface is intentionally small") is the only novel content. This duplication wastes readers' attention and amplifies the F-002 misalignment about deployment scope.
+- **Suggested fix:** Either fold Current Boundaries into a single revised Status block (with the deployment-artifact correction from F-002) or drop it.
+
+Root README findings: F-001 through F-013 (3 critical, 6 important, 4 minor).
 
 ## 2. Website load-bearing pages (`getting-started.mdx`, `routes.mdx`, `tools.mdx`, `deployment.mdx`)
 

--- a/docs/superpowers/audits/2026-05-06-docs-audit.md
+++ b/docs/superpowers/audits/2026-05-06-docs-audit.md
@@ -640,7 +640,111 @@ Supporting pages findings: F-040 through F-074 (13 critical, 15 important, 7 min
 
 ## 4. Templates (`AGENTS.md`, `CLAUDE.md`)
 
-_(pending — Task 5)_
+### F-075: AGENTS.md and CLAUDE.md are byte-identical duplicates with no divergence
+- **Surface:** Templates
+- **File:** apps/web/content/templates/AGENTS.md:1, apps/web/content/templates/CLAUDE.md:1
+- **Type:** gap
+- **Severity:** minor
+- **Description:** The two files are character-for-character identical. Either both should diverge to address audience-specific concerns (Codex vs. Claude), or one should be the canonical source and the other a generated/forwarded copy. Maintaining two identical copies guarantees they will drift out of sync over time, and every finding below applies to both files at the same line.
+- **Suggested fix:** Pick a canonical path (e.g., AGENTS.md) and have CLAUDE.md either be a thin pointer (`See AGENTS.md`) or be generated from the same source during scaffolding. If they must diverge, document the rationale and mark the differences.
+
+### F-076: Route entry directive omits the `agent` route kind shipping today
+- **Surface:** Templates
+- **File:** apps/web/content/templates/AGENTS.md:9-12, apps/web/content/templates/CLAUDE.md:9-12
+- **Type:** misalignment
+- **Severity:** critical
+- **Description:** The "Project Shape" section claims a route's `index.ts` "MUST export exactly ONE of `workflow`, `graph`, `chain`." But `packages/sdk/src/route-config.ts` declares `RouteKind = "agent" | "chain" | "graph" | "workflow"`, and `packages/core/src/discovery/discover-routes.ts:94-133` actively detects an `agent` export (and a `default` export of a `DawnAgent` descriptor) as a valid fourth route kind. Coding agents reading this template will believe `agent` is unsupported and avoid the preferred path for LLM-driven routes.
+- **Suggested fix:** Add `agent` (Dawn agent descriptor from `@dawn-ai/sdk`) as a fourth bullet, and note that the descriptor may be the `default` export. Cross-link to the agent authoring guide.
+
+### F-077: No mention of `agent()` descriptor from `@dawn-ai/sdk` or its retry config
+- **Surface:** Templates
+- **File:** apps/web/content/templates/AGENTS.md:26-56, apps/web/content/templates/CLAUDE.md:26-56
+- **Type:** gap
+- **Severity:** critical
+- **Description:** `@dawn-ai/sdk` exports `agent({ model, systemPrompt, retry?: { maxAttempts, baseDelay } })` (see `packages/sdk/src/agent.ts:25-32` and `packages/sdk/src/index.ts:1-2`). This is the supported way to author LLM-backed routes today, and `dawn build` has a dedicated `route.kind === "agent"` codepath that auto-binds tools (see `packages/cli/src/commands/build.ts:80-106`). The template never mentions `agent()`, the `model`/`systemPrompt`/`retry` fields, or the known model IDs surface — so an agent following this template will never produce an LLM-driven route.
+- **Suggested fix:** Add a "Defining an agent route" section showing `import { agent } from "@dawn-ai/sdk"` with `export default agent({ model, systemPrompt, retry })`, and explicitly note that tools in the same route's `tools/` directory are auto-bound at build time.
+
+### F-078: Tool authoring example omits the `context` parameter on the runtime signature
+- **Surface:** Templates
+- **File:** apps/web/content/templates/AGENTS.md:28-33, apps/web/content/templates/CLAUDE.md:28-33
+- **Type:** misalignment
+- **Severity:** important
+- **Description:** The example shows `export default async (input: { readonly tenant: string }) => { ... }`. The actual runtime signature accepted by tool discovery is `(input, context) => ...` where `context` is `{ middleware?: Readonly<Record<string, unknown>>, signal: AbortSignal }` (see `packages/cli/src/lib/runtime/tool-discovery.ts:14-23` and `packages/cli/src/lib/runtime/dawn-context.ts:3-7`). The `signal` is how a tool participates in cooperative cancellation; `middleware` is how a tool reads request-scoped state populated by `src/middleware.ts`. The single-arg form still works, but the template never tells the agent the second parameter exists.
+- **Suggested fix:** Show the canonical signature `(input, ctx) => ...` and document `ctx.signal` (AbortSignal) and `ctx.middleware` (request-scoped readonly bag). Note the second parameter is optional but recommended for any tool that does network I/O or needs middleware context.
+
+### F-079: Tools-only-in-route directive contradicts shared `src/tools/` discovery
+- **Surface:** Templates
+- **File:** apps/web/content/templates/AGENTS.md:14, apps/web/content/templates/CLAUDE.md:14, apps/web/content/templates/AGENTS.md:78, apps/web/content/templates/CLAUDE.md:78
+- **Type:** error
+- **Severity:** critical
+- **Description:** Two directives state tools live in `src/app/**/tools/*.ts` only, and the "Do Not" list explicitly says "Do NOT put tools outside a route's `tools/` directory." But `packages/cli/src/lib/runtime/tool-discovery.ts:31-49` discovers tools from BOTH `src/tools/` (shared scope) and `<routeDir>/tools/` (route-local scope). Shared tools are merged into every route's tool registry; this is a deliberate, supported feature. Following the template's "Do Not" rule would force every shared utility tool to be duplicated per-route.
+- **Suggested fix:** Document both scopes. Recommend route-local tools as the default; explain that `src/tools/*.ts` files are picked up as shared tools available in every route's `ctx.tools`, and that route-local tools override shared tools with the same name.
+
+### F-080: Middleware surface entirely missing from the template
+- **Surface:** Templates
+- **File:** apps/web/content/templates/AGENTS.md:1-87, apps/web/content/templates/CLAUDE.md:1-87
+- **Type:** gap
+- **Severity:** critical
+- **Description:** `src/middleware.ts` is a first-class Dawn surface today: `@dawn-ai/sdk` exports `defineMiddleware`, `reject(status, body?)`, `allow(context?)`, and the `MiddlewareRequest`/`MiddlewareResult` types (see `packages/sdk/src/middleware.ts` and `packages/sdk/src/index.ts:13-17`). The middleware result's `context` flows into each tool call as `ctx.middleware` (see `packages/cli/src/lib/runtime/dawn-context.ts:14-26`). The template never mentions middleware, so an agent following it cannot author auth, tenancy, rate-limiting, or request-scoped context — all of which are intended use cases.
+- **Suggested fix:** Add a "Middleware" section after "Tool Authoring" describing `src/middleware.ts`, the `defineMiddleware` helper, the `allow(context)` / `reject(status, body)` outcomes, and how `ctx.middleware` becomes available to tools. Show a minimal example.
+
+### F-081: Commands list is missing `dawn build` and `dawn verify`
+- **Surface:** Templates
+- **File:** apps/web/content/templates/AGENTS.md:58-65, apps/web/content/templates/CLAUDE.md:58-65
+- **Type:** gap
+- **Severity:** critical
+- **Description:** The Commands section enumerates `check`, `routes`, `typegen`, `run`, `test`, `dev` but omits two commands shipped under `packages/cli/src/commands/`: `build.ts` (`dawn build` — produces `.dawn/build/langgraph.json` for LangGraph Platform deployment, see `packages/cli/src/commands/build.ts:124-152`) and `verify.ts` (`dawn verify` — runs four integrity checks: app, routes, typegen, deps, see `packages/cli/src/commands/verify.ts:162-218`). Since the template explicitly tells agents not to invent commands and not to deploy from Dawn directly, omitting `dawn build` leaves them with no documented bridge to LangGraph Platform.
+- **Suggested fix:** Add `dawn build` ("write `.dawn/build/langgraph.json` for LangGraph Platform deployment, paths-as-deps + env-as-file") and `dawn verify` ("integrity check across app/routes/typegen/deps; preferred CI gate"). Optionally clarify the relationship between `dawn check` (lightweight) and `dawn verify` (comprehensive).
+
+### F-082: Test helpers reference `@dawn-ai/sdk/testing` which is not an exported subpath
+- **Surface:** Templates
+- **File:** apps/web/content/templates/AGENTS.md:15, apps/web/content/templates/CLAUDE.md:15
+- **Type:** broken-example
+- **Severity:** critical
+- **Description:** The bullet says colocated `run.test.ts` files "Use `@dawn-ai/sdk/testing`." But `packages/sdk/package.json:23-28` declares only one export entry — `"."` — and `packages/sdk/src/index.ts` re-exports nothing under a `/testing` namespace. Importing from `@dawn-ai/sdk/testing` will resolve to nothing. The actual test runner today is `dawn test`, which discovers `run.test.ts` scenarios via `loadRunScenarios` (see `packages/cli/src/commands/test.ts:50-56`); these scenarios are JSON-style descriptors, not Vitest tests using SDK helpers.
+- **Suggested fix:** Replace the testing-helper bullet with the actual scenario-file shape (or link to the live test docs page). If a `@dawn-ai/sdk/testing` subpath is genuinely planned, gate the doc on it shipping; otherwise remove the claim.
+
+### F-083: `RouteTools<"/path">` example uses the route's literal pathname, but `dawn:routes` keys depend on generated typegen
+- **Surface:** Templates
+- **File:** apps/web/content/templates/AGENTS.md:46-55, apps/web/content/templates/CLAUDE.md:46-55
+- **Type:** misalignment
+- **Severity:** important
+- **Description:** The route entry example does `RouteTools<"/hello/[tenant]">` from `dawn:routes`. The template never explains that `dawn:routes` is a Vite-plugin-provided virtual module (or that typegen feeds the type), nor how this works in non-Vite consumers (e.g., during `dawn run`, which uses tsx). An agent landing in a fresh scaffold will hit a "Cannot find module 'dawn:routes'" error and have no template-provided debugging path. (Cross-reference `packages/vite-plugin/` for the actual provider.)
+- **Suggested fix:** Add a one-liner under "Project Shape" or "Route Entry" explaining that `dawn:routes` is a virtual module emitted by the Vite plugin and backed by `dawn.generated.d.ts` for type-only imports; tell agents to run `dawn typegen` if `RouteTools` does not resolve.
+
+### F-084: `RuntimeContext` description omits the `signal` field that all tools see
+- **Surface:** Templates
+- **File:** apps/web/content/templates/AGENTS.md:69, apps/web/content/templates/CLAUDE.md:69
+- **Type:** gap
+- **Severity:** minor
+- **Description:** The "Packages" bullet for `@dawn-ai/sdk` says it provides `RuntimeContext`, but the template never mentions that `RuntimeContext` carries `signal: AbortSignal` (see `packages/sdk/src/runtime-context.ts:7-10`). Combined with F-078, an agent cannot learn from this template that Dawn supports cooperative cancellation.
+- **Suggested fix:** In the Route Entry section or a new "Cancellation" subsection, show `ctx.signal` being passed to `fetch` / awaited operations.
+
+### F-085: `dawn.config.ts` directive is technically correct but understates the parser's strictness
+- **Surface:** Templates
+- **File:** apps/web/content/templates/AGENTS.md:7, apps/web/content/templates/CLAUDE.md:7
+- **Type:** misalignment
+- **Severity:** minor
+- **Description:** The bullet says "Only supported field is `appDir` (defaults to `src/app`). Do not invent other config." That is correct in spirit, but `packages/core/src/config.ts` is a custom hand-written tokenizer that rejects escaped string literals, all non-`appDir` properties, and any non-string-literal/non-const-binding right-hand side. Agents that try to add helpful patterns (template strings, computed values, JSDoc, even `as const`) will get cryptic "Unsupported dawn.config.ts syntax" errors. The template's directive is true but does not warn agents to expect a strict parser.
+- **Suggested fix:** Add a parenthetical or sub-bullet: "the config is parsed by a strict tokenizer — only string-literal `appDir: "..."` or `const X = "..."; export default { appDir: X }` are supported."
+
+### F-086: `dawn build` artifact (`langgraph.json`) is unmentioned despite being the production handoff
+- **Surface:** Templates
+- **File:** apps/web/content/templates/AGENTS.md:80, apps/web/content/templates/CLAUDE.md:80
+- **Type:** gap
+- **Severity:** important
+- **Description:** The "Do Not" bullet says "Do NOT deploy from Dawn directly — Dawn owns local development; production runs on LangGraph Platform." This is correct but leaves the deployment story incomplete: `dawn build` is the supported bridge — it writes `.dawn/build/langgraph.json` with paths-as-dependencies and env-as-file (see `packages/cli/src/commands/build.ts:124-145` and `packages/cli/src/lib/build/deployment-config.ts`). Without this, agents have no template-sanctioned path from "I have a Dawn app" to "I can deploy it."
+- **Suggested fix:** Convert this bullet into a positive directive: "To deploy, run `dawn build` and hand `.dawn/build/langgraph.json` to LangGraph Platform; do not edit the generated `langgraph.json` by hand."
+
+### F-087: Reference URLs (`dawnai.org/llms-full.txt`, `dawnai.org/llms.txt`) are unverified for current content
+- **Surface:** Templates
+- **File:** apps/web/content/templates/AGENTS.md:84-86, apps/web/content/templates/CLAUDE.md:84-86
+- **Type:** gap
+- **Severity:** minor
+- **Description:** The template directs agents to consume `https://dawnai.org/llms-full.txt` and `https://dawnai.org/llms.txt` for fuller reference, but the rest of this audit (Sections 2-3) is producing fixes for the same docs site. If those `llms*.txt` artifacts are generated from the website's content or hand-authored, they need to be kept in sync with the corrections being landed in PR B; otherwise agents pulled to the URLs will get the outdated, incorrect content while the in-repo template lists the same incorrect surface.
+- **Suggested fix:** Confirm whether `llms.txt` / `llms-full.txt` are generated from `apps/web/content/` or hand-authored. If generated, ensure the generator covers the new surfaces (agent, middleware, build, verify, retry, tool context). If hand-authored, file them as a follow-up audit target.
+
+Templates findings: F-075 through F-087 (6 critical, 3 important, 4 minor).
 
 ## 5. Public package READMEs (`@dawn-ai/sdk`, `@dawn-ai/cli`, `create-dawn-ai-app`)
 

--- a/docs/superpowers/plans/2026-05-06-docs-review.md
+++ b/docs/superpowers/plans/2026-05-06-docs-review.md
@@ -1,0 +1,1030 @@
+# Dawn Docs Review Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Audit and fix gaps, misalignments, and errors across user-facing Dawn docs (root README, website docs, templates, package READMEs); verify code examples on load-bearing pages run against current packages.
+
+**Architecture:** Two phases, five PRs total. Phase 1 produces a single audit report via six parallel subagents (PR 0). Phase 2 produces four independent fix PRs (A: root README, B: website docs + templates, C: public package READMEs fleshed out, D: internal package READMEs as stub-with-pointer). Fix PRs branch from `main` after PR 0 merges so they each have the audit available.
+
+**Tech Stack:** Markdown / MDX, Biome lint, pnpm workspace, Next.js (website build), TypeScript (code-example verification).
+
+**Worktree:** all controller-side work runs in `.worktrees/docs-review` on branch `feature/docs-review`. Fix PRs use temporary branches from `main`.
+
+---
+
+## Phase 1 — Audit
+
+### Task 1: Initialize audit report skeleton
+
+**Files:**
+- Create: `docs/superpowers/audits/2026-05-06-docs-audit.md`
+
+- [ ] **Step 1: Create the audit report skeleton**
+
+Write the file at `docs/superpowers/audits/2026-05-06-docs-audit.md` with this exact content:
+
+```markdown
+# Dawn Docs Audit — 2026-05-06
+
+**Status:** in progress
+**Spec:** `docs/superpowers/specs/2026-05-06-docs-review-design.md`
+**Plan:** `docs/superpowers/plans/2026-05-06-docs-review.md`
+
+## Findings format
+
+Each finding uses this schema:
+
+\`\`\`markdown
+### F-NNN: <one-line summary>
+- **Surface:** <surface>
+- **File:** <path:line if applicable>
+- **Type:** gap | misalignment | error | broken-example
+- **Severity:** critical | important | minor
+- **Description:** <what's wrong>
+- **Suggested fix:** <concrete change, or "needs design">
+\`\`\`
+
+Findings are numbered globally across all sections (F-001, F-002, ...). Each subagent claims a contiguous range and announces it in its closing summary so the next subagent picks up from F-(N+1).
+
+## 1. Root README (`README.md`)
+
+_(pending — Task 2)_
+
+## 2. Website load-bearing pages (`getting-started.mdx`, `routes.mdx`, `tools.mdx`, `deployment.mdx`)
+
+_(pending — Task 3)_
+
+## 3. Website supporting pages (`state.mdx`, `cli.mdx`, `dev-server.mdx`, `testing.mdx`)
+
+_(pending — Task 4)_
+
+## 4. Templates (`AGENTS.md`, `CLAUDE.md`)
+
+_(pending — Task 5)_
+
+## 5. Public package READMEs (`@dawn-ai/sdk`, `@dawn-ai/cli`, `create-dawn-ai-app`)
+
+_(pending — Task 6)_
+
+## 6. Internal package READMEs (config-biome, config-typescript, core, devkit, langchain, langgraph, vite-plugin)
+
+_(pending — Task 7)_
+
+## Summary
+
+_(pending — populated at the findings cut after Tasks 2–7)_
+```
+
+- [ ] **Step 2: Verify the file was created**
+
+Run: `wc -l docs/superpowers/audits/2026-05-06-docs-audit.md`
+Expected: at least 30 lines.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/superpowers/audits/2026-05-06-docs-audit.md
+git commit -m "docs: scaffold docs audit report"
+```
+
+---
+
+### Task 2: Audit Root README
+
+**Files:**
+- Read: `README.md`
+- Modify: `docs/superpowers/audits/2026-05-06-docs-audit.md` (section 1)
+
+- [ ] **Step 1: Dispatch root README auditor subagent**
+
+Use Task tool with subagent_type=general-purpose. Prompt (verbatim):
+
+```
+You are auditing the root README of the Dawn project. This is read-only research — do NOT edit any code or website docs. Your only output is appending findings to the audit report file.
+
+Read these files first:
+- README.md (the file under audit)
+- packages/cli/src/commands/*.ts (every CLI command and its options)
+- packages/sdk/src/index.ts (SDK exports)
+- packages/create-dawn-ai-app/src/bin.ts (scaffold CLI)
+- package.json (workspace scripts and metadata)
+
+For each claim in README.md, verify it matches the current code:
+- Every CLI command shown (e.g., `dawn check`, `dawn verify`, `dawn build`) must exist in packages/cli/src/commands
+- Every code snippet must reference current SDK exports
+- Every URL or file path must resolve (use Read or Glob to confirm)
+- Every install command must use the right package names
+- Every claim about "what Dawn does" must align with current capabilities (deployment via LangGraph platform, retry config, middleware, etc — these are recent features)
+
+Append findings to docs/superpowers/audits/2026-05-06-docs-audit.md under section "## 1. Root README". Use the F-NNN format (start at F-001). Severities: critical = users hit a wall; important = users confused; minor = style/wording. Number findings sequentially.
+
+End with a summary line: "Root README findings: F-001 through F-NNN (X critical, Y important, Z minor)."
+
+If you find no issues, write "_(no findings)_" under the section and report so in your summary.
+
+Report back with: the F-NNN range you used, the count by severity, and any judgment calls you made.
+```
+
+- [ ] **Step 2: Verify subagent appended findings**
+
+Run: `grep -E "^### F-" docs/superpowers/audits/2026-05-06-docs-audit.md | head -20`
+Expected: at least the F-NNN range the subagent reported, OR the section contains `_(no findings)_`.
+
+Read the section: confirm the format matches the schema (Surface, File, Type, Severity, Description, Suggested fix).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/superpowers/audits/2026-05-06-docs-audit.md
+git commit -m "docs(audit): root README findings"
+```
+
+---
+
+### Task 3: Audit Website Load-Bearing Pages (with code verification)
+
+**Files:**
+- Read: `apps/web/content/docs/getting-started.mdx`, `routes.mdx`, `tools.mdx`, `deployment.mdx`
+- Modify: `docs/superpowers/audits/2026-05-06-docs-audit.md` (section 2)
+
+- [ ] **Step 1: Dispatch load-bearing-pages auditor subagent**
+
+Use Task tool with subagent_type=general-purpose. Prompt (verbatim):
+
+```
+You are auditing the load-bearing website docs pages for Dawn. This is read-only research — do NOT edit any code or doc content. Your only output is appending findings to the audit report file.
+
+Files under audit:
+- apps/web/content/docs/getting-started.mdx
+- apps/web/content/docs/routes.mdx
+- apps/web/content/docs/tools.mdx
+- apps/web/content/docs/deployment.mdx
+
+For each page, do a structural review:
+- Every code block: extract and verify it typechecks against the current SDK. For TS/MDX snippets, write the snippet to a temp file under /tmp/dawn-doc-verify/<slug>.ts that imports from "@dawn-ai/sdk", "@dawn-ai/core", "@dawn-ai/langchain" as needed. Then run `cd /Users/blove/repos/dawn && pnpm exec tsc --noEmit --target esnext --moduleResolution bundler --module esnext /tmp/dawn-doc-verify/<slug>.ts 2>&1` and capture failures.
+- Every CLI command shown (`dawn dev`, `dawn check`, `dawn verify`, `dawn build`, `dawn routes`, `dawn typegen`) must exist in packages/cli/src/commands and accept the documented flags.
+- Every cross-link (`[link](/docs/foo)`) must resolve to an existing page in apps/web/content/docs/.
+- Every claim about routes, tools, agents, deployment must align with the current code.
+- For getting-started specifically: the documented scaffold flow must work. You don't need to actually scaffold (that's expensive), but each step must reference real commands and produce real files.
+
+Recent feature work that must be reflected:
+- `agent()` descriptor with optional `retry: { maxAttempts, baseDelay }` (added 2026-05-05)
+- `defineMiddleware`, `reject(status, body?)`, `allow(context?)` from @dawn-ai/sdk
+- `MiddlewareRequest` with parsed headers and params
+- Tool `run` second arg now includes `middleware?` field for context (added 2026-05-06)
+- `dawn build` produces `langgraph.json` with `dependencies: ["."]` and `env` as path
+- `dawn verify` includes a `deps` check (4 checks, not 3)
+
+Append findings to docs/superpowers/audits/2026-05-06-docs-audit.md under section "## 2. Website load-bearing pages". Use F-NNN format starting from where Task 2 left off (read the report first to find the highest existing F-number, then start at F-(N+1)).
+
+End with a summary line: "Load-bearing pages findings: F-NNN through F-MMM (X critical, Y important, Z minor)."
+
+Clean up your /tmp/dawn-doc-verify/ files when done.
+
+Report back with: the F-NNN range used, count by severity, list of pages with the most issues.
+```
+
+- [ ] **Step 2: Verify subagent appended findings and cleaned up tempfiles**
+
+Run: `grep -c "^### F-" docs/superpowers/audits/2026-05-06-docs-audit.md`
+Expected: increased by however many findings the subagent reported.
+
+Run: `ls /tmp/dawn-doc-verify/ 2>&1`
+Expected: directory not present, or empty.
+
+If tempfiles remain, run: `rm -rf /tmp/dawn-doc-verify`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/superpowers/audits/2026-05-06-docs-audit.md
+git commit -m "docs(audit): website load-bearing pages findings"
+```
+
+---
+
+### Task 4: Audit Website Supporting Pages
+
+**Files:**
+- Read: `apps/web/content/docs/state.mdx`, `cli.mdx`, `dev-server.mdx`, `testing.mdx`
+- Modify: `docs/superpowers/audits/2026-05-06-docs-audit.md` (section 3)
+
+- [ ] **Step 1: Dispatch supporting-pages auditor subagent**
+
+Use Task tool with subagent_type=general-purpose. Prompt (verbatim):
+
+```
+You are auditing the supporting website docs pages for Dawn. This is read-only research — structural review only, no code-example verification (those pages are lower-stakes).
+
+Files under audit:
+- apps/web/content/docs/state.mdx
+- apps/web/content/docs/cli.mdx
+- apps/web/content/docs/dev-server.mdx
+- apps/web/content/docs/testing.mdx
+
+For each page:
+- Read it end-to-end.
+- Cross-check every CLI command, file path, and code reference against the current source (packages/cli/src/commands, packages/sdk/src, packages/core/src).
+- Cross-check internal links — every [text](/docs/foo) must resolve to a real page in apps/web/content/docs/.
+- Look for content that became stale due to recent feature work:
+  - state.mdx: confirm Zod-based state defs and reducers match current `state.ts` semantics
+  - cli.mdx: every command flag must be real
+  - dev-server.mdx: ports, endpoints, /healthz behavior must match packages/cli/src/lib/dev/runtime-server.ts
+  - testing.mdx: testing helpers and DAWN_TEST_RUNNER guidance must match packages/cli/src/testing/index.ts
+- Note gaps where significant features have no mention (e.g., middleware page doesn't exist — but creating it is OUT OF SCOPE; record as a finding with "Suggested fix: defer to follow-up issue").
+
+Append findings to docs/superpowers/audits/2026-05-06-docs-audit.md under section "## 3. Website supporting pages". Use F-NNN starting from where Task 3 left off.
+
+End with a summary: "Supporting pages findings: F-NNN through F-MMM (X critical, Y important, Z minor)."
+
+Report back with: the F-NNN range, count by severity, and which pages drifted most.
+```
+
+- [ ] **Step 2: Verify subagent appended findings**
+
+Read section 3 of the audit report; confirm format compliance.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/superpowers/audits/2026-05-06-docs-audit.md
+git commit -m "docs(audit): website supporting pages findings"
+```
+
+---
+
+### Task 5: Audit Templates
+
+**Files:**
+- Read: `apps/web/content/templates/AGENTS.md`, `apps/web/content/templates/CLAUDE.md`
+- Modify: `docs/superpowers/audits/2026-05-06-docs-audit.md` (section 4)
+
+- [ ] **Step 1: Dispatch templates auditor subagent**
+
+Use Task tool with subagent_type=general-purpose. Prompt (verbatim):
+
+```
+You are auditing AI-agent prompt templates that ship with scaffolded Dawn apps. These are high-stakes — they tell future Claude/Codex sessions how to work in a Dawn app.
+
+Files under audit:
+- apps/web/content/templates/AGENTS.md
+- apps/web/content/templates/CLAUDE.md
+
+For each file:
+- Read it end-to-end.
+- Verify every directive matches actual current behavior. Examples:
+  - Claims about how routes are structured (file conventions, default exports)
+  - Claims about how tools are authored (default export signature: `(input, context) => ...`)
+  - Claims about state, config, middleware
+  - Claims about CLI commands and what they do
+- Cross-reference packages/sdk/src, packages/core/src, packages/cli/src/commands.
+- Pay special attention to anything that conflicts with recent feature work:
+  - Tool signature now includes `middleware?` in context
+  - Agent descriptor has optional retry config
+  - Middleware exists as `src/middleware.ts` with defineMiddleware/reject/allow
+  - `dawn build` writes langgraph.json (paths-as-deps, env-as-file)
+- Check that the two templates are consistent with each other where they cover the same topic. Inconsistency itself is a finding.
+
+Append findings to docs/superpowers/audits/2026-05-06-docs-audit.md under section "## 4. Templates". Use F-NNN starting from where Task 4 left off.
+
+End with a summary: "Templates findings: F-NNN through F-MMM (X critical, Y important, Z minor)."
+
+Report back with: the F-NNN range, count by severity, biggest divergence between current code and what the templates claim.
+```
+
+- [ ] **Step 2: Verify subagent appended findings**
+
+Read section 4 of the audit report; confirm format compliance.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/superpowers/audits/2026-05-06-docs-audit.md
+git commit -m "docs(audit): templates findings"
+```
+
+---
+
+### Task 6: Audit Public Package READMEs
+
+**Files:**
+- Read: `packages/sdk/README.md`, `packages/cli/README.md`, `packages/create-dawn-ai-app/README.md`
+- Modify: `docs/superpowers/audits/2026-05-06-docs-audit.md` (section 5)
+
+- [ ] **Step 1: Dispatch public-package-READMEs auditor subagent**
+
+Use Task tool with subagent_type=general-purpose. Prompt (verbatim):
+
+```
+You are auditing the README files for Dawn's three publicly-discoverable npm packages: @dawn-ai/sdk, @dawn-ai/cli, create-dawn-ai-app.
+
+Files under audit:
+- packages/sdk/README.md
+- packages/cli/README.md
+- packages/create-dawn-ai-app/README.md
+
+These currently are ~10-line stubs. The hybrid policy says public packages need a real README: overview, installation, key APIs, and a link to https://dawn-ai.org/docs/<page>.
+
+For each file, audit against the hybrid-policy expectations:
+- Has a clear one-paragraph overview of what the package does
+- Has install instructions (e.g., `npm install @dawn-ai/sdk`) that match the actual package name in package.json
+- Has the most important APIs/commands shown briefly with a code example or two
+- Links to the relevant website page for full docs
+- README will render reasonably on npmjs.com
+
+Each gap relative to that target is a finding (Type: gap, Severity: important by default).
+
+Cross-reference packages/sdk/src/index.ts, packages/cli/src/index.ts, packages/create-dawn-ai-app/src/bin.ts to know what to feature.
+
+Append findings to docs/superpowers/audits/2026-05-06-docs-audit.md under section "## 5. Public package READMEs". Use F-NNN starting from where Task 5 left off.
+
+End with a summary: "Public READMEs findings: F-NNN through F-MMM (X critical, Y important, Z minor)."
+
+Report back with: the F-NNN range, count, and which package needs the most work.
+```
+
+- [ ] **Step 2: Verify subagent appended findings**
+
+Read section 5 of the audit report; confirm format compliance.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/superpowers/audits/2026-05-06-docs-audit.md
+git commit -m "docs(audit): public package READMEs findings"
+```
+
+---
+
+### Task 7: Audit Internal Package READMEs
+
+**Files:**
+- Read: `packages/{config-biome,config-typescript,core,devkit,langchain,langgraph,vite-plugin}/README.md`
+- Modify: `docs/superpowers/audits/2026-05-06-docs-audit.md` (section 6)
+
+- [ ] **Step 1: Dispatch internal-package-READMEs auditor subagent**
+
+Use Task tool with subagent_type=general-purpose. Prompt (verbatim):
+
+```
+You are auditing the README files for Dawn's seven internal packages. These should be stub-with-pointer per the hybrid policy: a 5-10 line file that names the package, says what it is in one sentence, and points to the website for full docs.
+
+Files under audit:
+- packages/config-biome/README.md
+- packages/config-typescript/README.md
+- packages/core/README.md
+- packages/devkit/README.md
+- packages/langchain/README.md
+- packages/langgraph/README.md
+- packages/vite-plugin/README.md
+
+For each file, check:
+- Format consistency: do they all follow the same template? (If not, that's a finding.)
+- Each lists the right package name (matches package.json `name`)
+- Each has a one-line description that matches the package's actual purpose
+- Each points to https://dawn-ai.org or a more specific URL where appropriate
+- No stale claims (e.g., a claim about an API surface that has since been removed)
+
+Each inconsistency or gap is a finding (Type: gap or misalignment, Severity: minor unless content is materially wrong).
+
+Append findings to docs/superpowers/audits/2026-05-06-docs-audit.md under section "## 6. Internal package READMEs". Use F-NNN starting from where Task 6 left off.
+
+End with a summary: "Internal READMEs findings: F-NNN through F-MMM (X critical, Y important, Z minor)."
+
+Report back with: the F-NNN range, count by severity, whether the seven READMEs are consistent or all-different.
+```
+
+- [ ] **Step 2: Verify subagent appended findings**
+
+Read section 6 of the audit report; confirm format compliance.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/superpowers/audits/2026-05-06-docs-audit.md
+git commit -m "docs(audit): internal package READMEs findings"
+```
+
+---
+
+### Task 8: Findings cut and audit summary
+
+**Files:**
+- Modify: `docs/superpowers/audits/2026-05-06-docs-audit.md` (status header, Summary section)
+
+- [ ] **Step 1: Read the full audit report and tally findings by severity**
+
+Run: `grep -E "^- \\*\\*Severity:\\*\\*" docs/superpowers/audits/2026-05-06-docs-audit.md | sort | uniq -c`
+
+Capture the totals. Confirm against the per-section subagent summaries.
+
+- [ ] **Step 2: Present the summary to the user**
+
+Reply to the user with a structured summary, e.g.:
+
+```
+Audit complete. Findings:
+
+| Section | Critical | Important | Minor | Total |
+|---------|---------:|----------:|------:|------:|
+| Root README             | <n> | <n> | <n> | <n> |
+| Website load-bearing    | <n> | <n> | <n> | <n> |
+| Website supporting      | <n> | <n> | <n> | <n> |
+| Templates               | <n> | <n> | <n> | <n> |
+| Public READMEs          | <n> | <n> | <n> | <n> |
+| Internal READMEs        | <n> | <n> | <n> | <n> |
+| **Total**               | **<n>** | **<n>** | **<n>** | **<n>** |
+
+Per the spec, critical and important findings are in scope for the fix PRs. Minor findings get deferred to a follow-up issue list.
+
+Top critical findings: <bullet list of 3–5 with F-NNN references>
+
+Anything you'd like to recategorize before I open PR 0?
+```
+
+Wait for user confirmation before proceeding.
+
+- [ ] **Step 3: Update the audit report status and Summary section**
+
+Update the `**Status:**` line at the top of the report from `in progress` to `complete`.
+
+Replace the `## Summary` section with a populated version, e.g.:
+
+```markdown
+## Summary
+
+| Section | Critical | Important | Minor | Total |
+|---------|---------:|----------:|------:|------:|
+| Root README             | <n> | <n> | <n> | <n> |
+| ... etc ... |
+| **Total**               | **<n>** | **<n>** | **<n>** | **<n>** |
+
+**In scope for fix PRs:** all critical + important findings (N total).
+**Deferred:** minor findings will be filed as a follow-up GitHub issue.
+
+**Recategorization decisions:** <list any user-driven changes from Step 2, or "none">.
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/superpowers/audits/2026-05-06-docs-audit.md
+git commit -m "docs(audit): findings cut and summary"
+```
+
+---
+
+### Task 9: PR 0 — Open audit PR and merge on green
+
+**Files:**
+- (no new files — pushes the existing branch)
+
+- [ ] **Step 1: Push the docs-review branch**
+
+```bash
+cd /Users/blove/repos/dawn/.worktrees/docs-review
+git push -u origin feature/docs-review
+```
+
+Expected: branch pushes successfully to `origin/feature/docs-review`.
+
+- [ ] **Step 2: Open the audit PR**
+
+```bash
+gh pr create --title "docs: docs review audit (PR 0 of 5)" --body "$(cat <<'EOF'
+## Summary
+
+This is PR 0 of the docs review series. It lands the audit report and design docs.
+
+- Adds `docs/superpowers/specs/2026-05-06-docs-review-design.md`
+- Adds `docs/superpowers/plans/2026-05-06-docs-review.md`
+- Adds `docs/superpowers/audits/2026-05-06-docs-audit.md` with all critical and important findings categorized
+
+Subsequent PRs (A, B, C, D) implement the fixes. Each branches from `main` after this PR lands so they can read findings from the audit at a stable path.
+
+## Test plan
+
+- [x] Audit report follows the documented schema
+- [x] Findings tallied by severity match per-section summaries
+- [ ] CI green
+EOF
+)"
+```
+
+- [ ] **Step 3: Wait for CI to go green, then merge**
+
+```bash
+gh pr checks --watch
+```
+
+When green:
+
+```bash
+gh pr merge --squash --delete-branch
+```
+
+Expected: PR merges, branch deletes.
+
+- [ ] **Step 4: Sync local main and prepare for fix PRs**
+
+```bash
+cd /Users/blove/repos/dawn
+git checkout main
+git pull --rebase origin main
+```
+
+Expected: HEAD is at the squashed audit commit.
+
+---
+
+## Phase 2 — Fix PRs
+
+Each fix PR follows the same pattern: branch from `main`, dispatch one implementer subagent with the relevant audit slice, verify, push, open PR, wait green, merge.
+
+The implementer subagent for each fix PR receives:
+- Path to the audit report on `main` (now stable)
+- The exact F-NNN range / section that's relevant
+- The verification command for that PR
+- Explicit instruction to fix only critical and important findings (skip deferred minor ones unless trivial in the same edit)
+
+### Task 10: PR B — Website docs and templates
+
+**Files:**
+- Modify: `apps/web/content/docs/{getting-started,routes,tools,state,cli,dev-server,testing,deployment}.mdx`
+- Modify: `apps/web/content/templates/{AGENTS,CLAUDE}.md`
+
+PR B goes first because it's the largest and other PRs may reference website URLs that this PR stabilizes.
+
+- [ ] **Step 1: Branch from main**
+
+```bash
+cd /Users/blove/repos/dawn
+git checkout -b fix/docs-website main
+```
+
+- [ ] **Step 2: Dispatch website-docs implementer subagent**
+
+Use Task tool with subagent_type=general-purpose. Prompt (verbatim):
+
+```
+You are implementing fixes for the website docs and templates surface of the Dawn docs review.
+
+Read first:
+- docs/superpowers/audits/2026-05-06-docs-audit.md (the full audit report)
+- docs/superpowers/specs/2026-05-06-docs-review-design.md (for context, especially the escape hatch)
+
+Your scope: sections 2 (Website load-bearing pages), 3 (Website supporting pages), and 4 (Templates) of the audit.
+
+Implement only critical and important findings. Skip minor findings unless fixing one is trivial in the same edit (then mention it in your summary).
+
+Files you may modify:
+- apps/web/content/docs/{getting-started,routes,tools,state,cli,dev-server,testing,deployment}.mdx
+- apps/web/content/templates/{AGENTS,CLAUDE}.md
+
+You may NOT modify code in packages/* unless the audit's escape hatch applies (one-line change to make a documented API match the docs, with the docs being right). If you exercise the escape hatch, list the change in your summary so it gets called out in the PR description.
+
+For each finding F-NNN you address, leave a brief commit message that references the F-NNN.
+
+Verification before you finish:
+1. `cd /Users/blove/repos/dawn && pnpm --filter web build` — must succeed.
+2. For load-bearing pages, re-run any code-example verification the auditor did. Reuse a /tmp/dawn-doc-verify/ scratch dir, then clean up.
+3. Internal links: confirm every `[text](/docs/foo)` you wrote resolves to an existing page.
+
+Make small, frequent commits — one per finding (or per cohesive group of findings on the same page). Do NOT push or open a PR; that's the controller's job.
+
+Report back with:
+- Which F-NNN findings you addressed (and which you skipped, if any)
+- Any escape-hatch code changes
+- Output of `pnpm --filter web build` (last 5 lines)
+- A short list of files modified
+```
+
+- [ ] **Step 3: Dispatch spec-compliance reviewer subagent**
+
+Use Task tool with subagent_type=general-purpose. Prompt:
+
+```
+You are reviewing PR B — website docs fixes — against the audit report.
+
+Read:
+- docs/superpowers/audits/2026-05-06-docs-audit.md (sections 2, 3, 4)
+- The current diff (run: `git diff main..HEAD`)
+
+Confirm: each in-scope critical + important finding from sections 2, 3, 4 is addressed by the diff. Any not addressed must have a written justification in the implementer's report (escape-hatch, deferred, etc.).
+
+Flag any extra changes that don't correspond to a finding (scope creep).
+
+Approve or list specific gaps. Do not modify files.
+```
+
+If reviewer flags gaps, re-dispatch the implementer with explicit fix instructions, then re-review.
+
+- [ ] **Step 4: Dispatch code-quality reviewer subagent**
+
+Use Task tool with subagent_type=superpowers:code-reviewer. Prompt:
+
+```
+Review the diff for PR B (docs website fixes).
+
+BASE_SHA: $(git merge-base main HEAD)
+HEAD_SHA: HEAD
+DESCRIPTION: Website docs + templates fixes from the docs audit.
+
+Focus on: clarity, technical accuracy of code examples, internal link health, consistency across pages. Skip nitpicks.
+```
+
+If reviewer flags issues, re-dispatch the implementer to fix, then re-review.
+
+- [ ] **Step 5: Push and open PR**
+
+```bash
+git push -u origin fix/docs-website
+gh pr create --title "docs: website docs and templates fixes (PR B)" --body "$(cat <<'EOF'
+## Summary
+
+Fixes critical and important findings from sections 2, 3, 4 of `docs/superpowers/audits/2026-05-06-docs-audit.md` (website docs + templates).
+
+Findings addressed: <list F-NNN ranges from implementer report>.
+
+<If any escape-hatch code changes were made, list them here.>
+
+## Test plan
+
+- [x] `pnpm --filter web build` succeeds locally
+- [x] Internal links verified to resolve
+- [ ] CI green
+EOF
+)"
+```
+
+- [ ] **Step 6: Wait for CI green, merge**
+
+```bash
+gh pr checks --watch
+gh pr merge --squash --delete-branch
+```
+
+- [ ] **Step 7: Sync local main**
+
+```bash
+git checkout main
+git pull --rebase origin main
+```
+
+---
+
+### Task 11: PR A — Root README
+
+**Files:**
+- Modify: `README.md`
+
+- [ ] **Step 1: Branch from main**
+
+```bash
+cd /Users/blove/repos/dawn
+git checkout -b fix/docs-readme main
+```
+
+- [ ] **Step 2: Dispatch root-README implementer subagent**
+
+Use Task tool with subagent_type=general-purpose. Prompt (verbatim):
+
+```
+You are implementing fixes for the root README of the Dawn project.
+
+Read first:
+- docs/superpowers/audits/2026-05-06-docs-audit.md (full audit; focus on section 1)
+- docs/superpowers/specs/2026-05-06-docs-review-design.md (for the escape hatch)
+
+Your scope: section 1 (Root README) of the audit. Implement only critical and important findings.
+
+Files you may modify:
+- README.md
+
+You may NOT modify code in packages/* unless the audit's escape hatch applies.
+
+Verification before you finish:
+1. Every CLI command shown in README.md must exist (grep packages/cli/src/commands).
+2. Every code snippet typechecks against current SDK exports.
+3. Every internal/external link resolves.
+
+Make small commits — one per finding or cohesive group. Do NOT push or open a PR.
+
+Report back with:
+- F-NNN findings addressed
+- Any escape-hatch code changes
+- Files modified
+```
+
+- [ ] **Step 3: Dispatch spec-compliance reviewer subagent**
+
+Same pattern as Task 10 Step 3, but for section 1 of the audit.
+
+- [ ] **Step 4: Dispatch code-quality reviewer subagent**
+
+Same pattern as Task 10 Step 4.
+
+- [ ] **Step 5: Push and open PR**
+
+```bash
+git push -u origin fix/docs-readme
+gh pr create --title "docs: root README fixes (PR A)" --body "$(cat <<'EOF'
+## Summary
+
+Fixes critical and important findings from section 1 of `docs/superpowers/audits/2026-05-06-docs-audit.md` (root README).
+
+Findings addressed: <F-NNN list>.
+
+## Test plan
+
+- [x] CLI commands shown verified to exist
+- [x] Code snippets typecheck
+- [x] Links resolve
+- [ ] CI green
+EOF
+)"
+```
+
+- [ ] **Step 6: Wait for CI green, merge**
+
+```bash
+gh pr checks --watch
+gh pr merge --squash --delete-branch
+```
+
+- [ ] **Step 7: Sync local main**
+
+```bash
+git checkout main
+git pull --rebase origin main
+```
+
+---
+
+### Task 12: PR C — Public package READMEs (fleshed out)
+
+**Files:**
+- Modify: `packages/sdk/README.md`, `packages/cli/README.md`, `packages/create-dawn-ai-app/README.md`
+
+- [ ] **Step 1: Branch from main**
+
+```bash
+cd /Users/blove/repos/dawn
+git checkout -b fix/docs-public-readmes main
+```
+
+- [ ] **Step 2: Dispatch public-READMEs implementer subagent**
+
+Use Task tool with subagent_type=general-purpose. Prompt (verbatim):
+
+```
+You are fleshing out the README files for the three publicly-discoverable Dawn packages.
+
+Read first:
+- docs/superpowers/audits/2026-05-06-docs-audit.md (full audit; focus on section 5)
+- docs/superpowers/specs/2026-05-06-docs-review-design.md (for the hybrid policy)
+- packages/sdk/src/index.ts, packages/cli/src/commands/*.ts, packages/create-dawn-ai-app/src/bin.ts (to know what to feature)
+
+Your scope: section 5 (Public package READMEs) of the audit. Implement all in-scope findings.
+
+The hybrid policy says each public README needs:
+1. One-paragraph overview of what the package does
+2. Install instructions matching the package.json `name`
+3. Key APIs/commands shown briefly with a small code example or two
+4. Link to https://dawn-ai.org/docs/<page> for full docs
+
+Files you may modify (only these):
+- packages/sdk/README.md
+- packages/cli/README.md
+- packages/create-dawn-ai-app/README.md
+
+Verification before you finish:
+1. Each README's install command uses the right package name (compare to package.json).
+2. Each code example in the README typechecks. Use the same /tmp/dawn-doc-verify/ approach as the load-bearing-page auditor.
+3. Run `cd /Users/blove/repos/dawn && pnpm --filter @dawn-ai/sdk pack --dry-run`, same for `@dawn-ai/cli` and `create-dawn-ai-app`. Confirm READMEs are included in the published files list.
+4. Visually inspect each README for npm rendering (no broken markdown).
+
+Make small commits — one per package. Do NOT push or open a PR.
+
+Report back with:
+- F-NNN findings addressed
+- Output of `pack --dry-run` for each package (last few lines)
+- Files modified
+```
+
+- [ ] **Step 3: Dispatch spec-compliance reviewer subagent**
+
+Same pattern, scoped to section 5.
+
+- [ ] **Step 4: Dispatch code-quality reviewer subagent**
+
+Same pattern.
+
+- [ ] **Step 5: Push and open PR**
+
+```bash
+git push -u origin fix/docs-public-readmes
+gh pr create --title "docs: flesh out public package READMEs (PR C)" --body "$(cat <<'EOF'
+## Summary
+
+Fleshes out README.md for three publicly-discoverable Dawn packages per the hybrid policy in `docs/superpowers/specs/2026-05-06-docs-review-design.md`:
+- `packages/sdk/README.md`
+- `packages/cli/README.md`
+- `packages/create-dawn-ai-app/README.md`
+
+Each now has overview, install, key APIs, and a link to the website. Implements section 5 of the audit.
+
+## Test plan
+
+- [x] `pack --dry-run` includes README in published files for each package
+- [x] Code examples typecheck
+- [ ] CI green
+EOF
+)"
+```
+
+- [ ] **Step 6: Wait for CI green, merge**
+
+```bash
+gh pr checks --watch
+gh pr merge --squash --delete-branch
+```
+
+- [ ] **Step 7: Sync local main**
+
+```bash
+git checkout main
+git pull --rebase origin main
+```
+
+---
+
+### Task 13: PR D — Internal package READMEs (stub-with-pointer)
+
+**Files:**
+- Modify: `packages/{config-biome,config-typescript,core,devkit,langchain,langgraph,vite-plugin}/README.md`
+
+- [ ] **Step 1: Branch from main**
+
+```bash
+cd /Users/blove/repos/dawn
+git checkout -b fix/docs-internal-readmes main
+```
+
+- [ ] **Step 2: Dispatch internal-READMEs implementer subagent**
+
+Use Task tool with subagent_type=general-purpose. Prompt (verbatim):
+
+```
+You are normalizing the seven internal-package READMEs to a stub-with-pointer template per the hybrid policy.
+
+Read first:
+- docs/superpowers/audits/2026-05-06-docs-audit.md (full audit; focus on section 6)
+- docs/superpowers/specs/2026-05-06-docs-review-design.md (for the hybrid policy)
+
+Your scope: section 6 (Internal package READMEs) of the audit. Implement all in-scope findings, plus normalize all seven to a single template.
+
+Use this exact template (filling in package-specific values):
+
+```
+# @dawn-ai/<package-name>
+
+<One sentence describing what this package does. Be specific.>
+
+This package is an internal Dawn workspace package. For Dawn documentation, see <https://dawn-ai.org>.
+
+## License
+
+MIT
+```
+
+Files you may modify (only these):
+- packages/config-biome/README.md
+- packages/config-typescript/README.md
+- packages/core/README.md
+- packages/devkit/README.md
+- packages/langchain/README.md
+- packages/langgraph/README.md
+- packages/vite-plugin/README.md
+
+For each file:
+1. Confirm the package name matches `name` in the corresponding package.json.
+2. Pick a one-sentence description that's accurate to the current code (skim the package's src/index.ts for context).
+3. Use the template verbatim otherwise — including the website URL.
+
+Verification before you finish:
+1. `diff -u packages/config-biome/README.md packages/core/README.md` and similar — should differ only in package name and one-sentence description, nothing else.
+
+Make one commit per package, or a single commit normalizing all seven if they're trivial. Do NOT push or open a PR.
+
+Report back with:
+- F-NNN findings addressed
+- Confirmation that all seven READMEs now use the same template structure
+```
+
+- [ ] **Step 3: Dispatch spec-compliance reviewer subagent**
+
+Same pattern, scoped to section 6.
+
+- [ ] **Step 4: Dispatch code-quality reviewer subagent**
+
+Same pattern. (Likely will approve quickly given the small scope.)
+
+- [ ] **Step 5: Push and open PR**
+
+```bash
+git push -u origin fix/docs-internal-readmes
+gh pr create --title "docs: normalize internal package READMEs (PR D)" --body "$(cat <<'EOF'
+## Summary
+
+Normalizes the seven internal-package README.md files to a stub-with-pointer template per the hybrid policy in `docs/superpowers/specs/2026-05-06-docs-review-design.md`.
+
+Each now contains: package name, one-sentence description, link to https://dawn-ai.org, and license. Implements section 6 of the audit.
+
+## Test plan
+
+- [x] All seven READMEs follow the same template
+- [x] Each package name matches its package.json
+- [ ] CI green
+EOF
+)"
+```
+
+- [ ] **Step 6: Wait for CI green, merge**
+
+```bash
+gh pr checks --watch
+gh pr merge --squash --delete-branch
+```
+
+- [ ] **Step 7: Sync local main**
+
+```bash
+git checkout main
+git pull --rebase origin main
+```
+
+---
+
+### Task 14: File deferred-minor-findings issue and clean up
+
+**Files:**
+- (no files; GitHub issue + worktree cleanup)
+
+- [ ] **Step 1: File a follow-up GitHub issue listing all deferred minor findings**
+
+Run:
+
+```bash
+gh issue create --title "docs: deferred minor findings from 2026-05-06 audit" --body "$(cat <<'EOF'
+This issue tracks the minor-severity findings deferred from the docs review audit at `docs/superpowers/audits/2026-05-06-docs-audit.md`.
+
+These were intentionally out of scope for the five-PR docs review series (PR 0, A, B, C, D, all merged) so the fix PRs stayed reviewable.
+
+## Deferred findings
+
+<bulleted list of every "Severity: minor" finding from the audit, with F-NNN reference and one-line summary>
+
+Anyone can pick these up incrementally.
+EOF
+)"
+```
+
+Capture the issue URL.
+
+- [ ] **Step 2: Verify all five PRs merged and main is clean**
+
+```bash
+gh pr list --state merged --base main --head fix/docs-website,fix/docs-readme,fix/docs-public-readmes,fix/docs-internal-readmes,feature/docs-review --limit 10
+```
+
+Expected: five entries (audit + four fixes), all merged.
+
+```bash
+cd /Users/blove/repos/dawn
+git status -s
+```
+
+Expected: empty.
+
+- [ ] **Step 3: Clean up the docs-review worktree**
+
+```bash
+cd /Users/blove/repos/dawn
+git worktree remove .worktrees/docs-review
+git branch -D feature/docs-review 2>/dev/null || true
+```
+
+Expected: worktree directory and branch removed.
+
+- [ ] **Step 4: Final verification**
+
+Run: `git worktree list`
+Expected: only the main worktree (and any unrelated worktrees), no `.worktrees/docs-review`.
+
+Run: `git log --oneline -8 main`
+Expected: five recent doc-related commits visible.
+
+- [ ] **Step 5: Report completion to the user**
+
+Summarize: PR 0 + A/B/C/D all merged, deferred-minor issue filed at <URL>, worktree cleaned up.

--- a/docs/superpowers/specs/2026-05-06-docs-review-design.md
+++ b/docs/superpowers/specs/2026-05-06-docs-review-design.md
@@ -1,0 +1,116 @@
+# Dawn Docs Review — Design Spec
+
+**Date:** 2026-05-06
+**Status:** Approved (brainstorm complete; ready for plan)
+
+## Goal
+
+Find and fix gaps, misalignments, and errors across user-facing Dawn docs. Verify code examples on load-bearing pages actually run against the current packages. Produce an audit report and four targeted fix PRs.
+
+## Scope
+
+**In scope:**
+
+- Root `README.md`
+- Website docs: `apps/web/content/docs/*.mdx` (8 pages)
+- Templates that ship with scaffolded apps: `apps/web/content/templates/AGENTS.md`, `apps/web/content/templates/CLAUDE.md`
+- All package READMEs under `packages/*/README.md` (11 packages)
+
+**Out of scope (explicit):**
+
+- Internal historical docs in `docs/superpowers/specs/` and `docs/superpowers/plans/` — point-in-time artifacts, not maintained
+- `docs/next-iterations-roadmap.md` and `docs/thread-handoff.md` — internal tracking
+- Adding net-new docs pages (e.g., a new "middleware" page). Gaps requiring a brand-new page are recorded but deferred to a follow-up issue list
+- Website navigation, sidebar, layout, or styling changes — content only
+- Code changes to packages — this is a docs-only review
+
+**Escape hatch:** if a broken-example finding requires a one-line code change to make a documented API match the docs (and the docs are right), the implementer can include that in the website-docs PR with explicit callout in the PR description. Anything larger is deferred.
+
+## Architecture
+
+The work runs in two phases producing five PRs total:
+
+1. **Audit phase** — read-only. Six subagents dispatched in parallel, each with bounded surface ownership. They produce a single audit report at `docs/superpowers/audits/2026-05-06-docs-audit.md` with structured findings. The report ships as **PR 0** and merges to `main` before fix work begins, so each fix implementer can read its slice of the audit straight from `main`.
+
+2. **Fix phase** — write-only. Four independent PRs (A, B, C, D), one implementer subagent per PR. PRs branched from `main`, merged independently on green CI.
+
+Both phases run in the worktree at `.worktrees/docs-review`.
+
+## Audit Phase
+
+### Subagent decomposition
+
+| # | Subagent | Files | Verification |
+|---|----------|-------|---|
+| 1 | Root README auditor | `README.md` | Cross-reference every CLI command, code snippet, and file path against current source |
+| 2 | Website load-bearing pages auditor | `getting-started.mdx`, `routes.mdx`, `tools.mdx`, `deployment.mdx` | Structural review **and** code-example verification (extract snippets → temp fixture → `pnpm exec tsc --noEmit`; for getting-started, scaffold via packed tarballs and run `dawn check`/`dawn verify`) |
+| 3 | Website supporting pages auditor | `state.mdx`, `cli.mdx`, `dev-server.mdx`, `testing.mdx` | Structural only |
+| 4 | Templates auditor | `AGENTS.md`, `CLAUDE.md` | Verify every directive matches actual current behavior. These ship with scaffolded apps |
+| 5 | Public package READMEs auditor | `packages/{sdk,cli,create-dawn-ai-app}/README.md` | Compare current stubs against hybrid-policy expectations |
+| 6 | Internal package READMEs auditor | `packages/{config-biome,config-typescript,core,devkit,langchain,langgraph,vite-plugin}/README.md` | Verify stub-with-pointer format consistency |
+
+Subagents 1, 4, 5, 6 are independent and dispatched in parallel. Subagents 2 and 3 are dispatched after 1, 4, 5, 6 begin (they share build-tooling state but don't conflict on files).
+
+### Findings format
+
+Each subagent appends to the audit report under its section using a fixed schema:
+
+```markdown
+### F-NNN: <one-line summary>
+- **Surface:** <surface>
+- **File:** <path:line if applicable>
+- **Type:** gap | misalignment | error | broken-example
+- **Severity:** critical | important | minor
+- **Description:** <what's wrong>
+- **Suggested fix:** <concrete change, or "needs design">
+```
+
+Severity meanings:
+
+- **critical:** users hit a wall (broken example, wrong instruction that prevents a working app)
+- **important:** users get confused or take the wrong path, but recoverable
+- **minor:** style, wording, dead links to non-blocking content
+
+### Findings cut
+
+Before dispatching fix PRs, the controller presents the audit summary to the user. Critical and important findings are in scope. Minor findings get deferred to a follow-up issue list. This is the gate that keeps fix PRs reviewable.
+
+### PR 0 — audit report
+
+After the findings cut, the agreed-upon audit report is opened as a PR against `main` and merged on green CI. This makes the report durable and gives each fix implementer a stable reference path on `main`.
+
+## Fix Phase
+
+### PRs
+
+| PR | Surface | Verification |
+|----|---------|---|
+| A | `README.md` | All code/CLI refs grep-verified against source |
+| B | `apps/web/content/docs/*.mdx` + `templates/*.md` | `pnpm --filter web build` clean; load-bearing examples scaffolded & run |
+| C | `packages/{sdk,cli,create-dawn-ai-app}/README.md` (hybrid-policy: real overview + install + key APIs + link to website) | `npm pack --dry-run` clean; readable when rendered |
+| D | The other 7 package READMEs (stub-with-pointer per hybrid policy) | Visual inspection; pointer format consistent |
+
+### Implementer flow per PR
+
+1. Read its slice of the audit (only findings for its surface)
+2. Implement the fixes on a branch from `main`
+3. Run the relevant verification
+4. Push branch + open PR
+5. Spec-compliance review (against audit findings) → quality review → fix loops until both pass
+6. Wait for CI green, then merge
+
+PRs land independently. Default order is **B → A → C → D** (B is largest, A may reference website URLs, C/D are quick cleanup). Any PR can ship first if others get blocked.
+
+### Worktree lifecycle
+
+- Created at `.worktrees/docs-review` from `main` at the start of the audit phase
+- Each fix PR is branched from `main` directly, not from the worktree branch — keeps PRs independent
+- Worktree cleaned up via superpowers:finishing-a-development-branch after the last fix PR merges
+
+## Success Criteria
+
+- Audit report at `docs/superpowers/audits/2026-05-06-docs-audit.md` merged to `main` (PR 0) with all critical and important findings categorized
+- Four fix PRs (A, B, C, D) merged to `main`, all CI green
+- Code examples in `getting-started.mdx`, `routes.mdx`, `tools.mdx`, `deployment.mdx` verified to run against current packages
+- Hybrid READMEs policy applied: 3 fleshed out, 7 as stub-with-pointer
+- Minor-severity findings captured in a follow-up issue list (or GitHub issues)


### PR DESCRIPTION
## Summary

This is PR 0 of the docs review series. It lands the audit report and design docs.

- Adds `docs/superpowers/specs/2026-05-06-docs-review-design.md`
- Adds `docs/superpowers/plans/2026-05-06-docs-review.md`
- Adds `docs/superpowers/audits/2026-05-06-docs-audit.md` with 115 findings categorized:
  - 39 critical, 45 important, 31 minor
  - 84 critical+important findings will be addressed by PRs A, B, C, D
  - 31 minor findings will be filed as a follow-up GitHub issue

## Findings overview

| Section | Critical | Important | Minor | Total |
|---------|---------:|----------:|------:|------:|
| Root README                | 3  | 6  | 5  | 14  |
| Website load-bearing       | 12 | 10 | 4  | 26  |
| Website supporting         | 14 | 14 | 7  | 35  |
| Templates                  | 6  | 3  | 4  | 13  |
| Public package READMEs     | 4  | 10 | 5  | 19  |
| Internal package READMEs   | 0  | 2  | 6  | 8   |
| **Total**                  | **39** | **45** | **31** | **115** |

## Next steps

After this PR lands, four fix PRs branch from `main` and ship independently:
- **PR B** — website docs + templates (largest scope; goes first)
- **PR A** — root README
- **PR C** — public package READMEs (fleshed out per hybrid policy)
- **PR D** — internal package READMEs (stub-with-pointer per hybrid policy)

## Test plan

- [x] Audit report follows the documented schema (every finding has Surface/File/Type/Severity/Description/Suggested fix)
- [x] Audit refreshed against current main HEAD (brand assets PR #38)
- [x] Findings tallied by severity match per-section subagent reports
- [ ] CI green