### PR TITLE
fix(langchain): preserve user messages with capability prompts

### DIFF
--- a/packages/cli/src/lib/dev/classify-change.ts
+++ b/packages/cli/src/lib/dev/classify-change.ts
@@ -1,6 +1,10 @@
-export type ChangeClassification = "typegen" | "restart"
+export type ChangeClassification = "ignore" | "typegen" | "restart"
 
 export function classifyChange(relativePath: string): ChangeClassification {
+  if (relativePath === "workspace" || relativePath.startsWith("workspace/")) {
+    return "ignore"
+  }
+
   // Tool files: any path containing /tools/<name>.ts (not .d.ts)
   if (/\/tools\/[^/]+\.ts$/.test(relativePath) && !relativePath.endsWith(".d.ts")) {
     return "typegen"

--- a/packages/cli/src/lib/dev/dev-session.ts
+++ b/packages/cli/src/lib/dev/dev-session.ts
@@ -184,6 +184,10 @@ class InternalDevSession {
 
     const classification = classifyChange(relative)
 
+    if (classification === "ignore") {
+      return
+    }
+
     if (classification === "typegen") {
       this.scheduleTypegen()
     } else {

--- a/packages/cli/test/classify-change.test.ts
+++ b/packages/cli/test/classify-change.test.ts
@@ -33,4 +33,9 @@ describe("classifyChange", () => {
   test(".d.ts file in tools returns restart (not a real tool)", () => {
     expect(classifyChange("src/app/hello/[tenant]/tools/greet.d.ts")).toBe("restart")
   })
+
+  test("workspace runtime data changes are ignored", () => {
+    expect(classifyChange("workspace/AGENTS.md")).toBe("ignore")
+    expect(classifyChange("workspace/notes/output.md")).toBe("ignore")
+  })
 })

--- a/packages/langchain/src/agent-adapter.ts
+++ b/packages/langchain/src/agent-adapter.ts
@@ -1,7 +1,7 @@
 import type { PromptFragment, StreamTransformer } from "@dawn-ai/core"
 import type { DawnAgent, RetryConfig } from "@dawn-ai/sdk"
 import { isDawnAgent } from "@dawn-ai/sdk"
-import { HumanMessage } from "@langchain/core/messages"
+import { type BaseMessageLike, HumanMessage } from "@langchain/core/messages"
 import { isRetryableError, withRetry } from "./retry.js"
 import { materializeStateSchema, type ResolvedStateField } from "./state-adapter.js"
 import { convertToolToLangChain } from "./tool-converter.js"
@@ -40,6 +40,20 @@ function assertAgentLike(entry: unknown): asserts entry is AgentLike {
 // changes, the cache key must include a hash of the fragments/transformers.
 const materializedAgents = new WeakMap<DawnAgent, AgentLike>()
 
+export function composePromptMessages(
+  systemPrompt: string,
+  promptFragments: readonly PromptFragment[],
+  state: Record<string, unknown>,
+): BaseMessageLike[] {
+  const rendered = promptFragments
+    .filter((f) => f.placement === "after_user_prompt")
+    .map((f) => f.render(state))
+    .filter((s) => s.length > 0)
+  const composed = [systemPrompt, ...rendered].join("\n\n")
+  const messages = Array.isArray(state.messages) ? (state.messages as BaseMessageLike[]) : []
+  return [{ role: "system", content: composed }, ...messages]
+}
+
 async function materializeAgent(
   descriptor: DawnAgent,
   tools: readonly DawnToolDefinition[],
@@ -73,14 +87,8 @@ async function materializeAgent(
     // can reflect live state (e.g., the current todos list).
     prompt:
       fragments.length > 0
-        ? (state: Record<string, unknown>) => {
-            const rendered = fragments
-              .filter((f) => f.placement === "after_user_prompt")
-              .map((f) => f.render(state))
-              .filter((s) => s.length > 0)
-            const composed = [descriptor.systemPrompt, ...rendered].join("\n\n")
-            return [{ role: "system", content: composed }]
-          }
+        ? (state: Record<string, unknown>) =>
+            composePromptMessages(descriptor.systemPrompt, fragments, state)
         : descriptor.systemPrompt,
   }
 

--- a/packages/langchain/test/agent-prompt-fragments.test.ts
+++ b/packages/langchain/test/agent-prompt-fragments.test.ts
@@ -1,0 +1,26 @@
+import { HumanMessage } from "@langchain/core/messages"
+import { describe, expect, it } from "vitest"
+import { composePromptMessages } from "../src/agent-adapter.js"
+
+describe("agent prompt fragments", () => {
+  it("prepends the composed system prompt without dropping state messages", () => {
+    const messages = [new HumanMessage("Read the skill, then update AGENTS.md.")]
+    const rendered = composePromptMessages(
+      "Base system prompt.",
+      [
+        {
+          placement: "after_user_prompt",
+          render: (state) => `Current plan: ${String(state.todos ?? "(empty)")}`,
+        },
+      ],
+      { messages, todos: "(empty)" },
+    )
+
+    expect(rendered).toHaveLength(2)
+    expect(rendered[0]).toEqual({
+      role: "system",
+      content: "Base system prompt.\n\nCurrent plan: (empty)",
+    })
+    expect(rendered[1]).toBe(messages[0])
+  })
+})


### PR DESCRIPTION
## Summary

Fixes the chat example agent drift by correcting the Dawn LangChain adapter's function-form prompt wiring. LangGraph treats a function `prompt` as the complete LLM input; Dawn was returning only the composed system prompt when capability fragments were present, so the model never saw the user's message and improvised unrelated coding tasks.

Also prevents `dawn dev` from restarting when the agent writes runtime data under `workspace/`, which was cutting off successful chat-example runs immediately after `writeFile`.

## Changes

- Preserve `state.messages` when rendering capability prompt fragments, by returning `[composed system message, ...state.messages]`.
- Add a regression test for prompt fragment composition so user messages cannot be dropped again.
- Classify `workspace/` changes as `ignore` in the dev watcher so AGENTS.md/file writes do not kill in-flight runs.
- Add CLI classification coverage for ignored workspace runtime data.

## Root Cause

There were two separate issues visible in the smoke client:

1. **Primary drift/loop root cause:** capability fragments switched Dawn from a string prompt to LangGraph's function-form `prompt`. For string prompts, LangGraph prepends a SystemMessage to `state.messages`. For function prompts, LangGraph passes the function result directly to the model. Dawn returned only the system prompt, dropping the user message. That explains the consistent off-script Python/Flask/GitHub-report hallucinations.
2. **Post-fix run cutoff:** once the model actually followed the request and called `writeFile`, the dev watcher saw `workspace/*` as source changes, restarted the runtime child, and turned the final event into `Runtime server shutting down`.

## Manual Chrome Smoke

Baseline on `origin/main` / `2ba0773`, prompt: `Read the recover-from-failure skill, give me a 2-bullet TL;DR, then append a note to AGENTS.md.`

- tool calls: 7
- plan_update events: 6
- `readSkill`: 0
- `writeFile`: 1, against `app.py`
- `write_todos`: 6 tool calls / 18 log mentions
- final: `Runtime server shutting down`
- behavior: hallucinated Flask app task (`Create minimal Flask app.py that returns 'Hello, World!'`), never loaded the requested skill, never updated AGENTS.md.

After this PR, same original chat prompt stack (`gpt-5`, high reasoning, planning + AGENTS.md + skills):

| Probe | Tool calls | readSkill | writeFile | write_todos | plan_update | Final |
| --- | ---: | ---: | ---: | ---: | ---: | --- |
| recover-from-failure -> append AGENTS.md | 4 | 1 | 1 | 2 | 2 | `TL;DR` with 2 bullets; notes AGENTS.md updated |
| workspace-conventions -> write summary file | 6 | 1 | 1 | 4 | 4 | 2-bullet TL;DR; notes file written |
| recover-from-failure -> write retry-rule.md | 5 | 1 | 1 | 3 | 3 | confirms skill loaded and file written |

Across all 3 fixed probes:

- no recursion-limit error
- no Python/Flask/scaffold/GitHub-report hallucination
- `readSkill` called exactly once per probe
- `writeFile` called exactly once per probe
- final assistant message returned successfully

## Verification

- `pnpm --filter @dawn-ai/langchain test -- agent-prompt-fragments.test.ts` (red before fix, green after)
- `pnpm --filter @dawn-ai/cli test -- classify-change.test.ts` (red before watcher fix, green after)
- `pnpm build`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test` (63 files, 425 tests)