### PR TITLE
ci: require changeset when packages/*/src/ or README.md changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,24 @@ on:
       - main
 
 jobs:
+  changesets:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Require changeset for user-facing changes
+        env:
+          BASE_REF: origin/${{ github.event.pull_request.base.ref }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+        run: node scripts/check-changesets.mjs
+
   validate:
     runs-on: ubuntu-latest
     timeout-minutes: 30

--- a/scripts/check-changesets.mjs
+++ b/scripts/check-changesets.mjs
@@ -1,0 +1,88 @@
+/**
+ * Require a changeset when user-facing files change.
+ *
+ * Runs in CI on pull requests. Compares the PR head against `BASE_REF`
+ * (defaults to `origin/main`) and fails if either:
+ *   - any file under `packages/<pkg>/src/` changed, OR
+ *   - any `packages/<pkg>/README.md` changed
+ * AND no new file was added under `.changeset/`.
+ *
+ * Empty changesets (created via `pnpm changeset --empty`) satisfy the check
+ * — they're how you opt out for genuinely no-version-bump changes.
+ *
+ * Excluded from the check:
+ *   - The auto-managed `changeset-release/main` branch (skip).
+ *   - PRs from `dependabot[bot]` or `github-actions[bot]` (skip).
+ */
+
+import { execSync } from "node:child_process"
+
+const baseRef = process.env.BASE_REF ?? "origin/main"
+const headRef = process.env.HEAD_REF ?? ""
+const prAuthor = process.env.PR_AUTHOR ?? ""
+
+if (headRef === "changeset-release/main") {
+  console.log("Changesets check skipped (auto-managed Version Packages branch).")
+  process.exit(0)
+}
+
+if (prAuthor === "dependabot[bot]" || prAuthor === "github-actions[bot]") {
+  console.log(`Changesets check skipped (PR author: ${prAuthor}).`)
+  process.exit(0)
+}
+
+let changed
+try {
+  changed = execSync(`git diff --name-only --diff-filter=ACMR ${baseRef}...HEAD`, {
+    encoding: "utf8",
+  })
+    .trim()
+    .split("\n")
+    .filter(Boolean)
+} catch (error) {
+  console.error(
+    `Changesets check could not diff against ${baseRef}: ${error instanceof Error ? error.message : String(error)}`,
+  )
+  console.error("Hint: ensure git fetch-depth is unrestricted in CI (fetch-depth: 0).")
+  process.exit(1)
+}
+
+const userFacingPatterns = [/^packages\/[^/]+\/src\//, /^packages\/[^/]+\/README\.md$/]
+
+const userFacingChanges = changed.filter((path) =>
+  userFacingPatterns.some((pattern) => pattern.test(path)),
+)
+
+const newChangesets = changed.filter(
+  (path) =>
+    path.startsWith(".changeset/") && path.endsWith(".md") && path !== ".changeset/README.md",
+)
+
+if (userFacingChanges.length === 0) {
+  console.log("Changesets check skipped (no user-facing changes detected).")
+  process.exit(0)
+}
+
+if (newChangesets.length === 0) {
+  console.error("Changeset required.")
+  console.error("")
+  console.error("This PR changes user-facing files in packages/* but does not include a")
+  console.error("changeset, so the next release will not pick up the change.")
+  console.error("")
+  console.error("Files that triggered this check:")
+  for (const path of userFacingChanges) {
+    console.error(`  - ${path}`)
+  }
+  console.error("")
+  console.error("Add a changeset:")
+  console.error("  pnpm changeset")
+  console.error("")
+  console.error("If this PR is genuinely a no-op for consumers (internal refactor, test-only,")
+  console.error("etc.), add an empty changeset to opt out:")
+  console.error("  pnpm changeset --empty")
+  process.exit(1)
+}
+
+console.log(
+  `Changesets check passed (${userFacingChanges.length} user-facing change(s), ${newChangesets.length} changeset(s) added).`,
+)


### PR DESCRIPTION
## Summary

Adds a CI gate that fails PRs touching user-facing files in \`packages/*\` without a new changeset. Closes the drift class where production-readiness (#34) and middleware-context-to-tools (#36) both shipped without changesets, leaving the auto-managed Version Packages PR stale and forcing a retroactive changesets-only PR (#47) before v0.1.7 could ship.

## How it works

- New \`scripts/check-changesets.mjs\` script
- New \`changesets\` job in CI, runs only on \`pull_request\` events
- Compares \`origin/<base>...HEAD\`; fails if any \`packages/*/src/\` or \`packages/*/README.md\` changed without at least one new \`.changeset/*.md\` file

**Skipped automatically for:**
- The \`changeset-release/main\` branch (the auto-managed Version Packages PR doesn't get a meta-changeset)
- \`dependabot[bot]\` and \`github-actions[bot]\` PRs

## Opt-out

For genuine internal-only changes that shouldn't bump a version, add an empty changeset:

\`\`\`
pnpm changeset --empty
\`\`\`

## Self-validation

This PR itself touches only \`.github/workflows/ci.yml\` and \`scripts/\` — no \`packages/*\` changes — so the new check will skip itself with \"no user-facing changes detected\".

Local simulation:
- No \`packages/*\` changes → \`Changesets check skipped (no user-facing changes detected).\` ✓
- Modify \`packages/sdk/src/index.ts\` without changeset → exits 1 with a clear error message ✓
- Modify \`packages/sdk/src/index.ts\` AND add a \`.changeset/foo.md\` → \`Changesets check passed.\` ✓

## Test plan

- [x] Local simulation passes for all three scenarios
- [ ] CI green on this PR (the changesets job should run and skip itself)