### PR TITLE
feat: upgrade @langchain/* to 1.x and zod to 4.x

### DIFF
--- a/.changeset/langchain-1x-zod-4.md
+++ b/.changeset/langchain-1x-zod-4.md
@@ -1,0 +1,7 @@
+---
+"@dawn-ai/langchain": major
+"@dawn-ai/cli": minor
+"@dawn-ai/vite-plugin": minor
+---
+
+Upgrade `@langchain/core` (0.3 → 1.x), `@langchain/langgraph` (0.2 → 1.x), `@langchain/openai` (0.3 → 1.x), and `zod` (3 → 4). Removes the dual-zod-version cast workaround in `tool-converter.ts`; `DynamicStructuredTool` now accepts Standard Schema directly. Downstream consumers must align on the new peer ranges (`@langchain/core >=1.1.0`).

--- a/docs/superpowers/plans/2026-05-15-langchain-1x-zod-4-upgrade.md
+++ b/docs/superpowers/plans/2026-05-15-langchain-1x-zod-4-upgrade.md
@@ -1,0 +1,449 @@
+# LangChain 1.x + Zod 4 Upgrade Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Migrate Dawn from `@langchain/{core,langgraph,openai}@0.x` + `zod@3.24.4` to LangChain `1.x` + `zod@4`. Drop the transitive `zod-to-json-schema`. Remove the cast-through-unknown workaround in `tool-converter.ts`.
+
+**Architecture:** Single PR off `main`. Disciplined commit boundaries: one logical change per commit. Discovery-driven within each task — bump deps, run typecheck, fix what TS flags. The four files in `packages/langchain/src/` are the primary work; `packages/cli` and `packages/vite-plugin` get minor audit fixes.
+
+**Tech Stack:** TypeScript 6.0.2, pnpm 10.33.0, turbo, `@langchain/core@1.x`, `@langchain/langgraph@1.x`, `@langchain/openai@1.x`, `openai@6.x`, `zod@4.x`.
+
+**Spec:** [docs/superpowers/specs/2026-05-15-langchain-1x-zod-4-upgrade-design.md](../specs/2026-05-15-langchain-1x-zod-4-upgrade-design.md)
+
+**Working directory:** `/Users/blove/repos/dawn/.claude/worktrees/langchain-1x-upgrade` (branch `claude/langchain-1x-upgrade`).
+
+---
+
+## Task 1: Bump dependency versions
+
+**Files:**
+- Modify: `packages/langchain/package.json`
+- Modify: `packages/vite-plugin/package.json`
+- Modify: `packages/cli/package.json`
+
+- [ ] **Step 1: Bump `packages/langchain/package.json`**
+
+In `dependencies`, change:
+```json
+"@langchain/langgraph": "^0.2.71"  →  "@langchain/langgraph": "^1.3.0"
+"@langchain/openai":   "^0.3.17"   →  "@langchain/openai":   "^1.4.5"
+```
+
+In `peerDependencies`, change:
+```json
+"@langchain/core": ">=0.3.0"  →  "@langchain/core": ">=1.1.0"
+```
+
+In `devDependencies`, change:
+```json
+"@langchain/core":     "0.3.80"   →  "@langchain/core":     "1.1.46"
+"@langchain/langgraph":"0.2.71"   →  "@langchain/langgraph":"1.3.0"
+"@langchain/openai":   "0.3.17"   →  "@langchain/openai":   "1.4.5"
+"zod":                 "3.24.4"   →  "zod":                 "4.4.3"
+```
+
+- [ ] **Step 2: Bump `packages/vite-plugin/package.json`**
+
+Change:
+```json
+"zod": "3.24.4"  →  "zod": "4.4.3"
+```
+
+- [ ] **Step 3: Bump `packages/cli/package.json`**
+
+Change:
+```json
+"@langchain/core": "0.3.80"  →  "@langchain/core": "1.1.46"
+```
+
+- [ ] **Step 4: Install and update lockfile**
+
+Run: `pnpm install`
+Expected: install succeeds. May see deprecation warnings; capture them but proceed.
+
+- [ ] **Step 5: Verify `zod-to-json-schema` is gone from the resolution**
+
+Run: `pnpm why zod-to-json-schema 2>&1 | head -20`
+Expected: either "no dependents" or it only appears in transitive `@langchain` packages that still ship it but don't require it for Dawn. If it's still listed as a direct dependency of any `@dawn-ai/*` package, that's a bug — flag it.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/langchain/package.json packages/vite-plugin/package.json packages/cli/package.json pnpm-lock.yaml
+git commit -m "chore(deps): bump @langchain/* to 1.x and zod to 4.x"
+```
+
+---
+
+## Task 2: Audit and fix `packages/langchain/src/tool-converter.ts`
+
+**Files:**
+- Modify: `packages/langchain/src/tool-converter.ts`
+
+- [ ] **Step 1: Run typecheck to surface failures**
+
+Run: `pnpm --filter @dawn-ai/langchain typecheck 2>&1 | tee /tmp/tool-converter-errors.log | head -60`
+Capture errors that mention `tool-converter.ts`. Other-file errors are addressed in later tasks; ignore them here.
+
+- [ ] **Step 2: Remove the cast and the workaround comment**
+
+In `packages/langchain/src/tool-converter.ts` at the `new DynamicStructuredTool({...})` call (currently around lines 22–34):
+
+Replace:
+```ts
+  // Cast through unknown to bridge the dual-Zod version type incompatibility
+  // (package uses zod@3.24.4; @langchain/core uses zod@3.25.x — structurally identical at runtime)
+  return new DynamicStructuredTool({
+    name: tool.name,
+    description: tool.description ?? "",
+    schema: schema as unknown as z.ZodObject<z.ZodRawShape>,
+    func: async (input, _runManager, config) => {
+      const signal = config?.signal ?? new AbortController().signal
+      const result = await tool.run(input, {
+        ...(middlewareContext ? { middleware: middlewareContext } : {}),
+        signal,
+      })
+      return JSON.stringify(result)
+    },
+  }) as unknown as DynamicStructuredTool
+```
+
+With:
+```ts
+  return new DynamicStructuredTool({
+    name: tool.name,
+    description: tool.description ?? "",
+    schema,
+    func: async (input, _runManager, config) => {
+      const signal = config?.signal ?? new AbortController().signal
+      const result = await tool.run(input, {
+        ...(middlewareContext ? { middleware: middlewareContext } : {}),
+        signal,
+      })
+      return JSON.stringify(result)
+    },
+  })
+```
+
+- [ ] **Step 3: Handle the helper return type**
+
+The `toZodSchema` helper ends with:
+```ts
+return z.record(z.string(), z.unknown()) as unknown as z.ZodObject<z.ZodRawShape>
+```
+
+With zod 4, `z.record(z.string(), z.unknown())` is no longer assignable to `z.ZodObject<z.ZodRawShape>` — it never was, the cast hid it. Two options:
+
+- **Option A (preferred):** Keep `z.record` as the fallback shape, but change `toZodSchema`'s return type to `z.ZodTypeAny` and propagate that through `convertToolToLangChain`. `DynamicStructuredTool` in 1.x accepts any Standard Schema.
+- **Option B:** Replace `z.record(...)` with `z.object({})` as the empty fallback. Loses the "any extra fields allowed" semantics but matches the declared return type.
+
+Choose Option A. Update:
+```ts
+function toZodSchema(value: unknown): z.ZodTypeAny {
+  if (isZodObject(value)) return value
+  if (isJsonSchemaObject(value)) return jsonSchemaToZod(value)
+  return z.record(z.string(), z.unknown())
+}
+```
+
+And update `isZodObject`'s return type narrowing to `z.ZodObject<z.ZodRawShape>` if needed — likely no change required since the predicate still returns the same shape.
+
+- [ ] **Step 4: Audit zod 4 API surface used in this file**
+
+The helpers use: `z.object`, `z.string`, `z.number`, `z.boolean`, `z.array`, `z.unknown`, `z.record`, `.optional()`. These are stable in zod 4. **One specific check:** confirm `z.record(z.string(), z.unknown())` (two-arg form) is what's already in the code (it is, per the current source). Single-arg `z.record(z.unknown())` would be a zod 4 break, but the file already uses the two-arg form.
+
+- [ ] **Step 5: Typecheck again**
+
+Run: `pnpm --filter @dawn-ai/langchain typecheck 2>&1 | grep -i "tool-converter" | head`
+Expected: no errors in `tool-converter.ts`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/langchain/src/tool-converter.ts
+git commit -m "refactor(langchain): drop dual-zod cast in tool-converter
+
+LangChain 1.x accepts Standard Schema directly; with Dawn now on a
+single zod 4 there is no version split to bridge. Removes the cast
+and updates the fallback helper's return type to ZodTypeAny."
+```
+
+---
+
+## Task 3: Audit and fix `packages/langchain/src/state-adapter.ts`
+
+**Files:**
+- Modify: `packages/langchain/src/state-adapter.ts` (only if typecheck flags it)
+
+- [ ] **Step 1: Typecheck**
+
+Run: `pnpm --filter @dawn-ai/langchain typecheck 2>&1 | grep -i "state-adapter" | head`
+
+- [ ] **Step 2: If no errors, skip to Task 4. If errors exist, fix them.**
+
+The most likely issue: the `biome-ignore lint/suspicious/noExplicitAny` comment at the bottom of `materializeStateSchema` returns `Annotation.Root(spec as any)`. LangGraph 1.x retains `Annotation.Root` with the same shape, so this should continue to work. If TS flags a new issue with how `spec` is typed, narrow the type explicitly rather than expanding the `as any`.
+
+If TS flags it: replace the cast with a properly typed `spec` (record of `Annotation` instances), keeping the same runtime behavior.
+
+- [ ] **Step 3: Commit (only if changes were made)**
+
+```bash
+git add packages/langchain/src/state-adapter.ts
+git commit -m "refactor(langchain): state-adapter for langgraph 1.x"
+```
+
+If no changes were needed, skip the commit and proceed to Task 4.
+
+---
+
+## Task 4: Audit and fix `packages/langchain/src/agent-adapter.ts`
+
+This is the riskiest file. It calls `createReactAgent`, `ChatOpenAI`, and `streamEvents({version: "v2"})`. Each is a candidate for an API change in 1.x.
+
+**Files:**
+- Modify: `packages/langchain/src/agent-adapter.ts`
+
+- [ ] **Step 1: Typecheck**
+
+Run: `pnpm --filter @dawn-ai/langchain typecheck 2>&1 | grep -i "agent-adapter" | head -40`
+
+- [ ] **Step 2: Audit `ChatOpenAI` constructor**
+
+The current code:
+```ts
+const llm = new ChatOpenAI({
+  model: descriptor.model,
+})
+```
+
+In `@langchain/openai@1.x`, the `model` field is unchanged. Confirm no error here. If TS flags it (e.g., `apiKey` now required), pass `apiKey: process.env.OPENAI_API_KEY` defensively.
+
+- [ ] **Step 3: Audit `createReactAgent`**
+
+The current code:
+```ts
+const compiled = createReactAgent(agentOptions as any)
+```
+
+with options `{ llm, tools, prompt, stateSchema? }`.
+
+In `@langchain/langgraph@1.x`, `createReactAgent` is in `@langchain/langgraph/prebuilt` and accepts a similar options shape. The argument names should be unchanged (`llm`, `tools`, `prompt`, `stateSchema`). If TS flags issues, consult the type signature via:
+```bash
+node -e "import('@langchain/langgraph/prebuilt').then(m => console.log(Object.keys(m)))"
+```
+and adjust option names accordingly.
+
+- [ ] **Step 4: Audit `streamEvents({version: "v2"})`**
+
+The current code uses `streamEvents` with `version: "v2"`. LangChain 1.x may have introduced `version: "v3"` or removed `"v2"`. The event names consumed (`on_chat_model_stream`, `on_tool_start`, `on_tool_end`, `on_chain_end`) and their data shapes need to be confirmed in 1.x.
+
+**Verification approach:**
+1. Check the `streamEvents` type signature in `@langchain/core` — find what `version` values it accepts now.
+2. If `"v2"` is still accepted, no change needed.
+3. If only `"v3"` is accepted, change to `version: "v3"` and verify the event names and data shapes are the same (they were stable from v2 → v3 per the LangChain JS changelog; the v3 changes were largely additive).
+
+If event names or shapes change, update the `switch (event.event)` cases accordingly.
+
+- [ ] **Step 5: Run typecheck after edits**
+
+Run: `pnpm --filter @dawn-ai/langchain typecheck 2>&1 | grep -i "agent-adapter" | head`
+Expected: no errors in `agent-adapter.ts`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/langchain/src/agent-adapter.ts
+git commit -m "refactor(langchain): agent-adapter for @langchain/openai 1.x and langgraph 1.x"
+```
+
+---
+
+## Task 5: Audit and fix `packages/langchain/src/tool-loop.ts`
+
+**Files:**
+- Modify: `packages/langchain/src/tool-loop.ts` (only if typecheck flags it)
+
+- [ ] **Step 1: Typecheck**
+
+Run: `pnpm --filter @dawn-ai/langchain typecheck 2>&1 | grep -i "tool-loop" | head`
+
+- [ ] **Step 2: If no errors, skip to Task 6. If errors exist, fix them.**
+
+The file imports `AIMessage` and `ToolMessage` from `@langchain/core/messages`. The shapes (`.tool_calls` on `AIMessage`, `ToolMessage({ content, tool_call_id })` constructor) are stable across the 0.3 → 1.x boundary per the LangChain changelog.
+
+If TS flags `tool_calls` shape changes (e.g., a renamed property or stricter typing on `call.args`), update the predicate `isAIMessageWithToolCalls` and the `result.tool_calls.map(...)` body accordingly. Keep semantics identical.
+
+- [ ] **Step 3: Commit (only if changes were made)**
+
+```bash
+git add packages/langchain/src/tool-loop.ts
+git commit -m "refactor(langchain): tool-loop for @langchain/core 1.x messages"
+```
+
+---
+
+## Task 6: Audit and fix `packages/langchain/src/chain-adapter.ts`
+
+This file was not inspected during planning. It exists in the package and may also need updates.
+
+**Files:**
+- Modify: `packages/langchain/src/chain-adapter.ts` (only if typecheck flags it)
+
+- [ ] **Step 1: Typecheck**
+
+Run: `pnpm --filter @dawn-ai/langchain typecheck 2>&1 | grep -i "chain-adapter" | head`
+
+- [ ] **Step 2: If no errors, skip to Task 7. If errors exist, fix them.**
+
+Use the same approach as Task 5: identify the failing API call, look up its 1.x replacement, make the minimal change.
+
+- [ ] **Step 3: Commit (only if changes were made)**
+
+```bash
+git add packages/langchain/src/chain-adapter.ts
+git commit -m "refactor(langchain): chain-adapter for langchain 1.x"
+```
+
+---
+
+## Task 7: Audit `packages/cli/src/commands/build.ts`
+
+**Files:**
+- Modify: `packages/cli/src/commands/build.ts` (only if typecheck flags it)
+
+- [ ] **Step 1: Typecheck the cli package**
+
+Run: `pnpm --filter @dawn-ai/cli typecheck 2>&1 | head -40`
+
+- [ ] **Step 2: If no errors in build.ts, skip to Task 8. If errors exist, fix them.**
+
+The file imports from `@langchain/core`. Most likely candidates for breakage are type imports that moved subpaths in 1.x. Look at the failing import; if the type now lives in a different subpath (e.g., `@langchain/core/runnables` vs `@langchain/core/messages`), update the import.
+
+- [ ] **Step 3: Commit (only if changes were made)**
+
+```bash
+git add packages/cli/src/commands/build.ts
+git commit -m "refactor(cli): build.ts imports for @langchain/core 1.x"
+```
+
+---
+
+## Task 8: Audit `packages/vite-plugin/src/index.ts`
+
+**Files:**
+- Modify: `packages/vite-plugin/src/index.ts` (only if typecheck flags it)
+
+- [ ] **Step 1: Typecheck**
+
+Run: `pnpm --filter @dawn-ai/vite-plugin typecheck 2>&1 | head -40`
+
+- [ ] **Step 2: If no errors, skip to Task 9. If errors exist, fix them.**
+
+Zod 4 breaking patterns to look for:
+- `z.string().nonempty()` → `z.string().min(1)`
+- `z.record(valueType)` → `z.record(z.string(), valueType)`
+- `z.setErrorMap` → `z.config({ customError })`
+
+If the file uses any of these, replace them. Otherwise the file should compile unchanged.
+
+- [ ] **Step 3: Commit (only if changes were made)**
+
+```bash
+git add packages/vite-plugin/src/index.ts
+git commit -m "refactor(vite-plugin): zod 4 API adjustments"
+```
+
+---
+
+## Task 9: Full workspace verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Clean rebuild**
+
+Run from repo root:
+```bash
+pnpm install
+pnpm build
+```
+Expected: all packages build successfully.
+
+- [ ] **Step 2: Typecheck**
+
+Run: `pnpm typecheck`
+Expected: passes across all workspace packages.
+
+- [ ] **Step 3: Tests**
+
+Run: `pnpm test`
+Expected: passes. If a test snapshots zod error messages and breaks, update the snapshot — zod 4 changed error phrasing.
+
+- [ ] **Step 4: Lint**
+
+Run: `pnpm lint`
+Expected: passes. Common breakages: unused imports left over from removed code.
+
+- [ ] **Step 5: Pack check**
+
+Run: `pnpm pack:check`
+Expected: passes. Confirms the packed package shapes haven't shifted.
+
+- [ ] **Step 6: Verify `zod-to-json-schema` removal**
+
+Run: `pnpm why zod-to-json-schema 2>&1`
+Expected: no direct Dawn dependency. (Transitive presence inside other `@langchain` packages is acceptable; what matters is that Dawn doesn't pull it in directly.)
+
+- [ ] **Step 7: Verify the cast is gone**
+
+Run: `grep -n "as unknown as z.ZodObject" packages/langchain/src/tool-converter.ts`
+Expected: no matches.
+
+If any verification fails, fix and commit. Do not proceed to Task 10 with failing checks.
+
+---
+
+## Task 10: Push branch and open PR
+
+- [ ] **Step 1: Push**
+
+```bash
+git push -u origin claude/langchain-1x-upgrade
+```
+
+- [ ] **Step 2: Open PR**
+
+```bash
+gh pr create --title "feat: upgrade @langchain/* to 1.x and zod to 4.x" --body "$(cat <<'EOF'
+## Summary
+- Bumps \`@langchain/core\` (0.3.80 → 1.1.46), \`@langchain/langgraph\` (0.2.71 → 1.3.0), \`@langchain/openai\` (0.3.17 → 1.4.5)
+- Bumps \`zod\` (3.24.4 → 4.4.3) in \`packages/langchain\` and \`packages/vite-plugin\`
+- Drops the cast-through-unknown workaround in \`packages/langchain/src/tool-converter.ts\` — single zod version means no version split to bridge
+- Transitive \`openai\` v4 → v6 via @langchain/openai
+
+## Why
+Dawn pinned \`zod@3.24.4\` below \`@langchain/core@0.3.80\`'s declared floor of \`^3.25.32\`. That mismatch caused pnpm to hoist a second zod for LangChain, and \`tool-converter.ts:25\` worked around the resulting type incompatibility with \`as unknown as z.ZodObject<z.ZodRawShape>\`. It also surfaced as \`Package subpath './v3' is not defined by "exports" in zod@3.24.4\` whenever the LangChain bridge generated tool schemas. Aligning on a single zod 4 fixes both.
+
+## Spec
+- Spec: \`docs/superpowers/specs/2026-05-15-langchain-1x-zod-4-upgrade-design.md\`
+
+## Test plan
+- [x] \`pnpm install\` succeeds without zod or @langchain peer-dep warnings
+- [x] \`pnpm typecheck\` passes
+- [x] \`pnpm test\` passes
+- [x] \`pnpm build\` passes
+- [x] \`pnpm lint\` passes
+- [x] \`pnpm pack:check\` passes
+- [x] \`pnpm why zod-to-json-schema\` shows no direct Dawn dependency
+- [x] The cast-through-unknown in tool-converter.ts is gone
+
+## Follow-up
+After this merges: rebase PR #140 (\`examples/chat\`) on the new main and drop its README "Known issues" section about the zod mismatch.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 3: Print the PR URL**
+
+The `gh pr create` command prints the URL; capture it for the final summary.

--- a/docs/superpowers/specs/2026-05-15-langchain-1x-zod-4-upgrade-design.md
+++ b/docs/superpowers/specs/2026-05-15-langchain-1x-zod-4-upgrade-design.md
@@ -1,0 +1,152 @@
+# LangChain 1.x + Zod 4 Upgrade — Design
+
+**Date:** 2026-05-15
+**Status:** Draft — pending user approval
+**Owner:** Brian Love
+
+## Summary
+
+Migrate Dawn from `@langchain/{core,langgraph,openai}@0.x` + `zod@3.24.4` to LangChain `1.x` + `zod@4`. Drop the transitive `zod-to-json-schema` dependency (LangGraph 1.x speaks Standard Schema directly) and remove the cast-through-unknown workaround in `packages/langchain/src/tool-converter.ts` that exists solely to bridge a dual-zod version split. Audit `@langchain/openai` usage for v0.3 → v1 breaking changes. One PR off `main`, atomic merge.
+
+## Motivation
+
+Dawn pins `zod@3.24.4` in `packages/langchain` and `packages/vite-plugin`. This is *below* `@langchain/core@0.3.80`'s declared floor of `^3.25.32`. Pnpm therefore hoists a second zod for LangChain, and `packages/langchain/src/tool-converter.ts:25` paper-overs the resulting type incompatibility with `as unknown as z.ZodObject<z.ZodRawShape>`.
+
+The mismatch surfaces visibly when Dawn's LangChain bridge generates tool schemas at agent invocation:
+```
+Package subpath './v3' is not defined by "exports" in zod@3.24.4
+…/zod-to-json-schema/dist/esm/parsers/array.js
+```
+This is what blocks the canonical chat example (PR #140) from running an end-to-end agent loop without a workaround.
+
+Beyond fixing the bug, the upgrade unlocks LangChain's modern surface area — Standard Schema, the 1.x streaming model, Code Interpreter and Programmatic Tool Calling support — which Dawn's eventual phase-3 opinionated harness work will need.
+
+## Non-goals
+
+- New features. Upgrade and simplify only.
+- LLM-touching smoke tests in CI (existing `pnpm test` and typecheck are sufficient for this PR).
+- Adopting the OpenAI Responses API. `ChatOpenAI` continues to use Chat Completions.
+- Touching `examples/chat`. PR #140 is held; it gets a follow-up commit after this PR merges to drop its "Known issues" section.
+- Expanding `KnownModelId` or other SDK-level type changes.
+- Adopting new LangGraph 1.x features beyond what the upgrade itself requires (`Send` improvements, ContextHub, etc.).
+
+## Target versions
+
+| Package | Current | Target |
+|---|---|---|
+| `@langchain/core` | `0.3.80` | `^1.1.46` |
+| `@langchain/langgraph` | `0.2.71` | `^1.3.0` |
+| `@langchain/openai` | `0.3.17` | `^1.4.5` |
+| `openai` (transitive) | `^4.77.0` | `^6.34.0` |
+| `zod` | `3.24.4` | `^4.4.3` |
+| `zod-to-json-schema` | (transitive) | **removed** |
+
+## Affected Dawn packages
+
+| Package | Scope of change |
+|---|---|
+| `packages/langchain` | All four source files (`agent-adapter.ts`, `state-adapter.ts`, `tool-converter.ts`, `tool-loop.ts`). Cast removed. `zod-to-json-schema` dropped. `@langchain/openai` usage audited. |
+| `packages/cli` | `commands/build.ts` audit for `@langchain/core` imports that may have moved. |
+| `packages/vite-plugin` | Zod pin bump. `src/index.ts` updated for any zod 4 API changes. |
+| `packages/sdk` | No direct dep on zod or `@langchain/*` — re-verified after upgrade; expected no source changes. |
+| `apps/web` | No direct dep. No changes. |
+| `examples/chat/*` | Not touched in this PR. Handled in the #140 follow-up after merge. |
+
+## Code-level changes (per file)
+
+### `packages/langchain/src/tool-converter.ts`
+
+- Remove `as unknown as z.ZodObject<z.ZodRawShape>` cast at line 25.
+- Remove the surrounding comment about dual-zod-version incompatibility.
+- Pass Dawn's zod 4 `ZodObject` directly to `DynamicStructuredTool`. LangChain 1.x's tool schema field accepts Standard Schema, so zod 4 objects qualify natively.
+- Remove any `zod-to-json-schema` import.
+
+### `packages/langchain/src/state-adapter.ts`
+
+- Continues to build a LangGraph `Annotation.Root` from the route's Zod state schema, merged with `MessagesAnnotation`. The `Annotation` / `MessagesAnnotation` API surface is unchanged between LangGraph 0.2 and 1.x (verified against the 1.x changelog).
+- Zod 4 inference is stricter; expect 1–3 line tweaks at field-introspection sites. The auto-reducer heuristic (append for array, replace for scalar — see `packages/core/src/state/resolve-state-fields.ts`) keeps working as long as field metadata reads correctly from zod 4.
+
+### `packages/langchain/src/agent-adapter.ts`
+
+- Wires `agent({ model, systemPrompt })` to a compiled LangGraph graph.
+- `ChatOpenAI` instantiation: confirm parameter names match `@langchain/openai@1`. `modelName` was deprecated in 0.3 in favor of `model`; `temperature`, `maxTokens`, `apiKey` shapes unchanged.
+- `bindTools()` is stable. Returns the bound model.
+- No expected API rename, but the audit step verifies.
+
+### `packages/langchain/src/tool-loop.ts`
+
+- ReAct-style loop reading `lastMessage.tool_calls`. The `AIMessage` shape and `tool_calls` array shape are stable across the 0.3 → 1.x boundary.
+- Expected to be a no-op or trivial type-tweak after deps bump.
+
+### `packages/cli/src/commands/build.ts`
+
+- Has one `@langchain/core` import (per the file map). Audit to confirm it still resolves; most type imports in `@langchain/core` are stable, but value imports occasionally moved between subpaths in 1.x.
+
+### `packages/vite-plugin/src/index.ts`
+
+- Uses zod for config validation. Zod 4 retains `.object()`, `.string()`, `.parse()`, `.safeParse()` shapes. Audit for any of the breaking-change patterns listed below.
+
+## Expected zod 4 breaking changes to handle
+
+If present in Dawn code (will be discovered via typecheck after the bump):
+
+1. `z.string().nonempty()` removed → replace with `z.string().min(1)`.
+2. `z.record(valueType)` → `z.record(keyType, valueType)` (two-arg form required).
+3. `z.setErrorMap` → `z.config({ customError })`.
+4. `.transform()` inference subtleties — fix with explicit type parameters if needed.
+5. `.preprocess` signature unchanged; inference slightly different — fix with explicit input/output types if needed.
+6. Error message phrasing changed — may break tests that snapshot zod error messages.
+
+## LangChain 1.x changes to handle
+
+1. Tool schema field accepts Standard Schema — zod 4 objects pass directly (this is the cleanup payoff).
+2. `Annotation.Root` / `MessagesAnnotation` unchanged.
+3. `tool_calls` shape on `AIMessage` stable.
+4. `createReactAgent` from `@langchain/langgraph/prebuilt` widened to accept Standard Schema — only relevant if Dawn uses it (Dawn does not appear to; it has its own `tool-loop.ts`).
+
+## OpenAI SDK v4 → v6 (transitive)
+
+1. `new OpenAI({ apiKey })` shape unchanged.
+2. Chat Completions remains the default API used by `ChatOpenAI`; Responses API is opt-in via a separate class. No forced migration.
+3. Streaming event shapes for chat completions stable; LangChain wraps them.
+4. Embeddings API shape unchanged (not used in Dawn).
+
+## Execution strategy
+
+A single PR off `main` with disciplined commit boundaries (one logical change per commit) so review chunks naturally and `git bisect` stays useful. Order:
+
+1. Bump dep versions in `packages/langchain/package.json` and `packages/vite-plugin/package.json` (and any others surfaced by audit). Single commit.
+2. `pnpm install` + lockfile commit.
+3. Fix `packages/langchain/src/tool-converter.ts` — remove cast, drop `zod-to-json-schema` if imported.
+4. Fix `packages/langchain/src/state-adapter.ts` — zod 4 API tweaks.
+5. Fix `packages/langchain/src/agent-adapter.ts` — `@langchain/openai` v1 audit + any rename.
+6. Fix `packages/langchain/src/tool-loop.ts` — likely no-op; commit only if changes required.
+7. Fix `packages/cli/src/commands/build.ts` — only if audit surfaces issues.
+8. Fix `packages/vite-plugin/src/index.ts` — only if zod 4 API changes affect it.
+9. Drop `zod-to-json-schema` from any explicit dependency lists (and remove unused imports). Update lockfile.
+10. Final `pnpm install && pnpm build && pnpm typecheck && pnpm test && pnpm lint && pnpm pack:check` from the repo root — verify all green.
+
+Run `pnpm typecheck` after each code commit to localize regressions. Type errors are the upgrade's primary signal; treat them as a checklist.
+
+## Success criteria
+
+- `pnpm install` succeeds with no `zod` or `@langchain/*` peer-dep warnings.
+- `pnpm typecheck`, `pnpm test`, `pnpm build`, `pnpm lint` all pass.
+- `pnpm pack:check` passes.
+- `pnpm why zod-to-json-schema` returns no results (transitive removal verified).
+- `packages/langchain/src/tool-converter.ts` no longer contains the cast or the dual-zod-version comment.
+- Diff is bounded to `packages/{langchain,cli,vite-plugin}` plus lockfile and the workspace-level `package.json` if a dependency override was needed (not expected).
+- No new features. No unrelated refactors. No new tests in this PR.
+
+## Follow-up after this PR merges
+
+1. Rebase the chat-example branch (`claude/keen-nightingale-44b28b`, PR #140) on the new `main`.
+2. Commit on #140 removes the "Known issues — `zod-to-json-schema` peer-dep mismatch" section from `examples/chat/README.md`.
+3. Locally run `examples/chat` end-to-end with an `OPENAI_API_KEY`. Confirm a tool-call round-trip completes.
+4. Re-request review on #140.
+
+## Open questions
+
+- **`packages/cli/src/commands/build.ts`'s exact `@langchain/core` usage** — to be confirmed during execution. If it imports value-level APIs that moved subpaths, audit may surface a sub-task; if it's type-only imports, this is a no-op.
+- **Whether `packages/sdk` has any indirect dependence on a specific zod version** — believed to be `(string & {})` fallbacks only, but worth re-confirming during typecheck.
+- **Lockfile churn** — major-version dep bumps cascade through the lockfile. Expect a sizeable lockfile diff. Not a problem; just noting it for the reviewer.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -52,7 +52,7 @@
   "devDependencies": {
     "@dawn-ai/config-typescript": "workspace:*",
     "@dawn-ai/sdk": "workspace:*",
-    "@langchain/core": "0.3.80",
+    "@langchain/core": "1.1.46",
     "@types/node": "25.6.0"
   }
 }

--- a/packages/langchain/package.json
+++ b/packages/langchain/package.json
@@ -37,18 +37,18 @@
   },
   "dependencies": {
     "@dawn-ai/sdk": "workspace:*",
-    "@langchain/langgraph": "^0.2.71",
-    "@langchain/openai": "^0.3.17"
+    "@langchain/langgraph": "^1.3.0",
+    "@langchain/openai": "^1.4.5"
   },
   "peerDependencies": {
-    "@langchain/core": ">=0.3.0"
+    "@langchain/core": ">=1.1.0"
   },
   "devDependencies": {
     "@dawn-ai/config-typescript": "workspace:*",
-    "@langchain/core": "0.3.80",
-    "@langchain/langgraph": "0.2.71",
-    "@langchain/openai": "0.3.17",
+    "@langchain/core": "1.1.46",
+    "@langchain/langgraph": "1.3.0",
+    "@langchain/openai": "1.4.5",
     "@types/node": "25.6.0",
-    "zod": "3.24.4"
+    "zod": "4.4.3"
   }
 }

--- a/packages/langchain/src/tool-converter.ts
+++ b/packages/langchain/src/tool-converter.ts
@@ -20,12 +20,10 @@ export function convertToolToLangChain(
 ): DynamicStructuredTool {
   const schema = toZodSchema(tool.schema)
 
-  // Cast through unknown to bridge the dual-Zod version type incompatibility
-  // (package uses zod@3.24.4; @langchain/core uses zod@3.25.x — structurally identical at runtime)
   return new DynamicStructuredTool({
     name: tool.name,
     description: tool.description ?? "",
-    schema: schema as unknown as z.ZodObject<z.ZodRawShape>,
+    schema,
     func: async (input, _runManager, config) => {
       const signal = config?.signal ?? new AbortController().signal
       const result = await tool.run(input, {
@@ -34,13 +32,13 @@ export function convertToolToLangChain(
       })
       return JSON.stringify(result)
     },
-  }) as unknown as DynamicStructuredTool
+  })
 }
 
-function toZodSchema(value: unknown): z.ZodObject<z.ZodRawShape> {
+function toZodSchema(value: unknown): z.ZodTypeAny {
   if (isZodObject(value)) return value
   if (isJsonSchemaObject(value)) return jsonSchemaToZod(value)
-  return z.record(z.string(), z.unknown()) as unknown as z.ZodObject<z.ZodRawShape>
+  return z.record(z.string(), z.unknown())
 }
 
 function isZodObject(value: unknown): value is z.ZodObject<z.ZodRawShape> {
@@ -69,7 +67,7 @@ function isJsonSchemaObject(value: unknown): value is JsonSchemaObject {
 }
 
 function jsonSchemaToZod(schema: JsonSchemaObject): z.ZodObject<z.ZodRawShape> {
-  const shape: z.ZodRawShape = {}
+  const shape: Record<string, z.ZodTypeAny> = {}
   const required = new Set(schema.required ?? [])
 
   for (const [key, prop] of Object.entries(schema.properties ?? {})) {

--- a/packages/vite-plugin/package.json
+++ b/packages/vite-plugin/package.json
@@ -42,6 +42,6 @@
   "devDependencies": {
     "@dawn-ai/config-typescript": "workspace:*",
     "@types/node": "25.6.0",
-    "zod": "3.24.4"
+    "zod": "4.4.3"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -132,8 +132,8 @@ importers:
         specifier: workspace:*
         version: link:../sdk
       '@langchain/core':
-        specifier: 0.3.80
-        version: 0.3.80(openai@4.104.0(zod@3.25.76))
+        specifier: 1.1.46
+        version: 1.1.46(openai@6.37.0(zod@4.4.3))
       '@types/node':
         specifier: 25.6.0
         version: 25.6.0
@@ -199,24 +199,24 @@ importers:
         specifier: workspace:*
         version: link:../sdk
       '@langchain/langgraph':
-        specifier: ^0.2.71
-        version: 0.2.71(@langchain/core@0.3.80(openai@4.104.0(zod@3.24.4)))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(zod-to-json-schema@3.25.2(zod@3.24.4))
+        specifier: ^1.3.0
+        version: 1.3.0(@langchain/core@1.1.46(openai@6.37.0(zod@4.4.3)))(openai@6.37.0(zod@4.4.3))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(zod-to-json-schema@3.25.2(zod@4.4.3))(zod@4.4.3)
       '@langchain/openai':
-        specifier: ^0.3.17
-        version: 0.3.17(@langchain/core@0.3.80(openai@4.104.0(zod@3.24.4)))
+        specifier: ^1.4.5
+        version: 1.4.5(@langchain/core@1.1.46(openai@6.37.0(zod@4.4.3)))
     devDependencies:
       '@dawn-ai/config-typescript':
         specifier: workspace:*
         version: link:../config-typescript
       '@langchain/core':
-        specifier: 0.3.80
-        version: 0.3.80(openai@4.104.0(zod@3.24.4))
+        specifier: 1.1.46
+        version: 1.1.46(openai@6.37.0(zod@4.4.3))
       '@types/node':
         specifier: 25.6.0
         version: 25.6.0
       zod:
-        specifier: 3.24.4
-        version: 3.24.4
+        specifier: 4.4.3
+        version: 4.4.3
 
   packages/langgraph:
     dependencies:
@@ -256,8 +256,8 @@ importers:
         specifier: 25.6.0
         version: 25.6.0
       zod:
-        specifier: 3.24.4
-        version: 3.24.4
+        specifier: 4.4.3
+        version: 4.4.3
 
 packages:
 
@@ -865,45 +865,52 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
-  '@langchain/core@0.3.80':
-    resolution: {integrity: sha512-vcJDV2vk1AlCwSh3aBm/urQ1ZrlXFFBocv11bz/NBUfLWD5/UDNMzwPdaAd2dKvNmTWa9FM2lirLU3+JCf4cRA==}
-    engines: {node: '>=18'}
+  '@langchain/core@1.1.46':
+    resolution: {integrity: sha512-i8rDC83BpItxChCw4Lf+6tAr+k+OUcbirc5ZkrhI9ywYWmvxegUljLGOGYvtJNTbEAIFkhYIODPE5QRqyjF6sA==}
+    engines: {node: '>=20'}
 
-  '@langchain/langgraph-checkpoint@0.0.18':
-    resolution: {integrity: sha512-IS7zJj36VgY+4pf8ZjsVuUWef7oTwt1y9ylvwu0aLuOn1d0fg05Om9DLm3v2GZ2Df6bhLV1kfWAM0IAl9O5rQQ==}
+  '@langchain/langgraph-checkpoint@1.0.2':
+    resolution: {integrity: sha512-F4E5Tr0nt8FGghgdscJtHw+ABzChOHeI80R7Y1pjIHdiJom6c2ieo76vL+FWiny80JmoGqhrVAEIWrw0cXKPxg==}
     engines: {node: '>=18'}
     peerDependencies:
-      '@langchain/core': '>=0.2.31 <0.4.0'
+      '@langchain/core': ^1.1.44
 
-  '@langchain/langgraph-sdk@0.0.112':
-    resolution: {integrity: sha512-/9W5HSWCqYgwma6EoOspL4BGYxGxeJP6lIquPSF4FA0JlKopaUv58ucZC3vAgdJyCgg6sorCIV/qg7SGpEcCLw==}
+  '@langchain/langgraph-sdk@1.9.2':
+    resolution: {integrity: sha512-1kDPjR0VH/39q2h8k0Sxi35KxOvEQPModVCepxGLlRkbZmuWUH+zfICuJd3rmD1ByeOKQBZEaB7Y+VCYmSMt1w==}
     peerDependencies:
-      '@langchain/core': '>=0.2.31 <0.4.0'
       react: ^18 || ^19
       react-dom: ^18 || ^19
+      svelte: ^4.0.0 || ^5.0.0
+      vue: ^3.0.0
     peerDependenciesMeta:
-      '@langchain/core':
-        optional: true
       react:
         optional: true
       react-dom:
         optional: true
+      svelte:
+        optional: true
+      vue:
+        optional: true
 
-  '@langchain/langgraph@0.2.71':
-    resolution: {integrity: sha512-++p6NuU6aQX1aSrB+IDeXbnUCydb72HKiiQPgsGluWs1ZP61VTYydlEU6KPHHHp3JwROBzIbQHXY/G/ygHIrFg==}
+  '@langchain/langgraph@1.3.0':
+    resolution: {integrity: sha512-QvhTjiyqFPz81A+y6LHs223w6DTjv5+882DT4mup72bd72rRhNjTYo5fhes5um0swnKArvY/arc7KeFInfHHWw==}
     engines: {node: '>=18'}
     peerDependencies:
-      '@langchain/core': '>=0.2.36 <0.3.0 || >=0.3.40 < 0.4.0'
+      '@langchain/core': ^1.1.44
+      zod: ^3.25.32 || ^4.2.0
       zod-to-json-schema: ^3.x
     peerDependenciesMeta:
       zod-to-json-schema:
         optional: true
 
-  '@langchain/openai@0.3.17':
-    resolution: {integrity: sha512-uw4po32OKptVjq+CYHrumgbfh4NuD7LqyE+ZgqY9I/LrLc6bHLMc+sisHmI17vgek0K/yqtarI0alPJbzrwyag==}
-    engines: {node: '>=18'}
+  '@langchain/openai@1.4.5':
+    resolution: {integrity: sha512-bQ2WMIZfSh02trJLYSAtiIcD3j6EBCiAm9nw0dZWQsVaUxmWc3JJqs8uUte6AkMazmLHzcUIw+14UkXO5fRJvQ==}
+    engines: {node: '>=20'}
     peerDependencies:
-      '@langchain/core': '>=0.3.29 <0.4.0'
+      '@langchain/core': ^1.1.42
+
+  '@langchain/protocol@0.0.15':
+    resolution: {integrity: sha512-MllvbpMjqHevUm+v94M422mH7XKN+wGCvJRBVROTWBotEDOATYB4Ktk2UheYP859y9o2LlhtPek5t1T9eyfAbQ==}
 
   '@manypkg/find-root@1.1.0':
     resolution: {integrity: sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA==}
@@ -1450,14 +1457,8 @@ packages:
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
-  '@types/node-fetch@2.6.13':
-    resolution: {integrity: sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==}
-
   '@types/node@12.20.55':
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
-
-  '@types/node@18.19.130':
-    resolution: {integrity: sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==}
 
   '@types/node@25.6.0':
     resolution: {integrity: sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==}
@@ -1469,9 +1470,6 @@ packages:
 
   '@types/react@19.2.14':
     resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
-
-  '@types/retry@0.12.0':
-    resolution: {integrity: sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==}
 
   '@types/unist@2.0.11':
     resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
@@ -1545,10 +1543,6 @@ packages:
   '@vitest/utils@4.1.4':
     resolution: {integrity: sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw==}
 
-  abort-controller@3.0.0:
-    resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
-    engines: {node: '>=6.5'}
-
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -1559,10 +1553,6 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
-  agentkeepalive@4.6.0:
-    resolution: {integrity: sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==}
-    engines: {node: '>= 8.0.0'}
-
   ansi-colors@4.1.3:
     resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
     engines: {node: '>=6'}
@@ -1570,10 +1560,6 @@ packages:
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
-
-  ansi-styles@5.2.0:
-    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
-    engines: {node: '>=10'}
 
   argparse@1.0.10:
     resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
@@ -1592,9 +1578,6 @@ packages:
   astring@1.9.0:
     resolution: {integrity: sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==}
     hasBin: true
-
-  asynckit@0.4.0:
-    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
   bail@2.0.2:
     resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
@@ -1618,14 +1601,6 @@ packages:
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
-
-  call-bind-apply-helpers@1.0.2:
-    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
-    engines: {node: '>= 0.4'}
-
-  camelcase@6.3.0:
-    resolution: {integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==}
-    engines: {node: '>=10'}
 
   caniuse-lite@1.0.30001787:
     resolution: {integrity: sha512-mNcrMN9KeI68u7muanUpEejSLghOKlVhRqS/Za2IeyGllJ9I9otGpR9g3nsw7n4W378TE/LyIteA0+/FOZm4Kg==}
@@ -1666,10 +1641,6 @@ packages:
   collapse-white-space@2.1.0:
     resolution: {integrity: sha512-loKTxY1zCOuG4j9f6EPnuyyYkf58RnhhWTvRoZEokgB+WbdXehfjFviyOVYkqzEWz1Q5kRiZdBYS5SwxbQYwzw==}
 
-  combined-stream@1.0.8:
-    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
-    engines: {node: '>= 0.8'}
-
   comma-separated-tokens@2.0.3:
     resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
 
@@ -1696,20 +1667,12 @@ packages:
       supports-color:
         optional: true
 
-  decamelize@1.2.0:
-    resolution: {integrity: sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==}
-    engines: {node: '>=0.10.0'}
-
   decode-named-character-reference@1.3.0:
     resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
 
   deep-eql@5.0.2:
     resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
     engines: {node: '>=6'}
-
-  delayed-stream@1.0.0:
-    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
-    engines: {node: '>=0.4.0'}
 
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
@@ -1730,10 +1693,6 @@ packages:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
     engines: {node: '>=8'}
 
-  dunder-proto@1.0.1:
-    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
-    engines: {node: '>= 0.4'}
-
   enhanced-resolve@5.20.1:
     resolution: {integrity: sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==}
     engines: {node: '>=10.13.0'}
@@ -1746,27 +1705,11 @@ packages:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
     engines: {node: '>=0.12'}
 
-  es-define-property@1.0.1:
-    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
-    engines: {node: '>= 0.4'}
-
-  es-errors@1.3.0:
-    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
-    engines: {node: '>= 0.4'}
-
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
 
   es-module-lexer@2.0.0:
     resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
-
-  es-object-atoms@1.1.1:
-    resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
-    engines: {node: '>= 0.4'}
-
-  es-set-tostringtag@2.1.0:
-    resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
-    engines: {node: '>= 0.4'}
 
   esast-util-from-estree@2.0.0:
     resolution: {integrity: sha512-4CyanoAudUSBAn5K13H4JhsMH6L9ZP7XbLVe/dKybkxMO7eDyLsT8UHl9TRNrU2Gr9nz+FovfSIjuXWJ81uVwQ==}
@@ -1817,12 +1760,11 @@ packages:
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
 
-  event-target-shim@5.0.1:
-    resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
-    engines: {node: '>=6'}
-
   eventemitter3@4.0.7:
     resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
+
+  eventemitter3@5.0.4:
+    resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
 
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
@@ -1871,20 +1813,9 @@ packages:
   flatted@3.4.2:
     resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
-  form-data-encoder@1.7.2:
-    resolution: {integrity: sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==}
-
-  form-data@4.0.5:
-    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
-    engines: {node: '>= 6'}
-
   format@0.2.2:
     resolution: {integrity: sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==}
     engines: {node: '>=0.4.x'}
-
-  formdata-node@4.4.1:
-    resolution: {integrity: sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==}
-    engines: {node: '>= 12.20'}
 
   fs-extra@7.0.1:
     resolution: {integrity: sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==}
@@ -1899,17 +1830,6 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
-  function-bind@1.1.2:
-    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
-
-  get-intrinsic@1.3.0:
-    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
-    engines: {node: '>= 0.4'}
-
-  get-proto@1.0.1:
-    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
-    engines: {node: '>= 0.4'}
-
   get-tsconfig@4.13.7:
     resolution: {integrity: sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==}
 
@@ -1921,28 +1841,12 @@ packages:
     resolution: {integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==}
     engines: {node: '>=10'}
 
-  gopd@1.2.0:
-    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
-    engines: {node: '>= 0.4'}
-
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
   gray-matter@4.0.3:
     resolution: {integrity: sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==}
     engines: {node: '>=6.0'}
-
-  has-symbols@1.1.0:
-    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
-    engines: {node: '>= 0.4'}
-
-  has-tostringtag@1.0.2:
-    resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
-    engines: {node: '>= 0.4'}
-
-  hasown@2.0.3:
-    resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
-    engines: {node: '>= 0.4'}
 
   hast-util-from-html@2.0.3:
     resolution: {integrity: sha512-CUSRHXyKjzHov8yKsQjGOElXy/3EKpyX56ELnkHH34vDVw1N1XSQ1ZcAvTyAPtGqLTuKP/uxM+aLkSPqF/EtMw==}
@@ -1978,9 +1882,6 @@ packages:
     resolution: {integrity: sha512-tsYlhAYpjCKa//8rXZ9DqKEawhPoSytweBC2eNvcaDK+57RZLHGqNs3PZTQO6yekLFSuvA6AlnAfrw1uBvtb+Q==}
     hasBin: true
 
-  humanize-ms@1.2.1:
-    resolution: {integrity: sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==}
-
   iconv-lite@0.7.2:
     resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
     engines: {node: '>=0.10.0'}
@@ -2015,6 +1916,10 @@ packages:
 
   is-hexadecimal@2.0.1:
     resolution: {integrity: sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==}
+
+  is-network-error@1.3.2:
+    resolution: {integrity: sha512-PhBY86zaxNZUuWP6h13Vu5oFe0XY6/UlKzQnYFELzGVHygP3MxmvTfYSG7GN3aIab/iWudSMgjSnG9Dq+nHrgA==}
+    engines: {node: '>=16'}
 
   is-number@7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
@@ -2173,10 +2078,6 @@ packages:
 
   markdown-table@3.0.4:
     resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
-
-  math-intrinsics@1.1.0:
-    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
-    engines: {node: '>= 0.4'}
 
   mdast-util-find-and-replace@3.0.2:
     resolution: {integrity: sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==}
@@ -2345,14 +2246,6 @@ packages:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
 
-  mime-db@1.52.0:
-    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
-    engines: {node: '>= 0.6'}
-
-  mime-types@2.1.35:
-    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
-    engines: {node: '>= 0.6'}
-
   mri@1.2.0:
     resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
     engines: {node: '>=4'}
@@ -2394,20 +2287,6 @@ packages:
       sass:
         optional: true
 
-  node-domexception@1.0.0:
-    resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
-    engines: {node: '>=10.5.0'}
-    deprecated: Use your platform's native DOMException instead
-
-  node-fetch@2.7.0:
-    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
-    engines: {node: 4.x || >=6.0.0}
-    peerDependencies:
-      encoding: ^0.1.0
-    peerDependenciesMeta:
-      encoding:
-        optional: true
-
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
 
@@ -2417,12 +2296,12 @@ packages:
   oniguruma-to-es@4.3.6:
     resolution: {integrity: sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA==}
 
-  openai@4.104.0:
-    resolution: {integrity: sha512-p99EFNsA/yX6UhVO93f5kJsDRLAg+CTA2RBqdHK4RtK8u5IJw32Hyb2dTGKbnnFmnuoBv5r7Z2CURI9sGZpSuA==}
+  openai@6.37.0:
+    resolution: {integrity: sha512-0H5dEGFmmLv6KSd0W1w2nyL8WsLkX6yoLeQpU+dZAOuGcany5qkYQMmj35ZrKgb6yiyYqpUzFOpR8mZQkgqeEQ==}
     hasBin: true
     peerDependencies:
       ws: ^8.18.0
-      zod: ^3.23.8
+      zod: ^3.25 || ^4.0
     peerDependenciesMeta:
       ws:
         optional: true
@@ -2456,13 +2335,21 @@ packages:
     resolution: {integrity: sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==}
     engines: {node: '>=8'}
 
-  p-retry@4.6.2:
-    resolution: {integrity: sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==}
-    engines: {node: '>=8'}
+  p-queue@9.2.0:
+    resolution: {integrity: sha512-dWgLE8AH0HjQ9fe74pUkKkvzzYT18Inp4zra3lKHnnwqGvcfcUBrvF2EAVX+envufDNBOzpPq/IBUONDbI7+3g==}
+    engines: {node: '>=20'}
+
+  p-retry@7.1.1:
+    resolution: {integrity: sha512-J5ApzjyRkkf601HpEeykoiCvzHQjWxPAHhyjFcEUP2SWq0+35NKh8TLhpLw+Dkq5TZBFvUM6UigdE9hIVYTl5w==}
+    engines: {node: '>=20'}
 
   p-timeout@3.2.0:
     resolution: {integrity: sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==}
     engines: {node: '>=8'}
+
+  p-timeout@7.0.1:
+    resolution: {integrity: sha512-AxTM2wDGORHGEkPCt8yqxOTMgpfbEHqF51f/5fJCmwFC3C/zNcGT63SymH2ttOAaiIws2zVg4+izQCjrakcwHg==}
+    engines: {node: '>=20'}
 
   p-try@2.2.0:
     resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
@@ -2621,10 +2508,6 @@ packages:
 
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
-
-  retry@0.13.1:
-    resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
-    engines: {node: '>= 4'}
 
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
@@ -2805,9 +2688,6 @@ packages:
     resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
     engines: {node: '>=6'}
 
-  tr46@0.0.3:
-    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
-
   trim-lines@3.0.1:
     resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
 
@@ -2835,9 +2715,6 @@ packages:
     resolution: {integrity: sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==}
     engines: {node: '>=14.17'}
     hasBin: true
-
-  undici-types@5.26.5:
-    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
 
   undici-types@7.19.2:
     resolution: {integrity: sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==}
@@ -2872,11 +2749,11 @@ packages:
 
   uuid@10.0.0:
     resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
-  uuid@9.0.1:
-    resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
-    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
+  uuid@13.0.2:
+    resolution: {integrity: sha512-vzi9uRZ926x4XV73S/4qQaTwPXM2JBj6/6lI/byHH1jOpCzb0zDbfytgA9LcN/hzb2l7WQSQnxITOVx5un/wGw==}
     hasBin: true
 
   vfile-location@5.0.3:
@@ -3036,16 +2913,6 @@ packages:
   web-namespaces@2.0.1:
     resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
 
-  web-streams-polyfill@4.0.0-beta.3:
-    resolution: {integrity: sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==}
-    engines: {node: '>= 14'}
-
-  webidl-conversions@3.0.1:
-    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
-
-  whatwg-url@5.0.0:
-    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
-
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
@@ -3066,11 +2933,8 @@ packages:
     peerDependencies:
       zod: ^3.25.28 || ^4
 
-  zod@3.24.4:
-    resolution: {integrity: sha512-OdqJE9UDRPwWsrHjLN2F8bPxvwJBK22EHLWtanu0LSYr5YqzsaaW3RMgmjwr8Rypg5k+meEJdSPXJZXE/yqOMg==}
-
-  zod@3.25.76:
-    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
@@ -3547,20 +3411,15 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@langchain/core@0.3.80(openai@4.104.0(zod@3.24.4))':
+  '@langchain/core@1.1.46(openai@6.37.0(zod@4.4.3))':
     dependencies:
       '@cfworker/json-schema': 4.1.1
-      ansi-styles: 5.2.0
-      camelcase: 6.3.0
-      decamelize: 1.2.0
+      '@standard-schema/spec': 1.1.0
       js-tiktoken: 1.0.21
-      langsmith: 0.5.19(openai@4.104.0(zod@3.24.4))
+      langsmith: 0.5.19(openai@6.37.0(zod@4.4.3))
       mustache: 4.2.0
       p-queue: 6.6.2
-      p-retry: 4.6.2
-      uuid: 10.0.0
-      zod: 3.25.76
-      zod-to-json-schema: 3.25.2(zod@3.25.76)
+      zod: 4.4.3
     transitivePeerDependencies:
       - '@opentelemetry/api'
       - '@opentelemetry/exporter-trace-otlp-proto'
@@ -3568,66 +3427,61 @@ snapshots:
       - openai
       - ws
 
-  '@langchain/core@0.3.80(openai@4.104.0(zod@3.25.76))':
+  '@langchain/langgraph-checkpoint@1.0.2(@langchain/core@1.1.46(openai@6.37.0(zod@4.4.3)))':
     dependencies:
-      '@cfworker/json-schema': 4.1.1
-      ansi-styles: 5.2.0
-      camelcase: 6.3.0
-      decamelize: 1.2.0
-      js-tiktoken: 1.0.21
-      langsmith: 0.5.19(openai@4.104.0(zod@3.25.76))
-      mustache: 4.2.0
-      p-queue: 6.6.2
-      p-retry: 4.6.2
-      uuid: 10.0.0
-      zod: 3.25.76
-      zod-to-json-schema: 3.25.2(zod@3.25.76)
-    transitivePeerDependencies:
-      - '@opentelemetry/api'
-      - '@opentelemetry/exporter-trace-otlp-proto'
-      - '@opentelemetry/sdk-trace-base'
-      - openai
-      - ws
-
-  '@langchain/langgraph-checkpoint@0.0.18(@langchain/core@0.3.80(openai@4.104.0(zod@3.24.4)))':
-    dependencies:
-      '@langchain/core': 0.3.80(openai@4.104.0(zod@3.24.4))
+      '@langchain/core': 1.1.46(openai@6.37.0(zod@4.4.3))
       uuid: 10.0.0
 
-  '@langchain/langgraph-sdk@0.0.112(@langchain/core@0.3.80(openai@4.104.0(zod@3.24.4)))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@langchain/langgraph-sdk@1.9.2(openai@6.37.0(zod@4.4.3))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     dependencies:
+      '@langchain/core': 1.1.46(openai@6.37.0(zod@4.4.3))
+      '@langchain/protocol': 0.0.15
       '@types/json-schema': 7.0.15
-      p-queue: 6.6.2
-      p-retry: 4.6.2
-      uuid: 9.0.1
+      p-queue: 9.2.0
+      p-retry: 7.1.1
+      uuid: 13.0.2
     optionalDependencies:
-      '@langchain/core': 0.3.80(openai@4.104.0(zod@3.24.4))
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
-
-  '@langchain/langgraph@0.2.71(@langchain/core@0.3.80(openai@4.104.0(zod@3.24.4)))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(zod-to-json-schema@3.25.2(zod@3.24.4))':
-    dependencies:
-      '@langchain/core': 0.3.80(openai@4.104.0(zod@3.24.4))
-      '@langchain/langgraph-checkpoint': 0.0.18(@langchain/core@0.3.80(openai@4.104.0(zod@3.24.4)))
-      '@langchain/langgraph-sdk': 0.0.112(@langchain/core@0.3.80(openai@4.104.0(zod@3.24.4)))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      uuid: 10.0.0
-      zod: 3.24.4
-    optionalDependencies:
-      zod-to-json-schema: 3.25.2(zod@3.24.4)
     transitivePeerDependencies:
+      - '@opentelemetry/api'
+      - '@opentelemetry/exporter-trace-otlp-proto'
+      - '@opentelemetry/sdk-trace-base'
+      - openai
+      - ws
+
+  '@langchain/langgraph@1.3.0(@langchain/core@1.1.46(openai@6.37.0(zod@4.4.3)))(openai@6.37.0(zod@4.4.3))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(zod-to-json-schema@3.25.2(zod@4.4.3))(zod@4.4.3)':
+    dependencies:
+      '@langchain/core': 1.1.46(openai@6.37.0(zod@4.4.3))
+      '@langchain/langgraph-checkpoint': 1.0.2(@langchain/core@1.1.46(openai@6.37.0(zod@4.4.3)))
+      '@langchain/langgraph-sdk': 1.9.2(openai@6.37.0(zod@4.4.3))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@langchain/protocol': 0.0.15
+      '@standard-schema/spec': 1.1.0
+      uuid: 10.0.0
+      zod: 4.4.3
+    optionalDependencies:
+      zod-to-json-schema: 3.25.2(zod@4.4.3)
+    transitivePeerDependencies:
+      - '@opentelemetry/api'
+      - '@opentelemetry/exporter-trace-otlp-proto'
+      - '@opentelemetry/sdk-trace-base'
+      - openai
       - react
       - react-dom
-
-  '@langchain/openai@0.3.17(@langchain/core@0.3.80(openai@4.104.0(zod@3.24.4)))':
-    dependencies:
-      '@langchain/core': 0.3.80(openai@4.104.0(zod@3.24.4))
-      js-tiktoken: 1.0.21
-      openai: 4.104.0(zod@3.24.4)
-      zod: 3.24.4
-      zod-to-json-schema: 3.25.2(zod@3.24.4)
-    transitivePeerDependencies:
-      - encoding
+      - svelte
+      - vue
       - ws
+
+  '@langchain/openai@1.4.5(@langchain/core@1.1.46(openai@6.37.0(zod@4.4.3)))':
+    dependencies:
+      '@langchain/core': 1.1.46(openai@6.37.0(zod@4.4.3))
+      js-tiktoken: 1.0.21
+      openai: 6.37.0(zod@4.4.3)
+      zod: 4.4.3
+    transitivePeerDependencies:
+      - ws
+
+  '@langchain/protocol@0.0.15': {}
 
   '@manypkg/find-root@1.1.0':
     dependencies:
@@ -4041,16 +3895,7 @@ snapshots:
 
   '@types/ms@2.1.0': {}
 
-  '@types/node-fetch@2.6.13':
-    dependencies:
-      '@types/node': 25.6.0
-      form-data: 4.0.5
-
   '@types/node@12.20.55': {}
-
-  '@types/node@18.19.130':
-    dependencies:
-      undici-types: 5.26.5
 
   '@types/node@25.6.0':
     dependencies:
@@ -4063,8 +3908,6 @@ snapshots:
   '@types/react@19.2.14':
     dependencies:
       csstype: 3.2.3
-
-  '@types/retry@0.12.0': {}
 
   '@types/unist@2.0.11': {}
 
@@ -4164,25 +4007,15 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
-  abort-controller@3.0.0:
-    dependencies:
-      event-target-shim: 5.0.1
-
   acorn-jsx@5.3.2(acorn@8.16.0):
     dependencies:
       acorn: 8.16.0
 
   acorn@8.16.0: {}
 
-  agentkeepalive@4.6.0:
-    dependencies:
-      humanize-ms: 1.2.1
-
   ansi-colors@4.1.3: {}
 
   ansi-regex@5.0.1: {}
-
-  ansi-styles@5.2.0: {}
 
   argparse@1.0.10:
     dependencies:
@@ -4195,8 +4028,6 @@ snapshots:
   assertion-error@2.0.1: {}
 
   astring@1.9.0: {}
-
-  asynckit@0.4.0: {}
 
   bail@2.0.2: {}
 
@@ -4213,13 +4044,6 @@ snapshots:
       fill-range: 7.1.1
 
   cac@6.7.14: {}
-
-  call-bind-apply-helpers@1.0.2:
-    dependencies:
-      es-errors: 1.3.0
-      function-bind: 1.1.2
-
-  camelcase@6.3.0: {}
 
   caniuse-lite@1.0.30001787: {}
 
@@ -4251,10 +4075,6 @@ snapshots:
 
   collapse-white-space@2.1.0: {}
 
-  combined-stream@1.0.8:
-    dependencies:
-      delayed-stream: 1.0.0
-
   comma-separated-tokens@2.0.3: {}
 
   commander@14.0.3: {}
@@ -4273,15 +4093,11 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
-  decamelize@1.2.0: {}
-
   decode-named-character-reference@1.3.0:
     dependencies:
       character-entities: 2.0.2
 
   deep-eql@5.0.2: {}
-
-  delayed-stream@1.0.0: {}
 
   dequal@2.0.3: {}
 
@@ -4297,12 +4113,6 @@ snapshots:
     dependencies:
       path-type: 4.0.0
 
-  dunder-proto@1.0.1:
-    dependencies:
-      call-bind-apply-helpers: 1.0.2
-      es-errors: 1.3.0
-      gopd: 1.2.0
-
   enhanced-resolve@5.20.1:
     dependencies:
       graceful-fs: 4.2.11
@@ -4315,24 +4125,9 @@ snapshots:
 
   entities@6.0.1: {}
 
-  es-define-property@1.0.1: {}
-
-  es-errors@1.3.0: {}
-
   es-module-lexer@1.7.0: {}
 
   es-module-lexer@2.0.0: {}
-
-  es-object-atoms@1.1.1:
-    dependencies:
-      es-errors: 1.3.0
-
-  es-set-tostringtag@2.1.0:
-    dependencies:
-      es-errors: 1.3.0
-      get-intrinsic: 1.3.0
-      has-tostringtag: 1.0.2
-      hasown: 2.0.3
 
   esast-util-from-estree@2.0.0:
     dependencies:
@@ -4444,9 +4239,9 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.8
 
-  event-target-shim@5.0.1: {}
-
   eventemitter3@4.0.7: {}
+
+  eventemitter3@5.0.4: {}
 
   expect-type@1.3.0: {}
 
@@ -4491,22 +4286,7 @@ snapshots:
 
   flatted@3.4.2: {}
 
-  form-data-encoder@1.7.2: {}
-
-  form-data@4.0.5:
-    dependencies:
-      asynckit: 0.4.0
-      combined-stream: 1.0.8
-      es-set-tostringtag: 2.1.0
-      hasown: 2.0.3
-      mime-types: 2.1.35
-
   format@0.2.2: {}
-
-  formdata-node@4.4.1:
-    dependencies:
-      node-domexception: 1.0.0
-      web-streams-polyfill: 4.0.0-beta.3
 
   fs-extra@7.0.1:
     dependencies:
@@ -4522,26 +4302,6 @@ snapshots:
 
   fsevents@2.3.3:
     optional: true
-
-  function-bind@1.1.2: {}
-
-  get-intrinsic@1.3.0:
-    dependencies:
-      call-bind-apply-helpers: 1.0.2
-      es-define-property: 1.0.1
-      es-errors: 1.3.0
-      es-object-atoms: 1.1.1
-      function-bind: 1.1.2
-      get-proto: 1.0.1
-      gopd: 1.2.0
-      has-symbols: 1.1.0
-      hasown: 2.0.3
-      math-intrinsics: 1.1.0
-
-  get-proto@1.0.1:
-    dependencies:
-      dunder-proto: 1.0.1
-      es-object-atoms: 1.1.1
 
   get-tsconfig@4.13.7:
     dependencies:
@@ -4560,8 +4320,6 @@ snapshots:
       merge2: 1.4.1
       slash: 3.0.0
 
-  gopd@1.2.0: {}
-
   graceful-fs@4.2.11: {}
 
   gray-matter@4.0.3:
@@ -4570,16 +4328,6 @@ snapshots:
       kind-of: 6.0.3
       section-matter: 1.0.0
       strip-bom-string: 1.0.0
-
-  has-symbols@1.1.0: {}
-
-  has-tostringtag@1.0.2:
-    dependencies:
-      has-symbols: 1.1.0
-
-  hasown@2.0.3:
-    dependencies:
-      function-bind: 1.1.2
 
   hast-util-from-html@2.0.3:
     dependencies:
@@ -4680,10 +4428,6 @@ snapshots:
 
   human-id@4.1.3: {}
 
-  humanize-ms@1.2.1:
-    dependencies:
-      ms: 2.1.3
-
   iconv-lite@0.7.2:
     dependencies:
       safer-buffer: 2.1.2
@@ -4710,6 +4454,8 @@ snapshots:
       is-extglob: 2.1.1
 
   is-hexadecimal@2.0.1: {}
+
+  is-network-error@1.3.2: {}
 
   is-number@7.0.0: {}
 
@@ -4744,19 +4490,12 @@ snapshots:
 
   kind-of@6.0.3: {}
 
-  langsmith@0.5.19(openai@4.104.0(zod@3.24.4)):
+  langsmith@0.5.19(openai@6.37.0(zod@4.4.3)):
     dependencies:
       p-queue: 6.6.2
       uuid: 10.0.0
     optionalDependencies:
-      openai: 4.104.0(zod@3.24.4)
-
-  langsmith@0.5.19(openai@4.104.0(zod@3.25.76)):
-    dependencies:
-      p-queue: 6.6.2
-      uuid: 10.0.0
-    optionalDependencies:
-      openai: 4.104.0(zod@3.25.76)
+      openai: 6.37.0(zod@4.4.3)
 
   lightningcss-android-arm64@1.32.0:
     optional: true
@@ -4824,8 +4563,6 @@ snapshots:
   markdown-extensions@2.0.0: {}
 
   markdown-table@3.0.4: {}
-
-  math-intrinsics@1.1.0: {}
 
   mdast-util-find-and-replace@3.0.2:
     dependencies:
@@ -5279,12 +5016,6 @@ snapshots:
       braces: 3.0.3
       picomatch: 2.3.2
 
-  mime-db@1.52.0: {}
-
-  mime-types@2.1.35:
-    dependencies:
-      mime-db: 1.52.0
-
   mri@1.2.0: {}
 
   mrmime@2.0.1: {}
@@ -5319,12 +5050,6 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
-  node-domexception@1.0.0: {}
-
-  node-fetch@2.7.0:
-    dependencies:
-      whatwg-url: 5.0.0
-
   obug@2.1.1: {}
 
   oniguruma-parser@0.12.2: {}
@@ -5335,34 +5060,9 @@ snapshots:
       regex: 6.1.0
       regex-recursion: 6.0.2
 
-  openai@4.104.0(zod@3.24.4):
-    dependencies:
-      '@types/node': 18.19.130
-      '@types/node-fetch': 2.6.13
-      abort-controller: 3.0.0
-      agentkeepalive: 4.6.0
-      form-data-encoder: 1.7.2
-      formdata-node: 4.4.1
-      node-fetch: 2.7.0
+  openai@6.37.0(zod@4.4.3):
     optionalDependencies:
-      zod: 3.24.4
-    transitivePeerDependencies:
-      - encoding
-
-  openai@4.104.0(zod@3.25.76):
-    dependencies:
-      '@types/node': 18.19.130
-      '@types/node-fetch': 2.6.13
-      abort-controller: 3.0.0
-      agentkeepalive: 4.6.0
-      form-data-encoder: 1.7.2
-      formdata-node: 4.4.1
-      node-fetch: 2.7.0
-    optionalDependencies:
-      zod: 3.25.76
-    transitivePeerDependencies:
-      - encoding
-    optional: true
+      zod: 4.4.3
 
   outdent@0.5.0: {}
 
@@ -5387,14 +5087,20 @@ snapshots:
       eventemitter3: 4.0.7
       p-timeout: 3.2.0
 
-  p-retry@4.6.2:
+  p-queue@9.2.0:
     dependencies:
-      '@types/retry': 0.12.0
-      retry: 0.13.1
+      eventemitter3: 5.0.4
+      p-timeout: 7.0.1
+
+  p-retry@7.1.1:
+    dependencies:
+      is-network-error: 1.3.2
 
   p-timeout@3.2.0:
     dependencies:
       p-finally: 1.0.0
+
+  p-timeout@7.0.1: {}
 
   p-try@2.2.0: {}
 
@@ -5602,8 +5308,6 @@ snapshots:
   resolve-from@5.0.0: {}
 
   resolve-pkg-maps@1.0.0: {}
-
-  retry@0.13.1: {}
 
   reusify@1.1.0: {}
 
@@ -5817,8 +5521,6 @@ snapshots:
 
   totalist@3.0.1: {}
 
-  tr46@0.0.3: {}
-
   trim-lines@3.0.1: {}
 
   trough@2.2.0: {}
@@ -5844,8 +5546,6 @@ snapshots:
   typescript@5.8.3: {}
 
   typescript@6.0.2: {}
-
-  undici-types@5.26.5: {}
 
   undici-types@7.19.2: {}
 
@@ -5900,7 +5600,7 @@ snapshots:
 
   uuid@10.0.0: {}
 
-  uuid@9.0.1: {}
+  uuid@13.0.2: {}
 
   vfile-location@5.0.3:
     dependencies:
@@ -6025,15 +5725,6 @@ snapshots:
 
   web-namespaces@2.0.1: {}
 
-  web-streams-polyfill@4.0.0-beta.3: {}
-
-  webidl-conversions@3.0.1: {}
-
-  whatwg-url@5.0.0:
-    dependencies:
-      tr46: 0.0.3
-      webidl-conversions: 3.0.1
-
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
@@ -6045,16 +5736,11 @@ snapshots:
 
   yaml@2.9.0: {}
 
-  zod-to-json-schema@3.25.2(zod@3.24.4):
+  zod-to-json-schema@3.25.2(zod@4.4.3):
     dependencies:
-      zod: 3.24.4
+      zod: 4.4.3
+    optional: true
 
-  zod-to-json-schema@3.25.2(zod@3.25.76):
-    dependencies:
-      zod: 3.25.76
-
-  zod@3.24.4: {}
-
-  zod@3.25.76: {}
+  zod@4.4.3: {}
 
   zwitch@2.0.4: {}


### PR DESCRIPTION
## Summary
- Bumps `@langchain/core` (0.3.80 → 1.1.46), `@langchain/langgraph` (0.2.71 → 1.3.0), `@langchain/openai` (0.3.17 → 1.4.5)
- Bumps `zod` (3.24.4 → 4.4.3) in `packages/langchain` and `packages/vite-plugin`
- Drops the cast-through-unknown workaround in `packages/langchain/src/tool-converter.ts` — single zod version means no version split to bridge
- Transitive: `openai` v4 → v6 via `@langchain/openai`; `zod-to-json-schema` no longer a Dawn direct dependency (still present transitively inside `@langchain/langgraph`, which is unavoidable)

## Why
Dawn pinned `zod@3.24.4` below `@langchain/core@0.3.80`'s declared floor of `^3.25.32`. That mismatch caused pnpm to hoist a second zod for LangChain, and `tool-converter.ts:25` worked around the resulting type incompatibility with `as unknown as z.ZodObject<z.ZodRawShape>`. The mismatch also surfaced as `Package subpath './v3' is not defined by "exports" in zod@3.24.4` whenever the LangChain bridge generated tool schemas — which blocks the canonical chat example (PR #140) from running end-to-end. Aligning on a single zod 4 fixes both.

## What ended up changing
The plan budgeted six per-file fix tasks. Only one file actually needed code changes: `tool-converter.ts`. The other adapters (`agent-adapter`, `state-adapter`, `tool-loop`, `chain-adapter`) and the `cli` / `vite-plugin` files all typecheck cleanly against the 1.x APIs without modification — confirmed by full `pnpm typecheck`, `pnpm build`, `pnpm test`, `pnpm lint`, `pnpm pack:check`.

Inside `tool-converter.ts`:
- The cast `as unknown as z.ZodObject<z.ZodRawShape>` and its workaround comment are removed.
- `toZodSchema`'s return type widened from `z.ZodObject<z.ZodRawShape>` to `z.ZodTypeAny` (`DynamicStructuredTool` in 1.x accepts Standard Schema, so this just works).
- Local `shape` variable in `jsonSchemaToZod` retyped as `Record<string, z.ZodTypeAny>` to satisfy zod 4's now-`Readonly` `ZodRawShape`.

## Spec & plan
- Spec: `docs/superpowers/specs/2026-05-15-langchain-1x-zod-4-upgrade-design.md`
- Plan: `docs/superpowers/plans/2026-05-15-langchain-1x-zod-4-upgrade.md`

## Test plan
- [x] `pnpm install` clean
- [x] `pnpm build` — 9/9 packages
- [x] `pnpm typecheck` — 10/10
- [x] `pnpm test` — 321/321 tests, 49/49 files
- [x] `pnpm lint` — 11/11
- [x] `pnpm pack:check` — passed
- [x] `pnpm why zod-to-json-schema` — no direct `@dawn-ai/*` dependency
- [x] No `as unknown as z.ZodObject` left in `tool-converter.ts`

## Follow-up
After this merges: rebase PR #140 (`examples/chat`) on the new main and drop its README "Known issues" section about the zod mismatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)