### PR TITLE
feat: subagent stream bubbling + web picker + descriptor map caching

### DIFF
--- a/examples/chat/web/app/api/chat/route.ts
+++ b/examples/chat/web/app/api/chat/route.ts
@@ -8,21 +8,28 @@ export async function POST(req: NextRequest): Promise<Response> {
   const body = (await req.json()) as {
     threadId: string
     message: string
+    route?: string
   }
+
+  // Route picker: default to /chat for back-compat. /coordinator demonstrates
+  // the subagents capability with research + summarizer specialists.
+  const routeId = body.route === "coordinator" ? "/coordinator" : "/chat"
+  const routePath =
+    routeId === "/coordinator" ? "src/app/coordinator/index.ts" : "src/app/chat/index.ts"
 
   const upstream = await fetch(`${serverUrl}/runs/stream`, {
     method: "POST",
     headers: { "content-type": "application/json" },
     body: JSON.stringify({
-      assistant_id: "/chat#agent",
+      assistant_id: `${routeId}#agent`,
       input: {
         messages: [{ role: "user", content: body.message }],
       },
       metadata: {
         dawn: {
           mode: "agent",
-          route_id: "/chat",
-          route_path: "src/app/chat/index.ts",
+          route_id: routeId,
+          route_path: routePath,
           thread_id: body.threadId,
         },
       },

--- a/examples/chat/web/app/page.tsx
+++ b/examples/chat/web/app/page.tsx
@@ -6,11 +6,22 @@ function newThreadId(): string {
   return `t-${Math.random().toString(36).slice(2, 10)}`
 }
 
+type RouteId = "chat" | "coordinator"
+
 export default function Page() {
   const [threadId, setThreadId] = useState<string | null>(null)
   const [input, setInput] = useState("")
   const [events, setEvents] = useState<string[]>([])
   const [busy, setBusy] = useState(false)
+  const [route, setRoute] = useState<RouteId>("chat")
+
+  function switchRoute(next: RouteId) {
+    if (next === route) return
+    setRoute(next)
+    // New conversation when switching routes — each route has its own thread.
+    setThreadId(null)
+    setEvents([])
+  }
 
   async function send() {
     const tid = threadId ?? newThreadId()
@@ -24,7 +35,7 @@ export default function Page() {
     const res = await fetch("/api/chat", {
       method: "POST",
       headers: { "content-type": "application/json" },
-      body: JSON.stringify({ threadId: tid, message: msg }),
+      body: JSON.stringify({ threadId: tid, message: msg, route }),
     })
 
     if (!res.body) {
@@ -57,6 +68,34 @@ export default function Page() {
       <p style={{ color: "#666", fontSize: "0.9rem" }}>
         Disposable. Streams raw SSE events from <code>/api/chat</code>. See <code>README.md</code> for context.
       </p>
+      <div
+        role="radiogroup"
+        aria-label="Route"
+        style={{ display: "flex", gap: "0.5rem", margin: "0.5rem 0", fontSize: "0.9rem" }}
+      >
+        <label style={{ cursor: "pointer" }}>
+          <input
+            type="radio"
+            name="route"
+            value="chat"
+            checked={route === "chat"}
+            onChange={() => switchRoute("chat")}
+            disabled={busy}
+          />{" "}
+          /chat <span style={{ color: "#888" }}>(planning + skills + workspace tools)</span>
+        </label>
+        <label style={{ cursor: "pointer" }}>
+          <input
+            type="radio"
+            name="route"
+            value="coordinator"
+            checked={route === "coordinator"}
+            onChange={() => switchRoute("coordinator")}
+            disabled={busy}
+          />{" "}
+          /coordinator <span style={{ color: "#888" }}>(dispatches to research + summarizer)</span>
+        </label>
+      </div>
       <textarea
         value={input}
         onChange={(e) => setInput(e.target.value)}

--- a/packages/cli/src/lib/runtime/execute-route.ts
+++ b/packages/cli/src/lib/runtime/execute-route.ts
@@ -279,17 +279,12 @@ async function prepareRouteExecution(options: {
     const descriptor =
       normalized.kind === "agent" && isDawnAgent(normalized.entry) ? normalized.entry : undefined
 
-    // Lazily build a descriptor->routeId identity map by dynamically importing
-    // each route's entry file. This is required by the subagents marker to
-    // resolve `descriptor.subagents: [...]` overrides. Built once per
-    // prepareRouteExecution call (which is per request) — not a hot loop.
-    let cachedDescriptorMap: ReadonlyMap<DawnAgent, string> | undefined
-    const getDescriptorRouteMap = async (): Promise<ReadonlyMap<DawnAgent, string>> => {
-      if (cachedDescriptorMap) return cachedDescriptorMap
-      cachedDescriptorMap = await buildDescriptorRouteMap(routeManifest)
-      return cachedDescriptorMap
-    }
-    const descriptorRouteMap = await getDescriptorRouteMap()
+    // Build (or reuse) the descriptor->routeId identity map used by the
+    // subagents marker to resolve `agent({ subagents: [imported] })` overrides.
+    // The cache is keyed on the manifest object identity: stable across
+    // requests in production (one manifest per CLI invocation), naturally
+    // invalidated in dev when the runtime rebuilds the manifest.
+    const descriptorRouteMap = await getCachedDescriptorRouteMap(routeManifest)
 
     const applied = await applyCapabilities(registry, routeDir, {
       routeManifest,
@@ -615,6 +610,29 @@ function extractRouteParamNames(routeId: string): string[] {
  * Cost: this opens every agent route module in the manifest. Acceptable for
  * the current scale; if it becomes hot, cache by (appRoot, manifest-hash).
  */
+let descriptorRouteMapCache = new WeakMap<RouteManifest, Promise<ReadonlyMap<DawnAgent, string>>>()
+
+async function getCachedDescriptorRouteMap(
+  manifest: RouteManifest,
+): Promise<ReadonlyMap<DawnAgent, string>> {
+  let promise = descriptorRouteMapCache.get(manifest)
+  if (!promise) {
+    promise = buildDescriptorRouteMap(manifest)
+    descriptorRouteMapCache.set(manifest, promise)
+  }
+  return promise
+}
+
+export { getCachedDescriptorRouteMap }
+
+/**
+ * Test-only: reset the WeakMap-backed cache. Not exported via the package
+ * barrel — internal to this module's test suite.
+ */
+export function __resetDescriptorRouteMapCacheForTests(): void {
+  descriptorRouteMapCache = new WeakMap()
+}
+
 async function buildDescriptorRouteMap(
   manifest: RouteManifest,
 ): Promise<ReadonlyMap<DawnAgent, string>> {

--- a/packages/cli/src/lib/runtime/execute-route.ts
+++ b/packages/cli/src/lib/runtime/execute-route.ts
@@ -644,8 +644,10 @@ async function buildDescriptorRouteMap(
  *   1. Convention: route at `<routeDir>/subagents/<leaf>`
  *   2. Override: descriptor.subagents[i] whose routeId's last segment === leaf
  *
- * Streaming child events through executeResolvedRoute is deferred for v1;
- * the dispatcher's `invoke()` fallback emits one final subagent.end event.
+ * The returned graph exposes both `invoke` (one-shot) and `dawnStream`
+ * (yields Dawn StreamChunks). The dispatcher prefers `dawnStream` so
+ * intermediate child events (tool calls, tokens, capability events) bubble
+ * up to the parent stream as `subagent.<type>` envelopes.
  */
 function buildSubagentResolver(args: {
   readonly appRoot: string
@@ -702,6 +704,19 @@ function buildSubagentResolver(args: {
         // executeAgent's output for an agent-kind route is the raw
         // LangGraph state ({messages, ...}). Forward as-is.
         return result.output
+      },
+      // Stream child events so the parent stream can bubble subagent.*
+      // envelopes for intermediate tool calls, tokens, and capability events.
+      dawnStream: async function* (input: unknown, _config: unknown) {
+        for await (const chunk of streamResolvedRoute({
+          appRoot,
+          input,
+          routeFile: route.entryFile,
+          routeId: route.id,
+          routePath: route.pathname,
+        })) {
+          yield chunk
+        }
       },
     }
 

--- a/packages/cli/test/descriptor-route-map-cache.test.ts
+++ b/packages/cli/test/descriptor-route-map-cache.test.ts
@@ -9,9 +9,7 @@ import {
   getCachedDescriptorRouteMap,
 } from "../src/lib/runtime/execute-route.js"
 
-function manifest(
-  routes: { id: string; entryFile: string; routeDir: string }[],
-): RouteManifest {
+function manifest(routes: { id: string; entryFile: string; routeDir: string }[]): RouteManifest {
   return {
     appRoot: "/tmp",
     routes: routes.map((r) => ({

--- a/packages/cli/test/descriptor-route-map-cache.test.ts
+++ b/packages/cli/test/descriptor-route-map-cache.test.ts
@@ -1,0 +1,74 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import type { RouteManifest } from "@dawn-ai/core"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+
+import {
+  __resetDescriptorRouteMapCacheForTests,
+  getCachedDescriptorRouteMap,
+} from "../src/lib/runtime/execute-route.js"
+
+function manifest(
+  routes: { id: string; entryFile: string; routeDir: string }[],
+): RouteManifest {
+  return {
+    appRoot: "/tmp",
+    routes: routes.map((r) => ({
+      ...r,
+      pathname: r.id,
+      kind: "agent" as const,
+      segments: r.id
+        .split("/")
+        .filter(Boolean)
+        .map((seg) => ({ kind: "static" as const, raw: seg })),
+    })),
+  }
+}
+
+describe("getCachedDescriptorRouteMap", () => {
+  let tmp: string
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), "dawn-cache-test-"))
+    __resetDescriptorRouteMapCacheForTests()
+  })
+
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true })
+  })
+
+  it("returns the same Map instance for the same manifest object (cache hit)", async () => {
+    const entryFile = join(tmp, "a.ts")
+    writeFileSync(entryFile, `export default { __dawn: true }`)
+    const m = manifest([{ id: "/a", entryFile, routeDir: tmp }])
+
+    const first = await getCachedDescriptorRouteMap(m)
+    const second = await getCachedDescriptorRouteMap(m)
+
+    expect(second).toBe(first)
+  })
+
+  it("builds a fresh map for a different manifest object (cache miss)", async () => {
+    const entryFile = join(tmp, "b.ts")
+    writeFileSync(entryFile, `export default { __dawn: true }`)
+    const m1 = manifest([{ id: "/b", entryFile, routeDir: tmp }])
+    const m2 = manifest([{ id: "/b", entryFile, routeDir: tmp }])
+
+    const map1 = await getCachedDescriptorRouteMap(m1)
+    const map2 = await getCachedDescriptorRouteMap(m2)
+
+    expect(map2).not.toBe(map1)
+  })
+
+  it("populates descriptor entries for routes whose default export is a DawnAgent", async () => {
+    const entryFile = join(tmp, "agent.ts")
+    writeFileSync(
+      entryFile,
+      `import { agent } from "@dawn-ai/sdk"\nexport default agent({ model: "gpt-5", systemPrompt: "x" })\n`,
+    )
+    const m = manifest([{ id: "/a", entryFile, routeDir: tmp }])
+    const map = await getCachedDescriptorRouteMap(m)
+    expect(map).toBeInstanceOf(Map)
+  })
+})

--- a/packages/langchain/src/subagent-dispatcher.ts
+++ b/packages/langchain/src/subagent-dispatcher.ts
@@ -154,9 +154,7 @@ export async function dispatchSubagent(args: DispatchArgs): Promise<DispatchResu
               event: `subagent.${chunk.type}`,
               data: {
                 call_id: args.callId,
-                ...(typeof data === "object" && data !== null
-                  ? (data as object)
-                  : { value: data }),
+                ...(typeof data === "object" && data !== null ? (data as object) : { value: data }),
               },
             })
             break

--- a/packages/langchain/src/subagent-dispatcher.ts
+++ b/packages/langchain/src/subagent-dispatcher.ts
@@ -13,6 +13,19 @@ type Streamable = {
     name?: string
     data: { chunk?: unknown; output?: unknown }
   }>
+  // Dawn-native stream. Yields StreamChunks directly. When present,
+  // the dispatcher prefers this over streamEvents/invoke so intermediate
+  // child events bubble up as subagent.<type> envelopes.
+  dawnStream?: (
+    input: unknown,
+    config: unknown,
+  ) => AsyncIterable<{
+    type: string
+    data?: unknown
+    name?: string
+    input?: unknown
+    output?: unknown
+  }>
 }
 
 export interface DispatchArgs {
@@ -93,7 +106,64 @@ export async function dispatchSubagent(args: DispatchArgs): Promise<DispatchResu
   let output: unknown
   try {
     const streamable = args.childGraph as Streamable
-    if (typeof streamable.streamEvents === "function") {
+    if (typeof streamable.dawnStream === "function") {
+      for await (const chunk of streamable.dawnStream(
+        { messages: [{ role: "user", content: args.input }] },
+        childConfig,
+      )) {
+        switch (chunk.type) {
+          case "done":
+            output = (chunk as { output?: unknown }).output
+            break
+          case "tool_call":
+            args.writer({
+              event: "subagent.tool_call",
+              data: {
+                call_id: args.callId,
+                tool: (chunk as { name?: string }).name,
+                input: (chunk as { input?: unknown }).input,
+              },
+            })
+            break
+          case "tool_result":
+            args.writer({
+              event: "subagent.tool_result",
+              data: {
+                call_id: args.callId,
+                tool: (chunk as { name?: string }).name,
+                output: (chunk as { output?: unknown }).output,
+              },
+            })
+            break
+          case "chunk": {
+            const data = (chunk as { data?: unknown }).data
+            if (typeof data === "string" && data.length > 0) {
+              args.writer({
+                event: "subagent.message",
+                data: { call_id: args.callId, chunk: data },
+              })
+            }
+            break
+          }
+          default: {
+            // Capability-contributed events (e.g. plan_update). Prefix with
+            // subagent. and forward the chunk's data payload verbatim,
+            // attaching call_id.
+            const data = (chunk as { data?: unknown }).data
+            args.writer({
+              event: `subagent.${chunk.type}`,
+              data: {
+                call_id: args.callId,
+                ...(typeof data === "object" && data !== null
+                  ? (data as object)
+                  : { value: data }),
+              },
+            })
+            break
+          }
+        }
+      }
+    } else if (typeof streamable.streamEvents === "function") {
       for await (const event of streamable.streamEvents(
         { messages: [{ role: "user", content: args.input }] },
         { ...childConfig, version: "v2" },

--- a/packages/langchain/test/subagent-dispatcher.test.ts
+++ b/packages/langchain/test/subagent-dispatcher.test.ts
@@ -196,6 +196,55 @@ describe("dispatchSubagent — event bubbling", () => {
   })
 })
 
+describe("dispatchSubagent — dawnStream path", () => {
+  it("prefers dawnStream over streamEvents/invoke and bubbles Dawn StreamChunks as subagent.* envelopes", async () => {
+    const childGraph = {
+      invoke: vi.fn(),
+      // streamEvents not provided — confirm dawnStream takes precedence even if it were
+      dawnStream: async function* () {
+        yield { type: "tool_call", name: "readFile", input: { path: "x.md" } }
+        yield { type: "tool_result", name: "readFile", output: "contents" }
+        yield { type: "chunk", data: "Hello " }
+        yield {
+          type: "plan_update",
+          data: { todos: [{ content: "do thing", status: "pending" }] },
+        }
+        yield {
+          type: "done",
+          output: {
+            messages: [{ type: "ai", content: "child final", getType: () => "ai" }],
+          },
+        }
+      },
+    }
+
+    const events: Array<{ event: string; data: Record<string, unknown> }> = []
+    const result = await dispatchSubagent({
+      childGraph: childGraph as never,
+      input: "x",
+      parentConfig: {},
+      writer: (e) => events.push(e),
+      callId: "C",
+      childRouteId: "/r",
+      subagentName: "r",
+    })
+
+    expect(result.finalText).toBe("child final")
+    expect(childGraph.invoke).not.toHaveBeenCalled()
+
+    const tags = events.map((e) => e.event)
+    expect(tags).toContain("subagent.tool_call")
+    expect(tags).toContain("subagent.tool_result")
+    expect(tags).toContain("subagent.message")
+    expect(tags).toContain("subagent.plan_update")
+    expect(tags).toContain("subagent.end")
+
+    const planEvent = events.find((e) => e.event === "subagent.plan_update")!
+    expect(planEvent.data.call_id).toBe("C")
+    expect((planEvent.data as { todos?: unknown }).todos).toBeDefined()
+  })
+})
+
 import { bridgeSubagentTool } from "../src/subagent-tool-bridge.js"
 
 describe("bridgeSubagentTool — wraps run() with dispatcher", () => {


### PR DESCRIPTION
## Summary

Three follow-ups to PR #156, bundled:

**1. Intermediate child event bubbling** (closes deferred follow-up from #156).
Child runs now stream Dawn `StreamChunk`s through a new `dawnStream` method exposed by the subagent resolver. The dispatcher prefers `dawnStream` over `streamEvents` over `invoke` and translates each chunk type into a `subagent.<type>` envelope on the parent stream — `tool_call`, `tool_result`, `chunk` (→ `subagent.message`), and capability-contributed events (`plan_update`, etc) all bubble up with the parent's `call_id`. Previously the parent stream only saw `subagent.start` / `subagent.end` around opaque child runs.

**2. Web client route picker.** `examples/chat/web` now has a radio-group selector to drive either the existing `/chat` route or the new `/coordinator` route. Each route gets its own thread; switching routes resets the conversation.

**3. `descriptorRouteMap` caching** (closes the other deferred follow-up from #156).
Module-level `WeakMap<RouteManifest, Promise<Map>>` keyed on manifest object identity. Stable across requests in production (one manifest per CLI invocation), naturally invalidated in dev when the runtime rebuilds the manifest. Also removes the dead lazy wrapper around the previous per-request build.

## Test plan

- [x] New dispatcher test for the `dawnStream` path (precedence, capability-event bubbling, all expected envelope types)
- [x] Existing dispatcher + bridge tests still pass
- [x] New `descriptor-route-map-cache.test.ts` (3 cases: identity hit, identity miss on new manifest, soft build check)
- [x] Full repo: 456 tests passing across 69 files, build clean
- [x] Web client typecheck clean
- [x] **Live smoke against `/coordinator`** via curl: 2 dispatches, 2 `subagent.start` / 2 `subagent.end`, 1 `subagent.tool_call` + 1 `subagent.tool_result` (research called `readFile`), 64 `subagent.message` token chunks, 1 clean `done`, 0 errors

## Note

Validate CI didn't trigger on PR #156 — likely the same here. Investigating separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)