### PR TITLE
feat(examples/chat): enable planning capability via plan.md

### DIFF
--- a/examples/chat/README.md
+++ b/examples/chat/README.md
@@ -1,14 +1,18 @@
 # Chat — canonical Dawn harness example
 
-> **v1 status:** foundational harness primitives only (filesystem + bash).
-> Subagents, planning state, sandbox isolation, auto-summarization, and skills
-> are deferred — see "Deferred" below.
+> **Status:** foundational harness primitives (filesystem + bash) + the **planning capability**.
+> Subagents, sandbox isolation, auto-summarization, and skills are still deferred — see
+> "Deferred" below.
 
 ## What this shows
 
 - Dawn route discovery and the `tools/` convention
 - Filesystem tools (read/write/list) + bash, path-jailed to `./workspace`
-- `AGENTS.md` memory convention (manual in v1)
+- `AGENTS.md` memory convention (manual)
+- **Planning** — `plan.md` in the route directory opts the agent into the built-in
+  `write_todos` tool, a `todos` state channel, and a `plan_update` SSE event. Open the
+  smoke client's event log; you'll see `event: plan_update` lines whenever the agent
+  updates its plan.
 - End-to-end streaming from a Next.js client over SSE
 
 ## Quickstart
@@ -31,6 +35,7 @@ examples/chat/
 │       ├── state.ts
 │       ├── system-prompt.ts
 │       ├── workspace-path.ts
+│       ├── plan.md         # presence enables planning; seeds initial todos
 │       └── tools/          # listDir, readFile, writeFile, runBash
 └── web/                    # @dawn-example/chat-web (Next.js smoke client)
     └── app/
@@ -49,8 +54,7 @@ shell expansion — all possible. Do not point untrusted users at this example.
 These v1 deferrals are the explicit forcing function for Dawn's opinionated harness work:
 
 - Subagent delegation (`task`-style tool) — needs first-class subagent declarations
-- Planning state (`write_todos`) — needs build-time agent middleware + state channel composition
-- `AGENTS.md` auto-injection — same
+- `AGENTS.md` auto-injection — needs the skills convention
 - Skills (`skills/` dir + `SKILL.md` loader) — mirror of the `tools/` convention
 - Real sandbox isolation for `runBash` — needs pluggable execution backends
 - Tool-output offloading and context summarization — needs lifecycle hooks

--- a/examples/chat/server/src/app/chat/plan.md
+++ b/examples/chat/server/src/app/chat/plan.md
@@ -1,0 +1,3 @@
+- [ ] Read AGENTS.md if it exists in the workspace
+- [ ] Survey workspace contents before acting
+- [ ] Break multi-step requests into a written plan via write_todos


### PR DESCRIPTION
## Summary
- Adds \`plan.md\` to \`examples/chat/server/src/app/chat/\` (seeded with three starter todos) — opts the chat example into the phase-3 planning capability from #144.
- Updates the example README to reflect that planning is no longer deferred and to explain what the new \`plan_update\` SSE event is.

## Why
PR #144 shipped the planning capability but left the canonical chat example unaffected (opt-in only triggers when \`plan.md\` is present). This closes the loop so anyone running the example sees planning working end-to-end.

## Test plan
- [x] \`pnpm build\` — chat-server builds; \`dawn check\` still discovers the /chat route
- [x] Generated \`.dawn/dawn.generated.d.ts\` now lists \`write_todos\` in \`DawnRouteTools["/chat"]\`
- [ ] Manual smoke with an OPENAI_API_KEY: agent calls \`write_todos\`, smoke client's event log shows \`event: plan_update\` lines

## Follow-up
A richer web UI rendering of \`plan_update\` (sidebar / progress bar) is still deferred — out of scope for this PR. The smoke client's raw event log surfaces the event already.

🤖 Generated with [Claude Code](https://claude.com/claude-code)