### PR TITLE
[codex] support LangChain provider materialization

### DIFF
--- a/.changeset/provider-aware-agent-materialization.md
+++ b/.changeset/provider-aware-agent-materialization.md
@@ -1,0 +1,6 @@
+---
+"@dawn-ai/sdk": minor
+"@dawn-ai/langchain": minor
+---
+
+Add provider-aware agent materialization. Agent configs can now carry an optional `provider`, and the LangChain runtime infers providers for known model families or lazy-loads the explicit provider integration package for built-in provider IDs.

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -17,7 +17,7 @@ This guide is for engineers working inside the Dawn monorepo. It covers the curr
 - `@dawn-ai/core` owns app discovery, config loading, validation, and route type generation.
 - `@dawn-ai/sdk` owns the author-facing contract: types, helpers, runtime context, middleware, and tool authoring.
 - `@dawn-ai/langgraph` owns LangGraph-specific route module contracts and adapter code.
-- `@dawn-ai/langchain` owns LCEL chain support and OpenAI-backed `agent()` materialization.
+- `@dawn-ai/langchain` owns LCEL chain support and provider-aware `agent()` materialization.
 - `@dawn-ai/cli` owns the user-facing commands and the local runtime behavior.
 - `create-dawn-ai-app` owns app scaffolding.
 - `@dawn-ai/devkit` owns shared template and file-generation helpers.

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ export default agent({
 
 Add `state.ts` for a route state schema, `tools/*.ts` for route-local tools, `middleware.ts` for access control, and `run.test.ts` for colocated scenarios.
 
-The built-in `agent()` route materializes to a LangChain chat model. Dawn infers providers for known model families; set `provider` explicitly for aliases, ambiguous model names, local models, or provider routers. Raw `graph` and `chain` routes can still instantiate any provider directly.
+The built-in `agent()` route materializes to a LangChain chat model. Dawn infers providers for known model families; set `provider` explicitly to one of the supported built-in provider ids for aliases, ambiguous model names, local models, or provider-router model ids. Raw `graph` and `chain` routes can still instantiate any provider directly.
 
 ## Learn more
 

--- a/README.md
+++ b/README.md
@@ -136,6 +136,8 @@ export default agent({
 
 Add `state.ts` for a route state schema, `tools/*.ts` for route-local tools, `middleware.ts` for access control, and `run.test.ts` for colocated scenarios.
 
+The built-in `agent()` route materializes to a LangChain chat model. Dawn infers providers for known model families; set `provider` explicitly for aliases, ambiguous model names, local models, or provider routers. Raw `graph` and `chain` routes can still instantiate any provider directly.
+
 ## Learn more
 
 - [Getting started](apps/web/content/docs/getting-started.mdx)

--- a/apps/web/app/components/landing/Ecosystem.tsx
+++ b/apps/web/app/components/landing/Ecosystem.tsx
@@ -39,7 +39,7 @@ const CATEGORIES: readonly Category[] = [
         logoSrc: "/logos/providers/ollama.svg",
         logoIsWordmark: true,
       },
-      { name: "Bring-your-own graph/chain providers" },
+      { name: "Agent providers + BYO graph/chain" },
     ],
   },
   {
@@ -84,8 +84,9 @@ export function Ecosystem() {
           Plays well with your stack.
         </h2>
         <p className="mt-5 text-base text-ink-muted leading-[26px] max-w-[58ch]">
-          Dawn keeps the LangGraph.js ecosystem close: bring your own graph or chain providers,
-          observability, vector storage, and deployment target.
+          Dawn keeps the LangGraph.js ecosystem close: built-in agent providers where supported,
+          bring-your-own providers in graph and chain routes, plus observability, vector storage,
+          and deployment targets.
         </p>
 
         <div className="mt-12 grid sm:grid-cols-2 lg:grid-cols-4 gap-x-10 gap-y-10">

--- a/apps/web/app/components/landing/Faq.tsx
+++ b/apps/web/app/components/landing/Faq.tsx
@@ -96,9 +96,10 @@ const ITEMS = [
     answer: (
       <p>
         Nothing. Dawn is MIT-licensed open source with no paid tier, no usage meter, no hosted
-        service to sign up for. The built-in `agent()` materialization path is OpenAI-backed today;
-        raw graph and chain routes can instantiate other providers directly. Provider and deployment
-        costs are yours and flow directly to the services you choose.
+        service to sign up for. The built-in `agent()` route materializes to a LangChain chat model
+        and can infer known provider families; raw graph and chain routes can instantiate providers
+        directly. Provider and deployment costs are yours and flow directly to the services you
+        choose.
       </p>
     ),
   },

--- a/apps/web/app/components/landing/ProofStrip.tsx
+++ b/apps/web/app/components/landing/ProofStrip.tsx
@@ -81,7 +81,7 @@ export async function ProofStrip() {
 
           <div className="flex items-center gap-3">
             <span className="text-xs font-semibold uppercase tracking-[0.06em] text-ink-dim hidden md:inline">
-              Graph/chain providers
+              Agent + graph/chain providers
             </span>
             <div className="flex flex-wrap items-center gap-x-4 gap-y-2">
               <ProviderMark

--- a/apps/web/app/llms.txt/route.ts
+++ b/apps/web/app/llms.txt/route.ts
@@ -81,7 +81,7 @@ function buildLlmsTxt(): string {
       "## Packages",
       "- `@dawn-ai/sdk` — authoring contract (types, `RuntimeContext`, test helpers)",
       "- `@dawn-ai/langgraph` — LangGraph graphs/workflows adapter",
-      "- `@dawn-ai/langchain` — LangChain LCEL adapter and OpenAI-backed agent materialization",
+      "- `@dawn-ai/langchain` — LangChain LCEL adapter and provider-aware agent materialization",
       "- `@dawn-ai/cli` — the `dawn` CLI",
       "",
       "## Deployment",

--- a/apps/web/content/docs/agents.mdx
+++ b/apps/web/content/docs/agents.mdx
@@ -26,6 +26,30 @@ export default async (input: { readonly tenant: string }) => {
 
 Tools live next to the agent — `index.ts` is the agent entry, and any TS file in `tools/` is discovered for it. Param types are inferred from the function signature at `dawn build` time and made available to the generated graph.
 
+## Model providers
+
+The built-in `agent()` route materializes to a LangChain chat model. Dawn infers providers for known model families and lazy-loads the matching LangChain integration package. Raw `graph` and `chain` routes can still instantiate any provider directly.
+
+Set `provider` when the model name is an alias, ambiguous, local, or routed through a provider gateway:
+
+```ts title="src/app/(public)/hello/[tenant]/index.ts"
+import { agent } from "@dawn-ai/sdk"
+
+export default agent({
+  model: "llama3.1",
+  provider: "ollama",
+  systemPrompt: "You are a helpful assistant.",
+})
+```
+
+Dawn includes the OpenAI integration for the default path. Install other LangChain provider packages as your app needs them:
+
+```bash
+pnpm add @langchain/anthropic
+pnpm add @langchain/google-genai
+pnpm add @langchain/openrouter
+```
+
 ## When to pick an agent
 
 Dawn supports four route entry shapes. Pick the one that fits the problem:

--- a/apps/web/content/docs/agents.mdx
+++ b/apps/web/content/docs/agents.mdx
@@ -30,7 +30,7 @@ Tools live next to the agent — `index.ts` is the agent entry, and any TS file 
 
 The built-in `agent()` route materializes to a LangChain chat model. Dawn infers providers for known model families and lazy-loads the matching LangChain integration package. Raw `graph` and `chain` routes can still instantiate any provider directly.
 
-Set `provider` when the model name is an alias, ambiguous, local, or routed through a provider gateway:
+Set `provider` to one of the supported built-in provider ids when the model name is an alias, ambiguous, local, or routed through a provider gateway:
 
 ```ts title="src/app/(public)/hello/[tenant]/index.ts"
 import { agent } from "@dawn-ai/sdk"

--- a/apps/web/content/docs/agents.mdx
+++ b/apps/web/content/docs/agents.mdx
@@ -28,7 +28,7 @@ Tools live next to the agent — `index.ts` is the agent entry, and any TS file 
 
 ## Model providers
 
-The built-in `agent()` route materializes to a LangChain chat model. Dawn infers providers for known model families and lazy-loads the matching LangChain integration package. Raw `graph` and `chain` routes can still instantiate any provider directly.
+The built-in `agent()` route materializes to a LangChain chat model. Dawn infers providers for known model families and lazy-loads the matching LangChain integration package. Supported built-in provider ids are `openai`, `anthropic`, `google`, `mistral`, `groq`, `ollama`, `xai`, and `openrouter`; see [`ModelProviderId`](/docs/api#modelproviderid). Raw `graph` and `chain` routes can still instantiate any provider directly.
 
 Set `provider` to one of the supported built-in provider ids when the model name is an alias, ambiguous, local, or routed through a provider gateway:
 
@@ -45,9 +45,13 @@ export default agent({
 Dawn includes the OpenAI integration for the default path. Install other LangChain provider packages as your app needs them:
 
 ```bash
-pnpm add @langchain/anthropic
-pnpm add @langchain/google-genai
-pnpm add @langchain/openrouter
+pnpm add @langchain/anthropic     # anthropic
+pnpm add @langchain/google-genai  # google
+pnpm add @langchain/mistralai     # mistral
+pnpm add @langchain/groq          # groq
+pnpm add @langchain/ollama        # ollama
+pnpm add @langchain/xai           # xai
+pnpm add @langchain/openrouter    # openrouter
 ```
 
 ## When to pick an agent

--- a/apps/web/content/docs/api.mdx
+++ b/apps/web/content/docs/api.mdx
@@ -41,7 +41,7 @@ export interface AgentConfig {
 }
 ```
 
-Configuration passed to `agent()`. `description` is optional metadata for agent and subagent selection. `model` must be a `KnownModelId` string. `provider` is optional. When omitted, Dawn infers a provider for known model families. Set it explicitly for aliases, ambiguous model names, local models, or provider routers. `reasoning` maps to OpenAI reasoning-effort options when the selected model supports them. `retry` controls automatic retries on transient failures. `subagents` lists child agent descriptors exposed through Dawn's subagent capability. `systemPrompt` is sent as the system message on every invocation.
+Configuration passed to `agent()`. `description` is optional metadata for agent and subagent selection. `model` must be a `KnownModelId` string. `provider` is optional. When omitted, Dawn infers a provider for known model families. Set it explicitly to one of the supported built-in provider ids for aliases, ambiguous model names, local models, or provider-router model ids. `reasoning` maps to OpenAI reasoning-effort options when the selected model supports them. `retry` controls automatic retries on transient failures. `subagents` lists child agent descriptors exposed through Dawn's subagent capability. `systemPrompt` is sent as the system message on every invocation.
 
 The built-in `agent()` route materializes to a LangChain chat model. Dawn infers providers for known model families and lazy-loads the matching LangChain integration package. Raw `graph` and `chain` routes can still instantiate any provider directly.
 
@@ -326,9 +326,9 @@ The accepted type for `AgentConfig.model`. Includes named model IDs plus an esca
 export type ModelProviderId = BuiltInModelProviderId | (string & {})
 ```
 
-The accepted type for `AgentConfig.provider`. Built-in values are `openai`, `anthropic`, `google`, `mistral`, `groq`, `ollama`, `xai`, and `openrouter`. Custom strings are accepted for provider routers and downstream integrations.
+The accepted type for `AgentConfig.provider`. Built-in values are `openai`, `anthropic`, `google`, `mistral`, `groq`, `ollama`, `xai`, and `openrouter`. The type includes a custom-string escape hatch for future and downstream typing, but built-in `agent()` materialization currently accepts only the built-in provider ids.
 
-Use `provider` when `model` is an alias, an ambiguous local model name, or a provider-routed identifier. Without an explicit provider, Dawn conservatively infers OpenAI `gpt-*`, `o3*`, and `o4*`; Anthropic `claude-*`; Google `gemini-*`; Mistral `mistral-*`, `mixtral-*`, and `codestral-*`; and xAI `grok-*`.
+Use `provider` when `model` is an alias, an ambiguous local model name, or a provider-routed identifier. Set it to one of the supported built-in provider ids. Without an explicit provider, Dawn conservatively infers OpenAI `gpt-*`, `o3*`, and `o4*`; Anthropic `claude-*`; Google `gemini-*`; Mistral `mistral-*`, `mixtral-*`, and `codestral-*`; and xAI `grok-*`.
 
 ### `OpenAiModelId`
 

--- a/apps/web/content/docs/api.mdx
+++ b/apps/web/content/docs/api.mdx
@@ -33,6 +33,7 @@ See [Agents](/docs/agents).
 export interface AgentConfig {
   readonly description?: string
   readonly model: KnownModelId
+  readonly provider?: ModelProviderId
   readonly reasoning?: ReasoningConfig
   readonly retry?: RetryConfig
   readonly subagents?: readonly DawnAgent[]
@@ -40,7 +41,9 @@ export interface AgentConfig {
 }
 ```
 
-Configuration passed to `agent()`. `description` is optional metadata for agent and subagent selection. `model` must be a `KnownModelId` string. `reasoning` maps to OpenAI reasoning-effort options when the selected model supports them. `retry` controls automatic retries on transient failures. `subagents` lists child agent descriptors exposed through Dawn's subagent feature. `systemPrompt` is sent as the system message on every invocation. The current `agent()` materialization path is OpenAI-backed; use raw `graph` or `chain` routes when you instantiate another provider yourself.
+Configuration passed to `agent()`. `description` is optional metadata for agent and subagent selection. `model` must be a `KnownModelId` string. `provider` is optional. When omitted, Dawn infers a provider for known model families. Set it explicitly for aliases, ambiguous model names, local models, or provider routers. `reasoning` maps to OpenAI reasoning-effort options when the selected model supports them. `retry` controls automatic retries on transient failures. `subagents` lists child agent descriptors exposed through Dawn's subagent capability. `systemPrompt` is sent as the system message on every invocation.
+
+The built-in `agent()` route materializes to a LangChain chat model. Dawn infers providers for known model families and lazy-loads the matching LangChain integration package. Raw `graph` and `chain` routes can still instantiate any provider directly.
 
 See [Agents](/docs/agents), [Reasoning Effort](/docs/reasoning-effort), and [Subagents](/docs/subagents).
 
@@ -52,7 +55,7 @@ export interface ReasoningConfig {
 }
 ```
 
-Optional reasoning-effort tuning for OpenAI-backed `agent()` routes. Non-reasoning models ignore it.
+Optional reasoning-effort tuning for `agent()` routes. OpenAI reasoning models receive the matching reasoning-effort option; non-reasoning models ignore it.
 
 See [Reasoning Effort](/docs/reasoning-effort).
 
@@ -75,6 +78,7 @@ See [Retry](/docs/retry).
 export interface DawnAgent {
   readonly description?: string
   readonly model: string
+  readonly provider?: ModelProviderId
   readonly reasoning?: ReasoningConfig
   readonly retry?: RetryConfig
   readonly subagents?: readonly DawnAgent[]
@@ -316,6 +320,16 @@ export type KnownModelId = OpenAiModelId | GoogleModelId | (string & {})
 
 The accepted type for `AgentConfig.model`. Includes named model IDs plus an escape hatch (`string & {}`) for models not yet in the union. The escape hatch preserves autocomplete for the named values; it does not imply every provider has an adapter in the built-in `agent()` path.
 
+### `ModelProviderId`
+
+```ts
+export type ModelProviderId = BuiltInModelProviderId | (string & {})
+```
+
+The accepted type for `AgentConfig.provider`. Built-in values are `openai`, `anthropic`, `google`, `mistral`, `groq`, `ollama`, `xai`, and `openrouter`. Custom strings are accepted for provider routers and downstream integrations.
+
+Use `provider` when `model` is an alias, an ambiguous local model name, or a provider-routed identifier. Without an explicit provider, Dawn conservatively infers OpenAI `gpt-*`, `o3*`, and `o4*`; Anthropic `claude-*`; Google `gemini-*`; Mistral `mistral-*`, `mixtral-*`, and `codestral-*`; and xAI `grok-*`.
+
 ### `OpenAiModelId`
 
 ```ts
@@ -339,7 +353,7 @@ export type GoogleModelId =
   | "gemini-2.5-flash-lite"
 ```
 
-String literals accepted by the `KnownModelId` type for autocomplete. To run these models today, instantiate the matching provider in a raw `graph` or `chain` route.
+String literals accepted by the `KnownModelId` type for autocomplete. The built-in `agent()` route infers the Google provider for `gemini-*` model IDs; raw `graph` and `chain` routes can still instantiate Google or any other provider directly.
 
 ---
 

--- a/apps/web/content/docs/faq.mdx
+++ b/apps/web/content/docs/faq.mdx
@@ -10,7 +10,7 @@ Yes. Dawn is a meta-framework for LangGraph the way Next.js is a meta-framework 
 
 ### Can I bring my own model provider?
 
-Yes, but the route kind matters. The current `agent({ model })` materialization path is OpenAI-backed. For Anthropic, Google, Bedrock, local models, or any custom LangChain-compatible provider, use a raw `graph` or `chain` route and instantiate the provider yourself. The `KnownModelId` type provides autocomplete plus an arbitrary string fallback; it is not a provider adapter matrix. See [API Reference](/docs/api).
+Yes. The built-in `agent()` route materializes to a LangChain chat model. Dawn infers providers for known model families and lazy-loads the matching LangChain integration package. Set `provider` explicitly for aliases, ambiguous model names, local models, or provider routers. Raw `graph` and `chain` routes can still instantiate any provider directly. See [API Reference](/docs/api).
 
 ### How does Dawn compare to Mastra / CopilotKit / Vercel AI SDK?
 

--- a/apps/web/content/docs/faq.mdx
+++ b/apps/web/content/docs/faq.mdx
@@ -10,7 +10,7 @@ Yes. Dawn is a meta-framework for LangGraph the way Next.js is a meta-framework 
 
 ### Can I bring my own model provider?
 
-Yes. The built-in `agent()` route materializes to a LangChain chat model. Dawn infers providers for known model families and lazy-loads the matching LangChain integration package. Set `provider` explicitly for aliases, ambiguous model names, local models, or provider routers. Raw `graph` and `chain` routes can still instantiate any provider directly. See [API Reference](/docs/api).
+Yes. The built-in `agent()` route materializes to a LangChain chat model. Dawn infers providers for known model families and lazy-loads the matching LangChain integration package. Set `provider` explicitly to one of the supported built-in provider ids for aliases, ambiguous model names, local models, or provider-router model ids. Raw `graph` and `chain` routes can still instantiate any provider directly. See [API Reference](/docs/api).
 
 ### How does Dawn compare to Mastra / CopilotKit / Vercel AI SDK?
 

--- a/apps/web/content/docs/migrating-from-langgraph.mdx
+++ b/apps/web/content/docs/migrating-from-langgraph.mdx
@@ -283,7 +283,7 @@ export default {
 
 - **LangSmith.** Tracing, evaluations, datasets — Dawn does not wrap or proxy. Set `LANGSMITH_API_KEY` and traces flow.
 - **Checkpointer and persistence.** Whatever you pass to `.compile({ checkpointer })` keeps working. Dawn does not own the graph runtime.
-- **Model providers.** Raw `graph` and `chain` routes keep whatever LangChain-compatible providers you instantiate yourself. The built-in `agent()` route materializes to a LangChain chat model; Dawn infers providers for known model families and lazy-loads the matching LangChain integration package. Set `provider` explicitly for aliases, ambiguous model names, local models, or provider routers.
+- **Model providers.** Raw `graph` and `chain` routes keep whatever LangChain-compatible providers you instantiate yourself. The built-in `agent()` route materializes to a LangChain chat model; Dawn infers providers for known model families and lazy-loads the matching LangChain integration package. Set `provider` explicitly to one of the supported built-in provider ids for aliases, ambiguous model names, local models, or provider-router model ids.
 - **LangChain ecosystem packages.** `@langchain/core`, `@langchain/openai`, retrievers, document loaders — every one works inside a route.
 - **LangSmith deploy.** Same target. `dawn build` emits the generated `langgraph.json` and entry files LangSmith consumes.
 

--- a/apps/web/content/docs/migrating-from-langgraph.mdx
+++ b/apps/web/content/docs/migrating-from-langgraph.mdx
@@ -283,7 +283,7 @@ export default {
 
 - **LangSmith.** Tracing, evaluations, datasets — Dawn does not wrap or proxy. Set `LANGSMITH_API_KEY` and traces flow.
 - **Checkpointer and persistence.** Whatever you pass to `.compile({ checkpointer })` keeps working. Dawn does not own the graph runtime.
-- **Model providers.** Raw `graph` and `chain` routes keep whatever LangChain-compatible providers you instantiate yourself. The current `agent({ model })` materialization path is OpenAI-backed even though `KnownModelId` has an arbitrary string fallback.
+- **Model providers.** Raw `graph` and `chain` routes keep whatever LangChain-compatible providers you instantiate yourself. The built-in `agent()` route materializes to a LangChain chat model; Dawn infers providers for known model families and lazy-loads the matching LangChain integration package. Set `provider` explicitly for aliases, ambiguous model names, local models, or provider routers.
 - **LangChain ecosystem packages.** `@langchain/core`, `@langchain/openai`, retrievers, document loaders — every one works inside a route.
 - **LangSmith deploy.** Same target. `dawn build` emits the generated `langgraph.json` and entry files LangSmith consumes.
 

--- a/apps/web/content/prompts/index.ts
+++ b/apps/web/content/prompts/index.ts
@@ -41,7 +41,7 @@ const SCAFFOLD = `Help me scaffold a new Dawn app. Dawn is a TypeScript-first me
 
 5. Summarize what I can build next: add a tool, add a new route, write a scenario test.
 
-Key packages: \`@dawn-ai/sdk\` (authoring contract), \`@dawn-ai/langgraph\` (graphs/workflows), \`@dawn-ai/langchain\` (LCEL and OpenAI-backed agent materialization), \`@dawn-ai/cli\` (CLI).
+Key packages: \`@dawn-ai/sdk\` (authoring contract), \`@dawn-ai/langgraph\` (graphs/workflows), \`@dawn-ai/langchain\` (LCEL and provider-aware agent materialization), \`@dawn-ai/cli\` (CLI).
 
 Reference: https://dawnai.org/llms.txt
 `;

--- a/apps/web/content/templates/AGENTS.md
+++ b/apps/web/content/templates/AGENTS.md
@@ -43,7 +43,7 @@ export default agent({
 ```
 
 - `model` is a `KnownModelId` (autocomplete for listed ids, plus any custom string).
-- `provider?: ModelProviderId` is optional. Dawn infers providers for known model families; set it explicitly for aliases, ambiguous model names, local models, or provider routers. Raw graph/chain routes can still instantiate any provider directly.
+- `provider?: ModelProviderId` is optional. Dawn infers providers for known model families; set it explicitly to one of the supported built-in provider ids for aliases, ambiguous model names, local models, or provider-router model ids. Raw graph/chain routes can still instantiate any provider directly.
 - `retry?: { maxAttempts?: number, baseDelay?: number }` — applied per agent call.
 - Tools in the same route's `tools/` directory (and shared tools in `src/tools/`) are automatically wired into the generated agent graph at `dawn build` time.
 

--- a/apps/web/content/templates/AGENTS.md
+++ b/apps/web/content/templates/AGENTS.md
@@ -42,7 +42,8 @@ export default agent({
 })
 ```
 
-- `model` is a `KnownModelId` (autocomplete for listed ids, plus any custom string). The current `agent()` materialization path is OpenAI-backed; use raw graph/chain routes when wiring a different provider yourself.
+- `model` is a `KnownModelId` (autocomplete for listed ids, plus any custom string).
+- `provider?: ModelProviderId` is optional. Dawn infers providers for known model families; set it explicitly for aliases, ambiguous model names, local models, or provider routers. Raw graph/chain routes can still instantiate any provider directly.
 - `retry?: { maxAttempts?: number, baseDelay?: number }` — applied per agent call.
 - Tools in the same route's `tools/` directory (and shared tools in `src/tools/`) are automatically wired into the generated agent graph at `dawn build` time.
 

--- a/docs/superpowers/plans/2026-05-19-langchain-provider-materialization.md
+++ b/docs/superpowers/plans/2026-05-19-langchain-provider-materialization.md
@@ -1,0 +1,819 @@
+# LangChain Provider Materialization Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make Dawn's built-in `agent({ model })` materialization provider-aware across LangChain chat model integrations, using automatic inference with an explicit `provider` override and optional peer dependencies.
+
+**Architecture:** Add `provider?: ModelProviderId` to SDK descriptors, then replace direct `ChatOpenAI` construction in `@dawn-ai/langchain` with a resolver/factory pair. The resolver handles inference and user-facing errors; the factory lazy-imports provider packages and constructs the selected LangChain chat model. Existing `graph` and `chain` routes remain unchanged.
+
+**Tech Stack:** TypeScript, pnpm workspaces, Vitest 4, LangChain JS 1.x, LangGraph prebuilt React agents, Node.js 22.12+.
+
+---
+
+## References
+
+Spec: `docs/superpowers/specs/2026-05-19-langchain-provider-materialization-design.md`
+
+Current LangChain JS docs checked on May 19, 2026:
+- OpenRouter: `@langchain/openrouter`, `ChatOpenRouter` - https://docs.langchain.com/oss/javascript/integrations/chat/openrouter
+- Google Gemini: current docs still show `@langchain/google-genai`, `ChatGoogleGenerativeAI`, with a deprecation note toward `ChatGoogle` - https://docs.langchain.com/oss/javascript/integrations/chat/google_generative_ai
+- Anthropic: `@langchain/anthropic`, `ChatAnthropic` - https://docs.langchain.com/oss/javascript/integrations/providers/anthropic
+- Groq: `@langchain/groq`, `ChatGroq` - https://docs.langchain.com/oss/javascript/integrations/chat/groq
+- xAI: `@langchain/xai`, `ChatXAI` - https://docs.langchain.com/oss/javascript/integrations/chat/xai
+- Chat model index lists `ChatGoogle`, `ChatMistralAI`, `ChatOllama`, `ChatXAI`, and proxy guidance - https://docs.langchain.com/oss/javascript/integrations/chat
+
+## File Structure
+
+Create:
+- `packages/sdk/src/model-provider.ts` - public provider id types.
+- `packages/langchain/src/model-provider-resolver.ts` - model-to-provider inference and provider validation.
+- `packages/langchain/src/chat-model-factory.ts` - lazy provider imports and constructor wiring.
+- `packages/langchain/test/model-provider-resolver.test.ts` - inference and error tests.
+- `packages/langchain/test/chat-model-factory.test.ts` - factory tests with injected importers/constructors.
+
+Modify:
+- `packages/sdk/src/agent.ts` - descriptor carries `provider`.
+- `packages/sdk/src/index.ts` - export provider types.
+- `packages/sdk/test/agent.test.ts` - provider carry-through tests.
+- `packages/sdk/test/known-model-ids.test.ts` - provider type compatibility tests.
+- `packages/langchain/src/agent-adapter.ts` - call `resolveChatModel()` instead of `new ChatOpenAI(...)`.
+- `packages/langchain/src/index.ts` - export resolver/factory helpers only if useful for tests or advanced users.
+- `packages/langchain/package.json` - optional peer metadata and dev deps for provider integrations.
+- `packages/langchain/test/agent-adapter.test.ts` and `packages/langchain/test/agent-descriptor-integration.test.ts` - update comments/assertions away from OpenAI-only wording.
+- `packages/cli/test/build-command.test.ts` - ensure non-OpenAI descriptors preserve build artifact shape.
+- Docs and website copy found by `rg -n "OpenAI-backed|ChatOpenAI|KnownModelId|provider"` across `apps/web`, `packages/*/README.md`, `CONTRIBUTORS.md`, and `README.md`.
+
+## Task 1: Add Provider To The SDK Descriptor
+
+**Files:**
+- Create: `packages/sdk/src/model-provider.ts`
+- Modify: `packages/sdk/src/agent.ts`
+- Modify: `packages/sdk/src/index.ts`
+- Test: `packages/sdk/test/agent.test.ts`
+- Test: `packages/sdk/test/known-model-ids.test.ts`
+
+- [ ] **Step 1: Write failing SDK tests**
+
+Add to `packages/sdk/test/agent.test.ts`:
+
+```ts
+test("preserves optional provider on the descriptor", () => {
+  const descriptor = agent({
+    provider: "anthropic",
+    model: "claude-sonnet-4-5",
+    systemPrompt: "Hello",
+  })
+
+  expect(descriptor.provider).toBe("anthropic")
+})
+
+test("provider defaults to undefined when not provided", () => {
+  const descriptor = agent({ model: "gpt-4o-mini", systemPrompt: "Hello" })
+  expect(descriptor.provider).toBeUndefined()
+})
+```
+
+Add to `packages/sdk/test/known-model-ids.test.ts`:
+
+```ts
+import type { ModelProviderId } from "@dawn-ai/sdk"
+
+test("ModelProviderId accepts known providers and custom strings", () => {
+  expectTypeOf<"openai">().toMatchTypeOf<ModelProviderId>()
+  expectTypeOf<"anthropic">().toMatchTypeOf<ModelProviderId>()
+  expectTypeOf<string & {}>().toMatchTypeOf<ModelProviderId>()
+})
+```
+
+- [ ] **Step 2: Run SDK tests and verify failure**
+
+Run:
+
+```bash
+pnpm exec vitest --run --config packages/sdk/vitest.config.ts packages/sdk/test/agent.test.ts packages/sdk/test/known-model-ids.test.ts
+```
+
+Expected: FAIL because `provider` and `ModelProviderId` do not exist yet.
+
+- [ ] **Step 3: Add provider type**
+
+Create `packages/sdk/src/model-provider.ts`:
+
+```ts
+export type BuiltInModelProviderId =
+  | "openai"
+  | "anthropic"
+  | "google"
+  | "mistral"
+  | "groq"
+  | "ollama"
+  | "xai"
+  | "openrouter"
+
+export type ModelProviderId = BuiltInModelProviderId | (string & {})
+```
+
+- [ ] **Step 4: Carry provider through descriptors**
+
+Modify `packages/sdk/src/agent.ts`:
+
+```ts
+import type { KnownModelId } from "./known-model-ids.js"
+import type { ModelProviderId } from "./model-provider.js"
+```
+
+Add `readonly provider?: ModelProviderId` to both `DawnAgent` and `AgentConfig`, then add this spread inside `agent()`:
+
+```ts
+...(config.provider !== undefined ? { provider: config.provider } : {}),
+```
+
+- [ ] **Step 5: Export provider types**
+
+Modify `packages/sdk/src/index.ts`:
+
+```ts
+export type {
+  BuiltInModelProviderId,
+  ModelProviderId,
+} from "./model-provider.js"
+```
+
+- [ ] **Step 6: Run SDK tests and typecheck**
+
+Run:
+
+```bash
+pnpm exec vitest --run --config packages/sdk/vitest.config.ts packages/sdk/test/agent.test.ts packages/sdk/test/known-model-ids.test.ts
+pnpm --filter @dawn-ai/sdk typecheck
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/sdk/src/model-provider.ts packages/sdk/src/agent.ts packages/sdk/src/index.ts packages/sdk/test/agent.test.ts packages/sdk/test/known-model-ids.test.ts
+git commit -m "feat(sdk): add agent provider descriptor field"
+```
+
+## Task 2: Implement Conservative Provider Inference
+
+**Files:**
+- Create: `packages/langchain/src/model-provider-resolver.ts`
+- Create: `packages/langchain/test/model-provider-resolver.test.ts`
+
+- [ ] **Step 1: Write failing resolver tests**
+
+Create `packages/langchain/test/model-provider-resolver.test.ts`:
+
+```ts
+import { describe, expect, test } from "vitest"
+import {
+  inferProvider,
+  resolveProvider,
+  SUPPORTED_AGENT_PROVIDERS,
+} from "../src/model-provider-resolver.js"
+
+describe("model provider resolver", () => {
+  test.each([
+    ["gpt-4o-mini", "openai"],
+    ["gpt-5-mini", "openai"],
+    ["o4-mini", "openai"],
+    ["claude-sonnet-4-5", "anthropic"],
+    ["gemini-2.5-pro", "google"],
+    ["mistral-large-latest", "mistral"],
+    ["mixtral-8x7b", "mistral"],
+    ["codestral-latest", "mistral"],
+    ["grok-beta", "xai"],
+  ] as const)("infers %s as %s", (model, provider) => {
+    expect(inferProvider(model)).toBe(provider)
+  })
+
+  test.each(["my-custom-model", "llama-3.3-70b-versatile", "qwen3-32b", "deepseek-r1"])(
+    "does not infer ambiguous model %s",
+    (model) => {
+      expect(inferProvider(model)).toBeUndefined()
+    },
+  )
+
+  test("explicit provider bypasses inference", () => {
+    expect(resolveProvider({ provider: "groq", model: "llama-3.3-70b-versatile" })).toBe("groq")
+  })
+
+  test("unknown explicit provider fails with supported list", () => {
+    expect(() => resolveProvider({ provider: "unknown", model: "gpt-4o" })).toThrow(
+      `Unsupported agent provider "unknown". Supported providers: ${SUPPORTED_AGENT_PROVIDERS.join(", ")}.`,
+    )
+  })
+
+  test("unknown inferred provider asks for explicit provider", () => {
+    expect(() => resolveProvider({ model: "internal-alias" })).toThrow(
+      'Could not infer a LangChain provider for model "internal-alias".',
+    )
+  })
+})
+```
+
+- [ ] **Step 2: Run resolver tests and verify failure**
+
+Run:
+
+```bash
+pnpm exec vitest --run --config packages/langchain/vitest.config.ts packages/langchain/test/model-provider-resolver.test.ts
+```
+
+Expected: FAIL because the resolver module does not exist.
+
+- [ ] **Step 3: Implement resolver**
+
+Create `packages/langchain/src/model-provider-resolver.ts`:
+
+```ts
+import type { BuiltInModelProviderId, ModelProviderId } from "@dawn-ai/sdk"
+
+export const SUPPORTED_AGENT_PROVIDERS = [
+  "openai",
+  "anthropic",
+  "google",
+  "mistral",
+  "groq",
+  "ollama",
+  "xai",
+  "openrouter",
+] as const satisfies readonly BuiltInModelProviderId[]
+
+const supportedProviderSet = new Set<string>(SUPPORTED_AGENT_PROVIDERS)
+
+export function inferProvider(model: string): BuiltInModelProviderId | undefined {
+  const normalized = model.trim().toLowerCase()
+
+  if (/^(gpt-|o3|o4)/.test(normalized)) return "openai"
+  if (normalized.startsWith("claude-")) return "anthropic"
+  if (normalized.startsWith("gemini-")) return "google"
+  if (
+    normalized.startsWith("mistral-") ||
+    normalized.startsWith("mixtral-") ||
+    normalized.startsWith("codestral-")
+  ) {
+    return "mistral"
+  }
+  if (normalized.startsWith("grok-")) return "xai"
+
+  return undefined
+}
+
+export function resolveProvider(options: {
+  readonly model: string
+  readonly provider?: ModelProviderId
+}): BuiltInModelProviderId {
+  if (options.provider !== undefined) {
+    if (supportedProviderSet.has(options.provider)) {
+      return options.provider as BuiltInModelProviderId
+    }
+    throw new Error(
+      `Unsupported agent provider "${options.provider}". Supported providers: ${SUPPORTED_AGENT_PROVIDERS.join(", ")}.`,
+    )
+  }
+
+  const inferred = inferProvider(options.model)
+  if (inferred) return inferred
+
+  throw new Error(
+    `Could not infer a LangChain provider for model "${options.model}". Set provider explicitly on agent({ provider: "...", model: "${options.model}", ... }).`,
+  )
+}
+```
+
+- [ ] **Step 4: Run resolver tests**
+
+Run:
+
+```bash
+pnpm exec vitest --run --config packages/langchain/vitest.config.ts packages/langchain/test/model-provider-resolver.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/langchain/src/model-provider-resolver.ts packages/langchain/test/model-provider-resolver.test.ts
+git commit -m "feat(langchain): infer agent model providers"
+```
+
+## Task 3: Add Lazy Chat Model Factory
+
+**Files:**
+- Create: `packages/langchain/src/chat-model-factory.ts`
+- Create: `packages/langchain/test/chat-model-factory.test.ts`
+- Modify: `packages/langchain/package.json`
+
+- [ ] **Step 1: Confirm exact Google package before coding**
+
+Use official LangChain JS docs and current npm package availability to decide whether first-pass Google support should use:
+
+```ts
+import { ChatGoogleGenerativeAI } from "@langchain/google-genai"
+```
+
+or a newer:
+
+```ts
+import { ChatGoogle } from "@langchain/google"
+```
+
+Record the decision in the test names and docs comments. As of the spec, the docs still show `@langchain/google-genai` but warn it will be replaced by `ChatGoogle`.
+
+- [ ] **Step 2: Add optional peers and dev dependencies**
+
+Modify `packages/langchain/package.json`:
+
+```json
+"peerDependencies": {
+  "@langchain/core": ">=1.1.0",
+  "@langchain/anthropic": "^1.4.0",
+  "@langchain/google-genai": "^2.1.31",
+  "@langchain/mistralai": "^1.0.8",
+  "@langchain/groq": "^1.2.1",
+  "@langchain/ollama": "^1.2.7",
+  "@langchain/xai": "^1.3.18",
+  "@langchain/openrouter": "^0.2.5"
+},
+"peerDependenciesMeta": {
+  "@langchain/anthropic": { "optional": true },
+  "@langchain/google-genai": { "optional": true },
+  "@langchain/mistralai": { "optional": true },
+  "@langchain/groq": { "optional": true },
+  "@langchain/ollama": { "optional": true },
+  "@langchain/xai": { "optional": true },
+  "@langchain/openrouter": { "optional": true }
+}
+```
+
+Also add the provider packages to `devDependencies` with the same ranges so TypeScript can resolve dynamic imports during repo typecheck. These versions came from `pnpm view` during plan writing; re-check if implementation happens later.
+
+- [ ] **Step 3: Install/update lockfile**
+
+Run:
+
+```bash
+pnpm install
+```
+
+Expected: `pnpm-lock.yaml` updates with optional provider packages.
+
+- [ ] **Step 4: Write failing factory tests**
+
+Create `packages/langchain/test/chat-model-factory.test.ts`. Use an injected importer so missing-package and constructor-option behavior can be tested without real API calls:
+
+```ts
+import { describe, expect, test, vi } from "vitest"
+import { createChatModel, missingProviderPackageMessage } from "../src/chat-model-factory.js"
+
+class FakeModel {
+  constructor(readonly options: Record<string, unknown>) {}
+}
+
+describe("chat model factory", () => {
+  test("creates OpenAI with reasoningEffort", async () => {
+    const importer = vi.fn().mockResolvedValue({ ChatOpenAI: FakeModel })
+    const model = await createChatModel({
+      model: "gpt-5-mini",
+      provider: "openai",
+      reasoning: { effort: "high" },
+      importer,
+    })
+
+    expect(importer).toHaveBeenCalledWith("@langchain/openai")
+    expect((model as FakeModel).options).toEqual({
+      model: "gpt-5-mini",
+      reasoningEffort: "high",
+    })
+  })
+
+  test("does not pass OpenAI reasoningEffort to Anthropic", async () => {
+    const importer = vi.fn().mockResolvedValue({ ChatAnthropic: FakeModel })
+    const model = await createChatModel({
+      model: "claude-sonnet-4-5",
+      provider: "anthropic",
+      reasoning: { effort: "high" },
+      importer,
+    })
+
+    expect((model as FakeModel).options).toEqual({ model: "claude-sonnet-4-5" })
+  })
+
+  test("wraps missing optional peer with install command", async () => {
+    const importer = vi.fn().mockRejectedValue(Object.assign(new Error("Cannot find package"), { code: "ERR_MODULE_NOT_FOUND" }))
+
+    await expect(
+      createChatModel({ model: "claude-sonnet-4-5", provider: "anthropic", importer }),
+    ).rejects.toThrow(missingProviderPackageMessage("anthropic", "@langchain/anthropic"))
+  })
+})
+```
+
+- [ ] **Step 5: Run factory tests and verify failure**
+
+Run:
+
+```bash
+pnpm exec vitest --run --config packages/langchain/vitest.config.ts packages/langchain/test/chat-model-factory.test.ts
+```
+
+Expected: FAIL because the factory module does not exist.
+
+- [ ] **Step 6: Implement factory**
+
+Create `packages/langchain/src/chat-model-factory.ts` with a provider spec map and injectable importer:
+
+```ts
+import type { BuiltInModelProviderId, ReasoningConfig } from "@dawn-ai/sdk"
+
+type Importer = (specifier: string) => Promise<Record<string, unknown>>
+
+interface ProviderSpec {
+  readonly packageName: string
+  readonly exportName: string
+}
+
+const providerSpecs: Record<BuiltInModelProviderId, ProviderSpec> = {
+  openai: { packageName: "@langchain/openai", exportName: "ChatOpenAI" },
+  anthropic: { packageName: "@langchain/anthropic", exportName: "ChatAnthropic" },
+  google: { packageName: "@langchain/google-genai", exportName: "ChatGoogleGenerativeAI" },
+  mistral: { packageName: "@langchain/mistralai", exportName: "ChatMistralAI" },
+  groq: { packageName: "@langchain/groq", exportName: "ChatGroq" },
+  ollama: { packageName: "@langchain/ollama", exportName: "ChatOllama" },
+  xai: { packageName: "@langchain/xai", exportName: "ChatXAI" },
+  openrouter: { packageName: "@langchain/openrouter", exportName: "ChatOpenRouter" },
+}
+
+export function missingProviderPackageMessage(provider: BuiltInModelProviderId, packageName: string) {
+  return `Provider "${provider}" requires ${packageName}. Install it with: pnpm add ${packageName}`
+}
+```
+
+Then implement `createChatModel()`:
+
+```ts
+export async function createChatModel(options: {
+  readonly model: string
+  readonly provider: BuiltInModelProviderId
+  readonly reasoning?: ReasoningConfig
+  readonly importer?: Importer
+}): Promise<unknown> {
+  const spec = providerSpecs[options.provider]
+  const importer = options.importer ?? ((specifier: string) => import(specifier))
+
+  let moduleExports: Record<string, unknown>
+  try {
+    moduleExports = await importer(spec.packageName)
+  } catch (error) {
+    if (isMissingModuleError(error)) {
+      throw new Error(missingProviderPackageMessage(options.provider, spec.packageName))
+    }
+    throw error
+  }
+
+  const Constructor = moduleExports[spec.exportName]
+  if (typeof Constructor !== "function") {
+    throw new Error(`Provider "${options.provider}" package ${spec.packageName} does not export ${spec.exportName}.`)
+  }
+
+  const constructorOptions: Record<string, unknown> = { model: options.model }
+  if (options.provider === "openai" && options.reasoning?.effort) {
+    constructorOptions.reasoningEffort = options.reasoning.effort
+  }
+
+  return new Constructor(constructorOptions)
+}
+
+function isMissingModuleError(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    ("code" in error ? (error as { code?: unknown }).code === "ERR_MODULE_NOT_FOUND" : true) &&
+    /Cannot find (package|module)|ERR_MODULE_NOT_FOUND/i.test(error.message)
+  )
+}
+```
+
+- [ ] **Step 7: Run factory tests and typecheck**
+
+Run:
+
+```bash
+pnpm exec vitest --run --config packages/langchain/vitest.config.ts packages/langchain/test/chat-model-factory.test.ts
+pnpm --filter @dawn-ai/langchain typecheck
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add packages/langchain/package.json pnpm-lock.yaml packages/langchain/src/chat-model-factory.ts packages/langchain/test/chat-model-factory.test.ts
+git commit -m "feat(langchain): add provider chat model factory"
+```
+
+## Task 4: Wire Provider Resolution Into Agent Materialization
+
+**Files:**
+- Modify: `packages/langchain/src/agent-adapter.ts`
+- Modify: `packages/langchain/src/index.ts`
+- Modify: `packages/langchain/test/agent-adapter.test.ts`
+- Modify: `packages/langchain/test/agent-descriptor-integration.test.ts`
+
+- [ ] **Step 1: Write/adjust failing integration tests**
+
+In `packages/langchain/test/agent-adapter.test.ts`, add a test that uses a non-OpenAI model with explicit provider and asserts it no longer fails with OpenAI-only materialization wording. Keep the test tolerant of missing API keys:
+
+```ts
+test("DawnAgent descriptor accepts explicit non-OpenAI provider", async () => {
+  const descriptor = agent({
+    provider: "anthropic",
+    model: "claude-sonnet-4-5",
+    systemPrompt: "You are helpful.",
+  })
+
+  const error = await executeAgent({
+    entry: descriptor,
+    input: { question: "hi" },
+    routeParamNames: [],
+    signal: new AbortController().signal,
+    tools: [],
+  }).catch((e: Error) => e)
+
+  expect(error).toBeInstanceOf(Error)
+  expect((error as Error).message).not.toContain("ChatOpenAI")
+  expect((error as Error).message).not.toContain("must expose invoke")
+})
+```
+
+- [ ] **Step 2: Run targeted test and verify failure**
+
+Run:
+
+```bash
+pnpm exec vitest --run --config packages/langchain/vitest.config.ts packages/langchain/test/agent-adapter.test.ts
+```
+
+Expected before implementation: FAIL or still route through direct `ChatOpenAI`.
+
+- [ ] **Step 3: Replace direct ChatOpenAI construction**
+
+Modify `packages/langchain/src/agent-adapter.ts`:
+
+```ts
+import { createChatModel } from "./chat-model-factory.js"
+import { resolveProvider } from "./model-provider-resolver.js"
+```
+
+Replace:
+
+```ts
+const { ChatOpenAI } = await import("@langchain/openai")
+...
+const llm = new ChatOpenAI({ ... })
+```
+
+with:
+
+```ts
+const provider = resolveProvider({
+  model: descriptor.model,
+  provider: descriptor.provider,
+})
+const llm = await createChatModel({
+  model: descriptor.model,
+  provider,
+  reasoning: descriptor.reasoning,
+})
+```
+
+- [ ] **Step 4: Export focused helpers if needed**
+
+Modify `packages/langchain/src/index.ts` only if tests or downstream users need access:
+
+```ts
+export { createChatModel } from "./chat-model-factory.js"
+export { inferProvider, resolveProvider } from "./model-provider-resolver.js"
+export type { BuiltInModelProviderId, ModelProviderId } from "@dawn-ai/sdk"
+```
+
+Prefer exporting `inferProvider` and `resolveProvider` because they are useful for docs and advanced diagnostics. Do not export internal provider spec maps.
+
+- [ ] **Step 5: Update OpenAI-only comments**
+
+Change comments in `packages/langchain/test/agent-adapter.test.ts` and `packages/langchain/test/agent-descriptor-integration.test.ts` from “fail on ChatOpenAI” to “fail on provider construction or network call.”
+
+- [ ] **Step 6: Run LangChain tests**
+
+Run:
+
+```bash
+pnpm exec vitest --run --config packages/langchain/vitest.config.ts packages/langchain/test/model-provider-resolver.test.ts packages/langchain/test/chat-model-factory.test.ts packages/langchain/test/agent-adapter.test.ts packages/langchain/test/agent-descriptor-integration.test.ts
+pnpm --filter @dawn-ai/langchain typecheck
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/langchain/src/agent-adapter.ts packages/langchain/src/index.ts packages/langchain/test/agent-adapter.test.ts packages/langchain/test/agent-descriptor-integration.test.ts
+git commit -m "feat(langchain): resolve provider-aware agent models"
+```
+
+## Task 5: Cover CLI Build Artifact Stability
+
+**Files:**
+- Modify: `packages/cli/test/build-command.test.ts`
+
+- [ ] **Step 1: Add non-OpenAI build test**
+
+Add a second build test or extend the current one with a descriptor like:
+
+```ts
+export default agent({
+  model: "claude-sonnet-4-5",
+  systemPrompt: "Answer tenant support questions.",
+})
+```
+
+Assert the generated entry still imports `agentDescriptor`, imports discovered tools, and calls:
+
+```ts
+export const graph = await materializeAgentGraph({
+  descriptor: agentDescriptor,
+  tools: [tool0Definition],
+})
+```
+
+Do not assert provider package imports in build output; provider import remains runtime lazy behavior inside `@dawn-ai/langchain`.
+
+- [ ] **Step 2: Run build command test**
+
+Run:
+
+```bash
+pnpm exec vitest --run --config packages/cli/vitest.config.ts packages/cli/test/build-command.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/cli/test/build-command.test.ts
+git commit -m "test(cli): cover non-openai agent build output"
+```
+
+## Task 6: Update Documentation And Public Copy
+
+**Files:**
+- Modify: `apps/web/content/docs/api.mdx`
+- Modify: `apps/web/content/docs/agents.mdx`
+- Modify: `apps/web/content/docs/faq.mdx`
+- Modify: `apps/web/content/docs/migrating-from-langgraph.mdx`
+- Modify: `apps/web/content/templates/AGENTS.md`
+- Modify: `apps/web/content/prompts/index.ts`
+- Modify: `apps/web/app/llms.txt/route.ts`
+- Modify: `apps/web/app/components/landing/Faq.tsx`
+- Modify: `packages/langchain/README.md`
+- Modify: `packages/sdk/README.md`
+- Modify: `CONTRIBUTORS.md`
+- Modify: `README.md`
+- Optional if still accurate as fixture-specific docs: `docs/brand/README.md`, `docs/brand/quickstart.tape`, `docs/brand/capture-fixture.mjs`
+
+- [ ] **Step 1: Find stale OpenAI-only language**
+
+Run:
+
+```bash
+rg -n "OpenAI-backed|ChatOpenAI|KnownModelId|provider adapter|raw graph/chain routes when wiring a different provider" apps/web packages docs README.md CONTRIBUTORS.md
+```
+
+Expected: list of docs and comments that need updating.
+
+- [ ] **Step 2: Update API docs**
+
+In `apps/web/content/docs/api.mdx`, add `provider?: ModelProviderId` to `AgentConfig` and describe:
+
+```md
+`provider` is optional. When omitted, Dawn infers a provider for known model families. Set it explicitly for aliases, ambiguous model names, local models, or provider routers.
+```
+
+Add a `ModelProviderId` section near `KnownModelId`.
+
+- [ ] **Step 3: Update user guidance**
+
+Replace OpenAI-only claims with provider-aware wording:
+
+```md
+The built-in `agent()` route materializes to a LangChain chat model. Dawn infers providers for known model families and lazy-loads the matching LangChain integration package. Raw `graph` and `chain` routes can still instantiate any provider directly.
+```
+
+Document optional peer installs:
+
+```bash
+pnpm add @langchain/anthropic
+pnpm add @langchain/google-genai
+pnpm add @langchain/openrouter
+```
+
+- [ ] **Step 4: Preserve fixture-specific OpenAI docs**
+
+For `docs/brand/*`, keep `ChatOpenAI` wording only where the recording fixture intentionally stubs OpenAI. If a sentence describes Dawn generally, update it.
+
+- [ ] **Step 5: Run docs checks and web typecheck**
+
+Run:
+
+```bash
+node scripts/check-docs.mjs
+pnpm --filter @dawn-ai/web typecheck
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web packages/*/README.md README.md CONTRIBUTORS.md docs/brand scripts/check-docs.mjs
+git commit -m "docs: describe provider-aware agent materialization"
+```
+
+Adjust the `git add` paths to include only files actually modified.
+
+## Task 7: Full Verification
+
+**Files:**
+- No new files. This validates the whole branch.
+
+- [ ] **Step 1: Run focused package tests**
+
+Run:
+
+```bash
+pnpm exec vitest --run --config packages/sdk/vitest.config.ts packages/sdk/test/agent.test.ts packages/sdk/test/known-model-ids.test.ts
+pnpm exec vitest --run --config packages/langchain/vitest.config.ts packages/langchain/test/model-provider-resolver.test.ts packages/langchain/test/chat-model-factory.test.ts packages/langchain/test/agent-adapter.test.ts packages/langchain/test/agent-descriptor-integration.test.ts
+pnpm exec vitest --run --config packages/cli/vitest.config.ts packages/cli/test/build-command.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run package typechecks**
+
+Run:
+
+```bash
+pnpm --filter @dawn-ai/sdk typecheck
+pnpm --filter @dawn-ai/langchain typecheck
+pnpm --filter @dawn-ai/cli typecheck
+pnpm --filter @dawn-ai/web typecheck
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run repo lint and docs checks**
+
+Run:
+
+```bash
+pnpm lint
+node scripts/check-docs.mjs
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Run full test suite if time allows**
+
+Run:
+
+```bash
+pnpm test
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Inspect final diff**
+
+Run:
+
+```bash
+git status --short
+git diff --stat HEAD
+git diff --check
+```
+
+Expected: only intentional changes, no whitespace errors.
+
+- [ ] **Step 6: Commit final fixes if needed**
+
+If Task 7 produced fixes, commit them:
+
+```bash
+git add <changed-files>
+git commit -m "chore: verify provider materialization"
+```

--- a/docs/superpowers/specs/2026-05-19-langchain-provider-materialization-design.md
+++ b/docs/superpowers/specs/2026-05-19-langchain-provider-materialization-design.md
@@ -1,0 +1,238 @@
+# LangChain Provider Materialization Design
+
+## Summary
+
+Dawn's built-in `agent()` route should support LangChain chat model providers beyond OpenAI while keeping the authoring API simple. The default user experience remains `agent({ model, systemPrompt })`; Dawn infers the provider from known model naming patterns. Advanced users can set `provider` explicitly when inference is ambiguous, when using custom aliases, or when targeting OpenAI-compatible proxies.
+
+Provider integrations are optional peer dependencies. Dawn should not bundle every LangChain provider package into `@dawn-ai/langchain`; it should lazy-import the provider package only when the selected provider is used and emit an actionable install message when the package is missing.
+
+## Goals
+
+- Keep the common `agent({ model })` path provider-aware without requiring boilerplate.
+- Preserve today's OpenAI behavior for existing OpenAI model ids.
+- Add explicit provider override for ambiguous model strings and custom aliases.
+- Keep non-OpenAI provider packages optional so OpenAI-only apps do not pay install or version cost.
+- Make failures deterministic and helpful: unknown model names should explain how to set `provider`, and missing provider packages should explain what to install.
+- Keep raw `graph` and `chain` route behavior unchanged.
+
+## Non-Goals
+
+- Do not build a full model catalog or guarantee that every LangChain integration is supported in the first implementation.
+- Do not validate model availability against remote provider APIs.
+- Do not convert Dawn into a provider-agnostic LLM SDK; Dawn should only resolve the chat model needed to materialize `agent()` routes.
+- Do not change tool discovery, state schema materialization, subagent dispatch, route ids, or build artifact shape except where tests need provider coverage.
+
+## Public API
+
+Extend `AgentConfig` with an optional provider override:
+
+```ts
+export type ModelProviderId =
+  | "openai"
+  | "anthropic"
+  | "google"
+  | "mistral"
+  | "groq"
+  | "ollama"
+  | "xai"
+  | "openrouter"
+  | (string & {})
+
+export interface AgentConfig {
+  readonly description?: string
+  readonly model: KnownModelId
+  readonly provider?: ModelProviderId
+  readonly reasoning?: ReasoningConfig
+  readonly retry?: RetryConfig
+  readonly subagents?: readonly DawnAgent[]
+  readonly systemPrompt: string
+}
+```
+
+The current descriptor runtime shape should also carry `provider?: ModelProviderId`, but `DawnAgent.model` can remain `string` after branding. This preserves the existing descriptor pattern while exposing the provider to materialization.
+
+Common usage:
+
+```ts
+export default agent({
+  model: "claude-sonnet-4-5",
+  systemPrompt: "You are a helpful assistant.",
+})
+```
+
+Override usage:
+
+```ts
+export default agent({
+  provider: "anthropic",
+  model: "internal-claude-alias",
+  systemPrompt: "You are a helpful assistant.",
+})
+```
+
+OpenAI-compatible proxy usage should use a provider id that makes the behavior explicit, such as `openrouter`, rather than silently treating all custom strings as OpenAI.
+
+## Architecture
+
+Add a provider resolver layer inside `@dawn-ai/langchain` and have `materializeAgent()` call that layer instead of constructing `ChatOpenAI` directly.
+
+```ts
+const llm = await resolveChatModel({
+  model: descriptor.model,
+  provider: descriptor.provider,
+  reasoning: descriptor.reasoning,
+})
+```
+
+The provider resolver has three responsibilities:
+
+1. Select provider: use `descriptor.provider` when present, otherwise infer from `descriptor.model`.
+2. Load provider: lazy-import the matching LangChain package.
+3. Construct model: pass only options supported by that provider constructor.
+
+Keep this code split by responsibility:
+
+- `packages/sdk/src/model-provider.ts` - public provider id type.
+- `packages/sdk/src/agent.ts` - `AgentConfig.provider` and descriptor carry-through.
+- `packages/langchain/src/model-provider-resolver.ts` - provider inference, unknown-model errors, and missing-package errors.
+- `packages/langchain/src/chat-model-factory.ts` - provider-specific lazy imports and constructor wiring.
+- `packages/langchain/src/agent-adapter.ts` - replace direct `ChatOpenAI` construction with `resolveChatModel()`.
+
+## Provider Inference
+
+Inference should be conservative. It should map high-confidence model prefixes and exact families, and otherwise fail with a provider override instruction.
+
+Initial inference rules:
+
+- `gpt-*`, `o3*`, `o4*`, and known OpenAI ids -> `openai`
+- `claude-*` -> `anthropic`
+- `gemini-*` -> `google`
+- `mistral-*`, `mixtral-*`, `codestral-*` -> `mistral`
+- `llama*`, `qwen*`, `deepseek*`, and other local-style aliases should not automatically mean Ollama unless the model string is prefixed or the provider is explicit. Too many hosted providers serve these names.
+- `grok-*` -> `xai`
+
+If inference returns `undefined`, throw:
+
+```text
+Could not infer a LangChain provider for model "my-custom-model".
+Set provider explicitly, for example agent({ provider: "anthropic", model: "my-custom-model", ... }).
+```
+
+Provider-prefixed model ids can be considered later, but they are not part of the initial design because the approved API prefers automatic inference plus explicit `provider`.
+
+## Optional Peer Dependencies
+
+`@dawn-ai/langchain` should keep `@langchain/openai` as a normal dependency for backwards compatibility and mark other provider packages as optional peers:
+
+- `@langchain/anthropic`
+- `@langchain/google`
+- `@langchain/mistralai`
+- `@langchain/groq`
+- `@langchain/ollama`
+- `@langchain/xai`
+- `@langchain/openrouter`
+
+When a lazy import fails because the peer is missing, convert it into an actionable Dawn error:
+
+```text
+Provider "anthropic" requires @langchain/anthropic.
+Install it with: pnpm add @langchain/anthropic
+```
+
+Do not catch constructor errors that come from invalid API keys, invalid model ids, or provider runtime failures. Those should pass through with provider context preserved where useful.
+
+## Provider Constructors
+
+The first implementation should support a focused constructor map:
+
+- `openai` -> `new ChatOpenAI({ model, reasoningEffort? })`
+- `anthropic` -> `new ChatAnthropic({ model })`
+- `google` -> `new ChatGoogle({ model })` or the current LangChain JS Gemini chat model class after verification during implementation
+- `mistral` -> `new ChatMistralAI({ model })`
+- `groq` -> `new ChatGroq({ model })`
+- `ollama` -> `new ChatOllama({ model })`
+- `xai` -> `new ChatXAI({ model })`
+- `openrouter` -> `new ChatOpenRouter({ model })`
+
+Reasoning options should only be passed to providers that support them. Initially, keep `reasoning.effort` OpenAI-only unless a provider-specific mapping is explicitly verified.
+
+## Data Flow
+
+1. User exports a Dawn descriptor with `agent({ model, provider?, systemPrompt, ... })`.
+2. Dawn runtime or build identifies the route as `agent`.
+3. `executeAgent()` or generated build entry calls `materializeAgent()` / `materializeAgentGraph()`.
+4. `materializeAgent()` converts Dawn tools to LangChain tools.
+5. `resolveChatModel()` chooses and constructs the provider chat model.
+6. `createReactAgent()` receives the resolved chat model, tools, prompt, and optional state schema.
+7. Streaming, retry, subagent, prompt-fragment, and state-update behavior continue through the existing `agent-adapter.ts` path.
+
+## Error Handling
+
+Unknown provider:
+
+```text
+Unsupported agent provider "foo".
+Supported providers: openai, anthropic, google, mistral, groq, ollama, xai, openrouter.
+```
+
+Unknown model with no explicit provider:
+
+```text
+Could not infer a LangChain provider for model "foo".
+Set provider explicitly on agent({ provider: "...", model: "foo", ... }).
+```
+
+Missing optional peer:
+
+```text
+Provider "google" requires @langchain/google.
+Install it with: pnpm add @langchain/google
+```
+
+Provider-specific constructor or runtime errors should not be collapsed into generic Dawn errors.
+
+## Testing Strategy
+
+SDK tests:
+
+- `agent()` preserves `provider` in the returned descriptor.
+- `AgentConfig` accepts known provider ids and arbitrary provider strings.
+- Existing descriptors without `provider` remain valid.
+
+LangChain unit tests:
+
+- `inferProvider()` recognizes OpenAI, Anthropic, Google, Mistral, Groq, and xAI model patterns.
+- `inferProvider()` refuses ambiguous custom/local-style model names.
+- Explicit `provider` bypasses inference.
+- Missing optional peer import produces the expected install message.
+- OpenAI materialization still passes `reasoningEffort` only for OpenAI.
+- Non-OpenAI providers do not receive OpenAI-only `reasoningEffort`.
+
+CLI/build tests:
+
+- `dawn build` generated agent entries still call `materializeAgentGraph()`.
+- A non-OpenAI descriptor with tools generates the same artifact shape as OpenAI descriptors.
+- Runtime route execution reaches the materialization path with explicit provider metadata.
+
+Docs checks:
+
+- Update API reference, agents guide, FAQ, templates, README/package summaries, and generated `llms.txt` copy.
+- Replace “OpenAI-backed today” language with provider-aware materialization language.
+- Keep caveats that raw `graph` and `chain` routes can instantiate any LangChain-compatible provider directly.
+
+## Migration
+
+Existing OpenAI users should not need code changes.
+
+Existing custom model strings that accidentally relied on `ChatOpenAI({ model: custom })` are the compatibility risk. To preserve that path, the implementation can either:
+
+1. Keep arbitrary unknown strings on OpenAI for one release and warn in docs, or
+2. Require `provider: "openai"` for unknown strings immediately.
+
+The recommended behavior is option 2 because it avoids silently routing unknown provider names through OpenAI. If this is too breaking for pre-1.0 users, add a release-note caveat and a targeted compatibility test for explicit `provider: "openai"`.
+
+## Open Questions
+
+- Confirm exact current LangChain JS constructor option names for Google Gemini and OpenRouter before implementation.
+- Decide whether OpenAI-compatible custom `baseURL` support belongs in the first implementation or should remain a future provider option.
+- Decide whether provider-specific constructor options beyond `model` should be added now or deferred. The recommended first pass defers them.

--- a/packages/cli/test/build-command.test.ts
+++ b/packages/cli/test/build-command.test.ts
@@ -89,4 +89,69 @@ export default async function tenantGreet(input: { tenant: string }) {
     }
     expect(langgraph.graphs["/hello/[tenant]#agent"]).toBe("./.dawn/build/hello-tenant.ts:graph")
   })
+
+  test("generates a provider-agnostic materialized entry for non-OpenAI agent descriptors", async () => {
+    const appRoot = await createFixtureApp({
+      "src/app/(public)/support/[tenant]/index.ts": `import { agent } from "@dawn-ai/sdk"
+
+export default agent({
+  model: "claude-sonnet-4-5",
+  systemPrompt: "Answer tenant support questions.",
+})
+`,
+      "src/app/(public)/support/[tenant]/tools/tenant-greet.ts": `export const description = "Greet a tenant"
+export const schema = {
+  type: "object",
+  properties: {
+    tenant: { type: "string" },
+  },
+  required: ["tenant"],
+}
+
+export default async function tenantGreet(input: { tenant: string }) {
+  return { message: \`Hello, \${input.tenant}!\` }
+}
+`,
+    })
+    const stdout: string[] = []
+    const stderr: string[] = []
+
+    await runBuildCommand(
+      { clean: true, cwd: appRoot },
+      {
+        stderr: (message) => stderr.push(message),
+        stdout: (message) => stdout.push(message),
+      },
+    )
+
+    expect(stderr.join("")).toBe("")
+
+    const entry = await readFile(join(appRoot, ".dawn/build/support-tenant.ts"), "utf8")
+    expect(entry).toContain(
+      'import agentDescriptor from "../../src/app/(public)/support/[tenant]/index.js"',
+    )
+    expect(entry).toContain(
+      'import tool0 from "../../src/app/(public)/support/[tenant]/tools/tenant-greet.js"',
+    )
+    expect(entry).toContain('import { materializeAgentGraph } from "@dawn-ai/langchain"')
+    expect(entry).toContain('name: "tenant-greet"')
+    expect(entry).toContain(`export const graph = await materializeAgentGraph({
+  descriptor: agentDescriptor,
+  tools: [tool0Definition],
+})`)
+    expect(entry).not.toContain("@anthropic-ai")
+    expect(entry).not.toContain("@langchain/anthropic")
+    expect(entry).not.toContain("ChatAnthropic")
+    expect(entry).not.toContain("bindTools")
+    expect(entry).not.toContain("import { agent }")
+
+    const langgraph = JSON.parse(
+      await readFile(join(appRoot, ".dawn/build/langgraph.json"), "utf8"),
+    ) as {
+      readonly graphs: Record<string, string>
+    }
+    expect(langgraph.graphs["/support/[tenant]#agent"]).toBe(
+      "./.dawn/build/support-tenant.ts:graph",
+    )
+  })
 })

--- a/packages/cli/test/build-command.test.ts
+++ b/packages/cli/test/build-command.test.ts
@@ -135,13 +135,14 @@ export default async function tenantGreet(input: { tenant: string }) {
     )
     expect(entry).toContain('import { materializeAgentGraph } from "@dawn-ai/langchain"')
     expect(entry).toContain('name: "tenant-greet"')
-    expect(entry).toContain(`export const graph = await materializeAgentGraph({
-  descriptor: agentDescriptor,
-  tools: [tool0Definition],
-})`)
+    expect(entry).toContain("export const graph = await materializeAgentGraph({")
+    expect(entry).toContain("descriptor: agentDescriptor")
+    expect(entry).toContain("tools: [tool0Definition]")
     expect(entry).not.toContain("@anthropic-ai")
     expect(entry).not.toContain("@langchain/anthropic")
+    expect(entry).not.toContain("@langchain/openai")
     expect(entry).not.toContain("ChatAnthropic")
+    expect(entry).not.toContain("ChatOpenAI")
     expect(entry).not.toContain("bindTools")
     expect(entry).not.toContain("import { agent }")
 

--- a/packages/langchain/README.md
+++ b/packages/langchain/README.md
@@ -11,9 +11,13 @@ LangChain backend adapters Dawn uses to materialize `chain` routes and provider-
 Install optional provider integrations in applications as needed:
 
 ```bash
-pnpm add @langchain/anthropic
-pnpm add @langchain/google-genai
-pnpm add @langchain/openrouter
+pnpm add @langchain/anthropic     # anthropic
+pnpm add @langchain/google-genai  # google
+pnpm add @langchain/mistralai     # mistral
+pnpm add @langchain/groq          # groq
+pnpm add @langchain/ollama        # ollama
+pnpm add @langchain/xai           # xai
+pnpm add @langchain/openrouter    # openrouter
 ```
 
 This is an internal Dawn workspace package. For Dawn documentation, see <https://github.com/cacheplane/dawnai/tree/main/apps/web/content/docs>.

--- a/packages/langchain/README.md
+++ b/packages/langchain/README.md
@@ -4,7 +4,17 @@
 
 # @dawn-ai/langchain
 
-LangChain backend adapters Dawn uses to materialize `chain` and OpenAI-backed `agent` routes (tool conversion, streaming, retry).
+LangChain backend adapters Dawn uses to materialize `chain` routes and provider-aware `agent` routes (tool conversion, streaming, retry).
+
+`agent()` materialization resolves a LangChain chat model from the route descriptor. Dawn includes `@langchain/openai` for the default/backcompat path and lazy-loads optional provider packages when an agent selects or infers another provider.
+
+Install optional provider integrations in applications as needed:
+
+```bash
+pnpm add @langchain/anthropic
+pnpm add @langchain/google-genai
+pnpm add @langchain/openrouter
+```
 
 This is an internal Dawn workspace package. For Dawn documentation, see <https://github.com/cacheplane/dawnai/tree/main/apps/web/content/docs>.
 

--- a/packages/langchain/package.json
+++ b/packages/langchain/package.json
@@ -42,7 +42,7 @@
     "@langchain/openai": "^1.4.5"
   },
   "peerDependencies": {
-    "@langchain/core": ">=1.1.0",
+    "@langchain/core": ">=1.1.47",
     "@langchain/anthropic": "^1.4.0",
     "@langchain/google-genai": "^2.1.31",
     "@langchain/mistralai": "^1.0.8",

--- a/packages/langchain/package.json
+++ b/packages/langchain/package.json
@@ -42,13 +42,50 @@
     "@langchain/openai": "^1.4.5"
   },
   "peerDependencies": {
-    "@langchain/core": ">=1.1.0"
+    "@langchain/core": ">=1.1.0",
+    "@langchain/anthropic": "^1.4.0",
+    "@langchain/google-genai": "^2.1.31",
+    "@langchain/mistralai": "^1.0.8",
+    "@langchain/groq": "^1.2.1",
+    "@langchain/ollama": "^1.2.7",
+    "@langchain/xai": "^1.3.18",
+    "@langchain/openrouter": "^0.2.5"
+  },
+  "peerDependenciesMeta": {
+    "@langchain/anthropic": {
+      "optional": true
+    },
+    "@langchain/google-genai": {
+      "optional": true
+    },
+    "@langchain/mistralai": {
+      "optional": true
+    },
+    "@langchain/groq": {
+      "optional": true
+    },
+    "@langchain/ollama": {
+      "optional": true
+    },
+    "@langchain/xai": {
+      "optional": true
+    },
+    "@langchain/openrouter": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@dawn-ai/config-typescript": "workspace:*",
-    "@langchain/core": "1.1.46",
+    "@langchain/anthropic": "^1.4.0",
+    "@langchain/core": "1.1.47",
+    "@langchain/google-genai": "^2.1.31",
+    "@langchain/groq": "^1.2.1",
     "@langchain/langgraph": "1.3.0",
+    "@langchain/mistralai": "^1.0.8",
+    "@langchain/ollama": "^1.2.7",
     "@langchain/openai": "1.4.5",
+    "@langchain/openrouter": "^0.2.5",
+    "@langchain/xai": "^1.3.18",
     "@types/node": "25.6.0",
     "zod": "4.4.3"
   }

--- a/packages/langchain/package.json
+++ b/packages/langchain/package.json
@@ -42,7 +42,7 @@
     "@langchain/openai": "^1.4.5"
   },
   "peerDependencies": {
-    "@langchain/core": ">=1.1.47",
+    "@langchain/core": "^1.1.47",
     "@langchain/anthropic": "^1.4.0",
     "@langchain/google-genai": "^2.1.31",
     "@langchain/mistralai": "^1.0.8",

--- a/packages/langchain/src/agent-adapter.ts
+++ b/packages/langchain/src/agent-adapter.ts
@@ -2,6 +2,8 @@ import type { PromptFragment, StreamTransformer } from "@dawn-ai/core"
 import type { DawnAgent, RetryConfig } from "@dawn-ai/sdk"
 import { isDawnAgent } from "@dawn-ai/sdk"
 import { type BaseMessageLike, HumanMessage } from "@langchain/core/messages"
+import { createChatModel } from "./chat-model-factory.js"
+import { resolveProvider } from "./model-provider-resolver.js"
 import { isRetryableError, withRetry } from "./retry.js"
 import { materializeStateSchema, type ResolvedStateField } from "./state-adapter.js"
 import {
@@ -78,16 +80,17 @@ async function materializeAgent(
   }
 
   const { createReactAgent } = await import("@langchain/langgraph/prebuilt")
-  const { ChatOpenAI } = await import("@langchain/openai")
 
   const langchainTools = tools.map((tool) => convertToolToLangChain(tool, middlewareContext))
 
-  const llm = new ChatOpenAI({
+  const provider = resolveProvider({
     model: descriptor.model,
-    // Maps to OpenAI's reasoningEffort param. Non-reasoning models ignore it.
-    // Default is `medium` for pre-gpt-5.1 reasoning models per OpenAI docs.
-    // Bump to `high` for tool-use-heavy agents that aren't following directives.
-    ...(descriptor.reasoning?.effort ? { reasoningEffort: descriptor.reasoning.effort } : {}),
+    ...(descriptor.provider ? { provider: descriptor.provider } : {}),
+  })
+  const llm = await createChatModel({
+    model: descriptor.model,
+    provider,
+    ...(descriptor.reasoning ? { reasoning: descriptor.reasoning } : {}),
   })
 
   const fragments = promptFragments ?? []

--- a/packages/langchain/src/agent-adapter.ts
+++ b/packages/langchain/src/agent-adapter.ts
@@ -85,7 +85,7 @@ async function materializeAgent(
 
   const provider = resolveProvider({
     model: descriptor.model,
-    ...(descriptor.provider ? { provider: descriptor.provider } : {}),
+    ...(descriptor.provider !== undefined ? { provider: descriptor.provider } : {}),
   })
   const llm = await createChatModel({
     model: descriptor.model,

--- a/packages/langchain/src/chat-model-factory.ts
+++ b/packages/langchain/src/chat-model-factory.ts
@@ -42,7 +42,7 @@ export async function createChatModel(options: {
   try {
     moduleExports = await importer(spec.packageName)
   } catch (error) {
-    if (isMissingModuleError(error)) {
+    if (isMissingModuleError(error, spec.packageName)) {
       throw new Error(missingProviderPackageMessage(options.provider, spec.packageName))
     }
     throw error
@@ -63,10 +63,19 @@ export async function createChatModel(options: {
   return new (Constructor as ChatModelConstructor)(constructorOptions)
 }
 
-function isMissingModuleError(error: unknown): boolean {
+function isMissingModuleError(error: unknown, expectedPackageName: string): boolean {
   return (
     error instanceof Error &&
     ("code" in error ? (error as { code?: unknown }).code === "ERR_MODULE_NOT_FOUND" : true) &&
+    referencesPackageSpecifier(error.message, expectedPackageName) &&
     /Cannot find (package|module)|ERR_MODULE_NOT_FOUND/i.test(error.message)
+  )
+}
+
+function referencesPackageSpecifier(message: string, packageName: string): boolean {
+  return (
+    message.includes(`'${packageName}'`) ||
+    message.includes(`"${packageName}"`) ||
+    message.includes(`\`${packageName}\``)
   )
 }

--- a/packages/langchain/src/chat-model-factory.ts
+++ b/packages/langchain/src/chat-model-factory.ts
@@ -1,0 +1,72 @@
+import type { BuiltInModelProviderId, ReasoningConfig } from "@dawn-ai/sdk"
+
+type Importer = (specifier: string) => Promise<Record<string, unknown>>
+type ChatModelConstructor = new (options: Record<string, unknown>) => unknown
+
+interface ProviderSpec {
+  readonly packageName: string
+  readonly exportName: string
+}
+
+const providerSpecs: Record<BuiltInModelProviderId, ProviderSpec> = {
+  openai: { packageName: "@langchain/openai", exportName: "ChatOpenAI" },
+  anthropic: { packageName: "@langchain/anthropic", exportName: "ChatAnthropic" },
+  // Official LangChain JS docs and current npm availability support this stable package/class.
+  google: { packageName: "@langchain/google-genai", exportName: "ChatGoogleGenerativeAI" },
+  mistral: { packageName: "@langchain/mistralai", exportName: "ChatMistralAI" },
+  groq: { packageName: "@langchain/groq", exportName: "ChatGroq" },
+  ollama: { packageName: "@langchain/ollama", exportName: "ChatOllama" },
+  xai: { packageName: "@langchain/xai", exportName: "ChatXAI" },
+  openrouter: { packageName: "@langchain/openrouter", exportName: "ChatOpenRouter" },
+}
+
+export function missingProviderPackageMessage(
+  provider: BuiltInModelProviderId,
+  packageName: string,
+): string {
+  return `Provider "${provider}" requires ${packageName}. Install it with: pnpm add ${packageName}`
+}
+
+export async function createChatModel(options: {
+  readonly model: string
+  readonly provider: BuiltInModelProviderId
+  readonly reasoning?: ReasoningConfig
+  readonly importer?: Importer
+}): Promise<unknown> {
+  const spec = providerSpecs[options.provider]
+  const importer =
+    options.importer ??
+    ((specifier: string) => import(specifier) as Promise<Record<string, unknown>>)
+
+  let moduleExports: Record<string, unknown>
+  try {
+    moduleExports = await importer(spec.packageName)
+  } catch (error) {
+    if (isMissingModuleError(error)) {
+      throw new Error(missingProviderPackageMessage(options.provider, spec.packageName))
+    }
+    throw error
+  }
+
+  const Constructor = moduleExports[spec.exportName]
+  if (typeof Constructor !== "function") {
+    throw new Error(
+      `Provider "${options.provider}" package ${spec.packageName} does not export ${spec.exportName}.`,
+    )
+  }
+
+  const constructorOptions: Record<string, unknown> = { model: options.model }
+  if (options.provider === "openai" && options.reasoning?.effort) {
+    constructorOptions.reasoningEffort = options.reasoning.effort
+  }
+
+  return new (Constructor as ChatModelConstructor)(constructorOptions)
+}
+
+function isMissingModuleError(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    ("code" in error ? (error as { code?: unknown }).code === "ERR_MODULE_NOT_FOUND" : true) &&
+    /Cannot find (package|module)|ERR_MODULE_NOT_FOUND/i.test(error.message)
+  )
+}

--- a/packages/langchain/src/index.ts
+++ b/packages/langchain/src/index.ts
@@ -1,3 +1,4 @@
+export type { BuiltInModelProviderId, ModelProviderId } from "@dawn-ai/sdk"
 export type {
   AgentStreamChunk,
   DawnToolDefinition,
@@ -9,6 +10,8 @@ export {
   streamAgent,
 } from "./agent-adapter.js"
 export { chainAdapter } from "./chain-adapter.js"
+export { createChatModel } from "./chat-model-factory.js"
+export { inferProvider, resolveProvider } from "./model-provider-resolver.js"
 export type { RetryOptions } from "./retry.js"
 export { isRetryableError, withRetry } from "./retry.js"
 export { materializeStateSchema } from "./state-adapter.js"

--- a/packages/langchain/src/model-provider-resolver.ts
+++ b/packages/langchain/src/model-provider-resolver.ts
@@ -1,0 +1,53 @@
+import type { BuiltInModelProviderId, ModelProviderId } from "@dawn-ai/sdk"
+
+export const SUPPORTED_AGENT_PROVIDERS = [
+  "openai",
+  "anthropic",
+  "google",
+  "mistral",
+  "groq",
+  "ollama",
+  "xai",
+  "openrouter",
+] as const satisfies readonly BuiltInModelProviderId[]
+
+const supportedProviderSet = new Set<string>(SUPPORTED_AGENT_PROVIDERS)
+
+export function inferProvider(model: string): BuiltInModelProviderId | undefined {
+  const normalized = model.trim().toLowerCase()
+
+  if (/^(gpt-|o3|o4)/.test(normalized)) return "openai"
+  if (normalized.startsWith("claude-")) return "anthropic"
+  if (normalized.startsWith("gemini-")) return "google"
+  if (
+    normalized.startsWith("mistral-") ||
+    normalized.startsWith("mixtral-") ||
+    normalized.startsWith("codestral-")
+  ) {
+    return "mistral"
+  }
+  if (normalized.startsWith("grok-")) return "xai"
+
+  return undefined
+}
+
+export function resolveProvider(options: {
+  readonly model: string
+  readonly provider?: ModelProviderId
+}): BuiltInModelProviderId {
+  if (options.provider !== undefined) {
+    if (supportedProviderSet.has(options.provider)) {
+      return options.provider as BuiltInModelProviderId
+    }
+    throw new Error(
+      `Unsupported agent provider "${options.provider}". Supported providers: ${SUPPORTED_AGENT_PROVIDERS.join(", ")}.`,
+    )
+  }
+
+  const inferred = inferProvider(options.model)
+  if (inferred) return inferred
+
+  throw new Error(
+    `Could not infer a LangChain provider for model "${options.model}". Set provider explicitly on agent({ provider: "...", model: "${options.model}", ... }).`,
+  )
+}

--- a/packages/langchain/test/agent-adapter.test.ts
+++ b/packages/langchain/test/agent-adapter.test.ts
@@ -5,24 +5,46 @@ import { executeAgent } from "../src/agent-adapter.js"
 
 describe("executeAgent with DawnAgent descriptors", () => {
   test("DawnAgent descriptor is recognized and does not throw invoke error", async () => {
+    let openAIModel: unknown
+
+    vi.doMock("@langchain/langgraph/prebuilt", () => ({
+      createReactAgent: vi.fn((options: { llm: unknown }) => {
+        openAIModel = options.llm
+        return {
+          invoke: vi.fn().mockResolvedValue(new AIMessage({ content: "OpenAI!" })),
+        }
+      }),
+    }))
+    vi.doMock("@langchain/openai", () => ({
+      ChatOpenAI: class {
+        readonly options: Record<string, unknown>
+
+        constructor(options: Record<string, unknown>) {
+          this.options = options
+        }
+      },
+    }))
+
     const descriptor = agent({
       model: "gpt-4o-mini",
       systemPrompt: "You are helpful.",
     })
 
-    // Without a real LLM key, materialization will fail on provider construction
-    // or network call.
-    // but the error should NOT be "Agent entry must expose invoke(input)"
-    const error = await executeAgent({
+    const result = await executeAgent({
       entry: descriptor,
       input: { question: "hi" },
       routeParamNames: [],
       signal: new AbortController().signal,
       tools: [],
-    }).catch((e: Error) => e)
+    }).finally(() => {
+      vi.doUnmock("@langchain/langgraph/prebuilt")
+      vi.doUnmock("@langchain/openai")
+    })
 
-    expect(error).toBeInstanceOf(Error)
-    expect((error as Error).message).not.toContain("must expose invoke")
+    expect((result as AIMessage).content).toBe("OpenAI!")
+    expect((openAIModel as { options: Record<string, unknown> }).options).toEqual({
+      model: "gpt-4o-mini",
+    })
   })
 
   test("DawnAgent descriptor explicit provider overrides model inference", async () => {

--- a/packages/langchain/test/agent-adapter.test.ts
+++ b/packages/langchain/test/agent-adapter.test.ts
@@ -25,18 +25,70 @@ describe("executeAgent with DawnAgent descriptors", () => {
     expect((error as Error).message).not.toContain("must expose invoke")
   })
 
-  test("DawnAgent descriptor accepts explicit non-OpenAI provider", async () => {
+  test("DawnAgent descriptor explicit provider overrides model inference", async () => {
+    let groqModel: unknown
+
+    vi.doMock("@langchain/langgraph/prebuilt", () => ({
+      createReactAgent: vi.fn((options: { llm: unknown }) => {
+        groqModel = options.llm
+        return {
+          invoke: vi.fn().mockResolvedValue(new AIMessage({ content: "Groq!" })),
+        }
+      }),
+    }))
     vi.doMock("@langchain/openai", () => ({
       ChatOpenAI: class {
         constructor() {
-          throw new Error("ChatOpenAI should not materialize non-OpenAI provider")
+          throw new Error("ChatOpenAI should not materialize explicit Groq provider")
+        }
+      },
+    }))
+    vi.doMock("@langchain/groq", () => ({
+      ChatGroq: class {
+        readonly options: Record<string, unknown>
+
+        constructor(options: Record<string, unknown>) {
+          this.options = options
         }
       },
     }))
 
     const descriptor = agent({
-      provider: "anthropic",
-      model: "claude-sonnet-4-5",
+      provider: "groq",
+      model: "gpt-4o-mini",
+      systemPrompt: "You are helpful.",
+    })
+
+    const result = await executeAgent({
+      entry: descriptor,
+      input: { question: "hi" },
+      routeParamNames: [],
+      signal: new AbortController().signal,
+      tools: [],
+    }).finally(() => {
+      vi.doUnmock("@langchain/langgraph/prebuilt")
+      vi.doUnmock("@langchain/openai")
+      vi.doUnmock("@langchain/groq")
+    })
+
+    expect((result as AIMessage).content).toBe("Groq!")
+    expect((groqModel as { options: Record<string, unknown> }).options).toEqual({
+      model: "gpt-4o-mini",
+    })
+  })
+
+  test("DawnAgent descriptor rejects explicit falsy invalid provider", async () => {
+    vi.doMock("@langchain/openai", () => ({
+      ChatOpenAI: class {
+        constructor() {
+          throw new Error("ChatOpenAI should not materialize invalid explicit provider")
+        }
+      },
+    }))
+
+    const descriptor = agent({
+      provider: "" as never,
+      model: "gpt-4o-mini",
       systemPrompt: "You are helpful.",
     })
 
@@ -53,8 +105,8 @@ describe("executeAgent with DawnAgent descriptors", () => {
       })
 
     expect(error).toBeInstanceOf(Error)
+    expect((error as Error).message).toContain('Unsupported agent provider ""')
     expect((error as Error).message).not.toContain("ChatOpenAI")
-    expect((error as Error).message).not.toContain("must expose invoke")
   })
 
   test("DawnAgent descriptor infers non-OpenAI provider from model", async () => {

--- a/packages/langchain/test/agent-adapter.test.ts
+++ b/packages/langchain/test/agent-adapter.test.ts
@@ -10,7 +10,8 @@ describe("executeAgent with DawnAgent descriptors", () => {
       systemPrompt: "You are helpful.",
     })
 
-    // Without a real LLM key, materialization will fail on ChatOpenAI/network
+    // Without a real LLM key, materialization will fail on provider construction
+    // or network call.
     // but the error should NOT be "Agent entry must expose invoke(input)"
     const error = await executeAgent({
       entry: descriptor,
@@ -21,6 +22,69 @@ describe("executeAgent with DawnAgent descriptors", () => {
     }).catch((e: Error) => e)
 
     expect(error).toBeInstanceOf(Error)
+    expect((error as Error).message).not.toContain("must expose invoke")
+  })
+
+  test("DawnAgent descriptor accepts explicit non-OpenAI provider", async () => {
+    vi.doMock("@langchain/openai", () => ({
+      ChatOpenAI: class {
+        constructor() {
+          throw new Error("ChatOpenAI should not materialize non-OpenAI provider")
+        }
+      },
+    }))
+
+    const descriptor = agent({
+      provider: "anthropic",
+      model: "claude-sonnet-4-5",
+      systemPrompt: "You are helpful.",
+    })
+
+    const error = await executeAgent({
+      entry: descriptor,
+      input: { question: "hi" },
+      routeParamNames: [],
+      signal: new AbortController().signal,
+      tools: [],
+    })
+      .catch((e: Error) => e)
+      .finally(() => {
+        vi.doUnmock("@langchain/openai")
+      })
+
+    expect(error).toBeInstanceOf(Error)
+    expect((error as Error).message).not.toContain("ChatOpenAI")
+    expect((error as Error).message).not.toContain("must expose invoke")
+  })
+
+  test("DawnAgent descriptor infers non-OpenAI provider from model", async () => {
+    vi.doMock("@langchain/openai", () => ({
+      ChatOpenAI: class {
+        constructor() {
+          throw new Error("ChatOpenAI should not materialize inferred non-OpenAI provider")
+        }
+      },
+    }))
+
+    const descriptor = agent({
+      model: "claude-sonnet-4-5",
+      systemPrompt: "You are helpful.",
+    })
+
+    const error = await executeAgent({
+      entry: descriptor,
+      input: { question: "hi" },
+      routeParamNames: [],
+      signal: new AbortController().signal,
+      tools: [],
+    })
+      .catch((e: Error) => e)
+      .finally(() => {
+        vi.doUnmock("@langchain/openai")
+      })
+
+    expect(error).toBeInstanceOf(Error)
+    expect((error as Error).message).not.toContain("ChatOpenAI")
     expect((error as Error).message).not.toContain("must expose invoke")
   })
 

--- a/packages/langchain/test/agent-adapter.test.ts
+++ b/packages/langchain/test/agent-adapter.test.ts
@@ -110,10 +110,29 @@ describe("executeAgent with DawnAgent descriptors", () => {
   })
 
   test("DawnAgent descriptor infers non-OpenAI provider from model", async () => {
+    let anthropicModel: unknown
+
+    vi.doMock("@langchain/langgraph/prebuilt", () => ({
+      createReactAgent: vi.fn((options: { llm: unknown }) => {
+        anthropicModel = options.llm
+        return {
+          invoke: vi.fn().mockResolvedValue(new AIMessage({ content: "Anthropic!" })),
+        }
+      }),
+    }))
     vi.doMock("@langchain/openai", () => ({
       ChatOpenAI: class {
         constructor() {
           throw new Error("ChatOpenAI should not materialize inferred non-OpenAI provider")
+        }
+      },
+    }))
+    vi.doMock("@langchain/anthropic", () => ({
+      ChatAnthropic: class {
+        readonly options: Record<string, unknown>
+
+        constructor(options: Record<string, unknown>) {
+          this.options = options
         }
       },
     }))
@@ -123,21 +142,22 @@ describe("executeAgent with DawnAgent descriptors", () => {
       systemPrompt: "You are helpful.",
     })
 
-    const error = await executeAgent({
+    const result = await executeAgent({
       entry: descriptor,
       input: { question: "hi" },
       routeParamNames: [],
       signal: new AbortController().signal,
       tools: [],
+    }).finally(() => {
+      vi.doUnmock("@langchain/langgraph/prebuilt")
+      vi.doUnmock("@langchain/openai")
+      vi.doUnmock("@langchain/anthropic")
     })
-      .catch((e: Error) => e)
-      .finally(() => {
-        vi.doUnmock("@langchain/openai")
-      })
 
-    expect(error).toBeInstanceOf(Error)
-    expect((error as Error).message).not.toContain("ChatOpenAI")
-    expect((error as Error).message).not.toContain("must expose invoke")
+    expect((result as AIMessage).content).toBe("Anthropic!")
+    expect((anthropicModel as { options: Record<string, unknown> }).options).toEqual({
+      model: "claude-sonnet-4-5",
+    })
   })
 
   test("legacy agent with invoke() still works", async () => {

--- a/packages/langchain/test/agent-descriptor-integration.test.ts
+++ b/packages/langchain/test/agent-descriptor-integration.test.ts
@@ -9,7 +9,7 @@ describe("agent() descriptor integration", () => {
       systemPrompt: "You are a test assistant.",
     })
 
-    // Without a real LLM key, materialization will fail on ChatOpenAI creation
+    // Without a real LLM key, materialization will fail on provider construction
     // or network call — but it should NOT fail with "must expose invoke(input)"
     const error = await executeAgent({
       entry: descriptor,

--- a/packages/langchain/test/agent-descriptor-integration.test.ts
+++ b/packages/langchain/test/agent-descriptor-integration.test.ts
@@ -1,29 +1,67 @@
 import { agent } from "@dawn-ai/sdk"
-import { describe, expect, test } from "vitest"
+import { AIMessage } from "@langchain/core/messages"
+import { describe, expect, test, vi } from "vitest"
 import { executeAgent } from "../src/agent-adapter.js"
 
 describe("agent() descriptor integration", () => {
   test("DawnAgent descriptor is recognized and does not throw invoke error", async () => {
+    let openAIModel: unknown
+
+    vi.doMock("@langchain/langgraph/prebuilt", () => ({
+      createReactAgent: vi.fn((options: { llm: unknown }) => {
+        openAIModel = options.llm
+        return {
+          invoke: vi.fn().mockResolvedValue(new AIMessage({ content: "Descriptor!" })),
+        }
+      }),
+    }))
+    vi.doMock("@langchain/openai", () => ({
+      ChatOpenAI: class {
+        readonly options: Record<string, unknown>
+
+        constructor(options: Record<string, unknown>) {
+          this.options = options
+        }
+      },
+    }))
+
     const descriptor = agent({
       model: "gpt-4o-mini",
       systemPrompt: "You are a test assistant.",
     })
 
-    // Without a real LLM key, materialization will fail on provider construction
-    // or network call — but it should NOT fail with "must expose invoke(input)"
-    const error = await executeAgent({
+    const result = await executeAgent({
       entry: descriptor,
       input: { question: "hi" },
       routeParamNames: [],
       signal: new AbortController().signal,
       tools: [],
-    }).catch((e: Error) => e)
+    }).finally(() => {
+      vi.doUnmock("@langchain/langgraph/prebuilt")
+      vi.doUnmock("@langchain/openai")
+    })
 
-    expect(error).toBeInstanceOf(Error)
-    expect((error as Error).message).not.toContain("must expose invoke")
+    expect((result as AIMessage).content).toBe("Descriptor!")
+    expect((openAIModel as { options: Record<string, unknown> }).options).toEqual({
+      model: "gpt-4o-mini",
+    })
   })
 
   test("DawnAgent with tools passes tools to materialized agent", async () => {
+    let agentTools: readonly unknown[] | undefined
+
+    vi.doMock("@langchain/langgraph/prebuilt", () => ({
+      createReactAgent: vi.fn((options: { tools?: readonly unknown[] }) => {
+        agentTools = options.tools
+        return {
+          invoke: vi.fn().mockResolvedValue(new AIMessage({ content: "Tool ready!" })),
+        }
+      }),
+    }))
+    vi.doMock("@langchain/openai", () => ({
+      ChatOpenAI: class {},
+    }))
+
     const descriptor = agent({
       model: "gpt-4o-mini",
       systemPrompt: "Use tools.",
@@ -37,16 +75,18 @@ describe("agent() descriptor integration", () => {
       },
     ]
 
-    // Will fail on LLM connection, but should get past tool conversion
-    const error = await executeAgent({
+    const result = await executeAgent({
       entry: descriptor,
       input: { query: "test" },
       routeParamNames: [],
       signal: new AbortController().signal,
       tools,
-    }).catch((e: Error) => e)
+    }).finally(() => {
+      vi.doUnmock("@langchain/langgraph/prebuilt")
+      vi.doUnmock("@langchain/openai")
+    })
 
-    expect(error).toBeInstanceOf(Error)
-    expect((error as Error).message).not.toContain("must expose invoke")
+    expect((result as AIMessage).content).toBe("Tool ready!")
+    expect(agentTools).toHaveLength(1)
   })
 })

--- a/packages/langchain/test/chat-model-factory.test.ts
+++ b/packages/langchain/test/chat-model-factory.test.ts
@@ -39,11 +39,11 @@ describe("chat model factory", () => {
   })
 
   test("wraps missing optional peer with install command", async () => {
-    const importer = vi
-      .fn()
-      .mockRejectedValue(
-        Object.assign(new Error("Cannot find package"), { code: "ERR_MODULE_NOT_FOUND" }),
-      )
+    const importer = vi.fn().mockRejectedValue(
+      Object.assign(new Error("Cannot find package '@langchain/anthropic'"), {
+        code: "ERR_MODULE_NOT_FOUND",
+      }),
+    )
 
     await expect(
       createChatModel({ model: "claude-sonnet-4-5", provider: "anthropic", importer }),
@@ -64,14 +64,39 @@ describe("chat model factory", () => {
   })
 
   test("reports missing Google @langchain/google-genai optional peer", async () => {
-    const importer = vi
-      .fn()
-      .mockRejectedValue(
-        Object.assign(new Error("Cannot find package"), { code: "ERR_MODULE_NOT_FOUND" }),
-      )
+    const importer = vi.fn().mockRejectedValue(
+      Object.assign(new Error("Cannot find package '@langchain/google-genai'"), {
+        code: "ERR_MODULE_NOT_FOUND",
+      }),
+    )
 
     await expect(
       createChatModel({ model: "gemini-2.5-flash", provider: "google", importer }),
     ).rejects.toThrow(missingProviderPackageMessage("google", "@langchain/google-genai"))
+  })
+
+  test("preserves missing transitive dependency errors", async () => {
+    const transitiveError = Object.assign(new Error("Cannot find package 'some-transitive-dep'"), {
+      code: "ERR_MODULE_NOT_FOUND",
+    })
+    const importer = vi.fn().mockRejectedValue(transitiveError)
+
+    await expect(
+      createChatModel({ model: "claude-sonnet-4-5", provider: "anthropic", importer }),
+    ).rejects.toBe(transitiveError)
+  })
+
+  test("preserves errors for similarly named missing packages", async () => {
+    const similarPackageError = Object.assign(
+      new Error("Cannot find package '@langchain/anthropic-extra'"),
+      {
+        code: "ERR_MODULE_NOT_FOUND",
+      },
+    )
+    const importer = vi.fn().mockRejectedValue(similarPackageError)
+
+    await expect(
+      createChatModel({ model: "claude-sonnet-4-5", provider: "anthropic", importer }),
+    ).rejects.toBe(similarPackageError)
   })
 })

--- a/packages/langchain/test/chat-model-factory.test.ts
+++ b/packages/langchain/test/chat-model-factory.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test, vi } from "vitest"
+
+import { createChatModel, missingProviderPackageMessage } from "../src/chat-model-factory.js"
+
+class FakeModel {
+  constructor(readonly options: Record<string, unknown>) {}
+}
+
+describe("chat model factory", () => {
+  test("creates OpenAI with reasoningEffort", async () => {
+    const importer = vi.fn().mockResolvedValue({ ChatOpenAI: FakeModel })
+
+    const model = await createChatModel({
+      model: "gpt-5-mini",
+      provider: "openai",
+      reasoning: { effort: "high" },
+      importer,
+    })
+
+    expect(importer).toHaveBeenCalledWith("@langchain/openai")
+    expect((model as FakeModel).options).toEqual({
+      model: "gpt-5-mini",
+      reasoningEffort: "high",
+    })
+  })
+
+  test("does not pass OpenAI reasoningEffort to Anthropic", async () => {
+    const importer = vi.fn().mockResolvedValue({ ChatAnthropic: FakeModel })
+
+    const model = await createChatModel({
+      model: "claude-sonnet-4-5",
+      provider: "anthropic",
+      reasoning: { effort: "high" },
+      importer,
+    })
+
+    expect(importer).toHaveBeenCalledWith("@langchain/anthropic")
+    expect((model as FakeModel).options).toEqual({ model: "claude-sonnet-4-5" })
+  })
+
+  test("wraps missing optional peer with install command", async () => {
+    const importer = vi
+      .fn()
+      .mockRejectedValue(
+        Object.assign(new Error("Cannot find package"), { code: "ERR_MODULE_NOT_FOUND" }),
+      )
+
+    await expect(
+      createChatModel({ model: "claude-sonnet-4-5", provider: "anthropic", importer }),
+    ).rejects.toThrow(missingProviderPackageMessage("anthropic", "@langchain/anthropic"))
+  })
+
+  test("creates Google with @langchain/google-genai ChatGoogleGenerativeAI", async () => {
+    const importer = vi.fn().mockResolvedValue({ ChatGoogleGenerativeAI: FakeModel })
+
+    const model = await createChatModel({
+      model: "gemini-2.5-flash",
+      provider: "google",
+      importer,
+    })
+
+    expect(importer).toHaveBeenCalledWith("@langchain/google-genai")
+    expect((model as FakeModel).options).toEqual({ model: "gemini-2.5-flash" })
+  })
+
+  test("reports missing Google @langchain/google-genai optional peer", async () => {
+    const importer = vi
+      .fn()
+      .mockRejectedValue(
+        Object.assign(new Error("Cannot find package"), { code: "ERR_MODULE_NOT_FOUND" }),
+      )
+
+    await expect(
+      createChatModel({ model: "gemini-2.5-flash", provider: "google", importer }),
+    ).rejects.toThrow(missingProviderPackageMessage("google", "@langchain/google-genai"))
+  })
+})

--- a/packages/langchain/test/model-provider-resolver.test.ts
+++ b/packages/langchain/test/model-provider-resolver.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from "vitest"
+import {
+  inferProvider,
+  resolveProvider,
+  SUPPORTED_AGENT_PROVIDERS,
+} from "../src/model-provider-resolver.js"
+
+describe("model provider resolver", () => {
+  test.each([
+    ["gpt-4o-mini", "openai"],
+    ["gpt-5-mini", "openai"],
+    ["o3-mini", "openai"],
+    ["o4-mini", "openai"],
+    ["claude-sonnet-4-5", "anthropic"],
+    ["gemini-2.5-pro", "google"],
+    ["mistral-large-latest", "mistral"],
+    ["mixtral-8x7b", "mistral"],
+    ["codestral-latest", "mistral"],
+    ["grok-beta", "xai"],
+  ] as const)("infers %s as %s", (model, provider) => {
+    expect(inferProvider(model)).toBe(provider)
+  })
+
+  test.each([
+    "my-custom-model",
+    "llama-3.3-70b-versatile",
+    "qwen3-32b",
+    "deepseek-r1",
+  ])("does not infer ambiguous model %s", (model) => {
+    expect(inferProvider(model)).toBeUndefined()
+  })
+
+  test("explicit provider bypasses inference", () => {
+    expect(resolveProvider({ provider: "groq", model: "llama-3.3-70b-versatile" })).toBe("groq")
+  })
+
+  test("unknown explicit provider fails with supported list", () => {
+    expect(() => resolveProvider({ provider: "unknown", model: "gpt-4o" })).toThrow(
+      `Unsupported agent provider "unknown". Supported providers: ${SUPPORTED_AGENT_PROVIDERS.join(", ")}.`,
+    )
+  })
+
+  test("unknown inferred provider asks for explicit provider", () => {
+    expect(() => resolveProvider({ model: "internal-alias" })).toThrow(
+      'Could not infer a LangChain provider for model "internal-alias". Set provider explicitly on agent({ provider: "...", model: "internal-alias", ... }).',
+    )
+  })
+})

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -22,13 +22,13 @@ Requires Node.js 22.12+.
 
 The SDK groups around three surfaces:
 
-- **Agents** — `agent()`, `AgentConfig`, `DawnAgent`, `ReasoningConfig`, `RetryConfig`, `isDawnAgent`
+- **Agents** — `agent()`, `AgentConfig`, `DawnAgent`, `ModelProviderId`, `ReasoningConfig`, `RetryConfig`, `isDawnAgent`
 - **Middleware** — `defineMiddleware()`, `allow()`, `reject()`, `DawnMiddleware`, `MiddlewareRequest`, `MiddlewareResult`
 - **Route and runtime types** — `RouteConfig`, `RouteKind`, `RuntimeContext`, `RuntimeTool`, `ToolRegistry`, `KnownModelId`
 
 ### Declaring an agent route
 
-A Dawn route's `index.ts` exports an `agent()` descriptor. The `model` field is typed against `KnownModelId`; `reasoning` and `retry` are optional.
+A Dawn route's `index.ts` exports an `agent()` descriptor. The `model` field is typed against `KnownModelId`; `provider`, `reasoning`, and `retry` are optional.
 
 ```ts
 // src/app/hello/index.ts
@@ -40,6 +40,8 @@ export default agent({
   retry: { maxAttempts: 3, baseDelay: 250 },
 })
 ```
+
+`provider?: ModelProviderId` is optional. When omitted, Dawn infers a provider for known model families. Set it explicitly for aliases, ambiguous model names, local models, or provider routers.
 
 ### Defining middleware
 

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -41,7 +41,7 @@ export default agent({
 })
 ```
 
-`provider?: ModelProviderId` is optional. When omitted, Dawn infers a provider for known model families. Set it explicitly for aliases, ambiguous model names, local models, or provider routers.
+`provider?: ModelProviderId` is optional. When omitted, Dawn infers a provider for known model families. Set it explicitly to one of the supported built-in provider ids for aliases, ambiguous model names, local models, or provider-router model ids.
 
 ### Defining middleware
 

--- a/packages/sdk/src/agent.ts
+++ b/packages/sdk/src/agent.ts
@@ -1,3 +1,6 @@
+import type { KnownModelId } from "./known-model-ids.js"
+import type { ModelProviderId } from "./model-provider.js"
+
 const DAWN_AGENT: unique symbol = Symbol.for("dawn.agent") as unknown as typeof DAWN_AGENT
 
 declare const brand: unique symbol
@@ -27,17 +30,17 @@ export interface DawnAgent {
   readonly [brand]: "DawnAgent"
   readonly description?: string
   readonly model: string
+  readonly provider?: ModelProviderId
   readonly reasoning?: ReasoningConfig
   readonly retry?: RetryConfig
   readonly subagents?: readonly DawnAgent[]
   readonly systemPrompt: string
 }
 
-import type { KnownModelId } from "./known-model-ids.js"
-
 export interface AgentConfig {
   readonly description?: string
   readonly model: KnownModelId
+  readonly provider?: ModelProviderId
   readonly reasoning?: ReasoningConfig
   readonly retry?: RetryConfig
   readonly subagents?: readonly DawnAgent[]
@@ -48,6 +51,7 @@ export function agent(config: AgentConfig): DawnAgent {
   return {
     [DAWN_AGENT]: true,
     model: config.model,
+    ...(config.provider !== undefined ? { provider: config.provider } : {}),
     ...(config.reasoning ? { reasoning: config.reasoning } : {}),
     ...(config.retry ? { retry: config.retry } : {}),
     ...(config.description !== undefined ? { description: config.description } : {}),

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -12,6 +12,10 @@ export type {
   OpenAiModelId,
 } from "./known-model-ids.js"
 export type {
+  BuiltInModelProviderId,
+  ModelProviderId,
+} from "./model-provider.js"
+export type {
   ContinueResult,
   DawnMiddleware,
   MiddlewareRequest,

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -12,10 +12,6 @@ export type {
   OpenAiModelId,
 } from "./known-model-ids.js"
 export type {
-  BuiltInModelProviderId,
-  ModelProviderId,
-} from "./model-provider.js"
-export type {
   ContinueResult,
   DawnMiddleware,
   MiddlewareRequest,
@@ -23,6 +19,10 @@ export type {
   RejectResult,
 } from "./middleware.js"
 export { allow, defineMiddleware, reject } from "./middleware.js"
+export type {
+  BuiltInModelProviderId,
+  ModelProviderId,
+} from "./model-provider.js"
 export type { RouteConfig, RouteKind } from "./route-config.js"
 export type { RouteStateMap, RouteToolMap } from "./route-types.js"
 export type {

--- a/packages/sdk/src/model-provider.ts
+++ b/packages/sdk/src/model-provider.ts
@@ -1,0 +1,11 @@
+export type BuiltInModelProviderId =
+  | "openai"
+  | "anthropic"
+  | "google"
+  | "mistral"
+  | "groq"
+  | "ollama"
+  | "xai"
+  | "openrouter"
+
+export type ModelProviderId = BuiltInModelProviderId | (string & {})

--- a/packages/sdk/test/agent.test.ts
+++ b/packages/sdk/test/agent.test.ts
@@ -66,4 +66,19 @@ describe("agent()", () => {
 
     expect(descriptor.retry).toBeUndefined()
   })
+
+  test("preserves optional provider on the descriptor", () => {
+    const descriptor = agent({
+      provider: "anthropic",
+      model: "claude-sonnet-4-5",
+      systemPrompt: "Hello",
+    })
+
+    expect(descriptor.provider).toBe("anthropic")
+  })
+
+  test("provider defaults to undefined when not provided", () => {
+    const descriptor = agent({ model: "gpt-4o-mini", systemPrompt: "Hello" })
+    expect(descriptor.provider).toBeUndefined()
+  })
 })

--- a/packages/sdk/test/known-model-ids.test.ts
+++ b/packages/sdk/test/known-model-ids.test.ts
@@ -1,9 +1,4 @@
-import type {
-  GoogleModelId,
-  KnownModelId,
-  ModelProviderId,
-  OpenAiModelId,
-} from "@dawn-ai/sdk"
+import type { GoogleModelId, KnownModelId, ModelProviderId, OpenAiModelId } from "@dawn-ai/sdk"
 import { agent } from "@dawn-ai/sdk"
 import { describe, expect, expectTypeOf, test } from "vitest"
 

--- a/packages/sdk/test/known-model-ids.test.ts
+++ b/packages/sdk/test/known-model-ids.test.ts
@@ -1,4 +1,9 @@
-import type { GoogleModelId, KnownModelId, OpenAiModelId } from "@dawn-ai/sdk"
+import type {
+  GoogleModelId,
+  KnownModelId,
+  ModelProviderId,
+  OpenAiModelId,
+} from "@dawn-ai/sdk"
 import { agent } from "@dawn-ai/sdk"
 import { describe, expect, expectTypeOf, test } from "vitest"
 
@@ -21,5 +26,11 @@ describe("KnownModelId", () => {
   test("per-provider types are subtypes of KnownModelId", () => {
     expectTypeOf<OpenAiModelId>().toMatchTypeOf<KnownModelId>()
     expectTypeOf<GoogleModelId>().toMatchTypeOf<KnownModelId>()
+  })
+
+  test("ModelProviderId accepts known providers and custom strings", () => {
+    expectTypeOf<"openai">().toMatchTypeOf<ModelProviderId>()
+    expectTypeOf<"anthropic">().toMatchTypeOf<ModelProviderId>()
+    expectTypeOf<string & {}>().toMatchTypeOf<ModelProviderId>()
   })
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -192,7 +192,7 @@ importers:
         version: link:../sdk
       '@langchain/core':
         specifier: 1.1.46
-        version: 1.1.46(openai@6.37.0(zod@4.4.3))
+        version: 1.1.46(openai@6.37.0(ws@8.20.1)(zod@4.4.3))(ws@8.20.1)
       '@types/node':
         specifier: 25.6.0
         version: 25.6.0
@@ -265,17 +265,38 @@ importers:
         version: link:../sdk
       '@langchain/langgraph':
         specifier: ^1.3.0
-        version: 1.3.0(@langchain/core@1.1.46(openai@6.37.0(zod@4.4.3)))(openai@6.37.0(zod@4.4.3))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(zod-to-json-schema@3.25.2(zod@4.4.3))(zod@4.4.3)
+        version: 1.3.0(@langchain/core@1.1.47(openai@6.37.0(ws@8.20.1)(zod@4.4.3))(ws@8.20.1))(openai@6.37.0(ws@8.20.1)(zod@4.4.3))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(ws@8.20.1)(zod-to-json-schema@3.25.2(zod@4.4.3))(zod@4.4.3)
       '@langchain/openai':
         specifier: ^1.4.5
-        version: 1.4.5(@langchain/core@1.1.46(openai@6.37.0(zod@4.4.3)))
+        version: 1.4.5(@langchain/core@1.1.47(openai@6.37.0(ws@8.20.1)(zod@4.4.3))(ws@8.20.1))(ws@8.20.1)
     devDependencies:
       '@dawn-ai/config-typescript':
         specifier: workspace:*
         version: link:../config-typescript
+      '@langchain/anthropic':
+        specifier: ^1.4.0
+        version: 1.4.0(@langchain/core@1.1.47(openai@6.37.0(ws@8.20.1)(zod@4.4.3))(ws@8.20.1))
       '@langchain/core':
-        specifier: 1.1.46
-        version: 1.1.46(openai@6.37.0(zod@4.4.3))
+        specifier: 1.1.47
+        version: 1.1.47(openai@6.37.0(ws@8.20.1)(zod@4.4.3))(ws@8.20.1)
+      '@langchain/google-genai':
+        specifier: ^2.1.31
+        version: 2.1.31(@langchain/core@1.1.47(openai@6.37.0(ws@8.20.1)(zod@4.4.3))(ws@8.20.1))
+      '@langchain/groq':
+        specifier: ^1.2.1
+        version: 1.2.1(@langchain/core@1.1.47(openai@6.37.0(ws@8.20.1)(zod@4.4.3))(ws@8.20.1))
+      '@langchain/mistralai':
+        specifier: ^1.0.8
+        version: 1.0.8(@langchain/core@1.1.47(openai@6.37.0(ws@8.20.1)(zod@4.4.3))(ws@8.20.1))
+      '@langchain/ollama':
+        specifier: ^1.2.7
+        version: 1.2.7(@langchain/core@1.1.47(openai@6.37.0(ws@8.20.1)(zod@4.4.3))(ws@8.20.1))
+      '@langchain/openrouter':
+        specifier: ^0.2.5
+        version: 0.2.5(@langchain/core@1.1.47(openai@6.37.0(ws@8.20.1)(zod@4.4.3))(ws@8.20.1))(ws@8.20.1)(zod@4.4.3)
+      '@langchain/xai':
+        specifier: ^1.3.18
+        version: 1.3.18(@langchain/core@1.1.47(openai@6.37.0(ws@8.20.1)(zod@4.4.3))(ws@8.20.1))(ws@8.20.1)
       '@types/node':
         specifier: 25.6.0
         version: 25.6.0
@@ -329,6 +350,15 @@ packages:
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
+
+  '@anthropic-ai/sdk@0.95.2':
+    resolution: {integrity: sha512-Egddwo3sheo1PzUrMkZnH6VkQYwS0h/b/i8vSK8Ta9M45UQipAMeDFH57dYuDAfXMEUUGeKw6CMlremgMZgrSQ==}
+    hasBin: true
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
+    peerDependenciesMeta:
+      zod:
+        optional: true
 
   '@babel/runtime@7.29.2':
     resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
@@ -752,6 +782,10 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@google/generative-ai@0.24.1':
+    resolution: {integrity: sha512-MqO+MLfM6kjxcKoy0p1wRzG3b4ZZXtPI+z2IE26UogS2Cm/XHO+7gGRBh6gcJsOiIVoH93UwKvW4HdgiOZCy9Q==}
+    engines: {node: '>=18.0.0'}
+
   '@img/colour@1.1.0':
     resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
     engines: {node: '>=18'}
@@ -930,9 +964,31 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
+  '@langchain/anthropic@1.4.0':
+    resolution: {integrity: sha512-rs1yVydrHjyiD31uChdCnKZpmDuKa0Bpz8Raiy9GvqnqmfXPMe0oOrap/2paE+NRSinDbtax8mMpP/yv8EbO1A==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@langchain/core': ^1.1.47
+
   '@langchain/core@1.1.46':
     resolution: {integrity: sha512-i8rDC83BpItxChCw4Lf+6tAr+k+OUcbirc5ZkrhI9ywYWmvxegUljLGOGYvtJNTbEAIFkhYIODPE5QRqyjF6sA==}
     engines: {node: '>=20'}
+
+  '@langchain/core@1.1.47':
+    resolution: {integrity: sha512-+fiPu6ZFnJMrZyKeM77OIVPoMPAY6OKWacnPlojHtXTbMMzb2cEOKAJV0U07cDl86NHSCIYYa0i4CyKZzXbHQQ==}
+    engines: {node: '>=20'}
+
+  '@langchain/google-genai@2.1.31':
+    resolution: {integrity: sha512-lHIJGtZab0jqoufKRPXyHHg1nLXrE74LXd0ftgibWEACc1SpSLu6XwtA23+dX4l7Q/YeSgb9n40YJx5k00/fqw==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@langchain/core': ^1.1.47
+
+  '@langchain/groq@1.2.1':
+    resolution: {integrity: sha512-K3QK3lVTUqxheA9u8upwN0cu04cySyaoKRmnN3vp5fEWQjzm08TYEv6FypyVEcEx0ZzBrHaYKsZIZKZSINN3RQ==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@langchain/core': ^1.0.0
 
   '@langchain/langgraph-checkpoint@1.0.2':
     resolution: {integrity: sha512-F4E5Tr0nt8FGghgdscJtHw+ABzChOHeI80R7Y1pjIHdiJom6c2ieo76vL+FWiny80JmoGqhrVAEIWrw0cXKPxg==}
@@ -968,14 +1024,44 @@ packages:
       zod-to-json-schema:
         optional: true
 
+  '@langchain/mistralai@1.0.8':
+    resolution: {integrity: sha512-gvroJpw2bfPWk7Tkv/OmnVwj0lBpREOtTR53XT+qAgTP6kZz00vKI7IlzNCrL3TcZobUmIoujA7WnjX9ogNSIA==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@langchain/core': ^1.0.0
+
+  '@langchain/ollama@1.2.7':
+    resolution: {integrity: sha512-7Gu17q1dn4nKGB3ZYJyaaL8H/2k7LHvcL6V25S8cVDniTTSvd0fWzI5MzPJvbf9WPxBhvmf+rDDLAhOWljHEtQ==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@langchain/core': ^1.0.0
+
   '@langchain/openai@1.4.5':
     resolution: {integrity: sha512-bQ2WMIZfSh02trJLYSAtiIcD3j6EBCiAm9nw0dZWQsVaUxmWc3JJqs8uUte6AkMazmLHzcUIw+14UkXO5fRJvQ==}
     engines: {node: '>=20'}
     peerDependencies:
       '@langchain/core': ^1.1.42
 
+  '@langchain/openai@1.4.6':
+    resolution: {integrity: sha512-R92/hW1aFlL9YNWLDEy1ePBnsn83kPOINNsVD+asjTJKB/00Dwf6s0VBpgZLRJiSWOW/RvbLJ/V4Djayh5boyQ==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@langchain/core': ^1.1.47
+
+  '@langchain/openrouter@0.2.5':
+    resolution: {integrity: sha512-mDAHc7hQ+AmXadNZaAMHOQ+4EHwIOs9IiP0R8poftJKEkQZA6QId9MitFJuZ1JkRYRANIClX1VpLSGbtVFRvCg==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@langchain/core': ^1.0.0
+
   '@langchain/protocol@0.0.15':
     resolution: {integrity: sha512-MllvbpMjqHevUm+v94M422mH7XKN+wGCvJRBVROTWBotEDOATYB4Ktk2UheYP859y9o2LlhtPek5t1T9eyfAbQ==}
+
+  '@langchain/xai@1.3.18':
+    resolution: {integrity: sha512-wSaLV3SGgmbHnzknAgSp5Mme0uDAxG22v0BaqcckF9mj2xJUFdAHP4OLoibEKqWl071/GQ+smhrOXnYo2LkVww==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@langchain/core': ^1.0.0
 
   '@manypkg/find-root@1.1.0':
     resolution: {integrity: sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA==}
@@ -999,6 +1085,9 @@ packages:
     peerDependencies:
       '@types/react': '>=16'
       react: '>=16'
+
+  '@mistralai/mistralai@1.15.1':
+    resolution: {integrity: sha512-fb995eiz3r0KsBGtRjFV+/iLbX+UpfalxpF+YitT3R6ukrPD4PN+FGwwmYcRFhNAzVzDUtTVxQYnjQWEnwV5nw==}
 
   '@napi-rs/wasm-runtime@1.1.3':
     resolution: {integrity: sha512-xK9sGVbJWYb08+mTJt3/YV24WxvxpXcXtP6B172paPZ+Ts69Re9dAr7lKwJoeIx8OoeuimEiRZ7umkiUVClmmQ==}
@@ -1360,6 +1449,9 @@ packages:
 
   '@shikijs/vscode-textmate@10.0.2':
     resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
+
+  '@stablelib/base64@1.0.1':
+    resolution: {integrity: sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==}
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
@@ -1863,6 +1955,10 @@ packages:
   eventemitter3@5.0.4:
     resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
 
+  eventsource-parser@3.0.8:
+    resolution: {integrity: sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==}
+    engines: {node: '>=18.0.0'}
+
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
@@ -1880,6 +1976,9 @@ packages:
   fast-glob@3.3.3:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
     engines: {node: '>=8.6.0'}
+
+  fast-sha256@1.3.0:
+    resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
@@ -1944,6 +2043,10 @@ packages:
   gray-matter@4.0.3:
     resolution: {integrity: sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==}
     engines: {node: '>=6.0'}
+
+  groq-sdk@1.2.0:
+    resolution: {integrity: sha512-pMhSYXWcjiqvbOeKdv2zjci1BYjGdp04a40hnmQmJpKJyB6oa+gRndAqE128gwR0NLgYO+Wt1fIF46KNHcplsw==}
+    hasBin: true
 
   hast-util-from-html@2.0.3:
     resolution: {integrity: sha512-CUSRHXyKjzHov8yKsQjGOElXy/3EKpyX56ELnkHH34vDVw1N1XSQ1ZcAvTyAPtGqLTuKP/uxM+aLkSPqF/EtMw==}
@@ -2051,6 +2154,10 @@ packages:
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
+
+  json-schema-to-ts@3.1.1:
+    resolution: {integrity: sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==}
+    engines: {node: '>=16'}
 
   jsonfile@4.0.0:
     resolution: {integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==}
@@ -2387,6 +2494,9 @@ packages:
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
 
+  ollama@0.6.3:
+    resolution: {integrity: sha512-KEWEhIqE5wtfzEIZbDCLH51VFZ6Z3ZSa6sIOg/E/tBV8S51flyqBOXi+bRxlOYKDf8i327zG9eSTb8IJxvm3Zg==}
+
   oniguruma-parser@0.12.2:
     resolution: {integrity: sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw==}
 
@@ -2693,6 +2803,9 @@ packages:
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
+  standardwebhooks@1.0.0:
+    resolution: {integrity: sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==}
+
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
@@ -2794,6 +2907,9 @@ packages:
 
   trough@2.2.0:
     resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
+
+  ts-algebra@2.0.0:
+    resolution: {integrity: sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==}
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
@@ -3044,6 +3160,9 @@ packages:
   web-namespaces@2.0.1:
     resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
 
+  whatwg-fetch@3.6.20:
+    resolution: {integrity: sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==}
+
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
@@ -3053,6 +3172,18 @@ packages:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
     hasBin: true
+
+  ws@8.20.1:
+    resolution: {integrity: sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
 
   yaml@2.9.0:
     resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
@@ -3073,6 +3204,13 @@ packages:
 snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
+
+  '@anthropic-ai/sdk@0.95.2(zod@4.4.3)':
+    dependencies:
+      json-schema-to-ts: 3.1.1
+      standardwebhooks: 1.0.0
+    optionalDependencies:
+      zod: 4.4.3
 
   '@babel/runtime@7.29.2': {}
 
@@ -3419,6 +3557,8 @@ snapshots:
   '@esbuild/win32-x64@0.27.7':
     optional: true
 
+  '@google/generative-ai@0.24.1': {}
+
   '@img/colour@1.1.0':
     optional: true
 
@@ -3542,12 +3682,18 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@langchain/core@1.1.46(openai@6.37.0(zod@4.4.3))':
+  '@langchain/anthropic@1.4.0(@langchain/core@1.1.47(openai@6.37.0(ws@8.20.1)(zod@4.4.3))(ws@8.20.1))':
+    dependencies:
+      '@anthropic-ai/sdk': 0.95.2(zod@4.4.3)
+      '@langchain/core': 1.1.47(openai@6.37.0(ws@8.20.1)(zod@4.4.3))(ws@8.20.1)
+      zod: 4.4.3
+
+  '@langchain/core@1.1.46(openai@6.37.0(ws@8.20.1)(zod@4.4.3))(ws@8.20.1)':
     dependencies:
       '@cfworker/json-schema': 4.1.1
       '@standard-schema/spec': 1.1.0
       js-tiktoken: 1.0.21
-      langsmith: 0.5.19(openai@6.37.0(zod@4.4.3))
+      langsmith: 0.5.19(openai@6.37.0(ws@8.20.1)(zod@4.4.3))(ws@8.20.1)
       mustache: 4.2.0
       p-queue: 6.6.2
       zod: 4.4.3
@@ -3558,14 +3704,40 @@ snapshots:
       - openai
       - ws
 
-  '@langchain/langgraph-checkpoint@1.0.2(@langchain/core@1.1.46(openai@6.37.0(zod@4.4.3)))':
+  '@langchain/core@1.1.47(openai@6.37.0(ws@8.20.1)(zod@4.4.3))(ws@8.20.1)':
     dependencies:
-      '@langchain/core': 1.1.46(openai@6.37.0(zod@4.4.3))
+      '@cfworker/json-schema': 4.1.1
+      '@standard-schema/spec': 1.1.0
+      js-tiktoken: 1.0.21
+      langsmith: 0.5.19(openai@6.37.0(ws@8.20.1)(zod@4.4.3))(ws@8.20.1)
+      mustache: 4.2.0
+      p-queue: 6.6.2
+      zod: 4.4.3
+    transitivePeerDependencies:
+      - '@opentelemetry/api'
+      - '@opentelemetry/exporter-trace-otlp-proto'
+      - '@opentelemetry/sdk-trace-base'
+      - openai
+      - ws
+
+  '@langchain/google-genai@2.1.31(@langchain/core@1.1.47(openai@6.37.0(ws@8.20.1)(zod@4.4.3))(ws@8.20.1))':
+    dependencies:
+      '@google/generative-ai': 0.24.1
+      '@langchain/core': 1.1.47(openai@6.37.0(ws@8.20.1)(zod@4.4.3))(ws@8.20.1)
+
+  '@langchain/groq@1.2.1(@langchain/core@1.1.47(openai@6.37.0(ws@8.20.1)(zod@4.4.3))(ws@8.20.1))':
+    dependencies:
+      '@langchain/core': 1.1.47(openai@6.37.0(ws@8.20.1)(zod@4.4.3))(ws@8.20.1)
+      groq-sdk: 1.2.0
+
+  '@langchain/langgraph-checkpoint@1.0.2(@langchain/core@1.1.47(openai@6.37.0(ws@8.20.1)(zod@4.4.3))(ws@8.20.1))':
+    dependencies:
+      '@langchain/core': 1.1.47(openai@6.37.0(ws@8.20.1)(zod@4.4.3))(ws@8.20.1)
       uuid: 10.0.0
 
-  '@langchain/langgraph-sdk@1.9.2(openai@6.37.0(zod@4.4.3))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@langchain/langgraph-sdk@1.9.2(openai@6.37.0(ws@8.20.1)(zod@4.4.3))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(ws@8.20.1)':
     dependencies:
-      '@langchain/core': 1.1.46(openai@6.37.0(zod@4.4.3))
+      '@langchain/core': 1.1.47(openai@6.37.0(ws@8.20.1)(zod@4.4.3))(ws@8.20.1)
       '@langchain/protocol': 0.0.15
       '@types/json-schema': 7.0.15
       p-queue: 9.2.0
@@ -3581,11 +3753,11 @@ snapshots:
       - openai
       - ws
 
-  '@langchain/langgraph@1.3.0(@langchain/core@1.1.46(openai@6.37.0(zod@4.4.3)))(openai@6.37.0(zod@4.4.3))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(zod-to-json-schema@3.25.2(zod@4.4.3))(zod@4.4.3)':
+  '@langchain/langgraph@1.3.0(@langchain/core@1.1.47(openai@6.37.0(ws@8.20.1)(zod@4.4.3))(ws@8.20.1))(openai@6.37.0(ws@8.20.1)(zod@4.4.3))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(ws@8.20.1)(zod-to-json-schema@3.25.2(zod@4.4.3))(zod@4.4.3)':
     dependencies:
-      '@langchain/core': 1.1.46(openai@6.37.0(zod@4.4.3))
-      '@langchain/langgraph-checkpoint': 1.0.2(@langchain/core@1.1.46(openai@6.37.0(zod@4.4.3)))
-      '@langchain/langgraph-sdk': 1.9.2(openai@6.37.0(zod@4.4.3))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@langchain/core': 1.1.47(openai@6.37.0(ws@8.20.1)(zod@4.4.3))(ws@8.20.1)
+      '@langchain/langgraph-checkpoint': 1.0.2(@langchain/core@1.1.47(openai@6.37.0(ws@8.20.1)(zod@4.4.3))(ws@8.20.1))
+      '@langchain/langgraph-sdk': 1.9.2(openai@6.37.0(ws@8.20.1)(zod@4.4.3))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(ws@8.20.1)
       '@langchain/protocol': 0.0.15
       '@standard-schema/spec': 1.1.0
       uuid: 10.0.0
@@ -3603,16 +3775,55 @@ snapshots:
       - vue
       - ws
 
-  '@langchain/openai@1.4.5(@langchain/core@1.1.46(openai@6.37.0(zod@4.4.3)))':
+  '@langchain/mistralai@1.0.8(@langchain/core@1.1.47(openai@6.37.0(ws@8.20.1)(zod@4.4.3))(ws@8.20.1))':
     dependencies:
-      '@langchain/core': 1.1.46(openai@6.37.0(zod@4.4.3))
+      '@langchain/core': 1.1.47(openai@6.37.0(ws@8.20.1)(zod@4.4.3))(ws@8.20.1)
+      '@mistralai/mistralai': 1.15.1
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  '@langchain/ollama@1.2.7(@langchain/core@1.1.47(openai@6.37.0(ws@8.20.1)(zod@4.4.3))(ws@8.20.1))':
+    dependencies:
+      '@langchain/core': 1.1.47(openai@6.37.0(ws@8.20.1)(zod@4.4.3))(ws@8.20.1)
+      ollama: 0.6.3
+
+  '@langchain/openai@1.4.5(@langchain/core@1.1.47(openai@6.37.0(ws@8.20.1)(zod@4.4.3))(ws@8.20.1))(ws@8.20.1)':
+    dependencies:
+      '@langchain/core': 1.1.47(openai@6.37.0(ws@8.20.1)(zod@4.4.3))(ws@8.20.1)
       js-tiktoken: 1.0.21
-      openai: 6.37.0(zod@4.4.3)
+      openai: 6.37.0(ws@8.20.1)(zod@4.4.3)
       zod: 4.4.3
     transitivePeerDependencies:
       - ws
 
+  '@langchain/openai@1.4.6(@langchain/core@1.1.47(openai@6.37.0(ws@8.20.1)(zod@4.4.3))(ws@8.20.1))(ws@8.20.1)':
+    dependencies:
+      '@langchain/core': 1.1.47(openai@6.37.0(ws@8.20.1)(zod@4.4.3))(ws@8.20.1)
+      js-tiktoken: 1.0.21
+      openai: 6.37.0(ws@8.20.1)(zod@4.4.3)
+      zod: 4.4.3
+    transitivePeerDependencies:
+      - ws
+
+  '@langchain/openrouter@0.2.5(@langchain/core@1.1.47(openai@6.37.0(ws@8.20.1)(zod@4.4.3))(ws@8.20.1))(ws@8.20.1)(zod@4.4.3)':
+    dependencies:
+      '@langchain/core': 1.1.47(openai@6.37.0(ws@8.20.1)(zod@4.4.3))(ws@8.20.1)
+      '@langchain/openai': 1.4.6(@langchain/core@1.1.47(openai@6.37.0(ws@8.20.1)(zod@4.4.3))(ws@8.20.1))(ws@8.20.1)
+      eventsource-parser: 3.0.8
+      openai: 6.37.0(ws@8.20.1)(zod@4.4.3)
+    transitivePeerDependencies:
+      - ws
+      - zod
+
   '@langchain/protocol@0.0.15': {}
+
+  '@langchain/xai@1.3.18(@langchain/core@1.1.47(openai@6.37.0(ws@8.20.1)(zod@4.4.3))(ws@8.20.1))(ws@8.20.1)':
+    dependencies:
+      '@langchain/core': 1.1.47(openai@6.37.0(ws@8.20.1)(zod@4.4.3))(ws@8.20.1)
+      '@langchain/openai': 1.4.6(@langchain/core@1.1.47(openai@6.37.0(ws@8.20.1)(zod@4.4.3))(ws@8.20.1))(ws@8.20.1)
+    transitivePeerDependencies:
+      - ws
 
   '@manypkg/find-root@1.1.0':
     dependencies:
@@ -3672,6 +3883,15 @@ snapshots:
       '@types/mdx': 2.0.13
       '@types/react': 19.2.14
       react: 19.2.0
+
+  '@mistralai/mistralai@1.15.1':
+    dependencies:
+      ws: 8.20.1
+      zod: 4.4.3
+      zod-to-json-schema: 3.25.2(zod@4.4.3)
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
   '@napi-rs/wasm-runtime@1.1.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)':
     dependencies:
@@ -3896,6 +4116,8 @@ snapshots:
       '@types/hast': 3.0.4
 
   '@shikijs/vscode-textmate@10.0.2': {}
+
+  '@stablelib/base64@1.0.1': {}
 
   '@standard-schema/spec@1.1.0': {}
 
@@ -4418,6 +4640,8 @@ snapshots:
 
   eventemitter3@5.0.4: {}
 
+  eventsource-parser@3.0.8: {}
+
   expect-type@1.3.0: {}
 
   extend-shallow@2.0.1:
@@ -4435,6 +4659,8 @@ snapshots:
       glob-parent: 5.1.2
       merge2: 1.4.1
       micromatch: 4.0.8
+
+  fast-sha256@1.3.0: {}
 
   fastq@1.20.1:
     dependencies:
@@ -4503,6 +4729,8 @@ snapshots:
       kind-of: 6.0.3
       section-matter: 1.0.0
       strip-bom-string: 1.0.0
+
+  groq-sdk@1.2.0: {}
 
   hast-util-from-html@2.0.3:
     dependencies:
@@ -4659,18 +4887,24 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
+  json-schema-to-ts@3.1.1:
+    dependencies:
+      '@babel/runtime': 7.29.2
+      ts-algebra: 2.0.0
+
   jsonfile@4.0.0:
     optionalDependencies:
       graceful-fs: 4.2.11
 
   kind-of@6.0.3: {}
 
-  langsmith@0.5.19(openai@6.37.0(zod@4.4.3)):
+  langsmith@0.5.19(openai@6.37.0(ws@8.20.1)(zod@4.4.3))(ws@8.20.1):
     dependencies:
       p-queue: 6.6.2
       uuid: 10.0.0
     optionalDependencies:
-      openai: 6.37.0(zod@4.4.3)
+      openai: 6.37.0(ws@8.20.1)(zod@4.4.3)
+      ws: 8.20.1
 
   lightningcss-android-arm64@1.32.0:
     optional: true
@@ -5227,6 +5461,10 @@ snapshots:
 
   obug@2.1.1: {}
 
+  ollama@0.6.3:
+    dependencies:
+      whatwg-fetch: 3.6.20
+
   oniguruma-parser@0.12.2: {}
 
   oniguruma-to-es@4.3.6:
@@ -5235,8 +5473,9 @@ snapshots:
       regex: 6.1.0
       regex-recursion: 6.0.2
 
-  openai@6.37.0(zod@4.4.3):
+  openai@6.37.0(ws@8.20.1)(zod@4.4.3):
     optionalDependencies:
+      ws: 8.20.1
       zod: 4.4.3
 
   outdent@0.5.0: {}
@@ -5633,6 +5872,11 @@ snapshots:
 
   stackback@0.0.2: {}
 
+  standardwebhooks@1.0.0:
+    dependencies:
+      '@stablelib/base64': 1.0.1
+      fast-sha256: 1.3.0
+
   std-env@3.10.0: {}
 
   std-env@4.0.0: {}
@@ -5701,6 +5945,8 @@ snapshots:
   trim-lines@3.0.1: {}
 
   trough@2.2.0: {}
+
+  ts-algebra@2.0.0: {}
 
   tslib@2.8.1: {}
 
@@ -5955,6 +6201,8 @@ snapshots:
 
   web-namespaces@2.0.1: {}
 
+  whatwg-fetch@3.6.20: {}
+
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
@@ -5964,12 +6212,13 @@ snapshots:
       siginfo: 2.0.0
       stackback: 0.0.2
 
+  ws@8.20.1: {}
+
   yaml@2.9.0: {}
 
   zod-to-json-schema@3.25.2(zod@4.4.3):
     dependencies:
       zod: 4.4.3
-    optional: true
 
   zod@4.4.3: {}
 


### PR DESCRIPTION
## Summary
- Add SDK provider descriptors for agent routes and carry them through materialization.
- Add LangChain provider inference plus a lazy optional-peer chat model factory for OpenAI, Anthropic, Google, Mistral, Groq, Ollama, xAI, and OpenRouter.
- Update agent adapter wiring, CLI/provider-agnostic build coverage, and public docs for supported providers and optional packages.

## Validation
- pnpm test
- pnpm lint
- pnpm typecheck
- pnpm build
- node scripts/check-docs.mjs
- git diff --check origin/main..HEAD
