### PR TITLE
fix(core): planning write_todos schema + agents-md orientation prompt

### DIFF
--- a/.changeset/planning-schema-and-memory-prompt-fix.md
+++ b/.changeset/planning-schema-and-memory-prompt-fix.md
@@ -1,0 +1,8 @@
+---
+"@dawn-ai/core": patch
+---
+
+Two fixes surfaced by live LLM smoke testing the chat example end-to-end:
+
+- **Planning `write_todos` now declares a real zod schema.** Previously the tool's `schema` field was undefined; the LangChain bridge fell back to `z.record(z.string(), z.unknown())`, which produced JSON Schema without `properties`. OpenAI strict-mode tool calling rejected the tool with `400 Invalid schema for function 'write_todos': object schema missing properties`. Now the planning marker exports an explicit zod schema for `{ todos: Array<{ content, status }> }`. Adds `zod` as a runtime dependency of `@dawn-ai/core`.
+- **`# Memory` block now includes orientation text.** The agents-md prompt fragment used to inject `# Memory\n\n<content>` only. With both planning and memory loaded, the model often called `listDir` and `readFile` to look at AGENTS.md even though Dawn had already injected its contents. The fragment now opens with a short paragraph telling the agent the block IS the memory file, re-rendered each turn, and that the way to update it is `writeFile`. Existing unit tests still pass — the `# Memory` heading and content substrings are unchanged.

