### PR TITLE
fix: documented papercuts (offload JSON preview + macOS /private path normalization)

### DIFF
--- a/.changeset/offload-preview-pretty-json.md
+++ b/.changeset/offload-preview-pretty-json.md
@@ -1,0 +1,5 @@
+---
+"@dawn-ai/langchain": patch
+---
+
+Tool-output offload stubs now show a readable multi-line preview when the offloaded content is a single-line JSON blob (e.g. a tool that returned an object, whose newlines were escaped). `buildStub` pretty-prints JSON for the preview slice only — the stored file, its content hash, the size threshold, and the tool message content are all unchanged. Plain-text outputs are unaffected.

--- a/packages/cli/test/run-command.test.ts
+++ b/packages/cli/test/run-command.test.ts
@@ -802,7 +802,10 @@ async function invoke(
 }
 
 function normalizePrivatePath(path: string): string {
-  return path.replaceAll("/private/var/", "/var/")
+  // macOS resolves tmpdir paths under /private (e.g. /private/tmp, /private/var);
+  // drop the prefix wherever it appears (paths AND embedded in messages) so
+  // tmp-derived expected paths match process-realpath'd actuals.
+  return path.replaceAll("/private/", "/")
 }
 
 function expectTiming(payload: Record<string, unknown>): void {

--- a/packages/langchain/src/offload/stub.ts
+++ b/packages/langchain/src/offload/stub.ts
@@ -10,7 +10,7 @@ export interface BuildStubArgs {
  * single-line JSON blob (e.g. a tool returned an object, so newlines are escaped
  * as `\n`), pretty-print it so the preview shows readable lines instead of one
  * giant escaped line. Plain-text content (the common case) is returned as-is.
- * Only the preview is affected — the stored file and its hash stay byte-identical.
+ * Only the preview is affected — the stored file and its hash are unchanged.
  */
 function previewSource(content: string): string {
   const trimmed = content.trimStart()

--- a/packages/langchain/src/offload/stub.ts
+++ b/packages/langchain/src/offload/stub.ts
@@ -5,8 +5,27 @@ export interface BuildStubArgs {
   readonly thresholdChars: number
 }
 
+/**
+ * Source text used for the preview slice. When the offloaded content is a
+ * single-line JSON blob (e.g. a tool returned an object, so newlines are escaped
+ * as `\n`), pretty-print it so the preview shows readable lines instead of one
+ * giant escaped line. Plain-text content (the common case) is returned as-is.
+ * Only the preview is affected — the stored file and its hash stay byte-identical.
+ */
+function previewSource(content: string): string {
+  const trimmed = content.trimStart()
+  if (trimmed.startsWith("{") || trimmed.startsWith("[")) {
+    try {
+      return JSON.stringify(JSON.parse(content), null, 2)
+    } catch {
+      // Not valid JSON — fall through to the raw content.
+    }
+  }
+  return content
+}
+
 export function buildStub(args: BuildStubArgs): string {
-  const lines = args.content.split("\n").slice(0, args.previewLines)
+  const lines = previewSource(args.content).split("\n").slice(0, args.previewLines)
   const shown = lines.length
   const preview = lines.join("\n")
   const chars = args.content.length.toLocaleString("en-US")

--- a/packages/langchain/test/offload-stub.test.ts
+++ b/packages/langchain/test/offload-stub.test.ts
@@ -28,4 +28,33 @@ describe("buildStub", () => {
     })
     expect(stub).toContain("only one line")
   })
+
+  it("pretty-prints single-line JSON content for a readable multi-line preview", () => {
+    // A tool that returns an object is JSON.stringify'd to one line with escaped
+    // newlines; the preview should show real lines, not "first 1 line".
+    const content = JSON.stringify({ a: 1, b: { c: 2 }, items: ["x", "y"] })
+    const stub = buildStub({
+      content,
+      relPath: "tool-outputs/obj-1-a.txt",
+      previewLines: 10,
+      thresholdChars: 40000,
+    })
+    // Pretty-printed across multiple readable lines (not one escaped blob).
+    expect(stub).toContain('"a": 1')
+    expect(stub).toContain('"c": 2')
+    expect(stub).not.toContain("first 1 lines")
+  })
+
+  it("leaves non-JSON content untouched in the preview", () => {
+    const content = "plain text line one\nplain text line two"
+    const stub = buildStub({
+      content,
+      relPath: "tool-outputs/txt-1-a.txt",
+      previewLines: 10,
+      thresholdChars: 40000,
+    })
+    expect(stub).toContain("Preview (first 2 lines):")
+    expect(stub).toContain("plain text line one")
+    expect(stub).toContain("plain text line two")
+  })
 })

--- a/test/runtime/run-runtime-contract.test.ts
+++ b/test/runtime/run-runtime-contract.test.ts
@@ -1013,7 +1013,10 @@ async function runCommandWithInput(options: {
 }
 
 function normalizePrivatePath(path: string): string {
-  return path.replaceAll("/private/var/", "/var/")
+  // macOS resolves tmpdir paths under /private (e.g. /private/tmp, /private/var);
+  // drop the prefix wherever it appears (paths AND embedded in messages) so
+  // tmp-derived expected paths match process-realpath'd actuals.
+  return path.replaceAll("/private/", "/")
 }
 
 function createCancellationGraphSource(markerPath: string): string {


### PR DESCRIPTION
Knocks out the low-effort follow-ups documented in `project_phase_status.md`.

## 1. Offload preview shows "first 1 line" for JSON content (`@dawn-ai/langchain`, patch)
A tool returning an object is `JSON.stringify`'d to a single line with escaped `\n`, so the offload stub's preview (which splits on `\n`) showed only "first 1 line" of an unreadable escaped blob. `buildStub` now pretty-prints single-line JSON **for the preview slice only** — the stored file, its content hash, the size threshold, and the tool message content are all byte-identical; plain-text outputs are untouched. Added unit tests for the JSON and plain-text cases.

## 2. macOS `/private/tmp` path normalization (test-only)
On macOS, tmpdir paths resolve under `/private` (`/private/tmp`, `/private/var`), so tmp-derived expected paths didn't match process-realpath'd actuals — causing local-only false failures in `run-command.test.ts` ("modeled app discovery failure") and the runtime-contract lane (`/private/tmp` vs `/tmp`). The `normalizePrivatePath` helpers only stripped `/private/var/`; they now drop the `/private/` prefix wherever it appears (bare paths **and** embedded in error messages), matching the pattern already used in `test/smoke/run-smoke.test.ts`. Green on Linux CI before and after; this just unblocks local macOS runs.

## Verification
- `@dawn-ai/langchain` suite: 159 passing (incl. new stub tests).
- `@dawn-ai/cli` `run-command.test.ts`: 180/180 (was 1 failing locally on macOS).
- `pnpm verify:harness:runtime`: passed locally on macOS (was failing on the `/private/tmp` mismatch).

Note: the langchain patch bumps the `fixed` version group + re-majors `@dawn-ai/testing` per the changeset config — it only queues a Version Packages PR, no auto-publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)