### PR TITLE
fix(langchain): isolate subagent child config to stop event leak

### DIFF
--- a/packages/langchain/src/subagent-dispatcher.ts
+++ b/packages/langchain/src/subagent-dispatcher.ts
@@ -58,17 +58,22 @@ function buildChildConfig(
 ): Record<string, unknown> {
   const parentMeta = (parentConfig.metadata as Record<string, unknown> | undefined) ?? {}
   const parentDawn = (parentMeta.dawn as Record<string, unknown> | undefined) ?? {}
-  return {
-    ...parentConfig,
+  // Build a CLEAN child config: only Dawn metadata + abort signal.
+  // We deliberately omit `callbacks`, `runId`, `tags`, `runName`, etc. that
+  // LangChain's streamEvents v2 uses to propagate child events to the parent
+  // listener. Without this, every child token would also appear as a raw
+  // chunk on the parent stream (duplicating subagent.message envelopes).
+  const childConfig: Record<string, unknown> = {
     metadata: {
-      ...parentMeta,
-      dawn: {
-        ...parentDawn,
-        subagent_depth: nextDepth,
-        parent_call_id: callId,
-      },
+      // Preserve Dawn-namespaced metadata so depth + thread continuity work,
+      // but drop everything else.
+      dawn: { ...parentDawn, subagent_depth: nextDepth, parent_call_id: callId },
     },
   }
+  // Forward the abort signal if the parent provided one — the child should
+  // cancel when the parent cancels.
+  if (parentConfig.signal) childConfig.signal = parentConfig.signal
+  return childConfig
 }
 
 function extractFinalText(graphOutput: unknown): string {

--- a/packages/langchain/test/subagent-dispatcher.test.ts
+++ b/packages/langchain/test/subagent-dispatcher.test.ts
@@ -245,6 +245,66 @@ describe("dispatchSubagent — dawnStream path", () => {
   })
 })
 
+describe("dispatchSubagent — config isolation", () => {
+  it("does not leak parent callbacks/tags/runId into the child config", async () => {
+    let seenConfig: Record<string, unknown> | undefined
+    const childGraph = {
+      invoke: vi.fn(async (_input: unknown, config: unknown) => {
+        seenConfig = config as Record<string, unknown>
+        return { messages: [{ type: "ai", content: "ok", getType: () => "ai" }] }
+      }),
+    }
+    const sentinel = {}
+    await dispatchSubagent({
+      childGraph,
+      input: "x",
+      parentConfig: {
+        callbacks: [sentinel],
+        runId: "parent-run-id",
+        tags: ["parent-tag"],
+        runName: "ParentName",
+        metadata: { dawn: { thread_id: "t-1" } },
+      },
+      writer: () => {},
+      callId: "c",
+      childRouteId: "/r",
+      subagentName: "r",
+    })
+    expect(seenConfig?.callbacks).toBeUndefined()
+    expect(seenConfig?.runId).toBeUndefined()
+    expect(seenConfig?.tags).toBeUndefined()
+    expect(seenConfig?.runName).toBeUndefined()
+    // Dawn-namespaced metadata IS forwarded
+    const meta = seenConfig?.metadata as
+      | { dawn?: { thread_id?: string; subagent_depth?: number; parent_call_id?: string } }
+      | undefined
+    expect(meta?.dawn?.thread_id).toBe("t-1")
+    expect(meta?.dawn?.subagent_depth).toBe(1)
+    expect(meta?.dawn?.parent_call_id).toBe("c")
+  })
+
+  it("forwards the abort signal", async () => {
+    let seenConfig: Record<string, unknown> | undefined
+    const childGraph = {
+      invoke: vi.fn(async (_input: unknown, config: unknown) => {
+        seenConfig = config as Record<string, unknown>
+        return { messages: [{ type: "ai", content: "ok", getType: () => "ai" }] }
+      }),
+    }
+    const controller = new AbortController()
+    await dispatchSubagent({
+      childGraph,
+      input: "x",
+      parentConfig: { signal: controller.signal },
+      writer: () => {},
+      callId: "c",
+      childRouteId: "/r",
+      subagentName: "r",
+    })
+    expect(seenConfig?.signal).toBe(controller.signal)
+  })
+})
+
 import { bridgeSubagentTool } from "../src/subagent-tool-bridge.js"
 
 describe("bridgeSubagentTool — wraps run() with dispatcher", () => {


### PR DESCRIPTION
## Summary

Found via Chrome MCP web-client smoke against `examples/chat/coordinator`: every child model-token event appeared TWICE on the parent SSE stream — once as raw `event: chunk`, once as wrapped `event: subagent.message`. A client trying to render parent-only output separately from subagent output would see every child token doubled.

## Root cause

The dispatcher's `buildChildConfig` spread the parent `RunnableConfig`, which carries LangChain's streamEvents-v2 callback handlers. The child graph inherited those callbacks and fired its own model-stream events on the parent's listener.

## Fix

Build a clean child config that forwards only:
- `metadata.dawn` (Dawn-namespaced fields — preserves `thread_id`, sets `subagent_depth` + `parent_call_id`)
- `signal` (so child cancellation tracks parent cancellation)

Everything else (`callbacks`, `runId`, `tags`, `runName`) is dropped.

## Test plan

- [x] New regression test: `dispatchSubagent — config isolation` — asserts `callbacks`, `runId`, `tags`, `runName` do NOT leak; Dawn metadata DOES forward (thread continuity); abort signal forwards.
- [x] Existing dispatcher + bridge tests still pass (80 total in `@dawn-ai/langchain`, 458 total repo)
- [x] Build, lint, typecheck clean
- [ ] Manual Chrome MCP re-verify (post-merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)