### PR TITLE
fix(langchain): suppress child token leak via streamContext gate

### DIFF
--- a/packages/langchain/src/agent-adapter.ts
+++ b/packages/langchain/src/agent-adapter.ts
@@ -4,7 +4,11 @@ import { isDawnAgent } from "@dawn-ai/sdk"
 import { type BaseMessageLike, HumanMessage } from "@langchain/core/messages"
 import { isRetryableError, withRetry } from "./retry.js"
 import { materializeStateSchema, type ResolvedStateField } from "./state-adapter.js"
-import type { SubagentEvent } from "./subagent-dispatcher.js"
+import {
+  createSubagentStreamContext,
+  type SubagentEvent,
+  type SubagentStreamContext,
+} from "./subagent-dispatcher.js"
 import { bridgeSubagentTool, type SubagentResolverResult } from "./subagent-tool-bridge.js"
 import { convertToolToLangChain } from "./tool-converter.js"
 
@@ -164,6 +168,14 @@ export async function* streamAgent(options: AgentOptions): AsyncGenerator<AgentS
     })
   }
 
+  // Per-call counter shared with the dispatcher. While a child is active, the
+  // parent's on_chat_model_stream events are suppressed (LangChain v2
+  // streamEvents propagates child events to the parent listener via
+  // async-local-storage tracing, so without this gate every child token
+  // appears twice on the parent stream: once as a raw token chunk and once
+  // wrapped in a subagent.message envelope).
+  const streamContext = createSubagentStreamContext()
+
   const resolver = options.subagentResolver
   const hasTaskTool = options.tools.some((t) => t.name === "task")
   const effectiveTools: readonly DawnToolDefinition[] =
@@ -176,6 +188,7 @@ export async function* streamAgent(options: AgentOptions): AsyncGenerator<AgentS
                   subagentResolver: resolver,
                   writer: queueWriter,
                   parentConfig: config,
+                  streamContext,
                 }).run as DawnToolDefinition["run"],
               }
             : t,
@@ -203,6 +216,7 @@ export async function* streamAgent(options: AgentOptions): AsyncGenerator<AgentS
       retryConfig,
       options.streamTransformers,
       subagentEvents,
+      streamContext,
     )
     return
   }
@@ -224,6 +238,7 @@ export async function* streamAgent(options: AgentOptions): AsyncGenerator<AgentS
     options.retry,
     options.streamTransformers,
     subagentEvents,
+    streamContext,
   )
 }
 
