### PR TITLE
feat(create-dawn-app): scaffold a sample @dawn-ai/testing agent test in new apps

### DIFF
--- a/.changeset/scaffold-sample-agent-test.md
+++ b/.changeset/scaffold-sample-agent-test.md
@@ -1,0 +1,6 @@
+---
+"create-dawn-ai-app": minor
+"@dawn-ai/devkit": patch
+---
+
+`create-dawn-ai-app` now scaffolds a working `test/agent.test.ts` in new apps: it imports `@dawn-ai/testing`, adds it (plus `vitest`) to devDependencies, and wires a `"test": "vitest run"` script. The sample drives the generated `hello/[tenant]` agent route through `createAgentHarness` with an inline `script()` fixture, so a freshly scaffolded app has a passing, CI-safe agent test out of the box. This was deferred until `@dawn-ai/testing` was published to npm (now at 1.0.0).

--- a/apps/web/content/docs/testing-agents.mdx
+++ b/apps/web/content/docs/testing-agents.mdx
@@ -256,6 +256,39 @@ it.skipIf(!process.env.OPENAI_API_KEY)("filters open items against real model", 
 
 Do not put your API key in CI. Live tests are local-development tools for validating prompt changes against a real model before you mint or update fixture files.
 
+## Your scaffolded app already has a test
+
+`create-dawn-ai-app` generates `test/agent.test.ts` that imports `@dawn-ai/testing` and covers the default `hello/[tenant]` agent route. Run it immediately after scaffolding:
+
+```bash
+pnpm test
+```
+
+The generated test uses an inline `script()` for the happy-path scenario:
+
+```ts title="test/agent.test.ts"
+import { fileURLToPath } from "node:url"
+import { afterAll, it } from "vitest"
+import { createAgentHarness, expectFinalMessage, script } from "@dawn-ai/testing"
+
+const appRoot = fileURLToPath(new URL("..", import.meta.url))
+const h = await createAgentHarness({ appRoot, route: "/hello/[tenant]#agent" })
+afterAll(() => h.close())
+
+it("greets the tenant", async () => {
+  const run = await h.run({
+    input: "Say hello",
+    fixtures: script().user("Say hello").replies("Hello from Acme!"),
+  })
+  expectFinalMessage(run).toContain("Hello")
+}, 60_000)
+```
+
+Grow it by:
+
+1. **Adding more `script()` scenarios** — one `it` block per behaviour you want to pin.
+2. **Committing fixtures for complex flows** — use `writeFixtures` / `record` + `loadFixtures` for multi-turn or multi-tool scenarios that are tedious to hand-write.
+
 ## Related
 
 <RelatedCards items={[

--- a/packages/create-dawn-app/src/index.ts
+++ b/packages/create-dawn-app/src/index.ts
@@ -181,6 +181,7 @@ function createTemplateReplacements(
   readonly dawnPermissionsSpecifier: string
   readonly dawnSdkSpecifier: string
   readonly dawnSqliteStorageSpecifier: string
+  readonly dawnTestingSpecifier: string
   readonly dawnWorkspaceSpecifier: string
 } {
   if (options.mode === "internal") {
@@ -200,6 +201,7 @@ function createTemplateReplacements(
       dawnSqliteStorageSpecifier: createAbsoluteFileSpecifier(
         resolve(repoRoot, "packages/sqlite-storage"),
       ),
+      dawnTestingSpecifier: createAbsoluteFileSpecifier(resolve(repoRoot, "packages/testing")),
       dawnWorkspaceSpecifier: createAbsoluteFileSpecifier(resolve(repoRoot, "packages/workspace")),
     }
   }
@@ -214,6 +216,7 @@ function createTemplateReplacements(
     dawnPermissionsSpecifier: options.distTag,
     dawnSdkSpecifier: options.distTag,
     dawnSqliteStorageSpecifier: options.distTag,
+    dawnTestingSpecifier: options.distTag,
     dawnWorkspaceSpecifier: options.distTag,
   }
 }
@@ -243,6 +246,7 @@ async function applyInternalModePackageOverrides(
       "@dawn-ai/permissions": replacements.dawnPermissionsSpecifier,
       "@dawn-ai/sdk": replacements.dawnSdkSpecifier,
       "@dawn-ai/sqlite-storage": replacements.dawnSqliteStorageSpecifier,
+      "@dawn-ai/testing": replacements.dawnTestingSpecifier,
       "@dawn-ai/workspace": replacements.dawnWorkspaceSpecifier,
     },
   }

--- a/packages/create-dawn-app/test/create-app.test.ts
+++ b/packages/create-dawn-app/test/create-app.test.ts
@@ -81,6 +81,7 @@ describe("create-dawn-ai-app", () => {
     await assertExists(join(targetDir, "src/app/(public)/hello/[tenant]/index.ts"))
     await assertExists(join(targetDir, "src/app/(public)/hello/[tenant]/state.ts"))
     await assertExists(join(targetDir, "src/app/(public)/hello/[tenant]/tools/greet.ts"))
+    await assertExists(join(targetDir, "test/agent.test.ts"))
 
     const packageJson = JSON.parse(await readFile(join(targetDir, "package.json"), "utf8")) as {
       readonly name: string
@@ -91,15 +92,18 @@ describe("create-dawn-ai-app", () => {
 
     expect(packageJson.name).toBe("hello-dawn")
     expect(packageJson.scripts.build).toBe("tsc -p tsconfig.json")
+    expect(packageJson.scripts.test).toBe("vitest run")
     expect(packageJson.scripts.typecheck).toBe("tsc --noEmit")
     expect(packageJson.dependencies["@dawn-ai/core"]).not.toMatch(/^file:/)
     expect(packageJson.dependencies["@dawn-ai/cli"]).not.toMatch(/^file:/)
     expect(packageJson.dependencies["@dawn-ai/langchain"]).not.toMatch(/^file:/)
     expect(packageJson.devDependencies["@dawn-ai/config-typescript"]).not.toMatch(/^file:/)
+    expect(packageJson.devDependencies["@dawn-ai/testing"]).not.toMatch(/^file:/)
     expect(packageJson.dependencies["@dawn-ai/core"]).toBe("next")
     expect(packageJson.dependencies["@dawn-ai/cli"]).toBe("next")
     expect(packageJson.dependencies["@dawn-ai/langchain"]).toBe("next")
     expect(packageJson.devDependencies["@dawn-ai/config-typescript"]).toBe("next")
+    expect(packageJson.devDependencies["@dawn-ai/testing"]).toBe("next")
     await expect(access(join(targetDir, ".npmrc"), constants.F_OK)).rejects.toThrow()
   })
 
@@ -139,13 +143,16 @@ describe("create-dawn-ai-app", () => {
     }
 
     expect(packageJson.scripts.build).toBe("tsc -p tsconfig.json")
+    expect(packageJson.scripts.test).toBe("vitest run")
     expect(packageJson.dependencies["@dawn-ai/core"]).toMatch(/^file:/)
     expect(packageJson.dependencies["@dawn-ai/cli"]).toMatch(/^file:/)
     expect(packageJson.dependencies["@dawn-ai/langchain"]).toMatch(/^file:/)
     expect(packageJson.devDependencies["@dawn-ai/config-typescript"]).toMatch(/^file:/)
+    expect(packageJson.devDependencies["@dawn-ai/testing"]).toMatch(/^file:/)
     await assertExists(join(targetDir, "src/app/(public)/hello/[tenant]/index.ts"))
     await assertExists(join(targetDir, "src/app/(public)/hello/[tenant]/state.ts"))
     await assertExists(join(targetDir, "src/app/(public)/hello/[tenant]/tools/greet.ts"))
+    await assertExists(join(targetDir, "test/agent.test.ts"))
     await assertExists(join(targetDir, ".npmrc"))
   })
 

--- a/packages/devkit/src/testing/generated-app.ts
+++ b/packages/devkit/src/testing/generated-app.ts
@@ -11,6 +11,7 @@ export interface GeneratedAppSpecifiers {
   readonly dawnCore: string
   readonly dawnLangchain: string
   readonly dawnSdk: string
+  readonly dawnTesting: string
 }
 
 export interface CreateGeneratedAppOptions {
@@ -47,6 +48,7 @@ export async function createGeneratedApp(
       dawnCoreSpecifier: specifiers.dawnCore,
       dawnLangchainSpecifier: specifiers.dawnLangchain,
       dawnSdkSpecifier: specifiers.dawnSdk,
+      dawnTestingSpecifier: specifiers.dawnTesting,
     },
     targetDir: appRoot,
     templateDir,
@@ -71,5 +73,6 @@ function normalizeSpecifiers(
     dawnCore: specifiers?.dawnCore ?? "workspace:*",
     dawnLangchain: specifiers?.dawnLangchain ?? "workspace:*",
     dawnSdk: specifiers?.dawnSdk ?? "workspace:*",
+    dawnTesting: specifiers?.dawnTesting ?? "workspace:*",
   }
 }

--- a/packages/devkit/templates/app-basic/package.json.template
+++ b/packages/devkit/templates/app-basic/package.json.template
@@ -5,6 +5,7 @@
   "scripts": {
     "check": "dawn check",
     "build": "tsc -p tsconfig.json",
+    "test": "vitest run",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
@@ -16,7 +17,9 @@
   },
   "devDependencies": {
     "@dawn-ai/config-typescript": "{{dawnConfigTypescriptSpecifier}}",
+    "@dawn-ai/testing": "{{dawnTestingSpecifier}}",
     "@types/node": "25.6.0",
-    "typescript": "6.0.2"
+    "typescript": "6.0.2",
+    "vitest": "4.1.4"
   }
 }

--- a/packages/devkit/templates/app-basic/test/agent.test.ts.template
+++ b/packages/devkit/templates/app-basic/test/agent.test.ts.template
@@ -1,0 +1,15 @@
+import { fileURLToPath } from "node:url"
+import { afterAll, it } from "vitest"
+import { createAgentHarness, expectFinalMessage, script } from "@dawn-ai/testing"
+
+const appRoot = fileURLToPath(new URL("..", import.meta.url))
+const h = await createAgentHarness({ appRoot, route: "/hello/[tenant]#agent" })
+afterAll(() => h.close())
+
+it("greets the tenant", async () => {
+  const run = await h.run({
+    input: "Say hello",
+    fixtures: script().user("Say hello").replies("Hello from Acme!"),
+  })
+  expectFinalMessage(run).toContain("Hello")
+}, 60_000)

--- a/packages/devkit/test/generated-app.test.ts
+++ b/packages/devkit/test/generated-app.test.ts
@@ -1,4 +1,5 @@
-import { mkdtemp, readFile, rm } from "node:fs/promises"
+import { constants } from "node:fs"
+import { access, mkdtemp, readFile, rm } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { resolve } from "node:path"
 
@@ -37,6 +38,11 @@ describe("generated app helper", () => {
       expect(packageJson).toContain('"@dawn-ai/langchain": "workspace:*"')
       expect(packageJson).toContain('"@dawn-ai/sdk": "workspace:*"')
       expect(packageJson).toContain('"@dawn-ai/config-typescript": "workspace:*"')
+      expect(packageJson).toContain('"@dawn-ai/testing": "workspace:*"')
+      expect(packageJson).toContain('"test": "vitest run"')
+      await expect(
+        access(resolve(generatedApp.appRoot, "test/agent.test.ts"), constants.F_OK),
+      ).resolves.toBeUndefined()
     } finally {
       await rm(baseDir, { force: true, recursive: true })
     }

--- a/test/generated/fixtures/basic.expected.json
+++ b/test/generated/fixtures/basic.expected.json
@@ -6,6 +6,7 @@
     "scripts": {
       "check": "dawn check",
       "build": "tsc -p tsconfig.json",
+      "test": "vitest run",
       "typecheck": "tsc --noEmit"
     },
     "dependencies": {
@@ -18,8 +19,10 @@
     },
     "devDependencies": {
       "@dawn-ai/config-typescript": "<tarball:@dawn-ai/config-typescript>",
+      "@dawn-ai/testing": "<tarball:@dawn-ai/testing>",
       "@types/node": "<version:@types/node>",
-      "typescript": "<version:typescript>"
+      "typescript": "<version:typescript>",
+      "vitest": "<version:vitest>"
     },
     "pnpm": {
       "overrides": {
@@ -31,6 +34,7 @@
         "@dawn-ai/permissions": "<tarball:@dawn-ai/permissions>",
         "@dawn-ai/sdk": "<tarball:@dawn-ai/sdk>",
         "@dawn-ai/sqlite-storage": "<tarball:@dawn-ai/sqlite-storage>",
+        "@dawn-ai/testing": "<tarball:@dawn-ai/testing>",
         "@dawn-ai/workspace": "<tarball:@dawn-ai/workspace>"
       }
     }

--- a/test/generated/fixtures/custom-app-dir.expected.json
+++ b/test/generated/fixtures/custom-app-dir.expected.json
@@ -6,6 +6,7 @@
     "scripts": {
       "check": "dawn check",
       "build": "tsc -p tsconfig.json",
+      "test": "vitest run",
       "typecheck": "tsc --noEmit"
     },
     "dependencies": {
@@ -18,8 +19,10 @@
     },
     "devDependencies": {
       "@dawn-ai/config-typescript": "<tarball:@dawn-ai/config-typescript>",
+      "@dawn-ai/testing": "<tarball:@dawn-ai/testing>",
       "@types/node": "<version:@types/node>",
-      "typescript": "<version:typescript>"
+      "typescript": "<version:typescript>",
+      "vitest": "<version:vitest>"
     },
     "pnpm": {
       "overrides": {
@@ -31,6 +34,7 @@
         "@dawn-ai/permissions": "<tarball:@dawn-ai/permissions>",
         "@dawn-ai/sdk": "<tarball:@dawn-ai/sdk>",
         "@dawn-ai/sqlite-storage": "<tarball:@dawn-ai/sqlite-storage>",
+        "@dawn-ai/testing": "<tarball:@dawn-ai/testing>",
         "@dawn-ai/workspace": "<tarball:@dawn-ai/workspace>"
       }
     }

--- a/test/generated/harness.ts
+++ b/test/generated/harness.ts
@@ -42,6 +42,7 @@ interface PackedTarballs {
   readonly permissions: string
   readonly sdk: string
   readonly sqliteStorage: string
+  readonly testing: string
   readonly workspace: string
 }
 
@@ -171,6 +172,7 @@ export async function prepareGeneratedRuntimeApp(options: {
           "@dawn-ai/permissions",
           "@dawn-ai/sdk",
           "@dawn-ai/sqlite-storage",
+          "@dawn-ai/testing",
           "@dawn-ai/workspace",
         ],
         tempRoot: options.tempRoot,
@@ -458,6 +460,7 @@ async function rewriteDependenciesToTarballs(options: {
   packageJson.devDependencies = {
     ...packageJson.devDependencies,
     "@dawn-ai/config-typescript": options.tarballs.configTypescript,
+    "@dawn-ai/testing": options.tarballs.testing,
   }
   packageJson.pnpm = {
     ...(packageJson.pnpm ?? {}),
@@ -471,6 +474,7 @@ async function rewriteDependenciesToTarballs(options: {
       "@dawn-ai/permissions": options.tarballs.permissions,
       "@dawn-ai/sdk": options.tarballs.sdk,
       "@dawn-ai/sqlite-storage": options.tarballs.sqliteStorage,
+      "@dawn-ai/testing": options.tarballs.testing,
       "@dawn-ai/workspace": options.tarballs.workspace,
     },
   }
@@ -668,6 +672,7 @@ function toPackedTarballs(tarballs: Readonly<Record<string, string>>): PackedTar
     permissions: tarballs["@dawn-ai/permissions"]!,
     sdk: tarballs["@dawn-ai/sdk"],
     sqliteStorage: tarballs["@dawn-ai/sqlite-storage"]!,
+    testing: tarballs["@dawn-ai/testing"]!,
     workspace: tarballs["@dawn-ai/workspace"]!,
   }
 }

--- a/test/generated/run-generated-app.test.ts
+++ b/test/generated/run-generated-app.test.ts
@@ -34,6 +34,7 @@ interface PackedTarballs {
   readonly permissions: string
   readonly sdk: string
   readonly sqliteStorage: string
+  readonly testing: string
   readonly workspace: string
 }
 
@@ -176,6 +177,7 @@ async function runGeneratedAppScenario(
           "@dawn-ai/permissions",
           "@dawn-ai/sdk",
           "@dawn-ai/sqlite-storage",
+          "@dawn-ai/testing",
           "@dawn-ai/workspace",
         ],
         tempRoot,
@@ -307,6 +309,7 @@ async function rewriteDependenciesToTarballs(options: {
   packageJson.devDependencies = {
     ...packageJson.devDependencies,
     "@dawn-ai/config-typescript": options.tarballs.configTypescript,
+    "@dawn-ai/testing": options.tarballs.testing,
   }
   packageJson.pnpm = {
     ...(packageJson.pnpm ?? {}),
@@ -320,6 +323,7 @@ async function rewriteDependenciesToTarballs(options: {
       "@dawn-ai/permissions": options.tarballs.permissions,
       "@dawn-ai/sdk": options.tarballs.sdk,
       "@dawn-ai/sqlite-storage": options.tarballs.sqliteStorage,
+      "@dawn-ai/testing": options.tarballs.testing,
       "@dawn-ai/workspace": options.tarballs.workspace,
     },
   }
@@ -529,6 +533,7 @@ async function createExpectedInternalFixture(
       devDependencies: {
         ...expected.packageJson.devDependencies,
         "@dawn-ai/config-typescript": "<repo:@dawn-ai/config-typescript>",
+        "@dawn-ai/testing": "<repo:@dawn-ai/testing>",
       },
       pnpm: {
         overrides: {
@@ -540,6 +545,7 @@ async function createExpectedInternalFixture(
           "@dawn-ai/permissions": "<repo:@dawn-ai/permissions>",
           "@dawn-ai/sdk": "<repo:@dawn-ai/sdk>",
           "@dawn-ai/sqlite-storage": "<repo:@dawn-ai/sqlite-storage>",
+          "@dawn-ai/testing": "<repo:@dawn-ai/testing>",
           "@dawn-ai/workspace": "<repo:@dawn-ai/workspace>",
         },
       },
@@ -559,6 +565,7 @@ function toPackedTarballs(tarballs: Readonly<Record<string, string>>): PackedTar
     permissions: tarballs["@dawn-ai/permissions"]!,
     sdk: tarballs["@dawn-ai/sdk"],
     sqliteStorage: tarballs["@dawn-ai/sqlite-storage"]!,
+    testing: tarballs["@dawn-ai/testing"]!,
     workspace: tarballs["@dawn-ai/workspace"]!,
   }
 }
@@ -580,11 +587,13 @@ function normalizeForFixture(
     [context.tarballs.permissions, "<tarball:@dawn-ai/permissions>"],
     [context.tarballs.sdk, "<tarball:@dawn-ai/sdk>"],
     [context.tarballs.sqliteStorage, "<tarball:@dawn-ai/sqlite-storage>"],
+    [context.tarballs.testing, "<tarball:@dawn-ai/testing>"],
     [context.tarballs.workspace, "<tarball:@dawn-ai/workspace>"],
     [`/private${dirname(context.tarballs.cli)}`, "<packs-dir>"],
     [dirname(context.tarballs.cli), "<packs-dir>"],
     ["25.6.0", "<version:@types/node>"],
     ["6.0.2", "<version:typescript>"],
+    ["4.1.4", "<version:vitest>"],
   ]) as GeneratedAppScenarioResult
 }
 
@@ -603,9 +612,11 @@ function normalizeForInternalFixture(
     [pathToRepoPackageFileSpecifier("@dawn-ai/permissions"), "<repo:@dawn-ai/permissions>"],
     [pathToRepoPackageFileSpecifier("@dawn-ai/sdk"), "<repo:@dawn-ai/sdk>"],
     [pathToRepoPackageFileSpecifier("@dawn-ai/sqlite-storage"), "<repo:@dawn-ai/sqlite-storage>"],
+    [pathToRepoPackageFileSpecifier("@dawn-ai/testing"), "<repo:@dawn-ai/testing>"],
     [pathToRepoPackageFileSpecifier("@dawn-ai/workspace"), "<repo:@dawn-ai/workspace>"],
     ["25.6.0", "<version:@types/node>"],
     ["6.0.2", "<version:typescript>"],
+    ["4.1.4", "<version:vitest>"],
   ]) as GeneratedAppScenarioResult
 }
 
@@ -619,6 +630,7 @@ function pathToRepoPackageFileSpecifier(
     | "@dawn-ai/permissions"
     | "@dawn-ai/sdk"
     | "@dawn-ai/sqlite-storage"
+    | "@dawn-ai/testing"
     | "@dawn-ai/workspace",
 ): string {
   const packageDirByName = {
@@ -630,6 +642,7 @@ function pathToRepoPackageFileSpecifier(
     "@dawn-ai/permissions": "packages/permissions",
     "@dawn-ai/sdk": "packages/sdk",
     "@dawn-ai/sqlite-storage": "packages/sqlite-storage",
+    "@dawn-ai/testing": "packages/testing",
     "@dawn-ai/workspace": "packages/workspace",
   } as const
 

--- a/test/runtime/run-agent-protocol.test.ts
+++ b/test/runtime/run-agent-protocol.test.ts
@@ -182,6 +182,7 @@ describe("agent protocol permission interrupt + resume", () => {
           "@dawn-ai/permissions",
           "@dawn-ai/sdk",
           "@dawn-ai/sqlite-storage",
+          "@dawn-ai/testing",
           "@dawn-ai/workspace",
         ],
         tempRoot,
@@ -285,6 +286,7 @@ describe("agent protocol permission interrupt + resume", () => {
           "@dawn-ai/permissions",
           "@dawn-ai/sdk",
           "@dawn-ai/sqlite-storage",
+          "@dawn-ai/testing",
           "@dawn-ai/workspace",
         ],
         tempRoot,
@@ -371,6 +373,7 @@ describe("agent protocol permission interrupt + resume", () => {
             "@dawn-ai/permissions",
             "@dawn-ai/sdk",
             "@dawn-ai/sqlite-storage",
+            "@dawn-ai/testing",
             "@dawn-ai/workspace",
           ],
           tempRoot,
@@ -638,6 +641,7 @@ describe("agent protocol state persistence", () => {
           "@dawn-ai/permissions",
           "@dawn-ai/sdk",
           "@dawn-ai/sqlite-storage",
+          "@dawn-ai/testing",
           "@dawn-ai/workspace",
         ],
         tempRoot,
@@ -815,6 +819,7 @@ async function rewriteDependenciesToTarballs(options: {
   packageJson.devDependencies = {
     ...packageJson.devDependencies,
     "@dawn-ai/config-typescript": options.tarballs["@dawn-ai/config-typescript"],
+    "@dawn-ai/testing": options.tarballs["@dawn-ai/testing"],
   }
   packageJson.pnpm = {
     ...(packageJson.pnpm ?? {}),
@@ -828,6 +833,7 @@ async function rewriteDependenciesToTarballs(options: {
       "@dawn-ai/permissions": options.tarballs["@dawn-ai/permissions"],
       "@dawn-ai/sdk": options.tarballs["@dawn-ai/sdk"],
       "@dawn-ai/sqlite-storage": options.tarballs["@dawn-ai/sqlite-storage"],
+      "@dawn-ai/testing": options.tarballs["@dawn-ai/testing"],
       "@dawn-ai/workspace": options.tarballs["@dawn-ai/workspace"],
     },
   }

--- a/test/runtime/run-runtime-contract.test.ts
+++ b/test/runtime/run-runtime-contract.test.ts
@@ -485,6 +485,7 @@ async function withRuntimeScenario(
           "@dawn-ai/permissions",
           "@dawn-ai/sdk",
           "@dawn-ai/sqlite-storage",
+          "@dawn-ai/testing",
           "@dawn-ai/workspace",
         ],
         tempRoot,
@@ -723,6 +724,7 @@ async function rewriteDependenciesToTarballs(options: {
   packageJson.devDependencies = {
     ...packageJson.devDependencies,
     "@dawn-ai/config-typescript": options.tarballs["@dawn-ai/config-typescript"],
+    "@dawn-ai/testing": options.tarballs["@dawn-ai/testing"],
   }
   packageJson.pnpm = {
     ...(packageJson.pnpm ?? {}),
@@ -736,6 +738,7 @@ async function rewriteDependenciesToTarballs(options: {
       "@dawn-ai/permissions": options.tarballs["@dawn-ai/permissions"],
       "@dawn-ai/sdk": options.tarballs["@dawn-ai/sdk"],
       "@dawn-ai/sqlite-storage": options.tarballs["@dawn-ai/sqlite-storage"],
+      "@dawn-ai/testing": options.tarballs["@dawn-ai/testing"],
       "@dawn-ai/workspace": options.tarballs["@dawn-ai/workspace"],
     },
   }

--- a/test/smoke/run-smoke.test.ts
+++ b/test/smoke/run-smoke.test.ts
@@ -162,6 +162,7 @@ async function runSmokeScenario(fixtureName: SmokeFixtureName): Promise<HarnessL
           "@dawn-ai/permissions",
           "@dawn-ai/sdk",
           "@dawn-ai/sqlite-storage",
+          "@dawn-ai/testing",
           "@dawn-ai/workspace",
         ],
         tempRoot,
@@ -323,6 +324,7 @@ async function rewriteDependenciesToTarballs(options: {
   packageJson.devDependencies = {
     ...packageJson.devDependencies,
     "@dawn-ai/config-typescript": options.tarballs["@dawn-ai/config-typescript"],
+    "@dawn-ai/testing": options.tarballs["@dawn-ai/testing"],
   }
   packageJson.pnpm = {
     ...(packageJson.pnpm ?? {}),
@@ -336,6 +338,7 @@ async function rewriteDependenciesToTarballs(options: {
       "@dawn-ai/permissions": options.tarballs["@dawn-ai/permissions"],
       "@dawn-ai/sdk": options.tarballs["@dawn-ai/sdk"],
       "@dawn-ai/sqlite-storage": options.tarballs["@dawn-ai/sqlite-storage"],
+      "@dawn-ai/testing": options.tarballs["@dawn-ai/testing"],
       "@dawn-ai/workspace": options.tarballs["@dawn-ai/workspace"],
     },
   }


### PR DESCRIPTION
## What

Restores the scaffold sample test (originally #195's `73187f9`, reverted in `74376a9` because `@dawn-ai/testing` wasn't published yet). Now that **`@dawn-ai/testing@1.0.0` is live on npm**, new apps scaffold a passing, CI-safe agent test out of the box.

- **`create-dawn-app`**: thread the `@dawn-ai/testing` specifier through internal (file:) and external (dist-tag) template replacements.
- **devkit template** (`app-basic`): add `test/agent.test.ts.template`, `@dawn-ai/testing` + `vitest` devDeps, and a `"test": "vitest run"` script.
- **devkit `generated-app` helper**: expose the `dawnTesting` specifier.
- **docs**: restore the route-accurate scaffold section in `testing-agents.mdx`.

The scaffolded test drives the generated `hello/[tenant]` agent route through `createAgentHarness` with an inline `script()` fixture.

## Verification

- `@dawn-ai/devkit` unit tests: **5/5** (asserts the template ships the test file, devDep, and script).
- `create-dawn-ai-app` unit tests: **4/4** (asserts generated app shape, internal + external modes).
- Lint + typecheck: clean on both packages.
- **End-to-end:** generated an app via `--mode internal`, `pnpm install` resolved `@dawn-ai/testing@1.0.0`, and `pnpm test` passed **1/1**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)