### PR TITLE
feat(web): polish — rebranded 404, robots.txt, mobile menu, longer title

### DIFF
--- a/apps/web/app/components/MobileMenu.tsx
+++ b/apps/web/app/components/MobileMenu.tsx
@@ -3,28 +3,29 @@
 import Link from "next/link"
 import { usePathname } from "next/navigation"
 import { useEffect, useId, useRef, useState } from "react"
+import { CopyCommand } from "./CopyCommand"
 import { DOCS_NAV } from "./docs/nav"
 
 interface SiteLink {
   readonly label: string
   readonly href: string
   readonly external?: boolean
-  readonly cta?: boolean
 }
 
 const SITE_LINKS: readonly SiteLink[] = [
-  { label: "Blog", href: "/blog" },
   { label: "Docs", href: "/docs/getting-started" },
+  { label: "Blog", href: "/blog" },
+  { label: "Brand", href: "/brand" },
   { label: "GitHub", href: "https://github.com/cacheplane/dawnai", external: true },
-  { label: "Read the Docs", href: "/docs/getting-started", cta: true },
 ]
 
 /**
  * Full-screen mobile menu. Visible only below the md breakpoint.
  *
  * Trigger: hamburger button in the header.
- * Overlay: covers the full viewport with the cosmic-dark backdrop, lists
- *          Site links and (when on a docs page) the Documentation nav.
+ * Overlay: cream-palette full-viewport sheet listing site links and (on
+ *          a docs page) the Documentation nav. Primary action is the
+ *          install command — same as the desktop nav.
  * Close: × button, Esc, or tapping any link.
  */
 export function MobileMenu() {
@@ -142,14 +143,6 @@ export function MobileMenu() {
                     >
                       {link.label} <span aria-hidden>↗</span>
                     </a>
-                  ) : link.cta ? (
-                    <Link
-                      href={link.href}
-                      onClick={() => setIsOpen(false)}
-                      className="block text-base px-3 py-2.5 rounded-md bg-accent-saas text-accent-saas-ink font-semibold mt-2"
-                    >
-                      {link.label}
-                    </Link>
                   ) : (
                     <Link
                       href={link.href}
@@ -162,6 +155,9 @@ export function MobileMenu() {
                 </li>
               ))}
             </ul>
