### PR TITLE
feat(web): move ecosystem section below deploy story

### DIFF
--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -22,10 +22,9 @@ export default function HomePage() {
   return (
     <div className="landing-dark relative isolate">
       <PaletteScroller />
-      {/* Hero / Ecosystem / Problem aren't wrapped — the seamless navy bleed across them
+      {/* Hero / Problem aren't wrapped — the seamless navy bleed across them
           would break if their bgs faded in independently. Reveals begin at WhoItsFor. */}
       <HeroSection />
-      <EcosystemSection />
       <ProblemSection />
       <ScrollReveal>
         <WhoItsFor />
@@ -50,6 +49,9 @@ export default function HomePage() {
       </ScrollReveal>
       <ScrollReveal>
         <DeploySection />
+      </ScrollReveal>
+      <ScrollReveal>
+        <EcosystemSection />
       </ScrollReveal>
       <ScrollReveal>
         <FeatureGrid />


### PR DESCRIPTION
## Summary
- Move `EcosystemSection` from directly after the hero to below `DeploySection` on the landing page
- Wrap it in `<ScrollReveal>` to match the surrounding fade-in pattern
- Update the navy-bleed comment (Hero / Problem are now the unwrapped pair)

## Test plan
- [x] Verified DOM section order in Chrome at desktop (1440×900)
- [x] Verified ScrollReveal fade-in triggers on scroll into view
- [x] Visual check of Deploy → Ecosystem section seam (clean border, no layout shift)
