### PR TITLE
fix Scorecard publishing permissions

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -11,14 +11,16 @@ on:
 
 permissions:
   contents: read
-  security-events: write
-  id-token: write
 
 jobs:
   scorecard:
     name: Scorecard
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    permissions:
+      contents: read
+      id-token: write
+      security-events: write
     steps:
       - name: Checkout
         uses: actions/checkout@v6


### PR DESCRIPTION
## Summary

- move OpenSSF Scorecard write permissions from workflow scope to the `scorecard` job scope
- keep workflow-level permissions read-only so Scorecard `publish_results: true` passes workflow verification

## Root Cause

Scorecard publishing rejects workflows with workflow-level write permissions. The failing runs ended with:

```text
workflow verification failed: global perm is set to write: permission for security-events is set to write
```

The current workflow sets `security-events: write` and `id-token: write` globally. OSSF allows the Scorecard job to use `id-token: write`, and SARIF upload needs `security-events: write`, so those permissions belong on the job instead.

## Validation

- Ruby YAML parse: `.github/workflows/scorecard.yml OK`
- Dispatched Scorecard on the branch; it failed before the permission path because Scorecard only supports `workflow_dispatch` on the default branch. The fix must be verified by the next `main` Scorecard run after merge.
