### PR TITLE
feat(testing): capability coverage (HITL/subagents/planning/skills/memory) + appRoot capability activation

### DIFF
--- a/.changeset/testing-capability-coverage.md
+++ b/.changeset/testing-capability-coverage.md
@@ -1,0 +1,9 @@
+---
+"@dawn-ai/testing": minor
+"@dawn-ai/core": minor
+---
+
+`@dawn-ai/core`: the workspace and AGENTS.md capabilities now activate relative to the **app root** instead of `process.cwd()`, so they work when an app is run from any working directory (e.g. in-process tests, embedded use). No behavior change under `dawn dev` (where cwd is the app root). `CapabilityMarkerContext` gained a required `appRoot: string` field — if you construct that type in a custom capability marker or its tests, add `appRoot`.
+
+
+Extend `@dawn-ai/testing` to cover the rest of Dawn's agent capabilities. `AgentRunResult` now captures interrupts, plan updates, subagent runs, and the composed system prompt (read from aimock's request journal via `AimockHandle.getRequests()`); `harness.resume({ decision })` drives HITL interrupt→resume flows. New matchers: `expectInterrupt`/`expectNoInterrupt`, `expectSubagent`, `expectPlan`, `expectSystemPrompt` (and `expectPlan().toHaveLength`, `expectSystemPrompt().toMatch`). Dawn's own chat/coordinator example apps are now dogfooded with in-process e2e for HITL permissions, subagents, planning, skills, and AGENTS.md memory. The dogfood surfaced and fixed a harness bug: gpt-5/reasoning routes send the system prompt under the `developer` role, which the system-prompt capture now recognizes. No framework changes — all capability events were already emitted by the runtime. CI now runs the `@dawn-ai/testing` package suite and the chat-example capability e2e (both were previously absent from the vitest workspace).

