### PR TITLE
fix(core): discriminated-union / literal tool-input types (found by live smoke)

### DIFF
--- a/.changeset/fix-sp5-literal-tool-inputs.md
+++ b/.changeset/fix-sp5-literal-tool-inputs.md
@@ -1,0 +1,5 @@
+---
+"@dawn-ai/core": patch
+---
+
+Fix tool-input schema extraction for standalone literal types. A single string-literal type (e.g. a discriminated-union discriminant like `by: "date"`) was not recognized as an enum (only multi-member literal unions were), so it fell through to object extraction and was misread as an object carrying `String.prototype` methods (`charAt`, `toString`, …). This produced a bogus schema that rejected the correct argument, breaking every discriminated/object-union tool parameter end-to-end. Standalone string/number/boolean literals now extract correctly, and object extraction is guarded to genuine object types. Found by a live-API smoke test.

--- a/packages/core/src/typegen/extract-tool-schema.ts
+++ b/packages/core/src/typegen/extract-tool-schema.ts
@@ -191,6 +191,20 @@ function tsTypeToJsonSchema(
   if (typeString === "number") return { type: "number" }
   if (typeString === "boolean") return { type: "boolean" }
 
+  // Standalone literal types (e.g. a discriminant `by: "date"`). A single
+  // string literal is not a union, so the union→enum path above doesn't fire;
+  // without this it would fall through to tryObjectSchema and be misread as an
+  // object carrying String.prototype methods.
+  if (type.isStringLiteral()) {
+    return { type: "string", enum: [(type as ts.StringLiteralType).value] }
+  }
+  if (type.isNumberLiteral()) {
+    return { type: "number" }
+  }
+  if ((type.flags & ts.TypeFlags.BooleanLiteral) !== 0) {
+    return { type: "boolean" }
+  }
+
   // Try nested object
   const objSchema = tryObjectSchema(type, checker, depth)
   if (objSchema !== undefined) return objSchema
@@ -211,6 +225,11 @@ function tryObjectSchema(
       additionalProperties: boolean | JsonSchemaProperty
     }
   | undefined {
+  // Only genuine object types may be expanded into property schemas. Primitives
+  // and literal types expose prototype members via getProperties(); guarding on
+  // the Object type flag prevents emitting e.g. String.prototype as properties.
+  if ((type.flags & ts.TypeFlags.Object) === 0) return undefined
+
   const props = type.getProperties()
   const indexType = checker.getIndexTypeOfType(type, ts.IndexKind.String)
 

--- a/packages/core/test/extract-tool-schema.test.ts
+++ b/packages/core/test/extract-tool-schema.test.ts
@@ -348,4 +348,38 @@ export default async function sharedTool(input: { a: number }): Promise<{ b: num
     expect(action?.anyOf?.[0]?.type).toBe("object")
     expect(action?.anyOf?.[1]?.properties?.id).toEqual({ type: "number" })
   })
+
+  describe("standalone literal types (discriminated-union discriminants)", () => {
+    test("discriminated union: each member's discriminant field is a single string literal", async () => {
+      const schemas = await extractSchemasFromSource(`
+        export default async function f(input: {
+          sort: { by: "date"; dir: "asc" | "desc" } | { by: "name" }
+        }) { return input }
+      `)
+      const sort = schemas[0]?.parameters.properties.sort
+      expect(sort?.anyOf).toHaveLength(2)
+      // First member: by: "date"
+      expect(sort?.anyOf?.[0]?.properties?.by).toEqual({ type: "string", enum: ["date"] })
+      // First member: dir: "asc" | "desc"
+      expect(sort?.anyOf?.[0]?.properties?.dir).toEqual({ type: "string", enum: ["asc", "desc"] })
+      // Second member: by: "name"
+      expect(sort?.anyOf?.[1]?.properties?.by).toEqual({ type: "string", enum: ["name"] })
+    })
+
+    test("top-level single string literal field", async () => {
+      const schemas = await extractSchemasFromSource(`
+        export default async function f(input: { mode: "fast" }) { return input }
+      `)
+      expect(schemas[0]?.parameters.properties.mode).toEqual({ type: "string", enum: ["fast"] })
+    })
+
+    test("no String.prototype members (charAt etc.) leak into schema", async () => {
+      const schemas = await extractSchemasFromSource(`
+        export default async function f(input: {
+          sort: { by: "date"; dir: "asc" | "desc" } | { by: "name" }
+        }) { return input }
+      `)
+      expect(JSON.stringify(schemas[0])).not.toContain("charAt")
+    })
+  })
 })


### PR DESCRIPTION
## Summary
A live-API smoke test of Phase 3 found that **every discriminated/object-union tool parameter is broken end-to-end**. A real model emitted the correct argument (`sort: {by:"date", dir:"desc"}`) and Dawn's generated Zod schema **rejected** it.

**Root cause** (`packages/core/src/typegen/extract-tool-schema.ts`): a standalone string-literal type (e.g. the `by: "date"` discriminant) is only treated as an enum when it's inside a *multi-member* union. A single literal isn't a union, so it fell through to object extraction, where `type.getProperties()` returned all 50 `String.prototype` members (`charAt`, `toString`, …) — emitting a bogus object schema.

**Fix:**
1. Handle standalone string/number/boolean literal types directly (string literal → `{type:"string", enum:[value]}`).
2. Guard `tryObjectSchema` to genuine object types (`ts.TypeFlags.Object`) so no primitive can ever be expanded via prototype members.

## Why unit tests missed it
SP5's tests only covered multi-member literal unions (`"open"|"closed"`), which hit the working enum path. The single-literal discriminant case was never exercised, and no test went through a real model.

## Validation
- New regression tests (single-literal discriminant in a union, top-level single-literal field, no `charAt` in output).
- `@dawn-ai/core` extract-tool-schema 17/17, `@dawn-ai/langchain` tool-converter 17/17, lint + typecheck clean.
- **Live re-smoke (real OpenAI):** regenerated schema is clean (`by: {type:"string", enum:["date"]}`); the model's correct union arg `{by:"date",dir:"desc"}` is now accepted on the first attempt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)