--- a/examples/chat/server/src/app/chat/plan.md
+++ b/examples/chat/server/src/app/chat/plan.md
@@ -1,3 +1,10 @@
-- [ ] Read AGENTS.md if it exists in the workspace
-- [ ] Survey workspace contents before acting
-- [ ] Break multi-step requests into a written plan via write_todos
+<!--
+The presence of this file opts this route into Dawn's planning capability.
+
+It can be empty (as it is here) or seeded with markdown checklist items —
+the agent will start each thread with those items in its `todos` channel.
+
+For the canonical demo we keep the seed empty so the agent builds its own
+plan based on what the user actually asks, rather than ceremonially
+re-stating a fixed checklist on every request.
+-->

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -38,7 +38,8 @@
   "dependencies": {
     "@dawn-ai/sdk": "workspace:*",
     "tsx": "^4.8.1",
-    "typescript": "5.8.3"
+    "typescript": "5.8.3",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@dawn-ai/config-typescript": "workspace:*",

--- a/packages/core/src/capabilities/built-in/agents-md.ts
+++ b/packages/core/src/capabilities/built-in/agents-md.ts
@@ -3,7 +3,11 @@ import { resolve } from "node:path"
 import type { CapabilityMarker } from "../types.js"
 
 const MAX_MEMORY_BYTES = 64 * 1024
-const MEMORY_HEADER = "# Memory"
+const MEMORY_HEADER = `# Memory
+
+The block below is the live contents of \`workspace/AGENTS.md\`, re-read on every turn. This IS your persistent memory — do NOT re-read this file with any tool; the content here is always current. Update it by calling \`writeFile({ path: "AGENTS.md", content: "..." })\` when you learn something worth remembering.
+
+---`
 
 /**
  * Auto-injects the contents of <process.cwd()>/workspace/AGENTS.md into the

--- a/packages/core/src/capabilities/built-in/planning.ts
+++ b/packages/core/src/capabilities/built-in/planning.ts
@@ -1,5 +1,6 @@
 import { existsSync, readFileSync, statSync } from "node:fs"
 import { join } from "node:path"
+import { z } from "zod"
 import type { CapabilityMarker, PromptFragment, StreamTransformer } from "../types.js"
 import { type PlanTodo, parsePlanMarkdown } from "./plan-md-parser.js"
 
@@ -10,6 +11,16 @@ export interface RuntimeTodo {
   readonly content: string
   readonly status: "pending" | "in_progress" | "completed"
 }
+
+const TODO_STATUS = z.enum(["pending", "in_progress", "completed"])
+const WRITE_TODOS_INPUT = z.object({
+  todos: z.array(
+    z.object({
+      content: z.string().min(1),
+      status: TODO_STATUS,
+    }),
+  ),
+})
 
 const PLANNING_PROMPT_HEADER = `# Planning
 
@@ -28,6 +39,7 @@ export function createPlanningMarker(): CapabilityMarker {
         name: "write_todos",
         description:
           "Replace the agent's plan with the given list of todos. Pass the full list every time; this tool is not incremental.",
+        schema: WRITE_TODOS_INPUT,
         run: (input: unknown) => {
           // The actual state mutation happens in the langchain runtime;
           // this run() just echoes the canonicalized input back so the

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -222,6 +222,9 @@ importers:
       typescript:
         specifier: 5.8.3
         version: 5.8.3
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
     devDependencies:
       '@dawn-ai/config-typescript':
         specifier: workspace:*


### PR DESCRIPTION
## Summary
Two bug fixes surfaced by running the chat example end-to-end with a live OpenAI key after #147 landed.

### 1. \`write_todos\` rejected by OpenAI strict-mode tool calling
**Symptom:**
\`\`\`
event: done
data: {"output":{"error":"400 Invalid schema for function 'write_todos': object schema missing properties."}}
\`\`\`

**Cause:** The planning marker's \`write_todos\` tool didn't declare a \`schema\` field. The LangChain bridge fell back to \`z.record(z.string(), z.unknown())\`, which produces JSON Schema without \`properties\`. OpenAI strict mode rejects.

**Fix:** Planning marker now exports an explicit zod schema for \`{ todos: Array<{ content, status }> }\`. Adds \`zod\` as a runtime dep of \`@dawn-ai/core\` (was already transitively available via \`@dawn-ai/sdk\`'s consumers, but not a direct dep).

### 2. Agent re-reads AGENTS.md instead of using the injected memory
**Symptom:** With memory loaded (\`# Memory\` block injected with content), the agent still calls \`listDir({path: "."})\` and tries to \`readFile({ path: "AGENTS.md" })\` instead of just using the memory to answer the question.

**Cause:** The original prompt fragment was bare:
\`\`\`
# Memory

<file content>
\`\`\`

Without orientation, the model treats the heading as just another section and doesn't connect it to the AGENTS.md file the workspace contains.

**Fix:** The \`# Memory\` heading now includes an orientation paragraph explaining the block IS the live AGENTS.md content (re-rendered each turn) and that \`writeFile\` is how to update it. Existing unit tests still pass — the heading and content substrings are unchanged.

### 3. Drop the prescriptive seed checklist from the chat example's plan.md
**Bonus:** The chat-example \`plan.md\` was seeded with three meta-instructional items:
\`\`\`md
- [ ] Read AGENTS.md if it exists in the workspace
- [ ] Survey workspace contents before acting
- [ ] Break multi-step requests into a written plan via write_todos
\`\`\`

This dominated agent behavior — even for a simple question, the agent would dutifully start executing this fixed checklist. Replaced with an HTML comment that explains the file's role but contributes no todos. The file's presence still opts the route into planning; the agent now builds its own plan based on what the user actually asks.

## Honest limitations from this round of smoke testing
Even with these fixes, gpt-5-mini on simple memory-recall questions tends to call \`listDir\` first rather than answering directly from the injected memory. This is content/prompt-engineering territory and beyond the scope of these targeted fixes. The framework primitives (tool schema validation, memory injection, planning state) all work as designed.

## Test plan
- [x] \`pnpm install\`
- [x] \`pnpm build\` — 11/11
- [x] \`pnpm typecheck\` — 12/12
- [x] \`pnpm test\` — 361/361 (no test count change; existing agents-md/planning tests cover the substrings)
- [x] \`pnpm lint\` — clean
- [x] \`pnpm pack:check\` — passes
- [x] Local smoke against the dev server: agent no longer fails with strict-mode schema error; LLM behavior verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)