### PR TITLE
feat(core,cli): phase 3 — skills capability (sub-project 2b)

### DIFF
--- a/.changeset/phase3-skills.md
+++ b/.changeset/phase3-skills.md
@@ -1,0 +1,11 @@
+---
+"@dawn-ai/core": minor
+"@dawn-ai/cli": minor
+---
+
+Add the phase-3 skills capability. A route with `src/app/<route>/skills/<name>/SKILL.md` files now exposes them to the agent via:
+
+- An always-on `# Skills` section in the system prompt listing each skill's name + description
+- A `readSkill({ name })` tool the agent calls to load a skill's full body on demand
+
+Each `SKILL.md` requires YAML frontmatter with `description`; `name` defaults to the directory name and can be overridden. The body lives in conversation history after `readSkill` returns it (not re-injected each turn) — matches the deepagents / Claude Code convention. Typegen includes `readSkill` in `RouteTools` when a route has skills. The chat example ships two seeded skills (`workspace-conventions`, `recover-from-failure`).

--- a/docs/superpowers/plans/2026-05-16-phase3-skills.md
+++ b/docs/superpowers/plans/2026-05-16-phase3-skills.md
@@ -1,0 +1,920 @@
+# Phase 3 — Skills Capability Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development.
+
+**Goal:** Add a `createSkillsMarker()` capability to `@dawn-ai/core` so that any route with `src/app/<route>/skills/<name>/SKILL.md` files automatically gets a `# Skills` section in its system prompt and a `readSkill({name})` tool the agent uses to load skill bodies on demand. Wire it into `prepareRouteExecution` alongside the existing markers. Add two example skills to `examples/chat` to demo.
+
+**Architecture:** Two new files in `@dawn-ai/core`: a small hand-rolled YAML-frontmatter parser, and the `skills` capability marker that uses it. `readSkill` is a plain capability tool (no state mutation). Registration is one line in `execute-route.ts`.
+
+**Tech Stack:** TypeScript 6.0.2, vitest, `@dawn-ai/{core,langchain,cli}`. No new npm dependencies (frontmatter is hand-rolled).
+
+**Spec:** [docs/superpowers/specs/2026-05-16-phase3-skills-design.md](../specs/2026-05-16-phase3-skills-design.md)
+
+**Working directory:** `/Users/blove/repos/dawn/.claude/worktrees/skills` (branch `claude/skills`).
+
+---
+
+## File map
+
+**Create:**
+- `packages/core/src/capabilities/built-in/frontmatter.ts` — minimal YAML-block parser
+- `packages/core/test/capabilities/frontmatter.test.ts` — parser tests
+- `packages/core/src/capabilities/built-in/skills.ts` — `createSkillsMarker` + `readSkill` tool
+- `packages/core/test/capabilities/skills.test.ts` — marker tests
+- `packages/langchain/test/skills.test.ts` — integration shape test
+- `examples/chat/server/src/app/chat/skills/workspace-conventions/SKILL.md`
+- `examples/chat/server/src/app/chat/skills/recover-from-failure/SKILL.md`
+- `.changeset/phase3-skills.md`
+
+**Modify:**
+- `packages/core/src/index.ts` — re-export `createSkillsMarker`
+- `packages/cli/src/lib/runtime/execute-route.ts` — add `createSkillsMarker()` to the registry
+- `examples/chat/README.md` — mark skills as shipped (out of Deferred)
+
+---
+
+## Task 1: Frontmatter parser + tests
+
+**Files:**
+- Create: `packages/core/src/capabilities/built-in/frontmatter.ts`
+- Create: `packages/core/test/capabilities/frontmatter.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `packages/core/test/capabilities/frontmatter.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest"
+import { parseFrontmatter } from "../../src/capabilities/built-in/frontmatter.js"
+
+describe("parseFrontmatter", () => {
+  it("returns empty frontmatter and full body when input has no frontmatter", () => {
+    const input = "# Just a heading\n\nSome content."
+    expect(parseFrontmatter(input)).toEqual({
+      frontmatter: {},
+      body: "# Just a heading\n\nSome content.",
+    })
+  })
+
+  it("returns empty frontmatter when missing closing ---", () => {
+    const input = "---\nname: foo\nbody continues"
+    expect(parseFrontmatter(input)).toEqual({
+      frontmatter: {},
+      body: "---\nname: foo\nbody continues",
+    })
+  })
+
+  it("parses a single key/value", () => {
+    const input = "---\nname: debug-python\n---\n\n# Body"
+    expect(parseFrontmatter(input)).toEqual({
+      frontmatter: { name: "debug-python" },
+      body: "# Body",
+    })
+  })
+
+  it("parses multiple keys", () => {
+    const input =
+      "---\nname: debug-python\ndescription: Debug stack traces.\n---\n\n# Body content"
+    expect(parseFrontmatter(input)).toEqual({
+      frontmatter: { name: "debug-python", description: "Debug stack traces." },
+      body: "# Body content",
+    })
+  })
+
+  it("strips surrounding double-quotes from values", () => {
+    const input = '---\nname: "with spaces"\n---\nbody'
+    expect(parseFrontmatter(input)).toEqual({
+      frontmatter: { name: "with spaces" },
+      body: "body",
+    })
+  })
+
+  it("strips surrounding single-quotes from values", () => {
+    const input = "---\nname: 'with spaces'\n---\nbody"
+    expect(parseFrontmatter(input)).toEqual({
+      frontmatter: { name: "with spaces" },
+      body: "body",
+    })
+  })
+
+  it("ignores comment lines (start with #)", () => {
+    const input = "---\n# this is a comment\nname: foo\n# another comment\n---\nbody"
+    expect(parseFrontmatter(input)).toEqual({
+      frontmatter: { name: "foo" },
+      body: "body",
+    })
+  })
+
+  it("ignores blank lines inside frontmatter", () => {
+    const input = "---\nname: foo\n\ndescription: bar\n---\nbody"
+    expect(parseFrontmatter(input)).toEqual({
+      frontmatter: { name: "foo", description: "bar" },
+      body: "body",
+    })
+  })
+
+  it("trims whitespace from keys and values", () => {
+    const input = "---\n  name  :   foo  \n---\nbody"
+    expect(parseFrontmatter(input)).toEqual({
+      frontmatter: { name: "foo" },
+      body: "body",
+    })
+  })
+
+  it("handles CRLF line endings", () => {
+    const input = "---\r\nname: foo\r\n---\r\nbody"
+    expect(parseFrontmatter(input)).toEqual({
+      frontmatter: { name: "foo" },
+      body: "body",
+    })
+  })
+
+  it("preserves multi-line body verbatim (minus the first leading newline)", () => {
+    const input = "---\nname: foo\n---\n\nLine 1\nLine 2\n\nLine 4"
+    expect(parseFrontmatter(input)).toEqual({
+      frontmatter: { name: "foo" },
+      body: "Line 1\nLine 2\n\nLine 4",
+    })
+  })
+
+  it("returns empty body when nothing follows the closing ---", () => {
+    const input = "---\nname: foo\n---"
+    expect(parseFrontmatter(input)).toEqual({
+      frontmatter: { name: "foo" },
+      body: "",
+    })
+  })
+
+  it("returns empty frontmatter (the whole input as body) when input starts with --- but not --- followed by newline", () => {
+    const input = "--- not really frontmatter\nname: foo"
+    expect(parseFrontmatter(input)).toEqual({
+      frontmatter: {},
+      body: "--- not really frontmatter\nname: foo",
+    })
+  })
+
+  it("treats a line without a colon as ignored (no key)", () => {
+    const input = "---\nname: foo\nthis line has no colon\ndescription: bar\n---\nbody"
+    expect(parseFrontmatter(input)).toEqual({
+      frontmatter: { name: "foo", description: "bar" },
+      body: "body",
+    })
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+pnpm install
+pnpm --filter @dawn-ai/sdk build
+pnpm --filter @dawn-ai/core test -- frontmatter.test
+```
+
+Expected: FAIL — `Cannot find module '../../src/capabilities/built-in/frontmatter.js'`.
+
+- [ ] **Step 3: Implement the parser**
+
+Create `packages/core/src/capabilities/built-in/frontmatter.ts`:
+
+```ts
+/**
+ * Minimal YAML-frontmatter parser. Sufficient for Dawn's skill files,
+ * which use a flat `key: value` block at the top delimited by `---` lines.
+ *
+ * Supports: keys, double-quoted values, single-quoted values, `#` comments,
+ * blank lines, CRLF endings, leading/trailing whitespace.
+ *
+ * Does NOT support: nested objects, arrays, multi-line strings, anchors,
+ * any other real YAML feature. If a skill needs full YAML, swap to the
+ * `yaml` npm package without changing this module's contract.
+ */
+export interface ParsedFrontmatter {
+  readonly frontmatter: Readonly<Record<string, string>>
+  readonly body: string
+}
+
+const OPEN_MARKER = /^---\r?\n/
+const CLOSE_MARKER = /\r?\n---\r?\n?/
+
+export function parseFrontmatter(input: string): ParsedFrontmatter {
+  if (!OPEN_MARKER.test(input)) {
+    return { frontmatter: {}, body: input }
+  }
+  const openLen = OPEN_MARKER.exec(input)?.[0].length ?? 0
+  const afterOpen = input.slice(openLen)
+  const closeMatch = CLOSE_MARKER.exec(afterOpen)
+  if (!closeMatch) {
+    return { frontmatter: {}, body: input }
+  }
+  const block = afterOpen.slice(0, closeMatch.index)
+  const bodyStart = closeMatch.index + closeMatch[0].length
+  const body = afterOpen.slice(bodyStart).replace(/^\r?\n/, "")
+  const frontmatter = parseFrontmatterBlock(block)
+  return { frontmatter, body }
+}
+
+function parseFrontmatterBlock(block: string): Record<string, string> {
+  const out: Record<string, string> = {}
+  for (const rawLine of block.split(/\r?\n/)) {
+    const line = rawLine.trim()
+    if (line.length === 0) continue
+    if (line.startsWith("#")) continue
+    const colonIdx = line.indexOf(":")
+    if (colonIdx < 0) continue
+    const key = line.slice(0, colonIdx).trim()
+    if (key.length === 0) continue
+    const rawValue = line.slice(colonIdx + 1).trim()
+    out[key] = stripQuotes(rawValue)
+  }
+  return out
+}
+
+function stripQuotes(value: string): string {
+  if (value.length >= 2) {
+    const first = value[0]
+    const last = value[value.length - 1]
+    if ((first === '"' && last === '"') || (first === "'" && last === "'")) {
+      return value.slice(1, -1)
+    }
+  }
+  return value
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+pnpm --filter @dawn-ai/core test -- frontmatter.test
+```
+
+Expected: 14/14 pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/core/src/capabilities/built-in/frontmatter.ts packages/core/test/capabilities/frontmatter.test.ts
+git commit -m "feat(core): minimal YAML-frontmatter parser for SKILL.md files"
+```
+
+---
+
+## Task 2: Skills marker + tests
+
+**Files:**
+- Create: `packages/core/src/capabilities/built-in/skills.ts`
+- Create: `packages/core/test/capabilities/skills.test.ts`
+- Modify: `packages/core/src/index.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `packages/core/test/capabilities/skills.test.ts`:
+
+```ts
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import { createSkillsMarker } from "../../src/capabilities/built-in/skills.js"
+
+describe("createSkillsMarker", () => {
+  let routeDir: string
+
+  beforeEach(() => {
+    routeDir = mkdtempSync(join(tmpdir(), "dawn-skills-"))
+  })
+
+  afterEach(() => {
+    rmSync(routeDir, { recursive: true, force: true })
+  })
+
+  function writeSkill(name: string, frontmatter: string, body: string): void {
+    const dir = join(routeDir, "skills", name)
+    mkdirSync(dir, { recursive: true })
+    const content = frontmatter ? `---\n${frontmatter}\n---\n\n${body}` : body
+    writeFileSync(join(dir, "SKILL.md"), content, "utf8")
+  }
+
+  it("does not detect when skills/ directory is absent", async () => {
+    const marker = createSkillsMarker()
+    expect(await marker.detect(routeDir)).toBe(false)
+  })
+
+  it("does not detect when skills/ exists but is empty", async () => {
+    mkdirSync(join(routeDir, "skills"), { recursive: true })
+    const marker = createSkillsMarker()
+    expect(await marker.detect(routeDir)).toBe(false)
+  })
+
+  it("does not detect when skills/<name>/ has no SKILL.md", async () => {
+    mkdirSync(join(routeDir, "skills", "stub"), { recursive: true })
+    const marker = createSkillsMarker()
+    expect(await marker.detect(routeDir)).toBe(false)
+  })
+
+  it("detects when at least one skills/<name>/SKILL.md exists", async () => {
+    writeSkill("foo", "description: A foo skill.", "body")
+    const marker = createSkillsMarker()
+    expect(await marker.detect(routeDir)).toBe(true)
+  })
+
+  it("load contributes exactly one tool (readSkill) and one promptFragment, no state/transformers", async () => {
+    writeSkill("foo", "description: A foo skill.", "body")
+    const marker = createSkillsMarker()
+    const contribution = await marker.load(routeDir)
+    expect(contribution.tools?.map((t) => t.name)).toEqual(["readSkill"])
+    expect(contribution.promptFragment?.placement).toBe("after_user_prompt")
+    expect(contribution.stateFields).toBeUndefined()
+    expect(contribution.streamTransformers).toBeUndefined()
+  })
+
+  it("uses directory name as the skill name when frontmatter omits it", async () => {
+    writeSkill("debug-python", "description: Debug Python.", "# Body")
+    const marker = createSkillsMarker()
+    const contribution = await marker.load(routeDir)
+    const rendered = contribution.promptFragment?.render({}) ?? ""
+    expect(rendered).toContain("**debug-python** — Debug Python.")
+  })
+
+  it("uses frontmatter.name when provided, overriding the directory name", async () => {
+    writeSkill("dir-name", "name: override-name\ndescription: Overridden.", "body")
+    const marker = createSkillsMarker()
+    const contribution = await marker.load(routeDir)
+    const rendered = contribution.promptFragment?.render({}) ?? ""
+    expect(rendered).toContain("**override-name** — Overridden.")
+    expect(rendered).not.toContain("**dir-name**")
+  })
+
+  it("fails fast when a SKILL.md has no frontmatter", async () => {
+    writeSkill("bare", "", "# Just a body with no frontmatter")
+    const marker = createSkillsMarker()
+    await expect(marker.load(routeDir)).rejects.toThrow(/missing required frontmatter|missing required `description`/i)
+  })
+
+  it("fails fast when frontmatter lacks description", async () => {
+    writeSkill("no-desc", "name: no-desc", "body")
+    const marker = createSkillsMarker()
+    await expect(marker.load(routeDir)).rejects.toThrow(/missing required `description`/i)
+  })
+
+  it("fails fast when two skills resolve to the same name", async () => {
+    writeSkill("foo", "description: First.", "body")
+    writeSkill("bar", "name: foo\ndescription: Duplicate.", "body")
+    const marker = createSkillsMarker()
+    await expect(marker.load(routeDir)).rejects.toThrow(/duplicate skill name/i)
+  })
+
+  it("skips invalid directory names silently (leading dot or spaces)", async () => {
+    writeSkill("good", "description: Good one.", "body")
+    mkdirSync(join(routeDir, "skills", ".hidden"), { recursive: true })
+    writeFileSync(
+      join(routeDir, "skills", ".hidden", "SKILL.md"),
+      "---\ndescription: Hidden.\n---\nbody",
+      "utf8",
+    )
+    mkdirSync(join(routeDir, "skills", "has spaces"), { recursive: true })
+    writeFileSync(
+      join(routeDir, "skills", "has spaces", "SKILL.md"),
+      "---\ndescription: Spaced.\n---\nbody",
+      "utf8",
+    )
+    const marker = createSkillsMarker()
+    const contribution = await marker.load(routeDir)
+    const rendered = contribution.promptFragment?.render({}) ?? ""
+    expect(rendered).toContain("**good**")
+    expect(rendered).not.toContain("**.hidden**")
+    expect(rendered).not.toContain("has spaces")
+  })
+
+  it("rendered prompt fragment includes a '# Skills' header and a readSkill instruction", async () => {
+    writeSkill("foo", "description: A foo skill.", "body")
+    const marker = createSkillsMarker()
+    const contribution = await marker.load(routeDir)
+    const rendered = contribution.promptFragment?.render({}) ?? ""
+    expect(rendered).toContain("# Skills")
+    expect(rendered).toContain('readSkill({ name: "<name>" })')
+  })
+
+  it("readSkill returns the body for a known skill", async () => {
+    writeSkill("foo", "description: A foo skill.", "FOO BODY CONTENT")
+    const marker = createSkillsMarker()
+    const contribution = await marker.load(routeDir)
+    const readSkill = contribution.tools?.[0]
+    const result = await readSkill?.run({ name: "foo" }, {
+      signal: new AbortController().signal,
+    })
+    expect(result).toBe("FOO BODY CONTENT")
+  })
+
+  it("readSkill returns a helpful error for an unknown skill, listing what's available", async () => {
+    writeSkill("foo", "description: A.", "body")
+    writeSkill("bar", "description: B.", "body")
+    const marker = createSkillsMarker()
+    const contribution = await marker.load(routeDir)
+    const readSkill = contribution.tools?.[0]
+    const result = await readSkill?.run({ name: "nope" }, {
+      signal: new AbortController().signal,
+    })
+    expect(result).toContain("Unknown skill: nope")
+    expect(result).toContain("bar")
+    expect(result).toContain("foo")
+  })
+
+  it("readSkill validates input shape (rejects non-string name)", async () => {
+    writeSkill("foo", "description: A.", "body")
+    const marker = createSkillsMarker()
+    const contribution = await marker.load(routeDir)
+    const readSkill = contribution.tools?.[0]
+    // Trying to run with invalid input — should throw or return an error message.
+    // The exact behavior depends on schema enforcement; the converter handles the
+    // schema layer. Here we just make sure run() doesn't crash on bad input.
+    await expect(async () => {
+      await readSkill?.run({ name: 42 }, { signal: new AbortController().signal })
+    }).rejects.toThrow()
+  })
+})
+```
+
+- [ ] **Step 2: Run tests to verify RED**
+
+```bash
+pnpm --filter @dawn-ai/core test -- skills.test
+```
+
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement the marker**
+
+Create `packages/core/src/capabilities/built-in/skills.ts`:
+
+```ts
+import { existsSync, readFileSync, readdirSync, statSync } from "node:fs"
+import { join } from "node:path"
+import { z } from "zod"
+import type { CapabilityMarker, PromptFragment } from "../types.js"
+import { parseFrontmatter } from "./frontmatter.js"
+
+const SKILLS_DIR = "skills"
+const SKILL_FILE = "SKILL.md"
+// Directory name must be a valid kebab-case-ish identifier. We exclude dotfiles,
+// spaces, and other punctuation that would make a poor agent-facing name.
+const VALID_DIR_NAME = /^[A-Za-z0-9][A-Za-z0-9_-]*$/
+
+const SKILLS_PROMPT_HEADER = `# Skills
+
+The following skills are available. To use one, call \`readSkill({ name: "<name>" })\` to load its full instructions before acting.`
+
+const READ_SKILL_INPUT = z.object({
+  name: z.string().min(1),
+})
+
+interface LoadedSkill {
+  readonly name: string
+  readonly description: string
+  readonly body: string
+  readonly path: string
+}
+
+export function createSkillsMarker(): CapabilityMarker {
+  return {
+    name: "skills",
+    detect: async (routeDir) => discoverSkillDirs(routeDir).length > 0,
+    load: async (routeDir) => {
+      const skills = loadSkills(routeDir)
+
+      const readSkill = {
+        name: "readSkill",
+        description: "Load the full instructions for a named skill.",
+        schema: READ_SKILL_INPUT,
+        run: async (input: unknown) => {
+          const { name } = READ_SKILL_INPUT.parse(input)
+          const found = skills.find((s) => s.name === name)
+          if (!found) {
+            const available = skills.map((s) => s.name).sort().join(", ")
+            return `Unknown skill: ${name}. Available: ${available}`
+          }
+          return found.body
+        },
+      }
+
+      const promptFragment: PromptFragment = {
+        placement: "after_user_prompt",
+        render: () => {
+          const lines = skills
+            .slice()
+            .sort((a, b) => a.name.localeCompare(b.name))
+            .map((s) => `- **${s.name}** — ${s.description}`)
+            .join("\n")
+          return `${SKILLS_PROMPT_HEADER}\n\n${lines}`
+        },
+      }
+
+      return {
+        tools: [readSkill],
+        promptFragment,
+      }
+    },
+  }
+}
+
+function discoverSkillDirs(routeDir: string): readonly string[] {
+  const skillsDir = join(routeDir, SKILLS_DIR)
+  if (!existsSync(skillsDir)) return []
+  let entries: string[]
+  try {
+    entries = readdirSync(skillsDir)
+  } catch {
+    return []
+  }
+  return entries.filter((name) => {
+    if (!VALID_DIR_NAME.test(name)) return false
+    const full = join(skillsDir, name)
+    let stat
+    try {
+      stat = statSync(full)
+    } catch {
+      return false
+    }
+    if (!stat.isDirectory()) return false
+    return existsSync(join(full, SKILL_FILE))
+  })
+}
+
+function loadSkills(routeDir: string): readonly LoadedSkill[] {
+  const dirNames = discoverSkillDirs(routeDir)
+  const loaded: LoadedSkill[] = []
+  const seenNames = new Set<string>()
+
+  for (const dirName of dirNames) {
+    const path = join(routeDir, SKILLS_DIR, dirName, SKILL_FILE)
+    let raw: string
+    try {
+      raw = readFileSync(path, "utf8")
+    } catch (error) {
+      throw new Error(`Failed to read ${path}: ${(error as Error).message}`)
+    }
+    const { frontmatter, body } = parseFrontmatter(raw)
+    if (Object.keys(frontmatter).length === 0) {
+      throw new Error(
+        `${path} is missing required frontmatter. Add a YAML block at the top with at least \`description: …\`.`,
+      )
+    }
+    const description = frontmatter.description
+    if (!description || description.length === 0) {
+      throw new Error(`${path} frontmatter is missing required \`description\` field.`)
+    }
+    const name = frontmatter.name && frontmatter.name.length > 0 ? frontmatter.name : dirName
+    if (seenNames.has(name)) {
+      const dupPath = loaded.find((s) => s.name === name)?.path
+      throw new Error(
+        `Duplicate skill name "${name}" — collision between ${dupPath} and ${path}. Each skill name must be unique.`,
+      )
+    }
+    seenNames.add(name)
+    loaded.push({ name, description, body, path })
+  }
+
+  return loaded
+}
+```
+
+- [ ] **Step 4: Re-export from core**
+
+Edit `packages/core/src/index.ts`. APPEND:
+
+```ts
+export { createSkillsMarker } from "./capabilities/built-in/skills.js"
+```
+
+- [ ] **Step 5: Run tests**
+
+```bash
+pnpm --filter @dawn-ai/core test -- skills.test
+```
+
+Expected: 15/15 pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/core/src/capabilities/built-in/skills.ts \
+        packages/core/test/capabilities/skills.test.ts \
+        packages/core/src/index.ts
+git commit -m "feat(core): skills CapabilityMarker (skills/<name>/SKILL.md → system prompt listing + readSkill tool)"
+```
+
+---
+
+## Task 3: Register the marker in the runtime
+
+**Files:**
+- Modify: `packages/cli/src/lib/runtime/execute-route.ts`
+
+- [ ] **Step 1: Find the registry creation**
+
+```bash
+grep -n "createCapabilityRegistry\|createPlanningMarker\|createAgentsMdMarker" packages/cli/src/lib/runtime/execute-route.ts
+```
+
+You'll see the registry already has two markers. Add a third.
+
+- [ ] **Step 2: Add the marker**
+
+In the `@dawn-ai/core` import block, add `createSkillsMarker`. Then update the registry array. Final state should look like:
+
+```ts
+import {
+  applyCapabilities,
+  createAgentsMdMarker,
+  createCapabilityRegistry,
+  createPlanningMarker,
+  createSkillsMarker,
+  // ... existing
+} from "@dawn-ai/core"
+
+// ... and downstream:
+
+const registry = createCapabilityRegistry([
+  createPlanningMarker(),
+  createAgentsMdMarker(),
+  createSkillsMarker(),
+])
+```
+
+(Order: planning → agents-md → skills. Registration order = render order in the system prompt.)
+
+- [ ] **Step 3: Build + typecheck**
+
+```bash
+pnpm --filter @dawn-ai/core build
+pnpm --filter @dawn-ai/cli typecheck
+```
+
+Expected: passes.
+
+- [ ] **Step 4: Run cli tests for no regression**
+
+```bash
+pnpm --filter @dawn-ai/cli test
+```
+
+Expected: passes, count unchanged.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/cli/src/lib/runtime/execute-route.ts
+git commit -m "feat(cli): register skills capability marker"
+```
+
+---
+
+## Task 4: Integration shape test in `@dawn-ai/langchain`
+
+**Files:**
+- Create: `packages/langchain/test/skills.test.ts`
+
+- [ ] **Step 1: Write the test**
+
+Create `packages/langchain/test/skills.test.ts`:
+
+```ts
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import {
+  applyCapabilities,
+  createCapabilityRegistry,
+  createSkillsMarker,
+} from "@dawn-ai/core"
+
+describe("skills capability — end-to-end shape", () => {
+  let routeDir: string
+
+  beforeEach(() => {
+    routeDir = mkdtempSync(join(tmpdir(), "dawn-skills-e2e-"))
+  })
+
+  afterEach(() => {
+    rmSync(routeDir, { recursive: true, force: true })
+  })
+
+  function writeSkill(name: string, description: string, body: string): void {
+    const dir = join(routeDir, "skills", name)
+    mkdirSync(dir, { recursive: true })
+    writeFileSync(
+      join(dir, "SKILL.md"),
+      `---\ndescription: ${description}\n---\n\n${body}`,
+      "utf8",
+    )
+  }
+
+  it("contributes nothing when skills/ is absent", async () => {
+    const registry = createCapabilityRegistry([createSkillsMarker()])
+    const result = await applyCapabilities(registry, routeDir)
+    expect(result.contributions).toEqual([])
+  })
+
+  it("contributes readSkill tool + prompt fragment when skills/ has at least one skill", async () => {
+    writeSkill("foo", "A foo skill.", "Foo body")
+    writeSkill("bar", "A bar skill.", "Bar body")
+    const registry = createCapabilityRegistry([createSkillsMarker()])
+    const result = await applyCapabilities(registry, routeDir)
+    expect(result.contributions).toHaveLength(1)
+    const contrib = result.contributions[0]?.contribution
+    expect(contrib?.tools?.map((t) => t.name)).toEqual(["readSkill"])
+    expect(contrib?.promptFragment?.placement).toBe("after_user_prompt")
+    const rendered = contrib?.promptFragment?.render({}) ?? ""
+    expect(rendered).toContain("# Skills")
+    expect(rendered).toContain("**bar** — A bar skill.")
+    expect(rendered).toContain("**foo** — A foo skill.")
+  })
+
+  it("readSkill returns the body content for the named skill", async () => {
+    writeSkill("recipe", "Cooking recipe.", "Step 1: heat the pan.\nStep 2: add oil.")
+    const registry = createCapabilityRegistry([createSkillsMarker()])
+    const result = await applyCapabilities(registry, routeDir)
+    const readSkill = result.contributions[0]?.contribution.tools?.[0]
+    const output = await readSkill?.run(
+      { name: "recipe" },
+      { signal: new AbortController().signal },
+    )
+    expect(output).toBe("Step 1: heat the pan.\nStep 2: add oil.")
+  })
+})
+```
+
+- [ ] **Step 2: Run the test**
+
+```bash
+pnpm --filter @dawn-ai/langchain test -- skills.test
+```
+
+Expected: 3/3 pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/langchain/test/skills.test.ts
+git commit -m "test(langchain): skills capability end-to-end shape"
+```
+
+---
+
+## Task 5: Seed example skills in the chat demo + README update
+
+**Files:**
+- Create: `examples/chat/server/src/app/chat/skills/workspace-conventions/SKILL.md`
+- Create: `examples/chat/server/src/app/chat/skills/recover-from-failure/SKILL.md`
+- Modify: `examples/chat/README.md`
+- Modify: `examples/chat/server/src/app/chat/system-prompt.ts` (optional one-line addition)
+
+- [ ] **Step 1: Create the first example skill**
+
+`examples/chat/server/src/app/chat/skills/workspace-conventions/SKILL.md`:
+
+```markdown
+---
+description: Reminders about how Dawn's workspace tools behave and what the path-jail allows.
+---
+
+# Workspace conventions
+
+The four workspace tools (`listDir`, `readFile`, `writeFile`, `runBash`) all
+operate inside `<example>/workspace/`. Reads and writes outside that directory
+are rejected by the path-jail with a clear error.
+
+- All paths are relative to the workspace root.
+- `listDir({ path: "." })` lists the workspace root.
+- `readFile({ path: "AGENTS.md" })` reads the memory file you also see in your
+  system prompt (so reading it again is redundant; prefer the version Dawn
+  injected for you).
+- `runBash` spawns inside the workspace with a hard timeout. Use it for one-shot
+  shell tasks; don't try to start long-lived background processes.
+
+If you get a "Path is outside workspace" error, the path needs to be relative
+to the workspace root and must not contain `..` segments.
+```
+
+- [ ] **Step 2: Create the second example skill**
+
+`examples/chat/server/src/app/chat/skills/recover-from-failure/SKILL.md`:
+
+```markdown
+---
+description: How to recover when a tool call fails — diagnose, not blindly retry.
+---
+
+# Recover from a failed tool call
+
+When a tool call returns an error:
+
+1. **Read the error message first.** Most Dawn tool errors are self-explanatory:
+   path-jail violations, file-too-large, command exit codes.
+2. **Don't retry the exact same call.** If `readFile({ path: "missing.txt" })`
+   returned "ENOENT", calling it again won't help. Either list the directory to
+   find the right name, or use `writeFile` to create the file.
+3. **Check `AGENTS.md` for known conventions before improvising.** The memory
+   file often documents the right approach the previous session figured out.
+4. **If three different approaches fail in a row, stop and ask the user.** Don't
+   keep flailing — explain what you tried and what went wrong.
+5. **Record what worked in `AGENTS.md`** (via `writeFile`) when you find a fix
+   that wasn't already documented. Future-you will thank you.
+```
+
+- [ ] **Step 3: Update example README**
+
+In `examples/chat/README.md`, find the "What this shows" section and add a bullet for skills:
+
+```markdown
+- **Skills** — `src/app/chat/skills/<name>/SKILL.md` files are auto-listed in
+  the agent's system prompt (name + description). The agent calls
+  `readSkill({ name })` to load a skill's full body on demand. Two example
+  skills ship with the demo: `workspace-conventions` and `recover-from-failure`.
+```
+
+Also in the "Deferred (Dawn phase-3 preview)" list near the bottom: remove the
+line about skills if it's there (likely something like `- Skills (skills/ dir + SKILL.md loader) — mirror of the tools/ convention`).
+
+- [ ] **Step 4: Optional — small system-prompt acknowledgment**
+
+In `examples/chat/server/src/app/chat/system-prompt.ts`, append a paragraph after the existing memory convention paragraph (preserve everything else):
+
+```
+When a task matches one of the skills listed below in the "# Skills" section,
+call \`readSkill({ name })\` to load that skill's full instructions before
+proceeding.
+```
+
+(This is optional — Dawn's auto-injected `# Skills` section already tells the
+agent what to do. But repeating it in the user-authored prompt reinforces the
+behavior.)
+
+- [ ] **Step 5: Verify the chat-server still builds + the route's typegen reflects readSkill**
+
+```bash
+pnpm --filter @dawn-example/chat-server build
+pnpm --filter @dawn-example/chat-server check
+cat examples/chat/server/.dawn/dawn.generated.d.ts | grep -A2 readSkill
+```
+
+Expected: build passes; `dawn check` reports the `/chat` route; generated `.d.ts` includes a `readSkill: (input: { name: string }) => Promise<string>` line under `DawnRouteTools["/chat"]`.
+
+(If the generated types don't include `readSkill`, that's the same kind of typegen wiring we had to do for `write_todos` in PR #144 — we'd need to add `readSkill` as a `PLANNING_EXTRA_TOOL`-equivalent in `packages/cli/src/lib/typegen/run-typegen.ts`. Mention as a follow-up in your report if so.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add examples/chat/server/src/app/chat/skills examples/chat/README.md examples/chat/server/src/app/chat/system-prompt.ts
+git commit -m "feat(examples/chat): seed two example skills + README"
+```
+
+---
+
+## Task 6: Full workspace verification
+
+- [ ] **Step 1:** `pnpm install`
+- [ ] **Step 2:** `pnpm build` — expect 11/11 green
+- [ ] **Step 3:** `pnpm typecheck` — expect 12/12
+- [ ] **Step 4:** `pnpm test` — expect previous count + 32 new (~14 frontmatter + ~15 skills + 3 langchain integration), all green
+- [ ] **Step 5:** `pnpm lint` — biome auto-fix any new-file issues; recommit as `style:` if needed
+- [ ] **Step 6:** `pnpm pack:check`
+
+---
+
+## Task 7: Changeset
+
+**Files:**
+- Create: `.changeset/phase3-skills.md`
+
+```markdown
+---
+"@dawn-ai/core": minor
+"@dawn-ai/cli": minor
+---
+
+Add the phase-3 skills capability. A route with `src/app/<route>/skills/<name>/SKILL.md` files now exposes them to the agent via:
+
+- An always-on `# Skills` section in the system prompt listing each skill's name + description
+- A `readSkill({ name })` tool the agent calls to load a skill's full body on demand
+
+Each `SKILL.md` requires YAML frontmatter with `description`; `name` defaults to the directory name and can be overridden. The body lives in conversation history after `readSkill` returns it (not re-injected each turn) — matches the deepagents / Claude Code convention. The chat example ships two seeded skills.
+```
+
+```bash
+git add .changeset/phase3-skills.md
+git commit -m "chore: changeset for phase-3 skills capability"
+```
+
+---
+
+## Task 8: Push + PR (controller-side)
+
+```bash
+git push -u origin claude/skills
+gh pr create --title "feat(core,cli): phase 3 — skills capability" --body <<<...
+gh pr merge <N> --squash --delete-branch --auto
+```
+
+Wait for CI green. Clean up worktree after merge.

--- a/docs/superpowers/specs/2026-05-16-phase3-skills-design.md
+++ b/docs/superpowers/specs/2026-05-16-phase3-skills-design.md
@@ -1,0 +1,297 @@
+# Phase 3 — Skills Capability (Sub-project 2b) — Design
+
+**Date:** 2026-05-16
+**Status:** Draft — pending user approval
+**Owner:** Brian Love
+
+## Summary
+
+Add a built-in skills capability to Dawn agents, opted in by the presence of a `skills/` directory in the route directory. Each skill is `src/app/<route>/skills/<name>/SKILL.md` with YAML frontmatter (required `description`; optional `name` defaulting to the directory name). Dawn auto-injects a `# Skills` section into the system prompt listing every available skill's name + description + how to load it. The agent loads a skill's full body on demand via a new `readSkill(name)` tool. Skill bodies live in conversation history; there is no state channel.
+
+This is the second user-facing capability in the phase-3 program (after planning + AGENTS.md autoload). It exercises the autowiring engine and the tool-injection pathway but **not** the state-mutation API or the `loaded_skills` state channel that an earlier draft assumed — research into deepagents and Claude Code revealed both leaders independently rejected that design. The industry-converged pattern is "list in prompt, body on demand."
+
+## Motivation
+
+For everything beyond the basic agent persona, an author wants to teach the agent *how to do specific things* — "how to debug a Python stack trace," "how to query our DB," "how to format a release note." These are too verbose to bake into the systemPrompt (would dominate every turn) and too specialized to qualify as memory (the agent doesn't need them for every conversation).
+
+Skills are the answer: a directory of named knowledge files the agent reaches for when relevant. The agent sees what's available at all times (a small constant cost in the system prompt — name + description per skill); the bulky body content is only loaded when actually needed.
+
+This unlocks the canonical "harness" use case: dropping in a curated knowledge library and watching the agent select among them.
+
+## Why this design (not the earlier draft)
+
+Earlier in this brainstorming session we sketched: `list_skills()` + `load_skill(name)` tools with a `loaded_skills` state channel that re-injects skill bodies into the system prompt every turn.
+
+Subsequent research found that **deepagents** ([github](https://github.com/langchain-ai/deepagentsjs/blob/main/libs/deepagents/src/middleware/skills.ts)) and **Claude Code** ([docs](https://code.claude.com/docs/en/skills)) independently rejected that design:
+
+- **No new tools** for listing/loading. deepagents reuses its existing `read_file`. Claude Code triggers via `/skill-name` or auto-invocation.
+- **No re-injection of bodies into the system prompt.** Only names + descriptions are always-visible. Bodies live in conversation history as a single tool-result message.
+- **No `unload_skill`.** The agent doesn't need it; the user controls via metadata gating (Claude Code's `paths`, `disable-model-invocation`) and configuration.
+
+We're adopting the same pattern. The earlier draft has been abandoned.
+
+## Non-goals
+
+- **Workspace-mutable skills.** Skill files live in `src/app/<route>/skills/`, source-controlled. The agent cannot create or modify skills. (Future: a `<workspace>/skills/` overlay for agent-learned skills, à la deepagents' multi-source pattern. Deferred.)
+- **Auto-summarization-aware skill retention.** Claude Code preserves the most recent invocation of each skill across compaction. Dawn defers this — when summarization ships as a separate capability, it will know about skills as a documented integration point. For v1, a long-running conversation can lose old skill bodies as messages scroll out.
+- **Skill packs with bundled assets.** Each skill is one markdown file (subdirectory `SKILL.md`); we don't yet support `assets/`, `scripts/`, or auxiliary files alongside. Adding later is additive (the subdirectory structure leaves room).
+- **`allowed-tools` / `model` / per-skill overrides.** Claude Code lets a skill scope which tools / model / context-fork policy it runs under. Powerful but expands the contract; v1 ships with vanilla skills only.
+- **The `loaded_skills` state channel from the earlier draft.** Replaced by "body in conversation history."
+- **`list_skills` / `load_skill` / `unload_skill` tools from the earlier draft.** Replaced by "system-prompt listing + `readSkill(name)`."
+- **State-channel mutation.** Skills don't use the 2c `{result, state}` API. Bodies live in messages, not state.
+
+## User-facing surface
+
+### Author surface — opt in by directory presence
+
+A route has skills if `src/app/<route>/skills/` exists with at least one `<name>/SKILL.md` file inside.
+
+Example layout:
+
+```
+src/app/chat/
+├── index.ts
+├── state.ts
+├── system-prompt.ts
+├── plan.md
+├── tools/
+│   ├── listDir.ts
+│   ├── readFile.ts
+│   ├── writeFile.ts
+│   └── runBash.ts
+└── skills/
+    ├── debug-python/
+    │   └── SKILL.md
+    ├── query-db/
+    │   └── SKILL.md
+    └── deploy-to-fly/
+        └── SKILL.md
+```
+
+Each `SKILL.md` opens with YAML frontmatter:
+
+```markdown
+---
+name: debug-python          # optional; defaults to the directory name ("debug-python")
+description: Step-by-step guide to root-causing a Python stack trace and proposing a fix.
+---
+
+# Debug a Python stack trace
+
+When you see a Python traceback:
+1. Identify the deepest non-library frame …
+…
+```
+
+**`description` is required.** Build fails fast (with the skill's path in the error) if a `SKILL.md` has no `description` field. The description is what the agent sees in the listing — sloppy descriptions yield bad load decisions.
+
+**`name` defaults to the directory name.** If frontmatter provides `name`, it's used as-is. The directory name is the canonical reference even when overridden — `readSkill(name)` accepts whichever the marker registered.
+
+Other frontmatter fields are silently ignored in v1 (so a SKILL.md authored for Claude Code or deepagents is forward-compatible).
+
+### What the agent sees
+
+Every model turn, the system prompt picks up a `# Skills` section between user prompt and other capability fragments:
+
+```
+<user systemPrompt>
+
+# Planning
+…
+
+# Memory
+…
+
+# Skills
+
+The following skills are available. To use one, call `readSkill({ name: "<name>" })` to load its full instructions before acting.
+
+- **debug-python** — Step-by-step guide to root-causing a Python stack trace and proposing a fix.
+- **query-db** — How to write idiomatic queries against our Postgres conventions (decimal money, JSONB params).
+- **deploy-to-fly** — Manual deploy runbook for the staging Fly app.
+```
+
+The fragment text (`The following skills are available…`) is Dawn-locked. The list is dynamic per route.
+
+When the agent decides to use a skill, it calls:
+
+```ts
+readSkill({ name: "debug-python" })
+```
+
+The tool returns the SKILL.md body (frontmatter stripped) as the ToolMessage content. The body is now in the conversation history. On subsequent turns the agent sees the body in its message thread for as long as the messages remain (i.e., until summarization eventually scrolls them out — a v1 limitation).
+
+If the agent calls `readSkill` with an unknown name, the tool returns `"Unknown skill: <name>. Available: debug-python, query-db, deploy-to-fly"` so the model can self-correct.
+
+### What the client sees
+
+No new SSE event type. Skill load is a normal `tool_call` / `tool_result` pair (`name: "readSkill"`). UIs that want to highlight skill loads can filter on that tool name.
+
+## Internal architecture
+
+### Where the marker lives
+
+| Concern | File |
+|---|---|
+| `createSkillsMarker()` factory + frontmatter parser + system-prompt renderer | `packages/core/src/capabilities/built-in/skills.ts` |
+| `readSkill` tool implementation (returns body for a given name) | Same file (built-in capability tool) |
+| YAML frontmatter parser | New helper `packages/core/src/capabilities/built-in/frontmatter.ts` (hand-rolled — no new npm dep; needs only `---` block extraction + minimal key:value parsing) |
+| Unit tests for parser + marker | `packages/core/test/capabilities/skills.test.ts`, `packages/core/test/capabilities/frontmatter.test.ts` |
+| Integration test (apply against a temp route with skills) | `packages/langchain/test/skills.test.ts` |
+
+### `createSkillsMarker()` contract
+
+```ts
+export function createSkillsMarker(): CapabilityMarker
+```
+
+**Detect:** returns `true` iff `<routeDir>/skills/` exists and contains at least one `<name>/SKILL.md`. The presence of an empty `skills/` directory is treated as not-opted-in.
+
+**Load:** scans the `skills/` directory, parses each `SKILL.md`'s frontmatter, validates `description` is present, and returns a contribution with:
+- One `tool`: `readSkill({ name: string }) → string` (the body for the named skill).
+- One `promptFragment` placement `after_user_prompt` whose `render(state)` produces the `# Skills` section, sourced from the parsed list (static — doesn't change at render time).
+- No `stateFields`, no `streamTransformers`.
+
+The skill list is read at marker-load time (once per `prepareRouteExecution` call) and cached on the contribution. Re-reading every turn isn't needed because the listing is static for the route's lifetime.
+
+### Frontmatter parser
+
+We hand-roll a small parser instead of pulling in a dep. Skills frontmatter is simple: it's a `---`-delimited YAML block at the top of the file with flat `key: value` pairs. We don't need full YAML — no nested objects, no arrays, no anchors. The parser:
+
+1. If the file doesn't start with `---\n`, return `{ body: <whole file>, frontmatter: {} }`.
+2. Read up to the second `---\n`. The content between is the frontmatter.
+3. Split by lines; for each `key: value` line, trim and store.
+4. Return `{ body: <everything after the second ---, with one leading newline stripped>, frontmatter: <parsed object> }`.
+
+Edge cases handled in the parser tests below: trailing whitespace, quoted values (`name: "thing"` strips quotes), comments (lines starting with `#`), missing close `---` (treat as no frontmatter).
+
+If down the road we need real YAML, swap to `yaml` (the npm package) without changing the marker's contract. Hand-rolled is fine for v1.
+
+### `readSkill` tool implementation
+
+```ts
+{
+  name: "readSkill",
+  description: "Load the full instructions for a named skill.",
+  schema: z.object({ name: z.string().min(1) }),
+  run: async (input: { name: string }) => {
+    const found = skills.find((s) => s.name === input.name)
+    if (!found) {
+      const available = skills.map((s) => s.name).join(", ")
+      return `Unknown skill: ${input.name}. Available: ${available}`
+    }
+    return found.body
+  },
+}
+```
+
+Plain return (no `{result, state}` wrapper); the body becomes the ToolMessage content via the existing JSON.stringify-or-verbatim-string path from sub-project 2c.
+
+Since `body` is a string and the converter passes strings through verbatim, the agent sees the raw markdown body in its ToolMessage (no surrounding quotes).
+
+### System-prompt fragment rendering
+
+The fragment's `render(_state)` is essentially:
+
+```ts
+const lines = skills.map((s) => `- **${s.name}** — ${s.description}`).join("\n")
+return `${SKILLS_PROMPT_HEADER}\n\n${lines}`
+```
+
+Where `SKILLS_PROMPT_HEADER` is the Dawn-locked block:
+
+```
+# Skills
+
+The following skills are available. To use one, call `readSkill({ name: "<name>" })` to load its full instructions before acting.
+```
+
+This fragment doesn't depend on state; `state` parameter is unused. (The interface still requires it for symmetry with other fragments like planning's `Current plan:`.)
+
+### Composition with other capabilities
+
+In `packages/cli/src/lib/runtime/execute-route.ts`, the registry becomes:
+
+```ts
+const registry = createCapabilityRegistry([
+  createPlanningMarker(),
+  createAgentsMdMarker(),
+  createSkillsMarker(),
+])
+```
+
+Order matters for prompt fragment composition (registration order = render order). Final system prompt structure:
+
+```
+<user systemPrompt>
+
+# Planning            (if plan.md present)
+…
+
+# Memory              (if workspace/AGENTS.md present)
+…
+
+# Skills              (if skills/<name>/SKILL.md files present)
+…
+```
+
+### Conflict detection
+
+The existing engine fails fast on tool-name collisions. If a user has `tools/readSkill.ts`, the build errors with both file paths in the message. (We'd consider this a feature: tools and skills share the agent's tool namespace, so the name needs to be unique.)
+
+State field collisions don't apply — skills contributes no state fields.
+
+## Edge cases & rules
+
+- **`skills/` directory exists but is empty** → `detect` returns `false`. No skills section, no tool injection. Equivalent to no `skills/` at all.
+- **`skills/<name>/` exists but has no `SKILL.md`** (e.g., just an `assets/` folder) → the skill is skipped, not an error. v1 doesn't support asset-only skill subfolders, but doesn't complain about them.
+- **A SKILL.md has no frontmatter** → build fails fast with `"<path>/SKILL.md is missing required frontmatter. Add a YAML block at the top with at least `description: …`."`
+- **A SKILL.md has frontmatter without `description`** → build fails fast with `"<path>/SKILL.md frontmatter is missing required `description` field."`
+- **A skill body is empty** (frontmatter only) → loadable but returns empty string. No special handling; the agent sees an empty ToolMessage. Author's choice.
+- **Skill bodies exceeding the model's context window** → tool returns the full body; the model handles overflow per usual. v1 doesn't truncate; we'd consider a soft cap (e.g., 16 KiB) if real cases emerge.
+- **Two skills resolve to the same `name` after frontmatter overrides** (one's directory is `foo`, another's frontmatter says `name: bar`, plus a separate `bar/`) → build fails fast on name collision with both paths.
+- **Non-UTF-8 SKILL.md** → caught by `readFileSync` in try/catch in the marker's load; surfaced as a build error with the path.
+- **Skill directory name is invalid** (e.g., starts with a dot, contains a space) → flag as not-a-skill silently. Only `<alphanumeric>(<alphanumeric>|-|_)*` is treated as a skill name.
+- **Subdirectories ignored** (e.g., `skills/debug-python/scripts/foo.py`) → present but irrelevant in v1. The marker only looks for `SKILL.md` at exactly `skills/<name>/SKILL.md`.
+
+## Tests
+
+| Test | File |
+|---|---|
+| Frontmatter parser: no frontmatter; single-key; multi-key; quoted values; comments; trailing whitespace; missing close marker; CRLF line endings | `packages/core/test/capabilities/frontmatter.test.ts` |
+| Marker: doesn't detect when no `skills/` directory | `packages/core/test/capabilities/skills.test.ts` |
+| Marker: doesn't detect when `skills/` is empty | same |
+| Marker: detects when at least one `skills/<name>/SKILL.md` exists | same |
+| Marker: load builds a list with each skill's name (default from dir name) + description | same |
+| Marker: load uses `name` from frontmatter when provided, overriding the directory name | same |
+| Marker: load fails fast when a SKILL.md has no frontmatter | same |
+| Marker: load fails fast when frontmatter lacks `description` | same |
+| Marker: load fails fast on duplicate skill names | same |
+| Marker: load ignores subdirectories with no SKILL.md | same |
+| Marker: load skips invalid directory names silently | same |
+| `readSkill` tool: returns body for known skill | same |
+| `readSkill` tool: returns helpful error for unknown skill with list of available | same |
+| Prompt fragment: rendered output contains `# Skills` header + each skill listed | same |
+| Integration: `applyCapabilities` against a temp route directory with two skills produces the expected contribution (tool + fragment, no state fields) | `packages/langchain/test/skills.test.ts` |
+
+No new LLM-touching tests.
+
+## Documentation deliverables
+
+- `examples/chat/README.md` — note that skills are now a shipped capability; remove from "Deferred" section.
+- `examples/chat/server/src/app/chat/skills/` — seed two example skills (`workspace-conventions/SKILL.md` and `recover-from-failure/SKILL.md`) to demonstrate the feature when running the example. Same approach we used for plan.md and AGENTS.md.
+- `examples/chat/server/src/app/chat/system-prompt.ts` — small addition mentioning skills are available (Dawn already lists them in its injected fragment; just one sentence acknowledging the capability).
+
+## Success criteria
+
+- A route with `skills/<name>/SKILL.md` files compiles, the agent's system prompt includes a `# Skills` section listing each skill's name + description, and the agent can call `readSkill({ name })` to get any skill's body as a ToolMessage.
+- A route without `skills/` is byte-for-byte identical in behavior to before this change.
+- Manual smoke: ask the chat-server agent a question that matches one of the seeded skills. Observe a `readSkill` tool call, then an answer that uses the skill's content.
+- All five workspace checks pass: install, build, typecheck, test, lint, pack:check.
+- Frontmatter parser tests cover at least 8 scenarios (per the test list above).
+
+## Open questions
+
+- **`readSkill` body size cap.** Should we soft-cap (e.g., 16 KiB) and return a truncation notice? Skipped for v1; the v1 limit is whatever the agent's context window allows, which is the same as any other large tool result.
+- **Multi-source skill discovery** (project + user + plugin). deepagents supports `sources: [...]` for layered overrides. Dawn v1 supports only `src/app/<route>/skills/` (project). Add layering in v2 when there's a concrete user-skills use case.
+- **Should we ship a small built-in skill library** (e.g., `dawn-builtin/` with skills like "explain your reasoning before acting") that comes free with any Dawn agent? Probably no for v1 — capability authors should own their skill content, not us. Revisit if there's demand.

--- a/examples/chat/README.md
+++ b/examples/chat/README.md
@@ -1,8 +1,8 @@
 # Chat — canonical Dawn harness example
 
-> **Status:** foundational harness primitives (filesystem + bash) + the **planning capability**.
-> Subagents, sandbox isolation, auto-summarization, and skills are still deferred — see
-> "Deferred" below.
+> **Status:** foundational harness primitives (filesystem + bash) + the **planning** and
+> **skills** capabilities. Subagents, sandbox isolation, and auto-summarization are still
+> deferred — see "Deferred" below.
 
 ## What this shows
 
@@ -13,6 +13,10 @@
   `write_todos` tool, a `todos` state channel, and a `plan_update` SSE event. Open the
   smoke client's event log; you'll see `event: plan_update` lines whenever the agent
   updates its plan.
+- **Skills** — `src/app/chat/skills/<name>/SKILL.md` files are auto-listed in
+  the agent's system prompt (name + description). The agent calls
+  `readSkill({ name })` to load a skill's full body on demand. Two example
+  skills ship with the demo: `workspace-conventions` and `recover-from-failure`.
 - End-to-end streaming from a Next.js client over SSE
 
 ## Model choice
@@ -60,7 +64,6 @@ shell expansion — all possible. Do not point untrusted users at this example.
 These v1 deferrals are the explicit forcing function for Dawn's opinionated harness work:
 
 - Subagent delegation (`task`-style tool) — needs first-class subagent declarations
-- Skills (`skills/` dir + `SKILL.md` loader) — mirror of the `tools/` convention
 - Real sandbox isolation for `runBash` — needs pluggable execution backends
 - Tool-output offloading and context summarization — needs lifecycle hooks
 - Nested-object tool inputs (e.g., `edit_file({ edits: [{ old, new }] })`) — typegen extension

--- a/examples/chat/server/src/app/chat/skills/recover-from-failure/SKILL.md
+++ b/examples/chat/server/src/app/chat/skills/recover-from-failure/SKILL.md
@@ -1,0 +1,19 @@
+---
+description: How to recover when a tool call fails — diagnose, not blindly retry.
+---
+
+# Recover from a failed tool call
+
+When a tool call returns an error:
+
+1. **Read the error message first.** Most Dawn tool errors are self-explanatory:
+   path-jail violations, file-too-large, command exit codes.
+2. **Don't retry the exact same call.** If `readFile({ path: "missing.txt" })`
+   returned "ENOENT", calling it again won't help. Either list the directory to
+   find the right name, or use `writeFile` to create the file.
+3. **Check `AGENTS.md` for known conventions before improvising.** The memory
+   file often documents the right approach the previous session figured out.
+4. **If three different approaches fail in a row, stop and ask the user.** Don't
+   keep flailing — explain what you tried and what went wrong.
+5. **Record what worked in `AGENTS.md`** (via `writeFile`) when you find a fix
+   that wasn't already documented. Future-you will thank you.

--- a/examples/chat/server/src/app/chat/skills/workspace-conventions/SKILL.md
+++ b/examples/chat/server/src/app/chat/skills/workspace-conventions/SKILL.md
@@ -1,0 +1,20 @@
+---
+description: Reminders about how Dawn's workspace tools behave and what the path-jail allows.
+---
+
+# Workspace conventions
+
+The four workspace tools (`listDir`, `readFile`, `writeFile`, `runBash`) all
+operate inside `<example>/workspace/`. Reads and writes outside that directory
+are rejected by the path-jail with a clear error.
+
+- All paths are relative to the workspace root.
+- `listDir({ path: "." })` lists the workspace root.
+- `readFile({ path: "AGENTS.md" })` reads the memory file you also see in your
+  system prompt (so reading it again is redundant; prefer the version Dawn
+  injected for you).
+- `runBash` spawns inside the workspace with a hard timeout. Use it for one-shot
+  shell tasks; don't try to start long-lived background processes.
+
+If you get a "Path is outside workspace" error, the path needs to be relative
+to the workspace root and must not contain `..` segments.

--- a/packages/cli/src/lib/runtime/execute-route.ts
+++ b/packages/cli/src/lib/runtime/execute-route.ts
@@ -7,6 +7,7 @@ import {
   createAgentsMdMarker,
   createCapabilityRegistry,
   createPlanningMarker,
+  createSkillsMarker,
   findDawnApp,
   type ResolvedStateField,
   resolveStateFields,
@@ -256,7 +257,11 @@ async function prepareRouteExecution(options: {
   > = []
 
   if (normalized.kind === "agent") {
-    const registry = createCapabilityRegistry([createPlanningMarker(), createAgentsMdMarker()])
+    const registry = createCapabilityRegistry([
+      createPlanningMarker(),
+      createAgentsMdMarker(),
+      createSkillsMarker(),
+    ])
     const applied = await applyCapabilities(registry, routeDir)
 
     if (applied.errors.length > 0) {

--- a/packages/cli/src/lib/typegen/run-typegen.ts
+++ b/packages/cli/src/lib/typegen/run-typegen.ts
@@ -1,4 +1,4 @@
-import { existsSync } from "node:fs"
+import { existsSync, readdirSync, statSync } from "node:fs"
 import { mkdir, writeFile } from "node:fs/promises"
 import { join } from "node:path"
 import type {
@@ -23,6 +23,36 @@ const PLANNING_EXTRA_TOOL: ExtractedToolType = {
   description: "Write or update the planning todo list for this agent.",
   inputType: `{ todos: ReadonlyArray<{ content: string; status: "pending" | "in_progress" | "completed" }> }`,
   outputType: `{ todos: Array<{ content: string; status: "pending" | "in_progress" | "completed" }> }`,
+}
+
+const SKILLS_EXTRA_TOOL: ExtractedToolType = {
+  name: "readSkill",
+  description: "Load the full instructions for a named skill.",
+  inputType: `{ name: string }`,
+  outputType: `string`,
+}
+
+const SKILL_DIR_NAME_RE = /^[A-Za-z0-9][A-Za-z0-9_-]*$/
+
+function hasSkills(routeDir: string): boolean {
+  const skillsDir = join(routeDir, "skills")
+  if (!existsSync(skillsDir)) return false
+  let entries: string[]
+  try {
+    entries = readdirSync(skillsDir)
+  } catch {
+    return false
+  }
+  return entries.some((name) => {
+    if (!SKILL_DIR_NAME_RE.test(name)) return false
+    const full = join(skillsDir, name)
+    try {
+      if (!statSync(full).isDirectory()) return false
+    } catch {
+      return false
+    }
+    return existsSync(join(full, "SKILL.md"))
+  })
 }
 
 export interface TypegenResult {
@@ -57,6 +87,9 @@ export async function runTypegen(options: {
     const extraTools: ExtractedToolType[] = []
     if (existsSync(join(route.routeDir, "plan.md"))) {
       extraTools.push(PLANNING_EXTRA_TOOL)
+    }
+    if (hasSkills(route.routeDir)) {
+      extraTools.push(SKILLS_EXTRA_TOOL)
     }
 
     routeToolTypes.push({

--- a/packages/core/src/capabilities/built-in/frontmatter.ts
+++ b/packages/core/src/capabilities/built-in/frontmatter.ts
@@ -1,0 +1,62 @@
+/**
+ * Minimal YAML-frontmatter parser. Sufficient for Dawn's skill files,
+ * which use a flat `key: value` block at the top delimited by `---` lines.
+ *
+ * Supports: keys, double-quoted values, single-quoted values, `#` comments,
+ * blank lines, CRLF endings, leading/trailing whitespace.
+ *
+ * Does NOT support: nested objects, arrays, multi-line strings, anchors,
+ * any other real YAML feature. If a skill needs full YAML, swap to the
+ * `yaml` npm package without changing this module's contract.
+ */
+export interface ParsedFrontmatter {
+  readonly frontmatter: Readonly<Record<string, string>>
+  readonly body: string
+}
+
+const OPEN_MARKER = /^---\r?\n/
+const CLOSE_MARKER = /\r?\n---\r?\n?/
+
+export function parseFrontmatter(input: string): ParsedFrontmatter {
+  if (!OPEN_MARKER.test(input)) {
+    return { frontmatter: {}, body: input }
+  }
+  const openLen = OPEN_MARKER.exec(input)?.[0].length ?? 0
+  const afterOpen = input.slice(openLen)
+  const closeMatch = CLOSE_MARKER.exec(afterOpen)
+  if (!closeMatch) {
+    return { frontmatter: {}, body: input }
+  }
+  const block = afterOpen.slice(0, closeMatch.index)
+  const bodyStart = closeMatch.index + closeMatch[0].length
+  const body = afterOpen.slice(bodyStart).replace(/^\r?\n/, "")
+  const frontmatter = parseFrontmatterBlock(block)
+  return { frontmatter, body }
+}
+
+function parseFrontmatterBlock(block: string): Record<string, string> {
+  const out: Record<string, string> = {}
+  for (const rawLine of block.split(/\r?\n/)) {
+    const line = rawLine.trim()
+    if (line.length === 0) continue
+    if (line.startsWith("#")) continue
+    const colonIdx = line.indexOf(":")
+    if (colonIdx < 0) continue
+    const key = line.slice(0, colonIdx).trim()
+    if (key.length === 0) continue
+    const rawValue = line.slice(colonIdx + 1).trim()
+    out[key] = stripQuotes(rawValue)
+  }
+  return out
+}
+
+function stripQuotes(value: string): string {
+  if (value.length >= 2) {
+    const first = value[0]
+    const last = value[value.length - 1]
+    if ((first === '"' && last === '"') || (first === "'" && last === "'")) {
+      return value.slice(1, -1)
+    }
+  }
+  return value
+}

--- a/packages/core/src/capabilities/built-in/skills.ts
+++ b/packages/core/src/capabilities/built-in/skills.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync, readdirSync, statSync } from "node:fs"
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs"
 import { join } from "node:path"
 import { z } from "zod"
 import type { CapabilityMarker, PromptFragment } from "../types.js"
@@ -40,7 +40,10 @@ export function createSkillsMarker(): CapabilityMarker {
           const { name } = READ_SKILL_INPUT.parse(input)
           const found = skills.find((s) => s.name === name)
           if (!found) {
-            const available = skills.map((s) => s.name).sort().join(", ")
+            const available = skills
+              .map((s) => s.name)
+              .sort()
+              .join(", ")
             return `Unknown skill: ${name}. Available: ${available}`
           }
           return found.body
@@ -79,7 +82,7 @@ function discoverSkillDirs(routeDir: string): readonly string[] {
   return entries.filter((name) => {
     if (!VALID_DIR_NAME.test(name)) return false
     const full = join(skillsDir, name)
-    let stat
+    let stat: ReturnType<typeof statSync>
     try {
       stat = statSync(full)
     } catch {

--- a/packages/core/src/capabilities/built-in/skills.ts
+++ b/packages/core/src/capabilities/built-in/skills.ts
@@ -1,0 +1,128 @@
+import { existsSync, readFileSync, readdirSync, statSync } from "node:fs"
+import { join } from "node:path"
+import { z } from "zod"
+import type { CapabilityMarker, PromptFragment } from "../types.js"
+import { parseFrontmatter } from "./frontmatter.js"
+
+const SKILLS_DIR = "skills"
+const SKILL_FILE = "SKILL.md"
+// Directory name must be a valid kebab-case-ish identifier. We exclude dotfiles,
+// spaces, and other punctuation that would make a poor agent-facing name.
+const VALID_DIR_NAME = /^[A-Za-z0-9][A-Za-z0-9_-]*$/
+
+const SKILLS_PROMPT_HEADER = `# Skills
+
+The following skills are available. To use one, call \`readSkill({ name: "<name>" })\` to load its full instructions before acting.`
+
+const READ_SKILL_INPUT = z.object({
+  name: z.string().min(1),
+})
+
+interface LoadedSkill {
+  readonly name: string
+  readonly description: string
+  readonly body: string
+  readonly path: string
+}
+
+export function createSkillsMarker(): CapabilityMarker {
+  return {
+    name: "skills",
+    detect: async (routeDir) => discoverSkillDirs(routeDir).length > 0,
+    load: async (routeDir) => {
+      const skills = loadSkills(routeDir)
+
+      const readSkill = {
+        name: "readSkill",
+        description: "Load the full instructions for a named skill.",
+        schema: READ_SKILL_INPUT,
+        run: async (input: unknown) => {
+          const { name } = READ_SKILL_INPUT.parse(input)
+          const found = skills.find((s) => s.name === name)
+          if (!found) {
+            const available = skills.map((s) => s.name).sort().join(", ")
+            return `Unknown skill: ${name}. Available: ${available}`
+          }
+          return found.body
+        },
+      }
+
+      const promptFragment: PromptFragment = {
+        placement: "after_user_prompt",
+        render: () => {
+          const lines = skills
+            .slice()
+            .sort((a, b) => a.name.localeCompare(b.name))
+            .map((s) => `- **${s.name}** — ${s.description}`)
+            .join("\n")
+          return `${SKILLS_PROMPT_HEADER}\n\n${lines}`
+        },
+      }
+
+      return {
+        tools: [readSkill],
+        promptFragment,
+      }
+    },
+  }
+}
+
+function discoverSkillDirs(routeDir: string): readonly string[] {
+  const skillsDir = join(routeDir, SKILLS_DIR)
+  if (!existsSync(skillsDir)) return []
+  let entries: string[]
+  try {
+    entries = readdirSync(skillsDir)
+  } catch {
+    return []
+  }
+  return entries.filter((name) => {
+    if (!VALID_DIR_NAME.test(name)) return false
+    const full = join(skillsDir, name)
+    let stat
+    try {
+      stat = statSync(full)
+    } catch {
+      return false
+    }
+    if (!stat.isDirectory()) return false
+    return existsSync(join(full, SKILL_FILE))
+  })
+}
+
+function loadSkills(routeDir: string): readonly LoadedSkill[] {
+  const dirNames = discoverSkillDirs(routeDir)
+  const loaded: LoadedSkill[] = []
+  const seenNames = new Set<string>()
+
+  for (const dirName of dirNames) {
+    const path = join(routeDir, SKILLS_DIR, dirName, SKILL_FILE)
+    let raw: string
+    try {
+      raw = readFileSync(path, "utf8")
+    } catch (error) {
+      throw new Error(`Failed to read ${path}: ${(error as Error).message}`)
+    }
+    const { frontmatter, body } = parseFrontmatter(raw)
+    if (Object.keys(frontmatter).length === 0) {
+      throw new Error(
+        `${path} is missing required frontmatter. Add a YAML block at the top with at least \`description: …\`.`,
+      )
+    }
+    const description = frontmatter.description
+    if (!description || description.length === 0) {
+      throw new Error(`${path} frontmatter is missing required \`description\` field.`)
+    }
+    const name = frontmatter.name && frontmatter.name.length > 0 ? frontmatter.name : dirName
+    if (seenNames.has(name)) {
+      const dupPath = loaded.find((s) => s.name === name)?.path
+      throw new Error(
+        `Duplicate skill name "${name}" — collision between ${dupPath} and ${path}. Each skill name must be unique.`,
+      )
+    }
+    seenNames.add(name)
+    loaded.push({ name, description, body, path })
+  }
+
+  return loaded
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,6 +1,7 @@
 export { createAgentsMdMarker } from "./capabilities/built-in/agents-md.js"
 export type { RuntimeTodo } from "./capabilities/built-in/planning.js"
 export { createPlanningMarker } from "./capabilities/built-in/planning.js"
+export { createSkillsMarker } from "./capabilities/built-in/skills.js"
 export type {
   AppliedContribution,
   ApplyResult,
@@ -17,7 +18,6 @@ export type {
   StreamTransformerInput,
   StreamTransformerOutput,
 } from "./capabilities/types.js"
-export { createSkillsMarker } from "./capabilities/built-in/skills.js"
 export { loadDawnConfig } from "./config.js"
 export { discoverRoutes } from "./discovery/discover-routes.js"
 export { assertDawnRoutesDir, findDawnApp } from "./discovery/find-dawn-app.js"

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -17,6 +17,7 @@ export type {
   StreamTransformerInput,
   StreamTransformerOutput,
 } from "./capabilities/types.js"
+export { createSkillsMarker } from "./capabilities/built-in/skills.js"
 export { loadDawnConfig } from "./config.js"
 export { discoverRoutes } from "./discovery/discover-routes.js"
 export { assertDawnRoutesDir, findDawnApp } from "./discovery/find-dawn-app.js"

--- a/packages/core/test/capabilities/frontmatter.test.ts
+++ b/packages/core/test/capabilities/frontmatter.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "vitest"
+import { parseFrontmatter } from "../../src/capabilities/built-in/frontmatter.js"
+
+describe("parseFrontmatter", () => {
+  it("returns empty frontmatter and full body when input has no frontmatter", () => {
+    const input = "# Just a heading\n\nSome content."
+    expect(parseFrontmatter(input)).toEqual({
+      frontmatter: {},
+      body: "# Just a heading\n\nSome content.",
+    })
+  })
+
+  it("returns empty frontmatter when missing closing ---", () => {
+    const input = "---\nname: foo\nbody continues"
+    expect(parseFrontmatter(input)).toEqual({
+      frontmatter: {},
+      body: "---\nname: foo\nbody continues",
+    })
+  })
+
+  it("parses a single key/value", () => {
+    const input = "---\nname: debug-python\n---\n\n# Body"
+    expect(parseFrontmatter(input)).toEqual({
+      frontmatter: { name: "debug-python" },
+      body: "# Body",
+    })
+  })
+
+  it("parses multiple keys", () => {
+    const input =
+      "---\nname: debug-python\ndescription: Debug stack traces.\n---\n\n# Body content"
+    expect(parseFrontmatter(input)).toEqual({
+      frontmatter: { name: "debug-python", description: "Debug stack traces." },
+      body: "# Body content",
+    })
+  })
+
+  it("strips surrounding double-quotes from values", () => {
+    const input = '---\nname: "with spaces"\n---\nbody'
+    expect(parseFrontmatter(input)).toEqual({
+      frontmatter: { name: "with spaces" },
+      body: "body",
+    })
+  })
+
+  it("strips surrounding single-quotes from values", () => {
+    const input = "---\nname: 'with spaces'\n---\nbody"
+    expect(parseFrontmatter(input)).toEqual({
+      frontmatter: { name: "with spaces" },
+      body: "body",
+    })
+  })
+
+  it("ignores comment lines (start with #)", () => {
+    const input = "---\n# this is a comment\nname: foo\n# another comment\n---\nbody"
+    expect(parseFrontmatter(input)).toEqual({
+      frontmatter: { name: "foo" },
+      body: "body",
+    })
+  })
+
+  it("ignores blank lines inside frontmatter", () => {
+    const input = "---\nname: foo\n\ndescription: bar\n---\nbody"
+    expect(parseFrontmatter(input)).toEqual({
+      frontmatter: { name: "foo", description: "bar" },
+      body: "body",
+    })
+  })
+
+  it("trims whitespace from keys and values", () => {
+    const input = "---\n  name  :   foo  \n---\nbody"
+    expect(parseFrontmatter(input)).toEqual({
+      frontmatter: { name: "foo" },
+      body: "body",
+    })
+  })
+
+  it("handles CRLF line endings", () => {
+    const input = "---\r\nname: foo\r\n---\r\nbody"
+    expect(parseFrontmatter(input)).toEqual({
+      frontmatter: { name: "foo" },
+      body: "body",
+    })
+  })
+
+  it("preserves multi-line body verbatim (minus the first leading newline)", () => {
+    const input = "---\nname: foo\n---\n\nLine 1\nLine 2\n\nLine 4"
+    expect(parseFrontmatter(input)).toEqual({
+      frontmatter: { name: "foo" },
+      body: "Line 1\nLine 2\n\nLine 4",
+    })
+  })
+
+  it("returns empty body when nothing follows the closing ---", () => {
+    const input = "---\nname: foo\n---"
+    expect(parseFrontmatter(input)).toEqual({
+      frontmatter: { name: "foo" },
+      body: "",
+    })
+  })
+
+  it("returns empty frontmatter (the whole input as body) when input starts with --- but not --- followed by newline", () => {
+    const input = "--- not really frontmatter\nname: foo"
+    expect(parseFrontmatter(input)).toEqual({
+      frontmatter: {},
+      body: "--- not really frontmatter\nname: foo",
+    })
+  })
+
+  it("treats a line without a colon as ignored (no key)", () => {
+    const input = "---\nname: foo\nthis line has no colon\ndescription: bar\n---\nbody"
+    expect(parseFrontmatter(input)).toEqual({
+      frontmatter: { name: "foo", description: "bar" },
+      body: "body",
+    })
+  })
+})

--- a/packages/core/test/capabilities/frontmatter.test.ts
+++ b/packages/core/test/capabilities/frontmatter.test.ts
@@ -27,8 +27,7 @@ describe("parseFrontmatter", () => {
   })
 
   it("parses multiple keys", () => {
-    const input =
-      "---\nname: debug-python\ndescription: Debug stack traces.\n---\n\n# Body content"
+    const input = "---\nname: debug-python\ndescription: Debug stack traces.\n---\n\n# Body content"
     expect(parseFrontmatter(input)).toEqual({
       frontmatter: { name: "debug-python", description: "Debug stack traces." },
       body: "# Body content",

--- a/packages/core/test/capabilities/skills.test.ts
+++ b/packages/core/test/capabilities/skills.test.ts
@@ -75,7 +75,9 @@ describe("createSkillsMarker", () => {
   it("fails fast when a SKILL.md has no frontmatter", async () => {
     writeSkill("bare", "", "# Just a body with no frontmatter")
     const marker = createSkillsMarker()
-    await expect(marker.load(routeDir)).rejects.toThrow(/missing required frontmatter|missing required `description`/i)
+    await expect(marker.load(routeDir)).rejects.toThrow(
+      /missing required frontmatter|missing required `description`/i,
+    )
   })
 
   it("fails fast when frontmatter lacks description", async () => {
@@ -127,9 +129,12 @@ describe("createSkillsMarker", () => {
     const marker = createSkillsMarker()
     const contribution = await marker.load(routeDir)
     const readSkill = contribution.tools?.[0]
-    const result = await readSkill?.run({ name: "foo" }, {
-      signal: new AbortController().signal,
-    })
+    const result = await readSkill?.run(
+      { name: "foo" },
+      {
+        signal: new AbortController().signal,
+      },
+    )
     expect(result).toBe("FOO BODY CONTENT")
   })
 
@@ -139,9 +144,12 @@ describe("createSkillsMarker", () => {
     const marker = createSkillsMarker()
     const contribution = await marker.load(routeDir)
     const readSkill = contribution.tools?.[0]
-    const result = await readSkill?.run({ name: "nope" }, {
-      signal: new AbortController().signal,
-    })
+    const result = await readSkill?.run(
+      { name: "nope" },
+      {
+        signal: new AbortController().signal,
+      },
+    )
     expect(result).toContain("Unknown skill: nope")
     expect(result).toContain("bar")
     expect(result).toContain("foo")

--- a/packages/core/test/capabilities/skills.test.ts
+++ b/packages/core/test/capabilities/skills.test.ts
@@ -1,0 +1,159 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import { createSkillsMarker } from "../../src/capabilities/built-in/skills.js"
+
+describe("createSkillsMarker", () => {
+  let routeDir: string
+
+  beforeEach(() => {
+    routeDir = mkdtempSync(join(tmpdir(), "dawn-skills-"))
+  })
+
+  afterEach(() => {
+    rmSync(routeDir, { recursive: true, force: true })
+  })
+
+  function writeSkill(name: string, frontmatter: string, body: string): void {
+    const dir = join(routeDir, "skills", name)
+    mkdirSync(dir, { recursive: true })
+    const content = frontmatter ? `---\n${frontmatter}\n---\n\n${body}` : body
+    writeFileSync(join(dir, "SKILL.md"), content, "utf8")
+  }
+
+  it("does not detect when skills/ directory is absent", async () => {
+    const marker = createSkillsMarker()
+    expect(await marker.detect(routeDir)).toBe(false)
+  })
+
+  it("does not detect when skills/ exists but is empty", async () => {
+    mkdirSync(join(routeDir, "skills"), { recursive: true })
+    const marker = createSkillsMarker()
+    expect(await marker.detect(routeDir)).toBe(false)
+  })
+
+  it("does not detect when skills/<name>/ has no SKILL.md", async () => {
+    mkdirSync(join(routeDir, "skills", "stub"), { recursive: true })
+    const marker = createSkillsMarker()
+    expect(await marker.detect(routeDir)).toBe(false)
+  })
+
+  it("detects when at least one skills/<name>/SKILL.md exists", async () => {
+    writeSkill("foo", "description: A foo skill.", "body")
+    const marker = createSkillsMarker()
+    expect(await marker.detect(routeDir)).toBe(true)
+  })
+
+  it("load contributes exactly one tool (readSkill) and one promptFragment, no state/transformers", async () => {
+    writeSkill("foo", "description: A foo skill.", "body")
+    const marker = createSkillsMarker()
+    const contribution = await marker.load(routeDir)
+    expect(contribution.tools?.map((t) => t.name)).toEqual(["readSkill"])
+    expect(contribution.promptFragment?.placement).toBe("after_user_prompt")
+    expect(contribution.stateFields).toBeUndefined()
+    expect(contribution.streamTransformers).toBeUndefined()
+  })
+
+  it("uses directory name as the skill name when frontmatter omits it", async () => {
+    writeSkill("debug-python", "description: Debug Python.", "# Body")
+    const marker = createSkillsMarker()
+    const contribution = await marker.load(routeDir)
+    const rendered = contribution.promptFragment?.render({}) ?? ""
+    expect(rendered).toContain("**debug-python** — Debug Python.")
+  })
+
+  it("uses frontmatter.name when provided, overriding the directory name", async () => {
+    writeSkill("dir-name", "name: override-name\ndescription: Overridden.", "body")
+    const marker = createSkillsMarker()
+    const contribution = await marker.load(routeDir)
+    const rendered = contribution.promptFragment?.render({}) ?? ""
+    expect(rendered).toContain("**override-name** — Overridden.")
+    expect(rendered).not.toContain("**dir-name**")
+  })
+
+  it("fails fast when a SKILL.md has no frontmatter", async () => {
+    writeSkill("bare", "", "# Just a body with no frontmatter")
+    const marker = createSkillsMarker()
+    await expect(marker.load(routeDir)).rejects.toThrow(/missing required frontmatter|missing required `description`/i)
+  })
+
+  it("fails fast when frontmatter lacks description", async () => {
+    writeSkill("no-desc", "name: no-desc", "body")
+    const marker = createSkillsMarker()
+    await expect(marker.load(routeDir)).rejects.toThrow(/missing required `description`/i)
+  })
+
+  it("fails fast when two skills resolve to the same name", async () => {
+    writeSkill("foo", "description: First.", "body")
+    writeSkill("bar", "name: foo\ndescription: Duplicate.", "body")
+    const marker = createSkillsMarker()
+    await expect(marker.load(routeDir)).rejects.toThrow(/duplicate skill name/i)
+  })
+
+  it("skips invalid directory names silently (leading dot or spaces)", async () => {
+    writeSkill("good", "description: Good one.", "body")
+    mkdirSync(join(routeDir, "skills", ".hidden"), { recursive: true })
+    writeFileSync(
+      join(routeDir, "skills", ".hidden", "SKILL.md"),
+      "---\ndescription: Hidden.\n---\nbody",
+      "utf8",
+    )
+    mkdirSync(join(routeDir, "skills", "has spaces"), { recursive: true })
+    writeFileSync(
+      join(routeDir, "skills", "has spaces", "SKILL.md"),
+      "---\ndescription: Spaced.\n---\nbody",
+      "utf8",
+    )
+    const marker = createSkillsMarker()
+    const contribution = await marker.load(routeDir)
+    const rendered = contribution.promptFragment?.render({}) ?? ""
+    expect(rendered).toContain("**good**")
+    expect(rendered).not.toContain("**.hidden**")
+    expect(rendered).not.toContain("has spaces")
+  })
+
+  it("rendered prompt fragment includes a '# Skills' header and a readSkill instruction", async () => {
+    writeSkill("foo", "description: A foo skill.", "body")
+    const marker = createSkillsMarker()
+    const contribution = await marker.load(routeDir)
+    const rendered = contribution.promptFragment?.render({}) ?? ""
+    expect(rendered).toContain("# Skills")
+    expect(rendered).toContain('readSkill({ name: "<name>" })')
+  })
+
+  it("readSkill returns the body for a known skill", async () => {
+    writeSkill("foo", "description: A foo skill.", "FOO BODY CONTENT")
+    const marker = createSkillsMarker()
+    const contribution = await marker.load(routeDir)
+    const readSkill = contribution.tools?.[0]
+    const result = await readSkill?.run({ name: "foo" }, {
+      signal: new AbortController().signal,
+    })
+    expect(result).toBe("FOO BODY CONTENT")
+  })
+
+  it("readSkill returns a helpful error for an unknown skill, listing what's available", async () => {
+    writeSkill("foo", "description: A.", "body")
+    writeSkill("bar", "description: B.", "body")
+    const marker = createSkillsMarker()
+    const contribution = await marker.load(routeDir)
+    const readSkill = contribution.tools?.[0]
+    const result = await readSkill?.run({ name: "nope" }, {
+      signal: new AbortController().signal,
+    })
+    expect(result).toContain("Unknown skill: nope")
+    expect(result).toContain("bar")
+    expect(result).toContain("foo")
+  })
+
+  it("readSkill validates input shape (rejects non-string name)", async () => {
+    writeSkill("foo", "description: A.", "body")
+    const marker = createSkillsMarker()
+    const contribution = await marker.load(routeDir)
+    const readSkill = contribution.tools?.[0]
+    await expect(async () => {
+      await readSkill?.run({ name: 42 }, { signal: new AbortController().signal })
+    }).rejects.toThrow()
+  })
+})

--- a/packages/langchain/test/skills.test.ts
+++ b/packages/langchain/test/skills.test.ts
@@ -1,0 +1,64 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import {
+  applyCapabilities,
+  createCapabilityRegistry,
+  createSkillsMarker,
+} from "@dawn-ai/core"
+
+describe("skills capability — end-to-end shape", () => {
+  let routeDir: string
+
+  beforeEach(() => {
+    routeDir = mkdtempSync(join(tmpdir(), "dawn-skills-e2e-"))
+  })
+
+  afterEach(() => {
+    rmSync(routeDir, { recursive: true, force: true })
+  })
+
+  function writeSkill(name: string, description: string, body: string): void {
+    const dir = join(routeDir, "skills", name)
+    mkdirSync(dir, { recursive: true })
+    writeFileSync(
+      join(dir, "SKILL.md"),
+      `---\ndescription: ${description}\n---\n\n${body}`,
+      "utf8",
+    )
+  }
+
+  it("contributes nothing when skills/ is absent", async () => {
+    const registry = createCapabilityRegistry([createSkillsMarker()])
+    const result = await applyCapabilities(registry, routeDir)
+    expect(result.contributions).toEqual([])
+  })
+
+  it("contributes readSkill tool + prompt fragment when skills/ has at least one skill", async () => {
+    writeSkill("foo", "A foo skill.", "Foo body")
+    writeSkill("bar", "A bar skill.", "Bar body")
+    const registry = createCapabilityRegistry([createSkillsMarker()])
+    const result = await applyCapabilities(registry, routeDir)
+    expect(result.contributions).toHaveLength(1)
+    const contrib = result.contributions[0]?.contribution
+    expect(contrib?.tools?.map((t) => t.name)).toEqual(["readSkill"])
+    expect(contrib?.promptFragment?.placement).toBe("after_user_prompt")
+    const rendered = contrib?.promptFragment?.render({}) ?? ""
+    expect(rendered).toContain("# Skills")
+    expect(rendered).toContain("**bar** — A bar skill.")
+    expect(rendered).toContain("**foo** — A foo skill.")
+  })
+
+  it("readSkill returns the body content for the named skill", async () => {
+    writeSkill("recipe", "Cooking recipe.", "Step 1: heat the pan.\nStep 2: add oil.")
+    const registry = createCapabilityRegistry([createSkillsMarker()])
+    const result = await applyCapabilities(registry, routeDir)
+    const readSkill = result.contributions[0]?.contribution.tools?.[0]
+    const output = await readSkill?.run(
+      { name: "recipe" },
+      { signal: new AbortController().signal },
+    )
+    expect(output).toBe("Step 1: heat the pan.\nStep 2: add oil.")
+  })
+})

--- a/packages/langchain/test/skills.test.ts
+++ b/packages/langchain/test/skills.test.ts
@@ -1,12 +1,8 @@
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
+import { applyCapabilities, createCapabilityRegistry, createSkillsMarker } from "@dawn-ai/core"
 import { afterEach, beforeEach, describe, expect, it } from "vitest"
-import {
-  applyCapabilities,
-  createCapabilityRegistry,
-  createSkillsMarker,
-} from "@dawn-ai/core"
 
 describe("skills capability — end-to-end shape", () => {
   let routeDir: string
@@ -22,11 +18,7 @@ describe("skills capability — end-to-end shape", () => {
   function writeSkill(name: string, description: string, body: string): void {
     const dir = join(routeDir, "skills", name)
     mkdirSync(dir, { recursive: true })
-    writeFileSync(
-      join(dir, "SKILL.md"),
-      `---\ndescription: ${description}\n---\n\n${body}`,
-      "utf8",
-    )
+    writeFileSync(join(dir, "SKILL.md"), `---\ndescription: ${description}\n---\n\n${body}`, "utf8")
   }
 
   it("contributes nothing when skills/ is absent", async () => {


### PR DESCRIPTION
## Summary
Third phase-3 capability after planning (#144) and AGENTS.md autoload (#146). Adds a built-in skills system: any route with \`src/app/<route>/skills/<name>/SKILL.md\` files automatically gets a \`# Skills\` section in its system prompt and a \`readSkill({ name })\` tool the agent calls to load skill bodies on demand.

## Why this design
Deep research into deepagents + Claude Code revealed both leaders independently rejected the "load_skill tool + state channel that re-injects bodies every turn" pattern. The industry-converged design:

- **Only skill name + description** live in the system prompt, always
- **Bodies loaded on demand** via a read tool (here: \`readSkill\`)
- **No \`load_skill\` / \`unload_skill\` tools** — bodies just live in conversation history
- **No state channel** — explicitly NOT using the 2c \`{result, state}\` API

This matches deepagents' \`createSkillsMiddleware\` and Claude Code's skills system. SKILL.md frontmatter is compatible with both, so authors can port skills in either direction.

## Spec & plan
- Spec: \`docs/superpowers/specs/2026-05-16-phase3-skills-design.md\`
- Plan: \`docs/superpowers/plans/2026-05-16-phase3-skills.md\`

## What changes
- **\`@dawn-ai/core\`**: new \`capabilities/built-in/frontmatter.ts\` (14 tests) — minimal YAML parser; \`capabilities/built-in/skills.ts\` (15 tests) — \`createSkillsMarker\` + \`readSkill\` tool. Hand-rolled parser, no new npm dep.
- **\`@dawn-ai/cli\`**: registers \`createSkillsMarker()\` in the runtime alongside planning + agents-md. Typegen extended to include \`readSkill\` in \`RouteTools\` when a route has \`skills/\`.
- **\`examples/chat\`**: two seeded SKILL.md files (\`workspace-conventions\`, \`recover-from-failure\`) demonstrate the convention. README updated.

## File layout
\`\`\`
src/app/<route>/skills/
├── <name>/
│   └── SKILL.md          # YAML frontmatter (description required, name optional)
└── ...
\`\`\`

## Edge cases handled (per spec)
- skills/ absent or empty → no opt-in
- skills/<name>/ without SKILL.md → silently ignored
- SKILL.md missing frontmatter → build fails fast with file path
- frontmatter without description → build fails fast
- duplicate skill names (across frontmatter overrides) → build fails fast
- invalid directory names (dotfiles, spaces) → silently skipped
- readSkill on unknown name → returns helpful error listing available skills

## Test plan
- [x] \`pnpm install\`
- [x] \`pnpm build\` — 11/11
- [x] \`pnpm typecheck\` — 12/12
- [x] \`pnpm test\` — 423/423 (+32 new: 14 frontmatter + 15 skills marker + 3 langchain integration)
- [x] \`pnpm lint\` — clean
- [x] \`pnpm pack:check\` — passes
- [x] Generated \`.dawn/dawn.generated.d.ts\` for the chat-server route includes \`readSkill: (input: { name: string }) => Promise<string>\` under \`DawnRouteTools["/chat"]\`

## Note on the 2c state-mutation API
Skills do NOT use it. We built sub-project 2c expecting Skills would need a \`loaded_skills\` state channel. Research changed that — the API is still valuable for future capabilities, just not this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)