### PR TITLE
docs: root README fixes (PR A)

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,9 +175,7 @@ pnpm exec dawn build
 
 ## Current Boundaries
 
-Dawn is not a deployment runtime. Local runtime ownership stops at `dawn dev`.
-
-Dawn is not a LangSmith trace replacement.
+Local runtime ownership stops at `dawn dev`. Production traffic runs on LangGraph Platform from the artifacts `dawn build` emits.
 
 The starter template surface is intentionally small, and the supported config surface is intentionally narrow.
 

--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@
 
 # Dawn
 
-Dawn is a TypeScript meta-framework for filesystem-based route discovery, route validation, type generation, local route execution, and a local development runtime.
+Dawn is a TypeScript meta-framework for authoring agents and workflows: filesystem-based route discovery, the `agent()` descriptor, route-local tools, per-route middleware, type generation, a local development runtime, and `dawn build` for producing LangGraph Platform deployment artifacts.
 
 ## Status
 
-This repository documents the current behavior only. It is intentionally narrow. Dawn is not a deployment runtime, not a LangSmith trace replacement, and not a hosted platform.
+This repository documents the current behavior only. Dawn does not host or run production traffic — `dawn build` produces deployment artifacts (`.dawn/build/langgraph.json` plus per-route entry files) that LangGraph Platform runs. Dawn is not a LangSmith trace replacement and not a hosted platform.
 
 ## Quickstart
 

--- a/README.md
+++ b/README.md
@@ -122,6 +122,10 @@ pnpm create dawn-ai-app my-dawn-app
 
 Validate the app structure and configuration for the current workspace.
 
+### `dawn verify`
+
+Run all four integrity checks (app, routes, typegen, deps) in one command. The canonical pre-deploy gate, with optional `--json` output for CI.
+
 ### `dawn routes`
 
 Discover and print the routes Dawn sees in the current app.
@@ -148,6 +152,14 @@ Start the local development runtime for interactive route execution.
 
 ```bash
 pnpm exec dawn dev
+```
+
+### `dawn build`
+
+Produce LangGraph Platform deployment artifacts under `.dawn/build/`. Emits a `langgraph.json` (with `dependencies: ["."]`, `node_version: "22"`, and an `env` path) plus per-route entry files. Agent routes have their tools bound at build time.
+
+```bash
+pnpm exec dawn build
 ```
 
 ## Packages

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This repository documents the current behavior only. It is intentionally narrow.
 1. Create a new app.
 
 ```bash
-pnpm create dawn-app my-dawn-app
+pnpm create dawn-ai-app my-dawn-app
 cd my-dawn-app
 pnpm install
 ```
@@ -68,12 +68,12 @@ The current `basic` scaffold ships:
 
 This is the user-first command set the README focuses on today, not an exhaustive internal CLI reference.
 
-### `create-dawn-app`
+### `create-dawn-ai-app`
 
 Scaffold a new Dawn app from the available template set.
 
 ```bash
-pnpm create dawn-app my-dawn-app
+pnpm create dawn-ai-app my-dawn-app
 ```
 
 ### `dawn check`

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ pnpm exec dawn build
 - `@dawn-ai/sdk` owns the backend-neutral author-facing contract: types, helpers, runtime context, and tool authoring.
 - `@dawn-ai/langgraph` is the LangGraph adapter that implements the `@dawn-ai/sdk` contract.
 - `@dawn-ai/cli` owns the user-facing commands and local runtime behavior.
-- `create-dawn-app` owns scaffolding for new apps.
+- `create-dawn-ai-app` owns scaffolding for new apps.
 - `@dawn-ai/devkit` owns shared template and file-generation helpers.
 - `@dawn-ai/config-typescript` provides the shared TypeScript workspace configuration.
 - `@dawn-ai/config-biome` provides the shared Biome workspace configuration.
@@ -180,6 +180,19 @@ Dawn is not a deployment runtime. Local runtime ownership stops at `dawn dev`.
 Dawn is not a LangSmith trace replacement.
 
 The starter template surface is intentionally small, and the supported config surface is intentionally narrow.
