### PR TITLE
feat(core,cli): phase 3 — AGENTS.md autoload capability

### DIFF
--- a/.changeset/phase3-agents-md.md
+++ b/.changeset/phase3-agents-md.md
@@ -1,0 +1,6 @@
+---
+"@dawn-ai/core": minor
+"@dawn-ai/cli": minor
+---
+
+Add the `agents-md` built-in capability: Dawn now auto-injects `<workspace>/AGENTS.md` into every agent's system prompt under a `# Memory` heading on every model turn. Always-on (no opt-in marker). Preserves the feedback loop — the agent updates its memory via `writeFile` and the next turn sees the change automatically. Re-reads the file each turn (64 KiB cap; oversize, empty, or unreadable files render empty or a one-line notice).

--- a/docs/superpowers/plans/2026-05-15-phase3-agents-md-autoload.md
+++ b/docs/superpowers/plans/2026-05-15-phase3-agents-md-autoload.md
@@ -1,0 +1,503 @@
+# Phase 3 — AGENTS.md Autoload Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task.
+
+**Goal:** Add a built-in capability that auto-injects `<workspace>/AGENTS.md` into the agent's system prompt on every model turn, preserving the agent-updates-its-own-memory loop.
+
+**Architecture:** New `createAgentsMdMarker()` in `@dawn-ai/core` returns a contribution with one promptFragment (no tools, no state, no transformers). `prepareRouteExecution` registers it alongside the existing planning marker. Render re-reads the file each turn via `readFileSync`, wrapped in try/catch for stat races.
+
+**Tech Stack:** TypeScript 6.0.2, pnpm/turbo, vitest, `@dawn-ai/{core,langchain,cli}`.
+
+**Spec:** [docs/superpowers/specs/2026-05-15-phase3-agents-md-autoload-design.md](../specs/2026-05-15-phase3-agents-md-autoload-design.md)
+
+**Working directory:** `/Users/blove/repos/dawn/.claude/worktrees/agents-md` (branch `claude/agents-md`).
+
+---
+
+## File map
+
+**Create:**
+- `packages/core/src/capabilities/built-in/agents-md.ts`
+- `packages/core/test/capabilities/agents-md.test.ts`
+- `packages/langchain/test/agents-md.test.ts`
+- `.changeset/phase3-agents-md.md`
+
+**Modify:**
+- `packages/core/src/index.ts` — re-export `createAgentsMdMarker`
+- `packages/cli/src/lib/runtime/execute-route.ts` — add `createAgentsMdMarker()` to the registry array
+- `examples/chat/server/src/app/chat/system-prompt.ts` — remove the "if AGENTS.md exists, run readFile" instruction
+- `examples/chat/README.md` — note AGENTS.md autoload is shipped (move out of deferred)
+
+---
+
+## Task 1: Marker implementation + tests
+
+**Files:**
+- Create: `packages/core/src/capabilities/built-in/agents-md.ts`
+- Create: `packages/core/test/capabilities/agents-md.test.ts`
+- Modify: `packages/core/src/index.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `packages/core/test/capabilities/agents-md.test.ts`:
+
+```ts
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import { createAgentsMdMarker } from "../../src/capabilities/built-in/agents-md.js"
+
+describe("createAgentsMdMarker", () => {
+  let routeDir: string
+  let workDir: string
+  let originalCwd: string
+
+  beforeEach(() => {
+    workDir = mkdtempSync(join(tmpdir(), "dawn-agents-md-"))
+    routeDir = join(workDir, "route")
+    mkdirSync(routeDir, { recursive: true })
+    originalCwd = process.cwd()
+    process.chdir(workDir)
+  })
+
+  afterEach(() => {
+    process.chdir(originalCwd)
+    rmSync(workDir, { recursive: true, force: true })
+  })
+
+  it("always detects (returns true)", async () => {
+    const marker = createAgentsMdMarker()
+    expect(await marker.detect(routeDir)).toBe(true)
+  })
+
+  it("load returns a single promptFragment, no tools/state/transformers", async () => {
+    const marker = createAgentsMdMarker()
+    const contribution = await marker.load(routeDir)
+    expect(contribution.promptFragment?.placement).toBe("after_user_prompt")
+    expect(contribution.tools).toBeUndefined()
+    expect(contribution.stateFields).toBeUndefined()
+    expect(contribution.streamTransformers).toBeUndefined()
+  })
+
+  it("renders empty string when workspace/AGENTS.md does not exist", async () => {
+    const marker = createAgentsMdMarker()
+    const contribution = await marker.load(routeDir)
+    expect(contribution.promptFragment?.render({})).toBe("")
+  })
+
+  it("renders content under '# Memory' heading when file exists", async () => {
+    mkdirSync(join(workDir, "workspace"), { recursive: true })
+    writeFileSync(join(workDir, "workspace", "AGENTS.md"), "Remember the pnpm convention.")
+    const marker = createAgentsMdMarker()
+    const contribution = await marker.load(routeDir)
+    const out = contribution.promptFragment?.render({}) ?? ""
+    expect(out).toContain("# Memory")
+    expect(out).toContain("Remember the pnpm convention.")
+  })
+
+  it("returns empty string when file is whitespace-only", async () => {
+    mkdirSync(join(workDir, "workspace"), { recursive: true })
+    writeFileSync(join(workDir, "workspace", "AGENTS.md"), "   \n\n  \n")
+    const marker = createAgentsMdMarker()
+    const contribution = await marker.load(routeDir)
+    expect(contribution.promptFragment?.render({})).toBe("")
+  })
+
+  it("returns size-notice (not body) when file exceeds 64 KiB", async () => {
+    mkdirSync(join(workDir, "workspace"), { recursive: true })
+    const big = "x".repeat(65 * 1024)
+    writeFileSync(join(workDir, "workspace", "AGENTS.md"), big)
+    const marker = createAgentsMdMarker()
+    const contribution = await marker.load(routeDir)
+    const out = contribution.promptFragment?.render({}) ?? ""
+    expect(out).toContain("# Memory")
+    expect(out).toContain("exceeds 64 KiB")
+    expect(out).not.toContain("xxxxxxxxxxx") // body NOT included
+  })
+
+  it("returns empty string when AGENTS.md is a directory (read throws)", async () => {
+    mkdirSync(join(workDir, "workspace", "AGENTS.md"), { recursive: true })
+    const marker = createAgentsMdMarker()
+    const contribution = await marker.load(routeDir)
+    expect(contribution.promptFragment?.render({})).toBe("")
+  })
+
+  it("re-reads the file on each render call", async () => {
+    mkdirSync(join(workDir, "workspace"), { recursive: true })
+    const path = join(workDir, "workspace", "AGENTS.md")
+    writeFileSync(path, "first")
+    const marker = createAgentsMdMarker()
+    const contribution = await marker.load(routeDir)
+    const first = contribution.promptFragment?.render({}) ?? ""
+    expect(first).toContain("first")
+    writeFileSync(path, "second")
+    const second = contribution.promptFragment?.render({}) ?? ""
+    expect(second).toContain("second")
+    expect(second).not.toContain("first")
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+pnpm --filter @dawn-ai/core test -- agents-md.test
+```
+Expected: FAIL — `Cannot find module '../../src/capabilities/built-in/agents-md.js'`.
+
+- [ ] **Step 3: Implement the marker**
+
+Create `packages/core/src/capabilities/built-in/agents-md.ts`:
+
+```ts
+import { existsSync, readFileSync, statSync } from "node:fs"
+import { resolve } from "node:path"
+import type { CapabilityMarker } from "../types.js"
+
+const MAX_MEMORY_BYTES = 64 * 1024
+const MEMORY_HEADER = "# Memory"
+
+/**
+ * Auto-injects the contents of <process.cwd()>/workspace/AGENTS.md into the
+ * agent's system prompt under a "# Memory" heading. Always-on: the presence
+ * of the file IS the opt-in. Re-reads the file on every model turn so the
+ * agent sees its own updated memory immediately after it calls writeFile.
+ */
+export function createAgentsMdMarker(): CapabilityMarker {
+  return {
+    name: "agents-md",
+    detect: async () => true,
+    load: async () => ({
+      promptFragment: {
+        placement: "after_user_prompt",
+        render: () => renderMemoryFragment(workspaceAgentsMdPath()),
+      },
+    }),
+  }
+}
+
+function workspaceAgentsMdPath(): string {
+  return resolve(process.cwd(), "workspace", "AGENTS.md")
+}
+
+function renderMemoryFragment(path: string): string {
+  if (!existsSync(path)) return ""
+
+  let size: number
+  try {
+    size = statSync(path).size
+  } catch {
+    return ""
+  }
+
+  if (size > MAX_MEMORY_BYTES) {
+    return `${MEMORY_HEADER}\n\n(workspace/AGENTS.md is ${size} bytes; exceeds ${MAX_MEMORY_BYTES} byte (64 KiB) limit — not loaded)`
+  }
+
+  let raw: string
+  try {
+    raw = readFileSync(path, "utf8")
+  } catch {
+    return ""
+  }
+
+  const trimmed = raw.trim()
+  if (trimmed.length === 0) return ""
+
+  return `${MEMORY_HEADER}\n\n${trimmed}`
+}
+```
+
+- [ ] **Step 4: Re-export from core**
+
+Edit `packages/core/src/index.ts`. Append:
+
+```ts
+export { createAgentsMdMarker } from "./capabilities/built-in/agents-md.js"
+```
+
+- [ ] **Step 5: Run tests**
+
+```bash
+pnpm --filter @dawn-ai/core test -- agents-md.test
+```
+Expected: 8/8 pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/core/src/capabilities/built-in/agents-md.ts \
+        packages/core/test/capabilities/agents-md.test.ts \
+        packages/core/src/index.ts
+git commit -m "feat(core): agents-md CapabilityMarker (autoload workspace/AGENTS.md into system prompt)"
+```
+
+---
+
+## Task 2: Register the marker in the runtime
+
+**Files:**
+- Modify: `packages/cli/src/lib/runtime/execute-route.ts`
+
+- [ ] **Step 1: Locate the registry creation**
+
+```bash
+grep -n "createCapabilityRegistry\|createPlanningMarker" packages/cli/src/lib/runtime/execute-route.ts
+```
+
+You'll find a line like:
+```ts
+const registry = createCapabilityRegistry([createPlanningMarker()])
+```
+
+- [ ] **Step 2: Add the new marker**
+
+Update the imports at the top to include `createAgentsMdMarker`:
+
+```ts
+import {
+  applyCapabilities,
+  createAgentsMdMarker,
+  createCapabilityRegistry,
+  createPlanningMarker,
+  // ... existing imports
+} from "@dawn-ai/core"
+```
+
+Change the registry construction to:
+
+```ts
+const registry = createCapabilityRegistry([
+  createPlanningMarker(),
+  createAgentsMdMarker(),
+])
+```
+
+- [ ] **Step 3: Typecheck**
+
+```bash
+pnpm --filter @dawn-ai/cli typecheck
+```
+Expected: passes.
+
+- [ ] **Step 4: Run cli tests to confirm no regression**
+
+```bash
+pnpm --filter @dawn-ai/cli test
+```
+Expected: existing test count unchanged, all passing.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/cli/src/lib/runtime/execute-route.ts
+git commit -m "feat(cli): register agents-md capability marker"
+```
+
+---
+
+## Task 3: End-to-end shape test in langchain
+
+**Files:**
+- Create: `packages/langchain/test/agents-md.test.ts`
+
+- [ ] **Step 1: Write the test**
+
+Create `packages/langchain/test/agents-md.test.ts`:
+
+```ts
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import {
+  applyCapabilities,
+  createAgentsMdMarker,
+  createCapabilityRegistry,
+} from "@dawn-ai/core"
+
+describe("agents-md capability — end-to-end shape", () => {
+  let routeDir: string
+  let workDir: string
+  let originalCwd: string
+
+  beforeEach(() => {
+    workDir = mkdtempSync(join(tmpdir(), "dawn-agents-md-e2e-"))
+    routeDir = join(workDir, "route")
+    mkdirSync(routeDir, { recursive: true })
+    originalCwd = process.cwd()
+    process.chdir(workDir)
+  })
+
+  afterEach(() => {
+    process.chdir(originalCwd)
+    rmSync(workDir, { recursive: true, force: true })
+  })
+
+  it("always contributes a promptFragment", async () => {
+    const registry = createCapabilityRegistry([createAgentsMdMarker()])
+    const result = await applyCapabilities(registry, routeDir)
+    expect(result.contributions).toHaveLength(1)
+    expect(result.contributions[0]?.contribution.promptFragment?.placement).toBe(
+      "after_user_prompt",
+    )
+  })
+
+  it("renders memory content when workspace/AGENTS.md exists", async () => {
+    mkdirSync(join(workDir, "workspace"), { recursive: true })
+    writeFileSync(join(workDir, "workspace", "AGENTS.md"), "Use pnpm, not npm.")
+    const registry = createCapabilityRegistry([createAgentsMdMarker()])
+    const result = await applyCapabilities(registry, routeDir)
+    const fragment = result.contributions[0]?.contribution.promptFragment
+    const rendered = fragment?.render({}) ?? ""
+    expect(rendered).toContain("# Memory")
+    expect(rendered).toContain("Use pnpm, not npm.")
+  })
+
+  it("renders empty when workspace/AGENTS.md is absent", async () => {
+    const registry = createCapabilityRegistry([createAgentsMdMarker()])
+    const result = await applyCapabilities(registry, routeDir)
+    const fragment = result.contributions[0]?.contribution.promptFragment
+    expect(fragment?.render({})).toBe("")
+  })
+
+  it("renders updated content after the file is rewritten", async () => {
+    mkdirSync(join(workDir, "workspace"), { recursive: true })
+    const path = join(workDir, "workspace", "AGENTS.md")
+    writeFileSync(path, "before")
+    const registry = createCapabilityRegistry([createAgentsMdMarker()])
+    const result = await applyCapabilities(registry, routeDir)
+    const fragment = result.contributions[0]?.contribution.promptFragment
+    expect(fragment?.render({})).toContain("before")
+    writeFileSync(path, "after")
+    expect(fragment?.render({})).toContain("after")
+    expect(fragment?.render({})).not.toContain("before")
+  })
+})
+```
+
+- [ ] **Step 2: Run the test**
+
+```bash
+pnpm --filter @dawn-ai/langchain test -- agents-md.test
+```
+Expected: 4/4 pass.
+
+- [ ] **Step 3: Confirm full langchain suite**
+
+```bash
+pnpm --filter @dawn-ai/langchain test
+```
+Expected: 38 + 4 = 42 tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/langchain/test/agents-md.test.ts
+git commit -m "test(langchain): agents-md capability end-to-end shape"
+```
+
+---
+
+## Task 4: Update the chat example (system prompt + README)
+
+**Files:**
+- Modify: `examples/chat/server/src/app/chat/system-prompt.ts`
+- Modify: `examples/chat/README.md`
+
+- [ ] **Step 1: Trim the system prompt**
+
+`examples/chat/server/src/app/chat/system-prompt.ts` currently contains a paragraph telling the agent to manually read AGENTS.md. After this change, Dawn auto-injects it; the line is redundant and slightly contradictory.
+
+Replace the "Memory convention" paragraph with a shorter version that keeps the "update when meaningful work happens" guidance but drops the "read at start" instruction.
+
+Read the file first:
+```bash
+cat examples/chat/server/src/app/chat/system-prompt.ts
+```
+
+Then edit so the Memory convention paragraph reads:
+
+> Memory convention: when you complete meaningful work, update `AGENTS.md` (via `writeFile`) so future-you remembers what mattered. Dawn auto-injects the current contents of `workspace/AGENTS.md` into your system prompt on every turn — you don't need to read it manually.
+
+Keep the rest of the file (the four tools list, the "Keep replies short" paragraph) unchanged.
+
+- [ ] **Step 2: Update README**
+
+`examples/chat/README.md` — bump AGENTS.md autoload out of the "Deferred" section. The current "Deferred" list mentions:
+> - `AGENTS.md` auto-injection — needs the skills convention
+
+Remove that line (the dependency was wrong; AGENTS.md autoload turned out to be smaller than skills and shipped on its own).
+
+In "What this shows," add a bullet for memory autoload alongside the existing bullets. Suggested wording:
+
+> - `AGENTS.md` memory autoload — Dawn auto-injects `workspace/AGENTS.md` into the system prompt on every turn; the agent updates it via `writeFile`
+
+- [ ] **Step 3: Typecheck the example server**
+
+```bash
+pnpm --filter @dawn-example/chat-server typecheck
+```
+Expected: passes.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add examples/chat/server/src/app/chat/system-prompt.ts examples/chat/README.md
+git commit -m "feat(examples/chat): rely on Dawn AGENTS.md autoload instead of manual readFile"
+```
+
+---
+
+## Task 5: Full workspace verification (controller-side)
+
+The controller runs this; not a subagent task. After tasks 1-4 are merged into the branch:
+
+- [ ] `pnpm install` — clean
+- [ ] `pnpm build` — all packages build
+- [ ] `pnpm typecheck` — all packages
+- [ ] `pnpm test` — full suite passes (added: 8 core + 4 langchain = 12 new tests)
+- [ ] `pnpm lint` — clean (run `biome check --write` on new test files if imports need sorting; recommit as a `style:` commit if so)
+- [ ] `pnpm pack:check` — passes
+
+If lint fails on new files, run biome's auto-fix for each affected package and commit:
+```bash
+pnpm --filter @dawn-ai/core exec biome check --write --config-path ../config-biome/biome.json package.json src test tsconfig.json vitest.config.ts
+pnpm --filter @dawn-ai/langchain exec biome check --write --config-path ../config-biome/biome.json package.json src test tsconfig.json vitest.config.ts
+```
+
+---
+
+## Task 6: Changeset
+
+**Files:**
+- Create: `.changeset/phase3-agents-md.md`
+
+- [ ] **Step 1: Create the changeset**
+
+```markdown
+---
+"@dawn-ai/core": minor
+"@dawn-ai/cli": minor
+---
+
+Add the `agents-md` built-in capability: Dawn now auto-injects `<workspace>/AGENTS.md` into every agent's system prompt under a `# Memory` heading on every model turn. Always-on (no opt-in marker). Preserves the feedback loop — the agent updates its memory via `writeFile` and the next turn sees the change automatically. Re-reads the file each turn (64 KiB cap; oversize, empty, or unreadable files render empty or a one-line notice).
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add .changeset/phase3-agents-md.md
+git commit -m "chore: changeset for phase-3 agents-md autoload"
+```
+
+---
+
+## Task 7: Push + PR (controller-side)
+
+- [ ] Push: `git push -u origin claude/agents-md`
+- [ ] Open PR via `gh pr create` with summary + spec/plan links + test plan + follow-up note (a separate PR will demonstrate the feature in the chat example smoke test).
+- [ ] Enable auto-merge: `gh pr merge <N> --squash --delete-branch --auto`
+- [ ] Wait for CI; if green, the PR auto-merges (review gate is off as of session 2026-05-15).
+- [ ] After merge: clean up worktree.

--- a/docs/superpowers/specs/2026-05-15-phase3-agents-md-autoload-design.md
+++ b/docs/superpowers/specs/2026-05-15-phase3-agents-md-autoload-design.md
@@ -1,0 +1,211 @@
+# Phase 3 — AGENTS.md Autoload (Sub-project 2a) — Design
+
+**Date:** 2026-05-15
+**Status:** Draft — approved verbally; spec authoritative
+**Owner:** Brian Love
+
+## Summary
+
+Add a built-in capability that auto-injects the contents of `<workspace>/AGENTS.md` into a Dawn agent's system prompt on every model turn. Always-on (no opt-in marker file): the presence of the data file IS the opt-in. Preserves the agent-updates-its-own-memory feedback loop — the agent calls `writeFile({ path: "AGENTS.md", content: ... })` via the existing filesystem tool and the next turn sees the updated memory in its prompt automatically.
+
+This is sub-project 2a of the phase-3 program. It exercises the autowiring engine shipped in #144 with the smallest possible additional capability — one promptFragment, no tool injection, no state-channel injection. Sub-project 2b (skills/ directory) is a separate later cycle.
+
+## Motivation
+
+The canonical chat example (`examples/chat`) currently teaches the agent the memory convention manually via the system prompt: "at the start of every task, run listDir; if AGENTS.md exists, readFile it." The agent burns two tool calls per task to load context that's the same every time. Auto-injection eliminates those calls and shifts memory access from a learned behavior to a framework guarantee.
+
+It also closes a row from the chat example's README "Deferred (phase-3 preview)" list — making the example honest about what Dawn ships today vs. what it doesn't.
+
+## Non-goals
+
+- **Sub-project 2b (skills/ + SKILL.md loader).** Distinct capability — agent-callable on-demand knowledge. Its own cycle.
+- **Route-dir AGENTS.md as static author instructions.** Different feature (not memory, since the agent can't update source-controlled files at runtime). Could fold into 2b or get a micro-sub-project later. Not this PR.
+- **Per-route workspace path configuration.** v1 hard-codes `<process.cwd()>/workspace` to match what the chat example does. Plumbing through `dawn.config.ts` is a follow-up when a concrete consumer needs it.
+- **Smart memory truncation.** Files over 64 KiB get a single line saying so; no semantic summarization, no head/tail keep.
+- **Per-thread memory files.** All threads in a workspace share `AGENTS.md`. Per-thread isolation would require state-channel coordination; deferred.
+- **A `memory_update` SSE event** when the agent writes AGENTS.md. Symmetric with `plan_update` and worth adding once a UI consumer exists; deferred.
+- **Backwards-compat shims.** Behavior is additive. Routes whose workspace has no AGENTS.md are byte-for-byte identical to today.
+
+## User-facing surface
+
+### Author surface
+
+None. The capability is always-on and requires no configuration. If `<workspace>/AGENTS.md` exists at the moment the agent renders its system prompt, its content is injected; otherwise nothing happens.
+
+The chat example demonstrates the convention with a seed `workspace/AGENTS.md` already present (committed via `examples/chat/.gitignore`'s `!workspace/AGENTS.md` exception).
+
+### What the agent sees
+
+On every model turn, the effective system prompt becomes:
+
+```
+<user systemPrompt>
+
+# Planning      (if plan.md present in route dir)
+...
+Current plan: ...
+
+# Memory        (if workspace/AGENTS.md present and non-empty)
+<file content, verbatim>
+```
+
+The `# Memory` heading is Dawn-locked. The content is the raw file contents — Dawn doesn't reformat, summarize, or annotate.
+
+### Feedback loop
+
+The agent already has the `writeFile` workspace tool from the chat example. When it calls `writeFile({ path: "AGENTS.md", content: "<updated>" })`:
+
+1. The file is rewritten (path-jailed to the workspace).
+2. On the next model turn, the prompt fragment re-reads `workspace/AGENTS.md` and injects the new content.
+3. The agent sees its own updated memory in context the very next turn — no need to issue another `readFile`.
+
+This is the property that distinguishes "memory" from "static instructions" and the reason workspace AGENTS.md is the right location.
+
+## Internal architecture
+
+### Where it lives
+
+| Concern | Location |
+|---|---|
+| `createAgentsMdMarker()` factory + promptFragment | `packages/core/src/capabilities/built-in/agents-md.ts` |
+| Unit tests | `packages/core/test/capabilities/agents-md.test.ts` |
+| End-to-end shape test | `packages/langchain/test/agents-md.test.ts` |
+| Public re-export | `packages/core/src/index.ts` (append) |
+| Registry registration | `packages/cli/src/lib/runtime/execute-route.ts` (add to the existing `createCapabilityRegistry([...])` array) |
+
+### Marker shape
+
+```ts
+export function createAgentsMdMarker(): CapabilityMarker {
+  return {
+    name: "agents-md",
+    detect: async () => true,       // always-on
+    load: async () => ({
+      promptFragment: {
+        placement: "after_user_prompt",
+        render: () => renderMemoryFragment(workspaceAgentsMdPath()),
+      },
+    }),
+  }
+}
+```
+
+The marker returns no tools, no state fields, no stream transformers — just one promptFragment.
+
+### `renderMemoryFragment` semantics
+
+```
+1. Resolve path to <process.cwd()>/workspace/AGENTS.md.
+2. existsSync(path) — if false, return "".
+3. statSync(path).size > 64 KiB — return:
+     "# Memory\n\n(workspace/AGENTS.md is {bytes} bytes; exceeds 64 KiB limit — not loaded)"
+4. readFileSync(path, "utf8") — wrapped in try/catch.
+   - Any error → return "" (don't crash the agent for a stat race or permission glitch).
+5. Trim whitespace. Empty string → return "".
+6. Otherwise return:
+     `# Memory\n\n${trimmed}`
+```
+
+The function is sync, takes no `state` argument (memory is file-backed, not state-backed), but its signature must accept `state` to satisfy the `PromptFragment` interface. The argument is unused.
+
+### Workspace root resolution
+
+For v1, the workspace root is `<process.cwd()>/workspace`. This matches what the chat example's tools already use via `workspaceRoot()`. Encapsulate the resolution in a private helper:
+
+```ts
+function workspaceAgentsMdPath(): string {
+  return resolve(process.cwd(), "workspace", "AGENTS.md")
+}
+```
+
+Document that the helper assumes the Dawn dev server's `cwd` is the route's package root (true today via `dawn dev`). Per-route configuration is a deferred follow-up.
+
+### Wiring into the engine
+
+`packages/cli/src/lib/runtime/execute-route.ts` currently does:
+
+```ts
+const registry = createCapabilityRegistry([createPlanningMarker()])
+```
+
+Changes to:
+
+```ts
+const registry = createCapabilityRegistry([
+  createPlanningMarker(),
+  createAgentsMdMarker(),
+])
+```
+
+That's the entire integration surface in the runtime. The existing prompt-fragment composition, contribution merging, and conflict detection logic from #144 already handle multiple markers and multiple fragments.
+
+### Prompt fragment ordering
+
+Multiple promptFragments on a single agent are rendered in **marker registration order**. With both markers registered, the order is `planning` then `agents-md`. This means the system prompt becomes:
+
+```
+<user systemPrompt>
+
+# Planning
+...
+
+# Memory
+...
+```
+
+Document this in the spec as the rule: registration order = render order. Later capabilities should not assume a particular order; if a capability needs a specific position relative to others, that needs explicit work (e.g., a `priority` field on the promptFragment).
+
+### Conflict detection
+
+Not applicable. The marker contributes no tools and no state fields, so the existing fail-fast collision checks have nothing to fire on. (The user is free to have a `tools/AGENTS.md` directory or whatever — no name clash.)
+
+## Edge cases & rules
+
+- **`workspace/` doesn't exist** (e.g., a fresh checkout that hasn't run anything yet) → no AGENTS.md → empty render. No directory creation. Don't preemptively `mkdir`.
+- **`AGENTS.md` exists but is empty / whitespace-only** → empty render. No `# Memory` heading.
+- **`AGENTS.md` exists but is 65 KiB** → render the size notice (single line, no content). Don't truncate to 64 KiB and inject the truncated body — silent truncation is worse than explicit refusal.
+- **`AGENTS.md` exists but isn't UTF-8** → `readFileSync(path, "utf8")` may produce mojibake. Don't try to detect encoding; let UTF-8 happen. If the read throws (extremely rare), the catch swallows it and returns empty.
+- **`AGENTS.md` is a symlink to outside `workspace/`** → not validated. The user owns their workspace. (The path-jail helper in the chat example covers writes; reads via this capability are read-only and the file is whatever the user committed.)
+- **`AGENTS.md` is a directory** → `statSync` returns a stat, `readFileSync` throws → caught → empty render. No crash.
+- **Race: file deleted between `existsSync` and `readFileSync`** → catch handles it → empty render.
+
+## Documentation deliverables in this PR
+
+- `examples/chat/server/src/app/chat/system-prompt.ts` — remove the "if AGENTS.md exists, run readFile" line; keep "update AGENTS.md when meaningful work happens." Cleaner: the system prompt no longer instructs the agent on something Dawn now does automatically.
+- `examples/chat/README.md` — note AGENTS.md autoload is shipped; remove the "AGENTS.md auto-injection — needs the skills convention" line from the Deferred section.
+
+Both tweaks land in this PR (small diffs, conceptually atomic with the capability).
+
+## Tests
+
+| Test | File |
+|---|---|
+| `createAgentsMdMarker` always detects (returns true) | `packages/core/test/capabilities/agents-md.test.ts` |
+| `load` returns a promptFragment with `placement: "after_user_prompt"` | same |
+| `load` returns no tools, no stateFields, no streamTransformers | same |
+| Render returns empty string when `<cwd>/workspace/AGENTS.md` doesn't exist | same |
+| Render returns content under `# Memory` heading when file exists with content | same |
+| Render returns empty string when file exists but is whitespace-only | same |
+| Render returns size-notice (with byte count) when file exceeds 64 KiB | same |
+| Render returns empty string when read throws (file is a directory; or doesn't exist between exists+read) | same |
+| Render re-reads on each call — modify file between two `render()` calls, observe new content | same |
+| End-to-end shape: `applyCapabilities` returns the agents-md contribution with the expected promptFragment | `packages/langchain/test/agents-md.test.ts` |
+
+Tests temporarily `chdir` into a temp directory so `process.cwd()` resolves to a controlled location. Restore cwd in `afterEach`. (Use `process.chdir(originalCwd)` in cleanup.)
+
+No new LLM-touching tests.
+
+## Success criteria
+
+- A new `agents-md` `CapabilityMarker` exists in `@dawn-ai/core`, registered alongside `planning` in `prepareRouteExecution`.
+- With a `workspace/AGENTS.md` file present, the agent's system prompt includes a `# Memory` block containing the file's content, re-rendered on every model turn.
+- Without a `workspace/AGENTS.md` file, the system prompt is unchanged from today's behavior (the fragment renders empty and gets filtered at compose time).
+- Manual smoke: edit `workspace/AGENTS.md` between two requests, the agent's behavior in the second request reflects the updated memory without an explicit `readFile` call.
+- Manual smoke: agent calls `writeFile({ path: "AGENTS.md", content: ... })`, the next turn's system prompt shows the updated content.
+- The chat example's system prompt no longer asks the agent to manually read AGENTS.md at task start.
+- `pnpm install`, `pnpm build`, `pnpm typecheck`, `pnpm test`, `pnpm lint`, `pnpm pack:check` all pass.
+
+## Open questions
+
+- **Should there be a "memory loaded" telemetry / log line?** Not in v1. Add only when there's a concrete debugging need.
+- **What if the user wants to disable autoload for a specific route?** Today, AGENTS.md is opt-in by presence (no file = no autoload). If a route's workspace has AGENTS.md for human reference but the user doesn't want it in the agent's prompt, the workaround is "don't have AGENTS.md in `workspace/`." A future `agents-md.disabled` marker file could opt-out, but no concrete user is asking for it.

--- a/examples/chat/README.md
+++ b/examples/chat/README.md
@@ -8,7 +8,7 @@
 
 - Dawn route discovery and the `tools/` convention
 - Filesystem tools (read/write/list) + bash, path-jailed to `./workspace`
-- `AGENTS.md` memory convention (manual)
+- `AGENTS.md` memory autoload — Dawn auto-injects `workspace/AGENTS.md` into the system prompt on every turn; the agent updates it via `writeFile`
 - **Planning** — `plan.md` in the route directory opts the agent into the built-in
   `write_todos` tool, a `todos` state channel, and a `plan_update` SSE event. Open the
   smoke client's event log; you'll see `event: plan_update` lines whenever the agent
@@ -54,7 +54,6 @@ shell expansion — all possible. Do not point untrusted users at this example.
 These v1 deferrals are the explicit forcing function for Dawn's opinionated harness work:
 
 - Subagent delegation (`task`-style tool) — needs first-class subagent declarations
-- `AGENTS.md` auto-injection — needs the skills convention
 - Skills (`skills/` dir + `SKILL.md` loader) — mirror of the `tools/` convention
 - Real sandbox isolation for `runBash` — needs pluggable execution backends
 - Tool-output offloading and context summarization — needs lifecycle hooks

--- a/examples/chat/server/src/app/chat/system-prompt.ts
+++ b/examples/chat/server/src/app/chat/system-prompt.ts
@@ -7,6 +7,6 @@ You operate in a sandboxed \`workspace/\` directory. You have four tools:
 - \`writeFile({ path, content })\` — create or overwrite a text file.
 - \`runBash({ command, timeoutSeconds })\` — run a shell command in the workspace. Use \`timeoutSeconds: 30\` unless the task clearly needs longer (max 120).
 
-Memory convention: at the start of every task, run \`listDir({ path: "." })\`. If \`AGENTS.md\` exists, read it with \`readFile({ path: "AGENTS.md" })\` before doing anything else. When you complete meaningful work, update \`AGENTS.md\` so future-you remembers what mattered.
+Memory convention: when you complete meaningful work, update \`AGENTS.md\` (via \`writeFile\`) so future-you remembers what mattered. Dawn auto-injects the current contents of \`workspace/AGENTS.md\` into your system prompt on every turn — you don't need to read it manually.
 
 Keep replies short. Prefer doing over narrating. When you finish a task, summarize what changed in one or two sentences.`

--- a/packages/cli/src/lib/runtime/execute-route.ts
+++ b/packages/cli/src/lib/runtime/execute-route.ts
@@ -256,10 +256,7 @@ async function prepareRouteExecution(options: {
   > = []
 
   if (normalized.kind === "agent") {
-    const registry = createCapabilityRegistry([
-      createPlanningMarker(),
-      createAgentsMdMarker(),
-    ])
+    const registry = createCapabilityRegistry([createPlanningMarker(), createAgentsMdMarker()])
     const applied = await applyCapabilities(registry, routeDir)
 
     if (applied.errors.length > 0) {

--- a/packages/cli/src/lib/runtime/execute-route.ts
+++ b/packages/cli/src/lib/runtime/execute-route.ts
@@ -4,6 +4,7 @@ import { isAbsolute, join, resolve } from "node:path"
 import {
   applyCapabilities,
   type CapabilityContribution,
+  createAgentsMdMarker,
   createCapabilityRegistry,
   createPlanningMarker,
   findDawnApp,
@@ -255,7 +256,10 @@ async function prepareRouteExecution(options: {
   > = []
 
   if (normalized.kind === "agent") {
-    const registry = createCapabilityRegistry([createPlanningMarker()])
+    const registry = createCapabilityRegistry([
+      createPlanningMarker(),
+      createAgentsMdMarker(),
+    ])
     const applied = await applyCapabilities(registry, routeDir)
 
     if (applied.errors.length > 0) {

--- a/packages/core/src/capabilities/built-in/agents-md.ts
+++ b/packages/core/src/capabilities/built-in/agents-md.ts
@@ -1,0 +1,56 @@
+import { existsSync, readFileSync, statSync } from "node:fs"
+import { resolve } from "node:path"
+import type { CapabilityMarker } from "../types.js"
+
+const MAX_MEMORY_BYTES = 64 * 1024
+const MEMORY_HEADER = "# Memory"
+
+/**
+ * Auto-injects the contents of <process.cwd()>/workspace/AGENTS.md into the
+ * agent's system prompt under a "# Memory" heading. Always-on: the presence
+ * of the file IS the opt-in. Re-reads the file on every model turn so the
+ * agent sees its own updated memory immediately after it calls writeFile.
+ */
+export function createAgentsMdMarker(): CapabilityMarker {
+  return {
+    name: "agents-md",
+    detect: async () => true,
+    load: async () => ({
+      promptFragment: {
+        placement: "after_user_prompt",
+        render: () => renderMemoryFragment(workspaceAgentsMdPath()),
+      },
+    }),
+  }
+}
+
+function workspaceAgentsMdPath(): string {
+  return resolve(process.cwd(), "workspace", "AGENTS.md")
+}
+
+function renderMemoryFragment(path: string): string {
+  if (!existsSync(path)) return ""
+
+  let size: number
+  try {
+    size = statSync(path).size
+  } catch {
+    return ""
+  }
+
+  if (size > MAX_MEMORY_BYTES) {
+    return `${MEMORY_HEADER}\n\n(workspace/AGENTS.md is ${size} bytes; exceeds 64 KiB limit — not loaded)`
+  }
+
+  let raw: string
+  try {
+    raw = readFileSync(path, "utf8")
+  } catch {
+    return ""
+  }
+
+  const trimmed = raw.trim()
+  if (trimmed.length === 0) return ""
+
+  return `${MEMORY_HEADER}\n\n${trimmed}`
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,3 +1,4 @@
+export { createAgentsMdMarker } from "./capabilities/built-in/agents-md.js"
 export type { RuntimeTodo } from "./capabilities/built-in/planning.js"
 export { createPlanningMarker } from "./capabilities/built-in/planning.js"
 export type {

--- a/packages/core/test/capabilities/agents-md.test.ts
+++ b/packages/core/test/capabilities/agents-md.test.ts
@@ -1,0 +1,95 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import { createAgentsMdMarker } from "../../src/capabilities/built-in/agents-md.js"
+
+describe("createAgentsMdMarker", () => {
+  let routeDir: string
+  let workDir: string
+  let originalCwd: string
+
+  beforeEach(() => {
+    workDir = mkdtempSync(join(tmpdir(), "dawn-agents-md-"))
+    routeDir = join(workDir, "route")
+    mkdirSync(routeDir, { recursive: true })
+    originalCwd = process.cwd()
+    process.chdir(workDir)
+  })
+
+  afterEach(() => {
+    process.chdir(originalCwd)
+    rmSync(workDir, { recursive: true, force: true })
+  })
+
+  it("always detects (returns true)", async () => {
+    const marker = createAgentsMdMarker()
+    expect(await marker.detect(routeDir)).toBe(true)
+  })
+
+  it("load returns a single promptFragment, no tools/state/transformers", async () => {
+    const marker = createAgentsMdMarker()
+    const contribution = await marker.load(routeDir)
+    expect(contribution.promptFragment?.placement).toBe("after_user_prompt")
+    expect(contribution.tools).toBeUndefined()
+    expect(contribution.stateFields).toBeUndefined()
+    expect(contribution.streamTransformers).toBeUndefined()
+  })
+
+  it("renders empty string when workspace/AGENTS.md does not exist", async () => {
+    const marker = createAgentsMdMarker()
+    const contribution = await marker.load(routeDir)
+    expect(contribution.promptFragment?.render({})).toBe("")
+  })
+
+  it("renders content under '# Memory' heading when file exists", async () => {
+    mkdirSync(join(workDir, "workspace"), { recursive: true })
+    writeFileSync(join(workDir, "workspace", "AGENTS.md"), "Remember the pnpm convention.")
+    const marker = createAgentsMdMarker()
+    const contribution = await marker.load(routeDir)
+    const out = contribution.promptFragment?.render({}) ?? ""
+    expect(out).toContain("# Memory")
+    expect(out).toContain("Remember the pnpm convention.")
+  })
+
+  it("returns empty string when file is whitespace-only", async () => {
+    mkdirSync(join(workDir, "workspace"), { recursive: true })
+    writeFileSync(join(workDir, "workspace", "AGENTS.md"), "   \n\n  \n")
+    const marker = createAgentsMdMarker()
+    const contribution = await marker.load(routeDir)
+    expect(contribution.promptFragment?.render({})).toBe("")
+  })
+
+  it("returns size-notice (not body) when file exceeds 64 KiB", async () => {
+    mkdirSync(join(workDir, "workspace"), { recursive: true })
+    const big = "x".repeat(65 * 1024)
+    writeFileSync(join(workDir, "workspace", "AGENTS.md"), big)
+    const marker = createAgentsMdMarker()
+    const contribution = await marker.load(routeDir)
+    const out = contribution.promptFragment?.render({}) ?? ""
+    expect(out).toContain("# Memory")
+    expect(out).toContain("exceeds 64 KiB")
+    expect(out).not.toContain("xxxxxxxxxxx") // body NOT included
+  })
+
+  it("returns empty string when AGENTS.md is a directory (read throws)", async () => {
+    mkdirSync(join(workDir, "workspace", "AGENTS.md"), { recursive: true })
+    const marker = createAgentsMdMarker()
+    const contribution = await marker.load(routeDir)
+    expect(contribution.promptFragment?.render({})).toBe("")
+  })
+
+  it("re-reads the file on each render call", async () => {
+    mkdirSync(join(workDir, "workspace"), { recursive: true })
+    const path = join(workDir, "workspace", "AGENTS.md")
+    writeFileSync(path, "first")
+    const marker = createAgentsMdMarker()
+    const contribution = await marker.load(routeDir)
+    const first = contribution.promptFragment?.render({}) ?? ""
+    expect(first).toContain("first")
+    writeFileSync(path, "second")
+    const second = contribution.promptFragment?.render({}) ?? ""
+    expect(second).toContain("second")
+    expect(second).not.toContain("first")
+  })
+})

--- a/packages/langchain/test/agents-md.test.ts
+++ b/packages/langchain/test/agents-md.test.ts
@@ -1,12 +1,8 @@
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
+import { applyCapabilities, createAgentsMdMarker, createCapabilityRegistry } from "@dawn-ai/core"
 import { afterEach, beforeEach, describe, expect, it } from "vitest"
-import {
-  applyCapabilities,
-  createAgentsMdMarker,
-  createCapabilityRegistry,
-} from "@dawn-ai/core"
 
 describe("agents-md capability — end-to-end shape", () => {
   let routeDir: string

--- a/packages/langchain/test/agents-md.test.ts
+++ b/packages/langchain/test/agents-md.test.ts
@@ -1,0 +1,68 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import {
+  applyCapabilities,
+  createAgentsMdMarker,
+  createCapabilityRegistry,
+} from "@dawn-ai/core"
+
+describe("agents-md capability — end-to-end shape", () => {
+  let routeDir: string
+  let workDir: string
+  let originalCwd: string
+
+  beforeEach(() => {
+    workDir = mkdtempSync(join(tmpdir(), "dawn-agents-md-e2e-"))
+    routeDir = join(workDir, "route")
+    mkdirSync(routeDir, { recursive: true })
+    originalCwd = process.cwd()
+    process.chdir(workDir)
+  })
+
+  afterEach(() => {
+    process.chdir(originalCwd)
+    rmSync(workDir, { recursive: true, force: true })
+  })
+
+  it("always contributes a promptFragment", async () => {
+    const registry = createCapabilityRegistry([createAgentsMdMarker()])
+    const result = await applyCapabilities(registry, routeDir)
+    expect(result.contributions).toHaveLength(1)
+    expect(result.contributions[0]?.contribution.promptFragment?.placement).toBe(
+      "after_user_prompt",
+    )
+  })
+
+  it("renders memory content when workspace/AGENTS.md exists", async () => {
+    mkdirSync(join(workDir, "workspace"), { recursive: true })
+    writeFileSync(join(workDir, "workspace", "AGENTS.md"), "Use pnpm, not npm.")
+    const registry = createCapabilityRegistry([createAgentsMdMarker()])
+    const result = await applyCapabilities(registry, routeDir)
+    const fragment = result.contributions[0]?.contribution.promptFragment
+    const rendered = fragment?.render({}) ?? ""
+    expect(rendered).toContain("# Memory")
+    expect(rendered).toContain("Use pnpm, not npm.")
+  })
+
+  it("renders empty when workspace/AGENTS.md is absent", async () => {
+    const registry = createCapabilityRegistry([createAgentsMdMarker()])
+    const result = await applyCapabilities(registry, routeDir)
+    const fragment = result.contributions[0]?.contribution.promptFragment
+    expect(fragment?.render({})).toBe("")
+  })
+
+  it("renders updated content after the file is rewritten", async () => {
+    mkdirSync(join(workDir, "workspace"), { recursive: true })
+    const path = join(workDir, "workspace", "AGENTS.md")
+    writeFileSync(path, "before")
+    const registry = createCapabilityRegistry([createAgentsMdMarker()])
+    const result = await applyCapabilities(registry, routeDir)
+    const fragment = result.contributions[0]?.contribution.promptFragment
+    expect(fragment?.render({})).toContain("before")
+    writeFileSync(path, "after")
+    expect(fragment?.render({})).toContain("after")
+    expect(fragment?.render({})).not.toContain("before")
+  })
+})


### PR DESCRIPTION
## Summary
- Second phase-3 sub-project after planning (#144).
- New `agents-md` capability marker in `@dawn-ai/core`. Always-on (no opt-in marker — the data file IS the opt-in).
- Dawn auto-injects `<process.cwd()>/workspace/AGENTS.md` into every agent's system prompt under a `# Memory` heading on every model turn.
- Re-reads the file each turn — the agent updates its memory via the existing `writeFile` tool, and the next turn's prompt reflects the change automatically. That's the feedback loop that distinguishes "memory" from "static instructions."

## Why
The chat example today teaches the agent to manually `readFile({ path: "AGENTS.md" })` at task start — two tool calls per task to load context that's the same every time. Auto-injection eliminates them and shifts memory access from a learned behavior to a framework guarantee.

## Spec & plan
- Spec: `docs/superpowers/specs/2026-05-15-phase3-agents-md-autoload-design.md`
- Plan: `docs/superpowers/plans/2026-05-15-phase3-agents-md-autoload.md`

## What changes
- **`@dawn-ai/core`**: new `capabilities/built-in/agents-md.ts` + tests. `createAgentsMdMarker()` factory exposed from the package root.
- **`@dawn-ai/cli`**: the runtime registry in `execute-route.ts` now includes `createAgentsMdMarker()` alongside `createPlanningMarker()`. Render order = registration order, so the system prompt becomes \`<user systemPrompt>\\n\\n# Planning\\n...\\n\\n# Memory\\n...\`.
- **`examples/chat`**: system prompt no longer instructs the agent to manually read AGENTS.md (Dawn handles it). README updates 'What this shows' and removes the now-outdated 'Deferred' bullet.

## Edge cases handled (per spec)
- No workspace/AGENTS.md → empty render, system prompt unchanged
- Empty / whitespace-only file → empty render
- File > 64 KiB → single-line size notice, body not included
- File is a directory or read throws → empty render (catch swallows; agent doesn't crash)
- File modified mid-thread → next turn sees the new content (re-read on each render call)

## Test plan
- [x] \`pnpm install\` clean
- [x] \`pnpm build\` — 11/11
- [x] \`pnpm typecheck\` — 12/12
- [x] \`pnpm test\` — 361/361 (12 new tests across core + langchain)
- [x] \`pnpm lint\` — clean (biome auto-formatted 2 files)
- [x] \`pnpm pack:check\` — passes

## Follow-up
A separate PR adds an explicit smoke test in the chat example that exercises the AGENTS.md feedback loop end-to-end (write → next turn sees update).

🤖 Generated with [Claude Code](https://claude.com/claude-code)