### PR TITLE
docs: website docs and templates fixes (PR B)

### DIFF
--- a/apps/web/content/docs/cli.mdx
+++ b/apps/web/content/docs/cli.mdx
@@ -1,6 +1,6 @@
 # CLI Reference
 
-Dawn ships a single `dawn` binary with six commands. Every command reads `dawn.config.ts` from the current working directory and operates on the app rooted there.
+Dawn ships a single `dawn` binary with eight commands: `build`, `check`, `dev`, `routes`, `run`, `test`, `typegen`, and `verify`. Every command reads `dawn.config.ts` from the current working directory (or from `--cwd <path>`) and operates on the app rooted there.
 
 ## `dawn check`
 
@@ -10,14 +10,28 @@ Validates the app structure and configuration.
 dawn check
 ```
 
-Checks:
-- `dawn.config.ts` exists and has only supported fields.
-- `package.json` exists.
-- Every route has exactly one of `workflow`, `graph`, or `chain` exported from `index.ts`.
-- Every route's `state.ts` exports a named state type.
-- No tool files have invalid shapes.
+Internally, `dawn check` loads `dawn.config.ts`, resolves the app root, runs `discoverRoutes`, and parses each route's tool definitions with `discoverToolDefinitions`. It surfaces:
 
-Exits non-zero on any violation with a detailed message.
+- A `dawn.config.ts` that fails to load.
+- Any route whose `index.ts` exports more than one (or none) of `agent`, `workflow`, `graph`, `chain`.
+- Any tool file that fails to parse.
+
+Output is a `Dawn app is valid: N routes discovered.` line followed by a per-route `- <pathname> (<kind>)` summary. Exits non-zero on any violation with a detailed message.
+
+## `dawn verify`
+
+Runs four checks in one call (`app`, `routes`, `typegen`, `deps`) — the canonical pre-deploy integrity gate.
+
+```
+dawn verify
+dawn verify --json
+```
+
+Flags:
+- `--cwd <path>` — operate on a different app root.
+- `--json` — emit a structured report (`{ status, appRoot, checks, counts }`) instead of human-readable text.
+
+The `deps` check covers missing packages and missing env vars (advisory) — uniquely useful before a deploy. See [Deployment](/docs/deployment) for the recommended workflow.
 
 ## `dawn routes`
 
@@ -25,28 +39,49 @@ Lists every route Dawn discovered and its computed pathname.
 
 ```
 dawn routes
+dawn routes --json
 ```
 
 Output:
 
 ```
-/hello/[tenant]   workflow   src/app/(public)/hello/[tenant]/index.ts
-/admin/users      graph      src/app/(internal)/admin/users/index.ts
+Discovered 2 Dawn routes in /path/to/app
+/hello/[tenant] -> src/app/(public)/hello/[tenant]/index.ts
+/admin/users -> src/app/(internal)/admin/users/index.ts
 ```
 
 Use this to confirm that route groups and dynamic segments are being parsed the way you expect.
 
 ## `dawn typegen`
 
-Regenerates `dawn.generated.d.ts` from the current state of every tool file.
+Regenerates `dawn.generated.d.ts` and per-route `.dawn/routes/<routeSlug>/tools.json` schema manifests.
 
 ```
 dawn typegen
 ```
 
+The success log reports route, tool-schema, and stateful-route counts. The `tools.json` artifacts are consumed by `dawn build` to emit LangGraph entries.
+
 <Callout type="info" title="Run automatically by dawn dev">
-  `dawn dev` runs `typegen` on every save. You only need to invoke it manually after a fresh clone, before CI, or after a tool signature change while the dev server isn't running.
+  `dawn dev` runs `typegen` (debounced) on saves that touch tool signatures or state schemas. You only need to invoke it manually after a fresh clone, before CI, or after a tool signature change while the dev server isn't running.
 </Callout>
+
+## `dawn build`
+
+Writes `.dawn/build/langgraph.json` plus per-route entry files under `.dawn/build/<routeSlug>.ts` — the artifacts you hand to LangGraph Platform.
+
+```
+dawn build
+dawn build --clean
+```
+
+Flags:
+- `--cwd <path>` — operate on a different app root.
+- `--clean` — wipe `.dawn/build/` before writing.
+
+The generated `langgraph.json` includes `graphs` (keyed by `<routeId>#<kind>`), `dependencies: ["."]`, `env` (`.env.example` if present, else `.env`), and `node_version: "22"`. For `agent` routes, the generated entry calls `agent.bindTools([...])` with every tool discovered for the route.
+
+See [Deployment](/docs/deployment) for the full bridge.
 
 ## `dawn run`
 
@@ -57,8 +92,10 @@ echo '{"tenant":"acme"}' | dawn run '/hello/[tenant]'
 ```
 
 Flags:
+- `--cwd <path>` — operate on a different app root.
 - `--url <url>` — run against a live dev server instead of the in-process runtime.
-- `--stream` — use the `/runs/stream` endpoint (requires `--url`) and pipe SSE events to stdout.
+
+The route argument can be the parameterized id (`/hello/[tenant]`) or the concrete pathname (`/hello/acme`); the input JSON's matching field supplies the dynamic-segment value.
 
 <Callout type="tip" title="Quote the path">
   Route paths contain `(`, `)`, `[`, and `]`. Always quote them in shell so they aren't expanded.
@@ -70,25 +107,25 @@ Runs every colocated `run.test.ts` scenario in the app.
 
 ```
 dawn test
+dawn test src/app/(public)/hello
 ```
 
 Flags:
-- `--url <url>` — run against a live dev server.
-- `--filter <pattern>` — only run scenarios whose describe/test name matches.
+- `--cwd <path>` — operate on a different app root.
 
-Exits non-zero on any failure with a diff per mismatched scenario. See [Testing](/docs/testing) for scenario authoring.
+The optional positional `[path]` argument narrows the discovered scenario set to a subdirectory. To target a live dev server, set `run: { url }` per-scenario inside `run.test.ts` (there is no command-level `--url` flag on `dawn test`). Exits non-zero on any failure with a diff per mismatched scenario. See [Testing](/docs/testing) for scenario authoring.
 
 ## `dawn dev`
 
-Starts the local runtime — hot reload + LangGraph Platform protocol.
+Starts the local runtime — hot reload + LangGraph Platform protocol. Bind address is fixed at `127.0.0.1`.
 
 ```
+dawn dev
 dawn dev --port 3001
 ```
 
 Flags:
-- `--port <n>` — HTTP port (default 3000).
-- `--host <addr>` — bind address (default 127.0.0.1).
+- `--port <n>` — HTTP port. Default: dynamically allocated. Pass `--port` for a stable address.
 
 See [Dev Server](/docs/dev-server) for the full protocol reference and architecture notes.
 
@@ -98,5 +135,6 @@ See [Dev Server](/docs/dev-server) for the full protocol reference and architect
 |---|---|
 | 0 | Success |
 | 1 | Validation failure (e.g. `dawn check`) or scenario failure (e.g. `dawn test`) |
-| 2 | Configuration error (missing `dawn.config.ts`, bad `appDir`) |
-| 3 | Internal error (bug — please file an issue) |
+| 2 | Configuration / runtime error (missing `dawn.config.ts`, bad `appDir`, scenario load failure) |
+
+Non-zero exit codes from underlying tools (Commander, child processes) may be propagated unchanged.

--- a/apps/web/content/docs/deployment.mdx
+++ b/apps/web/content/docs/deployment.mdx
@@ -1,46 +1,63 @@
 # Deployment
 
-Dawn itself is **not a deployment runtime**. It owns local development: `dawn dev`, `dawn run`, `dawn test`. Production runs on the **LangGraph Platform**, which Dawn's dev server already speaks natively. What runs locally runs in production without translation.
+Dawn does not host or run production traffic itself. It owns local development (`dawn dev`, `dawn run`, `dawn test`) **and** the build step that produces deployable artifacts (`dawn build`). Production runs on the **LangGraph Platform**, which Dawn's dev server already speaks natively. What runs locally runs in production after `dawn build` materializes the platform-ready entry files.
 
 ## The deployment path
 
 <Steps>
   <Step title="Verify locally">
     ```
-    dawn check
-    dawn routes
-    dawn typegen
-    dawn test
+    dawn verify
     ```
 
-    All four must pass. `dawn check` validates the app contract, `dawn routes` confirms discovery, `dawn typegen` regenerates ambient types, `dawn test` runs every scenario against the in-process runtime.
+    `dawn verify` runs four checks in one call: app contract, route discovery, typegen, and deps (missing packages and missing env vars). Pass `--json` for machine-readable output. The deps check is uniquely useful before a deploy — neither `dawn check` nor `dawn typegen` covers it.
+
+    Optionally follow with scenario coverage:
+
+    ```
+    dawn test
+    ```
   </Step>
   <Step title="Confirm protocol parity">
-    Run your tests against a live dev server:
+    Run scenarios against a live dev server by setting `run.url` per-scenario in your `run.test.ts` files (the command-level `--url` flag does not exist on `dawn test`). `dawn dev` exposes the same protocol endpoints as the deployed runtime — `/runs/wait` and `/runs/stream` — so request/response shape parity is guaranteed for those endpoints. Process boundaries, state persistence, and tool bindings are still re-materialized by `dawn build` for production, so this step is necessary but not sufficient.
 
     ```
     dawn dev --port 3001 &
