### PR TITLE
fix(cli): add sqlite-storage project reference to tsconfig.build (unblocks release)

### DIFF
--- a/packages/cli/tsconfig.build.json
+++ b/packages/cli/tsconfig.build.json
@@ -9,7 +9,8 @@
       "@dawn-ai/langchain": ["../langchain/src/index.ts"],
       "@dawn-ai/langgraph": ["../langgraph/src/index.ts"],
       "@dawn-ai/langgraph/*": ["../langgraph/src/*.ts"],
-      "@dawn-ai/permissions": ["../permissions/src/index.ts"]
+      "@dawn-ai/permissions": ["../permissions/src/index.ts"],
+      "@dawn-ai/sqlite-storage": ["../sqlite-storage/src/index.ts"]
     },
     "rootDir": "src"
   },
@@ -26,6 +27,9 @@
     },
     {
       "path": "../permissions"
+    },
+    {
+      "path": "../sqlite-storage"
     }
   ]
 }


### PR DESCRIPTION
## Problem

The release pipeline (`release.yml` → Validate Release Candidate → `pnpm ci:validate`) is red on `main`. `create-dawn-ai-app#build` exits 2 with:

```
error TS2307: Cannot find module '@dawn-ai/sqlite-storage' or its corresponding type declarations.
  ../cli/src/lib/dev/runtime-server.ts(4,43)
  ../cli/src/lib/runtime/execute-route.ts(29,...)
```

The `cli` imports `@dawn-ai/sqlite-storage` (value import in `execute-route.ts`, type import in `runtime-server.ts`) and declares it as a `workspace:*` dependency, but `packages/cli/tsconfig.build.json` omitted **both** the project reference and the `paths` mapping for it. In cold `tsc -b` builds — notably `create-dawn-ai-app`'s build script, which compiles the cli from source — sqlite-storage's `dist` may not be emitted yet, so resolution fails and blocks the release-candidate validation.

## Fix

Add `@dawn-ai/sqlite-storage` to `cli/tsconfig.build.json`'s `references` and `compilerOptions.paths`, matching the existing pattern for core/langchain/langgraph/permissions. This makes `tsc -b` build sqlite-storage from source before the cli, removing the ordering dependency on a pre-built `dist`.

## Verification

- Full clean turbo build (`rm -rf` all `dist`/`*.tsbuildinfo` → `pnpm build`): **15/15 successful** (previously failed at `@dawn-ai/cli#build`).
- Cold `create-dawn-ai-app` build (its `tsc -b ... cli/tsconfig.build.json` script) with sqlite-storage/cli/create-dawn-app dist cleaned: **passes** (previously TS2307).

No published runtime artifact changes — build-config only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)