### PR TITLE
fix(cli): exempt retrieval tools from output offloading (found by live smoke)

### DIFF
--- a/.changeset/fix-offload-exempt-retrieval.md
+++ b/.changeset/fix-offload-exempt-retrieval.md
@@ -1,0 +1,6 @@
+---
+"@dawn-ai/core": patch
+"@dawn-ai/cli": patch
+---
+
+Fix tool-output offloading so retrieval tools are exempt. Previously the workspace `readFile` tool — the very tool the agent uses to read back an offloaded output — had its own (large) result offloaded again, replacing it with a second pointer stub. The agent could never see the retrieved content. Retrieval/inspection tools (`readFile`, `listDir`) are now never offloaded; the new `dawn.config.ts` `toolOutput.noOffloadTools` option adds further exemptions (merged with the always-exempt built-ins). Found by a live-API smoke test.

--- a/docs/superpowers/specs/2026-06-03-tool-output-offload-exemption-design.md
+++ b/docs/superpowers/specs/2026-06-03-tool-output-offload-exemption-design.md
@@ -1,0 +1,64 @@
+# Tool-Output Offload Exemption for Retrieval Tools (Bugfix Design)
+
+**Status:** Approved for planning
+**Date:** 2026-06-03
+**Type:** Bugfix on sub-project 6a (tool-output offloading, PR #186)
+
+## Problem
+
+Offloading (sub-project 6a) intercepts every tool's output via `offload(content, tool.name)` in `convertToolToLangChain` and, when over the threshold, replaces it with a pointer+preview stub. But the **retrieval path is itself a tool** — the workspace `readFile` — whose entire job is to return the (large) offloaded content. So when the agent reads back an offloaded file, `readFile`'s output exceeds the threshold and is **offloaded again** into a new stub. The agent can never actually see the retrieved content: every read produces another pointer. The feature defeats itself.
+
+Confirmed by a live-API smoke (real model, chat example): `generateReport` offloaded correctly, the agent then called `readFile(path)` exactly as intended, and the result was a *second* offload stub (`tool-outputs/readFile-….txt`) instead of the report. The agent gave up without finding the embedded needle.
+
+The 6a unit/integration tests missed this because the integration test called `readFile` directly rather than through the agent's tool-dispatch wrapper where offloading is applied.
+
+## Goal
+
+Exempt retrieval/inspection tools from offloading so the agent can read back offloaded content, while still offloading genuinely large outputs from other tools (`runBash`, user tools).
+
+## Design
+
+**Exemption set.** A set of tool names whose output is never offloaded. The effective set is:
+
+```
+{ "readFile", "listDir" }  ∪  (dawn.config.toolOutput.noOffloadTools ?? [])
+```
+
+- `readFile` and `listDir` are **always** exempt (built-in defaults), regardless of config — exempting `readFile` is mandatory for retrieval correctness; a user list can only *add* exemptions, never remove these.
+- `listDir` is exempt as an inspection tool whose output is meant to be consumed directly (and re-offloading a listing is the same circular trap).
+- `runBash`, `writeFile`, and user-authored tools remain subject to offloading. `runBash` in particular is a prime offload target.
+
+**Where applied.** Inside the `OffloadFn` closure constructed in `packages/cli/src/lib/runtime/execute-route.ts` (where the offloader is already built with the workspace backend, threshold, and GC config). The closure gains a guard before delegating to `offloadToolOutput`:
+
+```ts
+const exempt = new Set<string>(["readFile", "listDir", ...(toolOutput.noOffloadTools ?? [])])
+const offload: OffloadFn = async (content, toolName) => {
+  if (exempt.has(toolName)) return content
+  return offloadToolOutput(content, { toolName, thresholdChars, previewLines, store })
+}
+```
+
+`packages/langchain/src/tool-converter.ts` is **unchanged** — it still calls `offload(content, tool.name)` for every tool. Mechanism stays in tool-converter; policy lives in the execute-route closure.
+
+**Config.** Add to the `DawnConfig.toolOutput` object in `packages/core/src/types.ts`:
+
+```ts
+/** Tool names whose output is never offloaded. Merged with the built-in
+ *  defaults (readFile, listDir), which are always exempt. */
+readonly noOffloadTools?: readonly string[]
+```
+
+## Out of scope
+
+- **Preview-shows-1-line cosmetic issue** (the preview is computed on the JSON-stringified content, so multi-line text previews as one line). It does not block retrieval — the agent gets the path and reads the file regardless. Tracked as a separate minor follow-up.
+- Ranged/paginated `readFile`. Not needed; full-content retrieval works once exempt.
+- Changing the offload threshold, GC, or storage behavior.
+
+## Testing
+
+**Unit** (`packages/cli` or `packages/langchain`, wherever the closure construction is unit-testable; if the closure is inline in execute-route, extract a small pure `buildOffloadFn({ exemptTools, ... })` helper so it can be tested directly):
+- exempt tool name → content returned unchanged even when length > threshold.
+- non-exempt tool name over threshold → offloaded (stub returned).
+- `noOffloadTools` from config is honored; `readFile`/`listDir` always present even if config omits them or provides an unrelated list.
+
+**Live re-smoke (the real proof, run manually with a real key):** in the chat example, a tool returns a >40k-char output → offloaded; the agent calls `readFile(path)` → receives the **full** content (not a second stub) → locates the `MARKER-DEEP-INSIDE-NEEDLE-42` token that lives at the end of the file (beyond any preview), proving full retrieval.

--- a/packages/cli/src/lib/runtime/execute-route.ts
+++ b/packages/cli/src/lib/runtime/execute-route.ts
@@ -976,8 +976,24 @@ function buildOffload(
   })
   const thresholdChars = t.offloadThresholdChars ?? 40_000
   const previewLines = t.previewLines ?? 10
