### PR TITLE
fix(cli): SSE payload double-wrap + chat-example tool-discipline + planning state-mutation follow-up doc

### DIFF
--- a/.changeset/harness-polish.md
+++ b/.changeset/harness-polish.md
@@ -1,0 +1,5 @@
+---
+"@dawn-ai/cli": patch
+---
+
+Fix SSE event payload double-wrap. `toSseEvent` used to emit `data: {"data": <value>}` for the built-in `chunk` event and for capability-contributed events like `plan_update`, when it should emit `data: <value>` directly. The shaped events (`tool_call`, `tool_result`, `done`) are unchanged.

--- a/docs/superpowers/specs/2026-05-16-planning-state-mutation-followup.md
+++ b/docs/superpowers/specs/2026-05-16-planning-state-mutation-followup.md
@@ -1,0 +1,65 @@
+# Planning capability — state mutation gap (follow-up)
+
+**Date:** 2026-05-16
+**Status:** Diagnosis only — needs its own brainstorm + fix cycle
+**Owner:** Brian Love
+
+## The bug
+
+`write_todos` doesn't actually update the `todos` state channel. The tool runs successfully, its output goes back to the agent as a ToolMessage, and the planning prompt fragment's `Current plan:` block always renders the initial value (empty or `plan.md` seed).
+
+Observed in live smoke testing of the chat example (#148 description). The agent calls `write_todos`, sees no state change reflected in its next-turn prompt, and re-calls `write_todos` with the same content — burning context and sometimes hitting the LangGraph recursion limit.
+
+## Root cause
+
+`packages/core/src/capabilities/built-in/planning.ts`:
+
+```ts
+const writeTodos = {
+  name: "write_todos",
+  // ...
+  run: (input: unknown) => {
+    // The actual state mutation happens in the langchain runtime;
+    // this run() just echoes the canonicalized input back so the
+    // tool result event carries the new todos.
+    const validated = validateWriteTodosInput(input)
+    return { todos: validated }
+  },
+}
+```
+
+The comment promised "langchain handles the mutation" — but it doesn't. The `tool-converter.ts` in `@dawn-ai/langchain` wraps the tool's return value via `JSON.stringify(result)` and emits it as a ToolMessage's content. LangGraph never sees an instruction to update the `todos` channel.
+
+## Why this is bigger than "polish"
+
+A real fix needs a framework concept: tools that mutate state channels. Options:
+
+1. **LangGraph `Command` returns.** A tool can return `new Command({ update: { todos: ... } })`; LangGraph applies the update via the channel's reducer. The tool-converter needs to detect `isCommand(result)` and pass it through without `JSON.stringify`. But `@dawn-ai/core`'s `planning.ts` doesn't import from `@langchain/langgraph` today — adopting `Command` either couples core to langgraph or moves the planning marker into `@dawn-ai/langchain`.
+
+2. **New `stateUpdate` metadata on the tool definition.** Capability tools declare which state field they mutate: `{ name, run, stateUpdate: (input, output) => Partial<State> }`. The langchain adapter intercepts tool results and constructs a Command from the metadata. Keeps core decoupled, but it's net-new API surface.
+
+3. **Reducer that derives state from messages.** The `todos` channel's reducer could scan recent messages for `write_todos` tool results and extract the latest. Conflates message processing with reduction; ugly.
+
+Recommended path: **option 1**, with the planning marker moved into `@dawn-ai/langchain` (which already has `Command` available). The CapabilityMarker interface stays in core; the planning marker registers from langchain.
+
+## Test/repro
+
+Live smoke with an OpenAI key against `examples/chat/server` with the seeded `workspace/AGENTS.md`. Ask the agent to make a plan, observe write_todos called repeatedly. The captured log from #148's smoke is in this session's transcript.
+
+Without a key, you can manually verify in a unit test by:
+1. Building a route with `plan.md`.
+2. Applying the planning marker.
+3. Calling the contributed `write_todos` tool's `run()` directly.
+4. Re-rendering the planning prompt fragment with `{ todos: [] }` as `state` — observe `Current plan: (empty)` even after `write_todos` "ran."
+
+## Scope of the fix PR
+
+- Move planning marker to `@dawn-ai/langchain` (or solve the import-Command-from-core problem).
+- `write_todos.run` returns `new Command({ update: { todos: validated } })`.
+- `tool-converter.ts` detects `isCommand` and passes through without serialization.
+- Test: invoke the route end-to-end (mocked LLM), call write_todos twice with different todos, verify state channel reflects the latest values.
+- Doc: update planning sub-project spec (#144 era) to reflect actual mechanism.
+
+## Out of scope here
+
+This file documents the gap. The fix itself is a separate sub-project — comparable in size to one of the phase-3 sub-projects, since it touches the core marker, the langchain bridge, and the tool-result event shape.

--- a/examples/chat/server/src/app/chat/system-prompt.ts
+++ b/examples/chat/server/src/app/chat/system-prompt.ts
@@ -7,6 +7,11 @@ You operate in a sandboxed \`workspace/\` directory. You have four tools:
 - \`writeFile({ path, content })\` — create or overwrite a text file.
 - \`runBash({ command, timeoutSeconds })\` — run a shell command in the workspace. Use \`timeoutSeconds: 30\` unless the task clearly needs longer (max 120).
 
-Memory convention: when you complete meaningful work, update \`AGENTS.md\` (via \`writeFile\`) so future-you remembers what mattered. Dawn auto-injects the current contents of \`workspace/AGENTS.md\` into your system prompt on every turn — you don't need to read it manually.
+Memory convention: when you complete meaningful work, update \`AGENTS.md\` (via \`writeFile\`) so future-you remembers what mattered. Dawn auto-injects the current contents of \`workspace/AGENTS.md\` into your system prompt on every turn under the "# Memory" heading — you don't need to read or list it manually.
+
+When the user asks a question:
+1. If the answer is already in your memory (the "# Memory" block above) or in the conversation, **answer directly without calling any tools**.
+2. Only reach for tools when the task genuinely requires reading a file, writing a file, or running a command in the workspace.
+3. Don't explore the workspace before answering a question that doesn't require exploration.
 
 Keep replies short. Prefer doing over narrating. When you finish a task, summarize what changed in one or two sentences.`

--- a/packages/cli/src/lib/runtime/stream-types.ts
+++ b/packages/cli/src/lib/runtime/stream-types.ts
@@ -28,9 +28,7 @@ export function toNdjsonLine(chunk: StreamChunk): string {
  * deep. The double-wrap was a real bug observed in live smoke testing.
  */
 export function toSseEvent(chunk: StreamChunk): string {
-  const payload = isDataOnlyChunk(chunk)
-    ? chunk.data
-    : omitType(chunk)
+  const payload = isDataOnlyChunk(chunk) ? chunk.data : omitType(chunk)
   return `event: ${chunk.type}\ndata: ${JSON.stringify(payload)}\n\n`
 }
 

--- a/packages/cli/src/lib/runtime/stream-types.ts
+++ b/packages/cli/src/lib/runtime/stream-types.ts
@@ -12,8 +12,37 @@ export function toNdjsonLine(chunk: StreamChunk): string {
   return JSON.stringify(chunk)
 }
 
+/**
+ * Format a chunk as an SSE event line. The `event:` line is the chunk's
+ * `type`, and `data:` is the JSON-serialized payload.
+ *
+ * The payload shape depends on the chunk:
+ *  - Chunks that carry their payload in a single `data` field (the built-in
+ *    `chunk` event and any capability-contributed event) emit that `data`
+ *    value directly, NOT wrapped in another `{ data: ... }` object.
+ *  - Chunks with named fields (`tool_call`, `tool_result`, `done`) emit the
+ *    remaining named fields as an object.
+ *
+ * Without this distinction, `{ type: "plan_update", data: { todos: [...] } }`
+ * would serialize to `data: { "data": { "todos": [...] } }` — one level too
+ * deep. The double-wrap was a real bug observed in live smoke testing.
+ */
 export function toSseEvent(chunk: StreamChunk): string {
-  return `event: ${chunk.type}\ndata: ${JSON.stringify(omitType(chunk))}\n\n`
+  const payload = isDataOnlyChunk(chunk)
+    ? chunk.data
+    : omitType(chunk)
+  return `event: ${chunk.type}\ndata: ${JSON.stringify(payload)}\n\n`
+}
+
+function isDataOnlyChunk(
+  chunk: StreamChunk,
+): chunk is { readonly type: string; readonly data: unknown } {
+  // The only built-in shape with a `data` field is the `chunk` event; all
+  // capability-contributed types are typed as `{ type: string; data: unknown }`
+  // by construction. Discriminate by checking that `data` is the only non-`type`
+  // own-enumerable key.
+  const keys = Object.keys(chunk).filter((k) => k !== "type")
+  return keys.length === 1 && keys[0] === "data"
 }
 
 function omitType(chunk: StreamChunk): Record<string, unknown> {

--- a/packages/cli/test/stream-types.test.ts
+++ b/packages/cli/test/stream-types.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest"
+import {
+  type StreamChunk,
+  toNdjsonLine,
+  toSseEvent,
+} from "../src/lib/runtime/stream-types.js"
+
+describe("toSseEvent", () => {
+  it("emits a tool_call event with name + input as the payload", () => {
+    const chunk: StreamChunk = {
+      type: "tool_call",
+      name: "listDir",
+      input: { path: "." },
+    }
+    expect(toSseEvent(chunk)).toBe(
+      `event: tool_call\ndata: ${JSON.stringify({ name: "listDir", input: { path: "." } })}\n\n`,
+    )
+  })
+
+  it("emits a tool_result event with name + output as the payload", () => {
+    const chunk: StreamChunk = {
+      type: "tool_result",
+      name: "readFile",
+      output: "hi",
+    }
+    expect(toSseEvent(chunk)).toBe(
+      `event: tool_result\ndata: ${JSON.stringify({ name: "readFile", output: "hi" })}\n\n`,
+    )
+  })
+
+  it("emits a done event with output as the payload", () => {
+    const chunk: StreamChunk = { type: "done", output: { final: true } }
+    expect(toSseEvent(chunk)).toBe(
+      `event: done\ndata: ${JSON.stringify({ output: { final: true } })}\n\n`,
+    )
+  })
+
+  it("emits a chunk event with the chunk data directly (not double-wrapped)", () => {
+    const chunk: StreamChunk = { type: "chunk", data: "hello" }
+    expect(toSseEvent(chunk)).toBe(`event: chunk\ndata: ${JSON.stringify("hello")}\n\n`)
+  })
+
+  it("emits a capability-contributed event with its data directly (not double-wrapped)", () => {
+    const chunk: StreamChunk = {
+      type: "plan_update",
+      data: { todos: [{ content: "x", status: "pending" }] },
+    }
+    expect(toSseEvent(chunk)).toBe(
+      `event: plan_update\ndata: ${JSON.stringify({ todos: [{ content: "x", status: "pending" }] })}\n\n`,
+    )
+  })
+
+  it("emits an object data payload directly when the only non-type field is `data`", () => {
+    const chunk: StreamChunk = { type: "custom_event", data: { a: 1, b: 2 } }
+    expect(toSseEvent(chunk)).toBe(
+      `event: custom_event\ndata: ${JSON.stringify({ a: 1, b: 2 })}\n\n`,
+    )
+  })
+
+  it("handles primitive data values (string, number, boolean, null)", () => {
+    expect(toSseEvent({ type: "chunk", data: 42 })).toBe(`event: chunk\ndata: 42\n\n`)
+    expect(toSseEvent({ type: "chunk", data: true })).toBe(`event: chunk\ndata: true\n\n`)
+    expect(toSseEvent({ type: "chunk", data: null })).toBe(`event: chunk\ndata: null\n\n`)
+  })
+})
+
+describe("toNdjsonLine", () => {
+  it("preserves the full chunk shape including type (unchanged behavior)", () => {
+    const chunk: StreamChunk = {
+      type: "plan_update",
+      data: { todos: [] },
+    }
+    expect(toNdjsonLine(chunk)).toBe(JSON.stringify(chunk))
+  })
+})

--- a/packages/cli/test/stream-types.test.ts
+++ b/packages/cli/test/stream-types.test.ts
@@ -1,9 +1,5 @@
 import { describe, expect, it } from "vitest"
-import {
-  type StreamChunk,
-  toNdjsonLine,
-  toSseEvent,
-} from "../src/lib/runtime/stream-types.js"
+import { type StreamChunk, toNdjsonLine, toSseEvent } from "../src/lib/runtime/stream-types.js"
 
 describe("toSseEvent", () => {
   it("emits a tool_call event with name + input as the payload", () => {


### PR DESCRIPTION
## Summary
Three follow-ups from last night's live-LLM smoke testing of the chat example.

### 1. ✅ Fix: SSE event payload double-wrap (\`@dawn-ai/cli\`)
\`toSseEvent\` emitted \`data: {"data": <value>}\` for the built-in \`chunk\` event and capability-contributed events like \`plan_update\`. \`omitType\` stripped \`type\` and JSON-stringified the rest, so a \`{type, data}\` chunk became \`{data}\` instead of just the bare value.

Fix: when the chunk has only \`type\` + \`data\`, emit \`chunk.data\` directly. Shaped events (\`tool_call\`, \`tool_result\`, \`done\`) keep their existing payload shape. 8 new vitest assertions in \`packages/cli/test/stream-types.test.ts\` cover both paths.

### 2. ✅ Partial fix: chat example agent no longer explores before answering memory questions
Added three numbered instructions to the chat example's system prompt that steer the agent to answer from memory/conversation first and reach for tools only when the task genuinely needs them.

Live smoke verification: a memory-recall question now produces **0 tool calls** (just streamed token chunks). Previous behavior was \`listDir\` + sometimes a recursion loop.

What the prompt tweak **doesn't** fix: gpt-5-mini still gives a generic "what would you like me to do" opener on the first message of a thread rather than answering from memory. That's a hard-coded model behavior bias not fixable from the system prompt alone. Documented as a known limitation.

### 3. 📝 Documented follow-up: planning state-mutation gap
New spec at \`docs/superpowers/specs/2026-05-16-planning-state-mutation-followup.md\`. The planning capability's \`write_todos\` doesn't actually mutate the \`todos\` state channel — the tool returns a string ToolMessage but the channel stays at its initial value. This causes the agent to re-call \`write_todos\` with the same content when it sees no state change reflected.

A real fix needs framework support for state-mutating tools (LangGraph \`Command\` returns or equivalent). Scoped as a separate sub-project; not in this PR.

## Test plan
- [x] \`pnpm install\`
- [x] \`pnpm build\` — 11/11
- [x] \`pnpm typecheck\` — 12/12
- [x] \`pnpm test\` — 369/369 (8 new stream-types tests)
- [x] \`pnpm lint\` — clean
- [x] \`pnpm pack:check\` — passes
- [x] Live smoke against the dev server with \`OPENAI_API_KEY\` — agent no longer makes redundant exploration tool calls; SSE event payloads now have the correct one-level-deep shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)