+
+## Documentation
+
+The canonical reference lives on the docs site:
+
+- [Getting started](https://dawn-ai.org/docs/getting-started)
+- [Routes](https://dawn-ai.org/docs/routes)
+- [Tools](https://dawn-ai.org/docs/tools)
+- [State](https://dawn-ai.org/docs/state)
+- [CLI](https://dawn-ai.org/docs/cli)
+- [Dev server](https://dawn-ai.org/docs/dev-server)
+- [Testing](https://dawn-ai.org/docs/testing)
+- [Deployment](https://dawn-ai.org/docs/deployment)
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -41,9 +41,16 @@ Route discovery starts at `src/app` by default.
 
 `appDir` is the only supported config option today.
 
-A route is a directory containing `index.ts`. The `index.ts` exports either a `workflow` function or a `graph` function/object:
+A route is a directory containing `index.ts`. The `index.ts` exports exactly one of four route kinds: an `agent` descriptor (the scaffold default), a `workflow` function, a `graph` function/object, or a `chain`:
 
 ```ts
+// agent-style route (the basic scaffold default)
+import { agent } from "@dawn-ai/sdk"
+export default agent({
+  model: "gpt-4o-mini",
+  systemPrompt: "You are a helpful assistant for the {tenant} organization.",
+})
+
 // workflow-style route
 export async function workflow(state, ctx) { return state }
 
@@ -51,18 +58,53 @@ export async function workflow(state, ctx) { return state }
 export async function graph(state, ctx) { return state }
 // or
 export const graph = { invoke: async (state, ctx) => state }
+
+// chain-style route
+export async function chain(state, ctx) { return state }
 ```
 
-Route directories may also include companion files such as `state.ts` and route-local tools under `tools/*.ts`.
+Route directories support these additional files:
 
-Route directories currently support these additional files:
+- `state.ts` — default-exported Zod schema describing the route's state shape (the scaffold uses `z.object({...})`).
+- `tools/*.ts` — route-local tools, each exporting `(input, ctx) => ...` where `ctx` is `{ middleware?, signal }`.
+- `reducers/<field>.ts` — optional per-field reducers that override the default merge behavior for state.
+- `run.test.ts` — colocated scenarios picked up by `dawn test`.
+- `page.tsx` — UI route surface.
 
-- `page.tsx` for UI routes
+The current `basic` scaffold ships an agent-style route:
 
-The current `basic` scaffold ships:
+- `src/app/(public)/hello/[tenant]/index.ts` — `export default agent({ model, systemPrompt })`
+- `src/app/(public)/hello/[tenant]/state.ts` — default-exported Zod schema
+- `src/app/(public)/hello/[tenant]/tools/greet.ts` — a route-local tool
 
-- `src/app/(public)/hello/[tenant]/index.ts`
-- `src/app/(public)/hello/[tenant]/tools/greet.ts`
+### Authoring agents
+
+`agent({ model, systemPrompt, retry?: { maxAttempts, baseDelay } })` is the recommended export for new routes. The optional `retry` config controls how the agent retries failed model calls. `dawn build` binds route-local tools to the agent at build time so the LLM can invoke them on LangGraph Platform.
+
+```ts
+import { agent } from "@dawn-ai/sdk"
+
+export default agent({
+  model: "gpt-4o-mini",
+  systemPrompt: "...",
+  retry: { maxAttempts: 3, baseDelay: 250 },
+})
+```
+
+### Middleware
+
+Per-route middleware runs before each invocation. Use `defineMiddleware` together with `reject(status, body?)` to deny a request, or `allow(context?)` to continue and pass an immutable context bag through to tools via `ctx.middleware`:
+
+```ts
+import { defineMiddleware, allow, reject } from "@dawn-ai/sdk"
+
+export default defineMiddleware(async (req) => {
+  if (!req.headers.authorization) return reject(401, { error: "unauthorized" })
+  return allow({ tenantId: req.params.tenant })
+})
+```
+
+`req` (`MiddlewareRequest`) carries `assistantId`, `headers`, `method`, `params`, `routeId`, and `url`. Middleware runs identically under `dawn dev` and on the deployed runtime.
 
 ## Commands
 


### PR DESCRIPTION
## Summary

Fixes critical and important findings from section 1 of `docs/superpowers/audits/2026-05-06-docs-audit.md` (root README).

**Findings addressed:** F-001, F-002, F-003, F-004, F-005, F-006, F-008, F-010, F-012 (all critical + important).

## Highlights

- Corrected scaffold command: `pnpm create dawn-ai-app` (was `dawn-app`, a non-existent npm package — F-003)
- Aligned App Contract with agent-first scaffold (F-004): all four route kinds listed, `agent` shown first
- Added `agent()` and middleware authoring sections (F-008): `agent({ model, systemPrompt, retry })`, `defineMiddleware`, `allow`, `reject`
- Added `dawn build` and `dawn verify` to Commands (F-006)
- Added Documentation section with links to website docs (F-012)
- Reconciled Status / Current Boundaries with deployment artifact reality (F-002)

## No code changes

This PR is docs-only.

## Test plan

- [x] All CLI commands shown verified to exist in packages/cli/src/commands
- [x] All SDK imports verified against packages/sdk/src/index.ts
- [x] Spec-compliance review passed (all in-scope findings addressed)
- [ ] CI green