### PR TITLE
test(langchain): prove tool state-mutation chain works end-to-end (closes #151 followup)

### DIFF
--- a/docs/superpowers/specs/2026-05-16-planning-state-mutation-followup.md
+++ b/docs/superpowers/specs/2026-05-16-planning-state-mutation-followup.md
@@ -1,7 +1,7 @@
 # Planning capability — state mutation gap (follow-up)
 
 **Date:** 2026-05-16
-**Status:** Diagnosis only — needs its own brainstorm + fix cycle
+**Status:** **RESOLVED in PR #150** — adopted the `{result, state}` wrapped-return shape via sub-project 2c. Planning's `write_todos` now mutates the `todos` channel. The "re-emission loop" observed in live LLM smoke turned out to be a model-behavior issue, not a framework issue — see [the runtime bug followup](2026-05-16-tool-state-mutation-runtime-bug-followup.md) for the full retrospective.
 **Owner:** Brian Love
 
 ## The bug

--- a/docs/superpowers/specs/2026-05-16-tool-state-mutation-runtime-bug-followup.md
+++ b/docs/superpowers/specs/2026-05-16-tool-state-mutation-runtime-bug-followup.md
@@ -1,7 +1,7 @@
 # Tool state mutation — Command not applied at runtime (follow-up)
 
 **Date:** 2026-05-16
-**Status:** Diagnosis only — needs investigation + fix
+**Status:** **RESOLVED — not a bug.** The framework works correctly. The live-LLM "loop" with `gpt-5` was model behavior (model hallucinated a Flask scaffolding task and looped on its own execution failure), not framework breakage. Two regression tests added in PR #152 prove the agent loop → tool → Command → state-channel chain works end-to-end. See "Resolution" section.
 **Owner:** Brian Love
 
 ## The bug
@@ -45,3 +45,33 @@ None. The planning capability surfaces the bug visibly (re-emission loop). Skill
 ## Why this PR is going out anyway
 
 PR #151 (this PR) adds the `reasoning.effort` API + updates the example to `gpt-5` — both useful regardless of the state-mutation bug. The bug is documented in this file as the next investigation target.
+
+---
+
+## Resolution (added retrospectively)
+
+Investigation in PR #152 added two deterministic tests that prove the framework chain works:
+
+1. **`packages/langchain/test/tool-converter-runtime.test.ts`** — invokes the converted tool via `tool.invoke(ToolCall, config)` (the same path ToolNode uses). Verifies the resulting Command's embedded ToolMessage has the right `tool_call_id` AND that `update.<stateField>` contains the expected value.
+
+2. **`packages/langchain/test/agent-state-update.test.ts`** — builds a real `createReactAgent` with our `materializeStateSchema(...)`-produced schema and a small hand-rolled `SequencedChatModel` that emits an `AIMessage` with `tool_calls`. After one tool call, `result.todos` correctly contains `[{ content: "first", status: "in_progress" }]`. The Command's update IS applied to the state channel; the chain is correct.
+
+### Why the live LLM looked broken
+
+Re-reading the captured smoke logs: gpt-5 received "Make a 3-item plan for refactoring a function..." and hallucinated a Flask scaffolding task (read the actual content of the 11 plan_update events — same Flask todos repeated). The model kept calling write_todos with the same plan because it was failing to execute Step 1 of the plan it made up (and thus stuck in a "should I update the plan? maybe I need a different plan" thrash), not because state.todos was empty.
+
+The final state showed `todos:[]` ONLY because the recursion-limit error replaced the normal completion output. Mid-run state was correctly populated — every `plan_update` SSE event proves that the prompt fragment had access to the updated todos (otherwise the transformer wouldn't have fired with the correct payload).
+
+### Hypothesis check
+
+The three hypotheses listed above turned out to all be wrong:
+1. ❌ Missing `tool_call_id` — test 1 shows it's preserved correctly.
+2. ❌ Command's `update` shape wrong — test 2 shows it lands on the channel.
+3. ❌ createReactAgent uses different tool node — same tool node, same Command application.
+4. ❌ State schema not applied — `result.todos` correctly typed and populated in test 2.
+
+### Lesson
+
+PR #150's test gap was that it stopped at "Command is constructed correctly" without testing "Command is applied to state by LangGraph." PR #152 closes that gap.
+
+The reasoning_effort/gpt-5 work in PR #151 was still valuable (knob exists, gpt-5 actually engages with tools). But it shouldn't have been justified by a misdiagnosed framework bug. The truer framing for #151: "the chat example's gpt-5-mini default doesn't reliably exercise tool-calling; gpt-5 is the model that does." Independent of any framework bug.

--- a/packages/langchain/test/agent-state-update.test.ts
+++ b/packages/langchain/test/agent-state-update.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Full agent-loop test with a mocked LLM: verify that when a tool returns
+ * `{result, state}`, the state channel actually updates after one turn.
+ *
+ * This catches the regression that live LLM testing surfaced: the
+ * tool-converter constructs the Command correctly (covered in unit tests),
+ * but if the agent loop / state schema isn't wired right, the Command's
+ * `update.todos` never lands on the channel and `state.todos` stays
+ * at its default.
+ *
+ * Uses a hand-rolled SequencedChatModel because @langchain/core's
+ * FakeStreamingChatModel doesn't preserve tool_calls when passed via
+ * `responses` (it only reads tool_calls from `chunks`).
+ */
+
+import { BaseChatModel } from "@langchain/core/language_models/chat_models"
+import { AIMessage, type BaseMessage } from "@langchain/core/messages"
+import type { ChatResult } from "@langchain/core/outputs"
+import { createReactAgent } from "@langchain/langgraph/prebuilt"
+import { describe, expect, it } from "vitest"
+import { materializeStateSchema } from "../src/state-adapter.js"
+import { convertToolToLangChain } from "../src/tool-converter.js"
+
+/**
+ * Minimal sequenced chat model: returns canned AIMessages in order on each
+ * call. Preserves tool_calls. Implements bindTools() as a no-op so
+ * createReactAgent accepts it.
+ */
+class SequencedChatModel extends BaseChatModel {
+  private cursor = 0
+  constructor(private readonly responses: AIMessage[]) {
+    super({})
+  }
+  _llmType(): string {
+    return "sequenced-fake"
+  }
+  async _generate(_messages: BaseMessage[]): Promise<ChatResult> {
+    const msg = this.responses[this.cursor]
+    this.cursor += 1
+    if (!msg) throw new Error("SequencedChatModel ran out of canned responses")
+    return {
+      generations: [{ text: typeof msg.content === "string" ? msg.content : "", message: msg }],
+    }
+  }
+  // biome-ignore lint/suspicious/noExplicitAny: bindTools signature in the BaseChatModel hierarchy is loose
+  bindTools(_tools: any): any {
+    return this
+  }
+}
+
+describe("agent loop — state channel updates after Command-returning tool", () => {
+  it("applies tool's {result, state} update to the named state channel", async () => {
+    const fakeModel = new SequencedChatModel([
+      new AIMessage({
+        content: "",
+        tool_calls: [
+          {
+            id: "call_test_1",
+            name: "write_todos",
+            args: { todos: [{ content: "first", status: "in_progress" }] },
+            type: "tool_call",
+          },
+        ],
+      }),
+      new AIMessage({ content: "Done." }),
+    ])
+
+    const writeTodosTool = {
+      name: "write_todos",
+      description: "Write todos to state",
+      run: (input: unknown) => {
+        const validated = (input as { todos: Array<{ content: string; status: string }> }).todos
+        return {
+          result: { todos: validated },
+          state: { todos: validated },
+        }
+      },
+    }
+    const converted = convertToolToLangChain(writeTodosTool)
+
+    const stateSchema = materializeStateSchema([{ name: "todos", reducer: "replace", default: [] }])
+
+    // biome-ignore lint/suspicious/noExplicitAny: dynamically-built options
+    const agent = createReactAgent({
+      llm: fakeModel,
+      tools: [converted],
+      stateSchema,
+    } as any)
+
+    const result = await agent.invoke({
+      messages: [{ role: "user", content: "Make a plan." }],
+    })
+
+    const finalState = result as { todos?: Array<{ content: string; status: string }> }
+    expect(finalState.todos).toEqual([{ content: "first", status: "in_progress" }])
+  })
+})

--- a/packages/langchain/test/tool-converter-runtime.test.ts
+++ b/packages/langchain/test/tool-converter-runtime.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Runtime integration tests for convertToolToLangChain — verify that the
+ * full ToolNode-style invocation path (tool.invoke(ToolCall, config))
+ * produces a Command whose embedded ToolMessage has the right tool_call_id.
+ *
+ * The unit tests in tool-converter.test.ts cover the direct func() invocation
+ * path; this file covers the actual call path that LangGraph's ToolNode uses,
+ * which is where the tool_call_id resolution actually happens.
+ */
+import { isCommand } from "@langchain/langgraph"
+import { describe, expect, it } from "vitest"
+import { convertToolToLangChain } from "../src/tool-converter.js"
+
+describe("convertToolToLangChain — runtime invoke path (ToolNode-style)", () => {
+  it("preserves tool_call_id when invoked via tool.invoke(ToolCall) for plain-result tools", async () => {
+    const tool = {
+      name: "echo",
+      description: "Echo input.",
+      run: async (input: unknown) => input,
+    }
+    const converted = convertToolToLangChain(tool)
+    const toolCall = {
+      type: "tool_call" as const,
+      id: "call_abc123",
+      name: "echo",
+      args: { msg: "hi" },
+    }
+    const result = await converted.invoke(toolCall)
+    // Plain return path → _formatToolOutput wraps as ToolMessage with the id
+    expect((result as { tool_call_id?: string }).tool_call_id).toBe("call_abc123")
+  })
+
+  it("preserves tool_call_id in Command's embedded ToolMessage when state is present", async () => {
+    const tool = {
+      name: "writeStuff",
+      description: "Write stuff to state.",
+      run: async () => ({
+        result: { ok: true },
+        state: { stuff: "value" },
+      }),
+    }
+    const converted = convertToolToLangChain(tool)
+    const toolCall = {
+      type: "tool_call" as const,
+      id: "call_xyz789",
+      name: "writeStuff",
+      args: {},
+    }
+    const result = await converted.invoke(toolCall)
+
+    // Our func returns a Command (lc_direct_tool_output=true), so _formatToolOutput
+    // returns it as-is. The Command's embedded ToolMessage in update.messages
+    // should have the right tool_call_id for LangGraph to pair with the AIMessage's tool_call.
+    expect(isCommand(result)).toBe(true)
+    const cmd = result as unknown as {
+      update: { messages?: Array<{ tool_call_id?: string; content?: unknown }> }
+    }
+    const msg = cmd.update.messages?.[0]
+    expect(msg?.tool_call_id).toBe("call_xyz789")
+    expect(msg?.content).toBe(JSON.stringify({ ok: true }))
+    expect((cmd.update as Record<string, unknown>).stuff).toBe("value")
+  })
+})


### PR DESCRIPTION
## Summary
Investigation of the runtime-bug followup spec from #151 ([docs/superpowers/specs/2026-05-16-tool-state-mutation-runtime-bug-followup.md](https://github.com/cacheplane/dawnai/blob/main/docs/superpowers/specs/2026-05-16-tool-state-mutation-runtime-bug-followup.md)).

**Finding: not a bug.** The framework's tool state-mutation chain works correctly end-to-end. The live-LLM "loop" was model behavior (gpt-5 hallucinated a Flask scaffolding task and looped on its own execution failure), not framework breakage.

## Two new regression tests

### \`packages/langchain/test/tool-converter-runtime.test.ts\`
Invokes the converted tool via \`tool.invoke(ToolCall, config)\` — the same call path \`ToolNode\` uses internally. Verifies the resulting Command's embedded \`ToolMessage\` has the right \`tool_call_id\` AND that \`update.<stateField>\` contains the expected value.

### \`packages/langchain/test/agent-state-update.test.ts\`
Builds a real \`createReactAgent\` with our \`materializeStateSchema(...)\`-produced schema and a hand-rolled \`SequencedChatModel\` (because \`@langchain/core\`'s \`FakeStreamingChatModel\` only reads \`tool_calls\` from \`chunks\`, not \`responses\`, and doesn't sequence responses). After one tool call, \`result.todos\` correctly contains \`[{ content: "first", status: "in_progress" }]\`. The Command's update IS applied to the state channel.

## Why the live LLM looked broken
Re-reading the captured smoke output from PR #151:
- gpt-5 received "Make a 3-item plan for refactoring a function..." 
- Hallucinated a Flask scaffolding task (the 11 \`plan_update\` events all contained the same Flask todos — "Scaffold Flask app files: app.py, requirements.txt, README.md")
- Each \`plan_update\` proves the state channel WAS updating mid-run (otherwise the transformer wouldn't have fired with the populated payload)
- Recursion-limit error replaced the normal completion output with \`todos:[]\`

The four hypotheses in the followup spec all turned out to be wrong:
- ❌ Missing \`tool_call_id\` — preserved correctly (test 1)
- ❌ Command \`update\` shape wrong — lands on the channel (test 2)
- ❌ \`createReactAgent\` uses different tool node — same path, same Command application
- ❌ State schema not applied — \`result.todos\` correctly typed and populated

## Both followup specs marked RESOLVED
- \`docs/superpowers/specs/2026-05-16-planning-state-mutation-followup.md\` (predates #150's fix) — confirmed resolved by #150
- \`docs/superpowers/specs/2026-05-16-tool-state-mutation-runtime-bug-followup.md\` (from #151) — appended a "Resolution" section explaining the misdiagnosis

## Test plan
- [x] \`pnpm install\`
- [x] \`pnpm build\` — 11/11
- [x] \`pnpm typecheck\` — 12/12  
- [x] \`pnpm test\` — 391/391 (+3 new: 2 in tool-converter-runtime.test.ts, 1 in agent-state-update.test.ts)
- [x] \`pnpm lint\` — clean (biome auto-fixed 1 file)
- [x] \`pnpm pack:check\` — passes

## Lesson
PR #150's test gap was that it stopped at "Command is constructed correctly" without testing "Command is applied to state by LangGraph." This PR closes that gap. Sub-project 2b (Skills) can now ship with confidence that its \`loaded_skills\` state channel will actually update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)