### PR TITLE
feat(web): SaaS rebrand follow-up — IntelliSense + DevLoop animated visuals

### DIFF
--- a/apps/web/app/components/landing-v2/DevLoopAnimation.tsx
+++ b/apps/web/app/components/landing-v2/DevLoopAnimation.tsx
@@ -1,0 +1,63 @@
+import { CodeFrame } from "../ui/CodeFrame"
+
+/**
+ * Animated terminal that simulates a Dawn dev-server reload cycle.
+ * Uses CSS keyframes to fade in lines on a loop. Respects prefers-reduced-motion
+ * — under reduced motion all lines render at full opacity statically.
+ */
+export function DevLoopAnimation() {
+  return (
+    <CodeFrame label="pnpm dev">
+      <div className="px-4 py-4 text-sm font-mono leading-[22px] text-ink min-h-[260px]">
+        <p>
+          <span className="text-ink-dim">$</span> pnpm dev
+        </p>
+        <p className="text-ink-dim mt-2">▲ Dawn dev server</p>
+        <p className="text-ink-dim">- Local: http://localhost:3000</p>
+
+        <p className="mt-3">
+          <span className="text-accent-saas">✓</span> Compiled in 412ms
+        </p>
+        <p>
+          <span className="text-accent-saas">✓</span> Graph state preserved across reload
+        </p>
+        <p className="text-ink-dim mt-2">‒ Watching for changes…</p>
+
+        <p
+          className="mt-3 devloop-line"
+          style={{ animation: "devloop 7s ease-in-out infinite", animationDelay: "0s" }}
+        >
+          <span className="text-accent-saas">✓</span> Updated route /support in 87ms
+        </p>
+        <p
+          className="devloop-line"
+          style={{ animation: "devloop 7s ease-in-out infinite", animationDelay: "2s" }}
+        >
+          <span className="text-accent-saas">✓</span> Tool tools/lookup-order updated in 31ms
+        </p>
+        <p
+          className="devloop-line"
+          style={{ animation: "devloop 7s ease-in-out infinite", animationDelay: "4s" }}
+        >
+          <span className="text-accent-saas">✓</span> Schema state.ts compiled in 22ms
+        </p>
+
+        <style>{`
+          .devloop-line { opacity: 0; }
+          @keyframes devloop {
+            0%, 5% { opacity: 0; transform: translateY(2px); }
+            10%, 90% { opacity: 1; transform: translateY(0); }
+            100% { opacity: 0; transform: translateY(0); }
+          }
+          @media (prefers-reduced-motion: reduce) {
+            .devloop-line {
+              opacity: 1 !important;
+              animation: none !important;
+              transform: none !important;
+            }
+          }
+        `}</style>
+      </div>
+    </CodeFrame>
+  )
+}

--- a/apps/web/app/components/landing-v2/FeatureDevLoop.tsx
+++ b/apps/web/app/components/landing-v2/FeatureDevLoop.tsx
@@ -1,24 +1,7 @@
-import { highlightLight } from "../../../lib/shiki/highlight-light"
-import { CodeFrame } from "../ui/CodeFrame"
+import { DevLoopAnimation } from "./DevLoopAnimation"
 import { FeatureBlock } from "./FeatureBlock"
 
-const TERMINAL = `$ pnpm dev
-
-  ▲ Dawn dev server
-
-  - Local:        http://localhost:3000
-  - Network:      http://192.168.1.42:3000
-
-  ✓ Compiled in 412ms
-  ✓ Graph state preserved across reload
-
-  ‒ Watching for changes…
-
-  ✓ Updated route /support in 87ms
-  ✓ Tool tools/lookup-order updated in 31ms`
-
-export async function FeatureDevLoop() {
-  const html = await highlightLight(TERMINAL, "bash")
+export function FeatureDevLoop() {
   return (
     <FeatureBlock
       eyebrow="Dev loop"
@@ -32,15 +15,7 @@ export async function FeatureDevLoop() {
       ]}
       link={{ href: "/docs/dev-server", label: "See dev server docs" }}
       imageSide="left"
-      visual={
-        <CodeFrame label="pnpm dev">
-          <div
-            className="px-4 py-4 text-sm font-mono leading-[22px] overflow-x-auto"
-            // biome-ignore lint/security/noDangerouslySetInnerHtml: shiki output is server-generated
-            dangerouslySetInnerHTML={{ __html: html }}
-          />
-        </CodeFrame>
-      }
+      visual={<DevLoopAnimation />}
     />
   )
 }

