### PR TITLE
feat(sdk,langchain): reasoning.effort on agent() + chat example uses gpt-5

### DIFF
--- a/.changeset/reasoning-effort.md
+++ b/.changeset/reasoning-effort.md
@@ -1,0 +1,6 @@
+---
+"@dawn-ai/sdk": minor
+"@dawn-ai/langchain": minor
+---
+
+`agent({...})` now accepts an optional `reasoning: { effort }` field. Maps to OpenAI's `reasoningEffort` parameter (`none | minimal | low | medium | high | xhigh`). Non-reasoning models silently ignore it. Useful for tool-use-heavy agents that aren't following directives at the default reasoning depth.

--- a/docs/superpowers/specs/2026-05-16-tool-state-mutation-runtime-bug-followup.md
+++ b/docs/superpowers/specs/2026-05-16-tool-state-mutation-runtime-bug-followup.md
@@ -1,0 +1,47 @@
+# Tool state mutation — Command not applied at runtime (follow-up)
+
+**Date:** 2026-05-16
+**Status:** Diagnosis only — needs investigation + fix
+**Owner:** Brian Love
+
+## The bug
+
+Sub-project 2c (PR #150) added the `{result, state}` wrapped-return API for capability tools. The langchain bridge correctly constructs a LangGraph `Command({update: {...stateUpdates, messages: [ToolMessage]}})` when a tool returns the wrapper. Unit + integration tests verified the Command's `update.todos` contains the expected value.
+
+But at runtime, end-to-end against a real LLM with `gpt-5`, the agent calls `write_todos` 11 times in a row with identical content, hits LangGraph's recursion limit, and the final state shows `todos: None` (or `[]` for non-error completions). The Command's update never lands on the state channel.
+
+Captured live-smoke evidence in this PR (#151): all 11 `plan_update` SSE events emitted with the same `{todos: [...3 same items...]}` payload. State never advanced; agent kept restating the plan because its "Current plan:" prompt fragment kept rendering `(empty)`.
+
+## What we verified does work
+
+1. `unwrapToolResult` detects the wrapper shape correctly (13 unit tests pass).
+2. `convertToolToLangChain` constructs a `Command` instance with the expected `update.todos` and embedded ToolMessage (integration test passes — `isCommand(result)` is true, `cmd.update.todos` matches).
+3. The planning capability's `stateFields` declaration includes `{name: "todos", reducer: "replace", default: []}` — channel exists in the schema.
+4. ToolNode's source explicitly preserves non-PARENT Commands and pushes them to `combinedOutputs` as-is (read in `@langchain/langgraph@1.3.0/dist/prebuilt/tool_node.js`).
+
+So the construction is right, the channel exists, and ToolNode passes the Command through. **The gap is in how LangGraph's runtime applies the Command's update to the channel state.**
+
+## Hypotheses (in order of plausibility)
+
+1. **Missing `tool_call_id` in the embedded ToolMessage.** Our `extractToolCallId(config)` helper returns `""` (empty string) because the config object's shape in `@langchain/openai@1.4.5`'s tool wrapper doesn't match the lookup paths we tried. LangGraph might reject Commands with anonymous ToolMessages, OR the AI agent loop fails to pair the tool result back to its call. If the call/result pairing breaks, the agent can't see the tool's output as a "response" → it re-issues the tool call.
+
+2. **Command's `update` shape is wrong for ToolNode.** Maybe LangGraph expects state mutations in a different key (e.g., `update.state` or `update.partial`) and our spreading of `stateUpdates` directly into `update` doesn't get picked up by the channel reducer.
+
+3. **createReactAgent's tool node is a different code path than ToolNode.** We read ToolNode's source assuming createReactAgent uses it. If createReactAgent uses a different tool execution wrapper, our Command might be dropped or ignored.
+
+4. **State schema isn't actually being applied to createReactAgent.** Maybe `agentOptions.stateSchema = materializeStateSchema(stateFields)` isn't enough — there might be a `stateSchema` vs `responseFormat` distinction we're missing.
+
+## Investigation plan
+
+1. Add a `console.log` (or proper debug) in `convertToolToLangChain` printing the `config` object and the resulting Command. Run live smoke. Compare to expected.
+2. Read `createReactAgent`'s source to see which tool wrapper it uses and whether it strips/transforms Commands.
+3. Build a minimal test: a tool that returns a known Command, fed through the full agent loop (mocked LLM), assert the state channel was updated.
+4. If hypothesis 1 confirms: fix `extractToolCallId` to read the right field. If 2: change the Command shape. If 3/4: deeper restructuring of how we wire state into createReactAgent.
+
+## Workaround until fixed
+
+None. The planning capability surfaces the bug visibly (re-emission loop). Skills (sub-project 2b) will hit the same bug if shipped — its `loaded_skills` channel won't update either.
+
+## Why this PR is going out anyway
+
+PR #151 (this PR) adds the `reasoning.effort` API + updates the example to `gpt-5` — both useful regardless of the state-mutation bug. The bug is documented in this file as the next investigation target.

--- a/examples/chat/README.md
+++ b/examples/chat/README.md
@@ -15,6 +15,12 @@
   updates its plan.
 - End-to-end streaming from a Next.js client over SSE
 
+## Model choice
+
+This example uses `gpt-5` with `reasoning: { effort: "high" }`. In live testing, smaller models (`gpt-5-mini`, `gpt-5-nano`) tend to ignore explicit tool-use directives and produce generic "what can I help you with?" responses on the first turn — they don't reliably exercise the planning + memory capabilities. `gpt-5` engages with tools and actually drives an agent loop. The tradeoff: each turn costs more.
+
+If you swap to a smaller model, expect to do more prompt-engineering work to get tool calls to fire.
+
 ## Quickstart
 
 ```bash

--- a/examples/chat/server/src/app/chat/index.ts
+++ b/examples/chat/server/src/app/chat/index.ts
@@ -2,6 +2,7 @@ import { agent } from "@dawn-ai/sdk"
 import { HARNESS_SYSTEM_PROMPT } from "./system-prompt.js"
 
 export default agent({
-  model: "gpt-5-mini",
+  model: "gpt-5",
+  reasoning: { effort: "high" },
   systemPrompt: HARNESS_SYSTEM_PROMPT,
 })

--- a/packages/langchain/src/agent-adapter.ts
+++ b/packages/langchain/src/agent-adapter.ts
@@ -59,6 +59,10 @@ async function materializeAgent(
 
   const llm = new ChatOpenAI({
     model: descriptor.model,
+    // Maps to OpenAI's reasoningEffort param. Non-reasoning models ignore it.
+    // Default is `medium` for pre-gpt-5.1 reasoning models per OpenAI docs.
+    // Bump to `high` for tool-use-heavy agents that aren't following directives.
+    ...(descriptor.reasoning?.effort ? { reasoningEffort: descriptor.reasoning.effort } : {}),
   })
 
   const fragments = promptFragments ?? []

--- a/packages/sdk/src/agent.ts
+++ b/packages/sdk/src/agent.ts
@@ -7,9 +7,26 @@ export interface RetryConfig {
   readonly baseDelay?: number
 }
 
+/**
+ * Reasoning model tuning. Currently maps to OpenAI's `reasoningEffort`
+ * parameter; non-reasoning models silently ignore it.
+ *
+ * Supported effort values (per OpenAI docs):
+ *   - "none"    — disable reasoning entirely (gpt-5.1+ only)
+ *   - "minimal" — fastest, smallest reasoning budget
+ *   - "low"     — light reasoning
+ *   - "medium"  — default for models before gpt-5.1
+ *   - "high"    — deeper reasoning; recommended for tool-use-heavy agents
+ *   - "xhigh"   — gpt-5.1-codex-max and later only
+ */
+export interface ReasoningConfig {
+  readonly effort?: "none" | "minimal" | "low" | "medium" | "high" | "xhigh"
+}
+
 export interface DawnAgent {
   readonly [brand]: "DawnAgent"
   readonly model: string
+  readonly reasoning?: ReasoningConfig
   readonly retry?: RetryConfig
   readonly systemPrompt: string
 }
@@ -18,6 +35,7 @@ import type { KnownModelId } from "./known-model-ids.js"
 
 export interface AgentConfig {
   readonly model: KnownModelId
+  readonly reasoning?: ReasoningConfig
   readonly retry?: RetryConfig
   readonly systemPrompt: string
 }
@@ -26,6 +44,7 @@ export function agent(config: AgentConfig): DawnAgent {
   return {
     [DAWN_AGENT]: true,
     model: config.model,
+    ...(config.reasoning ? { reasoning: config.reasoning } : {}),
     ...(config.retry ? { retry: config.retry } : {}),
     systemPrompt: config.systemPrompt,
   } as unknown as DawnAgent


### PR DESCRIPTION
## Summary
Three things in one PR:

### 1. New \`reasoning?: { effort }\` field on \`agent({...})\`
Author surface:
\`\`\`ts
agent({
  model: "gpt-5",
  reasoning: { effort: "high" },
  systemPrompt: "...",
})
\`\`\`
Maps to \`@langchain/openai\`'s \`reasoningEffort\` constructor option. Six supported values per OpenAI docs: \`none | minimal | low | medium | high | xhigh\`. Non-reasoning models silently ignore it. Defaults are model-specific (\`medium\` for pre-\`gpt-5.1\` reasoning models).

### 2. Chat example switches to \`gpt-5\` with \`effort: "high"\`
Live smoke testing showed \`gpt-5-mini\` ignored explicit tool-use directives and produced generic "what can I help you with" greetings — even with \`reasoning.effort\` bumped to \`high\`. \`gpt-5\` actually engages with the tools and exercises planning + memory capabilities (visible \`tool_call\` and \`plan_update\` events fire).

Tradeoff: each turn costs more. The README's new "Model choice" section explains the tradeoff so anyone running the example understands what they're paying for.

### 3. Documented follow-up: tool state mutation isn't applied at runtime
\`docs/superpowers/specs/2026-05-16-tool-state-mutation-runtime-bug-followup.md\`

Live smoke also surfaced a deeper bug from PR #150: the \`Command\` construction works in isolation (unit tests pass), but LangGraph isn't applying the \`Command.update.todos\` to the state channel at runtime. The planning re-emission loop returns with \`gpt-5\` — the agent calls \`write_todos\` 11 times with identical content because "Current plan:" stays empty.

Diagnosis in the spec. Most likely cause: missing \`tool_call_id\` in the embedded ToolMessage (our \`extractToolCallId\` helper returns \`""\` when LangGraph's config shape doesn't match our lookup paths). Next focused investigation.

## Test plan
- [x] \`pnpm install\`
- [x] \`pnpm build\` — 11/11
- [x] \`pnpm typecheck\` — 12/12
- [x] \`pnpm test\` — 388/388 (no new tests — the reasoning.effort field is a pass-through to @langchain/openai; the deeper state-mutation bug needs its own test pass)
- [x] \`pnpm lint\` — clean (biome auto-formatted 1 file)
- [x] Live smoke with both \`gpt-5-mini\` (no useful response) and \`gpt-5\` (engages with tools, state-mutation bug surfaces)

## Honest framing on what this PR doesn't fix
The reasoning.effort API is a real, useful knob. The model swap to \`gpt-5\` is the right default for an agent demo. But the state-mutation runtime bug (#150's regression) means the chat example still doesn't end cleanly — \`gpt-5\` exercises the framework correctly and reveals the bug. The bug spec is queued as the next focused fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)