### PR TITLE
test(examples/chat): capabilities integration test + illustrative AGENTS.md seed

### DIFF
--- a/examples/chat/server/src/app/chat/capabilities.test.ts
+++ b/examples/chat/server/src/app/chat/capabilities.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Verifies that Dawn's capability autowiring engine, when run against this
+ * chat route's directory, produces the expected contributions:
+ *
+ * - planning (because src/app/chat/plan.md is present) → write_todos tool,
+ *   todos state channel, planning prompt fragment, plan_update transformer.
+ * - agents-md (always-on) → memory prompt fragment that reads
+ *   <process.cwd()>/workspace/AGENTS.md on every render.
+ *
+ * These are example-level integration tests that exercise the framework's
+ * autowiring against the actual route's filesystem layout, without spinning
+ * up a real LLM. The framework-side unit tests for each marker live in
+ * @dawn-ai/core; this file just confirms the example wires together.
+ */
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { dirname, join, resolve } from "node:path"
+import { fileURLToPath } from "node:url"
+import {
+  applyCapabilities,
+  createAgentsMdMarker,
+  createCapabilityRegistry,
+  createPlanningMarker,
+} from "@dawn-ai/core"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+
+const ROUTE_DIR = dirname(fileURLToPath(import.meta.url))
+
+describe("chat route — autowired capabilities", () => {
+  let workDir: string
+  let originalCwd: string
+
+  beforeEach(() => {
+    workDir = mkdtempSync(join(tmpdir(), "chat-route-caps-"))
+    originalCwd = process.cwd()
+    process.chdir(workDir)
+  })
+
+  afterEach(() => {
+    process.chdir(originalCwd)
+    rmSync(workDir, { recursive: true, force: true })
+  })
+
+  it("includes both planning and agents-md contributions for the chat route", async () => {
+    const registry = createCapabilityRegistry([
+      createPlanningMarker(),
+      createAgentsMdMarker(),
+    ])
+    const result = await applyCapabilities(registry, ROUTE_DIR)
+
+    expect(result.errors).toEqual([])
+    expect(result.contributions.map((c) => c.markerName)).toEqual([
+      "planning",
+      "agents-md",
+    ])
+  })
+
+  it("planning contribution comes from this route's plan.md", async () => {
+    expect(existsSync(resolve(ROUTE_DIR, "plan.md"))).toBe(true)
+
+    const registry = createCapabilityRegistry([createPlanningMarker()])
+    const result = await applyCapabilities(registry, ROUTE_DIR)
+    const planning = result.contributions[0]?.contribution
+
+    expect(planning?.tools?.map((t) => t.name)).toEqual(["write_todos"])
+    expect(planning?.stateFields?.map((f) => f.name)).toEqual(["todos"])
+    expect(planning?.promptFragment?.placement).toBe("after_user_prompt")
+  })
+
+  it("agents-md fragment renders memory from <cwd>/workspace/AGENTS.md", async () => {
+    mkdirSync(join(workDir, "workspace"), { recursive: true })
+    writeFileSync(
+      join(workDir, "workspace", "AGENTS.md"),
+      "Project convention: tools are camelCase.",
+    )
+
+    const registry = createCapabilityRegistry([createAgentsMdMarker()])
+    const result = await applyCapabilities(registry, ROUTE_DIR)
+    const fragment = result.contributions[0]?.contribution.promptFragment
+    const rendered = fragment?.render({}) ?? ""
+
+    expect(rendered).toContain("# Memory")
+    expect(rendered).toContain("Project convention: tools are camelCase.")
+  })
+
+  it("agents-md fragment is empty when workspace/AGENTS.md is absent", async () => {
+    const registry = createCapabilityRegistry([createAgentsMdMarker()])
+    const result = await applyCapabilities(registry, ROUTE_DIR)
+    const fragment = result.contributions[0]?.contribution.promptFragment
+    expect(fragment?.render({})).toBe("")
+  })
+
+  it("closes the feedback loop: rewriting AGENTS.md changes the next render", async () => {
+    mkdirSync(join(workDir, "workspace"), { recursive: true })
+    const path = join(workDir, "workspace", "AGENTS.md")
+
+    writeFileSync(path, "Iteration 1: tools should be camelCase")
+    const registry = createCapabilityRegistry([createAgentsMdMarker()])
+    const result = await applyCapabilities(registry, ROUTE_DIR)
+    const fragment = result.contributions[0]?.contribution.promptFragment
+
+    const first = fragment?.render({}) ?? ""
+    expect(first).toContain("Iteration 1")
+
+    // Simulate the agent calling writeFile to update its memory.
+    writeFileSync(path, "Iteration 2: never modify generated files in .dawn/")
+    const second = fragment?.render({}) ?? ""
+
+    expect(second).toContain("Iteration 2")
+    expect(second).not.toContain("Iteration 1")
+  })
+
+  it("planning prompt re-renders todos from live state on each call", async () => {
+    const registry = createCapabilityRegistry([createPlanningMarker()])
+    const result = await applyCapabilities(registry, ROUTE_DIR)
+    const fragment = result.contributions[0]?.contribution.promptFragment
+
+    const empty = fragment?.render({ todos: [] }) ?? ""
+    expect(empty).toContain("(empty)")
+
+    const populated =
+      fragment?.render({
+        todos: [
+          { content: "investigate the bug", status: "in_progress" },
+          { content: "write a regression test", status: "pending" },
+        ],
+      }) ?? ""
+
+    expect(populated).toContain("[in_progress] investigate the bug")
+    expect(populated).toContain("[pending] write a regression test")
+  })
+})

