### PR TITLE
chore: add changesets for 0.1.7 release

### DIFF
--- a/.changeset/docs-overhaul.md
+++ b/.changeset/docs-overhaul.md
@@ -1,0 +1,12 @@
+---
+"@dawn-ai/sdk": patch
+"@dawn-ai/cli": patch
+"create-dawn-ai-app": patch
+---
+
+Docs overhaul.
+
+- **Public package READMEs** (`@dawn-ai/sdk`, `@dawn-ai/cli`, `create-dawn-ai-app`) fleshed out with overview, install, key APIs, and links to the website.
+- All package READMEs include the Dawn brand image header.
+
+No code or runtime behavior changes — README content only.

--- a/.changeset/middleware-context-to-tools.md
+++ b/.changeset/middleware-context-to-tools.md
@@ -1,0 +1,25 @@
+---
+"@dawn-ai/sdk": patch
+"@dawn-ai/cli": patch
+"@dawn-ai/langchain": patch
+---
+
+Middleware context now flows through to tools.
+
+A tool's second argument is now `{ middleware?: Readonly<Record<string, unknown>>, signal: AbortSignal }`. Whatever the global middleware passes via `allow({ ... })` is available to every tool invocation as `ctx.middleware` — for both `/runs/wait` and `/runs/stream` paths.
+
+Example:
+
+```ts
+// src/middleware.ts
+export default defineMiddleware(async (req) => {
+  const userId = await verifyToken(req.headers.authorization)
+  return allow({ userId })
+})
+
+// src/app/.../tools/lookup.ts
+export default async (input, { middleware }) => {
+  const userId = middleware?.userId
+  return await db.lookup(userId, input)
+}
+```

--- a/.changeset/production-readiness.md
+++ b/.changeset/production-readiness.md
@@ -1,0 +1,11 @@
+---
+"@dawn-ai/sdk": patch
+"@dawn-ai/cli": patch
+"@dawn-ai/langchain": patch
+---
+
+Production readiness: deployment config, LLM retry, request middleware.
+
+- **@dawn-ai/sdk:** `agent()` descriptor now accepts an optional `retry: { maxAttempts, baseDelay }`. Adds `defineMiddleware`, `reject(status, body?)`, `allow(context?)` for request middleware, plus `MiddlewareRequest`, `MiddlewareResult`, and `RetryConfig` types.
+- **@dawn-ai/cli:** `dawn build` produces a correctly-shaped `langgraph.json` for LangGraph Platform (`dependencies: ["."]`, `env` as file path). `dawn verify` adds an advisory `deps` check (4 checks total). Dev server loads `.env` files and runs middleware before route execution.
+- **@dawn-ai/langchain:** Per-agent retry config (`maxAttempts`, `baseDelayMs`) is wired through the agent adapter and applies to streaming and non-streaming paths.


### PR DESCRIPTION
## Summary

Adds changesets for the unreleased work since 0.1.6:

- **production-readiness.md** — `@dawn-ai/sdk`, `@dawn-ai/cli`, `@dawn-ai/langchain` (deployment config, LLM retry, request middleware)
- **middleware-context-to-tools.md** — `@dawn-ai/sdk`, `@dawn-ai/cli`, `@dawn-ai/langchain` (middleware context flows through to tool invocations)
- **docs-overhaul.md** — `@dawn-ai/sdk`, `@dawn-ai/cli`, `create-dawn-ai-app` (public README overhaul + brand image headers)

All marked `patch` per existing project convention. After this lands, the changesets action will (re)open the "Version Packages" PR and bump everything to `0.1.7`.

PR #32 was closed because it was stale (proposed 0.1.4 → 0.1.5 while main is at 0.1.6).

## Test plan

- [x] All three changeset files validate per `.changeset/config.json`
- [ ] CI green
- [ ] After merge, fresh "Version Packages" PR auto-opens