-  return (content, toolName) =>
-    offloadToolOutput(content, { toolName, thresholdChars, previewLines, store })
+  const exempt = exemptToolSet(t.noOffloadTools)
+  return (content, toolName) => {
+    // Retrieval/inspection tools (readFile, listDir, …) must never be
+    // offloaded: their output IS the content the agent asked to read, so
+    // re-offloading it would replace it with another pointer and make the
+    // offloaded data permanently unreadable.
+    if (exempt.has(toolName)) return Promise.resolve(content)
+    return offloadToolOutput(content, { toolName, thresholdChars, previewLines, store })
+  }
+}
+
+/**
+ * Tool names whose output is never offloaded: the built-in retrieval/inspection
+ * tools (always exempt) unioned with any caller-provided names. Exported for
+ * unit testing.
+ */
+export function exemptToolSet(noOffloadTools?: readonly string[]): ReadonlySet<string> {
+  return new Set<string>(["readFile", "listDir", ...(noOffloadTools ?? [])])
 }
 
 function isBoundaryError(error: unknown): boolean {

--- a/packages/cli/test/offload-exempt.test.ts
+++ b/packages/cli/test/offload-exempt.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest"
+import { exemptToolSet } from "../src/lib/runtime/execute-route.js"
+
+describe("exemptToolSet", () => {
+  it("always exempts the built-in retrieval/inspection tools", () => {
+    const exempt = exemptToolSet()
+    expect(exempt.has("readFile")).toBe(true)
+    expect(exempt.has("listDir")).toBe(true)
+  })
+
+  it("does not exempt offload-eligible tools", () => {
+    const exempt = exemptToolSet()
+    expect(exempt.has("runBash")).toBe(false)
+    expect(exempt.has("writeFile")).toBe(false)
+    expect(exempt.has("generateReport")).toBe(false)
+  })
+
+  it("merges caller-provided names with the built-in defaults", () => {
+    const exempt = exemptToolSet(["myCustomReader"])
+    expect(exempt.has("myCustomReader")).toBe(true)
+    // built-ins remain exempt even when a custom list is supplied
+    expect(exempt.has("readFile")).toBe(true)
+    expect(exempt.has("listDir")).toBe(true)
+  })
+
+  it("keeps readFile exempt even if the config list omits it", () => {
+    const exempt = exemptToolSet(["somethingElse"])
+    expect(exempt.has("readFile")).toBe(true)
+  })
+})

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -36,6 +36,13 @@ export interface DawnConfig {
     readonly ttlMs?: number
     /** Minimum ms between GC scans. Default 10000 (10s). */
     readonly gcThrottleMs?: number
+    /**
+     * Tool names whose output is never offloaded. Merged with the built-in
+     * defaults (`readFile`, `listDir`), which are always exempt — exempting
+     * the retrieval tools is required so the agent can read back offloaded
+     * content without it being re-offloaded.
+     */
+    readonly noOffloadTools?: readonly string[]
   }
 }
 


### PR DESCRIPTION
## Summary
A live-API smoke of sub-project 6a found that **offloaded tool outputs were unretrievable**. When a large tool output is offloaded to `workspace/tool-outputs/`, the agent reads it back with the workspace `readFile` tool — but `readFile`'s own (large) result was then **offloaded again** into a second pointer stub. Every read produced another pointer; the agent could never see the content.

## Root cause
`buildOffload`'s offload callback was applied to **every** tool's output, including the retrieval tool itself.

## Fix
Exempt retrieval/inspection tools from offloading. The effective exempt set is the built-in defaults `["readFile", "listDir"]` (always exempt — required for retrieval correctness) unioned with a new `dawn.config.ts` `toolOutput.noOffloadTools` option. `runBash`, `writeFile`, and user tools remain offload-eligible. The guard lives in the `buildOffload` closure (extracted as a testable `exemptToolSet` helper); `tool-converter.ts` is unchanged.

## Why 6a's tests missed it
The 6a integration test called `readFile` directly, not through the agent's tool-dispatch wrapper where offloading is applied — so the re-offload never triggered.

## Validation
- New unit tests for `exemptToolSet` (built-ins always present; config merges; non-exempt tools offload).
- `@dawn-ai/cli` typecheck + lint clean.
- **Live re-smoke (real OpenAI):** `generateReport` (125k chars) offloads to a stub; the agent calls `readFile(path)` and receives the **full 127k-char content including the `MARKER-DEEP-INSIDE-NEEDLE-42` token at the end of the file** (beyond any preview) — proving full retrieval works.

Spec: `docs/superpowers/specs/2026-06-03-tool-output-offload-exemption-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)