--- a/examples/chat/server/workspace/AGENTS.md
+++ b/examples/chat/server/workspace/AGENTS.md
@@ -1,7 +1,18 @@
 # Workspace memory
 
-This file is the persistent memory for this chat session. It survives across turns and threads.
+Dawn auto-injects this file's contents into the agent's system prompt on every
+turn. The agent updates it via `writeFile({ path: "AGENTS.md", content: ... })`
+when it learns something worth remembering across sessions.
 
-When you start a task, read this file first. When you finish meaningful work, append a short note here so the next session knows what you learned or built.
+This file is intentionally pre-seeded with a few illustrative facts so you can
+see the autoload in action on a fresh run. Replace this block with whatever
+matters for your project once the agent starts recording real notes.
 
-(Replace this seed text once you have something worth recording.)
+## Project facts (example seeds)
+
+- Workspace tools use camelCase names: `listDir`, `readFile`, `writeFile`, `runBash`.
+- The workspace root is `examples/chat/server/workspace`. Anything outside it is
+  off-limits — the tool layer path-jails reads and writes.
+- Plans live in the `todos` state channel (managed by `write_todos`), not in
+  this file. Use this file for things that should survive across sessions; use
+  planning for the current task's checklist.


### PR DESCRIPTION
## Summary
Follow-up to #146 (AGENTS.md autoload). Adds a vitest test in the chat route that exercises the autowiring engine end-to-end against the actual route's filesystem layout, and updates the seeded \`workspace/AGENTS.md\` to be illustrative rather than meta-instructional.

## What's in the test
\`examples/chat/server/src/app/chat/capabilities.test.ts\` (6 tests):

- Both \`planning\` and \`agents-md\` markers detect against this route, in registration order.
- \`planning\` contribution is sourced from the committed \`src/app/chat/plan.md\` — verifies the file is still there and parsed.
- \`agents-md\` fragment renders memory content under \`# Memory\` when \`workspace/AGENTS.md\` exists with content.
- \`agents-md\` fragment is empty when \`workspace/AGENTS.md\` is absent.
- **The feedback loop** — rewriting \`workspace/AGENTS.md\` between two \`render()\` calls makes the second render see the new content (proves the on-each-turn re-read claim).
- Planning prompt re-renders \`Current plan:\` from live state on each call (parallel property for the other capability).

Tests \`chdir\` into a temp dir so \`process.cwd()\` resolves to a controlled location for the agents-md marker. Restored in \`afterEach\`.

## What's in the seed update
\`examples/chat/server/workspace/AGENTS.md\` was generic placeholder text. Now seeds three concrete project facts (camelCase tool names, workspace path, plans live in the \`todos\` channel) so a fresh run of the example shows the agent receiving a non-trivial memory block on its first turn — visible in the smoke client's event log.

## Test plan
- [x] \`pnpm install\`
- [x] \`pnpm build\` — 11/11
- [x] \`pnpm typecheck\` — 12/12
- [x] \`pnpm --filter @dawn-example/chat-server test\` — **13/13** (6 new + 7 existing path-jail)
- [x] \`pnpm test\` (workspace) — 361/361 (chat-server tests are not in \`vitest.workspace.ts\` per the existing convention from #140; they run only via \`--filter\`)
- [x] \`pnpm lint\`, \`pnpm pack:check\`

## Note on the workspace test pipeline
The chat example is intentionally excluded from \`vitest.workspace.ts\` (per the spec for #140 — examples are documentation, not infrastructure). This test runs locally via \`pnpm --filter @dawn-example/chat-server test\`. If you want it gated in CI, that's a separate decision and a one-line change to \`vitest.workspace.ts\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)