### PR TITLE
docs: address remaining minor docs findings

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,13 +20,19 @@ cd my-dawn-app
 pnpm install
 ```
 
-2. Run the scaffolded route. The route path must be quoted because it contains `(`, `)`, and `[]`.
+2. Validate the app and generate types in one call.
+
+```bash
+pnpm exec dawn verify
+```
+
+3. Run the scaffolded route. The route path must be quoted because it contains `(`, `)`, and `[]`.
 
 ```bash
 echo '{"tenant":"acme"}' | pnpm exec dawn run "src/app/(public)/hello/[tenant]"
 ```
 
-3. Optionally start the local runtime in one terminal and send the same route through `--url` from another terminal.
+4. Optionally start the local runtime in one terminal and send the same route through `--url` from another terminal.
 
 ```bash
 pnpm exec dawn dev --port 3001
@@ -39,7 +45,7 @@ A Dawn app root contains `package.json` and `dawn.config.ts`.
 
 Route discovery starts at `src/app` by default.
 
-`appDir` is the only supported config option today.
+`appDir` is the only currently supported config option, and it defaults to `src/app`.
 
 A route is a directory containing `index.ts`. The `index.ts` exports exactly one of four route kinds: an `agent` descriptor (the scaffold default), a `workflow` function, a `graph` function/object, or a `chain`:
 
@@ -167,6 +173,8 @@ pnpm exec dawn build
 - `@dawn-ai/core` owns discovery, config loading, validation, and route types.
 - `@dawn-ai/sdk` owns the backend-neutral author-facing contract: types, helpers, runtime context, and tool authoring.
 - `@dawn-ai/langgraph` is the LangGraph adapter that implements the `@dawn-ai/sdk` contract.
+- `@dawn-ai/langchain` is the LangChain adapter that materializes `chain` and `agent` routes.
+- `@dawn-ai/vite-plugin` is the Vite plugin that drives Dawn's typegen pipeline (extracts tool types, emits ambient route declarations).
 - `@dawn-ai/cli` owns the user-facing commands and local runtime behavior.
 - `create-dawn-ai-app` owns scaffolding for new apps.
 - `@dawn-ai/devkit` owns shared template and file-generation helpers.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,4 +1,4 @@
-<p>
+<p align="center">
   <img src="https://raw.githubusercontent.com/cacheplane/dawnai/main/docs/brand/dawn-logo-horizontal-black-on-white.png" alt="Dawn" width="180" />
 </p>
 

--- a/packages/config-biome/README.md
+++ b/packages/config-biome/README.md
@@ -1,4 +1,4 @@
-<p>
+<p align="center">
   <img src="https://raw.githubusercontent.com/cacheplane/dawnai/main/docs/brand/dawn-logo-horizontal-black-on-white.png" alt="Dawn" width="180" />
 </p>
 

--- a/packages/config-typescript/README.md
+++ b/packages/config-typescript/README.md
@@ -1,4 +1,4 @@
-<p>
+<p align="center">
   <img src="https://raw.githubusercontent.com/cacheplane/dawnai/main/docs/brand/dawn-logo-horizontal-black-on-white.png" alt="Dawn" width="180" />
 </p>
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,4 +1,4 @@
-<p>
+<p align="center">
   <img src="https://raw.githubusercontent.com/cacheplane/dawnai/main/docs/brand/dawn-logo-horizontal-black-on-white.png" alt="Dawn" width="180" />
 </p>
 

--- a/packages/create-dawn-app/README.md
+++ b/packages/create-dawn-app/README.md
@@ -1,4 +1,4 @@
-<p>
+<p align="center">
   <img src="https://raw.githubusercontent.com/cacheplane/dawnai/main/docs/brand/dawn-logo-horizontal-black-on-white.png" alt="Dawn" width="180" />
 </p>
 

--- a/packages/devkit/README.md
+++ b/packages/devkit/README.md
@@ -1,4 +1,4 @@
-<p>
+<p align="center">
   <img src="https://raw.githubusercontent.com/cacheplane/dawnai/main/docs/brand/dawn-logo-horizontal-black-on-white.png" alt="Dawn" width="180" />
 </p>
 

--- a/packages/langchain/README.md
+++ b/packages/langchain/README.md
@@ -1,4 +1,4 @@
-<p>
+<p align="center">
   <img src="https://raw.githubusercontent.com/cacheplane/dawnai/main/docs/brand/dawn-logo-horizontal-black-on-white.png" alt="Dawn" width="180" />
 </p>
 

--- a/packages/langgraph/README.md
+++ b/packages/langgraph/README.md
@@ -1,4 +1,4 @@
-<p>
+<p align="center">
   <img src="https://raw.githubusercontent.com/cacheplane/dawnai/main/docs/brand/dawn-logo-horizontal-black-on-white.png" alt="Dawn" width="180" />
 </p>
 

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -1,4 +1,4 @@
-<p>
+<p align="center">
   <img src="https://raw.githubusercontent.com/cacheplane/dawnai/main/docs/brand/dawn-logo-horizontal-black-on-white.png" alt="Dawn" width="180" />
 </p>
 

--- a/packages/vite-plugin/README.md
+++ b/packages/vite-plugin/README.md
@@ -1,4 +1,4 @@
-<p>
+<p align="center">
   <img src="https://raw.githubusercontent.com/cacheplane/dawnai/main/docs/brand/dawn-logo-horizontal-black-on-white.png" alt="Dawn" width="180" />
 </p>
 


### PR DESCRIPTION
## Summary

Closes the remaining actionable minor findings from #45.

**Fixed in this PR (4):**
- **F-007** — README Quickstart now includes a `dawn verify` step between install and run
- **F-009** — Reworded `appDir` line to include the default value (`src/app`) inline
- **F-011** — Added `@dawn-ai/langchain` and `@dawn-ai/vite-plugin` to README Packages list
- **F-114** — Normalized brand image headers across all 10 package READMEs to centered (`<p align="center">`) for consistency with root README

**Already resolved by prior fix PRs (23):** F-013, F-022, F-026, F-029, F-030, F-044, F-052, F-055, F-056, F-062, F-065, F-071, F-075, F-084, F-085, F-093, F-099, F-100, F-105, F-106, F-108, F-110, F-111, F-112, F-113.

**Explicitly deferred (4):**
- F-087 (verify external `dawnai.org/llms-full.txt` URL) — operational, not a docs change
- F-115 (hardcoded `cacheplane/dawnai@main` raw URL) — tracking concern for future repo-rename
- F-073 / F-074 (new middleware/retry pages) — already deferred per spec (new pages out of scope)

After this lands, #45 can be closed.

## Test plan

- [x] `pnpm --filter web build` succeeds
- [x] `pack --dry-run` confirms README still in published files for `@dawn-ai/sdk`, `@dawn-ai/cli`, `create-dawn-ai-app`
- [ ] CI green