@@ -261,6 +276,7 @@ async function* streamFromRunnable(
   retryConfig?: RetryConfig,
   streamTransformers?: readonly StreamTransformer[],
   subagentEvents?: AgentStreamChunk[],
+  streamContext?: SubagentStreamContext,
 ): AsyncGenerator<AgentStreamChunk> {
   // Drains any pending subagent events queued by the bridge. Called before
   // each normal yield to keep ordering predictable on the single event loop.
@@ -319,6 +335,12 @@ async function* streamFromRunnable(
         yield* drainSubagentEvents()
         switch (event.event) {
           case "on_chat_model_stream": {
+            // Suppress while a child subagent run is active — child token
+            // events leak onto the parent's streamEvents listener via
+            // LangChain v2 async-local-storage tracing. The dispatcher
+            // already emits a `subagent.message` envelope for each child
+            // token, so emitting the raw token here would duplicate.
+            if (streamContext && streamContext.activeChildRuns > 0) break
             const content = (event.data.chunk as { content?: unknown })?.content
             if (content && typeof content === "string" && content.length > 0) {
               hasYielded = true

--- a/packages/langchain/src/index.ts
+++ b/packages/langchain/src/index.ts
@@ -4,8 +4,12 @@ export { chainAdapter } from "./chain-adapter.js"
 export type { RetryOptions } from "./retry.js"
 export { isRetryableError, withRetry } from "./retry.js"
 export { materializeStateSchema } from "./state-adapter.js"
-export type { SubagentEvent } from "./subagent-dispatcher.js"
-export { dispatchSubagent, MAX_SUBAGENT_DEPTH } from "./subagent-dispatcher.js"
+export type { SubagentEvent, SubagentStreamContext } from "./subagent-dispatcher.js"
+export {
+  createSubagentStreamContext,
+  dispatchSubagent,
+  MAX_SUBAGENT_DEPTH,
+} from "./subagent-dispatcher.js"
 export type { SubagentResolverResult } from "./subagent-tool-bridge.js"
 export { bridgeSubagentTool } from "./subagent-tool-bridge.js"
 export { convertToolToLangChain } from "./tool-converter.js"

--- a/packages/langchain/src/subagent-dispatcher.ts
+++ b/packages/langchain/src/subagent-dispatcher.ts
@@ -28,6 +28,21 @@ type Streamable = {
   }>
 }
 
+export interface SubagentStreamContext {
+  /**
+   * Active child-run depth. While > 0, the parent's streamFromRunnable should
+   * suppress on_chat_model_stream emissions because those events are firing
+   * for the child run via LangChain v2 streamEvents async-local-storage
+   * tracing. The dispatcher already emits a `subagent.message` envelope for
+   * each child token, so suppressing avoids duplicates on the parent stream.
+   */
+  activeChildRuns: number
+}
+
+export function createSubagentStreamContext(): SubagentStreamContext {
+  return { activeChildRuns: 0 }
+}
+
 export interface DispatchArgs {
   readonly childGraph: { invoke: (input: unknown, config: unknown) => Promise<unknown> }
   readonly input: string
@@ -36,6 +51,7 @@ export interface DispatchArgs {
   readonly callId: string
   readonly childRouteId: string
   readonly subagentName: string
+  readonly streamContext?: SubagentStreamContext
 }
 
 export interface DispatchResult {
@@ -108,6 +124,18 @@ export async function dispatchSubagent(args: DispatchArgs): Promise<DispatchResu
     },
   })
 
+  if (args.streamContext) args.streamContext.activeChildRuns++
+  try {
+    return await runChild(args, childConfig)
+  } finally {
+    if (args.streamContext) args.streamContext.activeChildRuns--
+  }
+}
+
+async function runChild(
+  args: DispatchArgs,
+  childConfig: Record<string, unknown>,
+): Promise<DispatchResult> {
   let output: unknown
   try {
     const streamable = args.childGraph as Streamable

--- a/packages/langchain/src/subagent-tool-bridge.ts
+++ b/packages/langchain/src/subagent-tool-bridge.ts
@@ -1,4 +1,8 @@
-import { dispatchSubagent, type SubagentEvent } from "./subagent-dispatcher.js"
+import {
+  dispatchSubagent,
+  type SubagentEvent,
+  type SubagentStreamContext,
+} from "./subagent-dispatcher.js"
 
 export interface SubagentResolverResult {
   readonly routeId: string
@@ -15,6 +19,11 @@ export interface BridgeOptions {
   readonly subagentResolver: (leafName: string) => SubagentResolverResult | undefined
   readonly writer: (event: SubagentEvent) => void
   readonly parentConfig?: Record<string, unknown>
+  /**
+   * Shared counter that gates the parent's `on_chat_model_stream` emissions
+   * while a child run is active. See `SubagentStreamContext`.
+   */
+  readonly streamContext?: SubagentStreamContext
 }
 
 export interface BridgedTaskTool {
@@ -51,6 +60,7 @@ export function bridgeSubagentTool(options: BridgeOptions): BridgedTaskTool {
         callId: generateCallId(),
         childRouteId: resolved.routeId,
         subagentName: subagent,
+        ...(options.streamContext ? { streamContext: options.streamContext } : {}),
       })
       return result.finalText
     },

--- a/packages/langchain/test/subagent-dispatcher.test.ts
+++ b/packages/langchain/test/subagent-dispatcher.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest"
-import { dispatchSubagent } from "../src/subagent-dispatcher.js"
+import { createSubagentStreamContext, dispatchSubagent } from "../src/subagent-dispatcher.js"
 
 describe("dispatchSubagent — happy path", () => {
   it("calls the child graph with a fresh state seeded by input and returns the final assistant text", async () => {
@@ -366,5 +366,68 @@ describe("bridgeSubagentTool — wraps run() with dispatcher", () => {
     await taskTool.run({ subagent: "x", input: "y" }, { signal: new AbortController().signal })
 
     expect(seenConfig?.metadata?.dawn?.subagent_depth).toBe(2)
+  })
+})
+
+describe("dispatchSubagent — stream context", () => {
+  it("increments and decrements activeChildRuns around the run", async () => {
+    const seenCounts: number[] = []
+    const streamContext = createSubagentStreamContext()
+    const childGraph = {
+      invoke: vi.fn(async () => {
+        seenCounts.push(streamContext.activeChildRuns)
+        return { messages: [{ type: "ai", content: "ok", getType: () => "ai" }] }
+      }),
+    }
+    expect(streamContext.activeChildRuns).toBe(0)
+    await dispatchSubagent({
+      childGraph,
+      input: "x",
+      parentConfig: {},
+      writer: () => {},
+      callId: "c",
+      childRouteId: "/r",
+      subagentName: "r",
+      streamContext,
+    })
+    expect(seenCounts).toEqual([1])
+    expect(streamContext.activeChildRuns).toBe(0)
+  })
+
+  it("decrements activeChildRuns even when the child throws", async () => {
+    const streamContext = createSubagentStreamContext()
+    const childGraph = {
+      invoke: vi.fn(async () => {
+        throw new Error("boom")
+      }),
+    }
+    await dispatchSubagent({
+      childGraph,
+      input: "x",
+      parentConfig: {},
+      writer: () => {},
+      callId: "c",
+      childRouteId: "/r",
+      subagentName: "r",
+      streamContext,
+    })
+    expect(streamContext.activeChildRuns).toBe(0)
+  })
+
+  it("does NOT increment when depth_exceeded short-circuit fires", async () => {
+    const streamContext = createSubagentStreamContext()
+    const childGraph = { invoke: vi.fn() }
+    await dispatchSubagent({
+      childGraph,
+      input: "x",
+      parentConfig: { metadata: { dawn: { subagent_depth: 3 } } },
+      writer: () => {},
+      callId: "c",
+      childRouteId: "/r",
+      subagentName: "r",
+      streamContext,
+    })
+    expect(streamContext.activeChildRuns).toBe(0)
+    expect(childGraph.invoke).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
## Summary

Fixes a duplicate-token bug on the parent SSE stream when a coordinator's `task` tool dispatches to a subagent. Each child model token was appearing twice: once as a raw `event: chunk` (from the parent's `on_chat_model_stream` listener picking up the child run via LangChain v2 async-local-storage tracing) and once as `event: subagent.message` (intentional, from the dispatcher's `dawnStream` translation).

PR #158 stripped `callbacks/runId/tags/runName` from the child `RunnableConfig`, but streamEvents v2 uses async-local-storage to trace nested runs across the entire execution tree regardless of explicit callbacks.

## Fix

- New `SubagentStreamContext` (a shared counter) created per-call in `streamAgent`.
- Dispatcher increments `activeChildRuns` around the child invocation in a `try/finally` (decrements on success, error, AND depth-cap; not incremented when depth_exceeded short-circuits).
- Parent's `streamFromRunnable` checks `streamContext.activeChildRuns > 0` and suppresses `on_chat_model_stream` emissions while a child is active. The dispatcher's `subagent.message` envelope still fires, so the client gets a single correlated stream.

## Test plan

- [x] 3 new unit tests covering increment/decrement, error path, and depth_exceeded short-circuit
- [x] `pnpm --filter @dawn-ai/langchain test` — 83/83 pass (was 80)
- [x] `pnpm test` — 461/461 pass repo-wide
- [x] `pnpm lint` — clean
- [x] `pnpm build` — clean
- [ ] Manual: re-run Chrome MCP web-client smoke against `examples/chat/coordinator` and confirm zero duplicate tokens

🤖 Generated with [Claude Code](https://claude.com/claude-code)