+            <div className="mt-5 px-3">
+              <CopyCommand command="pnpm create dawn-ai-app" />
+            </div>
           </div>
 
           {/* Documentation section — only on docs pages */}

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -28,8 +28,8 @@ export const metadata: Metadata = {
   metadataBase: new URL("https://dawnai.org"),
   applicationName: "Dawn AI",
   title: {
-    default: "Dawn — TypeScript meta-framework for LangGraph.js",
-    template: "%s | Dawn",
+    default: "Dawn AI — TypeScript meta-framework for LangGraph.js",
+    template: "%s | Dawn AI",
   },
   description:
     "Dawn adds file-system routing, route-local tools, generated types, and HMR to your existing LangGraph.js stack. Keep the runtime. Drop the boilerplate.",
@@ -48,14 +48,14 @@ export const metadata: Metadata = {
     type: "website",
     url: "https://dawnai.org",
     siteName: "Dawn AI",
-    title: "Dawn — TypeScript meta-framework for LangGraph.js",
+    title: "Dawn AI — TypeScript meta-framework for LangGraph.js",
     description:
       "Dawn adds file-system routing, route-local tools, generated types, and HMR to your existing LangGraph.js stack. Keep the runtime. Drop the boilerplate.",
     // Image is provided by app/opengraph-image.tsx (1200×630, cream palette).
   },
   twitter: {
     card: "summary_large_image",
-    title: "Dawn — TypeScript meta-framework for LangGraph.js",
+    title: "Dawn AI — TypeScript meta-framework for LangGraph.js",
     description:
       "Dawn adds file-system routing, route-local tools, generated types, and HMR to your existing LangGraph.js stack. Keep the runtime. Drop the boilerplate.",
     // Image is provided by app/twitter-image.tsx (re-exports opengraph-image).

--- a/apps/web/app/not-found.tsx
+++ b/apps/web/app/not-found.tsx
@@ -1,0 +1,61 @@
+import type { Metadata } from "next"
+import Link from "next/link"
+import { Eyebrow } from "./components/ui/Eyebrow"
+
+export const metadata: Metadata = {
+  title: "Page not found",
+  description: "We couldn't find that page. Try the docs, blog, or the homepage.",
+}
+
+interface DestinationProps {
+  readonly href: string
+  readonly label: string
+}
+
+function Destination({ href, label }: DestinationProps) {
+  return (
+    <Link
+      href={href}
+      className="inline-flex items-center gap-1.5 text-sm font-medium text-accent-saas hover:opacity-80 transition-opacity"
+    >
+      {label} <span aria-hidden="true">→</span>
+    </Link>
+  )
+}
+
+export default function NotFound() {
+  return (
+    <section className="bg-page">
+      <div className="max-w-[820px] mx-auto px-6 md:px-8 py-24 md:py-32">
+        <Eyebrow>404</Eyebrow>
+        <h1
+          className="font-display font-semibold text-ink mt-3 text-[40px] leading-[44px] md:text-[56px] md:leading-[60px] text-balance"
+          style={{
+            fontVariationSettings: "'opsz' 144, 'SOFT' 50, 'WONK' 0",
+            letterSpacing: "-0.015em",
+          }}
+        >
+          We couldn't find that page.
+        </h1>
+        <p className="mt-5 text-lg text-ink-muted leading-[30px] max-w-[52ch]">
+          The page may have moved, or the link you followed is out of date. Try one of these
+          instead:
+        </p>
+        <ul className="mt-8 flex flex-wrap gap-x-8 gap-y-3">
+          <li>
+            <Destination href="/" label="Home" />
+          </li>
+          <li>
+            <Destination href="/docs/getting-started" label="Read the docs" />
+          </li>
+          <li>
+            <Destination href="/blog" label="Latest from the blog" />
+          </li>
+          <li>
+            <Destination href="/brand" label="Brand assets" />
+          </li>
+        </ul>
+      </div>
+    </section>
+  )
+}

--- a/apps/web/app/robots.ts
+++ b/apps/web/app/robots.ts
@@ -1,0 +1,15 @@
+import type { MetadataRoute } from "next"
+
+const SITE_URL = "https://dawnai.org"
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: "*",
+      allow: "/",
+      disallow: ["/api/"],
+    },
+    sitemap: `${SITE_URL}/sitemap.xml`,
+    host: SITE_URL,
+  }
+}


### PR DESCRIPTION
Four small fixes from the post-deploy walkthrough through Chrome MCP.

## What's in

### 1. Rebranded 404 page
\`app/not-found.tsx\` replaces the default Next.js \`404 | This page could not be found.\` (system-ui, unstyled). Custom page uses Eyebrow + Fraunces H1 + amber destination links pointing at Home / Docs / Blog / Brand.

### 2. \`/robots.txt\` route
The production \`/robots.txt\` was returning the 404 page (no route existed). Added \`app/robots.ts\` allowing everything except \`/api/\` and pointing at \`/sitemap.xml\`.

### 3. Mobile menu polish
Dropped the \"Read the Docs\" CTA that duplicated the Docs nav item one row above. Added Brand to match desktop nav. Replaced the duplicate CTA with an install \`CopyCommand\` chip at the bottom — same primary action as the desktop header chip.

### 4. Longer default title
opengraph.xyz flagged the title as 49 chars (optimal 50-60). Changed \"Dawn —\" to \"Dawn AI —\" to match the wordmark used elsewhere — 53 chars. Template updated correspondingly so subpages render as \`Foo | Dawn AI\`.

## Test plan
- [x] pnpm typecheck — green
- [x] pnpm build — green
- [x] pnpm lint — green
- [x] Visual: /this-page-does-not-exist renders the new 404
- [x] Visual: /robots.txt returns expected content
- [x] Visual: mobile menu at 400px width shows Docs/Blog/Brand/GitHub + install chip
- [ ] CI green