--- a/apps/web/app/components/landing-v2/FeatureTypes.tsx
+++ b/apps/web/app/components/landing-v2/FeatureTypes.tsx
@@ -1,25 +1,7 @@
-import { highlightLight } from "../../../lib/shiki/highlight-light"
-import { CodeFrame } from "../ui/CodeFrame"
 import { FeatureBlock } from "./FeatureBlock"
+import { IntelliSenseVisual } from "./IntelliSenseVisual"
 
-const TYPES_CODE = `// state.ts — single source of truth
-export default z.object({
-  tenant: z.string(),
-  question: z.string(),
-  history: z.array(z.object({
-    role: z.enum(["user", "assistant"]),
-    content: z.string(),
-  })),
-})
-
-// inside a tool handler — state is inferred end-to-end
-async function summarize({ state }: ToolContext) {
-  // state.history is { role: "user" | "assistant"; content: string }[]
-  return state.history.map((m) => \`\${m.role}: \${m.content}\`).join("\\n")
-}`
-
-export async function FeatureTypes() {
-  const html = await highlightLight(TYPES_CODE, "typescript")
+export function FeatureTypes() {
   return (
     <FeatureBlock
       eyebrow="Types"
@@ -32,15 +14,7 @@ export async function FeatureTypes() {
         "Works with your existing tsconfig.json",
       ]}
       link={{ href: "/docs/state", label: "See type generation docs" }}
-      visual={
-        <CodeFrame label="state.ts → tools/*.ts">
-          <div
-            className="px-4 py-4 text-sm font-mono leading-[22px] overflow-x-auto"
-            // biome-ignore lint/security/noDangerouslySetInnerHtml: shiki output is server-generated
-            dangerouslySetInnerHTML={{ __html: html }}
-          />
-        </CodeFrame>
-      }
+      visual={<IntelliSenseVisual />}
     />
   )
 }

