### PR TITLE
feat(sdk): add @dawn-ai/sdk/testing as canonical home for test helpers

### DIFF
--- a/.changeset/move-testing-to-sdk.md
+++ b/.changeset/move-testing-to-sdk.md
@@ -1,0 +1,18 @@
+---
+"@dawn-ai/sdk": patch
+"@dawn-ai/cli": patch
+---
+
+Move testing helpers to `@dawn-ai/sdk/testing`.
+
+`expectError`, `expectMeta`, `expectOutput`, and the `RuntimeExecutionResult` type family now live at `@dawn-ai/sdk/testing` — the canonical home users have been intuitively reaching for. The old `@dawn-ai/cli/testing` subpath continues to work as a re-export for back-compat (and is now JSDoc-deprecated).
+
+```ts
+// Preferred
+import { expectError, expectMeta, expectOutput } from "@dawn-ai/sdk/testing"
+
+// Still works (re-exports from sdk)
+import { expectError, expectMeta, expectOutput } from "@dawn-ai/cli/testing"
+```
+
+No behavior change. The packed runtime contract test now exercises both subpaths.

--- a/apps/web/content/docs/testing.mdx
+++ b/apps/web/content/docs/testing.mdx
@@ -45,10 +45,10 @@ The `expect` object accepts:
 - `meta?` — match against `{ mode, routeId, routePath, executionSource }`.
 - `error?` — for `status: "failed"`, match `{ kind, message: string | { includes: string } }`.
 
