### PR TITLE
chore(release): downgrade langchain changeset to minor for 0.2.0

### DIFF
--- a/.changeset/langchain-1x-zod-4.md
+++ b/.changeset/langchain-1x-zod-4.md
@@ -1,5 +1,5 @@
 ---
-"@dawn-ai/langchain": major
+"@dawn-ai/langchain": minor
 "@dawn-ai/cli": minor
 "@dawn-ai/vite-plugin": minor
 ---


### PR DESCRIPTION
Downgrades the `@dawn-ai/langchain` bump in `.changeset/langchain-1x-zod-4.md` from **major → minor** so the next release of the `fixed` package group computes to **0.2.0** (minor) instead of **1.0.0** (major).

Context: the langchain 1.x / zod 4 upgrade is technically breaking, but we are not maintaining strict semver pre-1.0 and want to ship the whole suite as the next minor for production smoke testing. With all `@dawn-ai/*` packages in a `fixed` group, the lone `major` changeset would otherwise drag the entire suite to 1.0.0.

After this merges, the Version Packages PR (#139) recomputes to 0.2.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)