### PR TITLE
chore: drive cli.mdx completeness check from commander registry

### DIFF
--- a/scripts/check-docs.mjs
+++ b/scripts/check-docs.mjs
@@ -1,5 +1,6 @@
 import { readFileSync } from "node:fs"
 import { resolve } from "node:path"
+import { pathToFileURL } from "node:url"
 
 const repoRoot = resolve(import.meta.dirname, "..")
 
@@ -23,6 +24,57 @@ for (const check of checks) {
   for (const pattern of check.patterns) {
     if (!source.includes(pattern)) {
       failures.push(`${check.file} is missing required docs text: ${pattern}`)
+    }
+  }
+}
+
+// CLI surface check — drive from the commander registry to catch docs drift.
+// Every user-facing command name and every long option must be referenced in
+// cli.mdx. The internal `dev-child` command is excluded (not user-facing).
+const cliMdxPath = resolve(repoRoot, "apps/web/content/docs/cli.mdx")
+const cliMdx = readFileSync(cliMdxPath, "utf8")
+
+const cliEntryUrl = pathToFileURL(
+  resolve(repoRoot, "packages/cli/dist/index.js"),
+).href
+const cliEntry = await import(cliEntryUrl).catch((error) => {
+  failures.push(
+    `CLI surface check could not import packages/cli/dist/index.js — did you run pnpm build? (${error.message})`,
+  )
+  return null
+})
+
+if (cliEntry?.createProgram) {
+  const noopIo = {
+    stdout: () => undefined,
+    stderr: () => undefined,
+  }
+  const program = cliEntry.createProgram(noopIo)
+
+  const HIDDEN_COMMANDS = new Set(["__dev-child"])
+
+  for (const command of program.commands) {
+    const name = command.name()
+    if (HIDDEN_COMMANDS.has(name)) {
+      continue
+    }
+
+    if (!cliMdx.includes(`dawn ${name}`)) {
+      failures.push(
+        `apps/web/content/docs/cli.mdx is missing reference to command \`dawn ${name}\``,
+      )
+    }
+
+    for (const option of command.options) {
+      const flag = option.long ?? option.short
+      if (!flag) {
+        continue
+      }
+      if (!cliMdx.includes(flag)) {
+        failures.push(
+          `apps/web/content/docs/cli.mdx is missing reference to \`${flag}\` (option of \`dawn ${name}\`)`,
+        )
+      }
     }
   }
 }

--- a/scripts/check-docs.mjs
+++ b/scripts/check-docs.mjs
@@ -34,9 +34,7 @@ for (const check of checks) {
 const cliMdxPath = resolve(repoRoot, "apps/web/content/docs/cli.mdx")
 const cliMdx = readFileSync(cliMdxPath, "utf8")
 
-const cliEntryUrl = pathToFileURL(
-  resolve(repoRoot, "packages/cli/dist/index.js"),
-).href
+const cliEntryUrl = pathToFileURL(resolve(repoRoot, "packages/cli/dist/index.js")).href
 const cliEntry = await import(cliEntryUrl).catch((error) => {
   failures.push(
     `CLI surface check could not import packages/cli/dist/index.js — did you run pnpm build? (${error.message})`,


### PR DESCRIPTION
## Summary

Extends \`scripts/check-docs.mjs\` to introspect the CLI command tree at runtime: every user-facing command name and every option flag must appear in \`apps/web/content/docs/cli.mdx\`, or CI fails.

## Why

The docs audit (#39) found multiple drift instances of this exact class:
- F-046 — \`cli.mdx\` listed 3 of 8 commands
- F-052 / F-053 — documented non-existent flags (\`--url\`/\`--filter\` on \`dawn test\`)
- F-056 — typegen output description omitted artifacts

The \`cli.mdx\` content fixes landed in PR B (#40), but nothing prevents recurrence. This check makes the drift class fail-fast at \`pnpm ci:validate\` time.

## What it does

- Imports \`createProgram\` from the built \`@dawn-ai/cli\` (CI runs \`pnpm build\` before \`check-docs\`, so the dist is available)
- Walks every \`program.commands\` and asserts \`dawn <name>\` appears in \`cli.mdx\`
- Walks each command's \`options\` and asserts every long flag appears
- Excludes \`__dev-child\` (internal-only)

## Verification

- Passes against current main: \`Docs completeness check passed.\`
- Drift simulation (rename \`--port\` to \`--prt\`): \`apps/web/content/docs/cli.mdx is missing reference to \\\`--port\\\` (option of \\\`dawn dev\\\`)\`
- Drift simulation (rename a command): correctly fails

## Test plan

- [x] Passes locally
- [x] Simulated drift correctly fails the check
- [ ] CI green