-    dawn test --url http://127.0.0.1:3001
+    # In your run.test.ts: set run: { url: "http://127.0.0.1:3001" } per scenario
+    dawn test
+    ```
+  </Step>
+  <Step title="Build the deployment artifact">
+    `dawn build` writes `.dawn/build/langgraph.json` along with per-route entry files under `.dawn/build/<routeSlug>.ts`. For `agent` routes, the generated entry calls `agent.bindTools([...])` so every tool discovered for the route is wired to the LLM.
+
+    ```
+    dawn build --clean
     ```
 
-    If in-process and live-server tests both pass, the same inputs will pass on LangGraph Platform.
-  </Step>
-  <Step title="Declare assistants">
-    Create a `langgraph.json` at the app root mapping Dawn's discovered routes to LangGraph assistants:
+    A typical generated `.dawn/build/langgraph.json` looks like:
 
     ```json
     {
       "graphs": {
-        "hello": "./src/app/(public)/hello/[tenant]/index.ts:workflow"
+        "/hello/[tenant]#agent": "./.dawn/build/hello-tenant.ts:default"
       },
-      "env": ".env"
+      "dependencies": ["."],
+      "env": ".env.example",
+      "node_version": "22"
     }
     ```
 
-    Each entry binds an `assistant_id` (left side) to a route entry export (right side).
+    Notes:
+    - Each `assistant_id` is `<routeId>#<kind>` — e.g. `/hello/[tenant]#agent`. Use this exact string as `assistant_id` in any client request.
+    - `dependencies: ["."]` and `node_version: "22"` are required by LangGraph Platform.
+    - `env` resolves to `.env.example` when that file exists, else `.env`.
+    - If you keep a hand-authored `langgraph.json` at the app root, `dawn build` shallow-merges it on top of the generated values.
+  </Step>
+  <Step title="Per-route middleware (optional)">
+    `src/middleware.ts` (default-exporting a function from `defineMiddleware`) runs before every `/runs/wait` and `/runs/stream` request — identically in `dawn dev` and on LangGraph Platform. Use it to gate access by header, populate request-scoped context, or `reject(status, body)` unauthorized callers. See [Routes](/docs/routes#middleware) for the API.
   </Step>
   <Step title="Push to your Platform-connected remote">
-    The LangGraph Platform builds the image and provisions assistants keyed by `assistant_id`. From there, your agents and harnesses can hit the deployed endpoints using the same protocol they already speak locally.
+    The LangGraph Platform builds the image from `.dawn/build/` and provisions assistants keyed by the `<routeId>#<kind>` ids in the generated `langgraph.json`. From there, your agents and harnesses can hit the deployed endpoints using the same protocol they already speak locally.
   </Step>
 </Steps>
 
@@ -52,14 +69,10 @@ Dawn itself is **not a deployment runtime**. It owns local development: `dawn de
 
 ## Self-hosting
 
-If you can't or won't use the LangGraph Platform, you can self-host by wrapping Dawn's runtime in a Docker container that exposes the same protocol endpoints (`/runs/wait`, `/runs/stream`, `/assistants`). Dawn's dev server implementation (in `@dawn-ai/cli`) is the reference — it's the same process you'd run in production, just without the file watcher.
-
-<Callout type="tip" title="Dev server as reference">
-  `dawn dev` running on port 3001 is functionally identical to a deployed Dawn runtime. Point your staging tests at a `dawn dev` instance and you'll catch 95% of deployment issues before you ship.
-</Callout>
+If you can't or won't use the LangGraph Platform, build with `dawn build` and feed `.dawn/build/` to your own container. The generated entry files and `langgraph.json` are the canonical interface — the in-process `dawn dev` runtime is a reference for the same protocol surface (`/runs/wait`, `/runs/stream`, `/healthz`), but is not intended as a production runtime itself.
 
 ## Troubleshooting
 
 - **Tests pass in-process but fail live-server** — a tool or route isn't serializing cleanly. Check that inputs, outputs, and state are JSON-serializable (no Dates, Maps, classes).
-- **Assistant id not found** — the `langgraph.json` entry doesn't match what Dawn discovered. Run `dawn routes` to see the exact pathnames, then update the `graphs` mapping.
+- **Assistant id not found** — the request `assistant_id` doesn't match the `<routeId>#<kind>` keys in `.dawn/build/langgraph.json`. Inspect that file directly (`cat .dawn/build/langgraph.json`) or run `dawn verify --json` to confirm what was discovered.
 - **Type inference drifted** — run `dawn typegen` locally and commit `dawn.generated.d.ts`. The Platform build uses the committed file.

--- a/apps/web/content/docs/dev-server.mdx
+++ b/apps/web/content/docs/dev-server.mdx
@@ -8,11 +8,13 @@
 dawn dev
 ```
 
-By default the server listens on port 3000. Override with `--port`:
+By default the server binds an ephemeral localhost port (announced on stdout as `Dawn dev ready at http://127.0.0.1:<port>`). Pass `--port <n>` for a stable port:
 
 ```
 dawn dev --port 3001
 ```
+
+The bind address is always `127.0.0.1`.
 
 ## Invoking a route
 
@@ -22,49 +24,75 @@ With the server running in one terminal, you can hit it from another:
 echo '{"tenant":"acme"}' | dawn run '/hello/[tenant]' --url http://127.0.0.1:3001
 ```
 
-`dawn run` resolves the pathname to an `assistant_id`, POSTs to `/runs/wait`, and prints the result. This is the exact request path a production LangGraph Platform deployment would take.
+`dawn run` resolves the pathname to an `assistant_id` of the form `<routeId>#<kind>` (e.g. `/hello/[tenant]#agent`), POSTs to `/runs/wait`, and prints the result. This is the exact request path a production LangGraph Platform deployment would take.
 
 ## Protocol endpoints
 
+The dev server handles three endpoints. Anything else returns 404.
+
 <Tabs>
+  <Tab label="/healthz">
+    Readiness check.
+
+    ```
+    GET /healthz
+    -> 200 { "status": "ready" }
+    ```
+
+    Returns 200 once the child runtime is up; non-200 means not-ready. `dawn dev` itself uses this endpoint internally to detect readiness.
+  </Tab>
   <Tab label="/runs/wait">
-    Synchronous run — blocks until the route completes, returns the final state.
+    Synchronous run — blocks until the route completes, returns the final state as JSON.
 
     ```
     POST /runs/wait
-    Body: { assistant_id, input }
+    Body: {
+      "assistant_id": "/hello/[tenant]#agent",
+      "input": { "tenant": "acme" },
+      "metadata": {
+        "dawn": {
+          "mode": "agent",
+          "route_id": "/hello/[tenant]",
+          "route_path": "/hello/acme"
+        }
+      },
+      "on_completion": "delete"
+    }
     ```
+
+    The server validates the full envelope. `metadata.dawn.{mode, route_id, route_path}` must match the values registered for the `assistant_id`, or the server returns 400 with an `expected/received` diff. `on_completion: "delete"` is required.
   </Tab>
   <Tab label="/runs/stream">
-    Streaming run — returns an SSE stream of intermediate events as the route progresses.
+    Streaming run — same body shape as `/runs/wait`, returns an SSE stream (`content-type: text/event-stream`) of intermediate events as the route progresses.
 
     ```
     POST /runs/stream
-    Body: { assistant_id, input, stream_mode }
-    ```
-  </Tab>
-  <Tab label="/assistants">
-    Lists the assistants (routes) the server is serving.
-
-    ```
-    GET /assistants
+    Body: { /* same shape as /runs/wait */ }
     ```
   </Tab>
 </Tabs>
 
+The `assistant_id` format `<routeId>#<kind>` is the same format `dawn build` writes into the `graphs` map of `.dawn/build/langgraph.json`, so the same client request shape works against `dawn dev` and against a deployed runtime.
+
+## Middleware
+
+`src/middleware.ts` (default-exporting a function returned by `defineMiddleware`) runs before every `/runs/wait` and `/runs/stream` request. It can short-circuit a request with `reject(status, body?)`, or continue with `allow(context?)` — the optional `context` flows to every tool as `ctx.middleware` (a `Readonly<Record<string, unknown>>`).
+
+`MiddlewareRequest` shape: `{ assistantId, headers, method, params, routeId, url }`. See [Routes](/docs/routes#middleware) for the full reference; a dedicated middleware page is tracked as a follow-up.
+
 ## Hot reload
 
-When you save a route file, a tool, or a state file, the dev server:
+When you save a file under `src/app/`, the dev server:
 
 <Steps>
-  <Step title="Re-runs typegen">
-    Any tool signature changes are picked up and `dawn.generated.d.ts` is updated. Your IDE's TypeScript server sees the new types within seconds.
+  <Step title="Reclassifies the change">
+    Typegen-only changes (tool signatures, state schemas) trigger a debounced typegen run (~100ms) — the child does not restart. Structural changes restart the child.
   </Step>
-  <Step title="Restarts the child runtime">
-    Dawn uses a parent-child process architecture. The parent owns the HTTP server and file watcher; the child owns the route graph. On save, only the child restarts — in-flight requests complete before the swap.
+  <Step title="Restarts the child runtime when needed">
+    Dawn uses a parent-child process architecture. The parent owns the HTTP server and file watcher; the child owns the route graph. On a structural change the child is `stop()`ed (with a forced kill timeout — in-flight requests are given a brief grace window, then force-killed) and a fresh child is started.
   </Step>
   <Step title="Preserves assistant ids">
-    Assistants keep their stable ids across restarts, so any agent or harness holding an `assistant_id` continues to work without reconnection.
+    Assistants keep their stable ids (`<routeId>#<kind>`) across restarts, so any agent or harness holding an `assistant_id` continues to work without reconnection.
   </Step>
 </Steps>
 
@@ -74,9 +102,9 @@ When you save a route file, a tool, or a state file, the dev server:
 
 ## Logging
 
-Every request is logged to stdout with the pathname, assistant id, duration, and result status. Set `DEBUG=dawn:*` for verbose tracing of the parent/child handshake.
+Every request is logged to stdout with the pathname, assistant id, duration, and result status. Set `DAWN_DEV_SHUTDOWN_TIMEOUT_MS` to override the child-restart grace window (default ~5s).
 
 ## Next steps
 
 - [Testing](/docs/testing) — run scenarios against a live dev server
-- [Deployment](/docs/deployment) — ship the same runtime to LangGraph Platform
+- [Deployment](/docs/deployment) — `dawn build` and the LangGraph Platform handoff

--- a/apps/web/content/docs/getting-started.mdx
+++ b/apps/web/content/docs/getting-started.mdx
@@ -10,7 +10,7 @@ Dawn is a TypeScript-first framework for building graph-based AI agent systems. 
 ## Scaffold a new app
 
 ```bash
-npx create-dawn-app my-agent
+pnpm create dawn-ai-app my-agent
 cd my-agent
 pnpm install
 ```
@@ -27,37 +27,44 @@ my-agent/
     │   └── hello/
     │       └── [tenant]/
     │           ├── index.ts        # Route entry
-    │           ├── state.ts        # Route state type
+    │           ├── state.ts        # Route state schema (Zod)
     │           └── tools/
     │               └── greet.ts    # Co-located tool
     └── dawn.generated.d.ts         # Auto-generated types
 ```
 
+## Validate the app
+
+Before you run anything, confirm the app is well-formed and the generated types are up to date:
+
+```bash
+dawn verify
+```
+
+`dawn verify` runs four checks (app contract, route discovery, typegen, deps) in a single call. For a quicker individual gate while iterating, use `dawn check` and `dawn typegen` separately.
+
 ## Understand the route
 
 Each route is a directory under `src/app/` with an `index.ts` that exports exactly one of:
 
-- **`workflow`** — an async function that receives state and a typed context
-- **`graph`** — a LangGraph graph instance
-- **`chain`** — a LangChain LCEL Runnable
+- **`agent`** — a `DawnAgent` descriptor (default-exported) created via `agent({ model, systemPrompt })`. The scaffold default and the recommended path for LLM-driven routes.
+- **`workflow`** — an async function that receives state and a typed context.
+- **`graph`** — a LangGraph graph instance.
+- **`chain`** — a LangChain LCEL Runnable.
 
-The scaffolded app uses a `workflow` export:
+The scaffolded app uses an `agent` default export:
 
 ```typescript
-import type { RuntimeContext } from "@dawn-ai/sdk"
-import type { RouteTools } from "dawn:routes"
-import type { HelloState } from "./state.js"
+import { agent } from "@dawn-ai/sdk"
 
-export async function workflow(
-  state: HelloState,
-  ctx: RuntimeContext<RouteTools<"/hello/[tenant]">>
-) {
-  const result = await ctx.tools.greet({ tenant: state.tenant })
-  return { ...state, greeting: result.greeting }
-}
+export default agent({
+  model: "gpt-4o-mini",
+  systemPrompt:
+    "You are a helpful assistant for the {tenant} organization. Answer questions about the tenant.",
+})
 ```
 
-The `RouteTools<"/hello/[tenant]">` type is auto-generated from the tool files in the `tools/` directory. You get full autocomplete for `ctx.tools.greet()` with zero manual wiring.
+Tools in the route's `tools/` directory are auto-bound to the agent at `dawn build` time — the LLM picks when to invoke them. See [Routes](/docs/routes) for the `workflow` / `graph` / `chain` alternatives, and the optional `retry: { maxAttempts, baseDelay }` config.
 
 ## Add a tool
 
@@ -70,22 +77,19 @@ export default async (input: { readonly tenant: string }) => {
 }
 ```
 
-Dawn extracts the input and output types at build time using the TypeScript compiler API, then writes them to `dawn.generated.d.ts`. No Zod schemas, no manual type declarations.
+Dawn extracts the input and output types at build time using the TypeScript compiler API, then writes them to `dawn.generated.d.ts`. Tool inputs and outputs require no Zod schemas — that inference is what makes `ctx.tools.greet()` show up fully typed without any manual wiring. (Route state in `state.ts` does use a Zod schema; see [State](/docs/state).)
+
+The tool's runtime signature is `(input, ctx) => ...`, where `ctx` is `{ signal: AbortSignal, middleware?: Readonly<Record<string, unknown>> }`. Use `ctx.signal` to cooperate with cancellation; `ctx.middleware` carries request-scoped context populated by `src/middleware.ts`. See [Tools](/docs/tools) for the full reference.
 
 ## Run your agent
 
+`dawn run` reads JSON state from stdin, invokes the route, and prints the JSON result to stdout:
+
 ```bash
-dawn run '/hello/acme'
+echo '{"tenant":"acme"}' | dawn run '/hello/[tenant]'
 ```
 
-Dawn discovers the route matching `/hello/acme`, resolves `[tenant]` to `"acme"`, and executes the workflow. You should see:
-
-```
-Route    /hello/[tenant]
-Mode     workflow
-Tenant   acme
-✓ { greeting: "Hello, acme!" }
-```
+The output is JSON (`JSON.stringify(result, null, 2)`) — for the scaffold's agent route, that's the LLM's structured response after any tool calls. The `[tenant]` segment is resolved from the matching state field.
 
 ## Start the dev server
 
@@ -95,10 +99,19 @@ For iterative development with hot reload:
 dawn dev
 ```
 
-The dev server watches for file changes and restarts automatically. It exposes the same endpoints used by the LangGraph Platform — `/runs/wait` and `/runs/stream` — so what works locally works in production.
+The dev server watches for file changes and restarts automatically. It binds an ephemeral localhost port by default (announced on stdout); pass `--port <n>` for a stable port. It exposes the same endpoints used by the LangGraph Platform — `/runs/wait` and `/runs/stream` — so what works locally works in production.
+
+## Ship to production
+
+Run `dawn build` to write `.dawn/build/langgraph.json` plus per-route entry files. That directory is what you hand to LangGraph Platform. See [Deployment](/docs/deployment) for the full bridge.
 
 ## What's next
 
-- Explore the [Dawn GitHub repository](https://github.com/cacheplane/dawnai) for the full source
-- Read the template code in `src/app/` to understand route conventions
-- Try adding a new route directory with its own tools
+- [Routes](/docs/routes) — `agent`, `workflow`, `graph`, `chain`, middleware
+- [Tools](/docs/tools) — tool inputs, outputs, and runtime context
+- [State](/docs/state) — Zod state schemas and dynamic-segment merging
+- [CLI](/docs/cli) — every command flag and exit code
+- [Dev Server](/docs/dev-server) — protocol endpoints, hot reload, middleware
+- [Testing](/docs/testing) — scenario tests and live-server parity
+- [Deployment](/docs/deployment) — `dawn build` and LangGraph Platform handoff
+- [Dawn on GitHub](https://github.com/cacheplane/dawnai) — full source

--- a/apps/web/content/docs/routes.mdx
+++ b/apps/web/content/docs/routes.mdx
@@ -1,21 +1,37 @@
 # Routes
 
-Routes are the unit of work in Dawn. A route is a directory under `src/app/` containing an `index.ts` that exports exactly one of three entry types: a `workflow` function, a LangGraph `graph`, or a LangChain `chain`.
+Routes are the unit of work in Dawn. A route is a directory under `src/app/` containing an `index.ts` that exports exactly one of four entry types: an `agent` descriptor (the scaffold default), a `workflow` function, a LangGraph `graph`, or a LangChain `chain`.
 
 Routes are discovered by filesystem walk — **no registration, no config**.
 
 ## Route entry
 
-Every route's `index.ts` exports one entry. The three choices are interchangeable: a given route picks whichever best matches the work.
+Every route's `index.ts` exports one entry. The four choices are interchangeable: a given route picks whichever best matches the work.
 
 <Tabs>
+  <Tab label="agent">
+    The scaffold default and the preferred path for LLM-driven routes. `agent({ model, systemPrompt })` produces a `DawnAgent` descriptor that `dawn build` lowers into a tool-bound LangGraph node — the LLM picks when to invoke each route-local tool.
+
+    ```ts
+    import { agent } from "@dawn-ai/sdk"
+
+    export default agent({
+      model: "gpt-4o-mini",
+      systemPrompt:
+        "You are a helpful assistant for the {tenant} organization. Answer questions about the tenant.",
+    })
+    ```
+  </Tab>
   <Tab label="workflow">
-    The most common entry. A plain async function that takes state + runtime context, returns new state.
+    A plain async function that takes state + runtime context and returns new state. Use when you want explicit, code-driven orchestration.
 
     ```ts
     import type { RuntimeContext } from "@dawn-ai/sdk"
     import type { RouteTools } from "dawn:routes"
-    import type { HelloState } from "./state.js"
+    import type { z } from "zod"
+    import type state from "./state.js"
+
+    type HelloState = z.infer<typeof state>
 
     export async function workflow(
       state: HelloState,
@@ -43,8 +59,51 @@ Every route's `index.ts` exports one entry. The three choices are interchangeabl
 </Tabs>
 
 <Callout type="warn" title="Exactly one entry per route">
-  A single `index.ts` may export **only one** of `workflow`, `graph`, or `chain`. `dawn check` enforces this.
+  A single `index.ts` may export **only one** of `agent`, `workflow`, `graph`, or `chain`. Discovery enforces this — `dawn check`, `dawn routes`, `dawn build`, `dawn typegen`, and `dawn verify` all surface the violation.
 </Callout>
+
+## Agents
+
+Agent routes are descriptors authored with `agent()` from `@dawn-ai/sdk`:
+
+```ts
+import { agent } from "@dawn-ai/sdk"
+
+export default agent({
+  model: "gpt-4o-mini",
+  systemPrompt: "You are concise and accurate.",
+  retry: {
+    maxAttempts: 3,
+    baseDelay: 250,
+  },
+})
+```
+
+`AgentConfig` accepts:
+
+- `model` — a `KnownModelId` (typed string covering OpenAI, Anthropic, and Google model ids).
+- `systemPrompt` — the system message for the agent.
+- `retry?: RetryConfig` — optional `{ maxAttempts?: number, baseDelay?: number }` policy. See `packages/sdk/src/agent.ts` for the exact shape; a dedicated retry-policy reference is tracked as a follow-up.
+
+At build time, `dawn build` emits a LangGraph entry that calls `agent.bindTools(...)` with every tool discovered for the route, so any tool in the route's `tools/` directory (and any shared tool in `src/tools/`) is automatically available to the LLM.
+
+## Middleware
+
+`src/middleware.ts` (default-exporting a function returned by `defineMiddleware`) runs before every `/runs/wait` and `/runs/stream` request — locally under `dawn dev`, and on LangGraph Platform.
+
+```ts
+// src/middleware.ts
+import { allow, defineMiddleware, reject } from "@dawn-ai/sdk"
+
+export default defineMiddleware(async (req) => {
+  if (!req.headers["x-tenant-id"]) {
+    return reject(401, { error: "missing x-tenant-id" })
+  }
+  return allow({ tenantId: req.headers["x-tenant-id"] })
+})
+```
+
+`MiddlewareRequest` exposes `assistantId`, `routeId`, `headers`, `params`, `method`, and `url`. The optional `context` passed to `allow(...)` is forwarded to every tool as `ctx.middleware` (see [Tools](/docs/tools)). A dedicated middleware page is tracked as a follow-up; until then, the source of truth is `packages/sdk/src/middleware.ts`.
 
 ## Pathname rules
 
@@ -63,30 +122,37 @@ Run `dawn routes` to list every route Dawn discovered and its computed pathname.
 
 ## State
 
-Each route has a `state.ts` file that defines its state type:
+Each route has a `state.ts` file whose default export is a Zod schema:
 
 ```ts
 // src/app/(public)/hello/[tenant]/state.ts
-export interface HelloState {
-  readonly tenant: string
-  readonly greeting?: string
-}
+import { z } from "zod"
+
+export default z.object({
+  context: z.string().default(""),
+})
 ```
 
-Dynamic segment names become state fields automatically. `[tenant]` → `state.tenant`.
+Dawn extracts defaults from the schema at runtime and infers the TS type via `z.infer<typeof state>`. **Dynamic-segment fields (`[tenant]`) are injected from the URL path and should not be declared in the schema.** See [State](/docs/state) for the full reference, including custom reducers.
 
 ## Tools
 
-A route's `tools/` directory contains co-located tools. Tool types are inferred from source and made available on `ctx.tools` with full autocomplete. See [Tools](/docs/tools) for the full reference.
+A route's `tools/` directory contains co-located tools. Tool types are inferred from source and made available on `ctx.tools` with full autocomplete inside `workflow` / `graph` routes, or auto-bound to the agent for `agent` routes. See [Tools](/docs/tools) for the full reference.
 
 ## Running a route
 
-```
-dawn run '/hello/acme'
+```bash
+echo '{"tenant":"acme"}' | dawn run '/hello/[tenant]'
 ```
 
-`dawn run` reads state from stdin (JSON), resolves the pathname to a route, invokes the entry, and writes the result to stdout.
+`dawn run` reads state from stdin (JSON), resolves the pathname to a route, invokes the entry, and writes the JSON result to stdout. The route argument can be the parameterized id (`/hello/[tenant]`) or the concrete pathname (`/hello/acme`); the input JSON's matching field supplies the dynamic-segment value.
 
 <Callout type="tip" title="Tip">
   Quote the route path in your shell — route groups and dynamic segments contain `(`, `)`, and `[]` which shells expand.
 </Callout>
+
+## Related
+
+- [State](/docs/state) — schema, defaults, dynamic-segment merging, custom reducers
+- [CLI](/docs/cli) — `dawn run`, `dawn check`, `dawn verify`, `dawn build`
+- [Deployment](/docs/deployment) — `dawn build` output and LangGraph Platform handoff

--- a/apps/web/content/docs/state.mdx
+++ b/apps/web/content/docs/state.mdx
@@ -1,39 +1,63 @@
 # State
 
-Every route has a state type declared in a colocated `state.ts` file. State is the contract between the caller, the route's entry, and any tools the entry invokes.
+Every route has a state contract declared in a colocated `state.ts` file. State is the contract between the caller, the route's entry, and any tools the entry invokes.
 
 ## The shape
 
+`state.ts` default-exports a Zod schema. Dawn extracts defaults from the schema at runtime and you can derive the TS type via `z.infer<typeof state>`:
+
 ```ts
 // src/app/(public)/hello/[tenant]/state.ts
-export interface HelloState {
-  readonly tenant: string
-  readonly greeting?: string
-}
-```
+import { z } from "zod"
 
-`HelloState` is imported into `index.ts` and used as the first parameter of the `workflow` function (or the equivalent graph state type).
+export default z.object({
+  /** Accumulated context from tool call results */
+  context: z.string().default(""),
+})
+```
 
 ```ts
-import type { HelloState } from "./state.js"
+// src/app/(public)/hello/[tenant]/index.ts (workflow form)
+import type { RuntimeContext } from "@dawn-ai/sdk"
+import type { z } from "zod"
+import type state from "./state.js"
 
-export async function workflow(state: HelloState, ctx) {
-  // state.tenant is string
-  // state.greeting is string | undefined
+type HelloState = z.infer<typeof state>
+
+export async function workflow(state: HelloState, ctx: RuntimeContext) {
+  // state.context is string (Zod-parsed default `""` is applied when caller omits it)
 }
 ```
+
+<Callout type="info" title="Zod or any Standard Schema">
+  State discovery accepts either a Zod schema (matched by `.parse({})`) or any value that implements [Standard Schema](https://standardschema.dev/) (matched by the `~standard.validate({})` slot). The scaffold uses Zod; either works at runtime.
+</Callout>
 
 ## Dynamic segments become state fields
 
-If your route's directory contains a dynamic segment like `[tenant]`, that segment's value is populated on the state field of the same name at runtime.
+If your route's directory contains a dynamic segment like `[tenant]`, that segment's value is populated on the state field of the same name at runtime — **injected from the URL path, not declared in the Zod schema**.
 
 ```
 src/app/(public)/hello/[tenant]/  →  state.tenant populated from the pathname
 ```
 
+The schema only covers state your entry produces or the caller supplies. Dawn merges dynamic-segment values on top of the schema-derived defaults; double-declaring `tenant` in the Zod schema would conflict with the path injection.
+
 <Callout type="info" title="Naming matters">
   The dynamic segment name and the state field name must match exactly. Dawn wires them up by name, not by position.
 </Callout>
+
+## Custom reducers
+
+Each route may include a `reducers/` directory with one file per state field. The default export is a `(current, incoming) => merged` function that overrides Dawn's default merge for that field.
+
+```ts
+// src/app/(public)/hello/[tenant]/reducers/context.ts
+export default (current: string, incoming: string) =>
+  current ? `${current}\n${incoming}` : incoming
+```
+
+The file basename must equal the state-field name (`context.ts` → reduces `state.context`). Reducers are useful for accumulation patterns (concatenating logs, summing counters, deduplicating lists) where the default object spread is too coarse.
 
 ## Rules
 
@@ -42,19 +66,18 @@ src/app/(public)/hello/[tenant]/  →  state.tenant populated from the pathname
     Dawn serializes state across runtime boundaries (dev server, scenario tests, LangGraph Platform). Use primitives, plain objects, arrays. No classes, no Dates, no Maps.
   </Step>
   <Step title="Prefer readonly">
-    Mark fields `readonly`. The entry function returns a new state object rather than mutating the input. This keeps scenario tests deterministic and LangGraph checkpoint-safe.
+    Mark fields `readonly` (or use Zod's `.readonly()`) when they should not be mutated. The entry function returns a new state object rather than mutating the input. This keeps scenario tests deterministic and LangGraph checkpoint-safe.
   </Step>
   <Step title="Outputs accumulate">
-    A workflow returns `{ ...state, newField }` — merging new outputs into the existing state. Fields added during the run are typed as optional (`greeting?: string`) so the caller isn't forced to provide them.
+    A workflow returns `{ ...state, newField }` — merging new outputs into the existing state. Custom reducers (above) override the merge for a specific field.
   </Step>
 </Steps>
 
 ## State flow
 
-```
-caller stdin  →  state  →  workflow/graph/chain  →  new state  →  stdout
-                              ↓
-                           ctx.tools
-```
+State crosses the runtime boundary at every entry point:
 
-The state is the only thing that crosses the runtime boundary. Everything else — tool results, intermediate values — lives inside the entry for the duration of a single run.
+- `dawn run` — JSON via stdin, JSON via stdout.
+- `/runs/wait` and `/runs/stream` (locally under `dawn dev`, on LangGraph Platform in prod) — JSON over HTTP keyed by `assistant_id`.
+
+Tool results, intermediate values, and other in-route data live inside the entry for the duration of a single run; only the final state crosses the boundary.

--- a/apps/web/content/docs/testing.mdx
+++ b/apps/web/content/docs/testing.mdx
@@ -1,19 +1,23 @@
 # Testing
 
-Scenario tests are colocated with routes as `run.test.ts` files. Each scenario declares an input state and the expected output, and Dawn runs them against the real route runtime.
+Scenario tests are colocated with routes as `run.test.ts` files. Each scenario declares an input state and the expected output, and `dawn test` runs them against the real route runtime.
 
 ## A minimal test
 
+A scenario file is a default-exported array of plain scenario records — there is no `describe()` or `test()` wrapper, and the route is inferred from the file's directory:
+
 ```ts
 // src/app/(public)/hello/[tenant]/run.test.ts
-import { describe, test } from "@dawn-ai/sdk/testing"
-
-describe("/hello/[tenant]", () => {
-  test("greets a tenant", {
+export default [
+  {
+    name: "greets a tenant",
     input: { tenant: "acme" },
-    expected: { tenant: "acme", greeting: "Hello, acme!" },
-  })
-})
+    expect: {
+      status: "passed",
+      output: { tenant: "acme", greeting: "Hello, acme!" },
+    },
+  },
+]
 ```
 
 Run all scenarios:
@@ -22,48 +26,98 @@ Run all scenarios:
 dawn test
 ```
 
-Dawn discovers every `run.test.ts` under `src/app/`, invokes the route for each scenario, and compares output deep-equal against `expected`.
+Dawn discovers every `run.test.ts` under `src/app/`, invokes the route for each scenario, and evaluates the declarative expectation.
+
+## Scenario shape
+
+Each entry in the default-exported array is `{ name, input, expect, run?, assert? }`:
+
+- `name` — human-readable scenario name.
+- `input` — the JSON state passed to the route.
+- `expect` — declarative expectation (see below).
+- `run?` — optional run config: `{ url?: string }` to target a live dev server.
+- `assert?` — optional `(result) => void` callback for custom assertions, evaluated alongside `expect`.
+
+The `expect` object accepts:
+
+- `status` (required) — `"passed" | "failed"`.
+- `output?` — deep-equal match against the route's returned state.
+- `meta?` — match against `{ mode, routeId, routePath, executionSource }`.
+- `error?` — for `status: "failed"`, match `{ kind, message: string | { includes: string } }`.
+
+For programmatic assertions in `assert(result)`, import the helpers from `@dawn-ai/cli/testing`:
+
+```ts
+import { expectError, expectMeta, expectOutput } from "@dawn-ai/cli/testing"
+
+export default [
+  {
+    name: "custom assert",
+    input: { tenant: "acme" },
+    expect: { status: "passed" },
+    assert: (result) => {
+      expectOutput(result, { greeting: "Hello, acme!" })
+      expectMeta(result, { mode: "agent", routeId: "/hello/[tenant]" })
+    },
+  },
+]
+```
 
 ## Against a live dev server
 
-By default, tests run against the in-process route runtime. You can also point tests at a running `dawn dev` server to verify protocol parity:
+To exercise protocol parity against a running `dawn dev`, set `run.url` per-scenario. There is no command-level `--url` flag on `dawn test`.
+
+```ts
+export default [
+  {
+    name: "greets a tenant via dev server",
+    input: { tenant: "acme" },
+    run: { url: "http://127.0.0.1:3001" },
+    expect: {
+      status: "passed",
+      output: { tenant: "acme", greeting: "Hello, acme!" },
+    },
+  },
+]
+```
+
+Start the dev server first, then run `dawn test`:
 
 ```
 dawn dev --port 3001 &
-dawn test --url http://127.0.0.1:3001
+dawn test
 ```
 
 <Callout type="tip" title="Run both to confirm parity">
-  If the in-process run passes but the live-server run fails, something in your route doesn't survive the LangGraph Platform protocol. The live-server mode is how you catch this before deploy.
+  If the in-process scenario passes but the live-server scenario fails, something in your route doesn't survive the LangGraph Platform protocol. The live-server mode is how you catch this before deploy.
 </Callout>
+
+## Agents, retries, and middleware
+
+Two cross-cutting features shape what scenarios assert:
+
+- **Agent retries** — `agent({ retry: { maxAttempts, baseDelay } })` retries on transient errors. To assert the exhausted-retry path, set `expect.status: "failed"` and use `expect.error` (or an `assert` callback with `expectError`).
+- **Middleware** — `src/middleware.ts` runs before every `/runs/wait` and `/runs/stream` request. **Live-server scenarios (`run: { url }`) exercise middleware; in-process scenarios bypass it.** A scenario whose middleware calls `reject(...)` should set `expect.status: "failed"` with a matching `expect.error`.
+
+A dedicated middleware page is tracked as a follow-up.
 
 ## Mocking tools
 
-For routes that call external APIs, databases, or LLMs, stub the tools per-scenario:
-
-```ts
-test("with mocked greet", {
-  input: { tenant: "acme" },
-  expected: { tenant: "acme", greeting: "Hi from mock!" },
-  tools: {
-    greet: async () => ({ greeting: "Hi from mock!" }),
-  },
-})
-```
-
-The mock signature must match the tool's inferred input/output shape. TypeScript checks this at compile time.
+<Callout type="warn" title="Not supported today">
+  Per-scenario tool mocking (a `tools` field in the scenario record) is **not** part of the scenario surface today — extra keys are silently ignored. Use the `assert` callback for custom matchers, or stub external dependencies inside the tool itself (e.g. behind an env flag) until tool mocking lands. Tracked as a follow-up.
+</Callout>
 
 ## Rules
 
 <Steps>
   <Step title="File location">
-    `run.test.ts` must live in the route's directory, not a sibling or nested folder. Dawn matches tests to routes by directory, not by name.
+    `run.test.ts` must live in the route's directory, not a sibling or nested folder. Dawn matches tests to routes by directory.
   </Step>
-  <Step title="describe() matches the route">
-    The top-level `describe` block should pass the route's pathname. Dawn uses it to look up the correct route for the scenarios inside.
+  <Step title="Default-exported array">
+    The file's default export is the array of scenario records. There is no `describe()` or `test()` wrapper.
   </Step>
-  <Step title="expected is deep-equal by default">
-    Dawn compares the returned state deep-equal against `expected`. Use `expected.eq`, `expected.contains`, or custom matchers for partial or fuzzy matching (see `@dawn-ai/sdk/testing` for the full surface).
+  <Step title="Use the helpers from @dawn-ai/cli/testing for custom assertions">
+    `expectOutput`, `expectMeta`, and `expectError` cover deep-equal match (with helpful diffs). For partial or fuzzy matching today, use the declarative `expect` shape (`output`/`meta`/`error`) or write a custom predicate in `assert(result)`.
   </Step>
   <Step title="Keep scenarios focused">
     One scenario = one claim about the route's behavior. If you're adding branches, add more scenarios — don't inflate a single one.
@@ -72,10 +126,11 @@ The mock signature must match the tool's inferred input/output shape. TypeScript
 
 ## CI
 
-`dawn test` exits non-zero on any failure and outputs a diff per mismatched scenario. Wire it into your CI step after `dawn check` and `dawn typegen`:
+Use `dawn verify` as the integrity gate (it covers app, routes, typegen, and deps in one call), then run `dawn test`:
 
 ```yaml
-- run: pnpm exec dawn check
-- run: pnpm exec dawn typegen
+- run: pnpm exec dawn verify
 - run: pnpm exec dawn test
 ```
+
+`dawn verify` runs typegen and check internally, plus the deps check (missing packages, missing env vars) that bare `dawn check && dawn typegen` does not. `dawn test` exits non-zero on any failure and outputs a diff per mismatched scenario.

--- a/apps/web/content/docs/tools.mdx
+++ b/apps/web/content/docs/tools.mdx
@@ -1,6 +1,6 @@
 # Tools
 
-Tools are the units of work a route's entry can invoke. They live in a `tools/` subdirectory inside a route, are discovered automatically, and have their types **inferred from source** — no Zod schemas, no manual type wiring.
+Tools are the units of work a route's entry can invoke. They live in a `tools/` subdirectory inside a route, are discovered automatically, and have their **input and output types inferred from TypeScript source** — no Zod schemas required for tools. (Route state in `state.ts` does use Zod; see [State](/docs/state).)
 
 ## A minimal tool
 
@@ -11,23 +11,58 @@ export default async (input: { readonly tenant: string }) => {
 }
 ```
 
-That's it. Dawn extracts the input and output types at build time using the TypeScript compiler API and writes them into `dawn.generated.d.ts`. The tool becomes available as `ctx.tools.greet` inside the route's entry, fully typed.
+That's it. Dawn extracts the input and output types at build time using the TypeScript compiler API and writes them into `dawn.generated.d.ts`. The tool becomes available as `ctx.tools.greet` inside `workflow`/`graph` route entries (fully typed), and is auto-bound to the LLM at `dawn build` time inside `agent` route entries.
 
 <Callout type="info" title="No registration needed">
   Every `.ts` file in a route's `tools/` directory is automatically discovered. Drop a file in, save, and the type appears in `ctx.tools` on the next `dawn typegen` or `dawn dev` reload.
 </Callout>
 
-## Invoking a tool
+## The runtime signature
+
+The full runtime signature accepted by tool discovery is `(input, ctx) => ...`, where `ctx` is `{ signal: AbortSignal, middleware?: Readonly<Record<string, unknown>> }`:
 
 ```ts
-// in the route's index.ts
-export async function workflow(state, ctx) {
+// src/app/(public)/hello/[tenant]/tools/greet.ts
+export default async (
+  input: { readonly tenant: string },
+  ctx: { signal: AbortSignal; middleware?: Readonly<Record<string, unknown>> },
+) => {
+  // Cooperate with cancellation — the AbortSignal is always present.
+  const res = await fetch(`https://example.com/hello?tenant=${input.tenant}`, {
+    signal: ctx.signal,
+  })
+  // ctx.middleware is the readonly bag populated by allow({ ... }) in src/middleware.ts.
+  return { greeting: await res.text() }
+}
+```
+
+The second parameter is optional but recommended for any tool that does network I/O, holds long-running work, or needs middleware-derived context. See [Routes](/docs/routes#middleware) for how `defineMiddleware` and `allow(context)` populate `ctx.middleware`.
+
+## Invoking a tool
+
+Inside a `workflow` or `graph` route, tools are invoked through `ctx.tools.<name>(...)`:
+
+```ts
+// in the route's index.ts (workflow form)
+import type { RuntimeContext } from "@dawn-ai/sdk"
+import type { RouteTools } from "dawn:routes"
+import type { z } from "zod"
+import type state from "./state.js"
+
+type HelloState = z.infer<typeof state>
+
+export async function workflow(
+  state: HelloState,
+  ctx: RuntimeContext<RouteTools<"/hello/[tenant]">>,
+) {
   const result = await ctx.tools.greet({ tenant: state.tenant })
   return { ...state, greeting: result.greeting }
 }
 ```
 
 `ctx.tools.greet` has full IntelliSense — input shape, return shape, everything.
+
+Inside an `agent` route, you do not call tools yourself. `dawn build` binds the route's tools to the agent at build time and the LLM invokes them as needed. See [Routes](/docs/routes) for both forms side by side.
 
 ## Input and output rules
 
@@ -50,19 +85,17 @@ export async function workflow(state, ctx) {
   </Step>
 </Steps>
 
-## The generated declaration
+## The generated declarations
 
-Dawn writes a `dawn.generated.d.ts` file at your app root that looks roughly like:
+`dawn typegen` writes two artifacts:
 
-```ts
-declare module "dawn:routes" {
-  export type RouteTools<P> = DawnRouteTools[P]
-  // greet signature inferred from tools/greet.ts export
-}
-```
+- **`dawn.generated.d.ts`** at the app root — the ambient type module that backs `import type { RouteTools } from "dawn:routes"`. The emitted shape pivots over a `RouteTools<P>` lookup keyed by each discovered route pathname; `dawn typegen` populates the entries with concrete tool signatures inferred from source.
+- **`.dawn/routes/<routeSlug>/tools.json`** — per-route tool-schema manifests consumed by `dawn build` when emitting LangGraph entries.
 
-<Callout type="warn" title="Don't edit this file">
-  `dawn.generated.d.ts` is regenerated on every `dawn typegen` and by the dev server on save. Your edits will be wiped.
+To inspect the exact shape Dawn emits in your app, run `dawn typegen` and open `dawn.generated.d.ts`.
+
+<Callout type="warn" title="Don't edit these files">
+  `dawn.generated.d.ts` and the per-route `tools.json` files under `.dawn/routes/` are regenerated on every `dawn typegen` and by the dev server on save. Your edits will be wiped.
 </Callout>
 
 Regenerate manually if needed:

--- a/apps/web/content/templates/AGENTS.md
+++ b/apps/web/content/templates/AGENTS.md
@@ -4,80 +4,135 @@ This project uses **Dawn**, a TypeScript-first meta-framework for building graph
 
 ## Project Shape
 
-- **`dawn.config.ts`** at the repo root. Only supported field is `appDir` (defaults to `src/app`). Do not invent other config.
+- **`dawn.config.ts`** at the repo root. Only supported field is `appDir` (defaults to `src/app`). Do not invent other config. The config is parsed by a strict tokenizer — only string-literal `appDir: "..."` or `const X = "..."; export default { appDir: X }` are supported.
 - **`src/app/`** — all routes live here. A route is a directory containing `index.ts`.
 - **`src/app/**/index.ts`** — route entry. MUST export exactly ONE of:
-  - `workflow` (async function — most common)
+  - `agent` — a `DawnAgent` descriptor from `@dawn-ai/sdk`, typically the `default` export. Preferred for LLM-driven routes; tools auto-bind at build time.
+  - `workflow` (async function — explicit code-driven orchestration)
   - `graph` (LangGraph graph instance)
   - `chain` (LangChain LCEL Runnable)
-- **`src/app/**/state.ts`** — the route's state type. Imported by `index.ts`.
+- **`src/app/**/state.ts`** — the route's state schema (default-exported Zod schema). Imported by `index.ts`.
 - **`src/app/**/tools/*.ts`** — co-located tools. Each file has a default export that is an async function. Types are inferred and written to `dawn.generated.d.ts`.
-- **`src/app/**/run.test.ts`** — colocated scenario tests. Use `@dawn-ai/sdk/testing`.
+- **`src/tools/*.ts`** — shared tools (optional). Discovered alongside route-local tools and merged into every route's tool registry. Route-local tools override shared tools with the same name.
+- **`src/middleware.ts`** — optional. Default-exports a function returned by `defineMiddleware(...)`. Runs before every `/runs/wait` and `/runs/stream` request, on `dawn dev` and on LangGraph Platform.
+- **`src/app/**/run.test.ts`** — colocated scenario tests. Default-export an array of scenario records (`{ name, input, expect, run?, assert? }`). Custom assertion helpers live at `@dawn-ai/cli/testing` (`expectOutput`, `expectMeta`, `expectError`).
 - **`dawn.generated.d.ts`** — auto-generated. Do NOT edit by hand.
+- **`dawn:routes`** — virtual module emitted by the Dawn Vite plugin and backed by `dawn.generated.d.ts`. If `RouteTools` does not resolve, run `dawn typegen`.
 
 ## Pathname Rules
 
 - Directory segments become URL pathname segments.
 - Segments in parentheses `(public)` are route groups — excluded from the pathname.
-- Segments in brackets `[tenant]` are dynamic — they become state fields of the same name.
+- Segments in brackets `[tenant]` are dynamic — they are injected from the URL path onto state fields of the same name at runtime. Do NOT declare dynamic-segment fields in the Zod schema.
 
 Example: `src/app/(public)/hello/[tenant]/index.ts` → pathname `/hello/[tenant]`.
+
+## Defining an Agent Route
+
+```ts
+// src/app/(public)/hello/[tenant]/index.ts
+import { agent } from "@dawn-ai/sdk"
+
+export default agent({
+  model: "gpt-4o-mini",
+  systemPrompt:
+    "You are a helpful assistant for the {tenant} organization.",
+  // Optional retry policy:
+  // retry: { maxAttempts: 3, baseDelay: 250 },
+})
+```
+
+- `model` is a `KnownModelId` (covers OpenAI, Anthropic, and Google ids).
+- `retry?: { maxAttempts?: number, baseDelay?: number }` — applied per agent call.
+- Tools in the same route's `tools/` directory (and shared tools in `src/tools/`) are automatically bound to the agent at `dawn build` time.
 
 ## Tool Authoring
 
 ```ts
 // src/app/(public)/hello/[tenant]/tools/greet.ts
-export default async (input: { readonly tenant: string }) => {
+export default async (
+  input: { readonly tenant: string },
+  ctx: { signal: AbortSignal; middleware?: Readonly<Record<string, unknown>> },
+) => {
   return { greeting: `Hello, ${input.tenant}!` }
 }
 ```
 
-- Input type is inferred from the parameter annotation.
-- Output type is inferred from the return.
-- Tool is available as `ctx.tools.greet` inside the route's workflow, fully typed.
+- Input type is inferred from the parameter annotation; output type from the return.
+- The second parameter is optional but recommended:
+  - `ctx.signal` — `AbortSignal` for cooperative cancellation. Pass it to `fetch()` and any awaited operations.
+  - `ctx.middleware` — readonly bag populated by `allow({ ... })` in `src/middleware.ts`. Request-scoped context (auth, tenancy, etc.) flows through here.
 - Use `readonly` on input fields; Dawn preserves it.
-- Input and output must be JSON-serializable.
+- Input and output must be JSON-serializable (no `Date`, `Map`, classes, functions).
+- Tools may live in either route-local `tools/` (preferred default) OR shared `src/tools/`. Route-local names override shared names.
 
-## Route Entry
+## Middleware
+
+```ts
+// src/middleware.ts
+import { allow, defineMiddleware, reject } from "@dawn-ai/sdk"
+
+export default defineMiddleware(async (req) => {
+  if (!req.headers["x-tenant-id"]) {
+    return reject(401, { error: "missing x-tenant-id" })
+  }
+  return allow({ tenantId: req.headers["x-tenant-id"] })
+})
+```
+
+- `MiddlewareRequest`: `{ assistantId, headers, method, params, routeId, url }`.
+- Return `reject(status, body?)` to short-circuit the request, or `allow(context?)` to continue.
+- The `context` passed to `allow(...)` is forwarded to every tool as `ctx.middleware`.
+
+## Route Entry — workflow form (alternative to agent)
 
 ```ts
 // src/app/(public)/hello/[tenant]/index.ts
 import type { RuntimeContext } from "@dawn-ai/sdk"
 import type { RouteTools } from "dawn:routes"
-import type { HelloState } from "./state.js"
+import type { z } from "zod"
+import type state from "./state.js"
+
+type HelloState = z.infer<typeof state>
 
 export async function workflow(
   state: HelloState,
-  ctx: RuntimeContext<RouteTools<"/hello/[tenant]">>
+  ctx: RuntimeContext<RouteTools<"/hello/[tenant]">>,
 ) {
+  // ctx.signal is the request-scoped AbortSignal.
+  // ctx.tools.greet is fully typed from the route's tools/ directory.
   const result = await ctx.tools.greet({ tenant: state.tenant })
   return { ...state, greeting: result.greeting }
 }
 ```
 
+The `RouteTools<"/hello/[tenant]">` lookup uses the route's pathname as the key — these keys are populated by `dawn typegen`. Run `dawn typegen` if `dawn:routes` does not resolve.
+
 ## Commands (run via `pnpm exec`)
 
-- `dawn check` — validate app structure/config.
+- `dawn check` — validate app structure/config (lightweight).
+- `dawn verify` — full integrity check across app, routes, typegen, deps. Preferred CI gate.
 - `dawn routes` — list discovered routes.
-- `dawn typegen` — regenerate `dawn.generated.d.ts`.
+- `dawn typegen` — regenerate `dawn.generated.d.ts` and per-route `tools.json`.
 - `dawn run '/hello/acme'` — execute a route once with JSON stdin/stdout.
 - `dawn test` — run colocated `run.test.ts` scenarios.
 - `dawn dev` — local runtime server (LangGraph Platform protocol).
+- `dawn build` — write `.dawn/build/langgraph.json` and per-route entry files for LangGraph Platform deployment. Generated `langgraph.json` includes `dependencies: ["."]`, `env`, and `node_version: "22"`. Assistant ids are `<routeId>#<kind>` (e.g. `/hello/[tenant]#agent`).
 
 ## Packages
 
-- `@dawn-ai/sdk` — backend-neutral contract (types, `RuntimeContext`, test helpers).
+- `@dawn-ai/sdk` — backend-neutral contract: `agent`, `defineMiddleware`, `allow`, `reject`, types (`RuntimeContext` carries `signal: AbortSignal`, `AgentConfig`, `RetryConfig`, `MiddlewareRequest`, etc.).
 - `@dawn-ai/langgraph` — adapter for LangGraph graphs and workflows.
 - `@dawn-ai/langchain` — adapter for LangChain LCEL chains.
-- `@dawn-ai/cli` — the `dawn` CLI.
+- `@dawn-ai/cli` — the `dawn` CLI. Test helpers live at `@dawn-ai/cli/testing`.
 
 ## Do Not
 
-- Do NOT edit `dawn.generated.d.ts`.
-- Do NOT add Zod schemas for tool input/output — types are inferred.
-- Do NOT put tools outside a route's `tools/` directory.
-- Do NOT export more than one of `workflow`/`graph`/`chain` from a single `index.ts`.
-- Do NOT deploy from Dawn directly — Dawn owns local development; production runs on LangGraph Platform.
+- Do NOT edit `dawn.generated.d.ts` or files under `.dawn/`.
+- Do NOT add Zod schemas for tool input/output — types are inferred from TypeScript source.
+- Do NOT export more than one of `agent`/`workflow`/`graph`/`chain` from a single `index.ts`.
+- Do NOT declare dynamic-segment fields (e.g. `tenant`) in the `state.ts` Zod schema — they are injected from the URL path.
+- Do NOT edit `.dawn/build/langgraph.json` by hand. To deploy, run `dawn build` and hand `.dawn/build/` to LangGraph Platform.
 
 ## Reference
 

--- a/apps/web/content/templates/CLAUDE.md
+++ b/apps/web/content/templates/CLAUDE.md
@@ -4,80 +4,135 @@ This project uses **Dawn**, a TypeScript-first meta-framework for building graph
 
 ## Project Shape
 
-- **`dawn.config.ts`** at the repo root. Only supported field is `appDir` (defaults to `src/app`). Do not invent other config.
+- **`dawn.config.ts`** at the repo root. Only supported field is `appDir` (defaults to `src/app`). Do not invent other config. The config is parsed by a strict tokenizer — only string-literal `appDir: "..."` or `const X = "..."; export default { appDir: X }` are supported.
 - **`src/app/`** — all routes live here. A route is a directory containing `index.ts`.
 - **`src/app/**/index.ts`** — route entry. MUST export exactly ONE of:
-  - `workflow` (async function — most common)
+  - `agent` — a `DawnAgent` descriptor from `@dawn-ai/sdk`, typically the `default` export. Preferred for LLM-driven routes; tools auto-bind at build time.
+  - `workflow` (async function — explicit code-driven orchestration)
   - `graph` (LangGraph graph instance)
   - `chain` (LangChain LCEL Runnable)
-- **`src/app/**/state.ts`** — the route's state type. Imported by `index.ts`.
+- **`src/app/**/state.ts`** — the route's state schema (default-exported Zod schema). Imported by `index.ts`.
 - **`src/app/**/tools/*.ts`** — co-located tools. Each file has a default export that is an async function. Types are inferred and written to `dawn.generated.d.ts`.
-- **`src/app/**/run.test.ts`** — colocated scenario tests. Use `@dawn-ai/sdk/testing`.
+- **`src/tools/*.ts`** — shared tools (optional). Discovered alongside route-local tools and merged into every route's tool registry. Route-local tools override shared tools with the same name.
+- **`src/middleware.ts`** — optional. Default-exports a function returned by `defineMiddleware(...)`. Runs before every `/runs/wait` and `/runs/stream` request, on `dawn dev` and on LangGraph Platform.
+- **`src/app/**/run.test.ts`** — colocated scenario tests. Default-export an array of scenario records (`{ name, input, expect, run?, assert? }`). Custom assertion helpers live at `@dawn-ai/cli/testing` (`expectOutput`, `expectMeta`, `expectError`).
 - **`dawn.generated.d.ts`** — auto-generated. Do NOT edit by hand.
+- **`dawn:routes`** — virtual module emitted by the Dawn Vite plugin and backed by `dawn.generated.d.ts`. If `RouteTools` does not resolve, run `dawn typegen`.
 
 ## Pathname Rules
 
 - Directory segments become URL pathname segments.
 - Segments in parentheses `(public)` are route groups — excluded from the pathname.
-- Segments in brackets `[tenant]` are dynamic — they become state fields of the same name.
+- Segments in brackets `[tenant]` are dynamic — they are injected from the URL path onto state fields of the same name at runtime. Do NOT declare dynamic-segment fields in the Zod schema.
 
 Example: `src/app/(public)/hello/[tenant]/index.ts` → pathname `/hello/[tenant]`.
+
+## Defining an Agent Route
+
+```ts
+// src/app/(public)/hello/[tenant]/index.ts
+import { agent } from "@dawn-ai/sdk"
+
+export default agent({
+  model: "gpt-4o-mini",
+  systemPrompt:
+    "You are a helpful assistant for the {tenant} organization.",
+  // Optional retry policy:
+  // retry: { maxAttempts: 3, baseDelay: 250 },
+})
+```
+
+- `model` is a `KnownModelId` (covers OpenAI, Anthropic, and Google ids).
+- `retry?: { maxAttempts?: number, baseDelay?: number }` — applied per agent call.
+- Tools in the same route's `tools/` directory (and shared tools in `src/tools/`) are automatically bound to the agent at `dawn build` time.
 
 ## Tool Authoring
 
 ```ts
 // src/app/(public)/hello/[tenant]/tools/greet.ts
-export default async (input: { readonly tenant: string }) => {
+export default async (
+  input: { readonly tenant: string },
+  ctx: { signal: AbortSignal; middleware?: Readonly<Record<string, unknown>> },
+) => {
   return { greeting: `Hello, ${input.tenant}!` }
 }
 ```
 
-- Input type is inferred from the parameter annotation.
-- Output type is inferred from the return.
-- Tool is available as `ctx.tools.greet` inside the route's workflow, fully typed.
+- Input type is inferred from the parameter annotation; output type from the return.
+- The second parameter is optional but recommended:
+  - `ctx.signal` — `AbortSignal` for cooperative cancellation. Pass it to `fetch()` and any awaited operations.
+  - `ctx.middleware` — readonly bag populated by `allow({ ... })` in `src/middleware.ts`. Request-scoped context (auth, tenancy, etc.) flows through here.
 - Use `readonly` on input fields; Dawn preserves it.
-- Input and output must be JSON-serializable.
+- Input and output must be JSON-serializable (no `Date`, `Map`, classes, functions).
+- Tools may live in either route-local `tools/` (preferred default) OR shared `src/tools/`. Route-local names override shared names.
 
-## Route Entry
+## Middleware
+
+```ts
+// src/middleware.ts
+import { allow, defineMiddleware, reject } from "@dawn-ai/sdk"
+
+export default defineMiddleware(async (req) => {
+  if (!req.headers["x-tenant-id"]) {
+    return reject(401, { error: "missing x-tenant-id" })
+  }
+  return allow({ tenantId: req.headers["x-tenant-id"] })
+})
+```
+
+- `MiddlewareRequest`: `{ assistantId, headers, method, params, routeId, url }`.
+- Return `reject(status, body?)` to short-circuit the request, or `allow(context?)` to continue.
+- The `context` passed to `allow(...)` is forwarded to every tool as `ctx.middleware`.
+
+## Route Entry — workflow form (alternative to agent)
 
 ```ts
 // src/app/(public)/hello/[tenant]/index.ts
 import type { RuntimeContext } from "@dawn-ai/sdk"
 import type { RouteTools } from "dawn:routes"
-import type { HelloState } from "./state.js"
+import type { z } from "zod"
+import type state from "./state.js"
+
+type HelloState = z.infer<typeof state>
 
 export async function workflow(
   state: HelloState,
-  ctx: RuntimeContext<RouteTools<"/hello/[tenant]">>
+  ctx: RuntimeContext<RouteTools<"/hello/[tenant]">>,
 ) {
+  // ctx.signal is the request-scoped AbortSignal.
+  // ctx.tools.greet is fully typed from the route's tools/ directory.
   const result = await ctx.tools.greet({ tenant: state.tenant })
   return { ...state, greeting: result.greeting }
 }
 ```
 
+The `RouteTools<"/hello/[tenant]">` lookup uses the route's pathname as the key — these keys are populated by `dawn typegen`. Run `dawn typegen` if `dawn:routes` does not resolve.
+
 ## Commands (run via `pnpm exec`)
 
-- `dawn check` — validate app structure/config.
+- `dawn check` — validate app structure/config (lightweight).
+- `dawn verify` — full integrity check across app, routes, typegen, deps. Preferred CI gate.
 - `dawn routes` — list discovered routes.
-- `dawn typegen` — regenerate `dawn.generated.d.ts`.
+- `dawn typegen` — regenerate `dawn.generated.d.ts` and per-route `tools.json`.
 - `dawn run '/hello/acme'` — execute a route once with JSON stdin/stdout.
 - `dawn test` — run colocated `run.test.ts` scenarios.
 - `dawn dev` — local runtime server (LangGraph Platform protocol).
+- `dawn build` — write `.dawn/build/langgraph.json` and per-route entry files for LangGraph Platform deployment. Generated `langgraph.json` includes `dependencies: ["."]`, `env`, and `node_version: "22"`. Assistant ids are `<routeId>#<kind>` (e.g. `/hello/[tenant]#agent`).
 
 ## Packages
 
-- `@dawn-ai/sdk` — backend-neutral contract (types, `RuntimeContext`, test helpers).
+- `@dawn-ai/sdk` — backend-neutral contract: `agent`, `defineMiddleware`, `allow`, `reject`, types (`RuntimeContext` carries `signal: AbortSignal`, `AgentConfig`, `RetryConfig`, `MiddlewareRequest`, etc.).
 - `@dawn-ai/langgraph` — adapter for LangGraph graphs and workflows.
 - `@dawn-ai/langchain` — adapter for LangChain LCEL chains.
-- `@dawn-ai/cli` — the `dawn` CLI.
+- `@dawn-ai/cli` — the `dawn` CLI. Test helpers live at `@dawn-ai/cli/testing`.
 
 ## Do Not
 
-- Do NOT edit `dawn.generated.d.ts`.
-- Do NOT add Zod schemas for tool input/output — types are inferred.
-- Do NOT put tools outside a route's `tools/` directory.
-- Do NOT export more than one of `workflow`/`graph`/`chain` from a single `index.ts`.
-- Do NOT deploy from Dawn directly — Dawn owns local development; production runs on LangGraph Platform.
+- Do NOT edit `dawn.generated.d.ts` or files under `.dawn/`.
+- Do NOT add Zod schemas for tool input/output — types are inferred from TypeScript source.
+- Do NOT export more than one of `agent`/`workflow`/`graph`/`chain` from a single `index.ts`.
+- Do NOT declare dynamic-segment fields (e.g. `tenant`) in the `state.ts` Zod schema — they are injected from the URL path.
+- Do NOT edit `.dawn/build/langgraph.json` by hand. To deploy, run `dawn build` and hand `.dawn/build/` to LangGraph Platform.
 
 ## Reference
 


### PR DESCRIPTION
## Summary

Fixes 50+ critical and important findings from sections 2 (Website load-bearing), 3 (Website supporting), and 4 (Templates) of `docs/superpowers/audits/2026-05-06-docs-audit.md`.

**Findings addressed:** F-014..F-082 (critical+important), plus deferred follow-ups noted inline (F-073 middleware page, F-074 retry page, F-087 llms.txt — deferred per spec).

**Files changed (10):**
- `apps/web/content/docs/{getting-started,routes,tools,state,cli,dev-server,testing,deployment}.mdx`
- `apps/web/content/templates/{AGENTS,assistant}.md` (kept byte-identical per F-075)

## Notable changes

- `getting-started.mdx`: corrected scaffold command (`pnpm create dawn-ai-app`), aligned with `agent()`-shaped scaffold
- `deployment.mdx`: centered on `dawn build` (which produces correct `langgraph.json` shape); removed the hand-write-langgraph instructions
- `routes.mdx`, `tools.mdx`, `state.mdx`: aligned route kinds (`agent` is default), tool signature `(input, ctx)` with `ctx.middleware`, Zod-based state, dynamic segments
- `cli.mdx`: added `dawn build` and `dawn verify`; corrected flags
- `dev-server.mdx`: corrected endpoint inventory (`/healthz`, `/runs/wait`, `/runs/stream`), assistant_id format, body envelope
- `testing.mdx`: corrected import path (`@dawn-ai/cli/testing` not `@dawn-ai/sdk/testing`), real scenario shape, real helpers
- `templates/{AGENTS,assistant}.md`: aligned with current SDK surface; added middleware, retry, real route kinds

## No code changes

This PR is docs-only. The escape hatch was **not** invoked — F-082 (`@dawn-ai/sdk/testing` import) was a docs error, not a code gap (real helpers ship at `@dawn-ai/cli/testing`).

## Test plan

- [x] `pnpm --filter web build` succeeds locally
- [x] Internal links verified to resolve
- [x] Spec-compliance review passed (all in-scope findings addressed)
- [x] Code-quality review: APPROVED_WITH_NITS (minor polish only, none blocking)
- [ ] CI green
