### PR TITLE
feat(web): SaaS rebrand PR 1 — foundation tokens, primitives, chrome

### DIFF
--- a/apps/web/app/brand/page.tsx
+++ b/apps/web/app/brand/page.tsx
@@ -1,187 +1,235 @@
 import type { Metadata } from "next"
-import Image from "next/image"
-import Link from "next/link"
+import { Button } from "../components/ui/Button"
+import { Card } from "../components/ui/Card"
+import { CodeFrame } from "../components/ui/CodeFrame"
+import { Eyebrow } from "../components/ui/Eyebrow"
+import { ProviderMark } from "../components/ui/ProviderMark"
+import { StarBadge } from "../components/ui/StarBadge"
+import { Accordion } from "../components/ui/Accordion"
 
 export const metadata: Metadata = {
-  title: "Brand Assets",
-  description:
-    "Download official Dawn AI logos, icons, favicons, social images, and machine-readable asset metadata.",
+  title: "Brand",
+  description: "Dawn brand and design system.",
 }
 
-const downloads = [
-  {
-    label: "Horizontal logo",
-    format: "SVG",
-    href: "/brand/dawn-logo-horizontal-white.svg",
-    note: "White horizontal logo for dark backgrounds, website headers, and documentation.",
-  },
-  {
-    label: "Icon",
-    format: "SVG",
-    href: "/brand/dawn-icon-white.svg",
-    note: "Compact mark for logo grids, integrations, and small UI surfaces.",
-  },
-  {
-    label: "Social avatar",
-    format: "PNG",
-    href: "/social/dawn-social-avatar-white-on-black-1024.png",
-    note: "Square 1024px avatar for profiles, marketplaces, and social surfaces.",
-  },
-  {
-    label: "Favicon",
-    format: "ICO",
-    href: "/favicon.ico",
-    note: "Browser favicon file for web projects and references.",
-  },
-  {
-    label: "Web manifest",
-    format: "JSON",
-    href: "/site.webmanifest",
-    note: "Installable web app metadata for browsers and app surfaces.",
-  },
-  {
-    label: "Asset manifest",
-    format: "JSON",
-    href: "/brand/assets.json",
-    note: "Machine-readable index for coding agents and automation.",
-  },
-] as const
+interface SwatchProps {
+  readonly name: string
+  readonly token: string
+  readonly value: string
+}
 
-const dos = [
-  "Use the official files as provided.",
-  "Use white assets on dark backgrounds and black assets on light backgrounds.",
-  "Keep clear space around the logo and icon.",
-] as const
+function Swatch({ name, token, value }: SwatchProps) {
+  return (
+    <div className="flex items-center gap-3 py-2">
+      <span
+        className="inline-block w-10 h-10 rounded-md border border-divider"
+        style={{ backgroundColor: value }}
+        aria-hidden="true"
+      />
+      <div className="flex flex-col">
+        <span className="text-sm text-ink font-medium">{name}</span>
+        <span className="text-xs text-ink-muted font-mono">{token}</span>
+        <span className="text-xs text-ink-dim font-mono">{value}</span>
+      </div>
+    </div>
+  )
+}
 
-const donts = [
-  "Do not stretch, recolor, redraw, or modify the mark.",
-  "Do not place the logo on low-contrast backgrounds.",
-  "Do not use Dawn marks in a way that implies endorsement.",
-] as const
+const SWATCHES: readonly SwatchProps[] = [
+  { name: "Page", token: "--color-page", value: "#ffffff" },
+  { name: "Surface", token: "--color-surface", value: "#fafaf7" },
+  { name: "Surface (sunk)", token: "--color-surface-sunk", value: "#f4f2ec" },
+  { name: "Ink", token: "--color-ink", value: "#14110d" },
+  { name: "Ink (muted)", token: "--color-ink-muted", value: "#5a554c" },
+  { name: "Ink (dim)", token: "--color-ink-dim", value: "#8a857b" },
+  { name: "Divider", token: "--color-divider", value: "#e6e3da" },
+  { name: "Divider (strong)", token: "--color-divider-strong", value: "#cfcabd" },
+  { name: "Accent", token: "--color-accent-saas", value: "#d97706" },
+  { name: "Accent (soft)", token: "--color-accent-saas-soft", value: "#fef3c7" },
+]
 
 export default function BrandPage() {
   return (
-    <div className="px-6 py-14 sm:px-8 sm:py-20">
-      <section className="mx-auto grid max-w-6xl gap-10 lg:grid-cols-[minmax(0,1fr)_420px] lg:items-center">
-        <div>
-          <p className="mb-4 text-xs font-semibold uppercase tracking-widest text-accent-amber">
-            Brand Assets
-          </p>
+    <div className="bg-page">
+      <div className="max-w-[1100px] mx-auto px-6 md:px-8 py-16 md:py-24">
+
+        <section className="mb-16 md:mb-24">
+          <Eyebrow>Design system · v2 (in progress)</Eyebrow>
           <h1
-            className="font-display text-5xl font-semibold tracking-tight text-text-primary md:text-6xl"
-            style={{ fontVariationSettings: "'opsz' 144, 'SOFT' 50" }}
+            className="font-display text-[56px] leading-[60px] md:text-[72px] md:leading-[76px] font-semibold text-ink mt-3"
+            style={{ fontVariationSettings: "'opsz' 144, 'SOFT' 50, 'WONK' 0", letterSpacing: "-0.01em" }}
           >
-            Dawn Brand Assets
+            Dawn brand.
           </h1>
-          <p className="mt-5 max-w-2xl text-lg leading-relaxed text-text-secondary">
-            Official Dawn AI logos, icons, favicons, social images, and machine-readable metadata
-            for developers, documentation, and coding agents.
+          <p className="text-lg text-ink-muted mt-5 max-w-2xl leading-relaxed">
+            The visual language for Dawn — a restrained, infrastructure-grade
+            system built on off-white surfaces, near-black ink, and a single
+            amber accent. This page is the source of truth as the SaaS rebrand
+            lands across the site.
           </p>
-          <div className="mt-8 flex flex-wrap gap-3">
-            <a
-              href="/brand/dawn-ai-brand-assets.zip"
-              className="rounded-md bg-accent-amber px-5 py-2.5 text-sm font-semibold text-bg-primary transition-colors hover:bg-accent-amber-deep"
-            >
-              Download full brand kit
-            </a>
-            <a
-              href="/brand/assets.json"
-              className="rounded-md border border-border px-5 py-2.5 text-sm font-medium text-text-secondary transition-colors hover:border-text-muted hover:text-text-primary"
-            >
-              View asset manifest
-            </a>
-          </div>
-        </div>
+        </section>
 
-        <div className="rounded-lg border border-border bg-bg-card/60 p-6 sm:p-8">
-          <div className="rounded-md bg-black p-7 sm:p-8">
-            <Image
-              src="/brand/dawn-logo-horizontal-white.svg"
-              alt="Dawn AI horizontal logo"
-              width={720}
-              height={220}
-              className="h-auto w-full"
-              priority
-            />
-          </div>
-          <p className="mt-4 text-sm leading-relaxed text-text-muted">
-            Use the horizontal logo when space allows. Use the icon for compact placements.
-          </p>
-        </div>
-      </section>
+        <section className="mb-16 md:mb-24">
+          <Eyebrow>Color</Eyebrow>
+          <h2 className="font-display text-3xl md:text-4xl font-semibold text-ink mt-2 mb-6">
+            Tokens
+          </h2>
+          <Card className="p-6">
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-x-8 gap-y-1">
+              {SWATCHES.map((s) => (
+                <Swatch key={s.token} {...s} />
+              ))}
+            </div>
+          </Card>
+        </section>
 
-      <section className="mx-auto mt-16 max-w-6xl">
-        <div className="mb-6">
-          <h2 className="text-2xl font-semibold text-text-primary">Common Downloads</h2>
-          <p className="mt-2 text-sm text-text-muted">
-            Direct links for the files developers and agents most often need.
-          </p>
-        </div>
-
-        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-          {downloads.map((asset) => (
-            <a
-              key={asset.href}
-              href={asset.href}
-              className="rounded-lg border border-border bg-bg-card/50 p-4 transition-colors hover:border-accent-amber/50"
-            >
-              <span className="text-[11px] font-semibold uppercase tracking-widest text-accent-amber">
-                {asset.format}
-              </span>
-              <h3 className="mt-3 text-base font-semibold text-text-primary">{asset.label}</h3>
-              <p className="mt-2 text-sm leading-relaxed text-text-muted">{asset.note}</p>
-            </a>
-          ))}
-        </div>
-      </section>
-
-      <section className="mx-auto mt-16 grid max-w-6xl gap-6 lg:grid-cols-2">
-        <div className="rounded-lg border border-border bg-bg-card/40 p-6">
-          <h2 className="text-xl font-semibold text-text-primary">Usage Guidance</h2>
-          <div className="mt-5 grid gap-6 sm:grid-cols-2 lg:grid-cols-1 xl:grid-cols-2">
+        <section className="mb-16 md:mb-24">
+          <Eyebrow>Type</Eyebrow>
+          <h2 className="font-display text-3xl md:text-4xl font-semibold text-ink mt-2 mb-6">
+            Scale
+          </h2>
+          <Card className="p-6 space-y-6">
             <div>
-              <h3 className="text-sm font-semibold text-text-primary">Do</h3>
-              <ul className="mt-3 space-y-3">
-                {dos.map((item) => (
-                  <li key={item} className="text-sm leading-relaxed text-text-secondary">
-                    {item}
-                  </li>
-                ))}
-              </ul>
+              <p className="text-xs text-ink-dim font-mono mb-1">Display XL · Fraunces 600 · 72/76</p>
+              <p
+                className="font-display text-[72px] leading-[76px] font-semibold text-ink"
+                style={{ fontVariationSettings: "'opsz' 144, 'SOFT' 50, 'WONK' 0", letterSpacing: "-0.01em" }}
+              >
+                Build LangGraph agents.
+              </p>
             </div>
             <div>
-              <h3 className="text-sm font-semibold text-text-primary">Don't</h3>
-              <ul className="mt-3 space-y-3">
-                {donts.map((item) => (
-                  <li key={item} className="text-sm leading-relaxed text-text-secondary">
-                    {item}
-                  </li>
-                ))}
-              </ul>
+              <p className="text-xs text-ink-dim font-mono mb-1">H1 · Fraunces 600 · 40/44</p>
+              <p
+                className="font-display text-[40px] leading-[44px] font-semibold text-ink"
+                style={{ fontVariationSettings: "'opsz' 144, 'SOFT' 50, 'WONK' 0" }}
+              >
+                Routes for agents, not just pages.
+              </p>
             </div>
-          </div>
-        </div>
+            <div>
+              <p className="text-xs text-ink-dim font-mono mb-1">Body L · Inter 400 · 18/30</p>
+              <p className="text-lg text-ink leading-[30px] max-w-2xl">
+                Dawn adds file-system routing, route-local tools, generated
+                types, and HMR to your existing LangGraph.js stack.
+              </p>
+            </div>
+            <div>
+              <p className="text-xs text-ink-dim font-mono mb-1">Body · Inter 400 · 16/26</p>
+              <p className="text-base text-ink leading-[26px] max-w-2xl">
+                Keep the runtime. Drop the boilerplate.
+              </p>
+            </div>
+            <div>
+              <p className="text-xs text-ink-dim font-mono mb-1">Small · Inter 400 · 14/22</p>
+              <p className="text-sm text-ink-muted leading-[22px] max-w-2xl">
+                Production caveats, links, and supporting copy live at this size.
+              </p>
+            </div>
+            <div>
+              <p className="text-xs text-ink-dim font-mono mb-1">Code · JetBrains Mono 400 · 14/22</p>
+              <code className="text-sm text-ink font-mono">pnpm create dawn-ai-app my-agent</code>
+            </div>
+          </Card>
+        </section>
 
-        <div className="rounded-lg border border-border bg-bg-card/40 p-6">
-          <h2 className="text-xl font-semibold text-text-primary">For Coding Agents</h2>
-          <p className="mt-4 text-sm leading-relaxed text-text-secondary">
-            Use <code className="text-text-primary">/brand/assets.json</code> as the canonical
-            machine-readable index. It lists the full ZIP, common direct URLs, formats, dimensions,
-            background guidance, and recommended use cases without requiring HTML scraping.
-          </p>
-          <div className="mt-5 flex flex-wrap gap-3 text-sm">
-            <a href="/brand/assets.json" className="text-accent-amber hover:text-accent-amber-deep">
-              Open assets.json
-            </a>
-            <Link href="/llms.txt" className="text-accent-amber hover:text-accent-amber-deep">
-              llms.txt
-            </Link>
-            <Link href="/llms-full.txt" className="text-accent-amber hover:text-accent-amber-deep">
-              llms-full.txt
-            </Link>
+        <section className="mb-16 md:mb-24">
+          <Eyebrow>Primitives</Eyebrow>
+          <h2 className="font-display text-3xl md:text-4xl font-semibold text-ink mt-2 mb-6">
+            Components
+          </h2>
+
+          <div className="space-y-6">
+            <Card className="p-6">
+              <p className="text-xs text-ink-dim font-mono mb-3">Button</p>
+              <div className="flex flex-wrap items-center gap-3">
+                <Button variant="primary" href="/docs/getting-started">
+                  Read the docs
+                </Button>
+                <Button variant="secondary" href="https://github.com/cacheplane/dawnai" external>
+                  Star on GitHub
+                </Button>
+              </div>
+            </Card>
+
+            <Card className="p-6">
+              <p className="text-xs text-ink-dim font-mono mb-3">StarBadge</p>
+              <StarBadge />
+            </Card>
+
+            <Card className="p-6">
+              <p className="text-xs text-ink-dim font-mono mb-3">ProviderMark</p>
+              <div className="flex flex-wrap items-center gap-x-6 gap-y-2">
+                <ProviderMark name="OpenAI" href="https://openai.com" />
+                <ProviderMark name="Anthropic" href="https://www.anthropic.com" />
+                <ProviderMark name="Google" />
+                <ProviderMark name="Ollama" />
+              </div>
+            </Card>
+
+            <Card className="p-6">
+              <p className="text-xs text-ink-dim font-mono mb-3">CodeFrame</p>
+              <CodeFrame label="src/app/(public)/support/index.ts">
+                <pre className="m-0 px-4 py-4 text-sm font-mono text-ink leading-[22px] overflow-x-auto">
+{`import { agent } from "@dawn-ai/sdk"
+
+export default agent({
+  model: "openai:gpt-4o-mini",
+  systemPrompt: "Answer for {tenant}.",
+})`}
+                </pre>
+              </CodeFrame>
+            </Card>
+
+            <Card className="p-6">
+              <p className="text-xs text-ink-dim font-mono mb-3">Accordion</p>
+              <Accordion
+                defaultOpenId="ex-1"
+                items={[
+                  {
+                    id: "ex-1",
+                    question: "What is this primitive used for?",
+                    answer: (
+                      <p>
+                        The FAQ section on the rebranded landing page uses this
+                        primitive. It's keyboard-accessible and respects
+                        prefers-reduced-motion.
+                      </p>
+                    ),
+                  },
+                  {
+                    id: "ex-2",
+                    question: "Can multiple items be open at once?",
+                    answer: <p>No — only one item is open at a time by design.</p>,
+                  },
+                ]}
+              />
+            </Card>
           </div>
-        </div>
-      </section>
+        </section>
+
+        <section>
+          <Eyebrow>Status</Eyebrow>
+          <h2 className="font-display text-3xl md:text-4xl font-semibold text-ink mt-2 mb-3">
+            Rebrand progress
+          </h2>
+          <p className="text-base text-ink-muted leading-relaxed max-w-2xl">
+            This page reflects PR 1 of the SaaS-style rebrand: tokens,
+            primitives, refreshed Header and Footer. The landing page, docs, and
+            blog are migrated in subsequent PRs. See{" "}
+            <a
+              className="text-accent-saas hover:opacity-80"
+              href="https://github.com/cacheplane/dawnai/pulls"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              open PRs on GitHub
+            </a>
+            .
+          </p>
+        </section>
+
+      </div>
     </div>
   )
 }

--- a/apps/web/app/brand/page.tsx
+++ b/apps/web/app/brand/page.tsx
@@ -1,11 +1,11 @@
 import type { Metadata } from "next"
+import { Accordion } from "../components/ui/Accordion"
 import { Button } from "../components/ui/Button"
 import { Card } from "../components/ui/Card"
 import { CodeFrame } from "../components/ui/CodeFrame"
 import { Eyebrow } from "../components/ui/Eyebrow"
 import { ProviderMark } from "../components/ui/ProviderMark"
 import { StarBadge } from "../components/ui/StarBadge"
