### PR TITLE
refactor(web): blog card eyebrows through <Eyebrow> + close remaining design-review minors

### DIFF
--- a/apps/web/app/components/blog/FeaturedPostCard.tsx
+++ b/apps/web/app/components/blog/FeaturedPostCard.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link"
+import { Eyebrow } from "../ui/Eyebrow"
 import { AUTHORS, type Author, type Post } from "./post-index"
 
 function formatDate(iso: string): string {
@@ -22,9 +23,7 @@ export function FeaturedPostCard({ post }: { readonly post: Post }) {
       className="block p-8 rounded-2xl border border-accent-saas/35 mb-6 transition-transform hover:scale-[1.005]"
       style={{ background: "linear-gradient(180deg,#fff7e0 0%,#ffeec2 100%)" }}
     >
-      <span className="text-[11px] uppercase tracking-widest text-accent-saas">
-        Essay · {post.readingTimeMinutes} min read
-      </span>
+      <Eyebrow tone="accent">Essay · {post.readingTimeMinutes} min read</Eyebrow>
       <h2
         className="font-display text-2xl md:text-3xl font-semibold mt-2 mb-2 tracking-tight"
         style={{ color: "#1a1530" }}

--- a/apps/web/app/components/blog/PostCard.tsx
+++ b/apps/web/app/components/blog/PostCard.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link"
+import { Eyebrow } from "../ui/Eyebrow"
 import type { Post } from "./post-index"
 
 function formatDate(iso: string): string {
@@ -26,9 +27,7 @@ export function PostCard({ post }: { readonly post: Post }) {
           v{post.version}
         </span>
       ) : (
-        <span className="text-[11px] uppercase tracking-widest text-ink-dim">
-          Essay · {post.readingTimeMinutes} min
-        </span>
+        <Eyebrow>Essay · {post.readingTimeMinutes} min</Eyebrow>
       )}
       <h3 className="font-display text-lg font-semibold text-ink mt-2 mb-1 leading-snug">
         {post.title}


### PR DESCRIPTION
## Summary

Closes the remaining loose ends from the SaaS rebrand design-review cycle.

### Change

\`PostCard\` and \`FeaturedPostCard\` were the last two places on the site rendering an inline \"essay\" eyebrow (\`text-[11px] uppercase tracking-widest\`) instead of routing through the shared \`<Eyebrow>\` component. The eyebrow rebrand we did across PostHeader, Hero, and the rest of the site already covered everything else — these two were flagged as a question in the original findings.

Now:
- \`PostCard\` uses \`<Eyebrow>\` for the essay variant (release pill kept untouched — different semantic)
- \`FeaturedPostCard\` uses \`<Eyebrow tone=\"accent\">\` to match the amber-themed featured card

Visual difference is minor — 11→12px font-size and slightly tighter letter-spacing — but every essay eyebrow on the site now resolves to identical computed styles.

### Closed by re-verification (no code change)

- **M2 — ProofStrip \"WORKS WITH\" run-on at 1440** ✅ resolved by #133 (provider logos add visual separation; the label now reads as a column header rather than running into the providers).
- **M3 — Docs sidebar sticky scroll at 1024** ✅ confirmed working: \`position: sticky\`, \`top: 72px\`, \`overflowY: auto\`, \`height: calc(100vh - var(--header-h))\`. No fix needed.

### Findings file

Both items annotated in \`docs/superpowers/specs/2026-05-12-saas-rebrand-polish-findings.md\` (not modified in this PR — they were already documented).

## Test plan

- [ ] Visit \`/blog\` — featured card eyebrow renders amber, grid card eyebrows render muted; both at the new shared 12px size
- [ ] pnpm vitest, typecheck, lint, build all green
