### PR TITLE
feat: Phase 3 6b — opt-in conversation summarization (non-destructive preModelHook)

### DIFF
--- a/.changeset/phase3-conversation-summarization.md
+++ b/.changeset/phase3-conversation-summarization.md
@@ -1,0 +1,24 @@
+---
+"@dawn-ai/core": minor
+"@dawn-ai/langchain": minor
+"@dawn-ai/cli": minor
+---
+
+Add opt-in conversation summarization (Phase 3 sub-project 6b). When a thread's history exceeds a token threshold, the agent is fed a condensed view — a running summary of older turns plus the most recent turns verbatim — while the **full history stays intact in the checkpoint**. This is non-destructive: summarization runs as a LangGraph `preModelHook` that returns `llmInputMessages` for the turn only and never rewrites saved `messages`, so `GET /threads/:id/state`, resume, and restart always see the complete history (and there is no tool-call/result pairing hazard).
+
+Enable it in `dawn.config.ts`:
+
+```ts
+export default {
+  summarization: {
+    enabled: true,           // default false
+    maxTokens: 12_000,       // threshold over which older turns are summarized
+    keepRecentTurns: 6,      // most-recent turns kept verbatim
+    // model defaults to the route's model
+    // tokenCounter defaults to a lazy gpt-tokenizer (o200k_base) counter
+    // summarize defaults to a built-in single-LLM-call running-summary fold
+  },
+}
+```
+
+Both the token counter and the summarizer are pluggable (`tokenCounter`, `summarize`). The running summary is cached in agent state and refreshed incrementally — each turn folds only the newly-aged messages, so cost stays bounded. The turn-boundary split is pairing-safe (a tool-call message is never separated from its results). When summarization is disabled (the default), behavior is unchanged and `gpt-tokenizer` is never loaded. If the summarizer call fails on a given turn, the agent falls back to the full history for that turn rather than failing the run.

