### PR TITLE
fix(web): a11y — darken ink-dim for AA contrast + StarBadge aria order

### DIFF
--- a/apps/web/app/components/landing/ProofStrip.tsx
+++ b/apps/web/app/components/landing/ProofStrip.tsx
@@ -65,7 +65,7 @@ export async function ProofStrip() {
               href="https://github.com/cacheplane/dawnai"
               target="_blank"
               rel="noopener noreferrer"
-              aria-label={`Star Dawn on GitHub — ${stars} stars`}
+              aria-label={`${formatCount(stars)} stars on GitHub — star Dawn`}
               className="inline-flex items-center gap-1.5 text-sm text-ink-muted hover:text-ink transition-colors"
             >
               <StarIcon />

--- a/apps/web/app/components/ui/StarBadge.tsx
+++ b/apps/web/app/components/ui/StarBadge.tsx
@@ -36,7 +36,7 @@ export async function StarBadge({ className = "" }: StarBadgeProps) {
       href="https://github.com/cacheplane/dawnai"
       target="_blank"
       rel="noopener noreferrer"
-      aria-label={`Star Dawn on GitHub — ${stars} stars`}
+      aria-label={`${formatStars(stars)} stars on GitHub — star Dawn`}
       className={`inline-flex items-center gap-1.5 text-sm text-ink-muted hover:text-ink transition-colors ${className}`}
     >
       <StarIcon />

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -12,7 +12,7 @@
   --color-surface-sunk: #f4f2ec;
   --color-ink: #14110d;
   --color-ink-muted: #5a554c;
-  --color-ink-dim: #8a857b;
+  --color-ink-dim: #6b6657;
   --color-divider: #e6e3da;
   --color-divider-strong: #cfcabd;
   --color-accent-saas: #b45309;


### PR DESCRIPTION
Lighthouse mobile against \`dawnai.org\` flagged two real accessibility issues.

## What's fixed

### 1. \`--color-ink-dim\` failed AA contrast on every surface

The previous value \`#8a857b\` gave 3.67:1 on \`#ffffff\`, 3.5:1 on \`#fafaf7\`, and 3.27:1 on \`#f4f2ec\` — well under the 4.5:1 AA floor. ~30 elements across the homepage were affected: every Eyebrow (WHY DAWN, ROUTING, TOOLS, TYPES, DEV LOOP, COMPATIBILITY, ECOSYSTEM, TRY IT, FAQ, and the four MODELS/OBSERVABILITY/VECTOR STORES/DEPLOY TARGETS column labels), the ProofStrip \"stars\"/\"contributors\" suffix words, the DevLoopAnimation terminal muted lines, the entire footer bottom row, and PRODUCT/RESOURCES/LEGAL footer column headings.

Darkening to \`#6b6657\` gives:
- on \`#ffffff\` (page): **5.77:1** ✓
- on \`#fafaf7\` (surface): **5.55:1** ✓
- on \`#f4f2ec\` (surface-sunk): **5.27:1** ✓

All three pass AA comfortably. Hierarchy is preserved — ink → ink-muted → ink-dim still steps the warm sepia ramp, just compressed.

### 2. StarBadge aria-label ordering (WCAG 2.5.3)

Visible text was \"98 stars\". Aria-label was \"Star Dawn on GitHub — 98 stars\" — the visible text wasn't at the start of the accessible name. Reordered both ProofStrip's inline link and the StarBadge component to \`\"98 stars on GitHub — star Dawn\"\` so the visible text is the prefix.

## Test plan
- [x] pnpm typecheck — green
- [x] pnpm build — green
- [x] pnpm lint — green
- [ ] CI green
- [ ] After deploy: Lighthouse mobile a11y score → 100 (currently 96)
