### PR TITLE
refactor(web): store sourceFile on Post; use it for dynamic import

### DIFF
--- a/apps/web/app/blog/[slug]/page.tsx
+++ b/apps/web/app/blog/[slug]/page.tsx
@@ -50,8 +50,8 @@ export default async function BlogPostPage({ params }: PageProps) {
   if (!post) notFound()
 
   // Dynamic import resolves at build time because generateStaticParams enumerates slugs.
-  // Filename convention: YYYY-MM-DD-<slug>.mdx, reconstructed from post.date + post.slug.
-  const mod = (await import(`../../../content/blog/${post.date}-${post.slug}.mdx`)) as {
+  // post.sourceFile is the on-disk filename — authoritative even if frontmatter date drifts.
+  const mod = (await import(`../../../content/blog/${post.sourceFile}`)) as {
     default: React.ComponentType
   }
   const MdxContent = mod.default

--- a/apps/web/app/components/blog/post-index.test.ts
+++ b/apps/web/app/components/blog/post-index.test.ts
@@ -68,6 +68,13 @@ describe("loadPostsFromDir", () => {
     })
   })
 
+  it("preserves the on-disk filename as sourceFile", () => {
+    withFixture({ "2026-05-12-why-we-built-dawn.mdx": samplePost }, (dir) => {
+      const [p] = loadPostsFromDir(dir, { includeDrafts: false })
+      expect(p?.sourceFile).toBe("2026-05-12-why-we-built-dawn.mdx")
+    })
+  })
+
   it("computes reading time from body word count", () => {
     withFixture({ "2026-05-12-why-we-built-dawn.mdx": samplePost }, (dir) => {
       const [p] = loadPostsFromDir(dir, { includeDrafts: false })

--- a/apps/web/app/components/blog/post-index.ts
+++ b/apps/web/app/components/blog/post-index.ts
@@ -37,6 +37,9 @@ export interface Post {
   readonly ogImage?: string
   readonly draft: boolean
   readonly readingTimeMinutes: number
+  /** Original MDX filename (e.g. "2026-05-12-why-we-built-dawn.mdx").
+   *  Source of truth for locating the file — do not reconstruct from date/slug. */
+  readonly sourceFile: string
 }
 
 const DATE_PREFIX = /^\d{4}-\d{2}-\d{2}-/
@@ -101,6 +104,7 @@ function parsePost(filename: string, raw: string): Post {
     ...(fm.ogImage !== undefined && { ogImage: fm.ogImage }),
     draft: fm.draft === true,
     readingTimeMinutes: Math.max(1, Math.round(stats.minutes)),
+    sourceFile: filename,
   }
 }
 

--- a/apps/web/app/components/blog/rss-feed.test.ts
+++ b/apps/web/app/components/blog/rss-feed.test.ts
@@ -12,6 +12,7 @@ const samplePost: Post = {
   author: "brian",
   draft: false,
   readingTimeMinutes: 8,
+  sourceFile: "2026-05-12-why-we-built-dawn.mdx",
 }
 
 describe("buildRssFeed", () => {

--- a/apps/web/app/llms-full.txt/route.ts
+++ b/apps/web/app/llms-full.txt/route.ts
@@ -62,8 +62,7 @@ async function buildLlmsFull(): Promise<string> {
 
   sections.push("\n\n# Blog\n")
   for (const post of getAllPosts()) {
-    const filename = `${post.date}-${post.slug}.mdx`
-    const raw = readFileSync(join(process.cwd(), "content", "blog", filename), "utf8")
+    const raw = readFileSync(join(process.cwd(), "content", "blog", post.sourceFile), "utf8")
     sections.push(`\n## ${post.title}\n\n${raw}\n`)
   }
 

--- a/apps/web/next-env.d.ts
+++ b/apps/web/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
## Summary

Tightens the link between a Post and its on-disk MDX file. Previously the post page's dynamic import path was reconstructed from \`post.date + post.slug\`; if a frontmatter date ever drifted from the filename (a legal edit under the design), the import would 404 at build time. \`llms-full.txt\` had the same reconstruction.

Now \`parsePost\` records the original filename on each Post as \`sourceFile\`, and both consumers use it directly.

### Changes
- \`Post\` interface gains \`sourceFile: string\` (carries the original \`.mdx\` filename verbatim)
- \`parsePost\` populates it from the readdir filename
- \`/blog/[slug]/page.tsx\` imports \`../../../content/blog/\${post.sourceFile}\` instead of \`\${post.date}-\${post.slug}.mdx\`
- \`/llms-full.txt/route.ts\` reads via \`post.sourceFile\` instead of reconstructing
- Unit test added: \"preserves the on-disk filename as sourceFile\"

## Test plan

- [ ] \`pnpm vitest run apps/web\` — 10/10 (was 9; new sourceFile test added)
- [ ] \`pnpm --filter @dawn-ai/web build\` — all 3 post slugs pre-render
- [ ] Visit each /blog/<slug> in dev — MDX renders, no import errors
