### PR TITLE
docs: add Middleware and Retry pages

### DIFF
--- a/apps/web/app/components/docs/nav.ts
+++ b/apps/web/app/components/docs/nav.ts
@@ -19,6 +19,8 @@ export const DOCS_NAV: readonly DocsNavSection[] = [
       { label: "Routes", href: "/docs/routes" },
       { label: "Tools", href: "/docs/tools" },
       { label: "State", href: "/docs/state" },
+      { label: "Middleware", href: "/docs/middleware" },
+      { label: "Retry", href: "/docs/retry" },
     ],
   },
   {

--- a/apps/web/app/docs/middleware/page.tsx
+++ b/apps/web/app/docs/middleware/page.tsx
@@ -1,0 +1,9 @@
+import type { Metadata } from "next"
+import Content from "../../../content/docs/middleware.mdx"
+import { DocsPage } from "../../components/docs/DocsPage"
+
+export const metadata: Metadata = { title: "Middleware" }
+
+export default function Page() {
+  return <DocsPage href="/docs/middleware" Content={Content} />
+}

--- a/apps/web/app/docs/retry/page.tsx
+++ b/apps/web/app/docs/retry/page.tsx
@@ -1,0 +1,9 @@
+import type { Metadata } from "next"
+import Content from "../../../content/docs/retry.mdx"
+import { DocsPage } from "../../components/docs/DocsPage"
+
+export const metadata: Metadata = { title: "Retry" }
+
+export default function Page() {
+  return <DocsPage href="/docs/retry" Content={Content} />
+}

--- a/apps/web/content/docs/deployment.mdx
+++ b/apps/web/content/docs/deployment.mdx
@@ -54,7 +54,7 @@ Dawn does not host or run production traffic itself. It owns local development (
     - If you keep a hand-authored `langgraph.json` at the app root, `dawn build` shallow-merges it on top of the generated values.
   </Step>
   <Step title="Per-route middleware (optional)">
-    `src/middleware.ts` (default-exporting a function from `defineMiddleware`) runs before every `/runs/wait` and `/runs/stream` request — identically in `dawn dev` and on LangGraph Platform. Use it to gate access by header, populate request-scoped context, or `reject(status, body)` unauthorized callers. See [Routes](/docs/routes#middleware) for the API.
+    `src/middleware.ts` (default-exporting a function from `defineMiddleware`) runs before every `/runs/wait` and `/runs/stream` request — identically in `dawn dev` and on LangGraph Platform. Use it to gate access by header, populate request-scoped context, or `reject(status, body)` unauthorized callers. See [Middleware](/docs/middleware) for the API.
   </Step>
   <Step title="Push to your Platform-connected remote">
     The LangGraph Platform builds the image from `.dawn/build/` and provisions assistants keyed by the `<routeId>#<kind>` ids in the generated `langgraph.json`. From there, your agents and harnesses can hit the deployed endpoints using the same protocol they already speak locally.

--- a/apps/web/content/docs/dev-server.mdx
+++ b/apps/web/content/docs/dev-server.mdx
@@ -78,7 +78,7 @@ The `assistant_id` format `<routeId>#<kind>` is the same format `dawn build` wri
 
 `src/middleware.ts` (default-exporting a function returned by `defineMiddleware`) runs before every `/runs/wait` and `/runs/stream` request. It can short-circuit a request with `reject(status, body?)`, or continue with `allow(context?)` — the optional `context` flows to every tool as `ctx.middleware` (a `Readonly<Record<string, unknown>>`).
 
-`MiddlewareRequest` shape: `{ assistantId, headers, method, params, routeId, url }`. See [Routes](/docs/routes#middleware) for the full reference; a dedicated middleware page is tracked as a follow-up.
+`MiddlewareRequest` shape: `{ assistantId, headers, method, params, routeId, url }`. See [Middleware](/docs/middleware) for the full reference.
 
 ## Hot reload
 

--- a/apps/web/content/docs/middleware.mdx
+++ b/apps/web/content/docs/middleware.mdx
@@ -1,0 +1,116 @@
+# Middleware
+
+Dawn supports a single global request middleware for authentication, request shaping, and per-request context. The middleware runs once per request, before any route executes, and its decision (allow or reject) gates execution.
+
+## File location
+
+Define middleware as a default-exported function in `src/middleware.ts` (or `middleware.ts` at the app root):
+
+```ts
+// src/middleware.ts
+import { allow, defineMiddleware, reject } from "@dawn-ai/sdk"
+
+export default defineMiddleware(async (req) => {
+  if (!req.headers["x-api-key"]) {
+    return reject(401, { error: "Missing x-api-key" })
+  }
+  return allow()
+})
+```
+
+If `src/middleware.ts` is absent, every request is allowed.
+
+## API
+
+### `defineMiddleware(fn)`
+
+Identity helper that types `fn` as `DawnMiddleware`. Use it for editor inference:
+
+```ts
+type DawnMiddleware = (
+  req: MiddlewareRequest,
+) => Promise<MiddlewareResult> | MiddlewareResult
+```
+
+### `MiddlewareRequest`
+
+The argument every middleware receives. All values are pre-parsed:
+
+| Field | Shape | Notes |
+|---|---|---|
+| `headers` | `Readonly<Record<string, string>>` | Lowercase keys (Node convention). Multi-value headers joined with `, `. |
+| `params` | `Readonly<Record<string, string>>` | Dynamic-segment values extracted from the request input, e.g. `{ tenant: "acme" }` for `/hello/[tenant]`. |
+| `routeId` | `string` | E.g. `"/hello/[tenant]"`. |
+| `assistantId` | `string` | E.g. `"/hello/[tenant]#agent"`. |
+| `method` | `string` | HTTP method. |
+| `url` | `string` | Path + query, e.g. `"/runs/wait"`. |
+
+### `reject(status, body?)`
+
+Stops execution and responds with the given HTTP status. Optional `body` is JSON-encoded into the response.
+
+```ts
+return reject(401, { error: "Unauthorized" })
+return reject(403)  // body omitted
+```
+
+### `allow(context?)`
+
+Lets the request proceed. Optional `context` is a record of arbitrary values that flows into every tool invocation as `ctx.middleware`. See [Context flow to tools](#context-flow-to-tools) below.
+
+```ts
+return allow()
+return allow({ userId, plan: "pro" })
+```
+
+## Context flow to tools
+
+Whatever you pass to `allow({ ... })` is delivered to every tool call for that request via the second argument:
+
+```ts
+// src/middleware.ts
+export default defineMiddleware(async (req) => {
+  const userId = await verifyJwt(req.headers.authorization)
+  return allow({ userId })
+})
+
+// src/app/(public)/hello/[tenant]/tools/lookup.ts
+export default async (
+  input: { readonly query: string },
+  ctx: { readonly middleware?: Readonly<Record<string, unknown>>; readonly signal: AbortSignal },
+) => {
+  const userId = ctx.middleware?.userId as string | undefined
+  return await db.search(userId, input.query)
+}
+```
+
+Context is per-request — there is no shared state between requests. The `middleware` field is `undefined` if no middleware is defined, or if the middleware called `allow()` without arguments.
+
+## Single-function model
+
+Dawn middleware is intentionally a single global function, not an array of layered middlewares. If you need branching by route, do it with normal control flow inside the function:
+
+```ts
+export default defineMiddleware(async (req) => {
+  if (req.routeId.startsWith("/admin/")) {
+    return await requireAdmin(req)
+  }
+  return await requireApiKey(req)
+})
+```
+
+This keeps the request lifecycle predictable and avoids ordering questions about per-route middleware.
+
+## Where middleware runs
+
+Middleware runs in the dev server (`dawn dev`) and is included in the deployment artifacts produced by `dawn build`. Both `/runs/wait` and `/runs/stream` invoke middleware before any route executes. The `/healthz` endpoint bypasses middleware (it's a liveness probe).
+
+## Errors thrown from middleware
+
+If the middleware function throws, the request is rejected with HTTP `500`. Prefer explicit `reject(status, body?)` over throwing — it gives users a meaningful response.
+
+## Related
+
+- [Routes](/docs/routes) — how route discovery and dynamic segments work
+- [Tools](/docs/tools) — full tool authoring contract, including the `ctx` shape
+- [Dev Server](/docs/dev-server) — request envelope and assistant-id format

--- a/apps/web/content/docs/retry.mdx
+++ b/apps/web/content/docs/retry.mdx
@@ -1,0 +1,95 @@
+# Retry
+
+Agent routes can opt into automatic retry of transient LLM failures via the `retry` field on `agent()`. Retries apply to rate limits, server errors, network timeouts, and OpenAI overload responses — but not to non-transient errors like invalid API keys or model-not-found.
+
+## Configuring retry
+
+Set `retry` on the `agent()` descriptor:
+
+```ts
+// src/app/(public)/hello/[tenant]/index.ts
+import { agent } from "@dawn-ai/sdk"
+
+export default agent({
+  model: "gpt-4o-mini",
+  retry: { maxAttempts: 5, baseDelay: 500 },
+  systemPrompt: "You are a helpful assistant.",
+})
+```
+
+| Field | Default | Notes |
+|---|---|---|
+| `maxAttempts` | `3` | Total number of attempts (including the first call). `1` disables retry. |
+| `baseDelay` | `1000` (ms) | Base delay before the first retry. Backoff is exponential with jitter. |
+
+If `retry` is omitted, agents use the defaults (3 attempts, 1s base delay). To disable retry entirely, set `maxAttempts: 1`.
+
+## What's retried
+
+The retry policy retries on errors whose message indicates a transient condition:
+
+- **Rate limits:** `429`, `rate limit`
+- **Server errors:** `500`, `502`, `503`
+- **Network errors:** `ECONNRESET`, `ECONNREFUSED`, `ETIMEDOUT`, `timeout`, `network`
+- **OpenAI transient:** `overloaded`, `server_error`
+
+Anything else (invalid API key, model not found, schema validation errors, abort) fails immediately without retry.
+
+## Backoff
+
+Delay before retry `n` (zero-indexed) is:
+
+```
+delay = min(baseDelay * 2^n + jitter, 10s)
+jitter = random(0, 500ms)
+```
+
+So with the defaults (1s base, 3 attempts):
+
+| Attempt | Delay before this attempt |
+|---|---|
+| 1 (initial) | 0 |
+| 2 | ~1000–1500 ms |
+| 3 | ~2000–2500 ms |
+
+The cap at 10 seconds prevents pathological backoff for long retry chains.
+
+## Streaming behavior
+
+For streaming routes, retry only applies if the failure happens **before any token is yielded to the client**. Once tokens have been streamed, the partial response is committed — Dawn cannot retry a partially-emitted stream because the client has already seen content. In that case the error propagates to the SSE stream's `done` event.
+
+If you need stronger retry guarantees in streaming mode, lower `baseDelay` to make the initial connection retry faster, or wrap the call at a higher level in your client.
+
+## Abort signals
+
+If the request's `AbortSignal` fires mid-retry (client disconnect, server shutdown), the retry chain aborts immediately with `Operation aborted`. This is the same signal that propagates to your tool implementations as `ctx.signal`.
+
+## Per-route, not global
+
+Retry is configured per `agent()` descriptor. Different routes can have different policies:
+
+```ts
+// Critical billing-related route — fail fast on transient errors
+export default agent({
+  model: "gpt-4o-mini",
+  retry: { maxAttempts: 1 },
+  systemPrompt: "...",
+})
+```
+
+```ts
+// Best-effort summarization route — patient retry
+export default agent({
+  model: "gpt-4o-mini",
+  retry: { maxAttempts: 5, baseDelay: 2000 },
+  systemPrompt: "...",
+})
+```
+
+There is no global retry config — each route states its own intent.
+
+## Related
+
+- [Routes](/docs/routes) — `agent()` descriptor and the four route kinds
+- [Tools](/docs/tools) — tool error handling and the `ctx.signal` contract
+- [Deployment](/docs/deployment) — how retry composes with `dawn build` output

--- a/apps/web/content/docs/routes.mdx
+++ b/apps/web/content/docs/routes.mdx
@@ -83,7 +83,7 @@ export default agent({
 
 - `model` — a `KnownModelId` (typed string covering OpenAI, Anthropic, and Google model ids).
 - `systemPrompt` — the system message for the agent.
-- `retry?: RetryConfig` — optional `{ maxAttempts?: number, baseDelay?: number }` policy. See `packages/sdk/src/agent.ts` for the exact shape; a dedicated retry-policy reference is tracked as a follow-up.
+- `retry?: RetryConfig` — optional `{ maxAttempts?: number, baseDelay?: number }` policy. See [Retry](/docs/retry) for the full reference.
 
 At build time, `dawn build` emits a LangGraph entry that calls `agent.bindTools(...)` with every tool discovered for the route, so any tool in the route's `tools/` directory (and any shared tool in `src/tools/`) is automatically available to the LLM.
 
@@ -103,7 +103,7 @@ export default defineMiddleware(async (req) => {
 })
 ```
 
-`MiddlewareRequest` exposes `assistantId`, `routeId`, `headers`, `params`, `method`, and `url`. The optional `context` passed to `allow(...)` is forwarded to every tool as `ctx.middleware` (see [Tools](/docs/tools)). A dedicated middleware page is tracked as a follow-up; until then, the source of truth is `packages/sdk/src/middleware.ts`.
+`MiddlewareRequest` exposes `assistantId`, `routeId`, `headers`, `params`, `method`, and `url`. The optional `context` passed to `allow(...)` is forwarded to every tool as `ctx.middleware` (see [Tools](/docs/tools)). For the full reference, see [Middleware](/docs/middleware).
 
 ## Pathname rules
 

--- a/apps/web/content/docs/testing.mdx
+++ b/apps/web/content/docs/testing.mdx
@@ -96,10 +96,8 @@ dawn test
 
 Two cross-cutting features shape what scenarios assert:
 
-- **Agent retries** — `agent({ retry: { maxAttempts, baseDelay } })` retries on transient errors. To assert the exhausted-retry path, set `expect.status: "failed"` and use `expect.error` (or an `assert` callback with `expectError`).
-- **Middleware** — `src/middleware.ts` runs before every `/runs/wait` and `/runs/stream` request. **Live-server scenarios (`run: { url }`) exercise middleware; in-process scenarios bypass it.** A scenario whose middleware calls `reject(...)` should set `expect.status: "failed"` with a matching `expect.error`.
-
-A dedicated middleware page is tracked as a follow-up.
+- **Agent retries** — `agent({ retry: { maxAttempts, baseDelay } })` retries on transient errors. To assert the exhausted-retry path, set `expect.status: "failed"` and use `expect.error` (or an `assert` callback with `expectError`). See [Retry](/docs/retry).
+- **Middleware** — `src/middleware.ts` runs before every `/runs/wait` and `/runs/stream` request. **Live-server scenarios (`run: { url }`) exercise middleware; in-process scenarios bypass it.** A scenario whose middleware calls `reject(...)` should set `expect.status: "failed"` with a matching `expect.error`. See [Middleware](/docs/middleware).
 
 ## Mocking tools
 

--- a/apps/web/content/docs/tools.mdx
+++ b/apps/web/content/docs/tools.mdx
@@ -36,7 +36,7 @@ export default async (
 }
 ```
 
-The second parameter is optional but recommended for any tool that does network I/O, holds long-running work, or needs middleware-derived context. See [Routes](/docs/routes#middleware) for how `defineMiddleware` and `allow(context)` populate `ctx.middleware`.
+The second parameter is optional but recommended for any tool that does network I/O, holds long-running work, or needs middleware-derived context. See [Middleware](/docs/middleware) for how `defineMiddleware` and `allow(context)` populate `ctx.middleware`.
 
 ## Invoking a tool
 


### PR DESCRIPTION
## Summary

Closes F-073 and F-074 from the docs audit (#39) — both features ship today but had no dedicated documentation pages.

**New pages:**
- \`/docs/middleware\` — \`src/middleware.ts\`, \`defineMiddleware\`, \`allow(context?)\`, \`reject(status, body?)\`, the \`MiddlewareRequest\` shape, and how \`allow({ ... })\` context flows into tools as \`ctx.middleware\`.
- \`/docs/retry\` — \`agent({ retry: { maxAttempts, baseDelay } })\`, which errors retry, the backoff curve, streaming behavior, and abort-signal interaction.

**Updated:** the prior \"tracked as a follow-up\" stubs in \`routes.mdx\`, \`tools.mdx\`, \`dev-server.mdx\`, \`deployment.mdx\`, and \`testing.mdx\` now link to the new pages.

**Sidebar:** both pages added to the Core Concepts section.

## Test plan

- [x] \`pnpm --filter web build\` succeeds, both new routes show up in the build output
- [x] All cross-links to the new pages resolve
- [ ] CI green