--- a/apps/web/app/components/landing-v2/IntelliSenseVisual.tsx
+++ b/apps/web/app/components/landing-v2/IntelliSenseVisual.tsx
@@ -1,0 +1,66 @@
+import { highlightLight } from "../../../lib/shiki/highlight-light"
+import { CodeFrame } from "../ui/CodeFrame"
+
+const CODE = `import { z } from "zod"
+
+// state.ts — single source of truth
+export default z.object({
+  tenant: z.string(),
+  question: z.string(),
+  history: z.array(z.object({
+    role: z.enum(["user", "assistant"]),
+    content: z.string(),
+  })),
+})
+
+// inside a tool handler — state.history is inferred end-to-end
+async function summarize({ state }) {
+  return state.history.map((m) => \`\${m.role}: \${m.content}\`).join("\\n")
+}`
+
+export async function IntelliSenseVisual() {
+  const html = await highlightLight(CODE, "typescript")
+
+  return (
+    <div className="relative">
+      <CodeFrame label="state.ts → tools/*.ts">
+        <div
+          className="px-4 py-4 text-sm font-mono leading-[22px] overflow-x-auto"
+          // biome-ignore lint/security/noDangerouslySetInnerHtml: shiki output is sanitized
+          dangerouslySetInnerHTML={{ __html: html }}
+        />
+      </CodeFrame>
+
+      {/* IntelliSense popover — positioned over the .history member access */}
+      <div
+        className="absolute hidden md:block left-[58%] top-[68%] w-[320px] rounded-lg border border-divider bg-page text-left z-10"
+        role="tooltip"
+        aria-label="Inferred TypeScript type for state.history"
+        style={{
+          boxShadow:
+            "0 4px 10px rgba(20,17,13,0.06), 0 16px 40px -12px rgba(20,17,13,0.18)",
+        }}
+      >
+        <div className="px-3 py-2 border-b border-divider bg-surface-sunk">
+          <p className="text-[11px] font-mono text-ink-dim uppercase tracking-[0.06em]">
+            <span className="text-accent-saas">●</span> property
+          </p>
+          <p className="text-sm font-mono text-ink mt-0.5">
+            (property) history
+          </p>
+        </div>
+        <div className="px-3 py-2.5 space-y-2">
+          <pre className="text-xs font-mono text-ink leading-[18px] whitespace-pre-wrap">
+{`{
+  role: "user" | "assistant"
+  content: string
+}[]`}
+          </pre>
+          <p className="text-xs text-ink-muted leading-[18px]">
+            Inferred from <span className="font-mono text-ink">z.array(z.object(...))</span> in <span className="font-mono text-ink">state.ts</span>.
+          </p>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/app/components/landing-v2/IntelliSenseVisual.tsx
+++ b/apps/web/app/components/landing-v2/IntelliSenseVisual.tsx
@@ -37,27 +37,25 @@ export async function IntelliSenseVisual() {
         role="tooltip"
         aria-label="Inferred TypeScript type for state.history"
         style={{
-          boxShadow:
-            "0 4px 10px rgba(20,17,13,0.06), 0 16px 40px -12px rgba(20,17,13,0.18)",
+          boxShadow: "0 4px 10px rgba(20,17,13,0.06), 0 16px 40px -12px rgba(20,17,13,0.18)",
         }}
       >
         <div className="px-3 py-2 border-b border-divider bg-surface-sunk">
           <p className="text-[11px] font-mono text-ink-dim uppercase tracking-[0.06em]">
             <span className="text-accent-saas">●</span> property
           </p>
-          <p className="text-sm font-mono text-ink mt-0.5">
-            (property) history
-          </p>
+          <p className="text-sm font-mono text-ink mt-0.5">(property) history</p>
         </div>
         <div className="px-3 py-2.5 space-y-2">
           <pre className="text-xs font-mono text-ink leading-[18px] whitespace-pre-wrap">
-{`{
+            {`{
   role: "user" | "assistant"
   content: string
 }[]`}
           </pre>
           <p className="text-xs text-ink-muted leading-[18px]">
-            Inferred from <span className="font-mono text-ink">z.array(z.object(...))</span> in <span className="font-mono text-ink">state.ts</span>.
+            Inferred from <span className="font-mono text-ink">z.array(z.object(...))</span> in{" "}
+            <span className="font-mono text-ink">state.ts</span>.
           </p>
         </div>
       </div>


### PR DESCRIPTION
## Summary

Follow-up to the SaaS rebrand sequence. Replaces the static code blocks in FeatureTypes and FeatureDevLoop with two polished React components:

- IntelliSenseVisual: a CodeFrame with a positioned popover that looks like a VS Code IntelliSense tooltip, showing the inferred type for state.history.
- DevLoopAnimation: a CSS-animated terminal that cycles through edit-save-reload lines. Respects prefers-reduced-motion.

No image assets — both are pure React/CSS, AA-compliant, responsive, and swappable with real screenshots later if desired.

## Test plan
- [x] pnpm typecheck — green
- [x] pnpm build — green
- [x] pnpm lint — green
- [ ] CI green
- [ ] Visual: FeatureTypes shows the IntelliSense popover on desktop, code-only on mobile
- [ ] Visual: FeatureDevLoop cycles three reload lines on a 7s loop; reduced-motion shows all static