-For programmatic assertions in `assert(result)`, import the helpers from `@dawn-ai/cli/testing`:
+For programmatic assertions in `assert(result)`, import the helpers from `@dawn-ai/sdk/testing`:
 
 ```ts
-import { expectError, expectMeta, expectOutput } from "@dawn-ai/cli/testing"
+import { expectError, expectMeta, expectOutput } from "@dawn-ai/sdk/testing"
 
 export default [
   {
@@ -114,7 +114,7 @@ Two cross-cutting features shape what scenarios assert:
   <Step title="Default-exported array">
     The file's default export is the array of scenario records. There is no `describe()` or `test()` wrapper.
   </Step>
-  <Step title="Use the helpers from @dawn-ai/cli/testing for custom assertions">
+  <Step title="Use the helpers from @dawn-ai/sdk/testing for custom assertions">
     `expectOutput`, `expectMeta`, and `expectError` cover deep-equal match (with helpful diffs). For partial or fuzzy matching today, use the declarative `expect` shape (`output`/`meta`/`error`) or write a custom predicate in `assert(result)`.
   </Step>
   <Step title="Keep scenarios focused">

--- a/apps/web/content/templates/AGENTS.md
+++ b/apps/web/content/templates/AGENTS.md
@@ -15,7 +15,7 @@ This project uses **Dawn**, a TypeScript-first meta-framework for building graph
 - **`src/app/**/tools/*.ts`** — co-located tools. Each file has a default export that is an async function. Types are inferred and written to `dawn.generated.d.ts`.
 - **`src/tools/*.ts`** — shared tools (optional). Discovered alongside route-local tools and merged into every route's tool registry. Route-local tools override shared tools with the same name.
 - **`src/middleware.ts`** — optional. Default-exports a function returned by `defineMiddleware(...)`. Runs before every `/runs/wait` and `/runs/stream` request, on `dawn dev` and on LangGraph Platform.
-- **`src/app/**/run.test.ts`** — colocated scenario tests. Default-export an array of scenario records (`{ name, input, expect, run?, assert? }`). Custom assertion helpers live at `@dawn-ai/cli/testing` (`expectOutput`, `expectMeta`, `expectError`).
+- **`src/app/**/run.test.ts`** — colocated scenario tests. Default-export an array of scenario records (`{ name, input, expect, run?, assert? }`). Custom assertion helpers live at `@dawn-ai/sdk/testing` (`expectOutput`, `expectMeta`, `expectError`).
 - **`dawn.generated.d.ts`** — auto-generated. Do NOT edit by hand.
 - **`dawn:routes`** — virtual module emitted by the Dawn Vite plugin and backed by `dawn.generated.d.ts`. If `RouteTools` does not resolve, run `dawn typegen`.
 
@@ -124,7 +124,7 @@ The `RouteTools<"/hello/[tenant]">` lookup uses the route's pathname as the key 
 - `@dawn-ai/sdk` — backend-neutral contract: `agent`, `defineMiddleware`, `allow`, `reject`, types (`RuntimeContext` carries `signal: AbortSignal`, `AgentConfig`, `RetryConfig`, `MiddlewareRequest`, etc.).
 - `@dawn-ai/langgraph` — adapter for LangGraph graphs and workflows.
 - `@dawn-ai/langchain` — adapter for LangChain LCEL chains.
-- `@dawn-ai/cli` — the `dawn` CLI. Test helpers live at `@dawn-ai/cli/testing`.
+- `@dawn-ai/cli` — the `dawn` CLI. Test helpers live at `@dawn-ai/sdk/testing`.
 
 ## Do Not
 

--- a/apps/web/content/templates/CLAUDE.md
+++ b/apps/web/content/templates/CLAUDE.md
@@ -15,7 +15,7 @@ This project uses **Dawn**, a TypeScript-first meta-framework for building graph
 - **`src/app/**/tools/*.ts`** — co-located tools. Each file has a default export that is an async function. Types are inferred and written to `dawn.generated.d.ts`.
 - **`src/tools/*.ts`** — shared tools (optional). Discovered alongside route-local tools and merged into every route's tool registry. Route-local tools override shared tools with the same name.
 - **`src/middleware.ts`** — optional. Default-exports a function returned by `defineMiddleware(...)`. Runs before every `/runs/wait` and `/runs/stream` request, on `dawn dev` and on LangGraph Platform.
-- **`src/app/**/run.test.ts`** — colocated scenario tests. Default-export an array of scenario records (`{ name, input, expect, run?, assert? }`). Custom assertion helpers live at `@dawn-ai/cli/testing` (`expectOutput`, `expectMeta`, `expectError`).
+- **`src/app/**/run.test.ts`** — colocated scenario tests. Default-export an array of scenario records (`{ name, input, expect, run?, assert? }`). Custom assertion helpers live at `@dawn-ai/sdk/testing` (`expectOutput`, `expectMeta`, `expectError`).
 - **`dawn.generated.d.ts`** — auto-generated. Do NOT edit by hand.
 - **`dawn:routes`** — virtual module emitted by the Dawn Vite plugin and backed by `dawn.generated.d.ts`. If `RouteTools` does not resolve, run `dawn typegen`.
 
@@ -124,7 +124,7 @@ The `RouteTools<"/hello/[tenant]">` lookup uses the route's pathname as the key 
 - `@dawn-ai/sdk` — backend-neutral contract: `agent`, `defineMiddleware`, `allow`, `reject`, types (`RuntimeContext` carries `signal: AbortSignal`, `AgentConfig`, `RetryConfig`, `MiddlewareRequest`, etc.).
 - `@dawn-ai/langgraph` — adapter for LangGraph graphs and workflows.
 - `@dawn-ai/langchain` — adapter for LangChain LCEL chains.
-- `@dawn-ai/cli` — the `dawn` CLI. Test helpers live at `@dawn-ai/cli/testing`.
+- `@dawn-ai/cli` — the `dawn` CLI. Test helpers live at `@dawn-ai/sdk/testing`.
 
 ## Do Not
 

--- a/packages/cli/src/commands/test.ts
+++ b/packages/cli/src/commands/test.ts
@@ -1,7 +1,7 @@
+import { expectError, expectMeta, expectOutput } from "@dawn-ai/sdk/testing"
 import { type Command, CommanderError } from "commander"
 
 import { CliError, type CommandIo, formatErrorMessage, writeLine } from "../lib/output.js"
-import { expectError, expectMeta, expectOutput } from "../lib/runtime/assertions.js"
 import { executeRoute } from "../lib/runtime/execute-route.js"
 import { executeRouteServer } from "../lib/runtime/execute-route-server.js"
 import {

--- a/packages/cli/src/lib/runtime/result.ts
+++ b/packages/cli/src/lib/runtime/result.ts
@@ -1,49 +1,21 @@
-export type RuntimeExecutionMode = "agent" | "chain" | "graph" | "workflow"
+import type {
+  RuntimeExecutionErrorKind,
+  RuntimeExecutionFailureResult,
+  RuntimeExecutionMode,
+  RuntimeExecutionSuccessResult,
+  RuntimeExecutionTiming,
+} from "@dawn-ai/sdk/testing"
 
-export type RuntimeExecutionErrorKind =
-  | "app_discovery_error"
-  | "execution_error"
-  | "route_resolution_error"
-  | "server_transport_error"
-  | "unsupported_route_boundary"
-
-export interface RuntimeExecutionError {
-  readonly details?: Record<string, unknown>
-  readonly kind: RuntimeExecutionErrorKind
-  readonly message: string
-}
-
-export interface RuntimeExecutionTiming {
-  readonly durationMs: number
-  readonly finishedAt: string
-  readonly startedAt: string
-}
-
-export interface RuntimeExecutionBaseResult extends RuntimeExecutionTiming {
-  readonly appRoot: string | null
-  readonly diagnostics?: Record<string, unknown>
-  readonly executionSource: "in-process" | "server"
-  readonly mode: RuntimeExecutionMode | null
-  readonly routeId: string | null
-  readonly routePath: string | null
-}
-
-export interface RuntimeExecutionSuccessResult extends RuntimeExecutionBaseResult {
-  readonly appRoot: string
-  readonly executionSource: "in-process" | "server"
-  readonly mode: RuntimeExecutionMode
-  readonly output: unknown
-  readonly routeId: string
-  readonly routePath: string
-  readonly status: "passed"
-}
-
-export interface RuntimeExecutionFailureResult extends RuntimeExecutionBaseResult {
-  readonly error: RuntimeExecutionError
-  readonly status: "failed"
-}
-
-export type RuntimeExecutionResult = RuntimeExecutionSuccessResult | RuntimeExecutionFailureResult
+export type {
+  RuntimeExecutionBaseResult,
+  RuntimeExecutionError,
+  RuntimeExecutionErrorKind,
+  RuntimeExecutionFailureResult,
+  RuntimeExecutionMode,
+  RuntimeExecutionResult,
+  RuntimeExecutionSuccessResult,
+  RuntimeExecutionTiming,
+} from "@dawn-ai/sdk/testing"
 
 export function createRuntimeSuccessResult(options: {
   readonly appRoot: string

--- a/packages/cli/src/testing/index.ts
+++ b/packages/cli/src/testing/index.ts
@@ -1,1 +1,6 @@
-export { expectError, expectMeta, expectOutput } from "../lib/runtime/assertions.js"
+/**
+ * @deprecated Import from `@dawn-ai/sdk/testing` instead. This subpath
+ * re-exports the same helpers for back-compat and will continue to work,
+ * but new code should prefer the canonical SDK home.
+ */
+export { expectError, expectMeta, expectOutput } from "@dawn-ai/sdk/testing"

--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
       "@dawn-ai/core": resolve(rootDir, "../core/src/index.ts"),
       "@dawn-ai/langchain": resolve(rootDir, "../langchain/src/index.ts"),
       "@dawn-ai/langgraph": resolve(rootDir, "../langgraph/src/index.ts"),
+      "@dawn-ai/sdk/testing": resolve(rootDir, "../sdk/src/testing/index.ts"),
       "@dawn-ai/sdk": resolve(rootDir, "../sdk/src/index.ts"),
     },
   },

--- a/packages/langchain/vitest.config.ts
+++ b/packages/langchain/vitest.config.ts
@@ -9,6 +9,7 @@ export default defineConfig({
   resolve: {
     alias: {
       "@dawn-ai/langchain": resolve(rootDir, "src/index.ts"),
+      "@dawn-ai/sdk/testing": resolve(rootDir, "../sdk/src/testing/index.ts"),
       "@dawn-ai/sdk": resolve(rootDir, "../sdk/src/index.ts"),
     },
   },

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -24,6 +24,10 @@
     ".": {
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
+    },
+    "./testing": {
+      "types": "./dist/testing/index.d.ts",
+      "default": "./dist/testing/index.js"
     }
   },
   "publishConfig": {

--- a/packages/sdk/src/runtime-result.ts
+++ b/packages/sdk/src/runtime-result.ts
@@ -1,0 +1,52 @@
+/**
+ * Result envelope produced by `dawn run` and `dawn test` for a single route invocation.
+ * Test scenario authors assert against this shape via `expectOutput`, `expectMeta`, and
+ * `expectError` from `@dawn-ai/sdk/testing`.
+ */
+
+export type RuntimeExecutionMode = "agent" | "chain" | "graph" | "workflow"
+
+export type RuntimeExecutionErrorKind =
+  | "app_discovery_error"
+  | "execution_error"
+  | "route_resolution_error"
+  | "server_transport_error"
+  | "unsupported_route_boundary"
+
+export interface RuntimeExecutionError {
+  readonly details?: Record<string, unknown>
+  readonly kind: RuntimeExecutionErrorKind
+  readonly message: string
+}
+
+export interface RuntimeExecutionTiming {
+  readonly durationMs: number
+  readonly finishedAt: string
+  readonly startedAt: string
+}
+
+export interface RuntimeExecutionBaseResult extends RuntimeExecutionTiming {
+  readonly appRoot: string | null
+  readonly diagnostics?: Record<string, unknown>
+  readonly executionSource: "in-process" | "server"
+  readonly mode: RuntimeExecutionMode | null
+  readonly routeId: string | null
+  readonly routePath: string | null
+}
+
+export interface RuntimeExecutionSuccessResult extends RuntimeExecutionBaseResult {
+  readonly appRoot: string
+  readonly executionSource: "in-process" | "server"
+  readonly mode: RuntimeExecutionMode
+  readonly output: unknown
+  readonly routeId: string
+  readonly routePath: string
+  readonly status: "passed"
+}
+
+export interface RuntimeExecutionFailureResult extends RuntimeExecutionBaseResult {
+  readonly error: RuntimeExecutionError
+  readonly status: "failed"
+}
+
+export type RuntimeExecutionResult = RuntimeExecutionSuccessResult | RuntimeExecutionFailureResult

--- a/packages/sdk/src/testing/index.ts
+++ b/packages/sdk/src/testing/index.ts
@@ -1,8 +1,29 @@
-import type { RuntimeExecutionResult } from "./result.js"
+/**
+ * Assertion helpers for `dawn test` scenario `assert(result)` callbacks.
+ *
+ * @example
+ * ```ts
+ * import { expectError, expectMeta, expectOutput } from "@dawn-ai/sdk/testing"
+ *
+ * export default [
+ *   {
+ *     name: "greets",
+ *     input: { tenant: "acme" },
+ *     run: { url: "http://localhost:3000" },
+ *     assert: (result) => {
+ *       expectMeta(result, { mode: "agent", routeId: "/hello/[tenant]" })
+ *       expectOutput(result, { greeting: "Hello, acme!" })
+ *     },
+ *   },
+ * ]
+ * ```
+ */
+
+import type { RuntimeExecutionResult } from "../runtime-result.js"
 
 export interface RuntimeMetaExpectation {
   readonly executionSource?: "in-process" | "server"
-  readonly mode?: "graph" | "workflow" | null
+  readonly mode?: "agent" | "chain" | "graph" | "workflow" | null
   readonly routeId?: string | null
   readonly routePath?: string | null
 }
@@ -152,3 +173,14 @@ function formatValue(value: unknown): string {
 
   return JSON.stringify(value)
 }
+
+export type {
+  RuntimeExecutionBaseResult,
+  RuntimeExecutionError,
+  RuntimeExecutionErrorKind,
+  RuntimeExecutionFailureResult,
+  RuntimeExecutionMode,
+  RuntimeExecutionResult,
+  RuntimeExecutionSuccessResult,
+  RuntimeExecutionTiming,
+} from "../runtime-result.js"

--- a/test/generated/cli-testing-export.test.ts
+++ b/test/generated/cli-testing-export.test.ts
@@ -17,11 +17,14 @@ afterEach(async () => {
   await cleanupTrackedTempDirs(tempDirs)
 })
 
-describe("@dawn-ai/cli/testing", () => {
+describe.each([
+  { subpath: "@dawn-ai/sdk/testing", label: "sdk" },
+  { subpath: "@dawn-ai/cli/testing", label: "cli" },
+])("$subpath", ({ subpath, label }) => {
   test("packed consumers can import the published testing helpers", {
     timeout: 30_000,
   }, async () => {
-    const tempRoot = await createTrackedTempDir("dawn-cli-testing-pack-", tempDirs)
+    const tempRoot = await createTrackedTempDir(`dawn-${label}-testing-pack-`, tempDirs)
     const { installerDir, tarballs } = await createPackagedInstaller({
       packageNames: ["@dawn-ai/core", "@dawn-ai/langchain", "@dawn-ai/langgraph", "@dawn-ai/sdk", "@dawn-ai/cli"],
       tempRoot,
@@ -45,7 +48,7 @@ describe("@dawn-ai/cli/testing", () => {
     await writeFile(
       scriptPath,
       [
-        'import { expectError, expectMeta, expectOutput } from "@dawn-ai/cli/testing";',
+        `import { expectError, expectMeta, expectOutput } from "${subpath}";`,
         "const passed = {",
         '  appRoot: "/tmp/dawn-app",',
         "  durationMs: 1,",

--- a/test/generated/cli-testing-export.test.ts
+++ b/test/generated/cli-testing-export.test.ts
@@ -38,6 +38,7 @@ describe.each([
         requiredTarball(tarballs, "@dawn-ai/core"),
         requiredTarball(tarballs, "@dawn-ai/langchain"),
         requiredTarball(tarballs, "@dawn-ai/langgraph"),
+        requiredTarball(tarballs, "@dawn-ai/sdk"),
         requiredTarball(tarballs, "@dawn-ai/cli"),
       ],
       installerDir,

--- a/test/generated/fixtures/handwritten-runtime-app/src/app/(public)/hello/[tenant]/run.test.ts
+++ b/test/generated/fixtures/handwritten-runtime-app/src/app/(public)/hello/[tenant]/run.test.ts
@@ -1,4 +1,4 @@
-import { expectMeta, expectOutput } from "@dawn-ai/cli/testing"
+import { expectMeta, expectOutput } from "@dawn-ai/sdk/testing"
 
 export default [
   {

--- a/test/generated/harness.ts
+++ b/test/generated/harness.ts
@@ -533,7 +533,7 @@ async function writeRunScenarioFile(options: {
   await writeFile(
     runTestPath,
     [
-      'import { expectMeta, expectOutput } from "@dawn-ai/cli/testing"',
+      'import { expectMeta, expectOutput } from "@dawn-ai/sdk/testing"',
       "",
       "export default [",
       "  {",

--- a/test/runtime/vitest.config.ts
+++ b/test/runtime/vitest.config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
     alias: {
       "@dawn-ai/core": resolve(rootDir, "../../packages/core/src/index.ts"),
       "@dawn-ai/langgraph": resolve(rootDir, "../../packages/langgraph/src/index.ts"),
+      "@dawn-ai/sdk/testing": resolve(rootDir, "../../packages/sdk/src/testing/index.ts"),
       "@dawn-ai/sdk": resolve(rootDir, "../../packages/sdk/src/index.ts"),
     },
   },


### PR DESCRIPTION
## Summary

Moves \`expectError\`, \`expectMeta\`, \`expectOutput\` and the \`RuntimeExecutionResult\` type family from \`@dawn-ai/cli/testing\` to \`@dawn-ai/sdk/testing\` — the home every doc reader (and the audit's F-082 finding) intuitively expected. \`@dawn-ai/cli/testing\` continues to work as a deprecated re-export.

## Why

The audit (#39) flagged F-082 because templates and docs implied the helpers lived at \`@dawn-ai/sdk/testing\`. They didn't — they were at \`@dawn-ai/cli/testing\`. PR B (#40) corrected the docs to match the code; this PR moves the code to match user intuition.

## What changes

**Code:**
- \`packages/sdk/src/testing/index.ts\` — new canonical home for \`expectError\`/\`expectMeta\`/\`expectOutput\`
- \`packages/sdk/src/runtime-result.ts\` — \`RuntimeExecutionResult\` type family moved here
- \`packages/sdk/package.json\` — adds \`./testing\` subpath export
- \`packages/cli/src/lib/runtime/result.ts\` — re-exports types from sdk, keeps cli-local constructors
- \`packages/cli/src/testing/index.ts\` — \`@deprecated\` re-export from sdk for back-compat
- \`packages/cli/src/lib/runtime/assertions.ts\` — deleted (no internal callers)
- \`packages/cli/src/commands/test.ts\` — imports from \`@dawn-ai/sdk/testing\`
- vitest configs (\`cli\`, \`langchain\`, \`test/runtime\`) — add \`sdk/testing\` alias

**Docs:**
- \`apps/web/content/docs/testing.mdx\`, \`apps/web/content/templates/{AGENTS,assistant}.md\` — point to \`@dawn-ai/sdk/testing\`

**Tests:**
- \`test/generated/cli-testing-export.test.ts\` — exercises BOTH subpaths via \`describe.each\`
- \`test/generated/harness.ts\` + handwritten runtime-app fixture — use \`@dawn-ai/sdk/testing\` (canonical)

## Back-compat

\`@dawn-ai/cli/testing\` still works. The published \`@dawn-ai/cli\` package keeps the subpath export and the implementation re-exports from sdk. Existing user code continues to function unchanged.

## Test plan

- [x] 312 tests pass (including the dual-subpath packed-consumer test)
- [x] Lint clean
- [x] Docs completeness check passes
- [ ] CI green
