### PR TITLE
chore: ignore local tool-state dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ artifacts/
 .dawn/
 .superpowers/
 .vercel
+.claude/
+.knot/


### PR DESCRIPTION
Both directories are local-only working state — assistant Code's worktrees + project files in \`local tool-state/\`, Knot's state in \`.knot/\`. Without these gitignore entries, the main worktree shows them as untracked noise in every \`git status\`.

Single 2-line change to \`.gitignore\`.