--- a/docs/superpowers/plans/2026-06-06-testing-capability-coverage.md
+++ b/docs/superpowers/plans/2026-06-06-testing-capability-coverage.md
@@ -1,0 +1,944 @@
+# `@dawn-ai/testing` Capability Coverage Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extend `@dawn-ai/testing` to capture HITL interrupts, subagent events, plan updates, and the composed system prompt; add a `resume()` path and matchers; and dogfood all five Phase-3 capabilities (permissions, subagents, planning, skills, memory) in-process against the real example apps.
+
+**Architecture:** Additive harness extensions in `@dawn-ai/testing` (no framework changes — the runtime already emits the events, and aimock's `getRequests()` journal exposes the system prompt). Then capability e2e scenarios co-located with `examples/chat/server`.
+
+**Tech Stack:** TypeScript, pnpm/turbo, vitest, biome, `@copilotkit/aimock` 1.28, `@dawn-ai/cli/runtime`.
+
+**Worktree:** `/Users/blove/repos/dawn-capcov` (branch `feat/testing-capability-coverage`, off `origin/main` which includes `@dawn-ai/testing`).
+
+**Spec:** `docs/superpowers/specs/2026-06-06-testing-capability-coverage-design.md`.
+
+---
+
+## Background facts (verified — trust these)
+
+- **Current `AgentRunResult`** (`packages/testing/src/run-result.ts`): `{ finalMessage, messages, toolCalls, tokens, state, threadId }`. `collectRunResult(stream, threadId)` handles `chunk`/`tool_call`/`done` and DROPS everything else (`default: break`). It already has a `normalizeToolArgs` helper.
+- **Current harness** (`packages/testing/src/harness.ts`): `createAgentHarness({appRoot, route, fixtures?, mode?})` → `{ baseUrl, run({input, fixtures?}), reset(), close() }`. Only `mode:"in-process"` works. `run()` calls `streamResolvedRoute({appRoot, input:{messages:[{role:"user",content}]}, routeFile, routeId, routePath, threadId})` then `collectRunResult`. `close()` restores env + calls `__resetMaterializedAgentsForTests()`.
+- **`AimockHandle`** (`packages/testing/src/aimock-runner.ts`): `{ port, baseUrl, addFixtures(fixtures), stop() }`. The underlying `mock` is `LLMock`, which exposes `getRequests(): JournalEntry[]` where `JournalEntry.body` is a `ChatCompletionRequest` with `messages: {role, content}[]`.
+- **Runtime stream chunks** the runtime emits beyond chunk/tool_call/done: `{type:"interrupt", data:{interruptId, kind, detail}}`, `{type:"plan_update", data:{todos:[{content,status}]}}`, and subagent events `{type:"subagent.start", data:{call_id, subagent, route_id, depth}}`, `{type:"subagent.tool_call", data:{call_id, tool, input}}`, `{type:"subagent.tool_result", data:{call_id, tool, output}}`, `{type:"subagent.message", data:{call_id, chunk}}`, `{type:"subagent.end", data:{call_id, final_message}}` (or `{call_id, error}`).
+- **Resume**: `streamResolvedRoute` accepts `resumeDecision?: "once"|"always"|"deny"`; when set, the adapter replays `Command({resume})` against the parked thread (same `threadId`). In-process resume needs only `{appRoot, routeFile, routeId, routePath, threadId, resumeDecision}` (no `input`).
+- **Example apps** (`examples/chat/server`): chat route key `/chat#agent`; capabilities: workspace (`workspace/AGENTS.md` contains the line `# Workspace memory`), permissions (allow/deny bash in `dawn.config.ts`), planning (`src/app/chat/plan.md` → `writeTodos` tool), skills (`src/app/chat/skills/{workspace-conventions,recover-from-failure}/SKILL.md` → `readSkill` tool). Coordinator route key `/coordinator#agent` with subagents `research` + `summarizer` (→ `task` tool). The package name is `@dawn-example/chat-server`; it already deps on `@dawn-ai/testing` (devDependency, from PR #193) and has a `vitest --run` test script.
+- aimock matches fixtures on the **last user-message substring** + `turnIndex`/`hasToolResult`. The `script()` builder auto-assigns those.
+
+---
+
+## File Structure
+
+**`@dawn-ai/testing` (harness extensions):**
+- `packages/testing/src/aimock-runner.ts` — add `getRequests()` to `AimockHandle`.
+- `packages/testing/src/run-result.ts` — extend `AgentRunResult` + `collectRunResult` (capture interrupt/plan_update/subagent.*); add a `deriveSystemPrompt` helper over journal entries.
+- `packages/testing/src/harness.ts` — capture `systemPrompt` per turn; add `resume()`.
+- `packages/testing/src/matchers.ts` — add `expectInterrupt`/`expectNoInterrupt`/`expectSubagent`/`expectPlan`/`expectSystemPrompt`.
+- `packages/testing/src/index.ts` — export the new matchers + types.
+- `packages/testing/test/*.test.ts` — unit tests per unit.
+
+**Dogfood scenarios:**
+- `examples/chat/server/test/capabilities.e2e.test.ts` — the five capability scenarios.
+
+---
+
+## Task 1: `AimockHandle.getRequests()` — expose the journal
+
+**Files:**
+- Modify: `packages/testing/src/aimock-runner.ts`
+- Test: `packages/testing/test/aimock-runner.test.ts` (extend)
+
+- [ ] **Step 1: Add the failing test** (append to the existing file)
+
+```ts
+it("exposes received requests via getRequests()", async () => {
+  const mock = await startAimock({ fixtures: [{ match: {}, response: { content: "ok" } }] })
+  try {
+    await fetch(new URL("/v1/chat/completions", mock.baseUrl.replace(/\/v1$/, "")), {
+      method: "POST",
+      headers: { "content-type": "application/json", authorization: "Bearer test" },
+      body: JSON.stringify({ model: "gpt-4o-mini", messages: [{ role: "system", content: "SYS-MARKER" }, { role: "user", content: "hi" }] }),
+    })
+    const reqs = mock.getRequests()
+    expect(reqs.length).toBeGreaterThanOrEqual(1)
+    const last = reqs[reqs.length - 1] as { body?: { messages?: { role: string; content: unknown }[] } }
+    const sys = (last.body?.messages ?? []).filter((m) => m.role === "system").map((m) => m.content).join("\n")
+    expect(sys).toContain("SYS-MARKER")
+  } finally {
+    await mock.stop()
+  }
+})
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `pnpm --filter @dawn-ai/testing exec vitest --run test/aimock-runner.test.ts`
+Expected: FAIL — `mock.getRequests is not a function`.
+
+- [ ] **Step 3: Implement**
+
+In `aimock-runner.ts`, add to the `AimockHandle` interface and the returned object:
+
+```ts
+import type { AimockFixture } from "./fixture-builder.js"
+// JournalEntry isn't re-exported usefully for our needs; type the accessor loosely.
+export interface AimockHandle {
+  readonly port: number
+  readonly baseUrl: string
+  addFixtures(fixtures: readonly AimockFixture[]): void
+  /** All requests the mock has received (aimock's journal). */
+  getRequests(): ReadonlyArray<{ body: { messages?: Array<{ role: string; content: unknown }> } | null }>
+  stop(): Promise<void>
+}
+```
+
+In the returned object add:
+
+```ts
+    getRequests() {
+      return mock.getRequests() as ReadonlyArray<{
+        body: { messages?: Array<{ role: string; content: unknown }> } | null
+      }>
+    },
+```
+
+(Verify `mock.getRequests()` exists on the installed `LLMock` — it's in its `.d.ts`. If the return type differs, keep the loose cast above; we only read `.body.messages`.)
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `pnpm --filter @dawn-ai/testing exec vitest --run test/aimock-runner.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/testing/src/aimock-runner.ts packages/testing/test/aimock-runner.test.ts
+git commit -m "feat(testing): expose aimock request journal via AimockHandle.getRequests()"
+```
+
+---
+
+## Task 2: Extend `AgentRunResult` + `collectRunResult` to capture interrupt / plan_update / subagent events
+
+**Files:**
+- Modify: `packages/testing/src/run-result.ts`
+- Test: `packages/testing/test/run-result.test.ts` (extend)
+
+- [ ] **Step 1: Add failing tests** (append)
+
+```ts
+it("captures interrupts, plan updates, and folds subagent events", async () => {
+  async function* s() {
+    yield { type: "interrupt", data: { interruptId: "perm-1", kind: "command", detail: { command: "rm -rf tmp" } } }
+    yield { type: "plan_update", data: { todos: [{ content: "A", status: "pending" }] } }
+    yield { type: "plan_update", data: { todos: [{ content: "A", status: "completed" }] } }
+    yield { type: "subagent.start", data: { call_id: "c1", subagent: "research" } }
+    yield { type: "subagent.tool_call", data: { call_id: "c1", tool: "webSearch", input: { q: "x" } } }
+    yield { type: "subagent.end", data: { call_id: "c1", final_message: "found it" } }
+    yield { type: "done", output: { messages: [] } }
+  }
+  const r = await collectRunResult(s() as never, "t")
+  expect(r.interrupts).toEqual([{ interruptId: "perm-1", kind: "command", detail: { command: "rm -rf tmp" } }])
+  expect(r.planUpdates).toHaveLength(2)
+  expect(r.todos).toEqual([{ content: "A", status: "completed" }])
+  expect(r.subagents).toHaveLength(1)
+  expect(r.subagents[0]).toMatchObject({ name: "research", callId: "c1", finalMessage: "found it" })
+  expect(r.subagents[0]?.toolCalls).toEqual([{ name: "webSearch", args: { q: "x" } }])
+  expect(r.subagentEvents.length).toBeGreaterThanOrEqual(3)
+})
+
+it("captures a subagent error end", async () => {
+  async function* s() {
+    yield { type: "subagent.start", data: { call_id: "c1", subagent: "research" } }
+    yield { type: "subagent.end", data: { call_id: "c1", error: "boom" } }
+    yield { type: "done", output: { messages: [] } }
+  }
+  const r = await collectRunResult(s() as never, "t")
+  expect(r.subagents[0]).toMatchObject({ name: "research", error: "boom" })
+})
+
+it("defaults the new fields to empty when absent", async () => {
+  async function* s() { yield { type: "done", output: { messages: [] } } }
+  const r = await collectRunResult(s() as never, "t")
+  expect(r.interrupts).toEqual([])
+  expect(r.planUpdates).toEqual([])
+  expect(r.todos).toEqual([])
+  expect(r.subagents).toEqual([])
+  expect(r.systemPrompt).toBe("")
+})
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `pnpm --filter @dawn-ai/testing exec vitest --run test/run-result.test.ts`
+Expected: FAIL — new fields undefined.
+
+- [ ] **Step 3: Implement** — extend types + reducer in `run-result.ts`
+
+Add types near the top:
+
+```ts
+export interface InterruptInfo {
+  readonly interruptId: string
+  readonly kind: string
+  readonly detail?: unknown
+}
+export interface Todo {
+  readonly content: string
+  readonly status: "pending" | "in_progress" | "completed"
+}
+export interface SubagentRun {
+  readonly name: string
+  readonly callId: string
+  readonly toolCalls: ReadonlyArray<{ name: string; args: unknown }>
+  readonly finalMessage?: string
+  readonly error?: string
+}
+export interface SubagentEvent {
+  readonly event: string
+  readonly data: unknown
+}
+```
+
+Extend `AgentRunResult`:
+
+```ts
+export interface AgentRunResult {
+  readonly finalMessage: string
+  readonly messages: ReadonlyArray<Record<string, unknown>>
+  readonly toolCalls: ReadonlyArray<ObservedToolCall>
+  readonly tokens: ReadonlyArray<string>
+  readonly state: Record<string, unknown>
+  readonly threadId: string
+  readonly interrupts: ReadonlyArray<InterruptInfo>
+  readonly planUpdates: ReadonlyArray<{ todos: Todo[] }>
+  readonly todos: ReadonlyArray<Todo>
+  readonly subagents: ReadonlyArray<SubagentRun>
+  readonly subagentEvents: ReadonlyArray<SubagentEvent>
+  readonly systemPrompt: string
+}
+```
+
+In `collectRunResult`, add accumulators and cases. Add before the loop:
+
+```ts
+  const interrupts: InterruptInfo[] = []
+  const planUpdates: { todos: Todo[] }[] = []
+  const subagentEvents: SubagentEvent[] = []
+  const subagentsByCall = new Map<string, { name: string; callId: string; toolCalls: { name: string; args: unknown }[]; finalMessage?: string; error?: string }>()
+
+  function subagentFor(callId: string, name?: string) {
+    let s = subagentsByCall.get(callId)
+    if (!s) {
+      s = { name: name ?? "", callId, toolCalls: [] }
+      subagentsByCall.set(callId, s)
+    } else if (name && !s.name) {
+      s.name = name
+    }
+    return s
+  }
+```
+
+Replace the `default: break` with capability handling:
+
+```ts
+      case "interrupt": {
+        const d = (chunk as unknown as { data?: { interruptId?: string; kind?: string; detail?: unknown } }).data ?? {}
+        interrupts.push({ interruptId: d.interruptId ?? "", kind: d.kind ?? "", detail: d.detail })
+        break
+      }
+      case "plan_update": {
+        const d = (chunk as unknown as { data?: { todos?: Todo[] } }).data ?? {}
+        planUpdates.push({ todos: Array.isArray(d.todos) ? d.todos : [] })
+        break
+      }
+      default: {
+        const type = (chunk as { type: string }).type
+        if (typeof type === "string" && type.startsWith("subagent.")) {
+          const d = (chunk as unknown as { data?: Record<string, unknown> }).data ?? {}
+          subagentEvents.push({ event: type, data: d })
+          const callId = String((d.call_id as string) ?? "")
+          if (callId) {
+            const sub = type === "subagent.start"
+              ? subagentFor(callId, d.subagent as string | undefined)
+              : subagentFor(callId)
+            if (type === "subagent.tool_call") {
+              sub.toolCalls.push({ name: String(d.tool ?? ""), args: normalizeToolArgs(d.input) })
+            } else if (type === "subagent.end") {
+              if (typeof d.final_message === "string") sub.finalMessage = d.final_message
+              if (typeof d.error === "string") sub.error = d.error
+            }
+          }
+        }
+        break
+      }
+```
+
+Update the returned object:
+
+```ts
+  return {
+    threadId, tokens, toolCalls, state,
+    messages: Array.isArray(state.messages) ? (state.messages as Record<string, unknown>[]) : [],
+    finalMessage: finalMessageFrom(state),
+    interrupts,
+    planUpdates,
+    todos: planUpdates.length > 0 ? planUpdates[planUpdates.length - 1].todos : [],
+    subagents: [...subagentsByCall.values()],
+    subagentEvents,
+    systemPrompt: "",   // populated by the harness from the aimock journal (Task 3)
+  }
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `pnpm --filter @dawn-ai/testing exec vitest --run test/run-result.test.ts`
+Expected: PASS (incl. the existing tests — fields are additive).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/testing/src/run-result.ts packages/testing/test/run-result.test.ts
+git commit -m "feat(testing): capture interrupts, plan updates, subagent runs in collectRunResult"
+```
+
+---
+
+## Task 3: Capture `systemPrompt` per turn in the harness
+
+**Files:**
+- Modify: `packages/testing/src/harness.ts`
+- Test: `packages/testing/test/harness-fixtures.test.ts` (extend) — uses the existing probe app.
+
+- [ ] **Step 1: Add failing test** (append; the probe app at `packages/testing/test/fixtures/probe-app` has route `/chat#agent` with a `systemPrompt: "You are a test agent..."`)
+
+```ts
+it("captures the system prompt the model received", async () => {
+  const run = await h.run({
+    input: "hello there",
+    fixtures: script().user("hello there").replies("hi"),
+  })
+  expect(run.systemPrompt).toContain("test agent") // from the probe app's agent systemPrompt
+})
+```
+
+(Use the existing module-level `h` in that file; if none, create one with `createAgentHarness({ appRoot, route: "/chat#agent" })` + `afterAll(close)`.)
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `pnpm --filter @dawn-ai/testing exec vitest --run test/harness-fixtures.test.ts`
+Expected: FAIL — `systemPrompt` is `""`.
+
+- [ ] **Step 3: Implement** — snapshot the journal around the run and merge `systemPrompt`
+
+Add a private helper in `harness.ts`:
+
+```ts
+function systemPromptFromRequests(
+  reqs: ReadonlyArray<{ body: { messages?: Array<{ role: string; content: unknown }> } | null }>,
+): string {
+  // Use the LAST request of the turn (tool rounds re-send the same system prompt).
+  const last = reqs[reqs.length - 1]
+  const messages = last?.body?.messages ?? []
+  return messages
+    .filter((m) => m.role === "system")
+    .map((m) => (typeof m.content === "string" ? m.content : JSON.stringify(m.content)))
+    .join("\n")
+}
+```
+
+Refactor `run()` to snapshot before/slice after and merge into the result:
+
+```ts
+    async run(runOpts) {
+      if (runOpts.fixtures) {
+        const newFixtures = toFixtureSet(runOpts.fixtures)
+        if (newFixtures.length > 0) aimock.addFixtures(newFixtures)
+      }
+      const before = aimock.getRequests().length
+      const stream = streamResolvedRoute({
+        appRoot: options.appRoot,
+        input: { messages: [{ role: "user", content: runOpts.input }] },
+        routeFile: resolved.routeFile,
+        routeId: resolved.routeId,
+        routePath: resolved.routePath,
+        threadId,
+      })
+      const result = await collectRunResult(stream, threadId)
+      const turnReqs = aimock.getRequests().slice(before)
+      return { ...result, systemPrompt: systemPromptFromRequests(turnReqs) }
+    },
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `pnpm --filter @dawn-ai/testing exec vitest --run test/harness-fixtures.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/testing/src/harness.ts packages/testing/test/harness-fixtures.test.ts
+git commit -m "feat(testing): capture per-turn systemPrompt from the aimock journal"
+```
+
+---
+
+## Task 4: `harness.resume({ decision })`
+
+**Files:**
+- Modify: `packages/testing/src/harness.ts`
+- Test: covered by the HITL dogfood (Task 9); add a shape test here.
+
+- [ ] **Step 1: Add the method to the `AgentHarness` interface**
+
+```ts
+export interface AgentHarness {
+  readonly baseUrl: string
+  run(opts: { input: string; fixtures?: FixtureSet | ScriptBuilder }): Promise<AgentRunResult>
+  resume(opts: { decision: "once" | "always" | "deny"; fixtures?: FixtureSet | ScriptBuilder }): Promise<AgentRunResult>
+  reset(): void
+  close(): Promise<void>
+}
+```
+
+- [ ] **Step 2: Implement `resume()`** (next to `run()`), factoring the journal+collect logic
+
+Extract a shared helper inside `createAgentHarness` so `run` and `resume` share it:
+
+```ts
+    async function drive(streamInput: { input?: unknown; resumeDecision?: "once" | "always" | "deny" }) {
+      const before = aimock.getRequests().length
+      const stream = streamResolvedRoute({
+        appRoot: options.appRoot,
+        ...(streamInput.input !== undefined ? { input: streamInput.input } : {}),
+        ...(streamInput.resumeDecision ? { resumeDecision: streamInput.resumeDecision } : {}),
+        routeFile: resolved.routeFile,
+        routeId: resolved.routeId,
+        routePath: resolved.routePath,
+        threadId,
+      })
+      const result = await collectRunResult(stream, threadId)
+      const turnReqs = aimock.getRequests().slice(before)
+      return { ...result, systemPrompt: systemPromptFromRequests(turnReqs) }
+    }
+```
+
+Then:
+
+```ts
+    async run(runOpts) {
+      if (runOpts.fixtures) {
+        const f = toFixtureSet(runOpts.fixtures)
+        if (f.length > 0) aimock.addFixtures(f)
+      }
+      return drive({ input: { messages: [{ role: "user", content: runOpts.input }] } })
+    },
+    async resume(resumeOpts) {
+      if (resumeOpts.fixtures) {
+        const f = toFixtureSet(resumeOpts.fixtures)
+        if (f.length > 0) aimock.addFixtures(f)
+      }
+      return drive({ resumeDecision: resumeOpts.decision })
+    },
+```
+
+(`drive` must be declared before the returned `harness` object — define it as a `const`/function in the closure above `const harness`.)
+
+- [ ] **Step 3: Add a shape test** to `packages/testing/test/harness-fixtures.test.ts`
+
+```ts
+it("exposes a resume method", () => {
+  expect(typeof h.resume).toBe("function")
+})
+```
+
+- [ ] **Step 4: Validate**
+
+Run: `pnpm --filter @dawn-ai/testing build && pnpm --filter @dawn-ai/testing exec vitest --run test/harness-fixtures.test.ts`
+Expected: PASS. (Full resume behavior is exercised in Task 9.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/testing/src/harness.ts packages/testing/test/harness-fixtures.test.ts
+git commit -m "feat(testing): add harness.resume({decision}) for HITL flows"
+```
+
+---
+
+## Task 5: New matchers
+
+**Files:**
+- Modify: `packages/testing/src/matchers.ts`
+- Modify: `packages/testing/src/index.ts`
+- Test: `packages/testing/test/matchers.test.ts` (extend)
+
+- [ ] **Step 1: Add failing tests** (append)
+
+```ts
+import { expectInterrupt, expectNoInterrupt, expectPlan, expectSubagent, expectSystemPrompt } from "../src/matchers.js"
+
+const capRun = {
+  ...base,
+  interrupts: [{ interruptId: "perm-1", kind: "command", detail: { command: "rm -rf tmp" } }],
+  planUpdates: [{ todos: [{ content: "Write spec", status: "completed" }] }],
+  todos: [{ content: "Write spec", status: "completed" }],
+  subagents: [{ name: "research", callId: "c1", toolCalls: [{ name: "webSearch", args: {} }], finalMessage: "found it" }],
+  subagentEvents: [],
+  systemPrompt: "You are helpful.\n# Skills\n- refunds",
+} as unknown as import("../src/run-result.js").AgentRunResult
+
+it("expectInterrupt ofKind + withDetail", () => {
+  expectInterrupt(capRun).ofKind("command").withDetail({ command: "rm -rf tmp" })
+  expect(() => expectInterrupt(capRun).ofKind("nope")).toThrow()
+  expect(() => expectInterrupt({ ...capRun, interrupts: [] } as never)).toThrow()
+})
+it("expectNoInterrupt", () => {
+  expectNoInterrupt({ ...capRun, interrupts: [] } as never)
+  expect(() => expectNoInterrupt(capRun)).toThrow()
+})
+it("expectSubagent", () => {
+  expectSubagent(capRun, "research").called()
+  expectSubagent(capRun, "research").calledTool("webSearch")
+  expectSubagent(capRun, "research").finalMessageContains("found")
+  expect(() => expectSubagent(capRun, "missing").called()).toThrow()
+})
+it("expectPlan", () => {
+  expectPlan(capRun).toHaveTodo("Write spec")
+  expectPlan(capRun).toHaveStatus("Write spec", "completed")
+  expect(() => expectPlan(capRun).toHaveStatus("Write spec", "pending")).toThrow()
+})
+it("expectSystemPrompt", () => {
+  expectSystemPrompt(capRun).toContain("# Skills")
+  expect(() => expectSystemPrompt(capRun).toContain("nope")).toThrow()
+})
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `pnpm --filter @dawn-ai/testing exec vitest --run test/matchers.test.ts`
+Expected: FAIL — matchers not exported.
+
+- [ ] **Step 3: Implement** (append to `matchers.ts`; reuse the existing `fail()` + `isSubset()` helpers already in the file)
+
+```ts
+export function expectInterrupt(run: AgentRunResult) {
+  if (run.interrupts.length === 0) fail("expected at least one interrupt, got none")
+  const chain = {
+    ofKind(kind: string) {
+      if (!run.interrupts.some((i) => i.kind === kind)) {
+        fail(`expected an interrupt of kind "${kind}"; kinds: ${run.interrupts.map((i) => i.kind).join(", ")}`)
+      }
+      return chain
+    },
+    withDetail(partial: Record<string, unknown>) {
+      if (!run.interrupts.some((i) => isSubset(partial, i.detail))) {
+        fail(`expected an interrupt with detail ⊇ ${JSON.stringify(partial)}; got ${JSON.stringify(run.interrupts.map((i) => i.detail))}`)
+      }
+      return chain
+    },
+  }
+  return chain
+}
+
+export function expectNoInterrupt(run: AgentRunResult): void {
+  if (run.interrupts.length > 0) {
+    fail(`expected no interrupts, got ${run.interrupts.length}: ${JSON.stringify(run.interrupts.map((i) => i.kind))}`)
+  }
+}
+
+export function expectSubagent(run: AgentRunResult, name: string) {
+  const sub = run.subagents.find((s) => s.name === name)
+  return {
+    called() {
+      if (!sub) fail(`expected subagent "${name}" to be dispatched; subagents: ${run.subagents.map((s) => s.name).join(", ") || "(none)"}`)
+    },
+    calledTool(tool: string) {
+      if (!sub) fail(`expected subagent "${name}" (not dispatched)`)
+      if (!sub.toolCalls.some((t) => t.name === tool)) fail(`expected subagent "${name}" to call "${tool}"; called: ${sub.toolCalls.map((t) => t.name).join(", ") || "(none)"}`)
+    },
+    finalMessageContains(s: string) {
+      if (!sub) fail(`expected subagent "${name}" (not dispatched)`)
+      if (!(sub.finalMessage ?? "").includes(s)) fail(`expected subagent "${name}" final message to contain ${JSON.stringify(s)}; got ${JSON.stringify(sub.finalMessage)}`)
+    },
+  }
+}
+
+export function expectPlan(run: AgentRunResult) {
+  const todos = run.todos
+  return {
+    toHaveTodo(content: string) {
+      if (!todos.some((t) => t.content.includes(content))) fail(`expected a todo containing ${JSON.stringify(content)}; todos: ${JSON.stringify(todos)}`)
+    },
+    toHaveStatus(content: string, status: string) {
+      const t = todos.find((td) => td.content.includes(content))
+      if (!t) fail(`no todo containing ${JSON.stringify(content)}; todos: ${JSON.stringify(todos)}`)
+      else if (t.status !== status) fail(`expected todo ${JSON.stringify(content)} status ${status}, got ${t.status}`)
+    },
+    toHaveLength(n: number) {
+      if (todos.length !== n) fail(`expected ${n} todos, got ${todos.length}`)
+    },
+  }
+}
+
+export function expectSystemPrompt(run: AgentRunResult) {
+  return {
+    toContain(s: string) {
+      if (!run.systemPrompt.includes(s)) fail(`system prompt does not contain ${JSON.stringify(s)}; prompt starts: ${JSON.stringify(run.systemPrompt.slice(0, 200))}`)
+    },
+    toMatch(re: RegExp) {
+      if (!re.test(run.systemPrompt)) fail(`system prompt does not match ${re}`)
+    },
+  }
+}
+```
+
+Add to `packages/testing/src/index.ts` (with the other matcher exports):
+
+```ts
+export {
+  expectInterrupt,
+  expectNoInterrupt,
+  expectPlan,
+  expectSubagent,
+  expectSystemPrompt,
+} from "./matchers.js"
+```
+
+Also export the new types from the barrel (alongside the existing run-result exports):
+
+```ts
+export type { InterruptInfo, SubagentRun, SubagentEvent, Todo } from "./run-result.js"
+```
+
+- [ ] **Step 4: Run to verify it passes + full package suite**
+
+Run:
+```
+pnpm --filter @dawn-ai/testing exec vitest --run test/matchers.test.ts
+pnpm --filter @dawn-ai/testing build && pnpm --filter @dawn-ai/testing typecheck && pnpm --filter @dawn-ai/testing lint && pnpm --filter @dawn-ai/testing test
+```
+Expected: all green. `biome check --write` if formatting flagged.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/testing/src/matchers.ts packages/testing/src/index.ts packages/testing/test/matchers.test.ts
+git commit -m "feat(testing): capability matchers (interrupt/subagent/plan/systemPrompt)"
+```
+
+---
+
+## Task 6: Dogfood — Memory scenario
+
+**Files:**
+- Create: `examples/chat/server/test/capabilities.e2e.test.ts`
+- Test: itself.
+
+Co-located with the chat example. Each scenario creates its own harness with try/finally close (the chat app has all capabilities; per-scenario harnesses keep threads isolated).
+
+- [ ] **Step 1: Write the scenario**
+
+```ts
+// examples/chat/server/test/capabilities.e2e.test.ts
+import { fileURLToPath } from "node:url"
+import { expect, it } from "vitest"
+import { createAgentHarness, expectSystemPrompt, script } from "@dawn-ai/testing"
+
+const appRoot = fileURLToPath(new URL("..", import.meta.url))
+
+it("memory: AGENTS.md is injected into the system prompt", async () => {
+  const h = await createAgentHarness({ appRoot, route: "/chat#agent" })
+  try {
+    const run = await h.run({ input: "hello", fixtures: script().user("hello").replies("hi") })
+    expectSystemPrompt(run).toContain("Workspace memory") // a line from workspace/AGENTS.md
+  } finally {
+    await h.close()
+  }
+}, 60_000)
+```
+
+- [ ] **Step 2: Run to verify it passes**
+
+Run: `pnpm --filter @dawn-example/chat-server exec vitest --run test/capabilities.e2e.test.ts -t memory`
+Expected: PASS (the workspace capability injects `workspace/AGENTS.md`; its content includes "Workspace memory"). If the exact injected text differs, open `examples/chat/server/workspace/AGENTS.md`, pick a stable line actually present, and assert on that.
+
+- [ ] **Step 3: False-green check**
+
+Temporarily rename `examples/chat/server/workspace/AGENTS.md` → `AGENTS.md.bak`, re-run, confirm the test FAILS (no memory injected), then restore. Report the result.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add examples/chat/server/test/capabilities.e2e.test.ts
+git commit -m "test(chat): dogfood AGENTS.md memory injection via @dawn-ai/testing"
+```
+
+---
+
+## Task 7: Dogfood — Skills scenario
+
+**Files:**
+- Modify: `examples/chat/server/test/capabilities.e2e.test.ts`
+
+- [ ] **Step 1: Add the scenario**
+
+```ts
+import { expectToolCalled } from "@dawn-ai/testing"
+
+it("skills: the skills list is in the prompt and readSkill is callable", async () => {
+  const h = await createAgentHarness({ appRoot, route: "/chat#agent" })
+  try {
+    const run = await h.run({
+      input: "recover from the failure",
+      fixtures: script()
+        .user("recover from the failure")
+        .callsTool("readSkill", { name: "recover-from-failure" })
+        .replies("Recovered."),
+    })
+    expectSystemPrompt(run).toContain("# Skills")
+    expectToolCalled(run, "readSkill").withArgs({ name: "recover-from-failure" })
+  } finally {
+    await h.close()
+  }
+}, 60_000)
+```
+
+- [ ] **Step 2: Run + verify**
+
+Run: `pnpm --filter @dawn-example/chat-server exec vitest --run test/capabilities.e2e.test.ts -t skills`
+Expected: PASS. If the skills prompt heading differs from `# Skills` or the tool name/arg differs (check `examples/chat/server/src/app/chat/skills/` dir names + the skills capability's tool name `readSkill`), adjust to the real values.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add examples/chat/server/test/capabilities.e2e.test.ts
+git commit -m "test(chat): dogfood skills prompt injection + readSkill via @dawn-ai/testing"
+```
+
+---
+
+## Task 8: Dogfood — Planning scenario
+
+**Files:**
+- Modify: `examples/chat/server/test/capabilities.e2e.test.ts`
+
+- [ ] **Step 1: Add the scenario**
+
+```ts
+import { expectPlan } from "@dawn-ai/testing"
+
+it("planning: writeTodos surfaces a plan_update", async () => {
+  const h = await createAgentHarness({ appRoot, route: "/chat#agent" })
+  try {
+    const run = await h.run({
+      input: "plan the work",
+      fixtures: script()
+        .user("plan the work")
+        .callsTool("writeTodos", { todos: [{ content: "Draft the outline", status: "in_progress" }] })
+        .replies("Planned."),
+    })
+    expectPlan(run).toHaveTodo("Draft the outline")
+    expectPlan(run).toHaveStatus("Draft the outline", "in_progress")
+  } finally {
+    await h.close()
+  }
+}, 60_000)
+```
+
+- [ ] **Step 2: Run + verify**
+
+Run: `pnpm --filter @dawn-example/chat-server exec vitest --run test/capabilities.e2e.test.ts -t planning`
+Expected: PASS. Verify the `writeTodos` tool name + arg shape against the planning capability (`packages/core/src/capabilities/built-in/planning.ts`); the `writeTodos` tool takes `{ todos: [{content, status}] }`. If the tool requires the chat app's `plan.md` to be present to be contributed, it is (the chat route has `plan.md`).
+
+- [ ] **Step 3: False-green check**
+
+Temporarily change the fixture's `writeTodos` content to a different string, re-run, confirm `expectPlan().toHaveTodo("Draft the outline")` FAILS, then revert.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add examples/chat/server/test/capabilities.e2e.test.ts
+git commit -m "test(chat): dogfood planning plan_update via @dawn-ai/testing"
+```
+
+---
+
+## Task 9: Dogfood — HITL permissions scenario (interrupt → resume)
+
+**Files:**
+- Modify: `examples/chat/server/test/capabilities.e2e.test.ts`
+
+- [ ] **Step 1: Confirm the permissions interrupt envelope**
+
+Read `packages/permissions/src/*` + the workspace `runBash` capability to confirm the interrupt `kind` (e.g. `"command"`) and `detail` shape (e.g. `{ command, suggestedPattern }`) emitted when a non-allow-listed bash command runs. Note the exact values to assert. The chat `dawn.config.ts` allows `["ls","pwd","cat","echo","head","tail","wc"]` and denies `["rm -rf","sudo","chmod 777"]`; a command like `npm view react version` is neither → triggers an interactive permission interrupt (mode defaults to `interactive`).
+
+- [ ] **Step 2: Write the scenario**
+
+```ts
+import { expectInterrupt, expectNoInterrupt } from "@dawn-ai/testing"
+
+it("permissions: a non-allow-listed command interrupts, then resumes on approval", async () => {
+  const h = await createAgentHarness({ appRoot, route: "/chat#agent" })
+  try {
+    const run = await h.run({
+      input: "what version of react is published?",
+      fixtures: script()
+        .user("what version of react is published?")
+        .callsTool("runBash", { command: "npm view react version" })
+        .replies("React is at that version."),
+    })
+    expectInterrupt(run).ofKind("command").withDetail({ command: "npm view react version" })
+
+    const resumed = await h.resume({ decision: "once" })
+    expectToolCalled(resumed, "runBash")
+    expect(resumed.finalMessage.length).toBeGreaterThan(0)
+  } finally {
+    await h.close()
+  }
+}, 90_000)
+
+it("permissions: an allow-listed command runs without interrupt", async () => {
+  const h = await createAgentHarness({ appRoot, route: "/chat#agent" })
+  try {
+    const run = await h.run({
+      input: "list the files",
+      fixtures: script().user("list the files").callsTool("runBash", { command: "ls" }).replies("Listed."),
+    })
+    expectNoInterrupt(run)
+    expectToolCalled(run, "runBash")
+  } finally {
+    await h.close()
+  }
+}, 90_000)
+```
+
+- [ ] **Step 3: Run + verify**
+
+Run: `pnpm --filter @dawn-example/chat-server exec vitest --run test/capabilities.e2e.test.ts -t permissions`
+Expected: both PASS. Adjust the `runBash` tool name + `detail`/`kind` assertions to the real envelope confirmed in Step 1 (the `command` arg key may be `cmd` — verify the workspace `runBash` tool's input field name and use it consistently in the fixture + `withDetail`). If `mode` isn't `interactive` by default in the chat app and no interrupt fires, set `DAWN_PERMISSIONS_MODE=interactive` in the harness env via the app config (the chat config default applies).
+
+- [ ] **Step 4: False-green check**
+
+Change the resume decision test: temporarily assert `expectNoInterrupt(run)` on the non-allow-listed run — confirm it FAILS (an interrupt WAS raised), then revert. Confirms the interrupt is real, not absent.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add examples/chat/server/test/capabilities.e2e.test.ts
+git commit -m "test(chat): dogfood HITL permission interrupt + resume via @dawn-ai/testing"
+```
+
+---
+
+## Task 10: Dogfood — Subagents scenario
+
+**Files:**
+- Modify: `examples/chat/server/test/capabilities.e2e.test.ts`
+
+- [ ] **Step 1: Confirm the coordinator route + task tool**
+
+Read `examples/chat/server/src/app/coordinator/index.ts` + `subagents/research`. Confirm the route key (`/coordinator#agent`), the `task` tool name, and its input shape (`{ subagent, input }` or similar — check `packages/langchain/src/subagent-tool-bridge.ts` / the generated task tool). Note the child route's model/tools so the child fixture can be scripted (the child makes its own model call → needs a matching fixture).
+
+- [ ] **Step 2: Write the scenario**
+
+```ts
+import { expectSubagent } from "@dawn-ai/testing"
+
+it("subagents: coordinator dispatches the research subagent", async () => {
+  const h = await createAgentHarness({ appRoot, route: "/coordinator#agent" })
+  try {
+    const run = await h.run({
+      input: "research the topic and summarize",
+      fixtures: script()
+        // parent turn 0: dispatch the research subagent
+        .user("research the topic and summarize")
+        .callsTool("task", { subagent: "research", input: "the topic" })
+        // parent turn 1 (after subagent result): final synthesis
+        .replies("Here is the summary.")
+        // child (research) turn: its own user message is the task input
+        .user("the topic")
+        .replies("Research findings: X, Y, Z."),
+    })
+    expectSubagent(run, "research").called()
+    expectSubagent(run, "research").finalMessageContains("Research findings")
+  } finally {
+    await h.close()
+  }
+}, 120_000)
+```
+
+- [ ] **Step 3: Run + verify**
+
+Run: `pnpm --filter @dawn-example/chat-server exec vitest --run test/capabilities.e2e.test.ts -t subagents`
+Expected: PASS. The `task` tool input keys (`subagent`/`input`) and the child's user-message content (how the child turn is seeded) must match reality — confirm in Step 1 and adjust the fixture. The child fixture matches by its own user-message substring ("the topic").
+
+- [ ] **Step 4: FALLBACK (if Step 3 can't be made deterministic)**
+
+If the coordinator's child dispatch can't be scripted reliably via aimock (e.g. the child user message isn't a stable substring), create a dedicated minimal probe app under `packages/testing/test/fixtures/coordinator-probe/` with a parent route + one trivial subagent, script it deterministically, and run the scenario against that instead. Note in the commit that the real coordinator fell back to a probe app and why.
+
+- [ ] **Step 5: False-green check**
+
+Temporarily change the parent fixture to NOT call `task` (just `.replies(...)`), re-run, confirm `expectSubagent(run,"research").called()` FAILS, then revert.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add examples/chat/server/test/capabilities.e2e.test.ts packages/testing/test/fixtures 2>/dev/null
+git commit -m "test(chat): dogfood subagent dispatch via @dawn-ai/testing"
+```
+
+---
+
+## Task 11: Wire into CI, validate, changeset, PR
+
+**Files:**
+- Create: `.changeset/testing-capability-coverage.md`
+- Possibly modify: `examples/chat/server/package.json` (ensure the `test` script picks up `test/*.e2e.test.ts`).
+
+- [ ] **Step 1: Confirm the example's test lane runs the new file**
+
+Check `examples/chat/server/package.json` `test` script + any `vitest.config`. Ensure `test/capabilities.e2e.test.ts` is included by the glob. Confirm the example's tests run in CI (`turbo run test` includes `@dawn-example/chat-server`). If the example isn't in the CI test set, add it (mirror how the package tests are wired). Report what you found.
+
+- [ ] **Step 2: Write the changeset**
+
+```md
+---
+"@dawn-ai/testing": minor
+---
+
+Extend `@dawn-ai/testing` to cover the rest of Dawn's agent capabilities. `AgentRunResult` now captures interrupts, plan updates, subagent runs, and the composed system prompt (read from aimock's request journal); `harness.resume({ decision })` drives HITL interrupt→resume flows. New matchers: `expectInterrupt`/`expectNoInterrupt`, `expectSubagent`, `expectPlan`, `expectSystemPrompt`. Dawn's own example app is dogfooded with in-process e2e for HITL permissions, subagents, planning, skills, and AGENTS.md memory. No framework changes — all capability events were already emitted by the runtime.
+```
+
+- [ ] **Step 3: Full validation**
+
+Run:
+```
+pnpm -r --filter "@dawn-ai/*" build
+pnpm --filter @dawn-ai/testing typecheck && pnpm --filter @dawn-ai/testing lint && pnpm --filter @dawn-ai/testing test
+pnpm --filter @dawn-example/chat-server exec vitest --run test/capabilities.e2e.test.ts
+```
+Expected: all green (5 capability scenarios + the permissions allow-listed case). Revert the `apps/web/next-env.d.ts` churn if it appears.
+
+- [ ] **Step 4: Commit, push, PR, auto-merge**
+
+```bash
+git add .changeset/testing-capability-coverage.md examples/chat/server/package.json 2>/dev/null
+git commit -m "chore: changeset for @dawn-ai/testing capability coverage"
+git push -u origin feat/testing-capability-coverage
+gh pr create --title "feat(testing): capability coverage (HITL/subagents/planning/skills/memory) + harness extensions" --body-file <(printf '%s\n' "Extends @dawn-ai/testing to capture interrupts/plan/subagent/systemPrompt + harness.resume(); dogfoods all five Phase-3 capabilities in-process against the chat example. No framework changes. Spec: docs/superpowers/specs/2026-06-06-testing-capability-coverage-design.md" "" "🤖 Generated with [Claude Code](https://claude.com/claude-code)") --base main --head feat/testing-capability-coverage
+gh pr merge --auto --squash
+```
+
+- [ ] **Step 5: Update phase memory**
+
+Append a note to `memory/project_phase_status.md` recording the capability-coverage increment (matchers + resume + systemPrompt-via-journal; five capabilities dogfooded; real-model/drift still deferred).
+
+---
+
+## Self-review notes (for the executor)
+
+- **Type consistency:** `InterruptInfo`/`Todo`/`SubagentRun`/`SubagentEvent` defined in Task 2 are used by the matchers (Task 5) and exported in Task 5. `AgentRunResult.systemPrompt` defaults to `""` in `collectRunResult` (Task 2) and is overridden by the harness (Tasks 3–4). The harness `drive()` helper (Task 4) supersedes the `run()` body from Task 3 — implement Task 3's systemPrompt logic, then refactor into `drive()` in Task 4 (both share `systemPromptFromRequests`).
+- **Real-value verification:** Tasks 6–10 assert against the real chat/coordinator apps. The exact strings (AGENTS.md line, `# Skills` heading, `writeTodos`/`runBash`/`readSkill`/`task` tool names + arg keys, interrupt `kind`/`detail`, child user-message seeding) MUST be confirmed against the actual app/capability source before finalizing each assertion — each task says where to look. Prefer reading the source over guessing.
+- **Determinism:** every dogfood scenario scripts the model via `script()`; tools run for real. The subagent scenario is the riskiest (child fixture matching) — Task 10 has a probe-app fallback.
+- **No framework changes:** if any scenario seems to "need" a runtime change, stop and reconsider — the spec asserts the runtime already emits everything; the gap is only in the harness/observability layer.

--- a/docs/superpowers/specs/2026-06-06-testing-capability-coverage-design.md
+++ b/docs/superpowers/specs/2026-06-06-testing-capability-coverage-design.md
@@ -1,0 +1,141 @@
+# `@dawn-ai/testing` capability coverage + harness extensions (Design)
+
+**Status:** Approved for planning
+**Date:** 2026-06-06
+**Roadmap:** Follow-on to `@dawn-ai/testing` ([PR #193](https://github.com/cacheplane/dawnai/pull/193)). Extends the package to cover the remaining Phase-3 capabilities (HITL permissions, subagents, planning, skills, AGENTS.md memory) via aimock, and grows the harness with the affordances those scenarios require.
+
+## Problem
+
+`@dawn-ai/testing` shipped with Layer-A in-process coverage of SP5 (union schema), SP6a (offload), and summarization. But five Phase-3 capabilities have **zero** package-based e2e coverage: HITL permissions (interrupt → resume), subagents, planning, skills, and AGENTS.md memory. Those are also the features most likely to regress silently and the ones whose stream/state surfaces (`interrupt`, `subagent.*`, `plan_update`, the composed system prompt) the harness currently **drops** — `collectRunResult` only captures `chunk`/`tool_call`/`done`, `harness.run()` has no resume path, and the system prompt isn't observable. Closing this both protects those capabilities and forces the harness API to grow the right way.
+
+This increment is **Track 1 only** — capability coverage + the harness extensions. Real-model smoke and drift detection are explicitly **out of scope** (deferred to a later increment).
+
+## Verified facts (against the current runtime + aimock 1.28)
+
+- **Runtime stream chunks** (`packages/cli/src/lib/runtime/stream-types.ts`): `{type:"chunk",data}` | `{type:"tool_call",name,input}` | `{type:"tool_result",name,output}` | `{type:"done",output}` | `{type:string,data}` (catch-all for capability events).
+- **Interrupt**: emitted as `{type:"interrupt", data:{interruptId, kind, detail}}` (agent-adapter surfaces the capability's interrupt envelope verbatim). The permissions capability's `detail` carries `{command, suggestedPattern}` for bash and path info for path-jail.
+- **Resume**: `streamResolvedRoute({ resumeDecision: "once"|"always"|"deny" })` continues a parked thread by forwarding `Command({resume})`; the AP equivalent is `POST /threads/:id/resume {interrupt_id, decision}`.
+- **Subagents** (`packages/langchain/src/subagent-dispatcher.ts`): emit `subagent.start` `{call_id, subagent, route_id, depth}`, `subagent.tool_call` `{call_id, tool, input}`, `subagent.tool_result` `{call_id, tool, output}`, `subagent.message` `{call_id, chunk}`, `subagent.end` `{call_id, final_message}` (or `{call_id, error}`), plus `subagent.<capability>` passthrough.
+- **Planning** (`packages/core/src/capabilities/built-in/planning.ts`): a stream transformer observes `writeTodos` results and emits `{type:"plan_update", data:{todos:[{content,status}]}}`.
+- **System prompt observability**: `LLMock` exposes `getRequests(): JournalEntry[]`; `JournalEntry.body` is the full `ChatCompletionRequest` with `messages: ChatMessage[]`. The `system`-role message text is the exact composed prompt Dawn sent (capability prompt fragments included). No framework change needed to observe it.
+- **Probe targets** (`examples/chat/server`): the chat route has `plan.md` (planning), `skills/` (skills), `workspace/AGENTS.md` (memory), and `dawn.config.ts` permissions (allow/deny bash). A `coordinator` route has `subagents/research` + `subagents/summarizer`.
+- aimock matches fixtures on the **last user-message substring** (`match.userMessage`) + `turnIndex`/`hasToolResult`, NOT the whole prompt — so running against a real app's richer prompt is not brittle.
+
+## Architecture — harness extensions (the foundation)
+
+All additive and backward-compatible; existing `@dawn-ai/testing` tests are unaffected.
+
+### 1. `collectRunResult` captures the dropped events
+
+The reducer stops discarding capability chunks and folds them into new result fields:
+
+| Stream chunk | New field |
+|---|---|
+| `interrupt` | `interrupts: InterruptInfo[]` (`{interruptId, kind, detail}`) |
+| `plan_update` | `planUpdates: {todos:Todo[]}[]`; convenience `todos` = latest |
+| `subagent.*` | `subagentEvents: SubagentEvent[]` (raw) + folded `subagents: SubagentRun[]` |
+
+The subagent fold groups events by `call_id` into one `SubagentRun` per dispatched child: `{ name, callId, toolCalls: {name,args}[], finalMessage?, error? }`.
+
+### 2. `harness.resume({ decision })` — the HITL mechanism
+
+`run()` continues to send a fresh user message. A new sibling continues the **same thread** with a resume decision, driving `streamResolvedRoute({ resumeDecision })`:
+
+```ts
+const run = await h.run({ input: "...", fixtures: script().user("...").callsTool("runBash", {...}) })
+expectInterrupt(run).ofKind("command")
+const resumed = await h.resume({ decision: "once" })   // same thread, replays Command({resume})
+expectToolCalled(resumed, "runBash")
+```
+
+`resume()` returns a normal `AgentRunResult` for the resumed turn. `decision: "once" | "always" | "deny"`. The harness owns the thread id; callers pass nothing else. Resume re-enters the same in-process stream collection path as `run()`.
+
+### 3. `run.systemPrompt` — composed prompt via the aimock journal
+
+Each `run()`/`resume()` snapshots `mock.getRequests().length` before the turn and slices the journal after, isolating the model requests that turn made. `systemPrompt` = the concatenated text of `system`-role messages from that turn's (last) request body. This is the actual prompt Dawn composed — capability prompt fragments (skills listing, AGENTS.md memory) included. This is what makes skills + memory assertions possible with no framework change.
+
+Implementation note: the harness must read the journal off the live `LLMock` instance — `startAimock` will expose the handle (or a `getRequestsSince(n)` helper) so the harness can correlate per-turn. If journal correlation proves unreliable (e.g. concurrent turns), the fallback is a per-turn marker in the request, but the snapshot-slice approach is expected to suffice for the harness's serial run model.
+
+### 4. Extended `AgentRunResult` (additive)
+
+```ts
+interface AgentRunResult {
+  // existing
+  finalMessage: string; messages: SerializedMessage[]; toolCalls: ObservedToolCall[]
+  tokens: string[]; state: Record<string, unknown>; threadId: string
+  // new
+  interrupts: InterruptInfo[]          // { interruptId: string; kind: string; detail?: unknown }
+  planUpdates: { todos: Todo[] }[]     // Todo = { content: string; status: "pending"|"in_progress"|"completed" }
+  todos: Todo[]                        // convenience: latest planUpdate's todos (or [])
+  subagents: SubagentRun[]             // { name; callId; toolCalls: {name,args}[]; finalMessage?; error? }
+  subagentEvents: SubagentEvent[]      // raw { event: string; data: unknown }, for advanced assertions
+  systemPrompt: string                 // system text aimock received this turn ("" if none)
+}
+```
+
+## New matchers
+
+Runner-agnostic, throw `AssertionError` on failure (same style as existing matchers):
+
+```ts
+expectInterrupt(run)                       // at least one interrupt was raised (returns the chain)
+expectInterrupt(run).ofKind(kind)          // by interrupt kind (e.g. "command")
+expectInterrupt(run).withDetail(partial)   // interrupt.detail ⊇ partial (e.g. { command: "rm -rf tmp" })
+expectNoInterrupt(run)                     // run.interrupts is empty
+
+expectSubagent(run, name).called()                  // a SubagentRun with this name exists
+expectSubagent(run, name).calledTool(toolName)      // …that called this tool
+expectSubagent(run, name).finalMessageContains(s)   // …whose final message contains s
+
+expectPlan(run).toHaveTodo(content)                 // a todo with matching content exists
+expectPlan(run).toHaveStatus(content, status)       // …with this status
+expectPlan(run).toHaveLength(n)                     // latest plan has n todos
+
+expectSystemPrompt(run).toContain(s)
+expectSystemPrompt(run).toMatch(re)
+```
+
+Skills + memory reuse `expectSystemPrompt` and the existing `expectToolCalled("readSkill")`. No matcher invents data — each reads a Section-1 field. All exported from the package barrel.
+
+## Capability scenarios + probe targets
+
+Primary probe target is the **real example apps** — the truest dogfood (they already wire every capability), and robust because fixtures match on the user-message substring, not the whole prompt. Each scenario runs in-process (Layer A) via the extended harness.
+
+| # | Capability | Probe target | Scripted fixture | Assertions |
+|---|---|---|---|---|
+| 1 | HITL permissions | `examples/chat` (allow/deny bash seeded) | model → `runBash` with a non-allow-listed command | `expectInterrupt(run).ofKind("command").withDetail({command: ...})`; `h.resume({decision:"once"})` → `expectToolCalled(resumed,"runBash")` + final. Plus a `deny` path (run does not complete the tool) and an allow-listed command → `expectNoInterrupt`. (Exact `detail` shape confirmed against the permissions interrupt envelope during implementation.) |
+| 2 | Subagents | `examples/chat` `coordinator` route | parent → `task({subagent:"research", ...})`; child fixture replies | `expectSubagent(run,"research").called()` + `.finalMessageContains(...)`; parent's final synthesizes the child result. |
+| 3 | Planning | `examples/chat` (`plan.md`) | model → `writeTodos([...])` then a reply | `expectPlan(run).toHaveTodo(...)` + `.toHaveStatus(...)`; `run.planUpdates` reflects the update. |
+| 4 | Skills | `examples/chat` (`skills/`) | model → `readSkill({name})` then a reply | `expectSystemPrompt(run).toContain("# Skills")` + `expectToolCalled(run,"readSkill").withArgs({name})`. |
+| 5 | Memory | `examples/chat` (`workspace/AGENTS.md`) | model → a plain reply | `expectSystemPrompt(run).toContain("<known AGENTS.md line>")`. |
+
+Scenarios live in a new test file co-located with the app they exercise (e.g. `examples/chat/server/test/capabilities.e2e.test.ts`) so the dogfood sits next to the example and runs in CI's existing source-test lane.
+
+**Per-scenario fallback:** if a capability is awkward to trigger deterministically against the real example (most likely subagents, if the coordinator's child dispatch is finicky to script via aimock), that one scenario gets a dedicated minimal probe app under `packages/testing/test/fixtures/` instead. This is decided per-scenario during implementation and noted — not pre-built for all five.
+
+## Wiring / CI
+
+- New matchers + `resume()` + result fields ship from `@dawn-ai/testing` (the package's own unit tests cover the new matchers + `collectRunResult` folding with synthetic streams).
+- The five capability scenarios run in CI via the lane that already runs the example/package tests (`turbo run test` / the runtime lane). No new CI job.
+- A changeset bumps `@dawn-ai/testing` (minor — new matchers + `resume()` + result fields). No other package changes are required (the runtime already emits all needed events; observability is via aimock's journal).
+
+## Error handling / edge cases
+
+- **No interrupt when one is expected** (e.g. command was allow-listed) → `expectInterrupt` throws with the list of interrupts seen (empty). `expectNoInterrupt` is its inverse.
+- **Resume without a prior interrupt** → `harness.resume()` surfaces a clear error ("no parked interrupt on this thread") rather than a confusing runtime failure.
+- **Subagent event correlation** → fold strictly by `call_id`; an `subagent.end` with `error` populates `SubagentRun.error` so failure cases are assertable.
+- **System-prompt journal correlation** → snapshot-slice per turn; if a turn made multiple model requests (tool rounds), `systemPrompt` is taken from the turn's requests (the system text is stable across a turn's rounds). Empty string if no request was made.
+- **Backward compatibility** → all result fields are additive; existing tests and matchers are untouched.
+
+## Testing (of the new harness code)
+
+- **Unit (`@dawn-ai/testing`):** `collectRunResult` folds synthetic `interrupt`/`plan_update`/`subagent.*` chunks into the right fields (incl. multi-child subagent fold + error case); each new matcher passes/fails correctly against synthetic `AgentRunResult`s; `systemPrompt` derivation from a synthetic journal entry.
+- **Integration (dogfood):** the five capability scenarios above, in-process against the example apps, each with an adversarial false-green check during implementation (break the capability → the scenario fails).
+
+## Out of scope (explicit)
+
+- **Real-model smoke** (`skipIf(!OPENAI_API_KEY)` against the live model) — deferred to a later increment.
+- **Drift detection** (scheduled nightly re-record vs live API) — deferred.
+- **Browser/UI e2e** of the chat web client — separate effort.
+- **`createAgentHarness` http-inject / subprocess mode wiring** — the standalone `injectAgentProtocol`/`startSubprocessApp` primitives remain as-is; this increment is Layer-A capability coverage.
+- **Scaffold adoption** (sample test in `create-dawn-app`) — separate follow-up.

--- a/examples/chat/server/src/app/chat/capabilities.test.ts
+++ b/examples/chat/server/src/app/chat/capabilities.test.ts
@@ -5,7 +5,7 @@
  * - planning (because src/app/chat/plan.md is present) → writeTodos tool,
  *   todos state channel, planning prompt fragment, plan_update transformer.
  * - agents-md (always-on) → memory prompt fragment that reads
- *   <process.cwd()>/workspace/AGENTS.md on every render.
+ *   <appRoot>/workspace/AGENTS.md on every render.
  *
  * These are example-level integration tests that exercise the framework's
  * autowiring against the actual route's filesystem layout, without spinning
@@ -33,6 +33,8 @@ describe("chat route — autowired capabilities", () => {
   beforeEach(() => {
     workDir = mkdtempSync(join(tmpdir(), "chat-route-caps-"))
     originalCwd = process.cwd()
+    // NOTE: process.chdir is kept for test isolation but capabilities now use
+    // context.appRoot (workDir for agents-md, ROUTE_DIR for planning) rather than cwd.
     process.chdir(workDir)
   })
 
@@ -46,7 +48,7 @@ describe("chat route — autowired capabilities", () => {
       createPlanningMarker(),
       createAgentsMdMarker(),
     ])
-    const result = await applyCapabilities(registry, ROUTE_DIR, { routeManifest: { appRoot: ROUTE_DIR, routes: [] }, descriptor: undefined })
+    const result = await applyCapabilities(registry, ROUTE_DIR, { routeManifest: { appRoot: ROUTE_DIR, routes: [] }, descriptor: undefined, appRoot: ROUTE_DIR })
 
     expect(result.errors).toEqual([])
     expect(result.contributions.map((c) => c.markerName)).toEqual([
@@ -59,7 +61,7 @@ describe("chat route — autowired capabilities", () => {
     expect(existsSync(resolve(ROUTE_DIR, "plan.md"))).toBe(true)
 
     const registry = createCapabilityRegistry([createPlanningMarker()])
-    const result = await applyCapabilities(registry, ROUTE_DIR, { routeManifest: { appRoot: ROUTE_DIR, routes: [] }, descriptor: undefined })
+    const result = await applyCapabilities(registry, ROUTE_DIR, { routeManifest: { appRoot: ROUTE_DIR, routes: [] }, descriptor: undefined, appRoot: ROUTE_DIR })
     const planning = result.contributions[0]?.contribution
 
     expect(planning?.tools?.map((t) => t.name)).toEqual(["writeTodos"])
@@ -67,7 +69,7 @@ describe("chat route — autowired capabilities", () => {
     expect(planning?.promptFragment?.placement).toBe("after_user_prompt")
   })
 
-  it("agents-md fragment renders memory from <cwd>/workspace/AGENTS.md", async () => {
+  it("agents-md fragment renders memory from <appRoot>/workspace/AGENTS.md", async () => {
     mkdirSync(join(workDir, "workspace"), { recursive: true })
     writeFileSync(
       join(workDir, "workspace", "AGENTS.md"),
@@ -75,7 +77,8 @@ describe("chat route — autowired capabilities", () => {
     )
 
     const registry = createCapabilityRegistry([createAgentsMdMarker()])
-    const result = await applyCapabilities(registry, ROUTE_DIR, { routeManifest: { appRoot: ROUTE_DIR, routes: [] }, descriptor: undefined })
+    // Pass workDir as appRoot so the marker resolves AGENTS.md from workDir/workspace/.
+    const result = await applyCapabilities(registry, ROUTE_DIR, { routeManifest: { appRoot: workDir, routes: [] }, descriptor: undefined, appRoot: workDir })
     const fragment = result.contributions[0]?.contribution.promptFragment
     const rendered = fragment?.render({}) ?? ""
 
@@ -85,7 +88,7 @@ describe("chat route — autowired capabilities", () => {
 
   it("agents-md fragment is empty when workspace/AGENTS.md is absent", async () => {
     const registry = createCapabilityRegistry([createAgentsMdMarker()])
-    const result = await applyCapabilities(registry, ROUTE_DIR, { routeManifest: { appRoot: ROUTE_DIR, routes: [] }, descriptor: undefined })
+    const result = await applyCapabilities(registry, ROUTE_DIR, { routeManifest: { appRoot: workDir, routes: [] }, descriptor: undefined, appRoot: workDir })
     const fragment = result.contributions[0]?.contribution.promptFragment
     expect(fragment?.render({})).toBe("")
   })
@@ -96,7 +99,8 @@ describe("chat route — autowired capabilities", () => {
 
     writeFileSync(path, "Iteration 1: tools should be camelCase")
     const registry = createCapabilityRegistry([createAgentsMdMarker()])
-    const result = await applyCapabilities(registry, ROUTE_DIR, { routeManifest: { appRoot: ROUTE_DIR, routes: [] }, descriptor: undefined })
+    // Pass workDir as appRoot so AGENTS.md is read from workDir/workspace/.
+    const result = await applyCapabilities(registry, ROUTE_DIR, { routeManifest: { appRoot: workDir, routes: [] }, descriptor: undefined, appRoot: workDir })
     const fragment = result.contributions[0]?.contribution.promptFragment
 
     const first = fragment?.render({}) ?? ""
@@ -112,7 +116,7 @@ describe("chat route — autowired capabilities", () => {
 
   it("planning prompt re-renders todos from live state on each call", async () => {
     const registry = createCapabilityRegistry([createPlanningMarker()])
-    const result = await applyCapabilities(registry, ROUTE_DIR, { routeManifest: { appRoot: ROUTE_DIR, routes: [] }, descriptor: undefined })
+    const result = await applyCapabilities(registry, ROUTE_DIR, { routeManifest: { appRoot: ROUTE_DIR, routes: [] }, descriptor: undefined, appRoot: ROUTE_DIR })
     const fragment = result.contributions[0]?.contribution.promptFragment
 
     const empty = fragment?.render({ todos: [] }) ?? ""

--- a/examples/chat/server/test/capabilities.e2e.test.ts
+++ b/examples/chat/server/test/capabilities.e2e.test.ts
@@ -105,9 +105,7 @@ describe("chat capabilities", () => {
     })
     // Confirmed: workspace capability emits interrupt kind "command" with
     // detail { command, suggestedPattern } for bash gate "unknown" in interactive mode.
-    // (ofKind/withDetail are independent assertions — they do not chain.)
-    expectInterrupt(run).ofKind("command")
-    expectInterrupt(run).withDetail({ command: "npm view react version" })
+    expectInterrupt(run).ofKind("command").withDetail({ command: "npm view react version" })
 
     // Resume with a one-time approval; the gate releases and runBash executes.
     const resumed = await chat.resume({ decision: "once" })
@@ -151,7 +149,7 @@ describe("coordinator capabilities", () => {
         .user(childQuestion)
         .replies("Workspace tools use camelCase names: listDir, readFile, writeFile, runBash."),
     })
-    expectSubagent(run).called("research")
-    expectSubagent(run).finalMessageContains("camelCase")
+    expectSubagent(run, "research").called()
+    expectSubagent(run, "research").finalMessageContains("camelCase")
   }, 60_000)
 })

--- a/examples/chat/server/test/capabilities.e2e.test.ts
+++ b/examples/chat/server/test/capabilities.e2e.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Capability coverage e2e — dogfoods @dawn-ai/testing against the REAL chat
+ * example app (and the real coordinator route), in-process, with a mocked LLM.
+ *
+ * Each scenario reads the live capability behavior of the chat/coordinator
+ * routes (memory, skills, planning, permissions, subagents) and asserts the
+ * harness surfaces it. Tool names / interrupt envelopes / task input keys were
+ * confirmed against source before writing the assertions:
+ *
+ *  - memory     → AGENTS.md auto-injected under "# Memory"; AGENTS.md line
+ *                 "# Workspace memory" is rendered into the system prompt.
+ *  - skills     → skills/ dir autowires; prompt heading "# Skills"; tool readSkill({name}).
+ *  - planning   → plan.md autowires; tool writeTodos({todos:[{content,status}]});
+ *                 emits plan_update.
+ *  - permissions→ runBash({command}); non-allow-listed command emits interrupt
+ *                 kind "command" with detail {command}; resume({decision:"once"}).
+ *  - subagents  → coordinator dispatches via task({subagent,input}); child seeded
+ *                 with user message == the `input` value; subagent.start carries
+ *                 name "research".
+ *
+ * NOTE: the chat and coordinator harnesses each start their own aimock server
+ * and set process.env.OPENAI_BASE_URL. Because that env var is process-global
+ * and the per-descriptor LLM cache binds to whatever URL is live at first use,
+ * only ONE harness may be alive at a time. We therefore construct each harness
+ * in beforeAll and tear it down in afterAll (which resets the materialized-agent
+ * cache), rather than holding both open at module scope.
+ */
+import { fileURLToPath } from "node:url"
+import { afterAll, beforeAll, describe, it } from "vitest"
+import {
+  type AgentHarness,
+  createAgentHarness,
+  expectInterrupt,
+  expectNoInterrupt,
+  expectPlan,
+  expectSubagent,
+  expectSystemPrompt,
+  expectToolCalled,
+  script,
+} from "@dawn-ai/testing"
+
+const appRoot = fileURLToPath(new URL("..", import.meta.url))
+
+describe("chat capabilities", () => {
+  let chat: AgentHarness
+  beforeAll(async () => {
+    chat = await createAgentHarness({ appRoot, route: "/chat#agent" })
+  })
+  afterAll(() => chat.close())
+
+  // ── Scenario 1: memory (agents-md) ───────────────────────────────────────
+  it("memory: AGENTS.md is auto-injected into the system prompt", async () => {
+    chat.reset()
+    const run = await chat.run({
+      input: "what tooling conventions apply here?",
+      fixtures: script()
+        .user("what tooling conventions apply here?")
+        .replies("Tools are camelCase: listDir, readFile, writeFile, runBash."),
+    })
+    // Confirmed present in workspace/AGENTS.md (first heading line).
+    expectSystemPrompt(run).toContain("# Workspace memory")
+  }, 60_000)
+
+  // ── Scenario 2: skills ───────────────────────────────────────────────────
+  it("skills: # Skills heading present + readSkill loads a named skill", async () => {
+    chat.reset()
+    const run = await chat.run({
+      input: "how should I recover from a failed tool call?",
+      fixtures: script()
+        .user("how should I recover from a failed tool call?")
+        .callsTool("readSkill", { name: "recover-from-failure" })
+        .replies("Read the error first, don't blindly retry."),
+    })
+    // Confirmed heading in packages/core/src/capabilities/built-in/skills.ts.
+    expectSystemPrompt(run).toContain("# Skills")
+    expectToolCalled(run, "readSkill").withArgs({ name: "recover-from-failure" })
+  }, 60_000)
+
+  // ── Scenario 3: planning ─────────────────────────────────────────────────
+  it("planning: writeTodos emits a plan_update captured as todos", async () => {
+    chat.reset()
+    const run = await chat.run({
+      input: "draft an outline for the docs",
+      fixtures: script()
+        .user("draft an outline for the docs")
+        .callsTool("writeTodos", {
+          todos: [{ content: "Draft the outline", status: "in_progress" }],
+        })
+        .replies("Outline drafting is in progress."),
+    })
+    expectPlan(run).toHaveTodo("Draft the outline")
+    expectPlan(run).toHaveStatus("Draft the outline", "in_progress")
+  }, 60_000)
+
+  // ── Scenario 4: permissions (HITL) ───────────────────────────────────────
+  it("permissions: non-allow-listed runBash command interrupts, then resumes", async () => {
+    chat.reset()
+    // First turn: model asks to run a command NOT on the allow-list.
+    const run = await chat.run({
+      input: "check the latest react version on npm",
+      fixtures: script()
+        .user("check the latest react version on npm")
+        .callsTool("runBash", { command: "npm view react version" })
+        .replies("React's latest version is shown above."),
+    })
+    // Confirmed: workspace capability emits interrupt kind "command" with
+    // detail { command, suggestedPattern } for bash gate "unknown" in interactive mode.
+    // (ofKind/withDetail are independent assertions — they do not chain.)
+    expectInterrupt(run).ofKind("command")
+    expectInterrupt(run).withDetail({ command: "npm view react version" })
+
+    // Resume with a one-time approval; the gate releases and runBash executes.
+    const resumed = await chat.resume({ decision: "once" })
+    expectToolCalled(resumed, "runBash")
+  }, 60_000)
+
+  it("permissions: allow-listed ls runs without an interrupt", async () => {
+    chat.reset()
+    const run = await chat.run({
+      input: "list the workspace files",
+      fixtures: script()
+        .user("list the workspace files")
+        .callsTool("runBash", { command: "ls" })
+        .replies("Listed the workspace."),
+    })
+    expectNoInterrupt(run)
+    expectToolCalled(run, "runBash").withArgs({ command: "ls" })
+  }, 60_000)
+})
+
+// ── Scenario 5: subagents (coordinator route) ──────────────────────────────
+describe("coordinator capabilities", () => {
+  let coordinator: AgentHarness
+  beforeAll(async () => {
+    coordinator = await createAgentHarness({ appRoot, route: "/coordinator#agent" })
+  })
+  afterAll(() => coordinator.close())
+
+  it("subagents: task dispatches to the research subagent", async () => {
+    coordinator.reset()
+    const childQuestion = "What conventions are documented in AGENTS.md?"
+    const run = await coordinator.run({
+      input: "research the workspace conventions and summarize",
+      fixtures: script()
+        // Parent: dispatch to the research subagent.
+        .user("research the workspace conventions and summarize")
+        .callsTool("task", { subagent: "research", input: childQuestion })
+        .replies("Research complete: tools use camelCase names.")
+        // Child: the dispatcher seeds the child's user message with the `input`
+        // value passed to task(), so the fixture matches on that text.
+        .user(childQuestion)
+        .replies("Workspace tools use camelCase names: listDir, readFile, writeFile, runBash."),
+    })
+    expectSubagent(run).called("research")
+    expectSubagent(run).finalMessageContains("camelCase")
+  }, 60_000)
+})

--- a/examples/chat/server/vitest.config.ts
+++ b/examples/chat/server/vitest.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from "vitest/config"
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["test/**/*.test.ts", "src/**/*.test.ts"],
+    passWithNoTests: true,
+    // The capability e2e suites boot in-process agents + a real dawn dev
+    // subprocess and mutate process-global OPENAI_BASE_URL — run files
+    // sequentially to avoid cross-file env/port races.
+    fileParallelism: false,
+    testTimeout: 120_000,
+    hookTimeout: 120_000,
+  },
+})

--- a/packages/cli/src/lib/runtime/execute-route.ts
+++ b/packages/cli/src/lib/runtime/execute-route.ts
@@ -488,6 +488,7 @@ async function prepareRouteExecution(options: {
       descriptorRouteMap,
       ...(configBackends ? { backends: configBackends } : {}),
       permissions: permissionsStore,
+      appRoot: options.appRoot,
     })
 
     if (applied.errors.length > 0) {

--- a/packages/core/src/capabilities/built-in/agents-md.ts
+++ b/packages/core/src/capabilities/built-in/agents-md.ts
@@ -10,26 +10,33 @@ The block below is the live contents of \`workspace/AGENTS.md\`, re-read on ever
 ---`
 
 /**
- * Auto-injects the contents of <process.cwd()>/workspace/AGENTS.md into the
+ * Auto-injects the contents of <appRoot>/workspace/AGENTS.md into the
  * agent's system prompt under a "# Memory" heading. Always-on: the presence
  * of the file IS the opt-in. Re-reads the file on every model turn so the
  * agent sees its own updated memory immediately after it calls writeFile.
+ *
+ * Uses context.appRoot (not process.cwd()) so in-process test harnesses that
+ * pass an explicit app root activate this capability regardless of the test
+ * runner's working directory. In production (dawn dev), appRoot === cwd.
  */
 export function createAgentsMdMarker(): CapabilityMarker {
   return {
     name: "agents-md",
     detect: async (_routeDir, _context) => true,
-    load: async (_routeDir, _context) => ({
-      promptFragment: {
-        placement: "after_user_prompt",
-        render: () => renderMemoryFragment(workspaceAgentsMdPath()),
-      },
-    }),
+    load: async (_routeDir, context) => {
+      const agentsMdPath = workspaceAgentsMdPath(context.appRoot)
+      return {
+        promptFragment: {
+          placement: "after_user_prompt",
+          render: () => renderMemoryFragment(agentsMdPath),
+        },
+      }
+    },
   }
 }
 
-function workspaceAgentsMdPath(): string {
-  return resolve(process.cwd(), "workspace", "AGENTS.md")
+function workspaceAgentsMdPath(appRoot: string): string {
+  return resolve(appRoot, "workspace", "AGENTS.md")
 }
 
 function renderMemoryFragment(path: string): string {

--- a/packages/core/src/capabilities/built-in/workspace.ts
+++ b/packages/core/src/capabilities/built-in/workspace.ts
@@ -12,12 +12,13 @@ import type { CapabilityMarker, DawnToolDefinition } from "../types.js"
 const WORKSPACE_DIRNAME = "workspace"
 
 /**
- * Resolve the workspace root to a cwd-relative path. This matches the
- * AGENTS.md capability's resolution (process.cwd() + "workspace") so
- * the agent's memory and workspace tools point at the same directory.
+ * Resolve the workspace root relative to the given app root. In production
+ * (`dawn dev`) appRoot === process.cwd(), so this is a no-op change there.
+ * In-process testing harnesses pass the explicit app root so capabilities
+ * activate regardless of the test runner's working directory.
  */
-function workspaceRoot(): string {
-  return join(process.cwd(), WORKSPACE_DIRNAME)
+function workspaceRoot(appRoot: string): string {
+  return join(appRoot, WORKSPACE_DIRNAME)
 }
 
 const READ_FILE_INPUT = z.object({ path: z.string().min(1) })
@@ -224,9 +225,9 @@ function buildWorkspaceTools(
 export function createWorkspaceMarker(): CapabilityMarker {
   return {
     name: "workspace",
-    detect: async (_routeDir, _context) => existsSync(workspaceRoot()),
+    detect: async (_routeDir, context) => existsSync(workspaceRoot(context.appRoot)),
     load: async (_routeDir, context) => {
-      const root = workspaceRoot()
+      const root = workspaceRoot(context.appRoot)
       if (!existsSync(root)) return {}
       const fs = context.backends?.filesystem ?? localFilesystem()
       const exec = context.backends?.exec ?? localExec()

--- a/packages/core/src/capabilities/types.ts
+++ b/packages/core/src/capabilities/types.ts
@@ -12,6 +12,8 @@ export interface CapabilityMarkerContext {
     readonly exec?: ExecBackend
   }
   readonly permissions?: PermissionsStore
+  /** Absolute path to the Dawn app root. Capabilities should resolve app-relative paths (e.g. workspace/) against this, NOT process.cwd(). */
+  readonly appRoot: string
 }
 
 export interface DawnToolDefinition {

--- a/packages/core/test/capabilities/agents-md.test.ts
+++ b/packages/core/test/capabilities/agents-md.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { afterEach, beforeEach, describe, expect, it } from "vitest"
 import { createAgentsMdMarker } from "../../src/capabilities/built-in/agents-md.js"
+import type { CapabilityMarkerContext } from "../../src/capabilities/types.js"
 
 describe("createAgentsMdMarker", () => {
   let routeDir: string
@@ -14,6 +15,8 @@ describe("createAgentsMdMarker", () => {
     routeDir = join(workDir, "route")
     mkdirSync(routeDir, { recursive: true })
     originalCwd = process.cwd()
+    // NOTE: process.chdir kept for test isolation, but the marker now uses
+    // context.appRoot (workDir) rather than process.cwd() to resolve AGENTS.md.
     process.chdir(workDir)
   })
 
@@ -22,14 +25,22 @@ describe("createAgentsMdMarker", () => {
     rmSync(workDir, { recursive: true, force: true })
   })
 
+  function makeCtx(appRoot: string): CapabilityMarkerContext {
+    return {
+      routeManifest: { appRoot, routes: [] },
+      descriptor: undefined,
+      appRoot,
+    }
+  }
+
   it("always detects (returns true)", async () => {
     const marker = createAgentsMdMarker()
-    expect(await marker.detect(routeDir)).toBe(true)
+    expect(await marker.detect(routeDir, makeCtx(workDir))).toBe(true)
   })
 
   it("load returns a single promptFragment, no tools/state/transformers", async () => {
     const marker = createAgentsMdMarker()
-    const contribution = await marker.load(routeDir)
+    const contribution = await marker.load(routeDir, makeCtx(workDir))
     expect(contribution.promptFragment?.placement).toBe("after_user_prompt")
     expect(contribution.tools).toBeUndefined()
     expect(contribution.stateFields).toBeUndefined()
@@ -38,7 +49,7 @@ describe("createAgentsMdMarker", () => {
 
   it("renders empty string when workspace/AGENTS.md does not exist", async () => {
     const marker = createAgentsMdMarker()
-    const contribution = await marker.load(routeDir)
+    const contribution = await marker.load(routeDir, makeCtx(workDir))
     expect(contribution.promptFragment?.render({})).toBe("")
   })
 
@@ -46,7 +57,7 @@ describe("createAgentsMdMarker", () => {
     mkdirSync(join(workDir, "workspace"), { recursive: true })
     writeFileSync(join(workDir, "workspace", "AGENTS.md"), "Remember the pnpm convention.")
     const marker = createAgentsMdMarker()
-    const contribution = await marker.load(routeDir)
+    const contribution = await marker.load(routeDir, makeCtx(workDir))
     const out = contribution.promptFragment?.render({}) ?? ""
     expect(out).toContain("# Memory")
     expect(out).toContain("Remember the pnpm convention.")
@@ -56,7 +67,7 @@ describe("createAgentsMdMarker", () => {
     mkdirSync(join(workDir, "workspace"), { recursive: true })
     writeFileSync(join(workDir, "workspace", "AGENTS.md"), "   \n\n  \n")
     const marker = createAgentsMdMarker()
-    const contribution = await marker.load(routeDir)
+    const contribution = await marker.load(routeDir, makeCtx(workDir))
     expect(contribution.promptFragment?.render({})).toBe("")
   })
 
@@ -65,7 +76,7 @@ describe("createAgentsMdMarker", () => {
     const big = "x".repeat(65 * 1024)
     writeFileSync(join(workDir, "workspace", "AGENTS.md"), big)
     const marker = createAgentsMdMarker()
-    const contribution = await marker.load(routeDir)
+    const contribution = await marker.load(routeDir, makeCtx(workDir))
     const out = contribution.promptFragment?.render({}) ?? ""
     expect(out).toContain("# Memory")
     expect(out).toContain("exceeds 64 KiB")
@@ -75,7 +86,7 @@ describe("createAgentsMdMarker", () => {
   it("returns empty string when AGENTS.md is a directory (read throws)", async () => {
     mkdirSync(join(workDir, "workspace", "AGENTS.md"), { recursive: true })
     const marker = createAgentsMdMarker()
-    const contribution = await marker.load(routeDir)
+    const contribution = await marker.load(routeDir, makeCtx(workDir))
     expect(contribution.promptFragment?.render({})).toBe("")
   })
 
@@ -84,7 +95,7 @@ describe("createAgentsMdMarker", () => {
     const path = join(workDir, "workspace", "AGENTS.md")
     writeFileSync(path, "first")
     const marker = createAgentsMdMarker()
-    const contribution = await marker.load(routeDir)
+    const contribution = await marker.load(routeDir, makeCtx(workDir))
     const first = contribution.promptFragment?.render({}) ?? ""
     expect(first).toContain("first")
     writeFileSync(path, "second")

--- a/packages/core/test/capabilities/registry.test.ts
+++ b/packages/core/test/capabilities/registry.test.ts
@@ -30,6 +30,7 @@ describe("CapabilityRegistry + applyCapabilities", () => {
     const result = await applyCapabilities(registry, routeDir, {
       routeManifest: { appRoot: routeDir, routes: [] },
       descriptor: undefined,
+      appRoot: routeDir,
     })
     expect(result.contributions).toEqual([])
   })
@@ -50,6 +51,7 @@ describe("CapabilityRegistry + applyCapabilities", () => {
     const result = await applyCapabilities(registry, routeDir, {
       routeManifest: { appRoot: routeDir, routes: [] },
       descriptor: undefined,
+      appRoot: routeDir,
     })
     expect(result.contributions.map((c) => c.markerName)).toEqual(["first", "second"])
     expect(result.contributions[0]?.contribution.tools?.[0]?.name).toBe("alpha")
@@ -75,6 +77,7 @@ describe("CapabilityRegistry + applyCapabilities", () => {
     const result = await applyCapabilities(registry, routeDir, {
       routeManifest: { appRoot: routeDir, routes: [] },
       descriptor: undefined,
+      appRoot: routeDir,
     })
     expect(result.contributions.map((c) => c.markerName)).toEqual(["ok"])
     expect(result.errors).toHaveLength(1)
@@ -94,6 +97,7 @@ describe("CapabilityRegistry + applyCapabilities", () => {
     const result = await applyCapabilities(registry, routeDir, {
       routeManifest: { appRoot: routeDir, routes: [] },
       descriptor: undefined,
+      appRoot: routeDir,
     })
     expect(result.contributions).toEqual([])
     expect(result.errors).toHaveLength(1)

--- a/packages/core/test/capabilities/subagents.test.ts
+++ b/packages/core/test/capabilities/subagents.test.ts
@@ -20,7 +20,7 @@ function manifest(routes: Array<{ id: string; routeDir: string }>): RouteManifes
 }
 
 function ctx(routes: Array<{ id: string; routeDir: string }>): CapabilityMarkerContext {
-  return { routeManifest: manifest(routes), descriptor: undefined }
+  return { routeManifest: manifest(routes), descriptor: undefined, appRoot: "/app" }
 }
 
 describe("createSubagentsMarker — convention discovery", () => {
@@ -108,6 +108,7 @@ describe("createSubagentsMarker — descriptor override", () => {
       ]),
       descriptor: parent,
       descriptorRouteMap: new Map<DawnAgent, string>([[shared, "/shared"]]),
+      appRoot: "/app",
     }
     const detected = await marker.detect("/app/src/app/parent", context)
     expect(detected).toBe(true)
@@ -133,6 +134,7 @@ describe("createSubagentsMarker — descriptor override", () => {
       ]),
       descriptor: parent,
       descriptorRouteMap: new Map<DawnAgent, string>([[shared, "/shared"]]),
+      appRoot: "/app",
     }
     const contribution = await marker.load("/app/src/app/parent", context)
     expect(contribution.tools).toBeDefined()
@@ -164,6 +166,7 @@ describe("createSubagentsMarker — descriptor override", () => {
       ]),
       descriptor: parent,
       descriptorRouteMap: new Map<DawnAgent, string>([[shared, "/research"]]),
+      appRoot: "/app",
     }
     await expect(marker.load("/app/src/app/parent", context)).rejects.toThrow(
       /duplicate.*leaf.*research/i,

--- a/packages/core/test/capabilities/workspace.test.ts
+++ b/packages/core/test/capabilities/workspace.test.ts
@@ -13,10 +13,14 @@ function emptyManifest() {
   return { appRoot: "/app", routes: [] }
 }
 
-function ctx(extras: Partial<CapabilityMarkerContext> = {}): CapabilityMarkerContext {
+function ctx(
+  appRoot: string,
+  extras: Partial<CapabilityMarkerContext> = {},
+): CapabilityMarkerContext {
   return {
     routeManifest: emptyManifest(),
     descriptor: undefined,
+    appRoot,
     ...extras,
   }
 }
@@ -44,14 +48,14 @@ describe("createWorkspaceMarker — detect", () => {
     rmSync(appRoot, { recursive: true, force: true })
   })
 
-  it("returns false when no workspace/ directory exists at cwd", async () => {
-    const detected = await createWorkspaceMarker().detect(routeDir, ctx())
+  it("returns false when no workspace/ directory exists at appRoot", async () => {
+    const detected = await createWorkspaceMarker().detect(routeDir, ctx(appRoot))
     expect(detected).toBe(false)
   })
 
-  it("returns true when workspace/ exists at cwd", async () => {
+  it("returns true when workspace/ exists at appRoot", async () => {
     mkdirSync(join(appRoot, "workspace"))
-    const detected = await createWorkspaceMarker().detect(routeDir, ctx())
+    const detected = await createWorkspaceMarker().detect(routeDir, ctx(appRoot))
     expect(detected).toBe(true)
   })
 })
@@ -74,14 +78,14 @@ describe("createWorkspaceMarker — load", () => {
   })
 
   it("contributes exactly four tools when workspace/ exists", async () => {
-    const contribution = await createWorkspaceMarker().load(routeDir, ctx())
+    const contribution = await createWorkspaceMarker().load(routeDir, ctx(appRoot))
     const names = (contribution.tools ?? []).map((t) => t.name).sort()
     expect(names).toEqual(["listDir", "readFile", "runBash", "writeFile"])
   })
 
   it("contributes no tools when workspace/ is absent", async () => {
     rmSync(workspaceDir, { recursive: true })
-    const contribution = await createWorkspaceMarker().load(routeDir, ctx())
+    const contribution = await createWorkspaceMarker().load(routeDir, ctx(appRoot))
     expect(contribution.tools).toBeUndefined()
   })
 
@@ -94,7 +98,7 @@ describe("createWorkspaceMarker — load", () => {
     }
     const contribution = await createWorkspaceMarker().load(
       routeDir,
-      ctx({ backends: { filesystem: fakeBackend } }),
+      ctx(appRoot, { backends: { filesystem: fakeBackend } }),
     )
     const readTool = findTool(contribution.tools, "readFile")
     const result = await readTool.run(
@@ -105,7 +109,7 @@ describe("createWorkspaceMarker — load", () => {
     expect(fakeBackend.readFile).toHaveBeenCalledOnce()
     const firstCall = fakeBackend.readFile.mock.calls[0]
     if (!firstCall) throw new Error("readFile was not called")
-    expect(firstCall[0]).toBe(join(process.cwd(), "workspace", "hello.txt"))
+    expect(firstCall[0]).toBe(join(appRoot, "workspace", "hello.txt"))
   })
 
   it("rejects path-jail escapes when permissions store is present (non-interactive mode)", async () => {
@@ -115,7 +119,7 @@ describe("createWorkspaceMarker — load", () => {
       mode: "non-interactive",
     })
     await permissions.load()
-    const contribution = await createWorkspaceMarker().load(routeDir, ctx({ permissions }))
+    const contribution = await createWorkspaceMarker().load(routeDir, ctx(appRoot, { permissions }))
     const readTool = findTool(contribution.tools, "readFile")
     await expect(
       readTool.run({ path: "../../etc/passwd" }, { signal: new AbortController().signal }),
@@ -129,7 +133,7 @@ describe("createWorkspaceMarker — load", () => {
       mode: "bypass",
     })
     await permissions.load()
-    const contribution = await createWorkspaceMarker().load(routeDir, ctx({ permissions }))
+    const contribution = await createWorkspaceMarker().load(routeDir, ctx(appRoot, { permissions }))
     const readTool = findTool(contribution.tools, "readFile")
     // The file doesn't exist outside the workspace, so we expect ENOENT, NOT "outside workspace"
     await expect(
@@ -144,7 +148,7 @@ describe("createWorkspaceMarker — load", () => {
       mode: "non-interactive",
     })
     await permissions.load()
-    const contribution = await createWorkspaceMarker().load(routeDir, ctx({ permissions }))
+    const contribution = await createWorkspaceMarker().load(routeDir, ctx(appRoot, { permissions }))
     const runBash = findTool(contribution.tools, "runBash")
     await expect(
       runBash.run({ command: "ls" }, { signal: new AbortController().signal }),
@@ -158,7 +162,7 @@ describe("createWorkspaceMarker — load", () => {
       mode: "non-interactive",
     })
     await permissions.load()
-    const contribution = await createWorkspaceMarker().load(routeDir, ctx({ permissions }))
+    const contribution = await createWorkspaceMarker().load(routeDir, ctx(appRoot, { permissions }))
     const runBash = findTool(contribution.tools, "runBash")
     const result = await runBash.run(
       { command: "echo hi" },
@@ -169,7 +173,7 @@ describe("createWorkspaceMarker — load", () => {
 
   it("uses the default local backends when none configured", async () => {
     writeFileSync(join(workspaceDir, "ok.txt"), "ok", "utf8")
-    const contribution = await createWorkspaceMarker().load(routeDir, ctx())
+    const contribution = await createWorkspaceMarker().load(routeDir, ctx(appRoot))
     const readTool = findTool(contribution.tools, "readFile")
     const result = await readTool.run({ path: "ok.txt" }, { signal: new AbortController().signal })
     expect(result).toBe("ok")
@@ -181,7 +185,7 @@ describe("createWorkspaceMarker — load", () => {
     }
     const contribution = await createWorkspaceMarker().load(
       routeDir,
-      ctx({ backends: { exec: fakeExec } }),
+      ctx(appRoot, { backends: { exec: fakeExec } }),
     )
     const runBash = findTool(contribution.tools, "runBash")
     const result = await runBash.run(
@@ -196,7 +200,7 @@ describe("createWorkspaceMarker — load", () => {
   })
 
   it("marks all four tools as overridable", async () => {
-    const contribution = await createWorkspaceMarker().load(routeDir, ctx())
+    const contribution = await createWorkspaceMarker().load(routeDir, ctx(appRoot))
     for (const t of contribution.tools ?? []) {
       expect((t as unknown as { overridable?: boolean }).overridable).toBe(true)
     }
@@ -214,7 +218,7 @@ describe("createWorkspaceMarker — load", () => {
     }
     const contribution = await createWorkspaceMarker().load(
       routeDir,
-      ctx({ backends: { filesystem: fakeBackend } }),
+      ctx(appRoot, { backends: { filesystem: fakeBackend } }),
     )
     const readTool = findTool(contribution.tools, "readFile")
     await readTool.run({ path: "tool-outputs/x.txt" }, { signal: new AbortController().signal })
@@ -234,7 +238,7 @@ describe("createWorkspaceMarker — load", () => {
     }
     const contribution = await createWorkspaceMarker().load(
       routeDir,
-      ctx({ backends: { filesystem: fakeBackend } }),
+      ctx(appRoot, { backends: { filesystem: fakeBackend } }),
     )
     const readTool = findTool(contribution.tools, "readFile")
     await readTool.run({ path: "notes.md" }, { signal: new AbortController().signal })
@@ -253,7 +257,7 @@ describe("createWorkspaceMarker — load", () => {
     }
     const contribution = await createWorkspaceMarker().load(
       routeDir,
-      ctx({ backends: { filesystem: fakeBackend } }),
+      ctx(appRoot, { backends: { filesystem: fakeBackend } }),
     )
     const readTool = findTool(contribution.tools, "readFile")
     const result = await readTool.run(
@@ -276,7 +280,7 @@ describe("createWorkspaceMarker — load", () => {
 
     const contribution = await createWorkspaceMarker().load(
       routeDir,
-      ctx({ backends: { filesystem: tinyFs } }),
+      ctx(appRoot, { backends: { filesystem: tinyFs } }),
     )
     const readTool = findTool(contribution.tools, "readFile")
     const result = await readTool.run(

--- a/packages/core/test/capability-marker-context.test.ts
+++ b/packages/core/test/capability-marker-context.test.ts
@@ -21,6 +21,7 @@ describe("CapabilityMarkerContext is threaded into detect() and load()", () => {
     const fakeContext: CapabilityMarkerContext = {
       routeManifest: { appRoot: "/tmp", routes: [] },
       descriptor: undefined,
+      appRoot: "/tmp",
     }
     await applyCapabilities(registry, "/tmp/route", fakeContext)
     expect(seenDetectContext).toEqual(fakeContext)

--- a/packages/langchain/test/agents-md.test.ts
+++ b/packages/langchain/test/agents-md.test.ts
@@ -25,8 +25,9 @@ describe("agents-md capability — end-to-end shape", () => {
   it("always contributes a promptFragment", async () => {
     const registry = createCapabilityRegistry([createAgentsMdMarker()])
     const result = await applyCapabilities(registry, routeDir, {
-      routeManifest: { appRoot: routeDir, routes: [] },
+      routeManifest: { appRoot: workDir, routes: [] },
       descriptor: undefined,
+      appRoot: workDir,
     })
     expect(result.contributions).toHaveLength(1)
     expect(result.contributions[0]?.contribution.promptFragment?.placement).toBe(
@@ -39,8 +40,9 @@ describe("agents-md capability — end-to-end shape", () => {
     writeFileSync(join(workDir, "workspace", "AGENTS.md"), "Use pnpm, not npm.")
     const registry = createCapabilityRegistry([createAgentsMdMarker()])
     const result = await applyCapabilities(registry, routeDir, {
-      routeManifest: { appRoot: routeDir, routes: [] },
+      routeManifest: { appRoot: workDir, routes: [] },
       descriptor: undefined,
+      appRoot: workDir,
     })
     const fragment = result.contributions[0]?.contribution.promptFragment
     const rendered = fragment?.render({}) ?? ""
@@ -51,8 +53,9 @@ describe("agents-md capability — end-to-end shape", () => {
   it("renders empty when workspace/AGENTS.md is absent", async () => {
     const registry = createCapabilityRegistry([createAgentsMdMarker()])
     const result = await applyCapabilities(registry, routeDir, {
-      routeManifest: { appRoot: routeDir, routes: [] },
+      routeManifest: { appRoot: workDir, routes: [] },
       descriptor: undefined,
+      appRoot: workDir,
     })
     const fragment = result.contributions[0]?.contribution.promptFragment
     expect(fragment?.render({})).toBe("")
@@ -64,8 +67,9 @@ describe("agents-md capability — end-to-end shape", () => {
     writeFileSync(path, "before")
     const registry = createCapabilityRegistry([createAgentsMdMarker()])
     const result = await applyCapabilities(registry, routeDir, {
-      routeManifest: { appRoot: routeDir, routes: [] },
+      routeManifest: { appRoot: workDir, routes: [] },
       descriptor: undefined,
+      appRoot: workDir,
     })
     const fragment = result.contributions[0]?.contribution.promptFragment
     expect(fragment?.render({})).toContain("before")

--- a/packages/langchain/test/planning.test.ts
+++ b/packages/langchain/test/planning.test.ts
@@ -22,6 +22,7 @@ describe("planning capability — end-to-end shape", () => {
     const result = await applyCapabilities(registry, routeDir, {
       routeManifest: { appRoot: routeDir, routes: [] },
       descriptor: undefined,
+      appRoot: routeDir,
     })
     expect(result.contributions).toEqual([])
   })
@@ -32,6 +33,7 @@ describe("planning capability — end-to-end shape", () => {
     const result = await applyCapabilities(registry, routeDir, {
       routeManifest: { appRoot: routeDir, routes: [] },
       descriptor: undefined,
+      appRoot: routeDir,
     })
 
     expect(result.contributions).toHaveLength(1)
@@ -48,6 +50,7 @@ describe("planning capability — end-to-end shape", () => {
     const result = await applyCapabilities(registry, routeDir, {
       routeManifest: { appRoot: routeDir, routes: [] },
       descriptor: undefined,
+      appRoot: routeDir,
     })
     const todosField = result.contributions[0]?.contribution.stateFields?.[0]
     expect(todosField?.default).toEqual([
@@ -62,6 +65,7 @@ describe("planning capability — end-to-end shape", () => {
     const result = await applyCapabilities(registry, routeDir, {
       routeManifest: { appRoot: routeDir, routes: [] },
       descriptor: undefined,
+      appRoot: routeDir,
     })
     const fragment = result.contributions[0]?.contribution.promptFragment
     const r1 = fragment?.render({ todos: [] }) ?? ""
@@ -76,6 +80,7 @@ describe("planning capability — end-to-end shape", () => {
     const result = await applyCapabilities(registry, routeDir, {
       routeManifest: { appRoot: routeDir, routes: [] },
       descriptor: undefined,
+      appRoot: routeDir,
     })
     const transformer = result.contributions[0]?.contribution.streamTransformers?.[0]
 

--- a/packages/langchain/test/skills.test.ts
+++ b/packages/langchain/test/skills.test.ts
@@ -26,6 +26,7 @@ describe("skills capability — end-to-end shape", () => {
     const result = await applyCapabilities(registry, routeDir, {
       routeManifest: { appRoot: routeDir, routes: [] },
       descriptor: undefined,
+      appRoot: routeDir,
     })
     expect(result.contributions).toEqual([])
   })
@@ -37,6 +38,7 @@ describe("skills capability — end-to-end shape", () => {
     const result = await applyCapabilities(registry, routeDir, {
       routeManifest: { appRoot: routeDir, routes: [] },
       descriptor: undefined,
+      appRoot: routeDir,
     })
     expect(result.contributions).toHaveLength(1)
     const contrib = result.contributions[0]?.contribution
@@ -54,6 +56,7 @@ describe("skills capability — end-to-end shape", () => {
     const result = await applyCapabilities(registry, routeDir, {
       routeManifest: { appRoot: routeDir, routes: [] },
       descriptor: undefined,
+      appRoot: routeDir,
     })
     const readSkill = result.contributions[0]?.contribution.tools?.[0]
     const output = await readSkill?.run(

--- a/packages/testing/src/aimock-runner.ts
+++ b/packages/testing/src/aimock-runner.ts
@@ -8,7 +8,9 @@ export interface AimockHandle {
   /** Append more fixtures onto the live mock without restarting it. */
   addFixtures(fixtures: readonly AimockFixture[]): void
   /** All requests the mock has received (aimock's journal). */
-  getRequests(): ReadonlyArray<{ body: { messages?: Array<{ role: string; content: unknown }> } | null }>
+  getRequests(): ReadonlyArray<{
+    body: { messages?: Array<{ role: string; content: unknown }> } | null
+  }>
   stop(): Promise<void>
 }
 

--- a/packages/testing/src/aimock-runner.ts
+++ b/packages/testing/src/aimock-runner.ts
@@ -7,6 +7,8 @@ export interface AimockHandle {
   readonly baseUrl: string
   /** Append more fixtures onto the live mock without restarting it. */
   addFixtures(fixtures: readonly AimockFixture[]): void
+  /** All requests the mock has received (aimock's journal). */
+  getRequests(): ReadonlyArray<{ body: { messages?: Array<{ role: string; content: unknown }> } | null }>
   stop(): Promise<void>
 }
 
@@ -26,6 +28,11 @@ export async function startAimock(opts: {
       if (fixtures.length > 0) {
         mock.addFixturesFromJSON(fixtures as never)
       }
+    },
+    getRequests() {
+      return mock.getRequests() as ReadonlyArray<{
+        body: { messages?: Array<{ role: string; content: unknown }> } | null
+      }>
     },
     async stop() {
       if (stopped) return

--- a/packages/testing/src/harness.ts
+++ b/packages/testing/src/harness.ts
@@ -99,12 +99,15 @@ export async function createAgentHarness(options: AgentHarnessOptions): Promise<
       }
     }
     const snapshotLen = aimock.getRequests().length
+    // resolved is guaranteed non-null at this point: the catch block re-throws
+    // before returning, so if we reach drive() the null check already passed.
+    const r = resolved!
     const streamArgs: Parameters<typeof streamResolvedRoute>[0] = {
       appRoot: options.appRoot,
       input: driveOpts.input !== undefined ? { messages: [{ role: "user", content: driveOpts.input }] } : { messages: [] },
-      routeFile: resolved.routeFile,
-      routeId: resolved.routeId,
-      routePath: resolved.routePath,
+      routeFile: r.routeFile,
+      routeId: r.routeId,
+      routePath: r.routePath,
       threadId,
       ...(driveOpts.resumeDecision !== undefined ? { resumeDecision: driveOpts.resumeDecision } : {}),
     }
@@ -119,10 +122,16 @@ export async function createAgentHarness(options: AgentHarnessOptions): Promise<
       return baseUrl
     },
     async run(runOpts) {
-      return drive({ input: runOpts.input, fixtures: runOpts.fixtures })
+      return drive({
+        input: runOpts.input,
+        ...(runOpts.fixtures !== undefined ? { fixtures: runOpts.fixtures } : {}),
+      })
     },
     async resume(resumeOpts) {
-      return drive({ decision: resumeOpts.decision, fixtures: resumeOpts.fixtures, resumeDecision: resumeOpts.decision })
+      return drive({
+        resumeDecision: resumeOpts.decision,
+        ...(resumeOpts.fixtures !== undefined ? { fixtures: resumeOpts.fixtures } : {}),
+      })
     },
     reset() {
       threadId = randomUUID()

--- a/packages/testing/src/harness.ts
+++ b/packages/testing/src/harness.ts
@@ -41,7 +41,10 @@ export interface AgentHarnessOptions {
 export interface AgentHarness {
   readonly baseUrl: string
   run(opts: { input: string; fixtures?: FixtureSet | ScriptBuilder }): Promise<AgentRunResult>
-  resume(opts: { decision: "once" | "always" | "deny"; fixtures?: FixtureSet | ScriptBuilder }): Promise<AgentRunResult>
+  resume(opts: {
+    decision: "once" | "always" | "deny"
+    fixtures?: FixtureSet | ScriptBuilder
+  }): Promise<AgentRunResult>
   reset(): void
   close(): Promise<void>
 }
@@ -104,12 +107,17 @@ export async function createAgentHarness(options: AgentHarnessOptions): Promise<
     const r = resolved!
     const streamArgs: Parameters<typeof streamResolvedRoute>[0] = {
       appRoot: options.appRoot,
-      input: driveOpts.input !== undefined ? { messages: [{ role: "user", content: driveOpts.input }] } : { messages: [] },
+      input:
+        driveOpts.input !== undefined
+          ? { messages: [{ role: "user", content: driveOpts.input }] }
+          : { messages: [] },
       routeFile: r.routeFile,
       routeId: r.routeId,
       routePath: r.routePath,
       threadId,
-      ...(driveOpts.resumeDecision !== undefined ? { resumeDecision: driveOpts.resumeDecision } : {}),
+      ...(driveOpts.resumeDecision !== undefined
+        ? { resumeDecision: driveOpts.resumeDecision }
+        : {}),
     }
     const stream = streamResolvedRoute(streamArgs)
     const result = await collectRunResult(stream, threadId)

--- a/packages/testing/src/harness.ts
+++ b/packages/testing/src/harness.ts
@@ -16,6 +16,21 @@ function toFixtureSet(f: FixtureSet | ScriptBuilder): FixtureSet {
   return f.build()
 }
 
+/** Extract the system prompt from a slice of aimock journal requests. */
+function systemPromptFromRequests(
+  reqs: ReadonlyArray<{ body: { messages?: Array<{ role: string; content: unknown }> } | null }>,
+): string {
+  for (const req of reqs) {
+    const messages = req.body?.messages ?? []
+    for (const m of messages) {
+      if (m.role === "system" && typeof m.content === "string") {
+        return m.content
+      }
+    }
+  }
+  return ""
+}
+
 export interface AgentHarnessOptions {
   readonly appRoot: string
   readonly route: string
@@ -26,6 +41,7 @@ export interface AgentHarnessOptions {
 export interface AgentHarness {
   readonly baseUrl: string
   run(opts: { input: string; fixtures?: FixtureSet | ScriptBuilder }): Promise<AgentRunResult>
+  resume(opts: { decision: "once" | "always" | "deny"; fixtures?: FixtureSet | ScriptBuilder }): Promise<AgentRunResult>
   reset(): void
   close(): Promise<void>
 }
@@ -70,27 +86,43 @@ export async function createAgentHarness(options: AgentHarnessOptions): Promise<
   let threadId = randomUUID()
   let closed = false
 
+  /** Core drive helper — runs a single turn and merges systemPrompt. */
+  async function drive(driveOpts: {
+    fixtures?: FixtureSet | ScriptBuilder
+    input?: string
+    resumeDecision?: "once" | "always" | "deny"
+  }): Promise<AgentRunResult> {
+    if (driveOpts.fixtures) {
+      const newFixtures = toFixtureSet(driveOpts.fixtures)
+      if (newFixtures.length > 0) {
+        aimock.addFixtures(newFixtures)
+      }
+    }
+    const snapshotLen = aimock.getRequests().length
+    const streamArgs: Parameters<typeof streamResolvedRoute>[0] = {
+      appRoot: options.appRoot,
+      input: driveOpts.input !== undefined ? { messages: [{ role: "user", content: driveOpts.input }] } : { messages: [] },
+      routeFile: resolved.routeFile,
+      routeId: resolved.routeId,
+      routePath: resolved.routePath,
+      threadId,
+      ...(driveOpts.resumeDecision !== undefined ? { resumeDecision: driveOpts.resumeDecision } : {}),
+    }
+    const stream = streamResolvedRoute(streamArgs)
+    const result = await collectRunResult(stream, threadId)
+    const turnReqs = aimock.getRequests().slice(snapshotLen)
+    return { ...result, systemPrompt: systemPromptFromRequests(turnReqs) }
+  }
+
   const harness: AgentHarness = {
     get baseUrl() {
       return baseUrl
     },
     async run(runOpts) {
-      if (runOpts.fixtures) {
-        const newFixtures = toFixtureSet(runOpts.fixtures)
-        if (newFixtures.length > 0) {
-          // Append fixtures onto the live mock — no restart, port stays stable.
-          aimock.addFixtures(newFixtures)
-        }
-      }
-      const stream = streamResolvedRoute({
-        appRoot: options.appRoot,
-        input: { messages: [{ role: "user", content: runOpts.input }] },
-        routeFile: resolved.routeFile,
-        routeId: resolved.routeId,
-        routePath: resolved.routePath,
-        threadId,
-      })
-      return await collectRunResult(stream, threadId)
+      return drive({ input: runOpts.input, fixtures: runOpts.fixtures })
+    },
+    async resume(resumeOpts) {
+      return drive({ decision: resumeOpts.decision, fixtures: resumeOpts.fixtures, resumeDecision: resumeOpts.decision })
     },
     reset() {
       threadId = randomUUID()

--- a/packages/testing/src/harness.ts
+++ b/packages/testing/src/harness.ts
@@ -23,7 +23,10 @@ function systemPromptFromRequests(
   for (const req of reqs) {
     const messages = req.body?.messages ?? []
     for (const m of messages) {
-      if (m.role === "system" && typeof m.content === "string") {
+      // OpenAI chat models use role "system"; gpt-5 / reasoning models send the
+      // system prompt under role "developer". Accept either so the captured
+      // systemPrompt is populated regardless of which model the route uses.
+      if ((m.role === "system" || m.role === "developer") && typeof m.content === "string") {
         return m.content
       }
     }

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -15,10 +15,19 @@ export {
 } from "./http-inject.js"
 export {
   expectFinalMessage,
+  expectInterrupt,
+  expectNoInterrupt,
   expectOffloaded,
+  expectPlan,
   expectState,
   expectStreamedTokens,
+  expectSubagent,
+  expectSystemPrompt,
   expectToolCalled,
+  type InterruptInfo,
+  type SubagentEvent,
+  type SubagentRun,
+  type Todo,
 } from "./matchers.js"
 export { type RecordOptions, record } from "./record.js"
 export { type AgentRunResult, collectRunResult, type ObservedToolCall } from "./run-result.js"

--- a/packages/testing/src/matchers.ts
+++ b/packages/testing/src/matchers.ts
@@ -161,9 +161,7 @@ export function expectSubagent(run: AgentRunResult) {
       }
     },
     finalMessageContains(text: string) {
-      const found = run.subagents.some(
-        (s) => s.finalMessage !== undefined && s.finalMessage.includes(text),
-      )
+      const found = run.subagents.some((s) => s.finalMessage?.includes(text) ?? false)
       if (!found) {
         fail(
           `expected a subagent finalMessage to contain "${text}"; got: ${run.subagents.map((s) => s.finalMessage ?? "(no finalMessage)").join(", ") || "(no subagents)"}`,
@@ -175,6 +173,9 @@ export function expectSubagent(run: AgentRunResult) {
 
 export function expectPlan(run: AgentRunResult) {
   return {
+    toHaveLength(n: number) {
+      if (run.todos.length !== n) fail(`expected ${n} todos, got ${run.todos.length}`)
+    },
     toHaveTodo(content: string) {
       if (!run.todos.some((t) => t.content === content)) {
         fail(
@@ -204,6 +205,12 @@ export function expectSystemPrompt(run: AgentRunResult) {
           `expected systemPrompt to contain "${text}"; got: ${JSON.stringify(run.systemPrompt.slice(0, 120))}`,
         )
       }
+    },
+    toMatch(re: RegExp) {
+      if (!re.test(run.systemPrompt))
+        fail(
+          `expected systemPrompt to match ${re}; got: ${JSON.stringify(run.systemPrompt.slice(0, 120))}`,
+        )
     },
   }
 }

--- a/packages/testing/src/matchers.ts
+++ b/packages/testing/src/matchers.ts
@@ -1,7 +1,13 @@
 import { AssertionError } from "node:assert"
-import type { AgentRunResult, InterruptInfo, SubagentRun, SubagentEvent, Todo } from "./run-result.js"
+import type {
+  AgentRunResult,
+  InterruptInfo,
+  SubagentEvent,
+  SubagentRun,
+  Todo,
+} from "./run-result.js"
 
-export type { InterruptInfo, SubagentRun, SubagentEvent, Todo }
+export type { InterruptInfo, SubagentEvent, SubagentRun, Todo }
 
 function fail(message: string): never {
   throw new AssertionError({ message })
@@ -117,7 +123,9 @@ export function expectInterrupt(run: AgentRunResult) {
       }
     },
     withDetail(partial: Record<string, unknown>) {
-      const found = run.interrupts.some((i) => i.detail !== undefined && isSubset(partial, i.detail))
+      const found = run.interrupts.some(
+        (i) => i.detail !== undefined && isSubset(partial, i.detail),
+      )
       if (!found) {
         fail(
           `expected an interrupt with detail >= ${JSON.stringify(partial)}; got: ${JSON.stringify(run.interrupts.map((i) => i.detail))}`,
@@ -153,7 +161,9 @@ export function expectSubagent(run: AgentRunResult) {
       }
     },
     finalMessageContains(text: string) {
-      const found = run.subagents.some((s) => s.finalMessage !== undefined && s.finalMessage.includes(text))
+      const found = run.subagents.some(
+        (s) => s.finalMessage !== undefined && s.finalMessage.includes(text),
+      )
       if (!found) {
         fail(
           `expected a subagent finalMessage to contain "${text}"; got: ${run.subagents.map((s) => s.finalMessage ?? "(no finalMessage)").join(", ") || "(no subagents)"}`,
@@ -180,9 +190,7 @@ export function expectPlan(run: AgentRunResult) {
         )
       }
       if (todo.status !== status) {
-        fail(
-          `expected todo "${content}" to have status "${status}", but got "${todo.status}"`,
-        )
+        fail(`expected todo "${content}" to have status "${status}", but got "${todo.status}"`)
       }
     },
   }

--- a/packages/testing/src/matchers.ts
+++ b/packages/testing/src/matchers.ts
@@ -1,5 +1,7 @@
 import { AssertionError } from "node:assert"
-import type { AgentRunResult } from "./run-result.js"
+import type { AgentRunResult, InterruptInfo, SubagentRun, SubagentEvent, Todo } from "./run-result.js"
+
+export type { InterruptInfo, SubagentRun, SubagentEvent, Todo }
 
 function fail(message: string): never {
   throw new AssertionError({ message })
@@ -99,6 +101,102 @@ export function expectOffloaded(run: AgentRunResult, toolName: string): void {
     fail(
       `expected "${toolName}" output to be offloaded (stub marker), got: ${content.slice(0, 120)}`,
     )
+  }
+}
+
+export function expectInterrupt(run: AgentRunResult) {
+  if (run.interrupts.length === 0) {
+    fail("expected at least one interrupt, but none were captured")
+  }
+  return {
+    ofKind(kind: string) {
+      if (!run.interrupts.some((i) => i.kind === kind)) {
+        fail(
+          `expected an interrupt of kind "${kind}"; got: ${run.interrupts.map((i) => i.kind).join(", ") || "(none)"}`,
+        )
+      }
+    },
+    withDetail(partial: Record<string, unknown>) {
+      const found = run.interrupts.some((i) => i.detail !== undefined && isSubset(partial, i.detail))
+      if (!found) {
+        fail(
+          `expected an interrupt with detail >= ${JSON.stringify(partial)}; got: ${JSON.stringify(run.interrupts.map((i) => i.detail))}`,
+        )
+      }
+    },
+  }
+}
+
+export function expectNoInterrupt(run: AgentRunResult): void {
+  if (run.interrupts.length > 0) {
+    fail(
+      `expected no interrupts, but got ${run.interrupts.length}: ${run.interrupts.map((i) => i.kind).join(", ")}`,
+    )
+  }
+}
+
+export function expectSubagent(run: AgentRunResult) {
+  return {
+    called(name: string) {
+      if (!run.subagents.some((s) => s.name === name)) {
+        fail(
+          `expected subagent "${name}" to be called; subagents: ${run.subagents.map((s) => s.name).join(", ") || "(none)"}`,
+        )
+      }
+    },
+    calledTool(toolName: string) {
+      const found = run.subagents.some((s) => s.toolCalls.some((t) => t.name === toolName))
+      if (!found) {
+        fail(
+          `expected a subagent to call tool "${toolName}"; tool calls: ${run.subagents.flatMap((s) => s.toolCalls.map((t) => t.name)).join(", ") || "(none)"}`,
+        )
+      }
+    },
+    finalMessageContains(text: string) {
+      const found = run.subagents.some((s) => s.finalMessage !== undefined && s.finalMessage.includes(text))
+      if (!found) {
+        fail(
+          `expected a subagent finalMessage to contain "${text}"; got: ${run.subagents.map((s) => s.finalMessage ?? "(no finalMessage)").join(", ") || "(no subagents)"}`,
+        )
+      }
+    },
+  }
+}
+
+export function expectPlan(run: AgentRunResult) {
+  return {
+    toHaveTodo(content: string) {
+      if (!run.todos.some((t) => t.content === content)) {
+        fail(
+          `expected a todo with content "${content}"; todos: ${run.todos.map((t) => t.content).join(", ") || "(none)"}`,
+        )
+      }
+    },
+    toHaveStatus(content: string, status: string) {
+      const todo = run.todos.find((t) => t.content === content)
+      if (!todo) {
+        fail(
+          `expected a todo with content "${content}"; todos: ${run.todos.map((t) => t.content).join(", ") || "(none)"}`,
+        )
+      }
+      if (todo.status !== status) {
+        fail(
+          `expected todo "${content}" to have status "${status}", but got "${todo.status}"`,
+        )
+      }
+    },
+  }
+}
+
+export function expectSystemPrompt(run: AgentRunResult) {
+  return {
+    toContain(text: string) {
+      if (!run.systemPrompt.includes(text)) {
+        fail(
+          `expected systemPrompt to contain "${text}"; got: ${JSON.stringify(run.systemPrompt.slice(0, 120))}`,
+        )
+      }
+    },
   }
 }
 

--- a/packages/testing/src/matchers.ts
+++ b/packages/testing/src/matchers.ts
@@ -114,13 +114,14 @@ export function expectInterrupt(run: AgentRunResult) {
   if (run.interrupts.length === 0) {
     fail("expected at least one interrupt, but none were captured")
   }
-  return {
+  const chain = {
     ofKind(kind: string) {
       if (!run.interrupts.some((i) => i.kind === kind)) {
         fail(
           `expected an interrupt of kind "${kind}"; got: ${run.interrupts.map((i) => i.kind).join(", ") || "(none)"}`,
         )
       }
+      return chain
     },
     withDetail(partial: Record<string, unknown>) {
       const found = run.interrupts.some(
@@ -131,8 +132,10 @@ export function expectInterrupt(run: AgentRunResult) {
           `expected an interrupt with detail >= ${JSON.stringify(partial)}; got: ${JSON.stringify(run.interrupts.map((i) => i.detail))}`,
         )
       }
+      return chain
     },
   }
+  return chain
 }
 
 export function expectNoInterrupt(run: AgentRunResult): void {
@@ -143,32 +146,39 @@ export function expectNoInterrupt(run: AgentRunResult): void {
   }
 }
 
-export function expectSubagent(run: AgentRunResult) {
-  return {
-    called(name: string) {
-      if (!run.subagents.some((s) => s.name === name)) {
+export function expectSubagent(run: AgentRunResult, name: string) {
+  const sub = run.subagents.find((s) => s.name === name)
+  const chain = {
+    called() {
+      if (!sub) {
         fail(
-          `expected subagent "${name}" to be called; subagents: ${run.subagents.map((s) => s.name).join(", ") || "(none)"}`,
+          `expected subagent "${name}" to be dispatched; subagents: ${run.subagents.map((s) => s.name).join(", ") || "(none)"}`,
         )
       }
+      return chain
     },
     calledTool(toolName: string) {
-      const found = run.subagents.some((s) => s.toolCalls.some((t) => t.name === toolName))
-      if (!found) {
+      if (!sub) {
+        fail(`expected subagent "${name}" to be dispatched (it was not)`)
+      } else if (!sub.toolCalls.some((t) => t.name === toolName)) {
         fail(
-          `expected a subagent to call tool "${toolName}"; tool calls: ${run.subagents.flatMap((s) => s.toolCalls.map((t) => t.name)).join(", ") || "(none)"}`,
+          `expected subagent "${name}" to call tool "${toolName}"; called: ${sub.toolCalls.map((t) => t.name).join(", ") || "(none)"}`,
         )
       }
+      return chain
     },
     finalMessageContains(text: string) {
-      const found = run.subagents.some((s) => s.finalMessage?.includes(text) ?? false)
-      if (!found) {
+      if (!sub) {
+        fail(`expected subagent "${name}" to be dispatched (it was not)`)
+      } else if (!(sub.finalMessage ?? "").includes(text)) {
         fail(
-          `expected a subagent finalMessage to contain "${text}"; got: ${run.subagents.map((s) => s.finalMessage ?? "(no finalMessage)").join(", ") || "(no subagents)"}`,
+          `expected subagent "${name}" finalMessage to contain "${text}"; got: ${JSON.stringify(sub?.finalMessage)}`,
         )
       }
+      return chain
     },
   }
+  return chain
 }
 
 export function expectPlan(run: AgentRunResult) {

--- a/packages/testing/src/run-result.ts
+++ b/packages/testing/src/run-result.ts
@@ -6,6 +6,35 @@ export interface ObservedToolCall {
   readonly id?: string
 }
 
+export interface InterruptInfo {
+  readonly interruptId: string
+  readonly kind: string
+  readonly detail?: Record<string, unknown>
+}
+
+export interface Todo {
+  readonly content: string
+  readonly status: string
+}
+
+export interface SubagentToolCall {
+  readonly name: string
+  readonly args: unknown
+}
+
+export interface SubagentRun {
+  readonly callId: string
+  readonly name: string
+  readonly toolCalls: ReadonlyArray<SubagentToolCall>
+  readonly finalMessage?: string
+  readonly error?: string
+}
+
+export interface SubagentEvent {
+  readonly type: string
+  readonly data: Record<string, unknown>
+}
+
 export interface AgentRunResult {
   readonly finalMessage: string
   readonly messages: ReadonlyArray<Record<string, unknown>>
@@ -13,6 +42,12 @@ export interface AgentRunResult {
   readonly tokens: ReadonlyArray<string>
   readonly state: Record<string, unknown>
   readonly threadId: string
+  readonly interrupts: ReadonlyArray<InterruptInfo>
+  readonly planUpdates: ReadonlyArray<{ todos: ReadonlyArray<Todo> }>
+  readonly todos: ReadonlyArray<Todo>
+  readonly subagents: ReadonlyArray<SubagentRun>
+  readonly subagentEvents: ReadonlyArray<SubagentEvent>
+  readonly systemPrompt: string
 }
 
 function finalMessageFrom(state: Record<string, unknown>): string {
@@ -70,6 +105,24 @@ export async function collectRunResult(
   const toolCalls: ObservedToolCall[] = []
   let state: Record<string, unknown> = {}
 
+  const interrupts: InterruptInfo[] = []
+  const planUpdates: { todos: ReadonlyArray<Todo> }[] = []
+  let todos: ReadonlyArray<Todo> = []
+  const subagentEvents: SubagentEvent[] = []
+
+  // In-progress subagent runs keyed by call_id
+  const subagentMap = new Map<string, { callId: string; name: string; toolCalls: SubagentToolCall[]; finalMessage?: string; error?: string }>()
+  const finishedSubagents: SubagentRun[] = []
+
+  function subagentFor(callId: string): { callId: string; name: string; toolCalls: SubagentToolCall[]; finalMessage?: string; error?: string } {
+    let run = subagentMap.get(callId)
+    if (!run) {
+      run = { callId, name: callId, toolCalls: [] }
+      subagentMap.set(callId, run)
+    }
+    return run
+  }
+
   for await (const chunk of stream) {
     switch (chunk.type) {
       case "chunk":
@@ -90,6 +143,62 @@ export async function collectRunResult(
         if (out && typeof out === "object") state = out as Record<string, unknown>
         break
       }
+      case "interrupt": {
+        const d = (chunk as unknown as { data?: Record<string, unknown> }).data ?? {}
+        const info: InterruptInfo =
+          d.detail !== undefined
+            ? { interruptId: String(d.interruptId ?? ""), kind: String(d.kind ?? ""), detail: d.detail as Record<string, unknown> }
+            : { interruptId: String(d.interruptId ?? ""), kind: String(d.kind ?? "") }
+        interrupts.push(info)
+        break
+      }
+      case "plan_update": {
+        const d = (chunk as unknown as { data?: { todos?: unknown[] } }).data ?? {}
+        const rawTodos = Array.isArray(d.todos) ? d.todos : []
+        const update = { todos: rawTodos as ReadonlyArray<Todo> }
+        planUpdates.push(update)
+        todos = update.todos
+        break
+      }
+      case "subagent.start": {
+        const d = (chunk as unknown as { data?: Record<string, unknown> }).data ?? {}
+        const callId = String(d.call_id ?? "")
+        const run = subagentFor(callId)
+        run.name = String(d.subagent ?? callId)
+        subagentEvents.push({ type: chunk.type, data: d })
+        break
+      }
+      case "subagent.tool_call": {
+        const d = (chunk as unknown as { data?: Record<string, unknown> }).data ?? {}
+        const callId = String(d.call_id ?? "")
+        const run = subagentFor(callId)
+        run.toolCalls.push({ name: String(d.tool ?? ""), args: normalizeToolArgs(d.input) })
+        subagentEvents.push({ type: chunk.type, data: d })
+        break
+      }
+      case "subagent.end": {
+        const d = (chunk as unknown as { data?: Record<string, unknown> }).data ?? {}
+        const callId = String(d.call_id ?? "")
+        const run = subagentFor(callId)
+        if (d.final_message !== undefined) {
+          run.finalMessage = String(d.final_message)
+        }
+        if (d.error !== undefined) {
+          run.error = String(d.error)
+        }
+        subagentMap.delete(callId)
+        const finished: SubagentRun =
+          run.finalMessage !== undefined && run.error !== undefined
+            ? { callId: run.callId, name: run.name, toolCalls: run.toolCalls, finalMessage: run.finalMessage, error: run.error }
+            : run.finalMessage !== undefined
+              ? { callId: run.callId, name: run.name, toolCalls: run.toolCalls, finalMessage: run.finalMessage }
+              : run.error !== undefined
+                ? { callId: run.callId, name: run.name, toolCalls: run.toolCalls, error: run.error }
+                : { callId: run.callId, name: run.name, toolCalls: run.toolCalls }
+        finishedSubagents.push(finished)
+        subagentEvents.push({ type: chunk.type, data: d })
+        break
+      }
       default:
         break
     }
@@ -102,5 +211,11 @@ export async function collectRunResult(
     state,
     messages: Array.isArray(state.messages) ? (state.messages as Record<string, unknown>[]) : [],
     finalMessage: finalMessageFrom(state),
+    interrupts,
+    planUpdates,
+    todos,
+    subagents: finishedSubagents,
+    subagentEvents,
+    systemPrompt: "",
   }
 }

--- a/packages/testing/src/run-result.ts
+++ b/packages/testing/src/run-result.ts
@@ -111,10 +111,25 @@ export async function collectRunResult(
   const subagentEvents: SubagentEvent[] = []
 
   // In-progress subagent runs keyed by call_id
-  const subagentMap = new Map<string, { callId: string; name: string; toolCalls: SubagentToolCall[]; finalMessage?: string; error?: string }>()
+  const subagentMap = new Map<
+    string,
+    {
+      callId: string
+      name: string
+      toolCalls: SubagentToolCall[]
+      finalMessage?: string
+      error?: string
+    }
+  >()
   const finishedSubagents: SubagentRun[] = []
 
-  function subagentFor(callId: string): { callId: string; name: string; toolCalls: SubagentToolCall[]; finalMessage?: string; error?: string } {
+  function subagentFor(callId: string): {
+    callId: string
+    name: string
+    toolCalls: SubagentToolCall[]
+    finalMessage?: string
+    error?: string
+  } {
     let run = subagentMap.get(callId)
     if (!run) {
       run = { callId, name: callId, toolCalls: [] }
@@ -147,7 +162,11 @@ export async function collectRunResult(
         const d = (chunk as unknown as { data?: Record<string, unknown> }).data ?? {}
         const info: InterruptInfo =
           d.detail !== undefined
-            ? { interruptId: String(d.interruptId ?? ""), kind: String(d.kind ?? ""), detail: d.detail as Record<string, unknown> }
+            ? {
+                interruptId: String(d.interruptId ?? ""),
+                kind: String(d.kind ?? ""),
+                detail: d.detail as Record<string, unknown>,
+              }
             : { interruptId: String(d.interruptId ?? ""), kind: String(d.kind ?? "") }
         interrupts.push(info)
         break
@@ -189,9 +208,20 @@ export async function collectRunResult(
         subagentMap.delete(callId)
         const finished: SubagentRun =
           run.finalMessage !== undefined && run.error !== undefined
-            ? { callId: run.callId, name: run.name, toolCalls: run.toolCalls, finalMessage: run.finalMessage, error: run.error }
+            ? {
+                callId: run.callId,
+                name: run.name,
+                toolCalls: run.toolCalls,
+                finalMessage: run.finalMessage,
+                error: run.error,
+              }
             : run.finalMessage !== undefined
-              ? { callId: run.callId, name: run.name, toolCalls: run.toolCalls, finalMessage: run.finalMessage }
+              ? {
+                  callId: run.callId,
+                  name: run.name,
+                  toolCalls: run.toolCalls,
+                  finalMessage: run.finalMessage,
+                }
               : run.error !== undefined
                 ? { callId: run.callId, name: run.name, toolCalls: run.toolCalls, error: run.error }
                 : { callId: run.callId, name: run.name, toolCalls: run.toolCalls }

--- a/packages/testing/test/aimock-runner.test.ts
+++ b/packages/testing/test/aimock-runner.test.ts
@@ -22,3 +22,21 @@ it("stop() is idempotent", async () => {
   await mock.stop()
   await mock.stop()
 })
+
+it("exposes received requests via getRequests()", async () => {
+  const mock = await startAimock({ fixtures: [{ match: {}, response: { content: "ok" } }] })
+  try {
+    await fetch(new URL("/v1/chat/completions", mock.baseUrl.replace(/\/v1$/, "")), {
+      method: "POST",
+      headers: { "content-type": "application/json", authorization: "Bearer test" },
+      body: JSON.stringify({ model: "gpt-4o-mini", messages: [{ role: "system", content: "SYS-MARKER" }, { role: "user", content: "hi" }] }),
+    })
+    const reqs = mock.getRequests()
+    expect(reqs.length).toBeGreaterThanOrEqual(1)
+    const last = reqs[reqs.length - 1] as { body?: { messages?: { role: string; content: unknown }[] } }
+    const sys = (last.body?.messages ?? []).filter((m) => m.role === "system").map((m) => m.content).join("\n")
+    expect(sys).toContain("SYS-MARKER")
+  } finally {
+    await mock.stop()
+  }
+})

--- a/packages/testing/test/aimock-runner.test.ts
+++ b/packages/testing/test/aimock-runner.test.ts
@@ -29,12 +29,23 @@ it("exposes received requests via getRequests()", async () => {
     await fetch(new URL("/v1/chat/completions", mock.baseUrl.replace(/\/v1$/, "")), {
       method: "POST",
       headers: { "content-type": "application/json", authorization: "Bearer test" },
-      body: JSON.stringify({ model: "gpt-4o-mini", messages: [{ role: "system", content: "SYS-MARKER" }, { role: "user", content: "hi" }] }),
+      body: JSON.stringify({
+        model: "gpt-4o-mini",
+        messages: [
+          { role: "system", content: "SYS-MARKER" },
+          { role: "user", content: "hi" },
+        ],
+      }),
     })
     const reqs = mock.getRequests()
     expect(reqs.length).toBeGreaterThanOrEqual(1)
-    const last = reqs[reqs.length - 1] as { body?: { messages?: { role: string; content: unknown }[] } }
-    const sys = (last.body?.messages ?? []).filter((m) => m.role === "system").map((m) => m.content).join("\n")
+    const last = reqs[reqs.length - 1] as {
+      body?: { messages?: { role: string; content: unknown }[] }
+    }
+    const sys = (last.body?.messages ?? [])
+      .filter((m) => m.role === "system")
+      .map((m) => m.content)
+      .join("\n")
     expect(sys).toContain("SYS-MARKER")
   } finally {
     await mock.stop()

--- a/packages/testing/test/harness-fixtures.test.ts
+++ b/packages/testing/test/harness-fixtures.test.ts
@@ -43,3 +43,5 @@ it("captures the system prompt the model received", async () => {
   const run = await h.run({ input: "hello there", fixtures: script().user("hello there").replies("hi") })
   expect(run.systemPrompt).toContain("test agent") // probe app agent systemPrompt: "You are a test agent..."
 }, 60_000)
+
+it("exposes a resume method", () => { expect(typeof h.resume).toBe("function") })

--- a/packages/testing/test/harness-fixtures.test.ts
+++ b/packages/testing/test/harness-fixtures.test.ts
@@ -37,3 +37,9 @@ it("supports a second run() with new fixtures on the same persistent aimock (mul
   expectToolCalled(run2, "applyFilter").withArgs({ status: "closed" })
   expect(run2.finalMessage).toContain("Found 0")
 }, 60_000)
+
+it("captures the system prompt the model received", async () => {
+  h.reset()
+  const run = await h.run({ input: "hello there", fixtures: script().user("hello there").replies("hi") })
+  expect(run.systemPrompt).toContain("test agent") // probe app agent systemPrompt: "You are a test agent..."
+}, 60_000)

--- a/packages/testing/test/harness-fixtures.test.ts
+++ b/packages/testing/test/harness-fixtures.test.ts
@@ -40,8 +40,13 @@ it("supports a second run() with new fixtures on the same persistent aimock (mul
 
 it("captures the system prompt the model received", async () => {
   h.reset()
-  const run = await h.run({ input: "hello there", fixtures: script().user("hello there").replies("hi") })
+  const run = await h.run({
+    input: "hello there",
+    fixtures: script().user("hello there").replies("hi"),
+  })
   expect(run.systemPrompt).toContain("test agent") // probe app agent systemPrompt: "You are a test agent..."
 }, 60_000)
 
-it("exposes a resume method", () => { expect(typeof h.resume).toBe("function") })
+it("exposes a resume method", () => {
+  expect(typeof h.resume).toBe("function")
+})

--- a/packages/testing/test/matchers.test.ts
+++ b/packages/testing/test/matchers.test.ts
@@ -164,3 +164,12 @@ it("expectSystemPrompt.toContain passes when text is in systemPrompt", () => {
 it("expectSystemPrompt.toContain throws when text not found", () => {
   expect(() => expectSystemPrompt(withSystemPrompt).toContain("evil robot")).toThrow()
 })
+
+it("expectPlan.toHaveLength", () => {
+  expectPlan(withPlan).toHaveLength(1)
+  expect(() => expectPlan(withPlan).toHaveLength(999)).toThrow()
+})
+it("expectSystemPrompt.toMatch", () => {
+  expectSystemPrompt(withSystemPrompt).toMatch(/helpful/)
+  expect(() => expectSystemPrompt(withSystemPrompt).toMatch(/nope-xyz/)).toThrow()
+})

--- a/packages/testing/test/matchers.test.ts
+++ b/packages/testing/test/matchers.test.ts
@@ -1,8 +1,13 @@
 import { expect, it } from "vitest"
 import {
   expectFinalMessage,
+  expectInterrupt,
+  expectNoInterrupt,
+  expectPlan,
   expectState,
   expectStreamedTokens,
+  expectSubagent,
+  expectSystemPrompt,
   expectToolCalled,
 } from "../src/matchers.js"
 import type { AgentRunResult } from "../src/run-result.js"
@@ -14,6 +19,12 @@ const base: AgentRunResult = {
   finalMessage: "Found 2 items.",
   messages: [{}, {}, {}, {}],
   state: { messages: [{}, {}, {}, {}], runningSummary: { summary: "s" } },
+  interrupts: [],
+  planUpdates: [],
+  todos: [],
+  subagents: [],
+  subagentEvents: [],
+  systemPrompt: "",
 }
 
 it("expectToolCalled passes for a called tool and withArgs subset", () => {
@@ -57,4 +68,99 @@ it("expectOffloaded asserts the tool output was offloaded to a stub", () => {
   } as unknown as AgentRunResult
   expectOffloaded(run, "generateReport")
   expect(() => expectOffloaded(run, "applyFilter")).toThrow()
+})
+
+// ── capability matchers ────────────────────────────────────────────────────
+const withInterrupt: AgentRunResult = {
+  ...base,
+  interrupts: [{ interruptId: "perm-1", kind: "command", detail: { command: "rm -rf tmp" } }],
+}
+const withSubagent: AgentRunResult = {
+  ...base,
+  subagents: [
+    {
+      callId: "c1",
+      name: "research",
+      toolCalls: [{ name: "webSearch", args: { q: "x" } }],
+      finalMessage: "found it",
+    },
+  ],
+  subagentEvents: [
+    { type: "subagent.start", data: { call_id: "c1", subagent: "research" } },
+    { type: "subagent.tool_call", data: { call_id: "c1", tool: "webSearch", input: { q: "x" } } },
+    { type: "subagent.end", data: { call_id: "c1", final_message: "found it" } },
+  ],
+}
+const withPlan: AgentRunResult = {
+  ...base,
+  planUpdates: [
+    { todos: [{ content: "Write tests", status: "pending" }] },
+    { todos: [{ content: "Write tests", status: "completed" }] },
+  ],
+  todos: [{ content: "Write tests", status: "completed" }],
+}
+const withSystemPrompt: AgentRunResult = {
+  ...base,
+  systemPrompt: "You are a helpful assistant.",
+}
+
+it("expectInterrupt.ofKind passes for matching kind", () => {
+  expectInterrupt(withInterrupt).ofKind("command")
+})
+it("expectInterrupt.ofKind throws for wrong kind", () => {
+  expect(() => expectInterrupt(withInterrupt).ofKind("approval")).toThrow()
+})
+it("expectInterrupt.withDetail passes for matching detail subset", () => {
+  expectInterrupt(withInterrupt).withDetail({ command: "rm -rf tmp" })
+})
+it("expectInterrupt.withDetail throws when detail doesn't match", () => {
+  expect(() => expectInterrupt(withInterrupt).withDetail({ command: "other" })).toThrow()
+})
+it("expectInterrupt throws when there are no interrupts", () => {
+  expect(() => expectInterrupt(base).ofKind("command")).toThrow()
+})
+it("expectNoInterrupt passes when there are no interrupts", () => {
+  expectNoInterrupt(base)
+})
+it("expectNoInterrupt throws when there is an interrupt", () => {
+  expect(() => expectNoInterrupt(withInterrupt)).toThrow()
+})
+
+it("expectSubagent.called passes for a known subagent name", () => {
+  expectSubagent(withSubagent).called("research")
+})
+it("expectSubagent.called throws for unknown name", () => {
+  expect(() => expectSubagent(withSubagent).called("unknown")).toThrow()
+})
+it("expectSubagent.calledTool passes when the subagent used the tool", () => {
+  expectSubagent(withSubagent).calledTool("webSearch")
+})
+it("expectSubagent.calledTool throws when tool not called", () => {
+  expect(() => expectSubagent(withSubagent).calledTool("readFile")).toThrow()
+})
+it("expectSubagent.finalMessageContains passes when message contains text", () => {
+  expectSubagent(withSubagent).finalMessageContains("found it")
+})
+it("expectSubagent.finalMessageContains throws when text not found", () => {
+  expect(() => expectSubagent(withSubagent).finalMessageContains("nope")).toThrow()
+})
+
+it("expectPlan.toHaveTodo passes when todo content exists", () => {
+  expectPlan(withPlan).toHaveTodo("Write tests")
+})
+it("expectPlan.toHaveTodo throws when todo content not found", () => {
+  expect(() => expectPlan(withPlan).toHaveTodo("Deploy")).toThrow()
+})
+it("expectPlan.toHaveStatus passes for matching content+status", () => {
+  expectPlan(withPlan).toHaveStatus("Write tests", "completed")
+})
+it("expectPlan.toHaveStatus throws for wrong status", () => {
+  expect(() => expectPlan(withPlan).toHaveStatus("Write tests", "pending")).toThrow()
+})
+
+it("expectSystemPrompt.toContain passes when text is in systemPrompt", () => {
+  expectSystemPrompt(withSystemPrompt).toContain("helpful assistant")
+})
+it("expectSystemPrompt.toContain throws when text not found", () => {
+  expect(() => expectSystemPrompt(withSystemPrompt).toContain("evil robot")).toThrow()
 })

--- a/packages/testing/test/matchers.test.ts
+++ b/packages/testing/test/matchers.test.ts
@@ -119,6 +119,9 @@ it("expectInterrupt.withDetail throws when detail doesn't match", () => {
 it("expectInterrupt throws when there are no interrupts", () => {
   expect(() => expectInterrupt(base).ofKind("command")).toThrow()
 })
+it("expectInterrupt chains ofKind then withDetail", () => {
+  expectInterrupt(withInterrupt).ofKind("command").withDetail({ command: "rm -rf tmp" })
+})
 it("expectNoInterrupt passes when there are no interrupts", () => {
   expectNoInterrupt(base)
 })
@@ -127,22 +130,28 @@ it("expectNoInterrupt throws when there is an interrupt", () => {
 })
 
 it("expectSubagent.called passes for a known subagent name", () => {
-  expectSubagent(withSubagent).called("research")
+  expectSubagent(withSubagent, "research").called()
 })
 it("expectSubagent.called throws for unknown name", () => {
-  expect(() => expectSubagent(withSubagent).called("unknown")).toThrow()
+  expect(() => expectSubagent(withSubagent, "unknown").called()).toThrow()
 })
 it("expectSubagent.calledTool passes when the subagent used the tool", () => {
-  expectSubagent(withSubagent).calledTool("webSearch")
+  expectSubagent(withSubagent, "research").calledTool("webSearch")
 })
 it("expectSubagent.calledTool throws when tool not called", () => {
-  expect(() => expectSubagent(withSubagent).calledTool("readFile")).toThrow()
+  expect(() => expectSubagent(withSubagent, "research").calledTool("readFile")).toThrow()
+})
+it("expectSubagent.calledTool throws when subagent not dispatched", () => {
+  expect(() => expectSubagent(withSubagent, "unknown").calledTool("webSearch")).toThrow()
 })
 it("expectSubagent.finalMessageContains passes when message contains text", () => {
-  expectSubagent(withSubagent).finalMessageContains("found it")
+  expectSubagent(withSubagent, "research").finalMessageContains("found it")
 })
 it("expectSubagent.finalMessageContains throws when text not found", () => {
-  expect(() => expectSubagent(withSubagent).finalMessageContains("nope")).toThrow()
+  expect(() => expectSubagent(withSubagent, "research").finalMessageContains("nope")).toThrow()
+})
+it("expectSubagent.finalMessageContains throws when subagent not dispatched", () => {
+  expect(() => expectSubagent(withSubagent, "unknown").finalMessageContains("found it")).toThrow()
 })
 
 it("expectPlan.toHaveTodo passes when todo content exists", () => {

--- a/packages/testing/test/run-result.test.ts
+++ b/packages/testing/test/run-result.test.ts
@@ -49,3 +49,38 @@ it("passes through already-parsed tool-call args", async () => {
   const r = await collectRunResult(s() as never, "t")
   expect(r.toolCalls[0]?.args).toEqual({ a: 1 })
 })
+
+it("captures interrupts, plan updates, and folds subagent events", async () => {
+  async function* s() {
+    yield { type: "interrupt", data: { interruptId: "perm-1", kind: "command", detail: { command: "rm -rf tmp" } } }
+    yield { type: "plan_update", data: { todos: [{ content: "A", status: "pending" }] } }
+    yield { type: "plan_update", data: { todos: [{ content: "A", status: "completed" }] } }
+    yield { type: "subagent.start", data: { call_id: "c1", subagent: "research" } }
+    yield { type: "subagent.tool_call", data: { call_id: "c1", tool: "webSearch", input: { q: "x" } } }
+    yield { type: "subagent.end", data: { call_id: "c1", final_message: "found it" } }
+    yield { type: "done", output: { messages: [] } }
+  }
+  const r = await collectRunResult(s() as never, "t")
+  expect(r.interrupts).toEqual([{ interruptId: "perm-1", kind: "command", detail: { command: "rm -rf tmp" } }])
+  expect(r.planUpdates).toHaveLength(2)
+  expect(r.todos).toEqual([{ content: "A", status: "completed" }])
+  expect(r.subagents).toHaveLength(1)
+  expect(r.subagents[0]).toMatchObject({ name: "research", callId: "c1", finalMessage: "found it" })
+  expect(r.subagents[0]?.toolCalls).toEqual([{ name: "webSearch", args: { q: "x" } }])
+  expect(r.subagentEvents.length).toBeGreaterThanOrEqual(3)
+})
+it("captures a subagent error end", async () => {
+  async function* s() {
+    yield { type: "subagent.start", data: { call_id: "c1", subagent: "research" } }
+    yield { type: "subagent.end", data: { call_id: "c1", error: "boom" } }
+    yield { type: "done", output: { messages: [] } }
+  }
+  const r = await collectRunResult(s() as never, "t")
+  expect(r.subagents[0]).toMatchObject({ name: "research", error: "boom" })
+})
+it("defaults the new fields to empty when absent", async () => {
+  async function* s() { yield { type: "done", output: { messages: [] } } }
+  const r = await collectRunResult(s() as never, "t")
+  expect(r.interrupts).toEqual([]); expect(r.planUpdates).toEqual([]); expect(r.todos).toEqual([])
+  expect(r.subagents).toEqual([]); expect(r.systemPrompt).toBe("")
+})

--- a/packages/testing/test/run-result.test.ts
+++ b/packages/testing/test/run-result.test.ts
@@ -52,16 +52,24 @@ it("passes through already-parsed tool-call args", async () => {
 
 it("captures interrupts, plan updates, and folds subagent events", async () => {
   async function* s() {
-    yield { type: "interrupt", data: { interruptId: "perm-1", kind: "command", detail: { command: "rm -rf tmp" } } }
+    yield {
+      type: "interrupt",
+      data: { interruptId: "perm-1", kind: "command", detail: { command: "rm -rf tmp" } },
+    }
     yield { type: "plan_update", data: { todos: [{ content: "A", status: "pending" }] } }
     yield { type: "plan_update", data: { todos: [{ content: "A", status: "completed" }] } }
     yield { type: "subagent.start", data: { call_id: "c1", subagent: "research" } }
-    yield { type: "subagent.tool_call", data: { call_id: "c1", tool: "webSearch", input: { q: "x" } } }
+    yield {
+      type: "subagent.tool_call",
+      data: { call_id: "c1", tool: "webSearch", input: { q: "x" } },
+    }
     yield { type: "subagent.end", data: { call_id: "c1", final_message: "found it" } }
     yield { type: "done", output: { messages: [] } }
   }
   const r = await collectRunResult(s() as never, "t")
-  expect(r.interrupts).toEqual([{ interruptId: "perm-1", kind: "command", detail: { command: "rm -rf tmp" } }])
+  expect(r.interrupts).toEqual([
+    { interruptId: "perm-1", kind: "command", detail: { command: "rm -rf tmp" } },
+  ])
   expect(r.planUpdates).toHaveLength(2)
   expect(r.todos).toEqual([{ content: "A", status: "completed" }])
   expect(r.subagents).toHaveLength(1)
@@ -79,8 +87,13 @@ it("captures a subagent error end", async () => {
   expect(r.subagents[0]).toMatchObject({ name: "research", error: "boom" })
 })
 it("defaults the new fields to empty when absent", async () => {
-  async function* s() { yield { type: "done", output: { messages: [] } } }
+  async function* s() {
+    yield { type: "done", output: { messages: [] } }
+  }
   const r = await collectRunResult(s() as never, "t")
-  expect(r.interrupts).toEqual([]); expect(r.planUpdates).toEqual([]); expect(r.todos).toEqual([])
-  expect(r.subagents).toEqual([]); expect(r.systemPrompt).toBe("")
+  expect(r.interrupts).toEqual([])
+  expect(r.planUpdates).toEqual([])
+  expect(r.todos).toEqual([])
+  expect(r.subagents).toEqual([])
+  expect(r.systemPrompt).toBe("")
 })

--- a/vitest.workspace.ts
+++ b/vitest.workspace.ts
@@ -11,7 +11,9 @@ export default defineConfig({
       "./packages/langchain/vitest.config.ts",
       "./packages/langgraph/vitest.config.ts",
       "./packages/sdk/vitest.config.ts",
+      "./packages/testing/vitest.config.ts",
       "./packages/vite-plugin/vitest.config.ts",
+      "./examples/chat/server/vitest.config.ts",
     ],
   },
 })


### PR DESCRIPTION
## `@dawn-ai/testing` capability coverage + harness extensions

Extends `@dawn-ai/testing` to cover the remaining Phase-3 capabilities and dogfoods all five in-process against the real example apps. Spec: `docs/superpowers/specs/2026-06-06-testing-capability-coverage-design.md`.

### Harness extensions (`@dawn-ai/testing`)
- `AgentRunResult` now captures **interrupts**, **plan updates** (`todos`), **subagent runs** (folded by `call_id`), and the **composed system prompt** (read from aimock's request journal via the new `AimockHandle.getRequests()`).
- New `harness.resume({ decision })` drives HITL interrupt→resume flows (shared `drive()` helper backs `run()` + `resume()`).
- New matchers: `expectInterrupt().ofKind()/.withDetail()`, `expectNoInterrupt`, `expectSubagent(run,name).called()/.calledTool()/.finalMessageContains()`, `expectPlan().toHaveTodo()/.toHaveStatus()/.toHaveLength()`, `expectSystemPrompt().toContain()/.toMatch()`. Signatures aligned to the existing `expectToolCalled(run, name)` convention.

### Dogfood (in-process, real example apps)
HITL permissions (interrupt→resume + allow-listed no-interrupt), subagents (coordinator `task`→research), planning (`writeTodos`→plan), skills (`# Skills` + `readSkill`), AGENTS.md memory. Each false-green-verified.

### Framework fix (`@dawn-ai/core`) — surfaced by dogfooding
The workspace + AGENTS.md capabilities now activate relative to the **app root** instead of `process.cwd()`, so they work when an app runs from any cwd (in-process tests, embedded use). **No-op under `dawn dev`** (cwd === appRoot); mirrors the prior `buildOffload(appRoot)` fix. `CapabilityMarkerContext` gains a required `appRoot` field. Also fixed: gpt-5/reasoning routes send the system prompt under the `developer` role, now recognized by the harness's prompt capture.

### CI
Added `@dawn-ai/testing` (previously absent — its tests never ran in CI) and the chat-example capability e2e to the vitest workspace.

### Validation
`@dawn-ai/testing` 59/59, `@dawn-ai/core` 152/152, `@dawn-ai/langchain` 157/157, capability e2e 6/6 (under the CI repo-root cwd), build/typecheck/lint clean. The one `@dawn-ai/cli` `run-command` failure is the known macOS-only `/private/tmp` artifact (passes on Linux CI).

Changeset: `@dawn-ai/testing` + `@dawn-ai/core` minor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