-import { Accordion } from "../components/ui/Accordion"
 
 export const metadata: Metadata = {
   title: "Brand",
@@ -52,20 +52,21 @@ export default function BrandPage() {
   return (
     <div className="bg-page">
       <div className="max-w-[1100px] mx-auto px-6 md:px-8 py-16 md:py-24">
-
         <section className="mb-16 md:mb-24">
           <Eyebrow>Design system · v2 (in progress)</Eyebrow>
           <h1
             className="font-display text-[56px] leading-[60px] md:text-[72px] md:leading-[76px] font-semibold text-ink mt-3"
-            style={{ fontVariationSettings: "'opsz' 144, 'SOFT' 50, 'WONK' 0", letterSpacing: "-0.01em" }}
+            style={{
+              fontVariationSettings: "'opsz' 144, 'SOFT' 50, 'WONK' 0",
+              letterSpacing: "-0.01em",
+            }}
           >
             Dawn brand.
           </h1>
           <p className="text-lg text-ink-muted mt-5 max-w-2xl leading-relaxed">
-            The visual language for Dawn — a restrained, infrastructure-grade
-            system built on off-white surfaces, near-black ink, and a single
-            amber accent. This page is the source of truth as the SaaS rebrand
-            lands across the site.
+            The visual language for Dawn — a restrained, infrastructure-grade system built on
+            off-white surfaces, near-black ink, and a single amber accent. This page is the source
+            of truth as the SaaS rebrand lands across the site.
           </p>
         </section>
 
@@ -90,10 +91,15 @@ export default function BrandPage() {
           </h2>
           <Card className="p-6 space-y-6">
             <div>
-              <p className="text-xs text-ink-dim font-mono mb-1">Display XL · Fraunces 600 · 72/76</p>
+              <p className="text-xs text-ink-dim font-mono mb-1">
+                Display XL · Fraunces 600 · 72/76
+              </p>
               <p
                 className="font-display text-[72px] leading-[76px] font-semibold text-ink"
-                style={{ fontVariationSettings: "'opsz' 144, 'SOFT' 50, 'WONK' 0", letterSpacing: "-0.01em" }}
+                style={{
+                  fontVariationSettings: "'opsz' 144, 'SOFT' 50, 'WONK' 0",
+                  letterSpacing: "-0.01em",
+                }}
               >
                 Build LangGraph agents.
               </p>
@@ -110,8 +116,8 @@ export default function BrandPage() {
             <div>
               <p className="text-xs text-ink-dim font-mono mb-1">Body L · Inter 400 · 18/30</p>
               <p className="text-lg text-ink leading-[30px] max-w-2xl">
-                Dawn adds file-system routing, route-local tools, generated
-                types, and HMR to your existing LangGraph.js stack.
+                Dawn adds file-system routing, route-local tools, generated types, and HMR to your
+                existing LangGraph.js stack.
               </p>
             </div>
             <div>
@@ -127,7 +133,9 @@ export default function BrandPage() {
               </p>
             </div>
             <div>
-              <p className="text-xs text-ink-dim font-mono mb-1">Code · JetBrains Mono 400 · 14/22</p>
+              <p className="text-xs text-ink-dim font-mono mb-1">
+                Code · JetBrains Mono 400 · 14/22
+              </p>
               <code className="text-sm text-ink font-mono">pnpm create dawn-ai-app my-agent</code>
             </div>
           </Card>
@@ -171,7 +179,7 @@ export default function BrandPage() {
               <p className="text-xs text-ink-dim font-mono mb-3">CodeFrame</p>
               <CodeFrame label="src/app/(public)/support/index.ts">
                 <pre className="m-0 px-4 py-4 text-sm font-mono text-ink leading-[22px] overflow-x-auto">
-{`import { agent } from "@dawn-ai/sdk"
+                  {`import { agent } from "@dawn-ai/sdk"
 
 export default agent({
   model: "openai:gpt-4o-mini",
@@ -191,9 +199,8 @@ export default agent({
                     question: "What is this primitive used for?",
                     answer: (
                       <p>
-                        The FAQ section on the rebranded landing page uses this
-                        primitive. It's keyboard-accessible and respects
-                        prefers-reduced-motion.
+                        The FAQ section on the rebranded landing page uses this primitive. It's
+                        keyboard-accessible and respects prefers-reduced-motion.
                       </p>
                     ),
                   },
@@ -214,9 +221,8 @@ export default agent({
             Rebrand progress
           </h2>
           <p className="text-base text-ink-muted leading-relaxed max-w-2xl">
-            This page reflects PR 1 of the SaaS-style rebrand: tokens,
-            primitives, refreshed Header and Footer. The landing page, docs, and
-            blog are migrated in subsequent PRs. See{" "}
+            This page reflects PR 1 of the SaaS-style rebrand: tokens, primitives, refreshed Header
+            and Footer. The landing page, docs, and blog are migrated in subsequent PRs. See{" "}
             <a
               className="text-accent-saas hover:opacity-80"
               href="https://github.com/cacheplane/dawnai/pulls"
@@ -228,7 +234,6 @@ export default agent({
             .
           </p>
         </section>
-
       </div>
     </div>
   )

--- a/apps/web/app/components/CopyCommand.tsx
+++ b/apps/web/app/components/CopyCommand.tsx
@@ -22,18 +22,18 @@ export function CopyCommand({ command, className }: Props) {
 
   return (
     <div
-      className={`font-mono text-sm text-text-muted bg-bg-card inline-flex items-center gap-2 pl-4 pr-2 py-2 rounded-md border border-border ${
+      className={`font-mono text-sm text-ink-muted bg-surface inline-flex items-center gap-2 pl-4 pr-2 py-2 rounded-md border border-divider ${
         className ?? ""
       }`}
     >
       <span>
-        <span className="text-accent-amber">$</span> {command}
+        <span className="text-accent-saas">$</span> {command}
       </span>
       <button
         type="button"
         onClick={handleCopy}
         aria-label={copied ? "Copied" : `Copy command: ${command}`}
-        className="ml-1 p-1 rounded hover:bg-accent-amber/10 text-text-muted hover:text-accent-amber transition-colors"
+        className="ml-1 p-1 rounded hover:bg-accent-saas-soft text-ink-muted hover:text-accent-saas transition-colors"
       >
         {copied ? (
           <svg
@@ -44,7 +44,7 @@ export function CopyCommand({ command, className }: Props) {
             stroke="currentColor"
             strokeWidth="3"
             role="img"
-            className="text-accent-amber"
+            className="text-accent-saas"
           >
             <title>Copied</title>
             <polyline points="20 6 9 17 4 12" />

--- a/apps/web/app/components/Footer.tsx
+++ b/apps/web/app/components/Footer.tsx
@@ -14,58 +14,44 @@ interface Column {
 
 const COLUMNS: readonly Column[] = [
   {
-    heading: "Docs",
+    heading: "Product",
     items: [
-      { label: "Getting Started", href: "/docs/getting-started" },
-      { label: "Routes", href: "/docs/routes" },
-      { label: "Tools", href: "/docs/tools" },
-      { label: "State", href: "/docs/state" },
-      { label: "Testing", href: "/docs/testing" },
-      { label: "Dev Server", href: "/docs/dev-server" },
-      { label: "Deployment", href: "/docs/deployment" },
-      { label: "CLI", href: "/docs/cli" },
+      { label: "Docs", href: "/docs/getting-started" },
+      { label: "Examples", href: "/docs/recipes" },
+      { label: "Blog", href: "/blog" },
+      { label: "Brand", href: "/brand" },
     ],
   },
   {
-    heading: "Blog",
+    heading: "Resources",
     items: [
-      { label: "Latest posts", href: "/blog" },
-      { label: "RSS feed", href: "/blog/rss.xml", external: true },
-    ],
-  },
-  {
-    heading: "For Agents",
-    items: [
-      { label: "llms.txt", href: "/llms.txt", external: true },
-      { label: "llms-full.txt", href: "/llms-full.txt", external: true },
-      { label: "AGENTS.md", href: "/AGENTS.md", external: true },
-      { label: "CLAUDE.md", href: "/CLAUDE.md", external: true },
-      { label: "Scaffold prompt", href: "/prompts/scaffold", external: true },
-      { label: "Add a tool", href: "/prompts/add-a-tool", external: true },
-      { label: "Write a route", href: "/prompts/write-a-route", external: true },
-      { label: "Write a test", href: "/prompts/write-a-test", external: true },
-      { label: "Deploy", href: "/prompts/deploy", external: true },
-    ],
-  },
-  {
-    heading: "Ecosystem",
-    items: [
-      { label: "LangChain", href: "https://langchain.com", external: true },
-      { label: "LangGraph", href: "https://www.langchain.com/langgraph", external: true },
-      { label: "LangSmith", href: "https://smith.langchain.com", external: true },
-      { label: "TypeScript", href: "https://www.typescriptlang.org", external: true },
-      { label: "Vite", href: "https://vitejs.dev", external: true },
-    ],
-  },
-  {
-    heading: "Source",
-    items: [
-      { label: "Brand Assets", href: "/brand" },
       { label: "GitHub", href: "https://github.com/cacheplane/dawnai", external: true },
       { label: "npm", href: "https://www.npmjs.com/org/dawn-ai", external: true },
       {
+        label: "LangGraph.js",
+        href: "https://www.langchain.com/langgraph",
+        external: true,
+      },
+      { label: "RSS feed", href: "/blog/rss.xml", external: true },
+      { label: "llms.txt", href: "/llms.txt", external: true },
+    ],
+  },
+  {
+    heading: "Legal",
+    items: [
+      {
         label: "MIT License",
         href: "https://github.com/cacheplane/dawnai/blob/main/LICENSE",
+        external: true,
+      },
+      {
+        label: "Code of Conduct",
+        href: "https://github.com/cacheplane/dawnai/blob/main/CODE_OF_CONDUCT.md",
+        external: true,
+      },
+      {
+        label: "Security",
+        href: "https://github.com/cacheplane/dawnai/blob/main/SECURITY.md",
         external: true,
       },
     ],
@@ -73,8 +59,7 @@ const COLUMNS: readonly Column[] = [
 ]
 
 function FooterLink({ label, href, external }: LinkItem) {
-  const className =
-    "text-sm landing-text-muted hover:text-accent-amber-deep transition-colors block py-0.5"
+  const className = "text-sm text-ink-muted hover:text-ink transition-colors block py-0.5"
   if (external) {
     return (
       <a href={href} target="_blank" rel="noopener noreferrer" className={className}>
@@ -89,63 +74,20 @@ function FooterLink({ label, href, external }: LinkItem) {
   )
 }
 
-function GitHubIcon() {
-  return (
-    <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor" role="img" aria-hidden>
-      <title>GitHub</title>
-      <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z" />
-    </svg>
-  )
-}
-
-function NpmIcon() {
-  return (
-    <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor" role="img" aria-hidden>
-      <title>npm</title>
-      <path d="M0 0v16h16V0H0zm13 13h-2.5V5.5H8V13H3V3h10v10z" />
-    </svg>
-  )
-}
-
 export function Footer() {
   return (
-    <footer className="relative px-8 pt-20 pb-12 border-t landing-border">
-      <div className="max-w-6xl mx-auto">
-        <div className="grid grid-cols-2 md:grid-cols-6 gap-10 md:gap-8">
-          {/* Brand block — spans 2 cols on desktop, full width on mobile */}
-          <div className="col-span-2 md:col-span-2">
-            <BrandLogo imageClassName="h-8" variant="dark" />
-            <p className="text-sm landing-text-muted mt-3 leading-relaxed max-w-[36ch]">
-              The App Router for AI agents. A TypeScript-first meta-framework for LangChain.
+    <footer className="bg-surface border-t border-divider">
+      <div className="max-w-[1200px] mx-auto px-6 md:px-8 pt-16 pb-10">
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-10 md:gap-8">
+          <div className="col-span-2 md:col-span-1">
+            <BrandLogo imageClassName="h-7" />
+            <p className="text-sm text-ink-muted mt-3 leading-relaxed max-w-[28ch]">
+              TypeScript meta-framework for LangGraph.js.
             </p>
-            <div className="flex items-center gap-3 mt-5">
-              <a
-                href="https://github.com/cacheplane/dawnai"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="inline-flex items-center justify-center w-10 h-10 rounded-md border landing-border landing-text-muted hover:text-accent-amber-deep transition-colors"
-                style={{ borderColor: "var(--landing-border)" }}
-                aria-label="GitHub"
-              >
-                <GitHubIcon />
-              </a>
-              <a
-                href="https://www.npmjs.com/org/dawn-ai"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="inline-flex items-center justify-center w-10 h-10 rounded-md border landing-border landing-text-muted hover:text-accent-amber-deep transition-colors"
-                style={{ borderColor: "var(--landing-border)" }}
-                aria-label="npm"
-              >
-                <NpmIcon />
-              </a>
-            </div>
           </div>
-
-          {/* Link columns */}
           {COLUMNS.map((col) => (
             <div key={col.heading} className="flex flex-col gap-1">
-              <p className="text-[11px] font-semibold uppercase tracking-widest text-accent-amber-deep mb-3">
+              <p className="text-xs font-semibold uppercase tracking-[0.06em] text-ink-dim mb-3">
                 {col.heading}
               </p>
               {col.items.map((item) => (
@@ -154,13 +96,9 @@ export function Footer() {
             </div>
           ))}
         </div>
-
-        {/* Bottom bar */}
-        <div
-          className="mt-16 pt-6 border-t landing-border text-xs landing-text-muted text-center md:text-left"
-          style={{ borderColor: "var(--landing-border)" }}
-        >
-          {`© ${new Date().getFullYear()} Dawn · MIT-licensed · Built on the LangChain ecosystem`}
+        <div className="mt-12 pt-6 border-t border-divider flex flex-col md:flex-row gap-2 md:justify-between text-xs text-ink-dim">
+          <span>{`© ${new Date().getFullYear()} Dawn. MIT-licensed.`}</span>
+          <span>Built on the LangChain ecosystem.</span>
         </div>
       </div>
     </footer>

--- a/apps/web/app/components/HeaderInner.tsx
+++ b/apps/web/app/components/HeaderInner.tsx
@@ -3,8 +3,8 @@
 import Link from "next/link"
 import { usePathname } from "next/navigation"
 import { BrandLogo } from "./BrandLogo"
-import { MobileMenu } from "./MobileMenu"
 import { CopyCommand } from "./CopyCommand"
+import { MobileMenu } from "./MobileMenu"
 
 function GitHubIcon() {
   return (
@@ -32,9 +32,7 @@ export function HeaderInner({ repoUrl }: HeaderInnerProps) {
   const pathname = usePathname()
 
   const linkClass = (active: boolean) =>
-    active
-      ? "text-ink transition-colors"
-      : "text-ink-muted hover:text-ink transition-colors"
+    active ? "text-ink transition-colors" : "text-ink-muted hover:text-ink transition-colors"
 
   return (
     <header className="bg-page border-b border-divider">

--- a/apps/web/app/components/HeaderInner.tsx
+++ b/apps/web/app/components/HeaderInner.tsx
@@ -4,6 +4,7 @@ import Link from "next/link"
 import { usePathname } from "next/navigation"
 import { BrandLogo } from "./BrandLogo"
 import { MobileMenu } from "./MobileMenu"
+import { CopyCommand } from "./CopyCommand"
 
 function GitHubIcon() {
   return (
@@ -29,45 +30,39 @@ interface HeaderInnerProps {
 
 export function HeaderInner({ repoUrl }: HeaderInnerProps) {
   const pathname = usePathname()
-  const isLanding = pathname === "/"
 
-  const baseClasses = "flex justify-between items-center px-6 md:px-8 py-4"
-  const variantClasses = isLanding
-    ? "absolute top-0 left-0 right-0 z-10 bg-transparent"
-    : "border-b border-border-subtle"
+  const linkClass = (active: boolean) =>
+    active
+      ? "text-ink transition-colors"
+      : "text-ink-muted hover:text-ink transition-colors"
 
   return (
-    <header className={`landing-dark ${baseClasses} ${variantClasses}`}>
-      <BrandLogo imageClassName="h-8" />
-      <nav className="hidden md:flex items-center gap-6 text-sm text-text-secondary">
-        <Link
-          href="/blog"
-          className={
-            pathname.startsWith("/blog")
-              ? "text-text-primary transition-colors"
-              : "hover:text-text-primary transition-colors"
-          }
-        >
-          Blog
-        </Link>
-        <a
-          href={repoUrl}
-          target="_blank"
-          rel="noopener noreferrer"
-          aria-label="GitHub — 100+ stars"
-          className="inline-flex items-center gap-1.5 hover:text-text-primary transition-colors"
-        >
-          <GitHubIcon />
-          <span className="text-xs tabular-nums">100+</span>
-        </a>
-        <Link
-          href="/docs/getting-started"
-          className="bg-accent-amber text-bg-primary px-3 py-1.5 rounded-md font-semibold hover:bg-accent-amber-deep transition-colors"
-        >
-          Read the Docs
-        </Link>
-      </nav>
-      <MobileMenu />
+    <header className="bg-page border-b border-divider">
+      <div className="max-w-[1280px] mx-auto flex justify-between items-center px-6 md:px-8 py-4">
+        <BrandLogo imageClassName="h-8" />
+        <nav className="hidden md:flex items-center gap-6 text-sm">
+          <Link href="/docs/getting-started" className={linkClass(pathname.startsWith("/docs"))}>
+            Docs
+          </Link>
+          <Link href="/blog" className={linkClass(pathname.startsWith("/blog"))}>
+            Blog
+          </Link>
+          <Link href="/brand" className={linkClass(pathname === "/brand")}>
+            Brand
+          </Link>
+          <a
+            href={repoUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="GitHub"
+            className="inline-flex items-center gap-1.5 text-ink-muted hover:text-ink transition-colors"
+          >
+            <GitHubIcon />
+          </a>
+          <CopyCommand command="pnpm create dawn-ai-app" />
+        </nav>
+        <MobileMenu />
+      </div>
     </header>
   )
 }

--- a/apps/web/app/components/MobileMenu.tsx
+++ b/apps/web/app/components/MobileMenu.tsx
@@ -104,9 +104,7 @@ export function MobileMenu() {
         <div className="h-full overflow-y-auto">
           {/* Header strip */}
           <div className="flex items-center justify-between px-6 py-4 border-b border-divider">
-            <span className="text-xs uppercase tracking-widest text-ink-dim font-mono">
-              Menu
-            </span>
+            <span className="text-xs uppercase tracking-widest text-ink-dim font-mono">Menu</span>
             <button
               ref={closeRef}
               type="button"

--- a/apps/web/app/components/MobileMenu.tsx
+++ b/apps/web/app/components/MobileMenu.tsx
@@ -78,7 +78,7 @@ export function MobileMenu() {
         aria-label="Open menu"
         aria-expanded={isOpen}
         aria-controls={menuId}
-        className="md:hidden inline-flex items-center justify-center w-10 h-10 rounded-md text-text-secondary hover:text-text-primary hover:bg-bg-card transition-colors"
+        className="md:hidden inline-flex items-center justify-center w-10 h-10 rounded-md text-ink-muted hover:text-ink hover:bg-surface transition-colors"
       >
         <svg width="20" height="20" viewBox="0 0 24 24" fill="none" aria-hidden role="img">
           <title>Menu</title>
@@ -97,14 +97,14 @@ export function MobileMenu() {
         role="dialog"
         aria-modal="true"
         aria-label="Site menu"
-        className={`md:hidden fixed inset-0 z-50 bg-bg-primary transition-opacity duration-200 ease-out ${
+        className={`md:hidden fixed inset-0 z-50 bg-page transition-opacity duration-200 ease-out ${
           isOpen ? "opacity-100 pointer-events-auto" : "opacity-0 pointer-events-none"
         }`}
       >
         <div className="h-full overflow-y-auto">
           {/* Header strip */}
-          <div className="flex items-center justify-between px-6 py-4 border-b border-border-subtle">
-            <span className="text-xs uppercase tracking-widest text-text-muted font-mono">
+          <div className="flex items-center justify-between px-6 py-4 border-b border-divider">
+            <span className="text-xs uppercase tracking-widest text-ink-dim font-mono">
               Menu
             </span>
             <button
@@ -112,7 +112,7 @@ export function MobileMenu() {
               type="button"
               onClick={() => setIsOpen(false)}
               aria-label="Close menu"
-              className="inline-flex items-center justify-center w-10 h-10 rounded-md text-text-secondary hover:text-text-primary hover:bg-bg-card transition-colors"
+              className="inline-flex items-center justify-center w-10 h-10 rounded-md text-ink-muted hover:text-ink hover:bg-surface transition-colors"
             >
               <svg width="20" height="20" viewBox="0 0 24 24" fill="none" aria-hidden role="img">
                 <title>Close</title>
@@ -128,7 +128,7 @@ export function MobileMenu() {
 
           {/* Site section */}
           <div className="px-6 py-6">
-            <p className="font-mono text-[10px] uppercase tracking-[0.12em] text-text-muted mb-3">
+            <p className="font-mono text-[10px] uppercase tracking-[0.12em] text-ink-dim mb-3">
               Site
             </p>
             <ul className="flex flex-col gap-0.5">
@@ -140,7 +140,7 @@ export function MobileMenu() {
                       target="_blank"
                       rel="noopener noreferrer"
                       onClick={() => setIsOpen(false)}
-                      className="block text-base px-3 py-2.5 rounded-md text-text-secondary hover:text-text-primary hover:bg-bg-card transition-colors"
+                      className="block text-base px-3 py-2.5 rounded-md text-ink-muted hover:text-ink hover:bg-surface transition-colors"
                     >
                       {link.label} <span aria-hidden>↗</span>
                     </a>
@@ -148,7 +148,7 @@ export function MobileMenu() {
                     <Link
                       href={link.href}
                       onClick={() => setIsOpen(false)}
-                      className="block text-base px-3 py-2.5 rounded-md bg-accent-amber text-bg-primary font-semibold mt-2"
+                      className="block text-base px-3 py-2.5 rounded-md bg-accent-saas text-accent-saas-ink font-semibold mt-2"
                     >
                       {link.label}
                     </Link>
@@ -156,7 +156,7 @@ export function MobileMenu() {
                     <Link
                       href={link.href}
                       onClick={() => setIsOpen(false)}
-                      className="block text-base px-3 py-2.5 rounded-md text-text-secondary hover:text-text-primary hover:bg-bg-card transition-colors"
+                      className="block text-base px-3 py-2.5 rounded-md text-ink-muted hover:text-ink hover:bg-surface transition-colors"
                     >
                       {link.label}
                     </Link>
@@ -168,14 +168,14 @@ export function MobileMenu() {
 
           {/* Documentation section — only on docs pages */}
           {isDocsPage && (
-            <div className="px-6 pb-10 border-t border-border-subtle pt-6">
-              <p className="font-mono text-[10px] uppercase tracking-[0.12em] text-text-muted mb-3">
+            <div className="px-6 pb-10 border-t border-divider pt-6">
+              <p className="font-mono text-[10px] uppercase tracking-[0.12em] text-ink-dim mb-3">
                 Documentation
               </p>
               <nav className="space-y-5">
                 {DOCS_NAV.map((section) => (
                   <div key={section.label}>
-                    <p className="font-mono text-[10px] uppercase tracking-[0.12em] text-text-muted mb-1.5 px-3">
+                    <p className="font-mono text-[10px] uppercase tracking-[0.12em] text-ink-dim mb-1.5 px-3">
                       {section.label}
                     </p>
                     <ul className="space-y-0.5">
@@ -188,8 +188,8 @@ export function MobileMenu() {
                               onClick={() => setIsOpen(false)}
                               className={`block text-sm px-3 py-2 rounded-md transition-colors ${
                                 active
-                                  ? "text-accent-amber bg-accent-amber/8"
-                                  : "text-text-secondary hover:text-text-primary hover:bg-bg-card"
+                                  ? "text-accent-saas bg-accent-saas-soft"
+                                  : "text-ink-muted hover:text-ink hover:bg-surface"
                               }`}
                             >
                               {item.label}

--- a/apps/web/app/components/ui/Accordion.tsx
+++ b/apps/web/app/components/ui/Accordion.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState, type ReactNode } from "react"
+import { type ReactNode, useState } from "react"
 
 interface AccordionItem {
   readonly id: string
@@ -34,23 +34,19 @@ export function Accordion({ items, defaultOpenId }: AccordionProps) {
                 className="w-full flex items-center justify-between gap-4 py-5 text-left text-ink font-medium hover:text-accent-saas transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-divider-strong rounded"
               >
                 <span>{item.question}</span>
-                <span
-                  aria-hidden="true"
-                  className="text-ink-dim text-xl leading-none select-none"
-                >
+                <span aria-hidden="true" className="text-ink-dim text-xl leading-none select-none">
                   {isOpen ? "−" : "+"}
                 </span>
               </button>
             </h3>
-            <div
+            <section
               id={panelId}
-              role="region"
               aria-labelledby={buttonId}
               hidden={!isOpen}
               className="pb-5 pr-8 text-ink-muted text-sm leading-relaxed"
             >
               {item.answer}
-            </div>
+            </section>
           </li>
         )
       })}

--- a/apps/web/app/components/ui/Accordion.tsx
+++ b/apps/web/app/components/ui/Accordion.tsx
@@ -1,0 +1,59 @@
+"use client"
+
+import { useState, type ReactNode } from "react"
+
+interface AccordionItem {
+  readonly id: string
+  readonly question: string
+  readonly answer: ReactNode
+}
+
+interface AccordionProps {
+  readonly items: readonly AccordionItem[]
+  readonly defaultOpenId?: string
+}
+
+export function Accordion({ items, defaultOpenId }: AccordionProps) {
+  const [openId, setOpenId] = useState<string | null>(defaultOpenId ?? null)
+
+  return (
+    <ul className="divide-y divide-divider border-y border-divider">
+      {items.map((item) => {
+        const isOpen = openId === item.id
+        const panelId = `accordion-panel-${item.id}`
+        const buttonId = `accordion-button-${item.id}`
+        return (
+          <li key={item.id}>
+            <h3>
+              <button
+                id={buttonId}
+                type="button"
+                aria-expanded={isOpen}
+                aria-controls={panelId}
+                onClick={() => setOpenId(isOpen ? null : item.id)}
+                className="w-full flex items-center justify-between gap-4 py-5 text-left text-ink font-medium hover:text-accent-saas transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-divider-strong rounded"
+              >
+                <span>{item.question}</span>
+                <span
+                  aria-hidden="true"
+                  className="text-ink-dim text-xl leading-none select-none"
+                >
+                  {isOpen ? "−" : "+"}
+                </span>
+              </button>
+            </h3>
+            <div
+              id={panelId}
+              role="region"
+              aria-labelledby={buttonId}
+              hidden={!isOpen}
+              className="pb-5 pr-8 text-ink-muted text-sm leading-relaxed"
+            >
+              {item.answer}
+            </div>
+          </li>
+        )
+      })}
+    </ul>
+  )
+}

--- a/apps/web/app/components/ui/Button.tsx
+++ b/apps/web/app/components/ui/Button.tsx
@@ -1,0 +1,64 @@
+import Link from "next/link"
+import type { ComponentPropsWithoutRef, ReactNode } from "react"
+
+type ButtonVariant = "primary" | "secondary"
+
+interface BaseProps {
+  readonly variant?: ButtonVariant
+  readonly children: ReactNode
+}
+
+type ButtonAsLink = BaseProps & {
+  readonly href: string
+  readonly external?: boolean
+} & Omit<ComponentPropsWithoutRef<"a">, "href" | "children">
+
+type ButtonAsButton = BaseProps & {
+  readonly href?: undefined
+} & Omit<ComponentPropsWithoutRef<"button">, "children">
+
+export type ButtonProps = ButtonAsLink | ButtonAsButton
+
+const baseClasses =
+  "inline-flex items-center gap-1.5 font-medium text-sm rounded-md transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-page focus-visible:ring-divider-strong"
+
+const variantClasses: Record<ButtonVariant, string> = {
+  primary:
+    "px-4 py-2 bg-accent-saas text-accent-saas-ink hover:opacity-90 active:opacity-80",
+  secondary:
+    "px-4 py-2 text-ink hover:text-accent-saas border border-divider hover:border-divider-strong bg-page",
+}
+
+export function Button(props: ButtonProps) {
+  const variant = props.variant ?? "primary"
+  const className = `${baseClasses} ${variantClasses[variant]}`
+
+  if (props.href !== undefined) {
+    const { href, external, children, variant: _v, ...rest } = props
+    if (external) {
+      return (
+        <a
+          href={href}
+          target="_blank"
+          rel="noopener noreferrer"
+          className={className}
+          {...rest}
+        >
+          {children}
+        </a>
+      )
+    }
+    return (
+      <Link href={href} className={className} {...rest}>
+        {children}
+      </Link>
+    )
+  }
+
+  const { children, variant: _v, ...rest } = props
+  return (
+    <button type="button" className={className} {...rest}>
+      {children}
+    </button>
+  )
+}

--- a/apps/web/app/components/ui/Button.tsx
+++ b/apps/web/app/components/ui/Button.tsx
@@ -1,23 +1,29 @@
 import Link from "next/link"
-import type { ComponentPropsWithoutRef, ReactNode } from "react"
+import type { ReactNode } from "react"
 
 type ButtonVariant = "primary" | "secondary"
 
 interface BaseProps {
   readonly variant?: ButtonVariant
   readonly children: ReactNode
+  readonly className?: string
+  readonly id?: string
+  readonly "aria-label"?: string
 }
 
-type ButtonAsLink = BaseProps & {
+interface LinkButtonProps extends BaseProps {
   readonly href: string
   readonly external?: boolean
-} & Omit<ComponentPropsWithoutRef<"a">, "href" | "children">
+}
 
-type ButtonAsButton = BaseProps & {
+interface NativeButtonProps extends BaseProps {
   readonly href?: undefined
-} & Omit<ComponentPropsWithoutRef<"button">, "children">
+  readonly onClick?: () => void
+  readonly disabled?: boolean
+  readonly type?: "button" | "submit" | "reset"
+}
 
-export type ButtonProps = ButtonAsLink | ButtonAsButton
+export type ButtonProps = LinkButtonProps | NativeButtonProps
 
 const baseClasses =
   "inline-flex items-center gap-1.5 font-medium text-sm rounded-md transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-page focus-visible:ring-divider-strong"
@@ -29,50 +35,47 @@ const variantClasses: Record<ButtonVariant, string> = {
     "px-4 py-2 text-ink hover:text-accent-saas border border-divider hover:border-divider-strong bg-page",
 }
 
-function LinkButton(
-  props: ButtonAsLink & { className: string }
-) {
-  const { href, external, children, className, variant: _v, ...rest } = props
-
-  const linkProps = Object.fromEntries(
-    Object.entries(rest).filter(([_, v]) => v !== undefined)
-  ) as any
-
-  if (external === true) {
-    return (
-      <a href={href} target="_blank" rel="noopener noreferrer" className={className} {...linkProps}>
-        {children}
-      </a>
-    )
-  }
-  return (
-    <Link href={href} className={className} {...linkProps}>
-      {children}
-    </Link>
-  )
-}
-
-function NativeButton(
-  props: ButtonAsButton & { className: string }
-) {
-  const { children, className, variant: _v, ...rest } = props
-  const buttonProps = Object.fromEntries(
-    Object.entries(rest).filter(([_, v]) => v !== undefined)
-  ) as any
-
-  return (
-    <button type="button" className={className} {...buttonProps}>
-      {children}
-    </button>
-  )
-}
-
 export function Button(props: ButtonProps) {
   const variant = props.variant ?? "primary"
-  const className = `${baseClasses} ${variantClasses[variant]}`
+  const className = `${baseClasses} ${variantClasses[variant]} ${props.className ?? ""}`.trim()
 
   if (props.href !== undefined) {
-    return <LinkButton {...props} className={className} />
+    if (props.external === true) {
+      return (
+        <a
+          href={props.href}
+          target="_blank"
+          rel="noopener noreferrer"
+          className={className}
+          id={props.id}
+          aria-label={props["aria-label"]}
+        >
+          {props.children}
+        </a>
+      )
+    }
+    return (
+      <Link
+        href={props.href}
+        className={className}
+        id={props.id}
+        aria-label={props["aria-label"]}
+      >
+        {props.children}
+      </Link>
+    )
   }
-  return <NativeButton {...props} className={className} />
+
+  return (
+    <button
+      type={props.type ?? "button"}
+      onClick={props.onClick}
+      disabled={props.disabled}
+      className={className}
+      id={props.id}
+      aria-label={props["aria-label"]}
+    >
+      {props.children}
+    </button>
+  )
 }

--- a/apps/web/app/components/ui/Button.tsx
+++ b/apps/web/app/components/ui/Button.tsx
@@ -29,8 +29,7 @@ const baseClasses =
   "inline-flex items-center gap-1.5 font-medium text-sm rounded-md transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-page focus-visible:ring-divider-strong"
 
 const variantClasses: Record<ButtonVariant, string> = {
-  primary:
-    "px-4 py-2 bg-accent-saas text-accent-saas-ink hover:opacity-90 active:opacity-80",
+  primary: "px-4 py-2 bg-accent-saas text-accent-saas-ink hover:opacity-90 active:opacity-80",
   secondary:
     "px-4 py-2 text-ink hover:text-accent-saas border border-divider hover:border-divider-strong bg-page",
 }
@@ -55,12 +54,7 @@ export function Button(props: ButtonProps) {
       )
     }
     return (
-      <Link
-        href={props.href}
-        className={className}
-        id={props.id}
-        aria-label={props["aria-label"]}
-      >
+      <Link href={props.href} className={className} id={props.id} aria-label={props["aria-label"]}>
         {props.children}
       </Link>
     )

--- a/apps/web/app/components/ui/Button.tsx
+++ b/apps/web/app/components/ui/Button.tsx
@@ -29,36 +29,47 @@ const variantClasses: Record<ButtonVariant, string> = {
     "px-4 py-2 text-ink hover:text-accent-saas border border-divider hover:border-divider-strong bg-page",
 }
 
+function LinkButton({
+  href,
+  external,
+  children,
+  variant: _v,
+  className,
+  ...rest
+}: ButtonAsLink & { className: string }) {
+  if (external === true) {
+    return (
+      <a href={href} target="_blank" rel="noopener noreferrer" className={className} {...rest}>
+        {children}
+      </a>
+    )
+  }
+  return (
+    <Link href={href} className={className} {...rest}>
+      {children}
+    </Link>
+  )
+}
+
+function NativeButton({
+  children,
+  variant: _v,
+  className,
+  ...rest
+}: ButtonAsButton & { className: string }) {
+  return (
+    <button type="button" className={className} {...rest}>
+      {children}
+    </button>
+  )
+}
+
 export function Button(props: ButtonProps) {
   const variant = props.variant ?? "primary"
   const className = `${baseClasses} ${variantClasses[variant]}`
 
   if (props.href !== undefined) {
-    const { href, external, children, variant: _v, ...rest } = props as ButtonAsLink & Record<string, unknown>
-    if (external) {
-      return (
-        <a
-          href={href}
-          target="_blank"
-          rel="noopener noreferrer"
-          className={className}
-          {...(rest as Record<string, unknown>)}
-        >
-          {children}
-        </a>
-      )
-    }
-    return (
-      <Link href={href} className={className} {...(rest as Record<string, unknown>)}>
-        {children}
-      </Link>
-    )
+    return <LinkButton {...props} className={className} />
   }
-
-  const { children, variant: _v, ...rest } = props as ButtonAsButton & Record<string, unknown>
-  return (
-    <button type="button" className={className} {...(rest as Record<string, unknown>)}>
-      {children}
-    </button>
-  )
+  return <NativeButton {...props} className={className} />
 }

--- a/apps/web/app/components/ui/Button.tsx
+++ b/apps/web/app/components/ui/Button.tsx
@@ -29,36 +29,39 @@ const variantClasses: Record<ButtonVariant, string> = {
     "px-4 py-2 text-ink hover:text-accent-saas border border-divider hover:border-divider-strong bg-page",
 }
 
-function LinkButton({
-  href,
-  external,
-  children,
-  variant: _v,
-  className,
-  ...rest
-}: ButtonAsLink & { className: string }) {
+function LinkButton(
+  props: ButtonAsLink & { className: string }
+) {
+  const { href, external, children, className, variant: _v, ...rest } = props
+
+  const linkProps = Object.fromEntries(
+    Object.entries(rest).filter(([_, v]) => v !== undefined)
+  ) as any
+
   if (external === true) {
     return (
-      <a href={href} target="_blank" rel="noopener noreferrer" className={className} {...rest}>
+      <a href={href} target="_blank" rel="noopener noreferrer" className={className} {...linkProps}>
         {children}
       </a>
     )
   }
   return (
-    <Link href={href} className={className} {...rest}>
+    <Link href={href} className={className} {...linkProps}>
       {children}
     </Link>
   )
 }
 
-function NativeButton({
-  children,
-  variant: _v,
-  className,
-  ...rest
-}: ButtonAsButton & { className: string }) {
+function NativeButton(
+  props: ButtonAsButton & { className: string }
+) {
+  const { children, className, variant: _v, ...rest } = props
+  const buttonProps = Object.fromEntries(
+    Object.entries(rest).filter(([_, v]) => v !== undefined)
+  ) as any
+
   return (
-    <button type="button" className={className} {...rest}>
+    <button type="button" className={className} {...buttonProps}>
       {children}
     </button>
   )

--- a/apps/web/app/components/ui/Button.tsx
+++ b/apps/web/app/components/ui/Button.tsx
@@ -34,7 +34,7 @@ export function Button(props: ButtonProps) {
   const className = `${baseClasses} ${variantClasses[variant]}`
 
   if (props.href !== undefined) {
-    const { href, external, children, variant: _v, ...rest } = props
+    const { href, external, children, variant: _v, ...rest } = props as ButtonAsLink & Record<string, unknown>
     if (external) {
       return (
         <a
@@ -42,22 +42,22 @@ export function Button(props: ButtonProps) {
           target="_blank"
           rel="noopener noreferrer"
           className={className}
-          {...rest}
+          {...(rest as Record<string, unknown>)}
         >
           {children}
         </a>
       )
     }
     return (
-      <Link href={href} className={className} {...rest}>
+      <Link href={href} className={className} {...(rest as Record<string, unknown>)}>
         {children}
       </Link>
     )
   }
 
-  const { children, variant: _v, ...rest } = props
+  const { children, variant: _v, ...rest } = props as ButtonAsButton & Record<string, unknown>
   return (
-    <button type="button" className={className} {...rest}>
+    <button type="button" className={className} {...(rest as Record<string, unknown>)}>
       {children}
     </button>
   )

--- a/apps/web/app/components/ui/Card.tsx
+++ b/apps/web/app/components/ui/Card.tsx
@@ -17,8 +17,7 @@ export function Card({ children, tone = "surface", className = "" }: CardProps) 
     <div
       className={`rounded-xl border border-divider ${toneClasses[tone]} ${className}`}
       style={{
-        boxShadow:
-          "0 1px 2px rgba(20,17,13,0.04), 0 8px 24px -8px rgba(20,17,13,0.08)",
+        boxShadow: "0 1px 2px rgba(20,17,13,0.04), 0 8px 24px -8px rgba(20,17,13,0.08)",
       }}
     >
       {children}

--- a/apps/web/app/components/ui/Card.tsx
+++ b/apps/web/app/components/ui/Card.tsx
@@ -1,0 +1,27 @@
+import type { ReactNode } from "react"
+
+interface CardProps {
+  readonly children: ReactNode
+  readonly tone?: "surface" | "page" | "sunk"
+  readonly className?: string
+}
+
+const toneClasses: Record<NonNullable<CardProps["tone"]>, string> = {
+  page: "bg-page",
+  surface: "bg-surface",
+  sunk: "bg-surface-sunk",
+}
+
+export function Card({ children, tone = "surface", className = "" }: CardProps) {
+  return (
+    <div
+      className={`rounded-xl border border-divider ${toneClasses[tone]} ${className}`}
+      style={{
+        boxShadow:
+          "0 1px 2px rgba(20,17,13,0.04), 0 8px 24px -8px rgba(20,17,13,0.08)",
+      }}
+    >
+      {children}
+    </div>
+  )
+}

--- a/apps/web/app/components/ui/CodeFrame.tsx
+++ b/apps/web/app/components/ui/CodeFrame.tsx
@@ -1,0 +1,34 @@
+import type { ReactNode } from "react"
+
+interface CodeFrameProps {
+  readonly children: ReactNode
+  readonly label?: string
+  readonly className?: string
+}
+
+/**
+ * Browser-chrome frame for code or product visuals.
+ * Renders a top bar with traffic-light dots and an optional filename label,
+ * then the children below in a sunk surface.
+ */
+export function CodeFrame({ children, label, className = "" }: CodeFrameProps) {
+  return (
+    <div
+      className={`rounded-xl border border-divider bg-page overflow-hidden ${className}`}
+      style={{
+        boxShadow:
+          "0 1px 2px rgba(20,17,13,0.04), 0 8px 24px -8px rgba(20,17,13,0.08)",
+      }}
+    >
+      <div className="flex items-center gap-2 px-4 py-2.5 border-b border-divider bg-surface-sunk">
+        <span className="inline-block w-2.5 h-2.5 rounded-full bg-divider-strong" />
+        <span className="inline-block w-2.5 h-2.5 rounded-full bg-divider-strong" />
+        <span className="inline-block w-2.5 h-2.5 rounded-full bg-divider-strong" />
+        {label !== undefined ? (
+          <span className="ml-3 text-xs text-ink-muted font-mono truncate">{label}</span>
+        ) : null}
+      </div>
+      <div>{children}</div>
+    </div>
+  )
+}

--- a/apps/web/app/components/ui/CodeFrame.tsx
+++ b/apps/web/app/components/ui/CodeFrame.tsx
@@ -16,8 +16,7 @@ export function CodeFrame({ children, label, className = "" }: CodeFrameProps) {
     <div
       className={`rounded-xl border border-divider bg-page overflow-hidden ${className}`}
       style={{
-        boxShadow:
-          "0 1px 2px rgba(20,17,13,0.04), 0 8px 24px -8px rgba(20,17,13,0.08)",
+        boxShadow: "0 1px 2px rgba(20,17,13,0.04), 0 8px 24px -8px rgba(20,17,13,0.08)",
       }}
     >
       <div className="flex items-center gap-2 px-4 py-2.5 border-b border-divider bg-surface-sunk">

--- a/apps/web/app/components/ui/Eyebrow.tsx
+++ b/apps/web/app/components/ui/Eyebrow.tsx
@@ -1,0 +1,17 @@
+import type { ReactNode } from "react"
+
+interface EyebrowProps {
+  readonly children: ReactNode
+  readonly tone?: "default" | "accent"
+}
+
+export function Eyebrow({ children, tone = "default" }: EyebrowProps) {
+  const colorClass = tone === "accent" ? "text-accent-saas" : "text-ink-dim"
+  return (
+    <p
+      className={`text-xs font-semibold uppercase tracking-[0.06em] ${colorClass}`}
+    >
+      {children}
+    </p>
+  )
+}

--- a/apps/web/app/components/ui/Eyebrow.tsx
+++ b/apps/web/app/components/ui/Eyebrow.tsx
@@ -8,10 +8,6 @@ interface EyebrowProps {
 export function Eyebrow({ children, tone = "default" }: EyebrowProps) {
   const colorClass = tone === "accent" ? "text-accent-saas" : "text-ink-dim"
   return (
-    <p
-      className={`text-xs font-semibold uppercase tracking-[0.06em] ${colorClass}`}
-    >
-      {children}
-    </p>
+    <p className={`text-xs font-semibold uppercase tracking-[0.06em] ${colorClass}`}>{children}</p>
   )
 }

--- a/apps/web/app/components/ui/ProviderMark.tsx
+++ b/apps/web/app/components/ui/ProviderMark.tsx
@@ -1,0 +1,37 @@
+import type { ReactNode } from "react"
+
+interface ProviderMarkProps {
+  readonly name: string
+  readonly icon?: ReactNode
+  readonly href?: string
+}
+
+/**
+ * Inline word+mark for ecosystem rows. Renders the provider name with an
+ * optional icon to its left, optionally wrapped in an external link.
+ */
+export function ProviderMark({ name, icon, href }: ProviderMarkProps) {
+  const content = (
+    <span className="inline-flex items-center gap-1.5 text-sm text-ink-muted">
+      {icon !== undefined ? (
+        <span aria-hidden="true" className="inline-flex w-4 h-4">
+          {icon}
+        </span>
+      ) : null}
+      <span>{name}</span>
+    </span>
+  )
+  if (href !== undefined) {
+    return (
+      <a
+        href={href}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="hover:text-ink transition-colors"
+      >
+        {content}
+      </a>
+    )
+  }
+  return content
+}

--- a/apps/web/app/components/ui/ScreenshotFrame.tsx
+++ b/apps/web/app/components/ui/ScreenshotFrame.tsx
@@ -1,0 +1,58 @@
+import Image from "next/image"
+
+interface ScreenshotFrameProps {
+  readonly src: string
+  readonly alt: string
+  readonly width: number
+  readonly height: number
+  readonly caption?: string
+  readonly label?: string
+  readonly className?: string
+}
+
+/**
+ * Image variant of CodeFrame — browser-chrome top bar plus a next/image inside.
+ * Used for tooling screenshots (VS Code, terminal, file tree, etc.).
+ */
+export function ScreenshotFrame({
+  src,
+  alt,
+  width,
+  height,
+  caption,
+  label,
+  className = "",
+}: ScreenshotFrameProps) {
+  return (
+    <figure className={className}>
+      <div
+        className="rounded-xl border border-divider bg-page overflow-hidden"
+        style={{
+          boxShadow:
+            "0 1px 2px rgba(20,17,13,0.04), 0 8px 24px -8px rgba(20,17,13,0.08)",
+        }}
+      >
+        <div className="flex items-center gap-2 px-4 py-2.5 border-b border-divider bg-surface-sunk">
+          <span className="inline-block w-2.5 h-2.5 rounded-full bg-divider-strong" />
+          <span className="inline-block w-2.5 h-2.5 rounded-full bg-divider-strong" />
+          <span className="inline-block w-2.5 h-2.5 rounded-full bg-divider-strong" />
+          {label !== undefined ? (
+            <span className="ml-3 text-xs text-ink-muted font-mono truncate">{label}</span>
+          ) : null}
+        </div>
+        <Image
+          src={src}
+          alt={alt}
+          width={width}
+          height={height}
+          className="block w-full h-auto"
+        />
+      </div>
+      {caption !== undefined ? (
+        <figcaption className="mt-2 text-xs text-ink-muted text-center">
+          {caption}
+        </figcaption>
+      ) : null}
+    </figure>
+  )
+}

--- a/apps/web/app/components/ui/ScreenshotFrame.tsx
+++ b/apps/web/app/components/ui/ScreenshotFrame.tsx
@@ -28,8 +28,7 @@ export function ScreenshotFrame({
       <div
         className="rounded-xl border border-divider bg-page overflow-hidden"
         style={{
-          boxShadow:
-            "0 1px 2px rgba(20,17,13,0.04), 0 8px 24px -8px rgba(20,17,13,0.08)",
+          boxShadow: "0 1px 2px rgba(20,17,13,0.04), 0 8px 24px -8px rgba(20,17,13,0.08)",
         }}
       >
         <div className="flex items-center gap-2 px-4 py-2.5 border-b border-divider bg-surface-sunk">
@@ -40,18 +39,10 @@ export function ScreenshotFrame({
             <span className="ml-3 text-xs text-ink-muted font-mono truncate">{label}</span>
           ) : null}
         </div>
-        <Image
-          src={src}
-          alt={alt}
-          width={width}
-          height={height}
-          className="block w-full h-auto"
-        />
+        <Image src={src} alt={alt} width={width} height={height} className="block w-full h-auto" />
       </div>
       {caption !== undefined ? (
-        <figcaption className="mt-2 text-xs text-ink-muted text-center">
-          {caption}
-        </figcaption>
+        <figcaption className="mt-2 text-xs text-ink-muted text-center">{caption}</figcaption>
       ) : null}
     </figure>
   )

--- a/apps/web/app/components/ui/StarBadge.tsx
+++ b/apps/web/app/components/ui/StarBadge.tsx
@@ -1,7 +1,6 @@
 import { getGitHubStars } from "../../../lib/github-stars"
 
 interface StarBadgeProps {
-  readonly repoUrl?: string
   readonly className?: string
 }
 
@@ -26,14 +25,15 @@ function formatStars(count: number): string {
   return `${count}`
 }
 
-export async function StarBadge({
-  repoUrl = "https://github.com/cacheplane/dawnai",
-  className = "",
-}: StarBadgeProps) {
+/**
+ * GitHub star badge for the Dawn repo. Server component — wrap in
+ * <Suspense fallback={...}> at the call site to avoid blocking page streaming.
+ */
+export async function StarBadge({ className = "" }: StarBadgeProps) {
   const stars = await getGitHubStars()
   return (
     <a
-      href={repoUrl}
+      href="https://github.com/cacheplane/dawnai"
       target="_blank"
       rel="noopener noreferrer"
       aria-label={`Star Dawn on GitHub — ${stars} stars`}

--- a/apps/web/app/components/ui/StarBadge.tsx
+++ b/apps/web/app/components/ui/StarBadge.tsx
@@ -1,0 +1,46 @@
+import { getGitHubStars } from "../../../lib/github-stars"
+
+interface StarBadgeProps {
+  readonly repoUrl?: string
+  readonly className?: string
+}
+
+function StarIcon() {
+  return (
+    <svg
+      viewBox="0 0 16 16"
+      fill="currentColor"
+      aria-hidden="true"
+      focusable="false"
+      className="w-3.5 h-3.5"
+    >
+      <path d="M8 .25a.75.75 0 01.673.418l1.882 3.815 4.21.612a.75.75 0 01.416 1.279l-3.046 2.97.719 4.192a.75.75 0 01-1.088.791L8 12.347l-3.766 1.98a.75.75 0 01-1.088-.79l.72-4.194L.818 6.374a.75.75 0 01.416-1.28l4.21-.611L7.327.668A.75.75 0 018 .25z" />
+    </svg>
+  )
+}
+
+function formatStars(count: number): string {
+  if (count >= 1000) {
+    return `${(count / 1000).toFixed(1).replace(/\.0$/, "")}k`
+  }
+  return `${count}`
+}
+
+export async function StarBadge({
+  repoUrl = "https://github.com/cacheplane/dawnai",
+  className = "",
+}: StarBadgeProps) {
+  const stars = await getGitHubStars()
+  return (
+    <a
+      href={repoUrl}
+      target="_blank"
+      rel="noopener noreferrer"
+      aria-label={`Star Dawn on GitHub — ${stars} stars`}
+      className={`inline-flex items-center gap-1.5 text-sm text-ink-muted hover:text-ink transition-colors ${className}`}
+    >
+      <StarIcon />
+      <span className="tabular-nums">{formatStars(stars)}</span>
+    </a>
+  )
+}

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -19,6 +19,20 @@
   --color-accent-amber: #f59e0b;
   --color-accent-amber-deep: #d97706;
 
+  /* SaaS rebrand tokens (PR 1) — additive, do not modify existing cosmic/cream tokens.
+     Renamed to spec names in PR 6 cleanup. */
+  --color-page: #ffffff;
+  --color-surface: #fafaf7;
+  --color-surface-sunk: #f4f2ec;
+  --color-ink: #14110d;
+  --color-ink-muted: #5a554c;
+  --color-ink-dim: #8a857b;
+  --color-divider: #e6e3da;
+  --color-divider-strong: #cfcabd;
+  --color-accent-saas: #d97706;
+  --color-accent-saas-ink: #ffffff;
+  --color-accent-saas-soft: #fef3c7;
+
   --font-sans: var(--font-inter), ui-sans-serif, system-ui, sans-serif;
   --font-display: var(--font-fraunces), ui-serif, Georgia, serif;
   --font-mono: var(--font-jetbrains-mono), ui-monospace, "SFMono-Regular", monospace;

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -79,7 +79,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html
       lang="en"
-      className={`dark ${inter.variable} ${fraunces.variable} ${jetbrainsMono.variable}`}
+      className={`${inter.variable} ${fraunces.variable} ${jetbrainsMono.variable}`}
     >
       <body>
         <div className="min-h-screen flex flex-col">

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -77,10 +77,7 @@ export const metadata: Metadata = {
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
-    <html
-      lang="en"
-      className={`${inter.variable} ${fraunces.variable} ${jetbrainsMono.variable}`}
-    >
+    <html lang="en" className={`${inter.variable} ${fraunces.variable} ${jetbrainsMono.variable}`}>
       <body>
         <div className="min-h-screen flex flex-col">
           <Header />

--- a/apps/web/lib/github-stars.ts
+++ b/apps/web/lib/github-stars.ts
@@ -1,0 +1,26 @@
+const REPO = "cacheplane/dawnai"
+const FALLBACK = 100
+
+/**
+ * Fetches the GitHub star count for the Dawn repo.
+ * Uses Next.js fetch revalidation (1 hour) so the value is cached during
+ * production builds and refreshed during ISR. Returns a fallback on error.
+ */
+export async function getGitHubStars(): Promise<number> {
+  try {
+    const headers: HeadersInit = { Accept: "application/vnd.github+json" }
+    const token = process.env.GITHUB_TOKEN
+    if (token !== undefined && token !== "") {
+      headers.Authorization = `Bearer ${token}`
+    }
+    const response = await fetch(`https://api.github.com/repos/${REPO}`, {
+      headers,
+      next: { revalidate: 3600 },
+    })
+    if (!response.ok) return FALLBACK
+    const data = (await response.json()) as { stargazers_count?: number }
+    return typeof data.stargazers_count === "number" ? data.stargazers_count : FALLBACK
+  } catch {
+    return FALLBACK
+  }
+}

--- a/apps/web/next-env.d.ts
+++ b/apps/web/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/docs/superpowers/plans/2026-05-12-saas-rebrand-pr1-foundation.md
+++ b/docs/superpowers/plans/2026-05-12-saas-rebrand-pr1-foundation.md
@@ -1,0 +1,1566 @@
+# SaaS Rebrand PR 1 — Foundation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Land the visual foundation for the SaaS-style rebrand — new color + type tokens, reusable primitives (Button, Eyebrow, Card, CodeFrame, ScreenshotFrame, Accordion, StarBadge, ProviderMark), refreshed Header and Footer, and a rewritten `/brand` page that documents the new system. The home page still renders the existing cosmic landing; visible change is limited to chrome and the brand page.
+
+**Architecture:** Add new tokens to `app/globals.css` alongside the existing cream/cosmic system using collision-free names (`--color-page`, `--color-divider`, etc.). New primitives live under `apps/web/app/components/ui/`. Header drops the `landing-dark` scope and adopts the new system; Footer is rebuilt three-column. `/brand` page is rewritten to demo the new tokens, type scale, and primitives. CI stays green throughout.
+
+**Tech Stack:** Next.js 16 App Router, React 19, Tailwind v4 (`@theme` directive), Biome (lint), tsc (typecheck). No new test infrastructure — verification is typecheck + build + manual visual walk on dev server.
+
+**Spec:** [docs/superpowers/specs/2026-05-12-saas-rebrand-design.md](../specs/2026-05-12-saas-rebrand-design.md)
+
+**Token naming note:** The spec proposed `--color-bg`, `--color-border`, etc. To avoid collisions with the existing cream theme (which uses `--color-bg-primary`, `--color-border`), this PR uses `--color-page`, `--color-divider`, etc. Renaming to the spec names is deferred to PR 6 when the cosmic system is removed.
+
+---
+
+## File Structure
+
+**New files:**
+- `apps/web/app/components/ui/Button.tsx` — primary/secondary button primitive
+- `apps/web/app/components/ui/Eyebrow.tsx` — uppercase tracked label
+- `apps/web/app/components/ui/Card.tsx` — bordered surface primitive
+- `apps/web/app/components/ui/CodeFrame.tsx` — browser-chrome frame around content (used for shiki output)
+- `apps/web/app/components/ui/ScreenshotFrame.tsx` — image variant of CodeFrame
+- `apps/web/app/components/ui/Accordion.tsx` — keyboard-accessible disclosure list
+- `apps/web/app/components/ui/StarBadge.tsx` — GitHub star count badge (server component, build-time fetch)
+- `apps/web/app/components/ui/ProviderMark.tsx` — inline word+mark for ecosystem rows
+- `apps/web/lib/github-stars.ts` — build-time GitHub star count fetcher
+
+**Modified files:**
+- `apps/web/app/globals.css` — add new color tokens, font-size tokens; keep cream/cosmic tokens intact
+- `apps/web/app/components/Header.tsx` — passthrough, but updated repoUrl handling unchanged
+- `apps/web/app/components/HeaderInner.tsx` — drop `landing-dark` className, switch to new tokens, install-chip variant of nav action
+- `apps/web/app/components/Footer.tsx` — three-column SaaS-style rebuild on new tokens
+- `apps/web/app/brand/page.tsx` — rewrite as v2 system documentation
+- `apps/web/app/layout.tsx` — remove `className="dark"` on `<html>`
+
+**Untouched in this PR (delete or update in later PRs):**
+- `apps/web/app/page.tsx` and all `app/components/landing/*` — old cosmic landing still ships
+- `app/components/PaletteScroller.tsx`, `app/components/CreamSurface.tsx`, `app/components/ScrollReveal.tsx` — kept; deleted in PR 6
+- `apps/web/app/globals.css` cosmic-only declarations (`landing-dark` scope, `--landing-*` vars, body landing background) — kept; cleaned in PR 6
+- `apps/web/app/docs/**`, `apps/web/app/blog/**` — re-tokened in PR 7
+
+---
+
+## Verification Commands
+
+Run from the **repo root**:
+
+- Typecheck: `pnpm typecheck`
+- Build: `pnpm build`
+- Lint: `pnpm lint`
+- Dev server (for visual review): `pnpm --filter @dawn-ai/web dev` then open `http://localhost:3000` and `http://localhost:3000/brand`
+
+CI runs all of the above (per repo CI memory: build-before-typecheck ordering).
+
+---
+
+## Task 1: Add new color and type tokens to globals.css
+
+**Files:**
+- Modify: `apps/web/app/globals.css`
+
+- [ ] **Step 1: Read current globals.css**
+
+Run: open the file in your editor. Locate the existing `@theme { ... }` block at the top.
+
+- [ ] **Step 2: Add new tokens inside the existing `@theme` block**
+
+Insert the following declarations *after* the existing `--color-accent-amber-deep` line and *before* the `--font-sans` line so the cosmic/cream tokens stay untouched:
+
+```css
+  /* SaaS rebrand tokens (PR 1) — additive, do not modify existing cosmic/cream tokens.
+     Renamed to spec names in PR 6 cleanup. */
+  --color-page: #ffffff;
+  --color-surface: #fafaf7;
+  --color-surface-sunk: #f4f2ec;
+  --color-ink: #14110d;
+  --color-ink-muted: #5a554c;
+  --color-ink-dim: #8a857b;
+  --color-divider: #e6e3da;
+  --color-divider-strong: #cfcabd;
+  --color-accent-saas: #d97706;
+  --color-accent-saas-ink: #ffffff;
+  --color-accent-saas-soft: #fef3c7;
+```
+
+Display-type tokens (`text-display-xl`, `text-display-l`) are deferred to PR 2 when the Hero actually consumes them — the brand page uses arbitrary `text-[72px]` for the showcase.
+
+- [ ] **Step 3: Verify typecheck and build**
+
+Run from repo root:
+
+```bash
+pnpm typecheck
+pnpm build
+```
+
+Expected: both pass without new errors. The build will compile globals.css with the new tokens; existing pages keep rendering because no consumer references the new tokens yet.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/web/app/globals.css
+git commit -m "feat(web): add SaaS rebrand color and display-type tokens"
+```
+
+---
+
+## Task 2: Button primitive
+
+**Files:**
+- Create: `apps/web/app/components/ui/Button.tsx`
+
+- [ ] **Step 1: Create the directory**
+
+Run: `mkdir -p apps/web/app/components/ui`
+
+- [ ] **Step 2: Write `Button.tsx`**
+
+Path: `apps/web/app/components/ui/Button.tsx`
+
+```tsx
+import Link from "next/link"
+import type { ComponentPropsWithoutRef, ReactNode } from "react"
+
+type ButtonVariant = "primary" | "secondary"
+
+interface BaseProps {
+  readonly variant?: ButtonVariant
+  readonly children: ReactNode
+}
+
+type ButtonAsLink = BaseProps & {
+  readonly href: string
+  readonly external?: boolean
+} & Omit<ComponentPropsWithoutRef<"a">, "href" | "children">
+
+type ButtonAsButton = BaseProps & {
+  readonly href?: undefined
+} & Omit<ComponentPropsWithoutRef<"button">, "children">
+
+export type ButtonProps = ButtonAsLink | ButtonAsButton
+
+const baseClasses =
+  "inline-flex items-center gap-1.5 font-medium text-sm rounded-md transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-page focus-visible:ring-divider-strong"
+
+const variantClasses: Record<ButtonVariant, string> = {
+  primary:
+    "px-4 py-2 bg-accent-saas text-accent-saas-ink hover:opacity-90 active:opacity-80",
+  secondary:
+    "px-4 py-2 text-ink hover:text-accent-saas border border-divider hover:border-divider-strong bg-page",
+}
+
+export function Button(props: ButtonProps) {
+  const variant = props.variant ?? "primary"
+  const className = `${baseClasses} ${variantClasses[variant]}`
+
+  if (props.href !== undefined) {
+    const { href, external, children, variant: _v, ...rest } = props
+    if (external) {
+      return (
+        <a
+          href={href}
+          target="_blank"
+          rel="noopener noreferrer"
+          className={className}
+          {...rest}
+        >
+          {children}
+        </a>
+      )
+    }
+    return (
+      <Link href={href} className={className} {...rest}>
+        {children}
+      </Link>
+    )
+  }
+
+  const { children, variant: _v, ...rest } = props
+  return (
+    <button type="button" className={className} {...rest}>
+      {children}
+    </button>
+  )
+}
+```
+
+- [ ] **Step 3: Verify typecheck**
+
+Run: `pnpm typecheck`
+Expected: pass. (Build is not strictly required here since nothing imports the primitive yet, but typecheck catches API mistakes.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/web/app/components/ui/Button.tsx
+git commit -m "feat(web): add Button primitive for SaaS rebrand"
+```
+
+---
+
+## Task 3: Eyebrow primitive
+
+**Files:**
+- Create: `apps/web/app/components/ui/Eyebrow.tsx`
+
+- [ ] **Step 1: Write `Eyebrow.tsx`**
+
+Path: `apps/web/app/components/ui/Eyebrow.tsx`
+
+```tsx
+import type { ReactNode } from "react"
+
+interface EyebrowProps {
+  readonly children: ReactNode
+  readonly tone?: "default" | "accent"
+}
+
+export function Eyebrow({ children, tone = "default" }: EyebrowProps) {
+  const colorClass = tone === "accent" ? "text-accent-saas" : "text-ink-dim"
+  return (
+    <p
+      className={`text-xs font-semibold uppercase tracking-[0.06em] ${colorClass}`}
+    >
+      {children}
+    </p>
+  )
+}
+```
+
+- [ ] **Step 2: Verify typecheck**
+
+Run: `pnpm typecheck`
+Expected: pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/web/app/components/ui/Eyebrow.tsx
+git commit -m "feat(web): add Eyebrow primitive"
+```
+
+---
+
+## Task 4: Card primitive
+
+**Files:**
+- Create: `apps/web/app/components/ui/Card.tsx`
+
+- [ ] **Step 1: Write `Card.tsx`**
+
+Path: `apps/web/app/components/ui/Card.tsx`
+
+```tsx
+import type { ReactNode } from "react"
+
+interface CardProps {
+  readonly children: ReactNode
+  readonly tone?: "surface" | "page" | "sunk"
+  readonly className?: string
+}
+
+const toneClasses: Record<NonNullable<CardProps["tone"]>, string> = {
+  page: "bg-page",
+  surface: "bg-surface",
+  sunk: "bg-surface-sunk",
+}
+
+export function Card({ children, tone = "surface", className = "" }: CardProps) {
+  return (
+    <div
+      className={`rounded-xl border border-divider ${toneClasses[tone]} ${className}`}
+      style={{
+        boxShadow:
+          "0 1px 2px rgba(20,17,13,0.04), 0 8px 24px -8px rgba(20,17,13,0.08)",
+      }}
+    >
+      {children}
+    </div>
+  )
+}
+```
+
+- [ ] **Step 2: Verify typecheck**
+
+Run: `pnpm typecheck`
+Expected: pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/web/app/components/ui/Card.tsx
+git commit -m "feat(web): add Card primitive"
+```
+
+---
+
+## Task 5: CodeFrame primitive
+
+**Files:**
+- Create: `apps/web/app/components/ui/CodeFrame.tsx`
+
+- [ ] **Step 1: Write `CodeFrame.tsx`**
+
+Path: `apps/web/app/components/ui/CodeFrame.tsx`
+
+```tsx
+import type { ReactNode } from "react"
+
+interface CodeFrameProps {
+  readonly children: ReactNode
+  readonly label?: string
+  readonly className?: string
+}
+
+/**
+ * Browser-chrome frame for code or product visuals.
+ * Renders a top bar with traffic-light dots and an optional filename label,
+ * then the children below in a sunk surface.
+ */
+export function CodeFrame({ children, label, className = "" }: CodeFrameProps) {
+  return (
+    <div
+      className={`rounded-xl border border-divider bg-page overflow-hidden ${className}`}
+      style={{
+        boxShadow:
+          "0 1px 2px rgba(20,17,13,0.04), 0 8px 24px -8px rgba(20,17,13,0.08)",
+      }}
+    >
+      <div className="flex items-center gap-2 px-4 py-2.5 border-b border-divider bg-surface-sunk">
+        <span className="inline-block w-2.5 h-2.5 rounded-full bg-divider-strong" />
+        <span className="inline-block w-2.5 h-2.5 rounded-full bg-divider-strong" />
+        <span className="inline-block w-2.5 h-2.5 rounded-full bg-divider-strong" />
+        {label !== undefined ? (
+          <span className="ml-3 text-xs text-ink-muted font-mono truncate">{label}</span>
+        ) : null}
+      </div>
+      <div>{children}</div>
+    </div>
+  )
+}
+```
+
+- [ ] **Step 2: Verify typecheck**
+
+Run: `pnpm typecheck`
+Expected: pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/web/app/components/ui/CodeFrame.tsx
+git commit -m "feat(web): add CodeFrame primitive"
+```
+
+---
+
+## Task 6: ScreenshotFrame primitive
+
+**Files:**
+- Create: `apps/web/app/components/ui/ScreenshotFrame.tsx`
+
+- [ ] **Step 1: Write `ScreenshotFrame.tsx`**
+
+Path: `apps/web/app/components/ui/ScreenshotFrame.tsx`
+
+```tsx
+import Image from "next/image"
+
+interface ScreenshotFrameProps {
+  readonly src: string
+  readonly alt: string
+  readonly width: number
+  readonly height: number
+  readonly caption?: string
+  readonly label?: string
+  readonly className?: string
+}
+
+/**
+ * Image variant of CodeFrame — browser-chrome top bar plus a next/image inside.
+ * Used for tooling screenshots (VS Code, terminal, file tree, etc.).
+ */
+export function ScreenshotFrame({
+  src,
+  alt,
+  width,
+  height,
+  caption,
+  label,
+  className = "",
+}: ScreenshotFrameProps) {
+  return (
+    <figure className={className}>
+      <div
+        className="rounded-xl border border-divider bg-page overflow-hidden"
+        style={{
+          boxShadow:
+            "0 1px 2px rgba(20,17,13,0.04), 0 8px 24px -8px rgba(20,17,13,0.08)",
+        }}
+      >
+        <div className="flex items-center gap-2 px-4 py-2.5 border-b border-divider bg-surface-sunk">
+          <span className="inline-block w-2.5 h-2.5 rounded-full bg-divider-strong" />
+          <span className="inline-block w-2.5 h-2.5 rounded-full bg-divider-strong" />
+          <span className="inline-block w-2.5 h-2.5 rounded-full bg-divider-strong" />
+          {label !== undefined ? (
+            <span className="ml-3 text-xs text-ink-muted font-mono truncate">{label}</span>
+          ) : null}
+        </div>
+        <Image
+          src={src}
+          alt={alt}
+          width={width}
+          height={height}
+          className="block w-full h-auto"
+        />
+      </div>
+      {caption !== undefined ? (
+        <figcaption className="mt-2 text-xs text-ink-muted text-center">
+          {caption}
+        </figcaption>
+      ) : null}
+    </figure>
+  )
+}
+```
+
+- [ ] **Step 2: Verify typecheck**
+
+Run: `pnpm typecheck`
+Expected: pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/web/app/components/ui/ScreenshotFrame.tsx
+git commit -m "feat(web): add ScreenshotFrame primitive"
+```
+
+---
+
+## Task 7: Accordion primitive
+
+**Files:**
+- Create: `apps/web/app/components/ui/Accordion.tsx`
+
+- [ ] **Step 1: Write `Accordion.tsx`**
+
+Path: `apps/web/app/components/ui/Accordion.tsx`
+
+```tsx
+"use client"
+
+import { useState, type ReactNode } from "react"
+
+interface AccordionItem {
+  readonly id: string
+  readonly question: string
+  readonly answer: ReactNode
+}
+
+interface AccordionProps {
+  readonly items: readonly AccordionItem[]
+  readonly defaultOpenId?: string
+}
+
+export function Accordion({ items, defaultOpenId }: AccordionProps) {
+  const [openId, setOpenId] = useState<string | null>(defaultOpenId ?? null)
+
+  return (
+    <ul className="divide-y divide-divider border-y border-divider">
+      {items.map((item) => {
+        const isOpen = openId === item.id
+        const panelId = `accordion-panel-${item.id}`
+        const buttonId = `accordion-button-${item.id}`
+        return (
+          <li key={item.id}>
+            <h3>
+              <button
+                id={buttonId}
+                type="button"
+                aria-expanded={isOpen}
+                aria-controls={panelId}
+                onClick={() => setOpenId(isOpen ? null : item.id)}
+                className="w-full flex items-center justify-between gap-4 py-5 text-left text-ink font-medium hover:text-accent-saas transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-divider-strong rounded"
+              >
+                <span>{item.question}</span>
+                <span
+                  aria-hidden="true"
+                  className="text-ink-dim text-xl leading-none select-none"
+                >
+                  {isOpen ? "−" : "+"}
+                </span>
+              </button>
+            </h3>
+            <div
+              id={panelId}
+              role="region"
+              aria-labelledby={buttonId}
+              hidden={!isOpen}
+              className="pb-5 pr-8 text-ink-muted text-sm leading-relaxed"
+            >
+              {item.answer}
+            </div>
+          </li>
+        )
+      })}
+    </ul>
+  )
+}
+```
+
+- [ ] **Step 2: Verify typecheck**
+
+Run: `pnpm typecheck`
+Expected: pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/web/app/components/ui/Accordion.tsx
+git commit -m "feat(web): add Accordion primitive"
+```
+
+---
+
+## Task 8: GitHub star count fetcher
+
+**Files:**
+- Create: `apps/web/lib/github-stars.ts`
+
+- [ ] **Step 1: Write the fetcher**
+
+Path: `apps/web/lib/github-stars.ts`
+
+```ts
+const REPO = "cacheplane/dawnai"
+const FALLBACK = 100
+
+/**
+ * Fetches the GitHub star count for the Dawn repo.
+ * Uses Next.js fetch revalidation (1 hour) so the value is cached during
+ * production builds and refreshed during ISR. Returns a fallback on error.
+ */
+export async function getGitHubStars(): Promise<number> {
+  try {
+    const headers: HeadersInit = { Accept: "application/vnd.github+json" }
+    const token = process.env.GITHUB_TOKEN
+    if (token !== undefined && token !== "") {
+      headers.Authorization = `Bearer ${token}`
+    }
+    const response = await fetch(`https://api.github.com/repos/${REPO}`, {
+      headers,
+      next: { revalidate: 3600 },
+    })
+    if (!response.ok) return FALLBACK
+    const data = (await response.json()) as { stargazers_count?: number }
+    return typeof data.stargazers_count === "number" ? data.stargazers_count : FALLBACK
+  } catch {
+    return FALLBACK
+  }
+}
+```
+
+- [ ] **Step 2: Verify typecheck**
+
+Run: `pnpm typecheck`
+Expected: pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/web/lib/github-stars.ts
+git commit -m "feat(web): add GitHub stars fetcher with ISR revalidation"
+```
+
+---
+
+## Task 9: StarBadge primitive
+
+**Files:**
+- Create: `apps/web/app/components/ui/StarBadge.tsx`
+
+- [ ] **Step 1: Write `StarBadge.tsx`**
+
+Path: `apps/web/app/components/ui/StarBadge.tsx`
+
+```tsx
+import { getGitHubStars } from "../../../lib/github-stars"
+
+interface StarBadgeProps {
+  readonly repoUrl?: string
+  readonly className?: string
+}
+
+function StarIcon() {
+  return (
+    <svg
+      viewBox="0 0 16 16"
+      fill="currentColor"
+      aria-hidden="true"
+      focusable="false"
+      className="w-3.5 h-3.5"
+    >
+      <path d="M8 .25a.75.75 0 01.673.418l1.882 3.815 4.21.612a.75.75 0 01.416 1.279l-3.046 2.97.719 4.192a.75.75 0 01-1.088.791L8 12.347l-3.766 1.98a.75.75 0 01-1.088-.79l.72-4.194L.818 6.374a.75.75 0 01.416-1.28l4.21-.611L7.327.668A.75.75 0 018 .25z" />
+    </svg>
+  )
+}
+
+function formatStars(count: number): string {
+  if (count >= 1000) {
+    return `${(count / 1000).toFixed(1).replace(/\.0$/, "")}k`
+  }
+  return `${count}`
+}
+
+export async function StarBadge({
+  repoUrl = "https://github.com/cacheplane/dawnai",
+  className = "",
+}: StarBadgeProps) {
+  const stars = await getGitHubStars()
+  return (
+    <a
+      href={repoUrl}
+      target="_blank"
+      rel="noopener noreferrer"
+      aria-label={`Star Dawn on GitHub — ${stars} stars`}
+      className={`inline-flex items-center gap-1.5 text-sm text-ink-muted hover:text-ink transition-colors ${className}`}
+    >
+      <StarIcon />
+      <span className="tabular-nums">{formatStars(stars)}</span>
+    </a>
+  )
+}
+```
+
+- [ ] **Step 2: Verify typecheck and build**
+
+Run:
+
+```bash
+pnpm typecheck
+pnpm build
+```
+
+Expected: both pass. The `StarBadge` is a server component that fetches at build time; the build must complete the fetch (or fall back) without error.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/web/app/components/ui/StarBadge.tsx
+git commit -m "feat(web): add StarBadge primitive"
+```
+
+---
+
+## Task 10: ProviderMark primitive
+
+**Files:**
+- Create: `apps/web/app/components/ui/ProviderMark.tsx`
+
+- [ ] **Step 1: Write `ProviderMark.tsx`**
+
+Path: `apps/web/app/components/ui/ProviderMark.tsx`
+
+```tsx
+import type { ReactNode } from "react"
+
+interface ProviderMarkProps {
+  readonly name: string
+  readonly icon?: ReactNode
+  readonly href?: string
+}
+
+/**
+ * Inline word+mark for ecosystem rows. Renders the provider name with an
+ * optional icon to its left, optionally wrapped in an external link.
+ */
+export function ProviderMark({ name, icon, href }: ProviderMarkProps) {
+  const content = (
+    <span className="inline-flex items-center gap-1.5 text-sm text-ink-muted">
+      {icon !== undefined ? (
+        <span aria-hidden="true" className="inline-flex w-4 h-4">
+          {icon}
+        </span>
+      ) : null}
+      <span>{name}</span>
+    </span>
+  )
+  if (href !== undefined) {
+    return (
+      <a
+        href={href}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="hover:text-ink transition-colors"
+      >
+        {content}
+      </a>
+    )
+  }
+  return content
+}
+```
+
+- [ ] **Step 2: Verify typecheck**
+
+Run: `pnpm typecheck`
+Expected: pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/web/app/components/ui/ProviderMark.tsx
+git commit -m "feat(web): add ProviderMark primitive"
+```
+
+---
+
+## Task 11: Reskin shared chrome primitives (CopyCommand, MobileMenu)
+
+The Header refactor in Task 12 imports `CopyCommand` and `MobileMenu`. Both currently reference cream-theme tokens (`bg-bg-card`, `text-text-primary`, `bg-accent-amber`, `border-border-subtle`) that get removed in PR 6 cleanup. Reskin them now to the new SaaS tokens so the new header is consistent and PR 6 cleanup doesn't break them.
+
+**Files:**
+- Modify: `apps/web/app/components/CopyCommand.tsx`
+- Modify: `apps/web/app/components/MobileMenu.tsx`
+
+- [ ] **Step 1: Reskin `CopyCommand.tsx`**
+
+Replace the JSX return block in `apps/web/app/components/CopyCommand.tsx` (lines 22–69) with the new-token version. Keep the `"use client"` directive, imports, state, and `handleCopy` logic unchanged.
+
+The old return uses `text-text-muted`, `bg-bg-card`, `border-border`, `text-accent-amber`, `hover:bg-accent-amber/10`. The new version uses `text-ink-muted`, `bg-surface`, `border-divider`, `text-accent-saas`, `hover:bg-accent-saas-soft`.
+
+Replace this block:
+
+```tsx
+  return (
+    <div
+      className={`font-mono text-sm text-text-muted bg-bg-card inline-flex items-center gap-2 pl-4 pr-2 py-2 rounded-md border border-border ${
+        className ?? ""
+      }`}
+    >
+      <span>
+        <span className="text-accent-amber">$</span> {command}
+      </span>
+      <button
+        type="button"
+        onClick={handleCopy}
+        aria-label={copied ? "Copied" : `Copy command: ${command}`}
+        className="ml-1 p-1 rounded hover:bg-accent-amber/10 text-text-muted hover:text-accent-amber transition-colors"
+      >
+        {copied ? (
+          <svg
+            width="13"
+            height="13"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="3"
+            role="img"
+            className="text-accent-amber"
+          >
+            <title>Copied</title>
+            <polyline points="20 6 9 17 4 12" />
+          </svg>
+        ) : (
+          <svg
+            width="13"
+            height="13"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            role="img"
+          >
+            <title>Copy</title>
+            <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
+            <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+          </svg>
+        )}
+      </button>
+    </div>
+  )
+```
+
+with:
+
+```tsx
+  return (
+    <div
+      className={`font-mono text-sm text-ink-muted bg-surface inline-flex items-center gap-2 pl-4 pr-2 py-2 rounded-md border border-divider ${
+        className ?? ""
+      }`}
+    >
+      <span>
+        <span className="text-accent-saas">$</span> {command}
+      </span>
+      <button
+        type="button"
+        onClick={handleCopy}
+        aria-label={copied ? "Copied" : `Copy command: ${command}`}
+        className="ml-1 p-1 rounded hover:bg-accent-saas-soft text-ink-muted hover:text-accent-saas transition-colors"
+      >
+        {copied ? (
+          <svg
+            width="13"
+            height="13"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="3"
+            role="img"
+            className="text-accent-saas"
+          >
+            <title>Copied</title>
+            <polyline points="20 6 9 17 4 12" />
+          </svg>
+        ) : (
+          <svg
+            width="13"
+            height="13"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            role="img"
+          >
+            <title>Copy</title>
+            <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
+            <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+          </svg>
+        )}
+      </button>
+    </div>
+  )
+```
+
+- [ ] **Step 2: Reskin `MobileMenu.tsx`**
+
+In `apps/web/app/components/MobileMenu.tsx`, apply these token swaps. Each `old` string appears once in the file unless noted.
+
+| Old                                                          | New                                                             |
+|--------------------------------------------------------------|-----------------------------------------------------------------|
+| `text-text-secondary hover:text-text-primary hover:bg-bg-card` | `text-ink-muted hover:text-ink hover:bg-surface` (replace all 4 occurrences) |
+| `bg-bg-primary` (overlay)                                    | `bg-page`                                                       |
+| `border-border-subtle` (replace all 2 occurrences)           | `border-divider`                                                |
+| `text-text-muted` (replace all 4 occurrences)                | `text-ink-dim`                                                  |
+| `bg-accent-amber text-bg-primary` (CTA)                      | `bg-accent-saas text-accent-saas-ink`                           |
+| `text-accent-amber bg-accent-amber/8` (active docs link)     | `text-accent-saas bg-accent-saas-soft`                          |
+
+After the swaps, the MobileMenu renders on the new SaaS palette with the same structure and behavior.
+
+- [ ] **Step 3: Verify typecheck and build**
+
+Run from repo root:
+
+```bash
+pnpm typecheck
+pnpm build
+```
+
+Expected: both pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/web/app/components/CopyCommand.tsx apps/web/app/components/MobileMenu.tsx
+git commit -m "feat(web): reskin CopyCommand and MobileMenu to SaaS tokens"
+```
+
+---
+
+## Task 12: Refactor Header to new system
+
+**Files:**
+- Modify: `apps/web/app/components/HeaderInner.tsx`
+- Modify: `apps/web/app/layout.tsx`
+
+- [ ] **Step 1: Read `HeaderInner.tsx`**
+
+Open the file. Note the current structure: it uses `className="landing-dark"` on the `<header>` element, `text-text-secondary` and `bg-accent-amber` from the cream/cosmic system, and a "Read the Docs" CTA in the right slot.
+
+- [ ] **Step 2: Replace the file with the refactored version**
+
+Path: `apps/web/app/components/HeaderInner.tsx`
+
+```tsx
+"use client"
+
+import Link from "next/link"
+import { usePathname } from "next/navigation"
+import { BrandLogo } from "./BrandLogo"
+import { MobileMenu } from "./MobileMenu"
+import { CopyCommand } from "./CopyCommand"
+
+function GitHubIcon() {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      aria-hidden="true"
+      focusable="false"
+      fill="currentColor"
+      className="w-5 h-5"
+    >
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M12 0C5.37 0 0 5.37 0 12c0 5.3 3.438 9.8 8.205 11.387.6.113.82-.26.82-.577 0-.285-.01-1.04-.015-2.04-3.338.725-4.042-1.61-4.042-1.61-.547-1.387-1.335-1.757-1.335-1.757-1.09-.745.083-.73.083-.73 1.205.085 1.84 1.237 1.84 1.237 1.07 1.835 2.807 1.305 3.492.998.108-.775.42-1.305.762-1.605-2.665-.305-5.467-1.335-5.467-5.93 0-1.31.467-2.38 1.235-3.22-.123-.305-.535-1.527.118-3.18 0 0 1.008-.323 3.3 1.23.957-.267 1.98-.4 3-.405 1.02.005 2.043.138 3 .405 2.29-1.553 3.297-1.23 3.297-1.23.655 1.653.243 2.875.12 3.18.77.84 1.233 1.91 1.233 3.22 0 4.61-2.807 5.62-5.48 5.92.43.37.815 1.103.815 2.222 0 1.605-.015 2.898-.015 3.293 0 .32.217.697.825.578C20.565 21.795 24 17.297 24 12c0-6.63-5.37-12-12-12z"
+      />
+    </svg>
+  )
+}
+
+interface HeaderInnerProps {
+  readonly repoUrl: string
+}
+
+export function HeaderInner({ repoUrl }: HeaderInnerProps) {
+  const pathname = usePathname()
+
+  const linkClass = (active: boolean) =>
+    active
+      ? "text-ink transition-colors"
+      : "text-ink-muted hover:text-ink transition-colors"
+
+  return (
+    <header className="bg-page border-b border-divider">
+      <div className="max-w-[1280px] mx-auto flex justify-between items-center px-6 md:px-8 py-4">
+        <BrandLogo imageClassName="h-8" />
+        <nav className="hidden md:flex items-center gap-6 text-sm">
+          <Link href="/docs/getting-started" className={linkClass(pathname.startsWith("/docs"))}>
+            Docs
+          </Link>
+          <Link href="/blog" className={linkClass(pathname.startsWith("/blog"))}>
+            Blog
+          </Link>
+          <Link href="/brand" className={linkClass(pathname === "/brand")}>
+            Brand
+          </Link>
+          <a
+            href={repoUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="GitHub"
+            className="inline-flex items-center gap-1.5 text-ink-muted hover:text-ink transition-colors"
+          >
+            <GitHubIcon />
+          </a>
+          <CopyCommand command="pnpm create dawn-ai-app" />
+        </nav>
+        <MobileMenu />
+      </div>
+    </header>
+  )
+}
+```
+
+Notes:
+- `landing-dark` className is removed.
+- The "Read the Docs" CTA is replaced by a `CopyCommand` install chip — Docs is now in the main nav, and the install command is the primary right-side action.
+- Static "100+" star count is removed; PR 3 reintroduces a live star count in the ProofStrip section, not in the header.
+
+- [ ] **Step 3: Read `apps/web/app/layout.tsx`**
+
+Locate the `<html lang="en" className={`dark ${...}`}>` line.
+
+- [ ] **Step 4: Remove `dark` class from `<html>`**
+
+Edit `apps/web/app/layout.tsx` line ~80–83. Replace:
+
+```tsx
+    <html
+      lang="en"
+      className={`dark ${inter.variable} ${fraunces.variable} ${jetbrainsMono.variable}`}
+    >
+```
+
+with:
+
+```tsx
+    <html
+      lang="en"
+      className={`${inter.variable} ${fraunces.variable} ${jetbrainsMono.variable}`}
+    >
+```
+
+- [ ] **Step 5: Verify typecheck, build, and visual review**
+
+Run from repo root:
+
+```bash
+pnpm typecheck
+pnpm build
+```
+
+Expected: both pass.
+
+Then start the dev server: `pnpm --filter @dawn-ai/web dev`. Open `http://localhost:3000` — the cosmic landing should still render correctly under the new header (the `landing-dark` scope on the page wrapper still drives the section colors). Open `http://localhost:3000/docs/getting-started` — the header should now be light with cream-system content below; verify there are no obvious z-index or color regressions. Stop the dev server when satisfied.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web/app/components/HeaderInner.tsx apps/web/app/layout.tsx
+git commit -m "feat(web): refactor Header to SaaS rebrand tokens"
+```
+
+---
+
+## Task 13: Refactor Footer to three-column layout
+
+**Files:**
+- Modify: `apps/web/app/components/Footer.tsx`
+
+- [ ] **Step 1: Replace the Footer file**
+
+Path: `apps/web/app/components/Footer.tsx`
+
+```tsx
+import Link from "next/link"
+import { BrandLogo } from "./BrandLogo"
+
+interface LinkItem {
+  readonly label: string
+  readonly href: string
+  readonly external?: boolean
+}
+
+interface Column {
+  readonly heading: string
+  readonly items: readonly LinkItem[]
+}
+
+const COLUMNS: readonly Column[] = [
+  {
+    heading: "Product",
+    items: [
+      { label: "Docs", href: "/docs/getting-started" },
+      { label: "Examples", href: "/docs/recipes" },
+      { label: "Blog", href: "/blog" },
+      { label: "Brand", href: "/brand" },
+    ],
+  },
+  {
+    heading: "Resources",
+    items: [
+      { label: "GitHub", href: "https://github.com/cacheplane/dawnai", external: true },
+      { label: "npm", href: "https://www.npmjs.com/org/dawn-ai", external: true },
+      {
+        label: "LangGraph.js",
+        href: "https://www.langchain.com/langgraph",
+        external: true,
+      },
+      { label: "RSS feed", href: "/blog/rss.xml", external: true },
+      { label: "llms.txt", href: "/llms.txt", external: true },
+    ],
+  },
+  {
+    heading: "Legal",
+    items: [
+      {
+        label: "MIT License",
+        href: "https://github.com/cacheplane/dawnai/blob/main/LICENSE",
+        external: true,
+      },
+      {
+        label: "Code of Conduct",
+        href: "https://github.com/cacheplane/dawnai/blob/main/CODE_OF_CONDUCT.md",
+        external: true,
+      },
+      {
+        label: "Security",
+        href: "https://github.com/cacheplane/dawnai/blob/main/SECURITY.md",
+        external: true,
+      },
+    ],
+  },
+]
+
+function FooterLink({ label, href, external }: LinkItem) {
+  const className = "text-sm text-ink-muted hover:text-ink transition-colors block py-0.5"
+  if (external) {
+    return (
+      <a href={href} target="_blank" rel="noopener noreferrer" className={className}>
+        {label}
+      </a>
+    )
+  }
+  return (
+    <Link href={href} className={className}>
+      {label}
+    </Link>
+  )
+}
+
+export function Footer() {
+  return (
+    <footer className="bg-surface border-t border-divider">
+      <div className="max-w-[1200px] mx-auto px-6 md:px-8 pt-16 pb-10">
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-10 md:gap-8">
+          <div className="col-span-2 md:col-span-1">
+            <BrandLogo imageClassName="h-7" />
+            <p className="text-sm text-ink-muted mt-3 leading-relaxed max-w-[28ch]">
+              TypeScript meta-framework for LangGraph.js.
+            </p>
+          </div>
+          {COLUMNS.map((col) => (
+            <div key={col.heading} className="flex flex-col gap-1">
+              <p className="text-xs font-semibold uppercase tracking-[0.06em] text-ink-dim mb-3">
+                {col.heading}
+              </p>
+              {col.items.map((item) => (
+                <FooterLink key={item.label} {...item} />
+              ))}
+            </div>
+          ))}
+        </div>
+        <div className="mt-12 pt-6 border-t border-divider flex flex-col md:flex-row gap-2 md:justify-between text-xs text-ink-dim">
+          <span>{`© ${new Date().getFullYear()} Dawn. MIT-licensed.`}</span>
+          <span>Built on the LangChain ecosystem.</span>
+        </div>
+      </div>
+    </footer>
+  )
+}
+```
+
+- [ ] **Step 2: Verify typecheck and build**
+
+Run:
+
+```bash
+pnpm typecheck
+pnpm build
+```
+
+Expected: both pass.
+
+- [ ] **Step 3: Visual review**
+
+Start dev server: `pnpm --filter @dawn-ai/web dev`. Open `http://localhost:3000` — the footer should now be light cream with three columns + a brand block. Open `http://localhost:3000/docs/getting-started` — the same light footer should appear under the docs. Stop dev server.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/web/app/components/Footer.tsx
+git commit -m "feat(web): rebuild Footer in SaaS three-column layout"
+```
+
+---
+
+## Task 14: Rewrite /brand page as v2 system documentation
+
+**Files:**
+- Modify: `apps/web/app/brand/page.tsx`
+
+- [ ] **Step 1: Read the current `/brand` page**
+
+Open `apps/web/app/brand/page.tsx`. Note its current shape — it documents the cosmic palette, type, and assets.
+
+- [ ] **Step 2: Replace the brand page**
+
+Path: `apps/web/app/brand/page.tsx`
+
+```tsx
+import type { Metadata } from "next"
+import { Button } from "../components/ui/Button"
+import { Card } from "../components/ui/Card"
+import { CodeFrame } from "../components/ui/CodeFrame"
+import { Eyebrow } from "../components/ui/Eyebrow"
+import { ProviderMark } from "../components/ui/ProviderMark"
+import { StarBadge } from "../components/ui/StarBadge"
+import { Accordion } from "../components/ui/Accordion"
+
+export const metadata: Metadata = {
+  title: "Brand",
+  description: "Dawn brand and design system.",
+}
+
+interface SwatchProps {
+  readonly name: string
+  readonly token: string
+  readonly value: string
+}
+
+function Swatch({ name, token, value }: SwatchProps) {
+  return (
+    <div className="flex items-center gap-3 py-2">
+      <span
+        className="inline-block w-10 h-10 rounded-md border border-divider"
+        style={{ backgroundColor: value }}
+        aria-hidden="true"
+      />
+      <div className="flex flex-col">
+        <span className="text-sm text-ink font-medium">{name}</span>
+        <span className="text-xs text-ink-muted font-mono">{token}</span>
+        <span className="text-xs text-ink-dim font-mono">{value}</span>
+      </div>
+    </div>
+  )
+}
+
+const SWATCHES: readonly SwatchProps[] = [
+  { name: "Page", token: "--color-page", value: "#ffffff" },
+  { name: "Surface", token: "--color-surface", value: "#fafaf7" },
+  { name: "Surface (sunk)", token: "--color-surface-sunk", value: "#f4f2ec" },
+  { name: "Ink", token: "--color-ink", value: "#14110d" },
+  { name: "Ink (muted)", token: "--color-ink-muted", value: "#5a554c" },
+  { name: "Ink (dim)", token: "--color-ink-dim", value: "#8a857b" },
+  { name: "Divider", token: "--color-divider", value: "#e6e3da" },
+  { name: "Divider (strong)", token: "--color-divider-strong", value: "#cfcabd" },
+  { name: "Accent", token: "--color-accent-saas", value: "#d97706" },
+  { name: "Accent (soft)", token: "--color-accent-saas-soft", value: "#fef3c7" },
+]
+
+export default function BrandPage() {
+  return (
+    <div className="bg-page">
+      <div className="max-w-[1100px] mx-auto px-6 md:px-8 py-16 md:py-24">
+
+        {/* Header */}
+        <section className="mb-16 md:mb-24">
+          <Eyebrow>Design system · v2 (in progress)</Eyebrow>
+          <h1
+            className="font-display text-[56px] leading-[60px] md:text-[72px] md:leading-[76px] font-semibold text-ink mt-3"
+            style={{ fontVariationSettings: "'opsz' 144, 'SOFT' 50, 'WONK' 0", letterSpacing: "-0.01em" }}
+          >
+            Dawn brand.
+          </h1>
+          <p className="text-lg text-ink-muted mt-5 max-w-2xl leading-relaxed">
+            The visual language for Dawn — a restrained, infrastructure-grade
+            system built on off-white surfaces, near-black ink, and a single
+            amber accent. This page is the source of truth as the SaaS rebrand
+            lands across the site.
+          </p>
+        </section>
+
+        {/* Color */}
+        <section className="mb-16 md:mb-24">
+          <Eyebrow>Color</Eyebrow>
+          <h2 className="font-display text-3xl md:text-4xl font-semibold text-ink mt-2 mb-6">
+            Tokens
+          </h2>
+          <Card className="p-6">
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-x-8 gap-y-1">
+              {SWATCHES.map((s) => (
+                <Swatch key={s.token} {...s} />
+              ))}
+            </div>
+          </Card>
+        </section>
+
+        {/* Type */}
+        <section className="mb-16 md:mb-24">
+          <Eyebrow>Type</Eyebrow>
+          <h2 className="font-display text-3xl md:text-4xl font-semibold text-ink mt-2 mb-6">
+            Scale
+          </h2>
+          <Card className="p-6 space-y-6">
+            <div>
+              <p className="text-xs text-ink-dim font-mono mb-1">Display XL · Fraunces 600 · 72/76</p>
+              <p
+                className="font-display text-[72px] leading-[76px] font-semibold text-ink"
+                style={{ fontVariationSettings: "'opsz' 144, 'SOFT' 50, 'WONK' 0", letterSpacing: "-0.01em" }}
+              >
+                Build LangGraph agents.
+              </p>
+            </div>
+            <div>
+              <p className="text-xs text-ink-dim font-mono mb-1">H1 · Fraunces 600 · 40/44</p>
+              <p
+                className="font-display text-[40px] leading-[44px] font-semibold text-ink"
+                style={{ fontVariationSettings: "'opsz' 144, 'SOFT' 50, 'WONK' 0" }}
+              >
+                Routes for agents, not just pages.
+              </p>
+            </div>
+            <div>
+              <p className="text-xs text-ink-dim font-mono mb-1">Body L · Inter 400 · 18/30</p>
+              <p className="text-lg text-ink leading-[30px] max-w-2xl">
+                Dawn adds file-system routing, route-local tools, generated
+                types, and HMR to your existing LangGraph.js stack.
+              </p>
+            </div>
+            <div>
+              <p className="text-xs text-ink-dim font-mono mb-1">Body · Inter 400 · 16/26</p>
+              <p className="text-base text-ink leading-[26px] max-w-2xl">
+                Keep the runtime. Drop the boilerplate.
+              </p>
+            </div>
+            <div>
+              <p className="text-xs text-ink-dim font-mono mb-1">Small · Inter 400 · 14/22</p>
+              <p className="text-sm text-ink-muted leading-[22px] max-w-2xl">
+                Production caveats, links, and supporting copy live at this size.
+              </p>
+            </div>
+            <div>
+              <p className="text-xs text-ink-dim font-mono mb-1">Code · JetBrains Mono 400 · 14/22</p>
+              <code className="text-sm text-ink font-mono">pnpm create dawn-ai-app my-agent</code>
+            </div>
+          </Card>
+        </section>
+
+        {/* Primitives */}
+        <section className="mb-16 md:mb-24">
+          <Eyebrow>Primitives</Eyebrow>
+          <h2 className="font-display text-3xl md:text-4xl font-semibold text-ink mt-2 mb-6">
+            Components
+          </h2>
+
+          <div className="space-y-6">
+            <Card className="p-6">
+              <p className="text-xs text-ink-dim font-mono mb-3">Button</p>
+              <div className="flex flex-wrap items-center gap-3">
+                <Button variant="primary" href="/docs/getting-started">
+                  Read the docs
+                </Button>
+                <Button variant="secondary" href="https://github.com/cacheplane/dawnai" external>
+                  Star on GitHub
+                </Button>
+              </div>
+            </Card>
+
+            <Card className="p-6">
+              <p className="text-xs text-ink-dim font-mono mb-3">StarBadge</p>
+              <StarBadge />
+            </Card>
+
+            <Card className="p-6">
+              <p className="text-xs text-ink-dim font-mono mb-3">ProviderMark</p>
+              <div className="flex flex-wrap items-center gap-x-6 gap-y-2">
+                <ProviderMark name="OpenAI" href="https://openai.com" />
+                <ProviderMark name="Anthropic" href="https://www.anthropic.com" />
+                <ProviderMark name="Google" />
+                <ProviderMark name="Ollama" />
+              </div>
+            </Card>
+
+            <Card className="p-6">
+              <p className="text-xs text-ink-dim font-mono mb-3">CodeFrame</p>
+              <CodeFrame label="src/app/(public)/support/index.ts">
+                <pre className="m-0 px-4 py-4 text-sm font-mono text-ink leading-[22px] overflow-x-auto">
+{`import { agent } from "@dawn-ai/sdk"
+
+export default agent({
+  model: "openai:gpt-4o-mini",
+  systemPrompt: "Answer for {tenant}.",
+})`}
+                </pre>
+              </CodeFrame>
+            </Card>
+
+            <Card className="p-6">
+              <p className="text-xs text-ink-dim font-mono mb-3">Accordion</p>
+              <Accordion
+                defaultOpenId="ex-1"
+                items={[
+                  {
+                    id: "ex-1",
+                    question: "What is this primitive used for?",
+                    answer: (
+                      <p>
+                        The FAQ section on the rebranded landing page uses this
+                        primitive. It's keyboard-accessible and respects
+                        prefers-reduced-motion.
+                      </p>
+                    ),
+                  },
+                  {
+                    id: "ex-2",
+                    question: "Can multiple items be open at once?",
+                    answer: <p>No — only one item is open at a time by design.</p>,
+                  },
+                ]}
+              />
+            </Card>
+          </div>
+        </section>
+
+        {/* Status */}
+        <section>
+          <Eyebrow>Status</Eyebrow>
+          <h2 className="font-display text-3xl md:text-4xl font-semibold text-ink mt-2 mb-3">
+            Rebrand progress
+          </h2>
+          <p className="text-base text-ink-muted leading-relaxed max-w-2xl">
+            This page reflects PR 1 of the SaaS-style rebrand: tokens,
+            primitives, refreshed Header and Footer. The landing page, docs, and
+            blog are migrated in subsequent PRs. See{" "}
+            <a
+              className="text-accent-saas hover:opacity-80"
+              href="https://github.com/cacheplane/dawnai/pulls"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              open PRs on GitHub
+            </a>
+            .
+          </p>
+        </section>
+
+      </div>
+    </div>
+  )
+}
+```
+
+- [ ] **Step 3: Verify typecheck and build**
+
+Run:
+
+```bash
+pnpm typecheck
+pnpm build
+```
+
+Expected: both pass. The build will execute the `StarBadge` fetch — verify it completes (or falls back) without error.
+
+- [ ] **Step 4: Visual review**
+
+Start dev server: `pnpm --filter @dawn-ai/web dev`. Open `http://localhost:3000/brand`. Walk every section:
+- Color swatches render with correct values and labels.
+- Type scale renders at expected sizes and weights.
+- Buttons render in both variants and respond to hover.
+- StarBadge shows a number (live or fallback `100`).
+- ProviderMark row renders inline.
+- CodeFrame renders with traffic-light dots and the code block inside.
+- Accordion opens/closes on click; keyboard `Tab` reaches the trigger and `Enter`/`Space` toggle it.
+
+Open the page in mobile width (DevTools 375px). Verify the swatch grid, type, and components stack readably with no horizontal scroll.
+
+Stop the dev server.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/app/brand/page.tsx
+git commit -m "feat(web): rewrite /brand as SaaS rebrand v2 documentation"
+```
+
+---
+
+## Task 15: Lint pass
+
+**Files:**
+- All files modified in PR 1.
+
+- [ ] **Step 1: Run lint**
+
+Run from repo root: `pnpm lint`
+Expected: pass. If biome reports issues in new files, fix them inline and re-run.
+
+- [ ] **Step 2: Commit any lint fixes**
+
+If fixes were needed:
+
+```bash
+git add -A
+git commit -m "chore(web): biome lint pass"
+```
+
+If no fixes, skip this step.
+
+---
+
+## Task 16: Push branch and open PR
+
+**Files:** none.
+
+- [ ] **Step 1: Push the branch**
+
+Run from repo root:
+
+```bash
+git push -u origin claude/relaxed-morse-fed86b
+```
+
+- [ ] **Step 2: Open the PR**
+
+Run from repo root:
+
+```bash
+gh pr create --title "feat(web): SaaS rebrand PR 1 — foundation tokens, primitives, chrome" --body "$(cat <<'EOF'
+## Summary
+
+PR 1 of the SaaS-style rebrand sequence. Lands the visual foundation: new color and display-type tokens (additive, alongside existing cream/cosmic system), reusable primitives (Button, Eyebrow, Card, CodeFrame, ScreenshotFrame, Accordion, StarBadge, ProviderMark), refreshed Header and Footer, and a rewritten /brand page that documents the system.
+
+Spec: docs/superpowers/specs/2026-05-12-saas-rebrand-design.md
+Plan: docs/superpowers/plans/2026-05-12-saas-rebrand-pr1-foundation.md
+
+The home page still renders the existing cosmic landing — that's replaced in PR 2 (hero) and following PRs. Visible change in this PR is limited to header, footer, and /brand.
+
+## Test plan
+
+- [ ] pnpm typecheck — green
+- [ ] pnpm build — green
+- [ ] pnpm lint — green
+- [ ] CI: all checks green
+- [ ] Visual: /brand renders all sections with new tokens and primitives
+- [ ] Visual: / (landing) still renders cosmic landing correctly under the new header
+- [ ] Visual: /docs/getting-started renders under new chrome with no regressions
+- [ ] Visual: mobile width (375px) for / and /brand
+- [ ] Accordion keyboard-accessible (Tab/Enter/Space)
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 3: Capture the PR URL**
+
+The PR URL is returned by `gh pr create`. Save it for the next step.
+
+---
+
+## Task 17: Wait for CI and merge
+
+**Files:** none.
+
+- [ ] **Step 1: Watch CI**
+
+Run from repo root: `gh pr checks --watch`
+Expected: all checks complete and pass.
+
+If a check fails, do NOT merge. Fix the underlying issue with a new commit on the same branch and re-run CI.
+
+- [ ] **Step 2: Merge on green**
+
+Once all checks pass:
+
+```bash
+gh pr merge --squash --delete-branch
+```
+
+- [ ] **Step 3: Verify main is updated**
+
+```bash
+git fetch origin
+git log origin/main --oneline -5
+```
+
+Expected: the squashed PR 1 commit appears at the top.
+
+---
+
+## Self-Review Summary
+
+- **Spec coverage:** Tokens (Task 1), primitives Button/Eyebrow/Card/CodeFrame/ScreenshotFrame/Accordion/StarBadge/ProviderMark (Tasks 2–10), chrome reskin CopyCommand+MobileMenu (Task 11), Header refactor (Task 12), Footer rebuild (Task 13), /brand rewrite (Task 14), lint/PR/merge (Tasks 15–17). All PR 1 spec items addressed.
+- **Placeholder scan:** No TBDs or "implement later." All code is concrete.
+- **Token naming:** Plan uses `--color-page`/`--color-divider` instead of spec's `--color-bg`/`--color-border` to avoid collision; rename happens in PR 6 cleanup. Flagged in the header.
+- **Test infrastructure:** No new test infra added — vitest is configured for node-only `.ts` files, not React component tests. Verification is typecheck + build + manual dev-server walk, as the spec already permits ("Visual regression is manual").
+
+---
+
+## Trajectory: Subsequent PRs
+
+Each PR below gets its own plan written after the prior PR merges, so each plan is grounded in the actual post-merge code state.
+
+- **PR 2 — Hero replacement.** New `Hero.tsx` replaces the cosmic hero stack. Removes parallax/starfield from the landing.
+- **PR 3 — ProofStrip + WhyDawn.** Replaces ProblemSection, WhoItsFor, SolutionSection.
+- **PR 4 — Feature blocks.** Reusable FeatureBlock primitive + four section instances (Routing, Tools, Types, Dev loop). Replaces FeatureGrid, CodeExample.
+- **PR 5 — KeepTheRuntime + Ecosystem + Quickstart.** Replaces NotAReplacement, ComparisonTable, ArchitectureSection, DeploySection, EcosystemSection, HowItWorks.
+- **PR 6 — FAQ + FinalCta + cosmic cleanup.** Adds FAQ and FinalCta. Deletes PaletteScroller, palette stops, ScrollReveal (or replaces), CreamSurface, HeroEarthParallax, StarsSection, BigReveal, ComicStrip, MigrateCta, CtaSection, all cosmic globals/scope. Renames `--color-page` → `--color-bg` and `--color-divider` → `--color-border` if desired.
+- **PR 7 — Docs/blog re-token.** New tokens applied to docs/blog chrome and `mdx-components.tsx`.
+- **PR 8 — Calibration.** Amber tuning for AA contrast, copy polish, final visual walk.

--- a/docs/superpowers/specs/2026-05-12-saas-rebrand-design.md
+++ b/docs/superpowers/specs/2026-05-12-saas-rebrand-design.md
@@ -1,0 +1,371 @@
+# Dawn Website SaaS-Style Rebrand — Design
+
+**Date:** 2026-05-12
+**Scope:** Whole site (landing, header, footer, docs/blog chrome, brand page)
+**Type:** Visual rebrand + landing IA rewrite
+
+## Summary
+
+Rebrand the Dawn website around a restrained, developer-infrastructure aesthetic — off-white surfaces, near-black ink, single amber accent, Fraunces display + Inter body + JetBrains Mono code. Replace the current 17-section "cosmic dawn arc" landing page with a 14-section page structured for senior engineers and engineering managers evaluating Dawn for their team, with code-first product visuals and honest open-source proof points.
+
+This is a meaningful rebrand, not a polish pass. The cosmic palette, palette scroller, parallax earth, comic strip, and atmospheric scroll motion all go. Only the Dawn name, logo, wordmark, and the tagline "Build LangGraph agents like Next.js apps" survive from the current brand. The amber color and Fraunces typeface are retained because they fit the new direction, not because they're sacred.
+
+## Positioning & Audience
+
+**Product:** Dawn — TypeScript meta-framework for LangGraph.js.
+
+**Tagline (kept):** "Build LangGraph agents like Next.js apps."
+
+**Supporting line (kept, lightly editable):** "Dawn adds file-system routing, route-local tools, generated types, and HMR to your existing LangGraph.js stack. Keep the runtime. Drop the boilerplate."
+
+**Primary audience:** staff/principal engineers and engineering managers evaluating Dawn for their team. They need credibility, scope-of-claims clarity, honest pre-1.0 positioning, and a clean read on LangGraph compatibility.
+
+**Secondary audience (same page):** the implementer dev who will `pnpm create` and read the docs. They need a working install command and a code example that scans without marketing copy on top.
+
+**Tone:** plainspoken, opinionated where Dawn has a real opinion, honest about pre-1.0 status, no SaaS clichés. Confidence without overclaiming.
+
+**Page must not:**
+- Pretend Dawn has customer logos, business-outcome testimonials, compliance posture, or a sales motion.
+- Hide that it's pre-1.0 or that it builds on LangGraph.js (the runtime dependency is a feature, not a leak).
+- Inherit the cosmic/palette aesthetic. The dawn metaphor lives only in the name.
+
+## Visual System
+
+### Color tokens
+
+```
+--color-bg            #ffffff      page background
+--color-surface       #fafaf7      cards, bands
+--color-surface-sunk  #f4f2ec      FAQ, code wells, final CTA band
+--color-ink           #14110d      primary text
+--color-ink-muted     #5a554c      secondary text, captions
+--color-ink-dim       #8a857b      eyebrows, tertiary
+--color-border        #e6e3da      hairline borders
+--color-border-strong #cfcabd      heavier dividers, focus rings
+--color-accent        #d97706      primary CTA, links, marker emphasis (calibrated in PR 8)
+--color-accent-ink    #ffffff      text on amber surfaces
+--color-accent-soft   #fef3c7      amber-tinted highlight, used sparingly
+```
+
+The exact amber value is a starting point and gets tuned in PR 8 against AA contrast on small text. Likely shifts to `#b45309` for the CTA fill if `#d97706` doesn't meet AA against white.
+
+### Typography
+
+- Display: **Fraunces** (variable, opsz/SOFT/WONK kept). Weight 500–600.
+- Body: **Inter**. 400 body, 500 emphasis, 600 small caps eyebrows.
+- Code: **JetBrains Mono**. 400 body, 500 inline emphasis.
+
+Type scale (rough, calibrate in execution):
+
+```
+Display XL  72/76   Fraunces 600  -1% tracking
+Display L   56/60   Fraunces 600  -1%
+H1          40/44   Fraunces 600
+H2          28/34   Fraunces 600
+H3          20/28   Inter 600
+Body L      18/30   Inter 400
+Body        16/26   Inter 400
+Small       14/22   Inter 400
+Eyebrow     12/16   Inter 600 uppercase tracked +6%
+Code        14/22   JetBrains Mono 400
+```
+
+### Layout
+
+- Content max-width 1200px, header max-width 1280px.
+- Section vertical rhythm 96px desktop / 64px mobile.
+- Two-column feature blocks alternate text/visual; single column below 880px.
+- Card radius 12px outer, 8px inner for image frames.
+- One shadow token: `0 1px 2px rgba(20,17,13,0.04), 0 8px 24px -8px rgba(20,17,13,0.08)`.
+- Borders preferred over shadows; both together used sparingly.
+- No glassmorphism, no decorative gradients beyond an optional amber-to-transparent band on the final CTA.
+
+### Motion
+
+- Hover: opacity/border 120ms ease.
+- Reveal on scroll: 8px translate + opacity, 240ms ease, once. Respects `prefers-reduced-motion`.
+- No parallax, no palette scroller, no scroll-jacked timelines.
+
+### Accessibility floor
+
+- AA contrast on body text and CTAs.
+- Visible focus rings using `--color-border-strong` + 2px offset.
+- Reduced-motion fallback collapses reveals.
+
+## Page IA (Landing — 14 sections)
+
+### 1. Nav (Header)
+
+Left: Dawn wordmark. Center/right: Docs · Examples · Blog · GitHub. Right action: `CopyCommand` chip with `pnpm create dawn-ai-app` + "Docs" text link. Sticky, hairline border-bottom on scroll, no shadow.
+
+### 2. Hero
+
+- Eyebrow: `TypeScript meta-framework · for LangGraph.js`.
+- H1: "Build LangGraph agents like Next.js apps."
+- Sub: "Dawn adds file-system routing, route-local tools, generated types, and HMR to your existing LangGraph.js stack. **Keep the runtime. Drop the boilerplate.**"
+- Actions: `CopyCommand` (primary, amber) + "Read the docs" text link.
+- Visual: single browser-framed card showing a file tree on the left and a route file open on the right with shiki highlighting. Reuses current `HeroCodeShowcase` content, reskinned. No parallax, no starfield, no sun bloom.
+
+### 3. Proof strip
+
+Single row, `--color-surface` band. Contents:
+- "Built on LangGraph.js" lockup with LangChain mark + caption.
+- GitHub star count (build-time fetched with ISR revalidation).
+- Contributor count.
+- Model provider strip: "Works with OpenAI · Anthropic · Google · Ollama · any LangGraph-compatible model."
+
+No customer logos.
+
+### 4. Why Dawn (editorial)
+
+- H2: "Why we built Dawn."
+- 2–3 short paragraphs in editorial Fraunces + Inter setting. Names the gap (LangGraph is powerful but writing real agents in it is high-boilerplate, untyped, slow-to-iterate), names Dawn's bet (a Next.js-shaped framework over the LangGraph runtime), and what Dawn is explicitly not (a replacement runtime, an LLM router, a hosting product).
+
+### 5. Feature: File-system routing
+
+- Eyebrow: "Routing".
+- H2: "Routes for agents, not just pages."
+- 3-line para + 3–5 benefit bullets.
+- Visual: file tree screenshot (left) + route file shiki snippet (right).
+- "See routing docs →" link.
+
+### 6. Feature: Route-local tools
+
+- Eyebrow: "Tools".
+- H2: "Tools that live next to the route that uses them."
+- Benefit bullets + a tool definition snippet showing inferred argument types and how the route consumes the tool.
+- "See tools docs →" link.
+
+### 7. Feature: Generated types end-to-end
+
+- Eyebrow: "Types".
+- H2: "Types that follow the data."
+- Visual: VS Code screenshot (or carefully framed code with annotated callouts) showing IntelliSense on agent state inferred from a Zod schema, plus an inline code snippet.
+- "See type generation docs →" link.
+
+### 8. Feature: HMR + dev loop
+
+- Eyebrow: "Dev loop".
+- H2: "Edit, save, reload — without restarting the graph."
+- Terminal screenshot of the dev server output + benefit bullets (incremental compile, persistent state across edits, etc.).
+- Optional: short loop GIF/video showing edit→reload. Skippable.
+
+### 9. Keep the runtime (trust)
+
+- Eyebrow: "Compatibility".
+- H2: "Your bet on LangGraph.js stays your bet."
+- Editorial: Dawn compiles to LangGraph constructs; you can drop into raw `StateGraph` whenever you want; if Dawn disappears tomorrow, your graphs are still valid LangGraph code. Concrete checklist of "what Dawn does NOT do": replace the runtime, mediate LLM calls, host your agents, lock you into a deployment target.
+
+### 10. Compatibility & ecosystem
+
+- Eyebrow: "Ecosystem".
+- H2: "Plays well with your stack."
+- Text-and-mark grid (no carousel) grouped by category: Models, Observability (LangSmith), Vector stores, Deploy targets (Vercel / Cloudflare / Node / Docker). Each row is text + small marks, not a marketing logo wall.
+
+### 11. Quickstart — How to evaluate Dawn
+
+- Eyebrow: "Try it".
+- H2: "Three steps to know if Dawn fits."
+- Three numbered cards:
+  1. `pnpm create dawn-ai-app my-agent` (with `CopyCommand`).
+  2. Run an example: a route that calls a tool and returns typed state.
+  3. Port one of your existing LangGraph graphs — link to a porting guide.
+- Closes with "Read the docs →" + "See examples →".
+
+### 12. FAQ
+
+Accordion. Topics drafted from real docs in PR 6:
+- Is Dawn production-ready? (honest pre-1.0 answer + what "production-ready" looks like on the roadmap)
+- What's the relationship to LangGraph.js?
+- What about Deep Agents / planned features? (names Phase 3 roadmap explicitly)
+- Who maintains Dawn? Cadence?
+- License?
+- Can we use Dawn with hosted LangGraph platforms?
+- How does Dawn affect our observability/LangSmith setup?
+- What does Dawn cost?
+- Migration: porting an existing graph?
+
+First item open by default; rest collapsed.
+
+### 13. Final CTA band
+
+`--color-surface-sunk` full-width band.
+- H2: "Start building."
+- One supporting line.
+- Actions: `CopyCommand` (primary) + "Star on GitHub →" (secondary).
+
+### 14. Footer
+
+Three columns: Product (Docs, Examples, Blog, Brand), Resources (LangGraph.js, GitHub, Discussions, RSS), Legal (License, Code of Conduct, Security). Bottom row: wordmark, version (if surfaced), copyright.
+
+## Component Inventory
+
+### New / refactored (under `app/components/`)
+
+```
+Header.tsx                         refactor — wordmark + nav links + install chip; remove dark scope
+Footer.tsx                         refactor — three-column SaaS-style footer
+
+landing/                           full replacement of current 17 components
+  Hero.tsx                         new — replaces HeroSection + HeroEarthParallax + HeroCodeShowcase reskin
+  ProofStrip.tsx                   new
+  WhyDawn.tsx                      new
+  FeatureBlock.tsx                 new — reusable (eyebrow/H2/copy/bullets/visual/link)
+  FeatureBlockRouting.tsx          composes FeatureBlock
+  FeatureBlockTools.tsx            composes FeatureBlock
+  FeatureBlockTypes.tsx            composes FeatureBlock
+  FeatureBlockDevLoop.tsx          composes FeatureBlock
+  KeepTheRuntime.tsx               new — trust section
+  Ecosystem.tsx                    new
+  Quickstart.tsx                   new
+  Faq.tsx                          new — accordion (keyboard accessible)
+  FinalCta.tsx                     new
+
+shared primitives
+  CopyCommand.tsx                  keep, reskin to amber-on-cream
+  Button.tsx                       new — primary (amber filled), secondary (text+icon)
+  Eyebrow.tsx                      new
+  CodeFrame.tsx                    new — browser-chrome frame around shiki output
+  ScreenshotFrame.tsx              new — image variant with alt + caption
+  Card.tsx                         new
+  Accordion.tsx                    new — aria-friendly
+  StarBadge.tsx                    new — GitHub star count
+  ProviderMark.tsx                 new — small inline word+mark for ecosystem rows
+```
+
+### Deletions (PR 6)
+
+```
+app/components/PaletteScroller.tsx
+app/components/ScrollReveal.tsx                kept and adapted if reusable; otherwise replaced
+app/components/CreamSurface.tsx                obsolete (cream is the only system now)
+app/components/landing/HeroEarthParallax.tsx
+app/components/landing/HeroCodeShowcase.tsx    folded into new Hero
+app/components/landing/HeroSection.tsx
+app/components/landing/StarsSection.tsx
+app/components/landing/BigReveal.tsx
+app/components/landing/ComicStrip.tsx
+app/components/landing/ProblemSection.tsx      content absorbed into WhyDawn
+app/components/landing/SolutionSection.tsx     content absorbed into WhyDawn
+app/components/landing/ComparisonTable.tsx     replaced by KeepTheRuntime + FAQ
+app/components/landing/ArchitectureSection.tsx absorbed into KeepTheRuntime or dropped
+app/components/landing/CodeExample.tsx         folded into feature blocks
+app/components/landing/HowItWorks.tsx          replaced by Quickstart
+app/components/landing/MigrateCta.tsx          replaced by FinalCta
+app/components/landing/NotAReplacement.tsx     absorbed into KeepTheRuntime
+app/components/landing/WhoItsFor.tsx           dropped (audience is the lead-in to WhyDawn)
+app/components/landing/DeploySection.tsx       absorbed into Ecosystem
+app/components/landing/EcosystemSection.tsx    rebuilt as Ecosystem.tsx
+app/components/landing/FeatureGrid.tsx         replaced by feature blocks
+app/components/landing/CtaSection.tsx          replaced by FinalCta
+lib/palette/                                   palette stops + scroller engine
+```
+
+### Token / style changes
+
+```
+app/globals.css
+  - drop @theme cosmic tokens (dawn-black, neutral-gray)
+  - drop .landing-dark scope
+  - drop --landing-bg/fg/muted/surface/accent/hue/border vars
+  - drop body { background: var(--landing-bg) ... }
+  - introduce new @theme palette (Visual System)
+  - simplify body to bg/ink defaults
+
+app/layout.tsx
+  - remove `<html className="dark ...">`
+  - remove CreamSurface wrapper
+
+mdx-components.tsx
+  - prose-dawn link color → --color-accent
+  - inline code chip restyled
+```
+
+### Cross-site touchpoints (per "whole site" scope)
+
+```
+app/blog/**     re-token only (PR 7); no layout change
+app/docs/**     re-token; sidebar/links/headings recolored; ReadingLayout uses new --header-h
+app/brand/**    rewrite — documents the new system (PR 1)
+```
+
+### Tests / verification
+
+- Existing vitest setup. Add smoke render test per new section component.
+- Visual regression is manual — start dev server, walk the page.
+- AA contrast verified with axe-core or equivalent in PR 8.
+
+## Implementation Plan (PR Sequence)
+
+In-place rewrite. New tokens introduced alongside the cosmic system in PR 1 so old sections keep rendering until each is replaced. Cosmic system deleted in PR 6, not at the start. CI green at every step.
+
+**PR 1 — Foundation**
+- Add new color + type tokens to `app/globals.css` (no deletion).
+- Build primitives: `Button`, `Eyebrow`, `CodeFrame`, `ScreenshotFrame`, `Card`, `Accordion`, `StarBadge`, `ProviderMark`.
+- Refresh `Header` (drop dark scope, install chip) and `Footer` (three-column).
+- Rewrite `/brand` page as the v2 system documentation.
+- Page still renders old landing; visible change limited to chrome + brand page.
+
+**PR 2 — Hero replacement**
+- New `Hero.tsx` replaces hero stack.
+- `page.tsx` imports updated.
+- Old hero files left on disk until PR 6; not imported.
+- `<html className="dark">` removed from layout.
+
+**PR 3 — ProofStrip + WhyDawn**
+- Replaces `ProblemSection`, `WhoItsFor`, `SolutionSection`.
+
+**PR 4 — Feature blocks**
+- Reusable `FeatureBlock` primitive.
+- Four section instances: Routing, Tools, Types, Dev loop.
+- Replaces `FeatureGrid`, `CodeExample`.
+- Real shiki snippets and at least one VS Code IntelliSense screenshot captured.
+
+**PR 5 — KeepTheRuntime + Ecosystem + Quickstart**
+- Three sections in one PR.
+- Replaces `NotAReplacement`, `ComparisonTable`, `ArchitectureSection`, `DeploySection`, `EcosystemSection`, `HowItWorks`.
+
+**PR 6 — FAQ + FinalCta + cosmic cleanup**
+- New `Faq` and `FinalCta` sections.
+- Delete cosmic system (see Deletions above).
+- `page.tsx` now imports only new components.
+- Rebrand fully visible.
+
+**PR 7 — Docs/blog re-token pass**
+- Apply new tokens to docs and blog chrome (sidebar, links, headings, code chips, callouts).
+- `mdx-components.tsx` updated.
+- No layout changes.
+
+**PR 8 — Calibration**
+- Amber value tuning on cream (AA contrast).
+- Copy polish across all sections.
+- Final visual walk desktop + mobile.
+
+### Per-PR checks
+- `pnpm typecheck` + `pnpm build` + `pnpm test` (build-before-typecheck ordering per CI convention).
+- Smoke render test for new section components.
+- Manual visual review on dev server before requesting review.
+
+### Out of scope (deliberate)
+- `prefers-color-scheme: dark` support — no dark mode in this rebrand.
+- Animations beyond the lightweight reveal primitive.
+- Marketing copy beyond what fits each section's content slot — full copy review happens in PR 8.
+
+## Risks
+
+1. **Amber on cream contrast.** `#d97706` on `#ffffff` is borderline for AA on small text. Calibrated in PR 8; likely shifts to `#b45309` for CTA fill or moves to amber text on `--color-accent-soft` chip for non-CTA highlights.
+2. **Loss of visual personality.** Removing the palette scroller, parallax earth, and comic strip is a real subtraction. The page must earn restraint with editorial copy quality. Copy gets explicit attention in PR 8.
+3. **Recent work being deleted.** The last five commits on `main` are landing-section work. Worth one last look before PR 6 — new page can borrow editorial phrases the old sections already polished.
+4. **Pre-1.0 honesty in FAQ.** Wording "is Dawn production-ready?" wrong either oversells (loses trust with senior engineers) or undersells. Needs Brian-voice drafting.
+5. **Whole-site re-token blast radius.** Docs/blog MDX leans on tokens like `.prose-dawn` link styling and `.mdx-inline-code` chip. PR 7 includes a docs-page walk on dev server before merge.
+6. **GitHub star count freshness.** Build-time fetch with ISR revalidation, or display a range ("Hundreds of devs building") if exact count feels small.
+
+## Open Calibrations (deferred to execution)
+
+- Exact amber CTA value.
+- Hero artifact composition: file tree + one route file? tree + route + generated-types panel? Decided in PR 2.
+- Whether the four feature blocks (Routing/Tools/Types/Dev loop) all stand on their own or two collapse into one. Decided in PR 4.
+- Quickstart visual: static three-card layout, animated terminal recording, or screenshot loop. Decided in PR 5.
+- FAQ items + answers — drafted from real docs in PR 6.
+- Secondary CTA destination ("Star on GitHub" vs. Discussions vs. mailto). Decided in PR 6.
+- Whether `ScrollReveal` adapts to the new lighter motion or gets replaced. Decided in PR 6.


### PR DESCRIPTION
## Summary

PR 1 of the SaaS-style rebrand sequence. Lands the visual foundation: new color tokens (additive, alongside existing cream/cosmic system), reusable primitives (Button, Eyebrow, Card, CodeFrame, ScreenshotFrame, Accordion, StarBadge, ProviderMark), refreshed Header and Footer, reskinned CopyCommand and MobileMenu, and a rewritten /brand page that documents the system.

Spec: [docs/superpowers/specs/2026-05-12-saas-rebrand-design.md](https://github.com/cacheplane/dawnai/blob/assistant/relaxed-morse-fed86b/docs/superpowers/specs/2026-05-12-saas-rebrand-design.md)
Plan: [docs/superpowers/plans/2026-05-12-saas-rebrand-pr1-foundation.md](https://github.com/cacheplane/dawnai/blob/assistant/relaxed-morse-fed86b/docs/superpowers/plans/2026-05-12-saas-rebrand-pr1-foundation.md)

The home page still renders the existing cosmic landing — that's replaced in PR 2 (hero) and following PRs. Visible change in this PR: refreshed light Header + Footer site-wide, rewritten /brand page.

### What's in
- 11 new color tokens in `globals.css` (page/surface/surface-sunk/ink/ink-muted/ink-dim/divider/divider-strong/accent-saas/accent-saas-ink/accent-saas-soft), additive — old tokens untouched
- 8 new UI primitives under `app/components/ui/`
- `lib/github-stars.ts` with build-time fetch + ISR revalidation
- Header refactor (drops `landing-dark`, install chip in nav, full SaaS palette)
- Footer rebuilt three-column (Product / Resources / Legal)
- CopyCommand + MobileMenu reskinned to new tokens
- /brand page rewritten as v2 design system documentation
- `<html className="dark">` removed from layout

### What's not in (deferred to later PRs per the plan)
- Landing page sections (PR 2 hero, PR 3 proof+why, PR 4 features, PR 5 trust+ecosystem+quickstart, PR 6 FAQ+CTA+cosmic cleanup)
- Docs/blog re-token (PR 7)
- Final amber calibration + copy polish (PR 8)

## Test plan

- [x] `pnpm typecheck` — green
- [x] `pnpm build` — green
- [x] `pnpm lint` — green
- [ ] CI: all checks green
- [ ] Visual: /brand renders all sections with new tokens and primitives
- [ ] Visual: / (landing) still renders cosmic landing correctly under new light header
- [ ] Visual: /docs/getting-started renders under new chrome with no regressions
- [ ] Visual: mobile width (375px) for / and /brand and /docs
- [ ] Accordion keyboard-accessible (Tab/Enter/Space)
