### PR TITLE
chore(core): make sqlite-storage a direct dependency (unblock 0.2.0 release)

### DIFF
--- a/.changeset/core-sqlite-direct-dep.md
+++ b/.changeset/core-sqlite-direct-dep.md
@@ -1,0 +1,5 @@
+---
+"@dawn-ai/core": patch
+---
+
+Move `@dawn-ai/sqlite-storage` from `peerDependencies` to `dependencies`. It backs the default SQLite checkpointer/threads store that `@dawn-ai/core` ships, so a direct dependency reflects the real relationship and avoids requiring consumers to install it separately.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -38,6 +38,7 @@
   "dependencies": {
     "@dawn-ai/permissions": "workspace:*",
     "@dawn-ai/sdk": "workspace:*",
+    "@dawn-ai/sqlite-storage": "workspace:*",
     "@dawn-ai/workspace": "workspace:*",
     "@langchain/langgraph": "^1.3.0",
     "tsx": "^4.8.1",
@@ -45,7 +46,6 @@
     "zod": "^4.4.3"
   },
   "peerDependencies": {
-    "@dawn-ai/sqlite-storage": "workspace:*",
     "@langchain/langgraph-checkpoint": "^1.0.2"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -231,6 +231,9 @@ importers:
       '@dawn-ai/sdk':
         specifier: workspace:*
         version: link:../sdk
+      '@dawn-ai/sqlite-storage':
+        specifier: workspace:*
+        version: link:../sqlite-storage
       '@dawn-ai/workspace':
         specifier: workspace:*
         version: link:../workspace
@@ -250,9 +253,6 @@ importers:
       '@dawn-ai/config-typescript':
         specifier: workspace:*
         version: link:../config-typescript
-      '@dawn-ai/sqlite-storage':
-        specifier: workspace:*
-        version: link:../sqlite-storage
       '@langchain/langgraph-checkpoint':
         specifier: ^1.0.2
         version: 1.0.2(@langchain/core@1.1.47(openai@6.37.0(ws@8.20.1)(zod@4.4.3))(ws@8.20.1))


### PR DESCRIPTION
## What
Moves `@dawn-ai/sqlite-storage` from `@dawn-ai/core`'s **peerDependencies → dependencies** (keeps `workspace:*`). Regenerates `pnpm-lock.yaml` accordingly.

## Why
Two reasons:
1. **Correctness:** sqlite-storage backs the default SQLite checkpointer/threads store that core ships. A direct dependency models the real relationship; consumers no longer have to install it separately.
2. **Unblocks the 0.2.0 smoke-test release.** As a `peerDependency`, changesets' built-in peer-dependent rule auto-promoted `@dawn-ai/core` to a **major** bump whenever `sqlite-storage` was bumped (no major changeset required). The `fixed` package group then spread that major to all ten `@dawn-ai/*` packages, forcing the next release to `1.0.0`. As a direct dependency the peer-major rule no longer fires, so the group computes the intended **0.2.0** minor.

Verified locally with `changeset version`: all fixed-group packages → `0.2.0`. `pnpm install --lockfile-only` is clean.

> Note: the `onlyUpdatePeerDependentsWhenOutOfRange` + caret-range approach was rejected because this repo's `.npmrc` (`save-workspace-protocol=true`, `fail-if-no-match=true`) makes a plain-range peer on a not-yet-published version hard-fail `pnpm install`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)