### PR TITLE
[codex] Reframe Dawn blog feature summary

### DIFF
--- a/apps/web/content/blog/2026-05-12-why-we-built-dawn.mdx
+++ b/apps/web/content/blog/2026-05-12-why-we-built-dawn.mdx
@@ -138,13 +138,13 @@ So a route like `/hello/[tenant]` becomes an assistant id like:
 
 This matters because the Dawn project structure stays a TypeScript authoring experience, while the output is still a LangGraph-compatible deployment package.
 
-## What has changed recently
+## What we have built to date
 
-The first shape of Dawn was routing, tools, types, a dev server, and build output.
+The foundation of Dawn is routing, tools, types, a dev server, and build output.
 
-That was enough to prove the idea, but real agent applications need more than a single tool-calling loop.
+That proves the basic shape, but real agent applications need more than a single tool-calling loop.
 
-The current work adds the pieces I kept wanting once the route structure was in place.
+Here is what we have built to date around that route structure.
 
 ### Memory
 


### PR DESCRIPTION
## Summary
- Reframe the first Dawn blog post section from recent-change language to "what we have built to date".
- Keep the follow-up intentionally narrow to the requested wording/positioning change.

## Validation
- `node scripts/check-docs.mjs`
- `pnpm --filter @dawn-ai/web typecheck`
