### PR TITLE
docs: flesh out public package READMEs (PR C)

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -4,11 +4,66 @@
 
 # @dawn-ai/cli
 
-The `dawn` command-line interface for validating Dawn apps, inspecting routes, and generating route types.
+The `dawn` command-line interface — local development runtime, route execution, validation and typegen, and the build step that produces LangGraph Platform deployment artifacts. It is the primary tool for working on a Dawn app from first scaffold through deploy.
 
-Commands:
-- `dawn check`
-- `dawn routes`
-- `dawn typegen`
+## Install
 
-Install the package globally or use it as a project-local dependency to run Dawn app checks in CI and local development.
+Project-local (recommended):
+
+```sh
+npm install -D @dawn-ai/cli
+# or
+pnpm add -D @dawn-ai/cli
+```
+
+Global:
+
+```sh
+npm install -g @dawn-ai/cli
+# or
+pnpm add -g @dawn-ai/cli
+```
+
+Installs a `dawn` binary on your `PATH`. Requires Node.js 22.12+.
+
+## Commands
+
+| Command        | Description                                                  |
+|----------------|--------------------------------------------------------------|
+| `dawn dev`     | Start the Dawn local development runtime                     |
+| `dawn check`   | Validate a Dawn app (route discovery, tool definitions)      |
+| `dawn verify`  | Verify dependencies and generated types are in sync          |
+| `dawn build`   | Generate deployment artifacts for LangGraph Platform         |
+| `dawn run`     | Execute one Dawn route invocation                            |
+| `dawn test`    | Run route test scenarios                                     |
+| `dawn routes`  | List discovered Dawn routes (use `--json` for machine output)|
+| `dawn typegen` | Generate Dawn route and tool types into `.dawn/`             |
+
+## Usage
+
+```sh
+# Start the local dev runtime
+pnpm dawn dev
+
+# Validate the app and regenerate types
+pnpm dawn check
+pnpm dawn typegen
+
+# Produce LangGraph Platform deployment artifacts
+pnpm dawn build
+```
+
+Run `dawn <command> --help` for command-specific options.
+
+## Documentation
+
+Full reference and guides:
+
+- CLI — https://dawn-ai.org/docs/cli
+- Dev server — https://dawn-ai.org/docs/dev-server
+- Deployment — https://dawn-ai.org/docs/deployment
+- Getting started — https://dawn-ai.org/docs/getting-started
+
+## License
+
+MIT

--- a/packages/create-dawn-app/README.md
+++ b/packages/create-dawn-app/README.md
@@ -2,11 +2,62 @@
   <img src="https://raw.githubusercontent.com/cacheplane/dawnai/main/docs/brand/dawn-logo-horizontal-black-on-white.png" alt="Dawn" width="180" />
 </p>
 
-# create-dawn-app
+# create-dawn-ai-app
 
-Scaffold a new Dawn application from the supported starter templates.
+Scaffold a new Dawn application from the supported starter templates. Generates a working app with Dawn's canonical `src/app` route layout, an `agent()` route, and the Dawn packages wired up for local development.
 
-Current template support:
-- `basic`
+## Usage
 
-The generated app uses Dawn's canonical `src/app` route layout and installs the Dawn packages needed for local development.
+```sh
+pnpm create dawn-ai-app my-app
+# or
+npm create dawn-ai-app@latest my-app
+# or
+yarn create dawn-ai-app my-app
+```
+
+Then:
+
+```sh
+cd my-app
+pnpm install
+pnpm dawn dev
+```
+
+Requires Node.js 22.12+.
+
+### Options
+
+- `--template <name>` — choose a starter template (default: `basic`)
+
+## What you get
+
+The `basic` template scaffolds a Dawn app with one example route:
+
+```
+my-app/
+  dawn.config.ts
+  package.json
+  tsconfig.json
+  src/
+    app/
+      (public)/
+        hello/
+          [tenant]/
+            index.ts        # exports agent({...})
+            state.ts
+            tools/
+              greet.ts
+```
+
+The generated `package.json` wires `@dawn-ai/sdk`, `@dawn-ai/cli`, `@dawn-ai/core`, and `@dawn-ai/langchain`, with scripts for `dawn check`, `dawn build`, and `tsc` typecheck. Run any other `dawn` command via `pnpm dawn <command>`.
+
+## Next steps
+
+- Getting started — https://dawn-ai.org/docs/getting-started
+- Routes — https://dawn-ai.org/docs/routes
+- CLI — https://dawn-ai.org/docs/cli
+
+## License
+
+MIT

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -4,11 +4,68 @@
 
 # @dawn-ai/sdk
 