--- a/apps/web/next-env.d.ts
+++ b/apps/web/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/web/next-env.d.ts
+++ b/apps/web/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/docs/superpowers/plans/2026-06-04-phase3-conversation-summarization.md
+++ b/docs/superpowers/plans/2026-06-04-phase3-conversation-summarization.md
@@ -1,0 +1,954 @@
+# Conversation Summarization (Phase 3 / 6b) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Opt-in, non-destructive conversation summarization — a `preModelHook` feeds the model a condensed view (running summary + recent turns) once history crosses a token threshold, while full history stays in the checkpoint.
+
+**Architecture:** `createReactAgent`'s `preModelHook` returns `{ llmInputMessages }` (used as LLM input, does NOT mutate saved `messages`). A pairing-safe split keeps recent turns verbatim and folds older turns into a cached running summary, refreshed incrementally. Token counting defaults to a lazily-loaded `gpt-tokenizer`; both the counter and summarizer are swappable via `dawn.config.ts`.
+
+**Tech Stack:** TypeScript, `@langchain/langgraph@1.3.0` (`createReactAgent` + `preModelHook` + `llmInputMessages`), `@langchain/core` messages, `gpt-tokenizer`, vitest, `@copilotkit/aimock` (e2e). Packages: `@dawn-ai/core`, `@dawn-ai/langchain`, `@dawn-ai/cli`, root `test/`.
+
+**Spec:** `docs/superpowers/specs/2026-06-04-phase3-conversation-summarization-design.md`
+**Worktree:** `/Users/blove/repos/dawn-6b`, branch `feat/phase3-summarization`.
+
+---
+
+## File map
+
+**Modify (prerequisite refactor — Task 1):**
+- `packages/langchain/src/agent-adapter.ts` — `materializeAgent(...)` positional tail → single `opts` object; update 2 call sites.
+
+**Create (summarization units — `packages/langchain/src/summarization/`):**
+- `token-counter.ts` — `defaultTokenCounter`, `countMessagesTokens`.
+- `split.ts` — `splitForSummary` (pairing-safe).
+- `summarize.ts` — `defaultSummarize` (LLM call) + the summarization prompt.
+- `hook.ts` — `buildSummarizationHook`, `ResolvedSummarizationConfig`, `RunningSummary`.
+- `index.ts` — re-exports.
+
+**Modify (config + wiring):**
+- `packages/core/src/types.ts` — `DawnConfig.summarization?`.
+- `packages/langchain/src/agent-adapter.ts` — accept `summarization` in `opts`; pass `preModelHook` + add `runningSummary` state field when enabled.
+- `packages/langchain/src/index.ts` — export summarization public surface.
+- `packages/cli/src/lib/runtime/execute-route.ts` — resolve `config.summarization` + route model, thread to the adapter.
+- `packages/langchain/package.json` — add `gpt-tokenizer` dependency.
+
+**Tests:**
+- `packages/langchain/test/summarization-*.test.ts` (unit).
+- `test/runtime/run-summarization-e2e.test.ts` + `test/runtime/fixtures/aimock/summarization.json` (aimock e2e).
+
+---
+
+## Task 1: Refactor `materializeAgent` to an options object (prerequisite)
+
+**Context:** `materializeAgent` has 8 positional params; we're about to add a 9th (summarization). Collapse the optional tail into one `opts` object first. Private function — no public API change.
+
+**Files:**
+- Modify: `packages/langchain/src/agent-adapter.ts`
+
+- [ ] **Step 1: Read the current signature + both call sites**
+
+Run: `grep -n "materializeAgent(" packages/langchain/src/agent-adapter.ts`
+The signature is `materializeAgent(descriptor, tools, checkpointer, stateFields?, middlewareContext?, promptFragments?, options?, offload?)`. Call sites: `materializeAgentGraph` (~line 138) and the streaming path (~line 377).
+
+- [ ] **Step 2: Change the signature to an options bag**
+
+Keep the 3 required positionals; collapse the rest:
+
+```ts
+async function materializeAgent(
+  descriptor: DawnAgent,
+  tools: readonly DawnToolDefinition[],
+  checkpointer: BaseCheckpointSaver,
+  opts: {
+    readonly stateFields?: readonly ResolvedStateField[]
+    readonly middlewareContext?: Readonly<Record<string, unknown>>
+    readonly promptFragments?: readonly PromptFragment[]
+    readonly bypassCache?: boolean
+    readonly offload?: OffloadFn
+  } = {},
+): Promise<AgentLike> {
+```
+
+In the body, replace `options?.bypassCache` → `opts.bypassCache`; `stateFields` → `opts.stateFields`; `middlewareContext` → `opts.middlewareContext`; `promptFragments` → `opts.promptFragments`; `offload` → `opts.offload`. (The `convertToolToLangChain(tool, middlewareContext, offload)` call becomes `convertToolToLangChain(tool, opts.middlewareContext, opts.offload)`; the `fragments = promptFragments ?? []` becomes `opts.promptFragments ?? []`; the `if (stateFields && stateFields.length > 0)` becomes `opts.stateFields`.)
+
+- [ ] **Step 3: Update call site 1 (`materializeAgentGraph`, ~line 138)**
+
+```ts
+  return materializeAgent(options.descriptor, options.tools ?? [], options.checkpointer, {
+    ...(options.stateFields ? { stateFields: options.stateFields } : {}),
+    ...(options.promptFragments ? { promptFragments: options.promptFragments } : {}),
+  })
+```
+
+- [ ] **Step 4: Update call site 2 (streaming path, ~line 377)**
+
+```ts
+    const materializedAgent = await materializeAgent(options.entry, effectiveTools, options.checkpointer, {
+      ...(options.stateFields ? { stateFields: options.stateFields } : {}),
+      ...(options.middlewareContext ? { middlewareContext: options.middlewareContext } : {}),
+      ...(options.promptFragments ? { promptFragments: options.promptFragments } : {}),
+      ...(resolver && hasTaskTool ? { bypassCache: true } : {}),
+      ...(options.offload ? { offload: options.offload } : {}),
+    })
+```
+
+- [ ] **Step 5: Build, typecheck, test**
+
+Run: `pnpm --filter @dawn-ai/core --filter @dawn-ai/sdk --filter @dawn-ai/workspace --filter @dawn-ai/permissions --filter @dawn-ai/sqlite-storage --filter @dawn-ai/langchain build`
+Run: `pnpm --filter @dawn-ai/langchain typecheck && pnpm --filter @dawn-ai/langchain lint && pnpm --filter @dawn-ai/langchain test`
+Expected: all green (pure refactor, behavior unchanged).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/langchain/src/agent-adapter.ts
+git commit -m "refactor(langchain): collapse materializeAgent optional params into an options object"
+```
+
+---
+
+## Task 2: `DawnConfig.summarization` config type + langchain ResolvedSummarizationConfig
+
+**Files:**
+- Modify: `packages/core/src/types.ts`
+- Create: `packages/langchain/src/summarization/hook.ts` (types only in this task)
+
+- [ ] **Step 1: Add `summarization` to `DawnConfig`**
+
+In `packages/core/src/types.ts`, inside `DawnConfig` (sibling to `toolOutput`), add (place the import for `BaseMessage` if not present: `import type { BaseMessage } from "@langchain/core/messages"`):
+
+```ts
+  readonly summarization?: {
+    /** Enable conversation summarization. Default false. */
+    readonly enabled?: boolean
+    /** Token threshold over which older history is summarized. Default 12000. */
+    readonly maxTokens?: number
+    /** Most-recent turns kept verbatim (a turn starts at a HumanMessage). Default 6. */
+    readonly keepRecentTurns?: number
+    /** Model id for the summary LLM call. Defaults to the route's model. */
+    readonly model?: string
+    /** Token counter. Default: a lazy gpt-tokenizer (o200k_base) counter. */
+    readonly tokenCounter?: (text: string) => number
+    /** Summary generator. Default: a built-in single-LLM-call summarizer. */
+    readonly summarize?: (args: {
+      readonly messages: readonly BaseMessage[]
+      readonly model: string
+      readonly previousSummary?: string
+      readonly signal: AbortSignal
+    }) => Promise<string>
+  }
+```
+
+If `@langchain/core` is not already a dependency of `@dawn-ai/core`, prefer a structural type instead of importing `BaseMessage` to avoid a new dep: declare `readonly messages: readonly unknown[]` in the `summarize` arg. CHECK `packages/core/package.json` first; if `@langchain/core` is absent, use `unknown[]` and note it.
+
+- [ ] **Step 2: Define the resolved config + RunningSummary types**
+
+Create `packages/langchain/src/summarization/hook.ts` with just the types for now:
+
+```ts
+import type { BaseMessage } from "@langchain/core/messages"
+
+export interface RunningSummary {
+  readonly summary: string
+  readonly coveredCount: number
+}
+
+export type TokenCounter = (text: string) => number
+
+export type SummarizeFn = (args: {
+  readonly messages: readonly BaseMessage[]
+  readonly model: string
+  readonly previousSummary?: string
+  readonly signal: AbortSignal
+}) => Promise<string>
+
+export interface ResolvedSummarizationConfig {
+  readonly maxTokens: number
+  readonly keepRecentTurns: number
+  readonly model: string
+  readonly tokenCounter: TokenCounter
+  readonly summarize: SummarizeFn
+}
+```
+
+- [ ] **Step 3: Typecheck**
+
+Run: `pnpm --filter @dawn-ai/core --filter @dawn-ai/langchain typecheck`
+Expected: clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/core/src/types.ts packages/langchain/src/summarization/hook.ts
+git commit -m "feat(core,langchain): add summarization config types"
+```
+
+---
+
+## Task 3: Token counter (lazy gpt-tokenizer)
+
+**Files:**
+- Modify: `packages/langchain/package.json` (add `gpt-tokenizer`)
+- Create: `packages/langchain/src/summarization/token-counter.ts`
+- Test: `packages/langchain/test/summarization-token-counter.test.ts`
+
+- [ ] **Step 1: Add the dependency**
+
+Edit `packages/langchain/package.json` `dependencies`: add `"gpt-tokenizer": "^3.0.1"` (run `pnpm view gpt-tokenizer version` to pin the latest if 3.0.1 is stale; note which). Then `cd /Users/blove/repos/dawn-6b && pnpm install`.
+
+- [ ] **Step 2: Write the failing test**
+
+Create `packages/langchain/test/summarization-token-counter.test.ts`:
+
+```ts
+import { HumanMessage, AIMessage, ToolMessage } from "@langchain/core/messages"
+import { describe, expect, it } from "vitest"
+import { countMessagesTokens, defaultTokenCounter } from "../src/summarization/token-counter.js"
+
+describe("defaultTokenCounter", () => {
+  it("counts tokens for a plain string (close to word count for simple text)", async () => {
+    const n = await defaultTokenCounter("hello world this is a test")
+    expect(n).toBeGreaterThan(3)
+    expect(n).toBeLessThan(15)
+  })
+})
+
+describe("countMessagesTokens", () => {
+  it("sums a synchronous counter across message contents incl. tool calls", async () => {
+    // injected fake counter = char length, so totals are deterministic
+    const counter = (t: string) => t.length
+    const messages = [
+      new HumanMessage("abc"),
+      new AIMessage({ content: "", tool_calls: [{ id: "1", name: "t", args: { k: "v" } }] }),
+      new ToolMessage({ content: "result", tool_call_id: "1" }),
+    ]
+    const total = await countMessagesTokens(messages, counter)
+    // "abc"(3) + serialized tool_call (contains "t" and "v") + "result"(6) > 9
+    expect(total).toBeGreaterThan(9)
+  })
+})
+```
+
+Note `defaultTokenCounter` is async (it lazy-imports). `countMessagesTokens` accepts a sync `TokenCounter` and awaits nothing for the fake; but since the default counter is async, define `countMessagesTokens` to accept `(text) => number | Promise<number>` and await each. Adjust the test's `await` accordingly.
+
+- [ ] **Step 3: Run — expect FAIL**
+
+Run: `pnpm --filter @dawn-ai/langchain test summarization-token-counter`
+Expected: FAIL — module missing.
+
+- [ ] **Step 4: Implement**
+
+Create `packages/langchain/src/summarization/token-counter.ts`:
+
+```ts
+import type { BaseMessage } from "@langchain/core/messages"
+
+let encodeFn: ((text: string) => number[]) | undefined
+
+/**
+ * Default token counter. Lazily imports a single gpt-tokenizer encoding
+ * (o200k_base — current OpenAI models) so apps that don't enable
+ * summarization never load the ~1-2 MB tables. Async because of the lazy import.
+ */
+export async function defaultTokenCounter(text: string): Promise<number> {
+  if (!encodeFn) {
+    const mod = (await import("gpt-tokenizer/encoding/o200k_base")) as {
+      encode: (t: string) => number[]
+    }
+    encodeFn = mod.encode
+  }
+  return encodeFn(text).length
+}
+
+function messageToText(m: BaseMessage): string {
+  const parts: string[] = []
+  if (typeof m.content === "string") parts.push(m.content)
+  else parts.push(JSON.stringify(m.content))
+  const toolCalls = (m as { tool_calls?: unknown }).tool_calls
+  if (toolCalls) parts.push(JSON.stringify(toolCalls))
+  return parts.join("\n")
+}
+
+/** Sum a (possibly async) token counter across a message list. */
+export async function countMessagesTokens(
+  messages: readonly BaseMessage[],
+  counter: (text: string) => number | Promise<number>,
+): Promise<number> {
+  let total = 0
+  for (const m of messages) {
+    total += await counter(messageToText(m))
+  }
+  return total
+}
+```
+
+- [ ] **Step 5: Run — expect PASS; typecheck + lint**
+
+Run: `pnpm --filter @dawn-ai/langchain test summarization-token-counter && pnpm --filter @dawn-ai/langchain typecheck && pnpm --filter @dawn-ai/langchain lint`
+Expected: clean. (If `gpt-tokenizer/encoding/o200k_base` subpath doesn't resolve, check the package's exports map — the import may be `gpt-tokenizer/esm/encoding/o200k_base` or the default `gpt-tokenizer` with `encode`. Use the working subpath.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/langchain/package.json pnpm-lock.yaml packages/langchain/src/summarization/token-counter.ts packages/langchain/test/summarization-token-counter.test.ts
+git commit -m "feat(langchain): default gpt-tokenizer token counter (lazy, single encoding)"
+```
+
+---
+
+## Task 4: Pairing-safe `splitForSummary`
+
+**Context:** Split the message list into `{ toSummarize, recent }`. `recent` = the last `keepRecentTurns` turns where a turn boundary is a `HumanMessage`. The boundary must never fall between an `AIMessage` with `tool_calls` and its `ToolMessage`s — since turns start at HumanMessages and tool rounds occur within a turn, slicing at a HumanMessage boundary is inherently pairing-safe. Handle the case where there are fewer than `keepRecentTurns` HumanMessages (keep everything as `recent`).
+
+**Files:**
+- Create: `packages/langchain/src/summarization/split.ts`
+- Test: `packages/langchain/test/summarization-split.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { AIMessage, HumanMessage, ToolMessage } from "@langchain/core/messages"
+import { describe, expect, it } from "vitest"
+import { splitForSummary } from "../src/summarization/split.js"
+
+const H = (c: string) => new HumanMessage(c)
+const A = (c: string) => new AIMessage(c)
+const AT = (id: string) => new AIMessage({ content: "", tool_calls: [{ id, name: "t", args: {} }] })
+const T = (id: string) => new ToolMessage({ content: "r", tool_call_id: id })
+
+describe("splitForSummary", () => {
+  it("keeps the last N turns verbatim and summarizes the rest", () => {
+    const msgs = [H("u1"), A("a1"), H("u2"), A("a2"), H("u3"), A("a3")]
+    const { toSummarize, recent } = splitForSummary(msgs, 2)
+    // last 2 turns = [H(u2),A(a2),H(u3),A(a3)]; rest summarized
+    expect(recent.map((m) => (m.content as string))).toEqual(["u2", "a2", "u3", "a3"])
+    expect(toSummarize.map((m) => (m.content as string))).toEqual(["u1", "a1"])
+  })
+
+  it("never splits a tool round (recent starts on a HumanMessage)", () => {
+    // turn 2 contains a tool round; keeping 1 turn must include the whole round
+    const msgs = [H("u1"), A("a1"), H("u2"), AT("c1"), T("c1"), A("done")]
+    const { toSummarize, recent } = splitForSummary(msgs, 1)
+    expect((recent[0] as HumanMessage).content).toBe("u2")
+    expect(recent).toHaveLength(4) // H,AT,T,A — the whole turn, tool round intact
+    expect(toSummarize.map((m) => m.content as string)).toEqual(["u1", "a1"])
+  })
+
+  it("keeps everything as recent when fewer turns than keepRecentTurns", () => {
+    const msgs = [H("u1"), A("a1")]
+    const { toSummarize, recent } = splitForSummary(msgs, 5)
+    expect(toSummarize).toEqual([])
+    expect(recent).toEqual(msgs)
+  })
+})
+```
+
+- [ ] **Step 2: Run — expect FAIL**
+
+Run: `pnpm --filter @dawn-ai/langchain test summarization-split`
+Expected: FAIL — module missing.
+
+- [ ] **Step 3: Implement**
+
+Create `packages/langchain/src/summarization/split.ts`:
+
+```ts
+import type { BaseMessage } from "@langchain/core/messages"
+
+function isHuman(m: BaseMessage): boolean {
+  // getType() is the stable accessor across @langchain/core versions.
+  return typeof (m as { getType?: () => string }).getType === "function"
+    ? (m as { getType: () => string }).getType() === "human"
+    : (m as { _getType?: () => string })._getType?.() === "human"
+}
+
+/**
+ * Split into { toSummarize, recent } keeping the last `keepRecentTurns` turns
+ * verbatim. A turn begins at a HumanMessage; slicing on a HumanMessage boundary
+ * keeps every tool round (AIMessage-with-tool_calls + its ToolMessages) intact,
+ * so `recent` never starts mid-round. Fewer turns than requested → all recent.
+ */
+export function splitForSummary(
+  messages: readonly BaseMessage[],
+  keepRecentTurns: number,
+): { toSummarize: BaseMessage[]; recent: BaseMessage[] } {
+  if (keepRecentTurns <= 0) return { toSummarize: [...messages], recent: [] }
+  // Indices of HumanMessages = turn starts.
+  const humanIdx: number[] = []
+  messages.forEach((m, i) => {
+    if (isHuman(m)) humanIdx.push(i)
+  })
+  if (humanIdx.length <= keepRecentTurns) {
+    return { toSummarize: [], recent: [...messages] }
+  }
+  const cut = humanIdx[humanIdx.length - keepRecentTurns] as number
+  return { toSummarize: messages.slice(0, cut), recent: messages.slice(cut) }
+}
+```
+
+- [ ] **Step 4: Run — expect PASS; lint + typecheck**
+
+Run: `pnpm --filter @dawn-ai/langchain test summarization-split && pnpm --filter @dawn-ai/langchain typecheck && pnpm --filter @dawn-ai/langchain lint`
+Expected: clean. (If `getType`/`_getType` detection misbehaves, inspect a real `HumanMessage` instance — `new HumanMessage("x").getType()` returns `"human"` in @langchain/core 1.x. Use whichever the installed version exposes.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/langchain/src/summarization/split.ts packages/langchain/test/summarization-split.test.ts
+git commit -m "feat(langchain): pairing-safe splitForSummary (turn-boundary slicing)"
+```
+
+---
+
+## Task 5: Default summarizer (`defaultSummarize`)
+
+**Files:**
+- Create: `packages/langchain/src/summarization/summarize.ts`
+- Test: `packages/langchain/test/summarization-summarize.test.ts`
+
+- [ ] **Step 1: Write the failing test (inject a fake model via importer-style seam)**
+
+`defaultSummarize` builds a chat model via `createChatModel` and calls it. To test without a network, accept an optional `invokeModel` override in the args (defaulting to the real path), so the test injects a fake. Test:
+
+```ts
+import { HumanMessage, AIMessage } from "@langchain/core/messages"
+import { describe, expect, it } from "vitest"
+import { defaultSummarize } from "../src/summarization/summarize.js"
+
+describe("defaultSummarize", () => {
+  it("builds a prompt including previousSummary + messages and returns the model text", async () => {
+    let seenPrompt = ""
+    const result = await defaultSummarize({
+      messages: [new HumanMessage("user asked about X"), new AIMessage("assistant answered Y")],
+      model: "gpt-4o-mini",
+      previousSummary: "Earlier: greeted.",
+      signal: new AbortController().signal,
+      invokeModel: async (prompt: string) => {
+        seenPrompt = prompt
+        return "Updated summary: greeted, discussed X→Y."
+      },
+    })
+    expect(seenPrompt).toContain("Earlier: greeted.")     // folds previous summary
+    expect(seenPrompt).toContain("user asked about X")     // includes new messages
+    expect(result).toBe("Updated summary: greeted, discussed X→Y.")
+  })
+})
+```
+
+- [ ] **Step 2: Run — expect FAIL**
+
+Run: `pnpm --filter @dawn-ai/langchain test summarization-summarize`
+Expected: FAIL — module missing.
+
+- [ ] **Step 3: Implement**
+
+Create `packages/langchain/src/summarization/summarize.ts`:
+
+```ts
+import type { BaseMessage } from "@langchain/core/messages"
+import { createChatModel } from "../chat-model-factory.js"
+import { resolveProvider } from "../model-provider-resolver.js"
+
+function renderMessages(messages: readonly BaseMessage[]): string {
+  return messages
+    .map((m) => {
+      const role =
+        typeof (m as { getType?: () => string }).getType === "function"
+          ? (m as { getType: () => string }).getType()
+          : "message"
+      const content = typeof m.content === "string" ? m.content : JSON.stringify(m.content)
+      const toolCalls = (m as { tool_calls?: unknown[] }).tool_calls
+      const tc = toolCalls && toolCalls.length > 0 ? `\n[tool_calls: ${JSON.stringify(toolCalls)}]` : ""
+      return `${role}: ${content}${tc}`
+    })
+    .join("\n")
+}
+
+function buildPrompt(messages: readonly BaseMessage[], previousSummary?: string): string {
+  const prior = previousSummary
+    ? `Existing running summary so far:\n${previousSummary}\n\n`
+    : ""
+  return (
+    `${prior}New conversation messages to fold into the summary:\n${renderMessages(messages)}\n\n` +
+    `Write an updated, concise running summary of the ENTIRE conversation so far. ` +
+    `Preserve concrete facts, decisions, user goals, tool results, identifiers, and open questions. ` +
+    `Do not invent information. Output only the summary text.`
+  )
+}
+
+export async function defaultSummarize(args: {
+  readonly messages: readonly BaseMessage[]
+  readonly model: string
+  readonly previousSummary?: string
+  readonly signal: AbortSignal
+  /** Test seam: override the model invocation. */
+  readonly invokeModel?: (prompt: string) => Promise<string>
+}): Promise<string> {
+  const prompt = buildPrompt(args.messages, args.previousSummary)
+  if (args.invokeModel) return args.invokeModel(prompt)
+
+  const provider = resolveProvider({ model: args.model })
+  const llm = (await createChatModel({ model: args.model, provider })) as {
+    invoke: (input: unknown, options?: unknown) => Promise<{ content: unknown }>
+  }
+  const res = await llm.invoke([{ role: "user", content: prompt }], { signal: args.signal })
+  return typeof res.content === "string" ? res.content : JSON.stringify(res.content)
+}
+```
+
+(Verify `resolveProvider`'s real signature in `packages/langchain/src/model-provider-resolver.ts` and adapt the call. Verify `createChatModel`'s return has `.invoke`.)
+
+- [ ] **Step 4: Run — expect PASS; typecheck + lint**
+
+Run: `pnpm --filter @dawn-ai/langchain test summarization-summarize && pnpm --filter @dawn-ai/langchain typecheck && pnpm --filter @dawn-ai/langchain lint`
+Expected: clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/langchain/src/summarization/summarize.ts packages/langchain/test/summarization-summarize.test.ts
+git commit -m "feat(langchain): default LLM summarizer with running-summary prompt"
+```
+
+---
+
+## Task 6: `buildSummarizationHook` (the preModelHook)
+
+**Files:**
+- Modify: `packages/langchain/src/summarization/hook.ts`
+- Create: `packages/langchain/src/summarization/index.ts`
+- Test: `packages/langchain/test/summarization-hook.test.ts`
+
+- [ ] **Step 1: Write the failing test (fakes for counter + summarize, no LLM)**
+
+```ts
+import { AIMessage, HumanMessage } from "@langchain/core/messages"
+import { describe, expect, it, vi } from "vitest"
+import { buildSummarizationHook } from "../src/summarization/hook.js"
+
+const H = (c: string) => new HumanMessage(c)
+const A = (c: string) => new AIMessage(c)
+
+function cfg(over: Partial<Parameters<typeof buildSummarizationHook>[0]> = {}) {
+  return buildSummarizationHook({
+    maxTokens: 100,
+    keepRecentTurns: 1,
+    model: "fake",
+    tokenCounter: (t) => t.length, // chars as tokens
+    summarize: async () => "SUMMARY",
+    ...over,
+  })
+}
+
+describe("buildSummarizationHook", () => {
+  it("returns {} (no condensation) when under threshold", async () => {
+    const hook = cfg({ maxTokens: 10_000 })
+    const out = await hook({ messages: [H("hi"), A("yo")] })
+    expect(out).toEqual({})
+  })
+
+  it("returns condensed llmInputMessages + runningSummary when over threshold", async () => {
+    const hook = cfg({ maxTokens: 5, keepRecentTurns: 1 })
+    const msgs = [H("u1"), A("a1"), H("u2"), A("a2")]
+    const out = await hook({ messages: msgs })
+    expect(Array.isArray(out.llmInputMessages)).toBe(true)
+    // [summaryMessage, ...recent(last turn = H(u2),A(a2))]
+    const texts = (out.llmInputMessages as Array<{ content: string }>).map((m) => m.content)
+    expect(texts[0]).toContain("SUMMARY")
+    expect(texts.slice(1)).toEqual(["u2", "a2"])
+    expect(out.runningSummary).toMatchObject({ summary: "SUMMARY" })
+  })
+
+  it("incrementally folds only newly-aged messages (passes previousSummary + delta)", async () => {
+    const summarize = vi.fn(async () => "S2")
+    const hook = cfg({ maxTokens: 5, keepRecentTurns: 1, summarize })
+    const msgs = [H("u1"), A("a1"), H("u2"), A("a2"), H("u3"), A("a3")]
+    await hook({ messages: msgs, runningSummary: { summary: "S1", coveredCount: 2 } })
+    // already covered first 2 (u1,a1); toSummarize delta = messages[2..cut)
+    const callArg = summarize.mock.calls[0]![0] as { previousSummary?: string; messages: unknown[] }
+    expect(callArg.previousSummary).toBe("S1")
+    // delta should be u2,a2 (covered=2, cut keeps last turn u3,a3)
+    expect((callArg.messages as Array<{ content: string }>).map((m) => m.content)).toEqual(["u2", "a2"])
+  })
+
+  it("falls back to {} when the summarizer throws", async () => {
+    const hook = cfg({ maxTokens: 5, summarize: async () => { throw new Error("boom") } })
+    const out = await hook({ messages: [H("u1"), A("a1"), H("u2"), A("a2")] })
+    expect(out).toEqual({})
+  })
+})
+```
+
+- [ ] **Step 2: Run — expect FAIL**
+
+Run: `pnpm --filter @dawn-ai/langchain test summarization-hook`
+Expected: FAIL — `buildSummarizationHook` not implemented.
+
+- [ ] **Step 3: Implement**
+
+Append to `packages/langchain/src/summarization/hook.ts` (keep the types from Task 2):
+
+```ts
+import { HumanMessage, type BaseMessage } from "@langchain/core/messages"
+import { countMessagesTokens } from "./token-counter.js"
+import { splitForSummary } from "./split.js"
+
+export interface PreModelHookState {
+  readonly messages: BaseMessage[]
+  readonly runningSummary?: RunningSummary
+}
+
+export interface PreModelHookResult {
+  llmInputMessages?: BaseMessage[]
+  runningSummary?: RunningSummary
+}
+
+export function buildSummarizationHook(config: ResolvedSummarizationConfig) {
+  return async (state: PreModelHookState): Promise<PreModelHookResult> => {
+    const messages = state.messages ?? []
+    const total = await countMessagesTokens(messages, config.tokenCounter)
+    if (total <= config.maxTokens) return {}
+
+    const prev = state.runningSummary
+    const coveredCount = prev?.coveredCount ?? 0
+    const { toSummarize, recent } = splitForSummary(messages, config.keepRecentTurns)
+    // Only fold the messages that aged since last summary (between coveredCount and the cut).
+    const newlyAged = toSummarize.slice(coveredCount)
+
+    let summary = prev?.summary ?? ""
+    if (newlyAged.length > 0) {
+      try {
+        summary = await config.summarize({
+          messages: newlyAged,
+          model: config.model,
+          ...(prev?.summary ? { previousSummary: prev.summary } : {}),
+          signal: new AbortController().signal,
+        })
+      } catch {
+        // Summarization failed — fall back to full history this turn rather than break the run.
+        return {}
+      }
+    }
+    if (!summary) return {}
+
+    const summaryMessage = new HumanMessage(`Summary of earlier conversation:\n${summary}`)
+    return {
+      llmInputMessages: [summaryMessage, ...recent],
+      runningSummary: { summary, coveredCount: toSummarize.length },
+    }
+  }
+}
+```
+
+Create `packages/langchain/src/summarization/index.ts`:
+
+```ts
+export { defaultTokenCounter, countMessagesTokens } from "./token-counter.js"
+export { splitForSummary } from "./split.js"
+export { defaultSummarize } from "./summarize.js"
+export {
+  buildSummarizationHook,
+  type ResolvedSummarizationConfig,
+  type RunningSummary,
+  type TokenCounter,
+  type SummarizeFn,
+} from "./hook.js"
+```
+
+- [ ] **Step 4: Run — expect PASS; typecheck + lint**
+
+Run: `pnpm --filter @dawn-ai/langchain test summarization-hook && pnpm --filter @dawn-ai/langchain typecheck && pnpm --filter @dawn-ai/langchain lint`
+Expected: clean. (The signal in the test is unused by the fake; fine.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/langchain/src/summarization/hook.ts packages/langchain/src/summarization/index.ts packages/langchain/test/summarization-hook.test.ts
+git commit -m "feat(langchain): buildSummarizationHook (non-destructive preModelHook, incremental cache)"
+```
+
+---
+
+## Task 7: Wire summarization into the agent adapter
+
+**Files:**
+- Modify: `packages/langchain/src/agent-adapter.ts`
+- Modify: `packages/langchain/src/index.ts`
+
+- [ ] **Step 1: Accept summarization in `materializeAgent` opts + thread from the streaming path**
+
+Add to the `opts` object type in `materializeAgent` (from Task 1):
+
+```ts
+    readonly summarization?: import("./summarization/hook.js").ResolvedSummarizationConfig
+```
+
+In the body, after `agentOptions` is built and before `createReactAgent`, when summarization is present, add the preModelHook and ensure a `runningSummary` state channel exists:
+
+```ts
+  if (opts.summarization) {
+    const { buildSummarizationHook } = await import("./summarization/hook.js")
+    agentOptions.preModelHook = buildSummarizationHook(opts.summarization)
+    // Ensure runningSummary is a persisted state channel (replace reducer, default undefined).
+    const summaryField: ResolvedStateField = {
+      name: "runningSummary",
+      reducer: "replace",
+      default: undefined,
+    }
+    const fields = [...(opts.stateFields ?? []), summaryField]
+    agentOptions.stateSchema = materializeStateSchema(fields)
+  }
+```
+
+(Note: this must compose with the existing `if (opts.stateFields?.length) agentOptions.stateSchema = materializeStateSchema(opts.stateFields)` — restructure so that when summarization is on, the merged `fields` list is used; when off, the existing behavior is unchanged. Verify `ResolvedStateField` supports `reducer: "replace"` + `default: undefined` against `materializeStateSchema` in `state-adapter.ts`; if `default` must be non-undefined, use `null`.)
+
+- [ ] **Step 2: Thread `summarization` from the `streamAgent` options through to `materializeAgent`**
+
+Find the `streamAgent` options interface (it has `offload?`, `checkpointer`, etc.) and add `readonly summarization?: ResolvedSummarizationConfig`. In the `materializeAgent(options.entry, effectiveTools, options.checkpointer, { ... })` call (Task 1, call site 2), add `...(options.summarization ? { summarization: options.summarization } : {})`.
+
+- [ ] **Step 3: Export the public summarization surface**
+
+In `packages/langchain/src/index.ts`, add: `export * from "./summarization/index.js"`.
+
+- [ ] **Step 4: Build, typecheck, lint, test**
+
+Run: `pnpm --filter @dawn-ai/langchain build && pnpm --filter @dawn-ai/langchain typecheck && pnpm --filter @dawn-ai/langchain lint && pnpm --filter @dawn-ai/langchain test`
+Expected: clean; existing agent tests still pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/langchain/src/agent-adapter.ts packages/langchain/src/index.ts
+git commit -m "feat(langchain): wire summarization preModelHook + runningSummary state field"
+```
+
+---
+
+## Task 8: Resolve config + thread from execute-route
+
+**Context:** Mirror how `offload` is built (`buildOffload`) and threaded into `streamResolvedRoute`/`streamAgent`. Build a `ResolvedSummarizationConfig` from `config.summarization` + the route's model when `enabled`.
+
+**Files:**
+- Modify: `packages/cli/src/lib/runtime/execute-route.ts`
+
+- [ ] **Step 1: Add a `buildSummarization` resolver**
+
+Read how `buildOffload(config, filesystem, signal)` is defined + called in `execute-route.ts`. Add an analogous resolver:
+
+```ts
+import {
+  buildSummarizationHook, // not needed here; the adapter builds the hook. Import the types/defaults instead:
+} from "@dawn-ai/langchain"
+import { defaultTokenCounter, defaultSummarize, type ResolvedSummarizationConfig } from "@dawn-ai/langchain"
+
+function buildSummarization(
+  config: DawnConfig | undefined,
+  routeModel: string,
+): ResolvedSummarizationConfig | undefined {
+  const s = config?.summarization
+  if (!s?.enabled) return undefined
+  return {
+    maxTokens: s.maxTokens ?? 12_000,
+    keepRecentTurns: s.keepRecentTurns ?? 6,
+    model: s.model ?? routeModel,
+    tokenCounter: s.tokenCounter ?? defaultTokenCounter,
+    summarize: s.summarize ?? defaultSummarize,
+  }
+}
+```
+
+(`defaultTokenCounter` is async `(text) => Promise<number>`; `ResolvedSummarizationConfig.tokenCounter` is typed `(text) => number`. Widen `TokenCounter` to `(text: string) => number | Promise<number>` in `hook.ts` so the async default fits — update Task 2's type accordingly and re-run that package's typecheck. The hook already awaits the counter via `countMessagesTokens`.)
+
+- [ ] **Step 2: Resolve it where `offload` is resolved, using the route's model**
+
+Where `prepareRouteExecution` resolves `offload` and has the normalized descriptor/agent, also compute `const summarization = buildSummarization(config, normalized.entry.model)` (use the actual descriptor model accessor — for an agent route the model is on the descriptor; verify the field name). Add `...(summarization ? { summarization } : {})` to the prepared result object and to the `streamAgent`/`streamResolvedRoute` options where `offload` is passed.
+
+- [ ] **Step 3: Build + typecheck + lint**
+
+Run: `pnpm --filter @dawn-ai/core --filter @dawn-ai/langchain build && pnpm --filter @dawn-ai/cli typecheck && pnpm --filter @dawn-ai/cli lint`
+Expected: clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/cli/src/lib/runtime/execute-route.ts
+git commit -m "feat(cli): resolve summarization config + thread to agent (opt-in, route-model default)"
+```
+
+---
+
+## Task 9: aimock e2e — summarization across the threshold
+
+**Context:** Reuse the PR #190 aimock harness (`startAimock`, packed probe app, `startDevServer` with `OPENAI_BASE_URL`). Build a probe app whose `dawn.config.ts` enables summarization with a tiny `maxTokens`, drive a scripted multi-turn conversation, and assert the non-destructive contract.
+
+**Files:**
+- Create: `test/runtime/fixtures/aimock/summarization.json`
+- Create: `test/runtime/run-summarization-e2e.test.ts`
+- Modify: `test/runtime/vitest.config.ts` (include)
+
+- [ ] **Step 1: Study the existing aimock harness**
+
+Read `test/runtime/run-aimock-e2e.test.ts` (its `buildProbeApp`, fixture shape, `startDevServer` env wiring) and reuse the helpers identically. Note the fixture `match` keys (`userMessage`, `turnIndex`, `hasToolResult`) and `response.content`.
+
+- [ ] **Step 2: Author the fixture (several text turns to grow history)**
+
+Create `test/runtime/fixtures/aimock/summarization.json` — a sequence of assistant text replies keyed by `turnIndex`, enough turns that the accumulated history crosses a low `maxTokens` set in the probe app config:
+
+```json
+{
+  "fixtures": [
+    { "match": { "turnIndex": 0 }, "response": { "content": "Turn 0: noted your first point in detail. xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" } },
+    { "match": { "turnIndex": 1 }, "response": { "content": "Turn 1: noted your second point in detail. xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" } },
+    { "match": { "turnIndex": 2 }, "response": { "content": "Turn 2: final answer; the magic word is PINEAPPLE." } }
+  ]
+}
+```
+
+- [ ] **Step 3: Probe app with summarization enabled**
+
+In the test, build a probe app (reuse `buildProbeApp` or a local variant) whose `dawn.config.ts` is:
+
+```ts
+export default {
+  appDir: "src/app",
+  summarization: { enabled: true, maxTokens: 50, keepRecentTurns: 1 },
+}
+```
+
+(`maxTokens: 50` so 2–3 turns trigger it.) The route `src/app/chat/index.ts` is the same minimal `agent({ model: "gpt-4o-mini", systemPrompt: "..." })`. No tools needed for this scenario (or keep them; irrelevant). Drive three sequential `runs/wait` calls on the SAME thread with three user messages so history grows across turns.
+
+- [ ] **Step 4: Write the test**
+
+```ts
+it("summarizes across the token threshold without losing saved history", async () => {
+  const { appRoot } = await buildSummarizationProbeApp() // local helper, mirrors buildProbeApp + the config above
+  const aimock = await startAimock({ fixturePath: join(import.meta.dirname, "fixtures/aimock/summarization.json") })
+  const port = await allocatePort()
+  const server = await startDevServer({ cwd: appRoot, port, env: { OPENAI_BASE_URL: aimock.baseUrl, OPENAI_API_KEY: "test-not-used" } })
+  try {
+    const url = await server.waitForReady(30_000)
+    const tid = ((await (await fetch(new URL("/threads", url), { method: "POST", body: "{}", headers: { "content-type": "application/json" } })).json()) as { thread_id: string }).thread_id
+    const say = async (content: string) => {
+      const r = await fetch(new URL(`/threads/${tid}/runs/wait`, url), {
+        method: "POST", headers: { "content-type": "application/json" },
+        body: JSON.stringify({ route: "/chat#agent", input: { messages: [{ role: "user", content }] } }),
+      })
+      expect(r.status).toBe(200)
+      return r.json() as Promise<{ messages: Array<Record<string, unknown>> }>
+    }
+    await say("First message with a lot of detail to grow the history.")
+    await say("Second message, also detailed, pushing past the token threshold.")
+    await say("Third message — please give the final answer.")
+
+    // Saved state retains the FULL history (non-destructive).
+    const state = (await (await fetch(new URL(`/threads/${tid}/state`, url))).json()) as { values: { messages: unknown[]; runningSummary?: { summary?: string } } }
+    const humanCount = state.values.messages.filter((m) => Array.isArray((m as { id?: string[] }).id) && (m as { id: string[] }).id[2] === "HumanMessage").length
+    expect(humanCount).toBe(3) // all three user turns persisted, nothing destroyed
+    expect(state.values.runningSummary?.summary, "running summary populated after crossing threshold").toBeTruthy()
+  } finally {
+    await server.stop()
+    await aimock.stop()
+  }
+}, 180_000)
+```
+
+(Confirm `GET /state` returns `{ values: { messages, runningSummary } }` — check how the AP `state` endpoint serializes channels in `runtime-server.ts`; adjust the accessor to the real shape. The two invariants that matter: full history persisted + `runningSummary` populated.)
+
+- [ ] **Step 5: Add to include + run**
+
+Add `"test/runtime/run-summarization-e2e.test.ts"` to `test/runtime/vitest.config.ts` `include`. Run:
+Run: `pnpm exec vitest --run --config test/runtime/vitest.config.ts test/runtime/run-summarization-e2e.test.ts 2>&1 | tail -25`
+Expected: PASS — three turns complete, state has 3 HumanMessages + a populated `runningSummary`, no orphaned-tool-call errors. Debug against the real `/state` shape if the accessor is off.
+
+- [ ] **Step 6: Lint + commit**
+
+```bash
+git add test/runtime/run-summarization-e2e.test.ts test/runtime/fixtures/aimock/summarization.json test/runtime/vitest.config.ts
+git commit -m "test(runtime): aimock e2e — summarization across token threshold, history preserved"
+```
+
+---
+
+## Task 10: Full validation, changeset, chat-example seed, memory, PR
+
+**Files:**
+- Create: `.changeset/phase3-summarization.md`
+- Optionally modify: `examples/chat/server/dawn.config.ts` (demo seed — off by default, commented)
+
+- [ ] **Step 1: Full lane**
+
+```bash
+pnpm build && pnpm lint && pnpm typecheck && pnpm test
+pnpm exec vitest --run --config test/runtime/vitest.config.ts test/runtime/run-summarization-e2e.test.ts
+```
+Expected: green. (The pre-existing macOS-only `/private/tmp` `run-command.test.ts` artifact may fail locally — confirm it's that and unrelated; passes on Linux CI.)
+
+- [ ] **Step 2: Changeset**
+
+Create `.changeset/phase3-summarization.md`:
+
+```md
+---
+"@dawn-ai/core": minor
+"@dawn-ai/langchain": minor
+"@dawn-ai/cli": minor
+---
+
+Add opt-in conversation summarization (phase-3 sub-project 6b). When a thread's history exceeds a token threshold, a non-destructive `preModelHook` feeds the model a running summary plus recent turns (via `llmInputMessages`) while full history stays in the checkpoint — no destructive message removal, so no tool-call/result pairing hazard and `GET /state`/resume still see everything. Enable via `dawn.config.ts` `summarization: { enabled: true, maxTokens?, keepRecentTurns?, model?, tokenCounter?, summarize? }`. Token counting defaults to a lazily-loaded `gpt-tokenizer`; both the counter and the summarizer are swappable.
+```
+
+Run: `BASE_REF=origin/main HEAD_REF=feat/phase3-summarization node scripts/check-changesets.mjs` → passes.
+
+- [ ] **Step 3: Push + PR**
+
+```bash
+git add .changeset/phase3-summarization.md
+git commit -m "chore: changeset for conversation summarization"
+git push -u origin feat/phase3-summarization
+gh pr create --title "feat: phase3 6b — opt-in conversation summarization (non-destructive)" --body "$(cat <<'EOF'
+## Summary
+Final Phase-3 feature. Opt-in, non-destructive conversation summarization via a `createReactAgent` `preModelHook` returning `llmInputMessages` — condenses old turns into a cached running summary + recent verbatim turns while full history stays in the checkpoint. No destructive message removal → no tool-call/result pairing hazard; `GET /state`, resume, restart all see full history.
+
+- Token-threshold trigger; default counter = lazily-loaded `gpt-tokenizer` (single encoding, only loaded when enabled); both counter and summarizer swappable via `dawn.config.ts`.
+- Pairing-safe `splitForSummary` (turn-boundary slicing keeps tool rounds intact).
+- Incremental running summary cached in a `runningSummary` state field (bounded cost).
+- Also: collapsed `materializeAgent`'s 8 positional params into an options object.
+
+## Test plan
+- [x] Unit: token counter, pairing-safe split (incl. tool rounds), default summarizer, hook (under/over threshold, incremental fold, failure fallback)
+- [x] aimock e2e (no key): history crosses threshold → full history preserved in state + runningSummary populated
+- [x] Full build/lint/typecheck/test green
+
+Spec: docs/superpowers/specs/2026-06-04-phase3-conversation-summarization-design.md
+Plan: docs/superpowers/plans/2026-06-04-phase3-conversation-summarization.md
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 4: Update phase memory**
+
+In `/Users/blove/.claude/projects/-Users-blove-repos-dawn/memory/project_phase_status.md`: mark 6b shipped (PR link); note Phase 3 fully complete (all sub-projects incl. 6a+6b); record the non-destructive `preModelHook`/`llmInputMessages` architecture + the deferred destructive-compaction storage follow-up.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Non-destructive preModelHook + llmInputMessages → Tasks 6, 7. ✓
+- Opt-in config (enabled/maxTokens/keepRecentTurns/model/tokenCounter/summarize) → Task 2 (type), Task 8 (resolve+defaults). ✓
+- Default lazy gpt-tokenizer counter, swappable → Task 3, Task 8. ✓
+- Pairing-safe split → Task 4. ✓
+- Default summarizer, swappable → Task 5, Task 8. ✓
+- Incremental running-summary cache in state field → Task 6 (hook), Task 7 (state channel). ✓
+- Reuse route model default → Task 8. ✓
+- Failure fallback to full history → Task 6 (try/catch → {}). ✓
+- Composes with checkpointer (full history in state) → verified by Task 9 e2e (3 HumanMessages persist). ✓
+- Unit + aimock e2e tests → Tasks 3-6 (unit), Task 9 (e2e). ✓
+- materializeAgent options-object follow-up folded in → Task 1. ✓
+- Out-of-scope (destructive compaction, %-window) → not implemented. ✓
+
+**Placeholder scan:** Tasks 5/8/9 instruct verifying real signatures (`resolveProvider`, the descriptor model field, `GET /state` channel shape, the gpt-tokenizer subpath) against the actual code rather than hardcoding possibly-wrong names — deliberate, each gives the file to check + the semantic requirement. No TBD/vague steps.
+
+**Type consistency:** `ResolvedSummarizationConfig` fields used identically in Task 2 (def), Task 6 (consumer), Task 8 (builder). `RunningSummary { summary, coveredCount }` consistent across Task 6 hook + Task 7 state field. `TokenCounter` widened to `number | Promise<number>` noted in both Task 2 and Task 3/8 (the async default). `buildSummarizationHook(config)` single-arg consistent in Task 6 + Task 7. `runningSummary` channel name matches between hook return (Task 6) and state field (Task 7) and e2e assertion (Task 9).

--- a/docs/superpowers/specs/2026-06-04-phase3-conversation-summarization-design.md
+++ b/docs/superpowers/specs/2026-06-04-phase3-conversation-summarization-design.md
@@ -1,0 +1,100 @@
+# Phase 3 Sub-project 6b — Conversation Summarization (Design)
+
+**Status:** Approved for planning
+**Date:** 2026-06-04
+**Roadmap:** Phase 3 sub-project 6b — the second half of sub-project 6 (6a = tool-output offloading, shipped in #186). This is the final Phase-3 feature.
+
+## Problem
+
+Even with tool-output offloading (6a) keeping individual large outputs out of context, a long-running conversation accumulates many turns. On every turn the full message history is re-sent to the model. Past a point the history alone approaches the model's context window, causing context exhaustion (failed runs / unpredictable truncation), rising cost, and "lost in the middle" attention dilution. Offloading bounds single outputs; it does not bound *conversation length*. Summarization condenses old turns so a thread can continue indefinitely.
+
+## Goal
+
+When a thread's history exceeds a token threshold, feed the model a condensed view — a running summary of older turns plus recent turns verbatim — while preserving the full history in the checkpoint. Opt-in, token-accurate, and pluggable (swap the token counter or the summarizer).
+
+## Architecture — non-destructive `preModelHook` + `llmInputMessages`
+
+Dawn's agent runs on `createReactAgent` (`@langchain/langgraph@1.3.0`). That version natively supports `preModelHook` and a built-in `llmInputMessages` channel. **When a `preModelHook` returns `{ llmInputMessages }`, LangGraph uses that list as the LLM input for the turn and does NOT update `messages` in saved state** (verified against the installed `react_agent_executor.d.ts` and LangGraph docs).
+
+So summarization is a `preModelHook` that returns a condensed `llmInputMessages` while the real `messages` (full history) stay untouched in the SQLite checkpoint. This is decisive:
+
+- **No tool-call/result pairing hazard on persisted state.** We construct the condensed list ourselves; if a boundary is wrong it's a per-turn input bug we fully control, never a corrupted checkpoint. (This is the exact failure class that deferred 6b — LangGraph's stock `SummarizationNode`-as-`preModelHook` has documented orphaning bugs because it mutates state. We avoid mutation entirely.)
+- **Composes with everything.** Full history stays in the checkpoint → `GET /threads/{id}/state`, resume, and restart all see complete history. 6a's offloaded stubs are already small within that history. The summary is a *derived view*, never a destructive rewrite.
+- **Matches production consensus** (Letta tiered memory, deepagents, Claude Code `/compact`): keep a source of truth, derive the condensed view.
+
+Running summary is cached in a state field and refreshed **incrementally** (only newly-aged messages are folded in each turn) so cost stays bounded.
+
+## Configuration
+
+Opt-in via `dawn.config.ts` (tsx-evaluated, so it can carry functions like the backends fields):
+
+```ts
+summarization?: {
+  /** Enable summarization. Default false. */
+  readonly enabled?: boolean
+  /** Token threshold over which the older history is summarized. Default 12_000. */
+  readonly maxTokens?: number
+  /** Number of most-recent turns kept verbatim. Default 6. (A "turn" = a HumanMessage and everything up to the next HumanMessage.) */
+  readonly keepRecentTurns?: number
+  /** Model id for the summary LLM call. Default: the route's own model. */
+  readonly model?: string
+  /** Token counter. Default: a lazy gpt-tokenizer (o200k_base) counter. Swap for model-accurate counting. */
+  readonly tokenCounter?: (text: string) => number
+  /** Summary generator. Default: a built-in single-LLM-call summarizer. Bring your own. */
+  readonly summarize?: (args: {
+    readonly messages: readonly BaseMessage[]
+    readonly model: string
+    readonly previousSummary?: string
+    readonly signal: AbortSignal
+  }) => Promise<string>
+}
+```
+
+## Components (small, focused units)
+
+All new code lives in `packages/langchain/src/summarization/`.
+
+1. **`estimateTokens` (default token counter)** — `defaultTokenCounter(text): number`. Lazily `import("gpt-tokenizer/encoding/o200k_base")` on first use (single encoding, not the whole package), caches the `encode` fn, returns `encode(text).length`. `gpt-tokenizer` is a regular dependency of `@dawn-ai/langchain` (pure JS, no native deps), but is only imported when summarization is enabled and no custom `tokenCounter` is supplied — apps with 6b off never load the ~1–2 MB tables.
+
+2. **`countMessagesTokens(messages, counter)`** — serializes each message's content (and tool-call payloads) to text and sums `counter(text)` across the list. Pure given an injected counter.
+
+3. **`splitForSummary(messages, keepRecentTurns)`** — **pure, pairing-safe.** Returns `{ toSummarize, recent }`. The `recent` window is the last `keepRecentTurns` turns, where a turn boundary is a `HumanMessage`. Critically: `recent` must begin on a clean boundary so it never starts in the middle of a tool round (an `AIMessage` with `tool_calls` must keep its following `ToolMessage`s; the split point is moved earlier to a `HumanMessage` if needed). `toSummarize` is everything before that boundary. The system prompt is not part of `messages` (createReactAgent supplies it via `prompt`), so it is never summarized.
+
+4. **`summarizeMessages` (default summarizer)** — `defaultSummarize({ messages, model, previousSummary, signal })`: builds one chat-model call (via `createChatModel`) with a summarization prompt that folds `previousSummary` (if any) and the new `messages` into an updated running summary; returns the summary string. Swappable via `config.summarize`.
+
+5. **`buildSummarizationHook(config, routeModel)`** → a `preModelHook`:
+   - `counter = config.tokenCounter ?? defaultTokenCounter`
+   - if `countMessagesTokens(state.messages, counter) <= maxTokens` → return `{}` (no-op; model sees full history).
+   - else: read cached `state.runningSummary` (`{ summary, coveredCount }`); `splitForSummary` the messages beyond `coveredCount`; fold the newly-aged `toSummarize` into the summary via `summarize({ previousSummary, ... })`; update the cache; return `{ llmInputMessages: [summaryMessage, ...recent], runningSummary: { summary, coveredCount: newCovered } }`.
+   - `summaryMessage` is a `HumanMessage` (role-safe across providers) prefixed e.g. `"Summary of earlier conversation:\n<summary>"`. createReactAgent still prepends the route system prompt, so the LLM sees: system prompt → summary → recent turns.
+
+6. **State field** `runningSummary?: { summary: string; coveredCount: number }` — added to the agent's `stateSchema` only when summarization is enabled. Cached so each turn summarizes only the delta (bounded cost) and the summary persists across turns/restarts.
+
+## Wiring
+
+- `packages/langchain/src/agent-adapter.ts` — when summarization is enabled, pass `preModelHook: buildSummarizationHook(config, descriptor.model)` to `createReactAgent` and merge the `runningSummary` field into `stateSchema`.
+- `packages/cli/src/lib/runtime/execute-route.ts` — read `config.summarization` from `dawn.config.ts`, resolve the effective settings (defaults + route model), and thread them to the agent adapter (alongside how `offload` is already threaded).
+
+## Error handling / edge cases
+
+- **Summarizer LLM call fails** → log a warning and return `{}` (fall back to full history for that turn); never break the run because summarization failed. (Risk: a failed summary on an over-threshold turn may itself exceed the window — acceptable v1 behavior; the alternative, hard-failing, is worse.)
+- **Under threshold** → no summary LLM call and `llmInputMessages` is not set (model sees full history). The token counter still runs each turn to measure (that's the only per-turn cost when under threshold); with the default counter this lazy-loads `gpt-tokenizer` on the first measured turn. (When summarization is *disabled*, the counter never runs and `gpt-tokenizer` is never loaded.)
+- **`splitForSummary` can't find a clean boundary** (e.g. one enormous tool round) → keep everything in `recent` (summarize nothing this turn); summarization simply doesn't help that pathological case, but never orphans.
+- **Disabled (default)** → no `preModelHook`, no state field, zero behavior change. Existing agents are unaffected.
+
+## Testing
+
+**Unit (`packages/langchain`):**
+- `splitForSummary`: respects `keepRecentTurns`; never cuts between an `AIMessage`-with-`tool_calls` and its `ToolMessage`s (construct a history with tool rounds straddling the boundary and assert the split moves to a `HumanMessage`); handles the no-clean-boundary case.
+- `defaultTokenCounter`: lazy-imports, counts a known string within tolerance; `countMessagesTokens` sums across messages including tool-call content.
+- `buildSummarizationHook`: under threshold → `{}` (fake counter); over threshold → returns `llmInputMessages` = `[summary, ...recent]` and a `runningSummary`, using a fake `summarize` + fake counter (no real LLM); incremental — a second call only folds new messages (assert the fake `summarize` receives only the delta + `previousSummary`); summarizer-throws → `{}` fallback.
+
+**aimock e2e (runtime lane, CI-safe, no key — reuses the PR #190 harness):**
+- A scripted multi-turn conversation (via aimock fixtures) long enough to cross a low `maxTokens` set in the probe app's `dawn.config.ts`. Assert: (a) the saved state (`GET /state`) contains the FULL history; (b) the run completes coherently across the threshold (no orphaned-tool-call error); (c) `runningSummary` is populated in state. Use a small `maxTokens` so a few scripted turns trigger it deterministically.
+
+## Out of scope
+
+- **Destructive checkpoint compaction / storage bounding.** Non-destructive keeps full history in the checkpoint (grows over a very long thread). Bounding *storage* is a separate concern from bounding *context* and gets its own follow-up if it ever bites; it must not compromise this in-context architecture.
+- **%-of-context-window auto-sizing.** Use an absolute `maxTokens` + swappable counter rather than a per-model context-window table.
+- **Semantic/structured summaries** (e.g. extracting entities, decisions) — v1 is a single free-text running summary; a structured-summary `summarize` impl can be plugged in later.
+- **Summarizing the system prompt or offloaded file contents** — only conversation `messages` are summarized.

--- a/packages/cli/src/lib/runtime/execute-route.ts
+++ b/packages/cli/src/lib/runtime/execute-route.ts
@@ -22,10 +22,13 @@ import {
 } from "@dawn-ai/core"
 import {
   Command,
+  defaultSummarize,
+  defaultTokenCounter,
   executeAgent,
   type OffloadFn,
   OffloadStore,
   offloadToolOutput,
+  type ResolvedSummarizationConfig,
   type SubagentResolver,
   streamAgent,
 } from "@dawn-ai/langchain"
@@ -245,6 +248,7 @@ export async function* streamResolvedRoute(options: {
     subagentResolver,
     checkpointer,
     offload,
+    summarization,
   } = prepared
 
   if (normalized.kind !== "agent") {
@@ -277,6 +281,7 @@ export async function* streamResolvedRoute(options: {
     ...(stateFields ? { stateFields } : {}),
     tools,
     ...(offload ? { offload } : {}),
+    ...(summarization ? { summarization } : {}),
     ...(promptFragments && promptFragments.length > 0 ? { promptFragments } : {}),
     ...(streamTransformers && streamTransformers.length > 0 ? { streamTransformers } : {}),
     ...(subagentResolver ? { subagentResolver } : {}),
@@ -327,6 +332,7 @@ interface PreparedRoute {
   readonly checkpointer: BaseCheckpointSaver
   readonly threadsStore: ThreadsStore
   readonly offload?: OffloadFn
+  readonly summarization?: ResolvedSummarizationConfig
   readonly stateFields: readonly ResolvedStateField[] | undefined
   readonly tools: readonly DiscoveredToolDefinition[]
   readonly promptFragments?: ReadonlyArray<NonNullable<CapabilityContribution["promptFragment"]>>
@@ -425,6 +431,8 @@ async function prepareRouteExecution(options: {
     options.signal ?? new AbortController().signal,
   )
 
+  let summarization: ResolvedSummarizationConfig | undefined
+
   const checkpointer: BaseCheckpointSaver =
     configCheckpointer ??
     sqliteCheckpointer({ path: join(options.appRoot, ".dawn/checkpoints.sqlite") })
@@ -444,6 +452,8 @@ async function prepareRouteExecution(options: {
     const routeManifest = await discoverRoutes({ appRoot: options.appRoot })
     const descriptor =
       normalized.kind === "agent" && isDawnAgent(normalized.entry) ? normalized.entry : undefined
+
+    summarization = buildSummarization(loadedDawnConfig, descriptor?.model)
 
     // Build (or reuse) the descriptor->routeId identity map used by the
     // subagents marker to resolve `agent({ subagents: [imported] })` overrides.
@@ -569,6 +579,7 @@ async function prepareRouteExecution(options: {
     checkpointer,
     threadsStore,
     ...(offload ? { offload } : {}),
+    ...(summarization ? { summarization } : {}),
     ...(promptFragments.length > 0 ? { promptFragments } : {}),
     stateFields,
     ...(streamTransformers.length > 0 ? { streamTransformers } : {}),
@@ -615,6 +626,7 @@ async function executeRouteAtResolvedPath(options: {
       subagentResolver,
       checkpointer,
       offload,
+      summarization,
     } = prepared
     mode = normalized.kind
 
@@ -631,6 +643,7 @@ async function executeRouteAtResolvedPath(options: {
       ...(stateFields ? { stateFields } : {}),
       tools,
       ...(offload ? { offload } : {}),
+      ...(summarization ? { summarization } : {}),
       ...(options.signal ? { signal: options.signal } : {}),
       ...(promptFragments && promptFragments.length > 0 ? { promptFragments } : {}),
       ...(streamTransformers && streamTransformers.length > 0 ? { streamTransformers } : {}),
@@ -673,6 +686,7 @@ async function invokeEntry(
     readonly checkpointer?: BaseCheckpointSaver
     readonly middlewareContext?: Readonly<Record<string, unknown>>
     readonly offload?: OffloadFn
+    readonly summarization?: ResolvedSummarizationConfig
     readonly routeId: string
     readonly signal?: AbortSignal
     readonly stateFields?: readonly ResolvedStateField[]
@@ -715,6 +729,7 @@ async function invokeEntry(
       ...(agentContext?.stateFields ? { stateFields: agentContext.stateFields } : {}),
       tools: agentContext?.tools ?? [],
       ...(agentContext?.offload ? { offload: agentContext.offload } : {}),
+      ...(agentContext?.summarization ? { summarization: agentContext.summarization } : {}),
       ...(agentContext?.promptFragments && agentContext.promptFragments.length > 0
         ? { promptFragments: agentContext.promptFragments }
         : {}),
@@ -990,6 +1005,28 @@ function buildOffload(
       store,
       ...(toolCallId ? { toolCallId } : {}),
     })
+  }
+}
+
+function buildSummarization(
+  config: DawnConfig | undefined,
+  routeModel: string | undefined,
+): ResolvedSummarizationConfig | undefined {
+  const s = config?.summarization
+  if (!s?.enabled) return undefined
+  const model = s.model ?? routeModel
+  if (!model) return undefined // no model to summarize with — cannot enable
+  return {
+    maxTokens: s.maxTokens ?? 12_000,
+    keepRecentTurns: s.keepRecentTurns ?? 6,
+    model,
+    tokenCounter: s.tokenCounter ?? defaultTokenCounter,
+    // The core config types `messages` as `readonly unknown[]` because
+    // @dawn-ai/core cannot depend on @langchain/core. At runtime these are
+    // BaseMessage instances, so the cast to SummarizeFn is sound.
+    summarize:
+      (s.summarize as unknown as ResolvedSummarizationConfig["summarize"] | undefined) ??
+      defaultSummarize,
   }
 }
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -44,6 +44,25 @@ export interface DawnConfig {
      */
     readonly noOffloadTools?: readonly string[]
   }
+  readonly summarization?: {
+    /** Enable conversation summarization. Default false. */
+    readonly enabled?: boolean
+    /** Token threshold over which older history is summarized. Default 12000. */
+    readonly maxTokens?: number
+    /** Most-recent turns kept verbatim (a turn starts at a HumanMessage). Default 6. */
+    readonly keepRecentTurns?: number
+    /** Model id for the summary LLM call. Defaults to the route's model. */
+    readonly model?: string
+    /** Token counter. Default: a lazy gpt-tokenizer (o200k_base) counter. */
+    readonly tokenCounter?: (text: string) => number | Promise<number>
+    /** Summary generator. Default: a built-in single-LLM-call summarizer. */
+    readonly summarize?: (args: {
+      readonly messages: readonly unknown[]
+      readonly model: string
+      readonly previousSummary?: string
+      readonly signal: AbortSignal
+    }) => Promise<string>
+  }
 }
 
 export type RouteSegment =

--- a/packages/langchain/package.json
+++ b/packages/langchain/package.json
@@ -40,7 +40,8 @@
     "@dawn-ai/sdk": "workspace:*",
     "@dawn-ai/workspace": "workspace:*",
     "@langchain/langgraph": "^1.3.0",
-    "@langchain/openai": "^1.4.5"
+    "@langchain/openai": "^1.4.5",
+    "gpt-tokenizer": "^3.4.0"
   },
   "peerDependencies": {
     "@langchain/core": "^1.1.47",

--- a/packages/langchain/src/agent-adapter.ts
+++ b/packages/langchain/src/agent-adapter.ts
@@ -70,13 +70,15 @@ async function materializeAgent(
   descriptor: DawnAgent,
   tools: readonly DawnToolDefinition[],
   checkpointer: BaseCheckpointSaver,
-  stateFields?: readonly ResolvedStateField[],
-  middlewareContext?: Readonly<Record<string, unknown>>,
-  promptFragments?: readonly PromptFragment[],
-  options?: { readonly bypassCache?: boolean },
-  offload?: OffloadFn,
+  opts: {
+    readonly stateFields?: readonly ResolvedStateField[]
+    readonly middlewareContext?: Readonly<Record<string, unknown>>
+    readonly promptFragments?: readonly PromptFragment[]
+    readonly bypassCache?: boolean
+    readonly offload?: OffloadFn
+  } = {},
 ): Promise<AgentLike> {
-  if (!options?.bypassCache) {
+  if (!opts.bypassCache) {
     const cached = materializedAgents.get(descriptor)
     if (cached) {
       return cached
@@ -86,7 +88,7 @@ async function materializeAgent(
   const { createReactAgent } = await import("@langchain/langgraph/prebuilt")
 
   const langchainTools = tools.map((tool) =>
-    convertToolToLangChain(tool, middlewareContext, offload),
+    convertToolToLangChain(tool, opts.middlewareContext, opts.offload),
   )
 
   const provider = resolveProvider({
@@ -99,7 +101,7 @@ async function materializeAgent(
     ...(descriptor.reasoning ? { reasoning: descriptor.reasoning } : {}),
   })
 
-  const fragments = promptFragments ?? []
+  const fragments = opts.promptFragments ?? []
   const agentOptions: Record<string, unknown> = {
     llm,
     tools: langchainTools,
@@ -115,14 +117,14 @@ async function materializeAgent(
     checkpointer,
   }
 
-  if (stateFields && stateFields.length > 0) {
-    agentOptions.stateSchema = materializeStateSchema(stateFields)
+  if (opts.stateFields && opts.stateFields.length > 0) {
+    agentOptions.stateSchema = materializeStateSchema(opts.stateFields)
   }
 
   // biome-ignore lint/suspicious/noExplicitAny: dynamically-built options don't satisfy strict StateDefinition type
   const compiled = createReactAgent(agentOptions as any)
 
-  if (!options?.bypassCache) {
+  if (!opts.bypassCache) {
     materializedAgents.set(descriptor, compiled as unknown as AgentLike)
   }
   return compiled as unknown as AgentLike
@@ -135,14 +137,10 @@ export async function materializeAgentGraph(options: {
   readonly stateFields?: readonly ResolvedStateField[]
   readonly promptFragments?: readonly PromptFragment[]
 }): Promise<unknown> {
-  return materializeAgent(
-    options.descriptor,
-    options.tools ?? [],
-    options.checkpointer,
-    options.stateFields,
-    undefined,
-    options.promptFragments,
-  )
+  return materializeAgent(options.descriptor, options.tools ?? [], options.checkpointer, {
+    ...(options.stateFields ? { stateFields: options.stateFields } : {}),
+    ...(options.promptFragments ? { promptFragments: options.promptFragments } : {}),
+  })
 }
 
 export interface AgentStreamChunk {
@@ -378,11 +376,13 @@ export async function* streamAgent(options: AgentOptions): AsyncGenerator<AgentS
       options.entry,
       effectiveTools,
       options.checkpointer,
-      options.stateFields,
-      options.middlewareContext,
-      options.promptFragments,
-      resolver && hasTaskTool ? { bypassCache: true } : undefined,
-      options.offload,
+      {
+        ...(options.stateFields ? { stateFields: options.stateFields } : {}),
+        ...(options.middlewareContext ? { middlewareContext: options.middlewareContext } : {}),
+        ...(options.promptFragments ? { promptFragments: options.promptFragments } : {}),
+        ...(resolver && hasTaskTool ? { bypassCache: true } : {}),
+        ...(options.offload ? { offload: options.offload } : {}),
+      },
     )
     const retryConfig = options.entry.retry
     const runnableInput = isCommandInput ? options.input : { messages }

--- a/packages/langchain/src/agent-adapter.ts
+++ b/packages/langchain/src/agent-adapter.ts
@@ -14,6 +14,7 @@ import {
   type SubagentStreamContext,
 } from "./subagent-dispatcher.js"
 import { bridgeSubagentTool, type SubagentResolverResult } from "./subagent-tool-bridge.js"
+import { buildSummarizationHook, type ResolvedSummarizationConfig } from "./summarization/index.js"
 import { convertToolToLangChain, type OffloadFn } from "./tool-converter.js"
 
 export type SubagentResolver = (leafName: string) => SubagentResolverResult | undefined
@@ -76,6 +77,7 @@ async function materializeAgent(
     readonly promptFragments?: readonly PromptFragment[]
     readonly bypassCache?: boolean
     readonly offload?: OffloadFn
+    readonly summarization?: ResolvedSummarizationConfig
   } = {},
 ): Promise<AgentLike> {
   if (!opts.bypassCache) {
@@ -117,8 +119,21 @@ async function materializeAgent(
     checkpointer,
   }
 
-  if (opts.stateFields && opts.stateFields.length > 0) {
-    agentOptions.stateSchema = materializeStateSchema(opts.stateFields)
+  const runningSummaryField: ResolvedStateField = {
+    name: "runningSummary",
+    reducer: "replace",
+    default: undefined,
+  }
+  const effectiveStateFields: readonly ResolvedStateField[] = opts.summarization
+    ? [...(opts.stateFields ?? []).filter((f) => f.name !== "runningSummary"), runningSummaryField]
+    : (opts.stateFields ?? [])
+
+  if (effectiveStateFields.length > 0) {
+    agentOptions.stateSchema = materializeStateSchema(effectiveStateFields)
+  }
+
+  if (opts.summarization) {
+    agentOptions.preModelHook = buildSummarizationHook(opts.summarization)
   }
 
   // biome-ignore lint/suspicious/noExplicitAny: dynamically-built options don't satisfy strict StateDefinition type
@@ -136,10 +151,12 @@ export async function materializeAgentGraph(options: {
   readonly tools?: readonly DawnToolDefinition[]
   readonly stateFields?: readonly ResolvedStateField[]
   readonly promptFragments?: readonly PromptFragment[]
+  readonly summarization?: ResolvedSummarizationConfig
 }): Promise<unknown> {
   return materializeAgent(options.descriptor, options.tools ?? [], options.checkpointer, {
     ...(options.stateFields ? { stateFields: options.stateFields } : {}),
     ...(options.promptFragments ? { promptFragments: options.promptFragments } : {}),
+    ...(options.summarization ? { summarization: options.summarization } : {}),
   })
 }
 
@@ -303,6 +320,7 @@ export interface AgentOptions {
    * replay.
    */
   readonly threadId?: string
+  readonly summarization?: ResolvedSummarizationConfig
 }
 
 export async function executeAgent(options: AgentOptions): Promise<unknown> {
@@ -382,6 +400,7 @@ export async function* streamAgent(options: AgentOptions): AsyncGenerator<AgentS
         ...(options.promptFragments ? { promptFragments: options.promptFragments } : {}),
         ...(resolver && hasTaskTool ? { bypassCache: true } : {}),
         ...(options.offload ? { offload: options.offload } : {}),
+        ...(options.summarization ? { summarization: options.summarization } : {}),
       },
     )
     const retryConfig = options.entry.retry

--- a/packages/langchain/src/index.ts
+++ b/packages/langchain/src/index.ts
@@ -32,6 +32,7 @@ export {
 } from "./subagent-dispatcher.js"
 export type { SubagentResolverResult } from "./subagent-tool-bridge.js"
 export { bridgeSubagentTool } from "./subagent-tool-bridge.js"
+export * from "./summarization/index.js"
 export type { OffloadFn } from "./tool-converter.js"
 export { convertToolToLangChain } from "./tool-converter.js"
 export { executeWithToolLoop } from "./tool-loop.js"

--- a/packages/langchain/src/summarization/hook.ts
+++ b/packages/langchain/src/summarization/hook.ts
@@ -1,0 +1,23 @@
+import type { BaseMessage } from "@langchain/core/messages"
+
+export interface RunningSummary {
+  readonly summary: string
+  readonly coveredCount: number
+}
+
+export type TokenCounter = (text: string) => number | Promise<number>
+
+export type SummarizeFn = (args: {
+  readonly messages: readonly BaseMessage[]
+  readonly model: string
+  readonly previousSummary?: string
+  readonly signal: AbortSignal
+}) => Promise<string>
+
+export interface ResolvedSummarizationConfig {
+  readonly maxTokens: number
+  readonly keepRecentTurns: number
+  readonly model: string
+  readonly tokenCounter: TokenCounter
+  readonly summarize: SummarizeFn
+}

--- a/packages/langchain/src/summarization/hook.ts
+++ b/packages/langchain/src/summarization/hook.ts
@@ -1,4 +1,4 @@
-import { type BaseMessage, HumanMessage } from "@langchain/core/messages"
+import { type BaseMessage, SystemMessage } from "@langchain/core/messages"
 import { splitForSummary } from "./split.js"
 import { countMessagesTokens } from "./token-counter.js"
 
@@ -60,7 +60,7 @@ export function buildSummarizationHook(config: ResolvedSummarizationConfig) {
     }
     if (!summary) return {}
 
-    const summaryMessage = new HumanMessage(`Summary of earlier conversation:\n${summary}`)
+    const summaryMessage = new SystemMessage(`Summary of earlier conversation:\n${summary}`)
     return {
       llmInputMessages: [summaryMessage, ...recent],
       runningSummary: { summary, coveredCount: toSummarize.length },

--- a/packages/langchain/src/summarization/hook.ts
+++ b/packages/langchain/src/summarization/hook.ts
@@ -1,4 +1,6 @@
-import type { BaseMessage } from "@langchain/core/messages"
+import { type BaseMessage, HumanMessage } from "@langchain/core/messages"
+import { splitForSummary } from "./split.js"
+import { countMessagesTokens } from "./token-counter.js"
 
 export interface RunningSummary {
   readonly summary: string
@@ -20,4 +22,48 @@ export interface ResolvedSummarizationConfig {
   readonly model: string
   readonly tokenCounter: TokenCounter
   readonly summarize: SummarizeFn
+}
+
+export interface PreModelHookState {
+  readonly messages: BaseMessage[]
+  readonly runningSummary?: RunningSummary
+}
+
+export interface PreModelHookResult {
+  llmInputMessages?: BaseMessage[]
+  runningSummary?: RunningSummary
+}
+
+export function buildSummarizationHook(config: ResolvedSummarizationConfig) {
+  return async (state: PreModelHookState): Promise<PreModelHookResult> => {
+    const messages = state.messages ?? []
+    const total = await countMessagesTokens(messages, config.tokenCounter)
+    if (total <= config.maxTokens) return {}
+
+    const prev = state.runningSummary
+    const coveredCount = prev?.coveredCount ?? 0
+    const { toSummarize, recent } = splitForSummary(messages, config.keepRecentTurns)
+    const newlyAged = toSummarize.slice(coveredCount)
+
+    let summary = prev?.summary ?? ""
+    if (newlyAged.length > 0) {
+      try {
+        summary = await config.summarize({
+          messages: newlyAged,
+          model: config.model,
+          ...(prev?.summary ? { previousSummary: prev.summary } : {}),
+          signal: new AbortController().signal,
+        })
+      } catch {
+        return {}
+      }
+    }
+    if (!summary) return {}
+
+    const summaryMessage = new HumanMessage(`Summary of earlier conversation:\n${summary}`)
+    return {
+      llmInputMessages: [summaryMessage, ...recent],
+      runningSummary: { summary, coveredCount: toSummarize.length },
+    }
+  }
 }

--- a/packages/langchain/src/summarization/hook.ts
+++ b/packages/langchain/src/summarization/hook.ts
@@ -34,28 +34,42 @@ export interface PreModelHookResult {
   runningSummary?: RunningSummary
 }
 
-export function buildSummarizationHook(config: ResolvedSummarizationConfig) {
-  return async (state: PreModelHookState): Promise<PreModelHookResult> => {
+export function buildSummarizationHook(cfg: ResolvedSummarizationConfig) {
+  return async (
+    state: PreModelHookState,
+    nodeConfig?: { readonly signal?: AbortSignal },
+  ): Promise<PreModelHookResult> => {
     const messages = state.messages ?? []
-    const total = await countMessagesTokens(messages, config.tokenCounter)
-    if (total <= config.maxTokens) return {}
+    const total = await countMessagesTokens(messages, cfg.tokenCounter)
+    if (total <= cfg.maxTokens) return {}
 
     const prev = state.runningSummary
     const coveredCount = prev?.coveredCount ?? 0
-    const { toSummarize, recent } = splitForSummary(messages, config.keepRecentTurns)
+    const { toSummarize, recent } = splitForSummary(messages, cfg.keepRecentTurns)
     const newlyAged = toSummarize.slice(coveredCount)
 
     let summary = prev?.summary ?? ""
     if (newlyAged.length > 0) {
       try {
-        summary = await config.summarize({
+        summary = await cfg.summarize({
           messages: newlyAged,
-          model: config.model,
+          model: cfg.model,
           ...(prev?.summary ? { previousSummary: prev.summary } : {}),
-          signal: new AbortController().signal,
+          signal: nodeConfig?.signal ?? new AbortController().signal,
         })
-      } catch {
-        return {}
+      } catch (error) {
+        // Summarization failed this turn — fall back to the FULL history.
+        // We must explicitly set llmInputMessages to the full messages (not
+        // return {}), otherwise a stale condensed view from a prior turn would
+        // remain in the channel and the model would answer without the latest
+        // turn's messages.
+        if (process.env.DAWN_DEBUG_SUMMARIZATION === "1") {
+          console.warn(
+            "[dawn] summarization failed — falling back to full history this turn:",
+            error instanceof Error ? error.message : String(error),
+          )
+        }
+        return { llmInputMessages: messages }
       }
     }
     if (!summary) return {}

--- a/packages/langchain/src/summarization/index.ts
+++ b/packages/langchain/src/summarization/index.ts
@@ -1,0 +1,12 @@
+export {
+  buildSummarizationHook,
+  type PreModelHookResult,
+  type PreModelHookState,
+  type ResolvedSummarizationConfig,
+  type RunningSummary,
+  type SummarizeFn,
+  type TokenCounter,
+} from "./hook.js"
+export { splitForSummary } from "./split.js"
+export { defaultSummarize } from "./summarize.js"
+export { countMessagesTokens, defaultTokenCounter } from "./token-counter.js"

--- a/packages/langchain/src/summarization/split.ts
+++ b/packages/langchain/src/summarization/split.ts
@@ -1,0 +1,30 @@
+import type { BaseMessage } from "@langchain/core/messages"
+
+function isHuman(m: BaseMessage): boolean {
+  const getType = (m as { getType?: () => string }).getType
+  if (typeof getType === "function") return getType.call(m) === "human"
+  const legacy = (m as { _getType?: () => string })._getType
+  return typeof legacy === "function" ? legacy.call(m) === "human" : false
+}
+
+/**
+ * Split into { toSummarize, recent }, keeping the last `keepRecentTurns` turns
+ * verbatim. A turn begins at a HumanMessage; slicing on a HumanMessage boundary
+ * keeps every tool round (AIMessage-with-tool_calls + its ToolMessages) intact,
+ * so `recent` never starts mid-round. Fewer turns than requested -> all recent.
+ */
+export function splitForSummary(
+  messages: readonly BaseMessage[],
+  keepRecentTurns: number,
+): { toSummarize: BaseMessage[]; recent: BaseMessage[] } {
+  if (keepRecentTurns <= 0) return { toSummarize: [...messages], recent: [] }
+  const humanIdx: number[] = []
+  messages.forEach((m, i) => {
+    if (isHuman(m)) humanIdx.push(i)
+  })
+  if (humanIdx.length <= keepRecentTurns) {
+    return { toSummarize: [], recent: [...messages] }
+  }
+  const cut = humanIdx[humanIdx.length - keepRecentTurns] as number
+  return { toSummarize: messages.slice(0, cut), recent: messages.slice(cut) }
+}

--- a/packages/langchain/src/summarization/summarize.ts
+++ b/packages/langchain/src/summarization/summarize.ts
@@ -1,0 +1,46 @@
+import type { BaseMessage } from "@langchain/core/messages"
+import { createChatModel } from "../chat-model-factory.js"
+import { resolveProvider } from "../model-provider-resolver.js"
+
+function renderMessages(messages: readonly BaseMessage[]): string {
+  return messages
+    .map((m) => {
+      const getType = (m as { getType?: () => string }).getType
+      const role = typeof getType === "function" ? getType.call(m) : "message"
+      const content = typeof m.content === "string" ? m.content : JSON.stringify(m.content)
+      const toolCalls = (m as { tool_calls?: unknown[] }).tool_calls
+      const tc =
+        toolCalls && toolCalls.length > 0 ? `\n[tool_calls: ${JSON.stringify(toolCalls)}]` : ""
+      return `${role}: ${content}${tc}`
+    })
+    .join("\n")
+}
+
+function buildPrompt(messages: readonly BaseMessage[], previousSummary?: string): string {
+  const prior = previousSummary ? `Existing running summary so far:\n${previousSummary}\n\n` : ""
+  return (
+    `${prior}New conversation messages to fold into the summary:\n${renderMessages(messages)}\n\n` +
+    `Write an updated, concise running summary of the ENTIRE conversation so far. ` +
+    `Preserve concrete facts, decisions, user goals, tool results, identifiers, and open questions. ` +
+    `Do not invent information. Output only the summary text.`
+  )
+}
+
+export async function defaultSummarize(args: {
+  readonly messages: readonly BaseMessage[]
+  readonly model: string
+  readonly previousSummary?: string
+  readonly signal: AbortSignal
+  /** Test seam: override the model invocation. */
+  readonly invokeModel?: (prompt: string) => Promise<string>
+}): Promise<string> {
+  const prompt = buildPrompt(args.messages, args.previousSummary)
+  if (args.invokeModel) return args.invokeModel(prompt)
+
+  const provider = resolveProvider({ model: args.model })
+  const llm = (await createChatModel({ model: args.model, provider })) as {
+    invoke: (input: unknown, options?: unknown) => Promise<{ content: unknown }>
+  }
+  const res = await llm.invoke([{ role: "user", content: prompt }], { signal: args.signal })
+  return typeof res.content === "string" ? res.content : JSON.stringify(res.content)
+}

--- a/packages/langchain/src/summarization/token-counter.ts
+++ b/packages/langchain/src/summarization/token-counter.ts
@@ -1,0 +1,38 @@
+import type { BaseMessage } from "@langchain/core/messages"
+
+let encodeFn: ((text: string) => number[]) | undefined
+
+/**
+ * Default token counter. Lazily imports a single gpt-tokenizer encoding
+ * (o200k_base — current OpenAI models) so apps that don't enable summarization
+ * never load the large encoding tables. Async because of the lazy import.
+ */
+export async function defaultTokenCounter(text: string): Promise<number> {
+  if (!encodeFn) {
+    const mod = (await import("gpt-tokenizer/encoding/o200k_base")) as {
+      encode: (t: string) => number[]
+    }
+    encodeFn = mod.encode
+  }
+  return encodeFn(text).length
+}
+
+function messageToText(m: BaseMessage): string {
+  const parts: string[] = []
+  parts.push(typeof m.content === "string" ? m.content : JSON.stringify(m.content))
+  const toolCalls = (m as { tool_calls?: unknown }).tool_calls
+  if (toolCalls) parts.push(JSON.stringify(toolCalls))
+  return parts.join("\n")
+}
+
+/** Sum a (possibly async) token counter across a message list. */
+export async function countMessagesTokens(
+  messages: readonly BaseMessage[],
+  counter: (text: string) => number | Promise<number>,
+): Promise<number> {
+  let total = 0
+  for (const m of messages) {
+    total += await counter(messageToText(m))
+  }
+  return total
+}

--- a/packages/langchain/test/summarization-hook.test.ts
+++ b/packages/langchain/test/summarization-hook.test.ts
@@ -1,0 +1,74 @@
+import { AIMessage, HumanMessage } from "@langchain/core/messages"
+import { describe, expect, it, vi } from "vitest"
+import { buildSummarizationHook } from "../src/summarization/hook.js"
+
+const H = (c: string) => new HumanMessage(c)
+const A = (c: string) => new AIMessage(c)
+
+function makeHook(over: Record<string, unknown> = {}) {
+  return buildSummarizationHook({
+    maxTokens: 100,
+    keepRecentTurns: 1,
+    model: "fake",
+    tokenCounter: (t: string) => t.length, // chars as tokens
+    summarize: async () => "SUMMARY",
+    ...over,
+  } as never)
+}
+
+describe("buildSummarizationHook", () => {
+  it("returns {} when under the token threshold", async () => {
+    const hook = makeHook({ maxTokens: 10_000 })
+    const out = await hook({ messages: [H("hi"), A("yo")] })
+    expect(out).toEqual({})
+  })
+
+  it("returns condensed llmInputMessages + runningSummary when over threshold", async () => {
+    const hook = makeHook({ maxTokens: 5, keepRecentTurns: 1 })
+    const msgs = [H("u1"), A("a1"), H("u2"), A("a2")]
+    const out = await hook({ messages: msgs })
+    expect(Array.isArray(out.llmInputMessages)).toBe(true)
+    const texts = (out.llmInputMessages as Array<{ content: string }>).map((m) => m.content)
+    expect(texts[0]).toContain("SUMMARY")
+    expect(texts.slice(1)).toEqual(["u2", "a2"]) // last turn verbatim
+    expect(out.runningSummary).toMatchObject({ summary: "SUMMARY", coveredCount: 2 })
+  })
+
+  it("incrementally folds only the newly-aged delta (previousSummary + delta)", async () => {
+    const summarize = vi.fn(async () => "S2")
+    const hook = makeHook({ maxTokens: 5, keepRecentTurns: 1, summarize })
+    const msgs = [H("u1"), A("a1"), H("u2"), A("a2"), H("u3"), A("a3")]
+    await hook({ messages: msgs, runningSummary: { summary: "S1", coveredCount: 2 } })
+    const arg = summarize.mock.calls[0]?.[0] as {
+      previousSummary?: string
+      messages: Array<{ content: string }>
+    }
+    expect(arg.previousSummary).toBe("S1")
+    expect(arg.messages.map((m) => m.content)).toEqual(["u2", "a2"]) // delta only (toSummarize=[u1,a1,u2,a2], minus covered 2)
+  })
+
+  it("falls back to {} when the summarizer throws", async () => {
+    const hook = makeHook({
+      maxTokens: 5,
+      summarize: async () => {
+        throw new Error("boom")
+      },
+    })
+    const out = await hook({ messages: [H("u1"), A("a1"), H("u2"), A("a2")] })
+    expect(out).toEqual({})
+  })
+
+  it("reuses the cached summary with no delta (no summarizer call)", async () => {
+    const summarize = vi.fn(async () => "NEW")
+    const hook = makeHook({ maxTokens: 5, keepRecentTurns: 1, summarize })
+    const msgs = [H("u1"), A("a1"), H("u2"), A("a2")]
+    // coveredCount already equals toSummarize length (2) → no delta
+    const out = await hook({
+      messages: msgs,
+      runningSummary: { summary: "CACHED", coveredCount: 2 },
+    })
+    expect(summarize).not.toHaveBeenCalled()
+    const texts = (out.llmInputMessages as Array<{ content: string }>).map((m) => m.content)
+    expect(texts[0]).toContain("CACHED")
+  })
+})

--- a/packages/langchain/test/summarization-hook.test.ts
+++ b/packages/langchain/test/summarization-hook.test.ts
@@ -1,4 +1,4 @@
-import { AIMessage, HumanMessage } from "@langchain/core/messages"
+import { AIMessage, HumanMessage, SystemMessage } from "@langchain/core/messages"
 import { describe, expect, it, vi } from "vitest"
 import { buildSummarizationHook } from "../src/summarization/hook.js"
 
@@ -31,6 +31,7 @@ describe("buildSummarizationHook", () => {
     const texts = (out.llmInputMessages as Array<{ content: string }>).map((m) => m.content)
     expect(texts[0]).toContain("SUMMARY")
     expect(texts.slice(1)).toEqual(["u2", "a2"]) // last turn verbatim
+    expect(out.llmInputMessages?.[0] instanceof SystemMessage).toBe(true)
     expect(out.runningSummary).toMatchObject({ summary: "SUMMARY", coveredCount: 2 })
   })
 

--- a/packages/langchain/test/summarization-hook.test.ts
+++ b/packages/langchain/test/summarization-hook.test.ts
@@ -48,15 +48,22 @@ describe("buildSummarizationHook", () => {
     expect(arg.messages.map((m) => m.content)).toEqual(["u2", "a2"]) // delta only (toSummarize=[u1,a1,u2,a2], minus covered 2)
   })
 
-  it("falls back to {} when the summarizer throws", async () => {
+  it("falls back to full history when the summarizer throws (stale-view avoidance)", async () => {
+    // Fix: returning {} would leave a prior-turn condensed view in the
+    // llmInputMessages channel, causing the model to answer without the
+    // current turn's newest messages. Instead, we explicitly overwrite the
+    // channel with the full message list so the model always sees the latest.
+    const msgs = [H("u1"), A("a1"), H("u2"), A("a2")]
     const hook = makeHook({
       maxTokens: 5,
       summarize: async () => {
         throw new Error("boom")
       },
     })
-    const out = await hook({ messages: [H("u1"), A("a1"), H("u2"), A("a2")] })
-    expect(out).toEqual({})
+    const out = await hook({ messages: msgs })
+    expect(out.llmInputMessages).toHaveLength(msgs.length)
+    expect(out.llmInputMessages?.map((m) => m.content)).toEqual(msgs.map((m) => m.content))
+    expect(out.runningSummary).toBeUndefined()
   })
 
   it("reuses the cached summary with no delta (no summarizer call)", async () => {

--- a/packages/langchain/test/summarization-split.test.ts
+++ b/packages/langchain/test/summarization-split.test.ts
@@ -1,0 +1,47 @@
+import { AIMessage, HumanMessage, ToolMessage } from "@langchain/core/messages"
+import { describe, expect, it } from "vitest"
+import { splitForSummary } from "../src/summarization/split.js"
+
+const H = (c: string) => new HumanMessage(c)
+const A = (c: string) => new AIMessage(c)
+const AT = (id: string) => new AIMessage({ content: "", tool_calls: [{ id, name: "t", args: {} }] })
+const T = (id: string) => new ToolMessage({ content: "r", tool_call_id: id })
+
+describe("splitForSummary", () => {
+  it("keeps the last N turns verbatim and summarizes the rest", () => {
+    const msgs = [H("u1"), A("a1"), H("u2"), A("a2"), H("u3"), A("a3")]
+    const { toSummarize, recent } = splitForSummary(msgs, 2)
+    expect(recent.map((m) => m.content as string)).toEqual(["u2", "a2", "u3", "a3"])
+    expect(toSummarize.map((m) => m.content as string)).toEqual(["u1", "a1"])
+  })
+
+  it("never splits a tool round (recent starts on a HumanMessage, whole round kept)", () => {
+    const msgs = [H("u1"), A("a1"), H("u2"), AT("c1"), T("c1"), A("done")]
+    const { toSummarize, recent } = splitForSummary(msgs, 1)
+    expect((recent[0] as HumanMessage).content).toBe("u2")
+    expect(recent).toHaveLength(4) // H,AT,T,A — entire turn incl. tool round
+    expect(toSummarize.map((m) => m.content as string)).toEqual(["u1", "a1"])
+  })
+
+  it("keeps everything as recent when there are fewer turns than keepRecentTurns", () => {
+    const msgs = [H("u1"), A("a1")]
+    const { toSummarize, recent } = splitForSummary(msgs, 5)
+    expect(toSummarize).toEqual([])
+    expect(recent).toEqual(msgs)
+  })
+
+  it("returns all-to-summarize, none-recent when keepRecentTurns is 0", () => {
+    const msgs = [H("u1"), A("a1")]
+    const { toSummarize, recent } = splitForSummary(msgs, 0)
+    expect(recent).toEqual([])
+    expect(toSummarize).toEqual(msgs)
+  })
+
+  it("handles leading non-human messages before the first turn", () => {
+    // e.g. a leading system-ish/AI message before any human turn
+    const msgs = [A("preamble"), H("u1"), A("a1"), H("u2"), A("a2")]
+    const { toSummarize, recent } = splitForSummary(msgs, 1)
+    expect((recent[0] as HumanMessage).content).toBe("u2")
+    expect(toSummarize.map((m) => m.content as string)).toEqual(["preamble", "u1", "a1"])
+  })
+})

--- a/packages/langchain/test/summarization-summarize.test.ts
+++ b/packages/langchain/test/summarization-summarize.test.ts
@@ -1,0 +1,39 @@
+import { AIMessage, HumanMessage } from "@langchain/core/messages"
+import { describe, expect, it } from "vitest"
+import { defaultSummarize } from "../src/summarization/summarize.js"
+
+describe("defaultSummarize", () => {
+  it("builds a prompt with previousSummary + messages and returns the model text", async () => {
+    let seenPrompt = ""
+    const result = await defaultSummarize({
+      messages: [new HumanMessage("user asked about X"), new AIMessage("assistant answered Y")],
+      model: "gpt-4o-mini",
+      previousSummary: "Earlier: greeted.",
+      signal: new AbortController().signal,
+      invokeModel: async (prompt: string) => {
+        seenPrompt = prompt
+        return "Updated summary: greeted, discussed X then Y."
+      },
+    })
+    expect(seenPrompt).toContain("Earlier: greeted.")
+    expect(seenPrompt).toContain("user asked about X")
+    expect(seenPrompt).toContain("assistant answered Y")
+    expect(result).toBe("Updated summary: greeted, discussed X then Y.")
+  })
+
+  it("omits the previous-summary preamble when none is given", async () => {
+    let seenPrompt = ""
+    await defaultSummarize({
+      messages: [new HumanMessage("just one message")],
+      model: "gpt-4o-mini",
+      signal: new AbortController().signal,
+      invokeModel: async (prompt: string) => {
+        seenPrompt = prompt
+        return "summary"
+      },
+    })
+    expect(seenPrompt).toContain("just one message")
+    // no "Existing running summary" preamble
+    expect(seenPrompt).not.toContain("Existing running summary")
+  })
+})

--- a/packages/langchain/test/summarization-token-counter.test.ts
+++ b/packages/langchain/test/summarization-token-counter.test.ts
@@ -1,0 +1,30 @@
+import { AIMessage, HumanMessage, ToolMessage } from "@langchain/core/messages"
+import { describe, expect, it } from "vitest"
+import { countMessagesTokens, defaultTokenCounter } from "../src/summarization/token-counter.js"
+
+describe("defaultTokenCounter", () => {
+  it("counts tokens for a plain string", async () => {
+    const n = await defaultTokenCounter("hello world this is a test")
+    expect(n).toBeGreaterThan(3)
+    expect(n).toBeLessThan(15)
+  })
+})
+
+describe("countMessagesTokens", () => {
+  it("sums an injected counter across message contents incl. tool calls", async () => {
+    const counter = (t: string) => t.length // chars as tokens, deterministic
+    const messages = [
+      new HumanMessage("abc"),
+      new AIMessage({ content: "", tool_calls: [{ id: "1", name: "t", args: { k: "v" } }] }),
+      new ToolMessage({ content: "result", tool_call_id: "1" }),
+    ]
+    const total = await countMessagesTokens(messages, counter)
+    expect(total).toBeGreaterThan(9) // "abc"(3) + serialized tool_call + "result"(6)
+  })
+
+  it("awaits an async counter", async () => {
+    const counter = async (t: string) => t.length
+    const total = await countMessagesTokens([new HumanMessage("hello")], counter)
+    expect(total).toBe(5)
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -302,6 +302,9 @@ importers:
       '@langchain/openai':
         specifier: ^1.4.5
         version: 1.4.5(@langchain/core@1.1.47(openai@6.37.0(ws@8.20.1)(zod@4.4.3))(ws@8.20.1))(ws@8.20.1)
+      gpt-tokenizer:
+        specifier: ^3.4.0
+        version: 3.4.0
     devDependencies:
       '@dawn-ai/config-typescript':
         specifier: workspace:*
@@ -2114,6 +2117,9 @@ packages:
   globby@11.1.0:
     resolution: {integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==}
     engines: {node: '>=10'}
+
+  gpt-tokenizer@3.4.0:
+    resolution: {integrity: sha512-wxFLnhIXTDjYebd9A9pGl3e31ZpSypbpIJSOswbgop5jLte/AsZVDvjlbEuVFlsqZixVKqbcoNmRlFDf6pz/UQ==}
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
@@ -4786,6 +4792,8 @@ snapshots:
       ignore: 5.3.2
       merge2: 1.4.1
       slash: 3.0.0
+
+  gpt-tokenizer@3.4.0: {}
 
   graceful-fs@4.2.11: {}
 

--- a/test/runtime/fixtures/aimock/summarization.json
+++ b/test/runtime/fixtures/aimock/summarization.json
@@ -1,0 +1,7 @@
+{
+  "fixtures": [
+    { "match": { "userMessage": "APPLE_TURN" }, "response": { "content": "Noted about apples." } },
+    { "match": { "userMessage": "BANANA_TURN" }, "response": { "content": "Noted about bananas." } },
+    { "match": { "userMessage": "CHERRY_TURN" }, "response": { "content": "Noted about cherries." } }
+  ]
+}

--- a/test/runtime/run-aimock-e2e.test.ts
+++ b/test/runtime/run-aimock-e2e.test.ts
@@ -129,7 +129,7 @@ async function rewriteDependenciesToTarballs(options: {
 // buildProbeApp — packs all packages, generates app, writes tools + route
 // ---------------------------------------------------------------------------
 
-async function buildProbeApp(): Promise<{ appRoot: string }> {
+async function buildProbeApp(opts?: { summarization?: boolean }): Promise<{ appRoot: string }> {
   const tempRoot = await createTrackedTempDir("aimock-probe-", tempDirs)
 
   try {
@@ -180,6 +180,26 @@ async function buildProbeApp(): Promise<{ appRoot: string }> {
 
     // Create workspace/ so the offload capability activates
     await mkdir(join(appRoot, "workspace"), { recursive: true })
+
+    if (opts?.summarization) {
+      // Overwrite the basic template's `export default {}` with a summarization
+      // config. A custom tokenCounter (char length) + a deterministic summarize
+      // fn keep this fully deterministic and avoid an extra LLM round-trip to
+      // aimock for the summary itself. maxTokens:10 + keepRecentTurns:1 forces
+      // summarization to fire from the 2nd turn onward.
+      const dawnConfigSource = `
+export default {
+  summarization: {
+    enabled: true,
+    maxTokens: 10,
+    keepRecentTurns: 1,
+    tokenCounter: (text: string) => text.length,
+    summarize: async () => "DETERMINISTIC_SUMMARY_OF_OLD_TURNS",
+  },
+};
+`.trimStart()
+      await writeFile(join(appRoot, "dawn.config.ts"), dawnConfigSource, "utf8")
+    }
 
     // Run pnpm install
     const { spawnProcess } = await import("../../packages/devkit/src/testing/index.ts")
@@ -558,3 +578,97 @@ it("SP6a (fallback): content-hash filename is correct and readFile retrieves the
     await aimock.stop()
   }
 }, 120_000)
+
+// ---------------------------------------------------------------------------
+// SUMM: summarization is non-destructive across a tiny token threshold
+// ---------------------------------------------------------------------------
+
+it("SUMM: summarization preserves full history + populates runningSummary across the threshold (non-destructive)", async () => {
+  const { appRoot } = await buildProbeApp({ summarization: true })
+  const aimock = await startAimock({
+    fixturePath: join(import.meta.dirname, "fixtures/aimock/summarization.json"),
+  })
+  const port = await allocatePort()
+  const server = await startDevServer({
+    cwd: appRoot,
+    port,
+    env: { OPENAI_BASE_URL: aimock.baseUrl, OPENAI_API_KEY: "test-not-used" },
+  })
+  try {
+    const url = await server.waitForReady(30_000)
+
+    const tid = (
+      (await (
+        await fetch(new URL("/threads", url), {
+          method: "POST",
+          body: "{}",
+          headers: { "content-type": "application/json" },
+        })
+      ).json()) as { thread_id: string }
+    ).thread_id
+
+    // Three sequential turns on the same thread, each crossing the tiny
+    // threshold. The 2nd and 3rd turns trigger the preModelHook summary fold.
+    const tokens = ["APPLE_TURN", "BANANA_TURN", "CHERRY_TURN"]
+    for (const token of tokens) {
+      const run = await fetch(new URL(`/threads/${tid}/runs/wait`, url), {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          route: "/chat#agent",
+          input: { messages: [{ role: "user", content: `Question ${token} please.` }] },
+        }),
+      })
+      const body = await run.text()
+      // A 200 across all three turns also proves no orphaned-tool-call / pairing
+      // error was introduced by the condensed llmInputMessages.
+      expect(run.status, `runs/wait(${token}) returned ${run.status}: ${body}`).toBe(200)
+    }
+
+    // Read the persisted checkpoint state.
+    const stateRes = await fetch(new URL(`/threads/${tid}/state`, url))
+    expect(stateRes.status).toBe(200)
+    const state = (await stateRes.json()) as {
+      values?: {
+        messages?: Array<Record<string, unknown>>
+        runningSummary?: { summary?: string; coveredCount?: number } | null
+      }
+    }
+    const values = state.values ?? {}
+    const messages = values.messages ?? []
+
+    // (a) FULL history preserved — 3 HumanMessages survive in the checkpoint.
+    const humanCount = messages.filter((m) => {
+      const id = (m as { id?: string[] }).id
+      if (Array.isArray(id) && id[2] === "HumanMessage") return true
+      const typed = m as { type?: string; role?: string }
+      return typed.type === "human" || typed.role === "user"
+    }).length
+    expect(
+      humanCount,
+      `expected 3 HumanMessages in persisted history, got ${humanCount}: ${JSON.stringify(messages).slice(0, 800)}`,
+    ).toBe(3)
+
+    // (b) runningSummary populated by the incremental fold.
+    const rs = values.runningSummary
+    expect(rs, `runningSummary should be populated: ${JSON.stringify(values).slice(0, 800)}`).toBeTruthy()
+    expect(rs?.summary, "runningSummary.summary should contain the deterministic summary").toContain(
+      "DETERMINISTIC_SUMMARY_OF_OLD_TURNS",
+    )
+    expect(
+      typeof rs?.coveredCount === "number" && (rs?.coveredCount ?? 0) > 0,
+      `runningSummary.coveredCount should be > 0, got ${rs?.coveredCount}`,
+    ).toBe(true)
+
+    // (c) Non-destructive: the derived summary is NOT persisted into messages.
+    // It only ever appears in the per-turn llmInputMessages view.
+    const persisted = JSON.stringify(messages)
+    expect(
+      persisted.includes("DETERMINISTIC_SUMMARY_OF_OLD_TURNS"),
+      "the summary must NOT leak into persisted messages (non-destructive architecture)",
+    ).toBe(false)
+  } finally {
+    await server.stop()
+    await aimock.stop()
+  }
+}, 180_000)


### PR DESCRIPTION
## Phase 3 sub-project 6b — Conversation Summarization

The final Phase-3 feature. When a thread's history exceeds a token threshold, the agent is fed a **condensed view** (a running summary of older turns + recent turns verbatim) while the **full history stays intact in the checkpoint**.

### Architecture — non-destructive `preModelHook` + `llmInputMessages`
Summarization runs as a LangGraph `preModelHook` that returns `{ llmInputMessages }` for the turn only. The prebuilt feeds that condensed list to the model **without** rewriting the saved `messages` channel (verified against `@langchain/langgraph@1.3.0`). Consequences:
- **No checkpoint mutation** → `GET /threads/:id/state`, resume, and restart always see the complete history.
- **No tool-call/result pairing hazard** — the exact failure class that deferred 6b. The turn-boundary split (`splitForSummary`) cuts only at `HumanMessage` boundaries, so an `AIMessage` with `tool_calls` is never separated from its `ToolMessage`s.
- The summary is a derived per-turn view, never persisted into `messages`.

### Opt-in via `dawn.config.ts`
```ts
export default {
  summarization: {
    enabled: true,        // default false → zero behavior change, gpt-tokenizer never loads
    maxTokens: 12_000,    // threshold
    keepRecentTurns: 6,   // turns kept verbatim
    // model      → defaults to the route's model
    // tokenCounter → defaults to a lazy gpt-tokenizer (o200k_base) counter
    // summarize    → defaults to a built-in running-summary fold (single LLM call)
  },
}
```
Both `tokenCounter` and `summarize` are pluggable. The running summary is cached in agent state and folded **incrementally** — each turn summarizes only the newly-aged messages, so cost stays bounded.

### Robustness
- Summarizer failure on a turn → fall back to the **full** history that turn (explicitly overwrites `llmInputMessages` with the full list to avoid reusing a stale prior-turn condensed view); the run never fails because summarization failed. Debug-gated warn via `DAWN_DEBUG_SUMMARIZATION=1`.
- The real run `AbortSignal` is threaded into the summary LLM call (cancelled when the parent run aborts).

### Tests
- Unit (`@dawn-ai/langchain`): `splitForSummary` pairing safety + edge cases; lazy token counter; `defaultSummarize`; `buildSummarizationHook` (under/over threshold, incremental fold, throw→full-history fallback). 15 summarization tests.
- **aimock e2e** (`test/runtime/run-aimock-e2e.test.ts`, CI-safe, no API key): a 3-turn conversation crosses a tiny threshold and asserts (a) the checkpoint retains all 3 `HumanMessage`s, (b) `runningSummary` is populated, (c) the derived summary never leaks into persisted `messages`. All three turns return 200 — proving no orphaned-tool-call error across the threshold.

### Validation
- `@dawn-ai/core` / `@dawn-ai/langchain` / `@dawn-ai/cli`: typecheck ✅, lint ✅, unit tests ✅ (the single `run-command.test.ts` failure is a known macOS-only `/private/tmp` path-normalization artifact, green on Linux CI, untouched by this PR).
- Runtime e2e lane: 5/5 ✅.
- Final whole-implementation review: merge-ready, no Critical/Important findings.

Changeset: `@dawn-ai/core` + `@dawn-ai/langchain` + `@dawn-ai/cli` **minor**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
