### PR TITLE
Add fallback issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,7 @@
+## Summary
+
+<!-- Use the bug report or feature request form when possible. Keep this fallback issue focused and reproducible. -->
+
+## Details
+
+<!-- Include relevant packages, commands, versions, reproduction steps, expected behavior, and actual behavior. -->


### PR DESCRIPTION
## Summary
- add a small Markdown fallback issue template so GitHub community profile recognizes an issue template alongside the structured issue forms

## Validation
- git diff --check
- node scripts/check-docs.mjs