### PR TITLE
docs: normalize internal package READMEs (PR D)

### DIFF
--- a/packages/config-biome/README.md
+++ b/packages/config-biome/README.md
@@ -4,10 +4,10 @@
 
 # @dawn-ai/config-biome
 
-Reusable Biome configuration for Dawn packages and apps.
+Shared Biome lint/format configuration used by Dawn workspace packages.
 
-Exports:
-- `@dawn-ai/config-biome`
-- `@dawn-ai/config-biome/biome`
+This is an internal Dawn workspace package. For Dawn documentation, see <https://dawn-ai.org>.
 
-Use this package when a Dawn workspace wants the same formatter and linter defaults as the framework repo.
+## License
+
+MIT

--- a/packages/config-typescript/README.md
+++ b/packages/config-typescript/README.md
@@ -4,12 +4,10 @@
 
 # @dawn-ai/config-typescript
 
-Reusable TypeScript base configs for Dawn libraries, Node packages, and Next.js apps.
+Shared TypeScript compiler configurations (`base`, `library`, `node`, `nextjs`) for Dawn workspace packages.
 
-Exports:
-- `@dawn-ai/config-typescript/base`
-- `@dawn-ai/config-typescript/library`
-- `@dawn-ai/config-typescript/node`
-- `@dawn-ai/config-typescript/nextjs`
+This is an internal Dawn workspace package. For Dawn documentation, see <https://dawn-ai.org>.
 
-These configs are published so Dawn-generated apps can extend them directly.
+## License
+
+MIT

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -4,12 +4,10 @@
 
 # @dawn-ai/core
 
-Shared Dawn app discovery, config loading, route validation, and route type generation primitives.
+Filesystem-based route discovery, app config loading, state-field resolution, and typegen primitives that the Dawn CLI builds on.
 
-Public surface:
-- `loadDawnConfig()`
-- `findDawnApp()`
-- `discoverRoutes()`
-- `renderRouteTypes()`
+This is an internal Dawn workspace package. For Dawn documentation, see <https://dawn-ai.org>.
 
-This package owns Dawn's filesystem and metadata conventions. It does not provide a graph runtime.
+## License
+
+MIT

--- a/packages/devkit/README.md
+++ b/packages/devkit/README.md
@@ -4,11 +4,10 @@
 
 # @dawn-ai/devkit
 
-Shared template and file-writing helpers used by Dawn tooling.
+Internal scaffold templates and dev-time tooling shared between `@dawn-ai/cli` and `create-dawn-ai-app`.
 
-Public surface:
-- template resolution helpers
-- template copy/write helpers
-- packaged starter templates consumed by `create-dawn-app`
+This is an internal Dawn workspace package. For Dawn documentation, see <https://dawn-ai.org>.
 
-This package is intentionally small. It exists to keep Dawn scaffolding logic consistent across tools.
+## License
+
+MIT

--- a/packages/langchain/README.md
+++ b/packages/langchain/README.md
@@ -4,11 +4,10 @@
 
 # @dawn-ai/langchain
 
-LangChain backend adapter for Dawn `chain` route kind.
+LangChain backend adapters Dawn uses to materialize `chain` and `agent` routes (tool conversion, streaming, retry).
 
-Public surface:
-- `ChainAdapter` — `BackendAdapter` implementation for LCEL runnables
-- `convertTools()` — converts Dawn tools to LangChain `DynamicStructuredTool`
-- `toolLoop()` — Dawn-owned ReAct tool execution loop (no AgentExecutor dependency)
+This is an internal Dawn workspace package. For Dawn documentation, see <https://dawn-ai.org>.
 
-This package enables Dawn routes to use LangChain LCEL chains with filesystem-driven tool discovery and Dawn-owned execution semantics.
+## License
+
+MIT

--- a/packages/langgraph/README.md
+++ b/packages/langgraph/README.md
@@ -4,11 +4,10 @@
 
 # @dawn-ai/langgraph
 
-Thin Dawn contracts for LangGraph-style route modules.
+LangGraph runtime adapters and route module contracts (`graphAdapter`, `workflowAdapter`, `defineEntry`) used by the Dawn CLI.
 
-Public surface:
-- `defineEntry()`
-- `normalizeRouteModule()`
-- route module and route config types
+This is an internal Dawn workspace package. For Dawn documentation, see <https://dawn-ai.org>.
 
-This package keeps Dawn close to native graph and workflow authoring instead of wrapping execution in a second runtime.
+## License
+
+MIT

--- a/packages/vite-plugin/README.md
+++ b/packages/vite-plugin/README.md
@@ -4,13 +4,10 @@
 
 # @dawn-ai/vite-plugin
 
-Vite plugin for build-time Dawn tool schema inference.
+Vite plugin for Dawn's typegen pipeline (extracts tool types and generates route ambient declarations).
 
-Public surface:
-- `dawnToolSchemaPlugin()` — Vite plugin that watches tool files and runs typegen
-- `transformToolSource()` — injects `description` and `schema` exports from TypeScript types and JSDoc
-- `extractJsDoc()` — extracts JSDoc descriptions and `@param` tags
-- `extractParameterType()` — extracts TypeScript function parameter types
-- `generateZodSchema()` — generates Zod schema code from extracted type info
+This is an internal Dawn workspace package. For Dawn documentation, see <https://dawn-ai.org>.
 
-This plugin enables zero-boilerplate tool authoring by inferring Zod schemas from TypeScript function signatures at build time.
+## License
+
+MIT


### PR DESCRIPTION
## Summary

Normalizes the seven internal-package README.md files to a stub-with-pointer template per the hybrid policy in `docs/superpowers/specs/2026-05-06-docs-review-design.md`.

Each now contains: brand image, package name (matching package.json), one-sentence description (matching `src/index.ts` exports), pointer to `https://dawn-ai.org`, and license. Implements section 6 (F-107..F-113, F-115) of the audit.

**Findings addressed:**
- F-107 (no website pointer in any README) — all seven now point to dawn-ai.org
- F-108 (template inconsistency) — uniform structure across all seven
- F-109 (langchain wrong export names) — corrected
- F-110 (devkit wrong package name reference) — corrected
- F-111 (core omitted typegen/state) — accurate description
- F-112 (langgraph omitted graphAdapter/workflowAdapter) — included
- F-113 (vite-plugin elevated internal helpers) — generalized

## Verification

Pairwise diffs across all seven READMEs show only two line pairs differ — the `# @dawn-ai/<name>` heading and the description sentence. Everything else (image header, "internal Dawn workspace package" pointer line, License section) is byte-identical.

## Test plan

- [x] All seven READMEs follow the same template
- [x] Each package name matches its package.json
- [x] Pointer to https://dawn-ai.org present in all seven
- [ ] CI green