-TypeScript types for authoring Dawn routes and tools.
+The author-facing SDK for Dawn. Use it to declare agent routes, define request middleware, and type the runtime context, tools, and route metadata that the Dawn CLI consumes. Ships small runtime helpers (`agent()`, `defineMiddleware()`, `allow()`, `reject()`, `isDawnAgent()`) alongside the type primitives — it is the canonical entry point for authoring Dawn routes.
 
-Public surface:
-- `RuntimeContext` — context object passed to workflow and graph entry points (tools, abort signal)
-- `RuntimeTool`, `ToolRegistry` — tool type primitives
-- `RouteConfig`, `RouteKind` — route metadata types
+## Install
 
-This package is a pure type layer with no runtime dependencies. Import it in route `index.ts` files for type annotations.
+```sh
+npm install @dawn-ai/sdk
+# or
+pnpm add @dawn-ai/sdk
+# or
+yarn add @dawn-ai/sdk
+```
+
+Requires Node.js 22.12+.
+
+## Key APIs
+
+The SDK groups around three surfaces:
+
+- **Agents** — `agent()`, `AgentConfig`, `DawnAgent`, `RetryConfig`, `isDawnAgent`
+- **Middleware** — `defineMiddleware()`, `allow()`, `reject()`, `DawnMiddleware`, `MiddlewareRequest`, `MiddlewareResult`
+- **Route and runtime types** — `RouteConfig`, `RouteKind`, `RuntimeContext`, `RuntimeTool`, `ToolRegistry`, `KnownModelId`
+
+### Declaring an agent route
+
+A Dawn route's `index.ts` exports an `agent()` descriptor. The `model` field is typed against `KnownModelId`; `retry` is optional.
+
+```ts
+// src/app/hello/index.ts
+import { agent } from "@dawn-ai/sdk"
+
+export default agent({
+  model: "gpt-4o-mini",
+  systemPrompt: "You are a helpful assistant.",
+  retry: { maxAttempts: 3, baseDelay: 250 },
+})
+```
+
+### Defining middleware
+
+Middleware runs before a route invocation and can either continue (optionally attaching context) or reject with a status code.
+
+```ts
+// src/app/hello/middleware.ts
+import { allow, defineMiddleware, reject } from "@dawn-ai/sdk"
+
+export default defineMiddleware((req) => {
+  if (!req.headers.authorization) {
+    return reject(401, { error: "missing authorization" })
+  }
+  return allow({ tenant: req.params.tenant })
+})
+```
+
+## Documentation
+
+Full reference and guides:
+
+- Routes — https://dawn-ai.org/docs/routes
+- Tools — https://dawn-ai.org/docs/tools
+- State — https://dawn-ai.org/docs/state
+- Getting started — https://dawn-ai.org/docs/getting-started
+
+## License
+
+MIT


### PR DESCRIPTION
## Summary

Fleshes out README.md for three publicly-discoverable Dawn packages per the hybrid policy in `docs/superpowers/specs/2026-05-06-docs-review-design.md`:
- `packages/sdk/README.md` — overview + agent/middleware examples + key types
- `packages/cli/README.md` — all 8 commands + usage examples
- `packages/create-dawn-app/README.md` — scaffold usage + what-you-get

Each now has overview, install, key APIs, and links to the website. Implements section 5 (F-088..F-106) of the audit.

## Verification

- `pack --dry-run` confirms README.md is in the published files for all three packages
- Install commands match actual package.json `name` (`@dawn-ai/sdk`, `@dawn-ai/cli`, `create-dawn-ai-app`)
- Code examples import from `@dawn-ai/sdk` and mirror the scaffold's actual route shape

## No code changes

This PR is docs-only.

## Test plan

- [x] `pack --dry-run` includes README in published files for each package
- [x] Code examples reference real SDK exports
- [ ] CI green