### PR TITLE
refactor(harness): consolidate scaffold packaging + scaffold @dawn-ai/evals

### DIFF
--- a/.changeset/scaffold-evals.md
+++ b/.changeset/scaffold-evals.md
@@ -1,0 +1,6 @@
+---
+"create-dawn-ai-app": minor
+"@dawn-ai/devkit": patch
+---
+
+`create-dawn-ai-app` now scaffolds a sample `@dawn-ai/evals` eval (`evals/smoke.eval.ts`) plus an `eval` script in new apps, alongside the existing `@dawn-ai/testing` sample test, so a freshly scaffolded app can run `dawn eval` out of the box.

--- a/apps/web/content/docs/evals.mdx
+++ b/apps/web/content/docs/evals.mdx
@@ -204,6 +204,16 @@ PASS chat quality mean=1.00
 
 Commit the eval and any fixture files alongside your route. In CI, run `dawn eval` (replay only); locally, run `dawn eval --live` when you want to measure against the real model before updating fixtures.
 
+## Your scaffolded app already has an eval
+
+`create-dawn-ai-app` generates a sample `evals/smoke.eval.ts` next to the default route, adds `@dawn-ai/evals` as a dev dependency, and wires an `eval` script. Run it right after scaffolding:
+
+```bash
+pnpm eval
+```
+
+It replays a committed `script()` fixture against the generated agent route and gates on a `contains` scorer, so it passes deterministically with no API key. Grow it by adding cases to the dataset and more scorers, and switch to `dawn eval --live` when you want to check the real model.
+
 ## Related
 
 <RelatedCards items={[

--- a/docs/superpowers/plans/2026-06-07-harness-packaging-consolidation.md
+++ b/docs/superpowers/plans/2026-06-07-harness-packaging-consolidation.md
@@ -1,0 +1,593 @@
+# Harness-packaging Consolidation + `@dawn-ai/evals` Scaffold — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the 5 copy-pasted `rewriteDependenciesToTarballs` functions + 9 inline `packageNames` lists across the generated-app harness lanes with one shared, data-driven helper, then add `@dawn-ai/evals` to the `create-dawn-app` scaffold template.
+
+**Architecture:** A new `test/harness/scaffold-packaging.ts` exports `SCAFFOLD_PACKAGES` (the canonical workspace-package set to pack) and `rewriteGeneratedAppDependencies` (data-driven: swap any dep present in the packed-tarball map, set `pnpm.overrides` for every packed `SCAFFOLD_PACKAGES` entry, apply per-lane `extraDependencies`/`removeDependencies`). Each lane migrates to it (behavior-preserving — the existing harness lanes are the regression test). Then `@dawn-ai/evals` is added to `SCAFFOLD_PACKAGES` + the template + the `create-dawn-app`/devkit specifier threading.
+
+**Tech Stack:** TypeScript (ESM, `node:` builtins), vitest, pnpm pack/install, the generated-app harness (`test/harness/packaged-app.ts`, `test/generated`, `test/runtime`, `test/smoke`), changesets.
+
+**Spec:** `docs/superpowers/specs/2026-06-07-harness-packaging-consolidation-design.md`
+
+**CRITICAL invariant for the migration tasks (T2–T6):** they are **behavior-preserving**. The proof is that each lane's harness run stays green on a COLD build. A purely visual diff is NOT enough — getting the forced-deps/overrides wrong silently breaks cold installs (the exact 404 trap we're removing). Every migration task MUST run its harness lane to completion. Lanes: `pnpm verify:harness:framework` (covers `test/generated/*`), `pnpm verify:harness:runtime` (covers `test/runtime/*`), `pnpm verify:harness:smoke` (covers `test/smoke/*`). NOTE: on macOS the runtime-contract lane shows false `/private/tmp` failures that pass on CI Linux — if the ONLY failures are `/private/tmp` path-equality, treat the lane as green (the `normalizePrivatePath` helper handles them in the assertion code; a residual is environmental).
+
+---
+
+## Current-state reference (read before starting)
+
+Each lane currently has, inline, a `packageNames` array and a local `rewriteDependenciesToTarballs({ appRoot, tarballs })`. Their differences (confirmed against the code) — the only things that vary:
+
+| Lane file | forced extra direct deps | deletes | tarball key style |
+|---|---|---|---|
+| `test/generated/run-generated-app.test.ts` | none | none | named `PackedTarballs` (`tarballs.cli`) |
+| `test/generated/harness.ts` | none | none | named `PackedTarballs` |
+| `test/runtime/run-runtime-contract.test.ts` | `@dawn-ai/permissions`, `@dawn-ai/sqlite-storage`, `@dawn-ai/workspace` | `langchain`, `@langchain/openai` | string `tarballs["@dawn-ai/cli"]` |
+| `test/runtime/run-agent-protocol.test.ts` (×4 packageNames) | `@dawn-ai/permissions`, `@dawn-ai/sqlite-storage`, `@dawn-ai/workspace`, `@langchain/langgraph: "1.3.0"` | `langchain`, `@langchain/openai` | string |
+| `test/smoke/run-smoke.test.ts` | `@dawn-ai/permissions`, `@dawn-ai/sqlite-storage`, `@dawn-ai/workspace` | `langchain`, `@langchain/openai` | string |
+
+All five set `pnpm.overrides` to the same 10 `@dawn-ai/*` packages. The two generated-app lanes keep direct deps = the template's (`cli`/`core`/`langchain`/`sdk` + devDeps `config-typescript`/`testing`); the runtime/smoke lanes additionally force `permissions`/`sqlite-storage`/`workspace` as direct deps (their custom routes import them). **The forced-extra list does NOT grow when a scaffold dep is added unless that dep is a direct import in those custom runtime routes — `@dawn-ai/evals` is not, so adding it touches none of these per-lane options.**
+
+`test/harness/packaged-app.ts` `createPackagedInstaller({ packageNames })` already prepends `@dawn-ai/devkit` + `create-dawn-ai-app`, dedupes, packs each, returns `{ installerDir, tarballs: Record<string,string> }`.
+
+---
+
+## Task 1: Shared `scaffold-packaging` helper
+
+**Files:**
+- Create: `test/harness/scaffold-packaging.ts`
+- Test: `test/harness/scaffold-packaging.test.ts`
+
+> Note: `SCAFFOLD_PACKAGES` here is the CURRENT set (no `@dawn-ai/evals` yet) so T1–T6 are a pure behavior-preserving refactor. `@dawn-ai/evals` is added in Task 7.
+
+- [ ] **Step 1: Write the failing test `test/harness/scaffold-packaging.test.ts`**
+
+```typescript
+import { mkdtemp, readFile, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { describe, expect, it } from "vitest"
+import { rewriteGeneratedAppDependencies, SCAFFOLD_PACKAGES } from "./scaffold-packaging.js"
+
+async function makePkg(contents: unknown): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "scaffold-pkg-"))
+  await writeFile(join(dir, "package.json"), JSON.stringify(contents), "utf8")
+  return dir
+}
+async function readPkg(dir: string): Promise<any> {
+  return JSON.parse(await readFile(join(dir, "package.json"), "utf8"))
+}
+
+const tarballs = {
+  "@dawn-ai/cli": "/packs/cli.tgz",
+  "@dawn-ai/core": "/packs/core.tgz",
+  "@dawn-ai/permissions": "/packs/permissions.tgz",
+  "@dawn-ai/sqlite-storage": "/packs/sqlite.tgz",
+  "@dawn-ai/workspace": "/packs/workspace.tgz",
+  "@dawn-ai/config-typescript": "/packs/config-ts.tgz",
+  "@dawn-ai/devkit": "/packs/devkit.tgz", // present in tarballs but NOT in overrides
+  "create-dawn-ai-app": "/packs/create.tgz",
+}
+
+describe("SCAFFOLD_PACKAGES", () => {
+  it("lists @dawn-ai workspace packages, excluding devkit/create-dawn-ai-app", () => {
+    expect(SCAFFOLD_PACKAGES).toContain("@dawn-ai/cli")
+    expect(SCAFFOLD_PACKAGES).toContain("@dawn-ai/testing")
+    expect(SCAFFOLD_PACKAGES).not.toContain("@dawn-ai/devkit")
+    expect(SCAFFOLD_PACKAGES).not.toContain("create-dawn-ai-app")
+  })
+})
+
+describe("rewriteGeneratedAppDependencies", () => {
+  it("swaps existing deps/devDeps that are in the tarball map, leaves unknown deps untouched", async () => {
+    const dir = await makePkg({
+      dependencies: { "@dawn-ai/cli": "next", "@dawn-ai/core": "next", zod: "^3.24.0" },
+      devDependencies: { "@dawn-ai/config-typescript": "next", vitest: "4.1.4" },
+    })
+    await rewriteGeneratedAppDependencies({ appRoot: dir, tarballs })
+    const pkg = await readPkg(dir)
+    expect(pkg.dependencies["@dawn-ai/cli"]).toBe("/packs/cli.tgz")
+    expect(pkg.dependencies["@dawn-ai/core"]).toBe("/packs/core.tgz")
+    expect(pkg.dependencies.zod).toBe("^3.24.0")
+    expect(pkg.devDependencies["@dawn-ai/config-typescript"]).toBe("/packs/config-ts.tgz")
+    expect(pkg.devDependencies.vitest).toBe("4.1.4")
+  })
+
+  it("sets pnpm.overrides for every packed SCAFFOLD package (not devkit/create-app)", async () => {
+    const dir = await makePkg({ dependencies: { "@dawn-ai/cli": "next" } })
+    await rewriteGeneratedAppDependencies({ appRoot: dir, tarballs })
+    const pkg = await readPkg(dir)
+    expect(pkg.pnpm.overrides["@dawn-ai/cli"]).toBe("/packs/cli.tgz")
+    expect(pkg.pnpm.overrides["@dawn-ai/permissions"]).toBe("/packs/permissions.tgz")
+    expect(pkg.pnpm.overrides["@dawn-ai/devkit"]).toBeUndefined()
+    expect(pkg.pnpm.overrides["create-dawn-ai-app"]).toBeUndefined()
+  })
+
+  it("applies extraDependencies (forced direct deps + version strings) and removeDependencies", async () => {
+    const dir = await makePkg({
+      dependencies: { "@dawn-ai/cli": "next", langchain: "0.3.0", "@langchain/openai": "0.3.0" },
+    })
+    await rewriteGeneratedAppDependencies({
+      appRoot: dir,
+      tarballs,
+      extraDependencies: {
+        "@dawn-ai/permissions": tarballs["@dawn-ai/permissions"],
+        "@dawn-ai/sqlite-storage": tarballs["@dawn-ai/sqlite-storage"],
+        "@dawn-ai/workspace": tarballs["@dawn-ai/workspace"],
+        "@langchain/langgraph": "1.3.0",
+      },
+      removeDependencies: ["langchain", "@langchain/openai"],
+    })
+    const pkg = await readPkg(dir)
+    expect(pkg.dependencies.langchain).toBeUndefined()
+    expect(pkg.dependencies["@langchain/openai"]).toBeUndefined()
+    expect(pkg.dependencies["@dawn-ai/permissions"]).toBe("/packs/permissions.tgz")
+    expect(pkg.dependencies["@langchain/langgraph"]).toBe("1.3.0")
+  })
+})
+```
+
+- [ ] **Step 2: Run it (fails — module missing)**
+
+Run: `pnpm --filter @dawn-ai/cli exec vitest --run ../../test/harness/scaffold-packaging.test.ts` — if that path resolution is awkward, run from repo root: `pnpm exec vitest --run test/harness/scaffold-packaging.test.ts --config vitest.workspace.ts` is NOT valid; instead the harness tests run via the lane scripts. Simplest: `npx vitest run test/harness/scaffold-packaging.test.ts` from repo root.
+Expected: FAIL (cannot find `./scaffold-packaging.js`).
+
+- [ ] **Step 3: Write `test/harness/scaffold-packaging.ts`**
+
+```typescript
+import { readFile, writeFile } from "node:fs/promises"
+import { join } from "node:path"
+
+/**
+ * Canonical set of @dawn-ai/* workspace packages a generated app may depend on.
+ * createPackagedInstaller additionally packs @dawn-ai/devkit + create-dawn-ai-app,
+ * which are deliberately NOT in this list (they are never generated-app overrides).
+ */
+export const SCAFFOLD_PACKAGES: readonly string[] = [
+  "@dawn-ai/cli",
+  "@dawn-ai/config-typescript",
+  "@dawn-ai/core",
+  "@dawn-ai/langchain",
+  "@dawn-ai/langgraph",
+  "@dawn-ai/permissions",
+  "@dawn-ai/sdk",
+  "@dawn-ai/sqlite-storage",
+  "@dawn-ai/testing",
+  "@dawn-ai/workspace",
+]
+
+export interface RewriteGeneratedAppDepsOptions {
+  readonly appRoot: string
+  readonly tarballs: Readonly<Record<string, string>>
+  /** Forced deps to add (tarball paths for @dawn pkgs, or version strings e.g. @langchain/langgraph). */
+  readonly extraDependencies?: Readonly<Record<string, string>>
+  /** Dep keys to delete from deps+devDeps before rewriting (e.g. langchain, @langchain/openai). */
+  readonly removeDependencies?: readonly string[]
+}
+
+interface MutablePackageJson {
+  dependencies?: Record<string, string>
+  devDependencies?: Record<string, string>
+  pnpm?: { overrides?: Record<string, string> }
+}
+
+export async function rewriteGeneratedAppDependencies(
+  options: RewriteGeneratedAppDepsOptions,
+): Promise<void> {
+  const packageJsonPath = join(options.appRoot, "package.json")
+  const pkg = JSON.parse(await readFile(packageJsonPath, "utf8")) as MutablePackageJson
+
+  for (const key of options.removeDependencies ?? []) {
+    if (pkg.dependencies) delete pkg.dependencies[key]
+    if (pkg.devDependencies) delete pkg.devDependencies[key]
+  }
+
+  const swap = (deps: Record<string, string> | undefined): void => {
+    if (!deps) return
+    for (const name of Object.keys(deps)) {
+      const tarball = options.tarballs[name]
+      if (tarball) deps[name] = tarball
+    }
+  }
+  swap(pkg.dependencies)
+  swap(pkg.devDependencies)
+
+  if (options.extraDependencies) {
+    pkg.dependencies = { ...pkg.dependencies, ...options.extraDependencies }
+  }
+
+  // pnpm.overrides pins EVERY packed SCAFFOLD package (direct + transitive) to its
+  // tarball — this is what makes a cold install resolve offline. Data-driven: adding
+  // a package to SCAFFOLD_PACKAGES propagates here automatically.
+  const overrides: Record<string, string> = { ...(pkg.pnpm?.overrides ?? {}) }
+  for (const name of SCAFFOLD_PACKAGES) {
+    const tarball = options.tarballs[name]
+    if (tarball) overrides[name] = tarball
+  }
+  pkg.pnpm = { ...(pkg.pnpm ?? {}), overrides }
+
+  await writeFile(packageJsonPath, `${JSON.stringify(pkg, null, 2)}\n`, "utf8")
+}
+```
+
+- [ ] **Step 4: Run it (passes)**
+
+Run: `npx vitest run test/harness/scaffold-packaging.test.ts`
+Expected: PASS (4 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add test/harness/scaffold-packaging.ts test/harness/scaffold-packaging.test.ts
+git commit -m "test(harness): shared data-driven scaffold-packaging helper"
+```
+
+---
+
+## Task 2: Migrate the smoke lane
+
+**Files:**
+- Modify: `test/smoke/run-smoke.test.ts`
+
+- [ ] **Step 1: Read the current file.** Locate the inline `packageNames: [ ...10 @dawn pkgs ]` and the local `async function rewriteDependenciesToTarballs(...)`.
+
+- [ ] **Step 2: Replace the packageNames + rewrite usage.**
+  - Add import: `import { rewriteGeneratedAppDependencies, SCAFFOLD_PACKAGES } from "../harness/scaffold-packaging.js"`.
+  - Replace the inline `packageNames: [ ... ]` with `packageNames: [...SCAFFOLD_PACKAGES]`.
+  - Replace the call site `await rewriteDependenciesToTarballs({ appRoot, tarballs })` with:
+    ```typescript
+    await rewriteGeneratedAppDependencies({
+      appRoot,
+      tarballs,
+      extraDependencies: {
+        "@dawn-ai/permissions": tarballs["@dawn-ai/permissions"]!,
+        "@dawn-ai/sqlite-storage": tarballs["@dawn-ai/sqlite-storage"]!,
+        "@dawn-ai/workspace": tarballs["@dawn-ai/workspace"]!,
+      },
+      removeDependencies: ["langchain", "@langchain/openai"],
+    })
+    ```
+  - Delete the local `async function rewriteDependenciesToTarballs` definition.
+
+- [ ] **Step 3: Run the smoke lane (cold, must stay green).**
+
+Run: `pnpm verify:harness:smoke 2>&1 | grep -E "passed=|failed:|status:"`
+Expected: `status: passed`, `passed=1 failed=0`. (If failures appear, the forced-deps/overrides set drifted — compare the generated app's `package.json` under the preserved artifact dir against the pre-migration shape.)
+
+- [ ] **Step 4: Lint.** Run: `pnpm --filter @dawn-example/chat-server exec biome check --config-path ../../../packages/config-biome/biome.json test/smoke/run-smoke.test.ts` is wrong path; instead from repo root: `npx biome check --config-path packages/config-biome/biome.json test/smoke/run-smoke.test.ts`. Fix any issues.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add test/smoke/run-smoke.test.ts
+git commit -m "test(smoke): use shared scaffold-packaging helper"
+```
+
+---
+
+## Task 3: Migrate the runtime-contract lane
+
+**Files:**
+- Modify: `test/runtime/run-runtime-contract.test.ts`
+
+- [ ] **Step 1: Read the current file** — find the `packageNames` list and local `rewriteDependenciesToTarballs`.
+
+- [ ] **Step 2: Replace** (same shape as Task 2, but this lane forces the same three extra deps and the same deletes):
+  - Add import: `import { rewriteGeneratedAppDependencies, SCAFFOLD_PACKAGES } from "../harness/scaffold-packaging.js"`.
+  - `packageNames: [...SCAFFOLD_PACKAGES]`.
+  - Call site →
+    ```typescript
+    await rewriteGeneratedAppDependencies({
+      appRoot,
+      tarballs,
+      extraDependencies: {
+        "@dawn-ai/permissions": tarballs["@dawn-ai/permissions"]!,
+        "@dawn-ai/sqlite-storage": tarballs["@dawn-ai/sqlite-storage"]!,
+        "@dawn-ai/workspace": tarballs["@dawn-ai/workspace"]!,
+      },
+      removeDependencies: ["langchain", "@langchain/openai"],
+    })
+    ```
+  - Delete the local `rewriteDependenciesToTarballs`.
+
+- [ ] **Step 3: Run the runtime lane.**
+
+Run: `pnpm verify:harness:runtime 2>&1 | grep -E "passed=|failed:|status:"`
+Expected: `status: passed`. (macOS caveat: if the only failures are `/private/tmp` path-equality in run-runtime-contract, that's the known environmental issue — confirm by checking the failure messages are all `/private/tmp` vs `/tmp`.)
+
+- [ ] **Step 4: Lint** `npx biome check --config-path packages/config-biome/biome.json test/runtime/run-runtime-contract.test.ts` — fix issues.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add test/runtime/run-runtime-contract.test.ts
+git commit -m "test(runtime-contract): use shared scaffold-packaging helper"
+```
+
+---
+
+## Task 4: Migrate the agent-protocol lane (4 packageNames lists)
+
+**Files:**
+- Modify: `test/runtime/run-agent-protocol.test.ts`
+
+- [ ] **Step 1: Read the current file** — it has **four** inline `packageNames` lists and one local `rewriteDependenciesToTarballs` that additionally adds `@langchain/langgraph: "1.3.0"`.
+
+- [ ] **Step 2: Replace.**
+  - Add import: `import { rewriteGeneratedAppDependencies, SCAFFOLD_PACKAGES } from "../harness/scaffold-packaging.js"`.
+  - Replace **all four** `packageNames: [ ... ]` with `packageNames: [...SCAFFOLD_PACKAGES]`.
+  - Replace each `await rewriteDependenciesToTarballs({ appRoot, tarballs })` call (there may be one shared call or several) with:
+    ```typescript
+    await rewriteGeneratedAppDependencies({
+      appRoot,
+      tarballs,
+      extraDependencies: {
+        "@dawn-ai/permissions": tarballs["@dawn-ai/permissions"]!,
+        "@dawn-ai/sqlite-storage": tarballs["@dawn-ai/sqlite-storage"]!,
+        "@dawn-ai/workspace": tarballs["@dawn-ai/workspace"]!,
+        "@langchain/langgraph": "1.3.0",
+      },
+      removeDependencies: ["langchain", "@langchain/openai"],
+    })
+    ```
+  - Delete the local `rewriteDependenciesToTarballs`.
+
+- [ ] **Step 3: Run the runtime lane (covers agent-protocol).**
+
+Run: `pnpm verify:harness:runtime 2>&1 | grep -E "passed=|failed:|status:"`
+Expected: `status: passed` (modulo the macOS `/private/tmp` caveat).
+
+- [ ] **Step 4: Lint** `npx biome check --config-path packages/config-biome/biome.json test/runtime/run-agent-protocol.test.ts` — fix issues.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add test/runtime/run-agent-protocol.test.ts
+git commit -m "test(agent-protocol): use shared scaffold-packaging helper"
+```
+
+---
+
+## Task 5: Migrate `test/generated/harness.ts`
+
+**Files:**
+- Modify: `test/generated/harness.ts`
+
+This lane uses the named `PackedTarballs` interface + `toPackedTarballs` mapper. Remove them.
+
+- [ ] **Step 1: Read the current file** — find `interface PackedTarballs`, `function toPackedTarballs`, the inline `packageNames`, and `rewriteDependenciesToTarballs` (no extra/remove for this lane).
+
+- [ ] **Step 2: Replace.**
+  - Add import: `import { rewriteGeneratedAppDependencies, SCAFFOLD_PACKAGES } from "../harness/scaffold-packaging.js"`.
+  - `packageNames: [...SCAFFOLD_PACKAGES]`.
+  - Where the code does `tarballs = toPackedTarballs(packagedInstaller.tarballs)`, change `tarballs` to be the raw `packagedInstaller.tarballs` (`Record<string,string>`) and update its type annotation (the `tarballs` variable type changes from `PackedTarballs` to `Readonly<Record<string,string>>`).
+  - Replace the `rewriteDependenciesToTarballs` call with `await rewriteGeneratedAppDependencies({ appRoot, tarballs })` (no extra/remove).
+  - Delete `interface PackedTarballs`, `function toPackedTarballs`, and the local `rewriteDependenciesToTarballs`.
+  - If `PackedTarballs` is referenced elsewhere in this file (e.g. a `tarballs?: PackedTarballs` field on an options/return type), change those to `Readonly<Record<string, string>>`.
+
+- [ ] **Step 3: Run the framework lane.**
+
+Run: `pnpm verify:harness:framework 2>&1 | grep -E "passed=|failed:|status:"`
+Expected: `status: passed`. (The `run-generated-runtime-contract` suite runs through this harness; fixtures must still match.)
+
+- [ ] **Step 4: Lint** `npx biome check --config-path packages/config-biome/biome.json test/generated/harness.ts` — fix issues.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add test/generated/harness.ts
+git commit -m "test(generated-harness): use shared scaffold-packaging helper"
+```
+
+---
+
+## Task 6: Migrate `run-generated-app.test.ts` (incl. fixture normalizer)
+
+**Files:**
+- Modify: `test/generated/run-generated-app.test.ts`
+
+This file has its own `PackedTarballs`/`toPackedTarballs`, a local `rewriteDependenciesToTarballs` (no extra/remove), AND `normalizeForFixture`/`normalizeForInternalFixture` that build `<tarball:@dawn-ai/X>` / `<repo:@dawn-ai/X>` replacement pairs from the named `PackedTarballs` fields. Genericize the normalizers over the tarball map.
+
+- [ ] **Step 1: Read the current file** — find `interface PackedTarballs`, `toPackedTarballs`, `rewriteDependenciesToTarballs`, `normalizeForFixture`, `normalizeForInternalFixture`, `pathToRepoPackageFileSpecifier`.
+
+- [ ] **Step 2: Migrate packing + rewrite.**
+  - Add import: `import { rewriteGeneratedAppDependencies, SCAFFOLD_PACKAGES } from "../harness/scaffold-packaging.js"`.
+  - `packageNames: [...SCAFFOLD_PACKAGES]`.
+  - Change `tarballs` from `PackedTarballs` to the raw `packagedInstaller.tarballs` (`Record<string,string>`); update the variable's type and the `tarballs?: PackedTarballs` field on the scenario options/result types to `Readonly<Record<string, string>>`.
+  - Replace `rewriteDependenciesToTarballs({ appRoot, tarballs })` with `await rewriteGeneratedAppDependencies({ appRoot, tarballs })`.
+  - Delete `interface PackedTarballs`, `toPackedTarballs`, and local `rewriteDependenciesToTarballs`.
+
+- [ ] **Step 3: Genericize `normalizeForFixture`.** It currently has hardcoded pairs like `[context.tarballs.cli, "<tarball:@dawn-ai/cli>"]`. Replace those hardcoded `@dawn-ai/*` + `create-dawn-ai-app`/`@dawn-ai/devkit` tarball pairs with a generated list over the tarball map. Keep the existing non-tarball replacements (`<app-root>`, `<packs-dir>`, `<version:...>`). Concretely, build the replacement array like:
+
+```typescript
+const tarballPairs: Array<readonly [string, string]> = Object.entries(context.tarballs).map(
+  ([name, tarballPath]) => [tarballPath, `<tarball:${name}>`] as const,
+)
+```
+
+and spread `...tarballPairs` into the `normalizeValue(value, [ ... ])` array IN PLACE OF the hardcoded `[context.tarballs.cli, "<tarball:@dawn-ai/cli>"]` lines. Keep `[`/private`+dirname, "<packs-dir>"]` and version/app-root pairs. (Order: put `tarballPairs` where the old per-package lines were; the `<packs-dir>` collapse must still run — keep it after, matching current ordering.)
+
+- [ ] **Step 4: Genericize `normalizeForInternalFixture` + `pathToRepoPackageFileSpecifier`.** The internal normalizer maps each repo file: specifier → `<repo:@dawn-ai/X>`. Replace its hardcoded per-package lines with a loop over `SCAFFOLD_PACKAGES`:
+
+```typescript
+const repoPairs = SCAFFOLD_PACKAGES.map(
+  (name) => [pathToRepoPackageFileSpecifier(name), `<repo:${name}>`] as const,
+)
+```
+
+spread `...repoPairs` where the hardcoded `[pathToRepoPackageFileSpecifier("@dawn-ai/cli"), "<repo:@dawn-ai/cli>"]` lines were. Change `pathToRepoPackageFileSpecifier`'s parameter type from the explicit string-union to `string`, and its internal `packageDirByName` lookup: replace the hardcoded map with deriving the dir from the name — `resolve(REPO_ROOT, "packages", name.replace("@dawn-ai/", ""))` then `pathToFileURL(...).toString()`. (Confirm against the current body; the package dir for `@dawn-ai/X` is `packages/X`.)
+
+- [ ] **Step 5: Run the framework lane (fixtures must still match — pure refactor).**
+
+Run: `pnpm verify:harness:framework 2>&1 | grep -E "passed=|failed:|status:"`
+Expected: `status: passed`. If a fixture mismatch appears, the normalizer genericization changed a placeholder; diff the failing report's normalized output against the expected fixture and align the normalizer (do NOT edit the fixtures in this task — behavior is preserved).
+
+- [ ] **Step 6: Lint** `npx biome check --config-path packages/config-biome/biome.json test/generated/run-generated-app.test.ts` — fix issues.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add test/generated/run-generated-app.test.ts
+git commit -m "test(generated-app): use shared scaffold-packaging helper + generic fixture normalizers"
+```
+
+---
+
+## Task 7: Thread `@dawn-ai/evals` specifier through create-dawn-app + devkit
+
+**Files:**
+- Modify: `test/harness/scaffold-packaging.ts`
+- Modify: `packages/create-dawn-app/src/index.ts`
+- Modify: `packages/devkit/src/testing/generated-app.ts`
+
+- [ ] **Step 1: Add `@dawn-ai/evals` to `SCAFFOLD_PACKAGES`** in `test/harness/scaffold-packaging.ts` — insert `"@dawn-ai/evals",` in alphabetical position (after `@dawn-ai/core`). Update the `SCAFFOLD_PACKAGES` test in `test/harness/scaffold-packaging.test.ts` to also `expect(SCAFFOLD_PACKAGES).toContain("@dawn-ai/evals")`. Run `npx vitest run test/harness/scaffold-packaging.test.ts` → PASS.
+
+- [ ] **Step 2: Thread `dawnEvalsSpecifier` in `packages/create-dawn-app/src/index.ts`.** Read the file; mirror EXACTLY how `dawnTestingSpecifier` is handled. Add to the `createTemplateReplacements` return type `readonly dawnEvalsSpecifier: string`; in the internal-mode branch add `dawnEvalsSpecifier: createAbsoluteFileSpecifier(resolve(repoRoot, "packages/evals"))`; in the external-mode branch add `dawnEvalsSpecifier: options.distTag`; and in `applyInternalModePackageOverrides` add `"@dawn-ai/evals": replacements.dawnEvalsSpecifier,`.
+
+- [ ] **Step 3: Thread `dawnEvals` in `packages/devkit/src/testing/generated-app.ts`.** Add `readonly dawnEvals: string` to `GeneratedAppSpecifiers`; add `dawnEvals: specifiers?.dawnEvals ?? "workspace:*"` to `normalizeSpecifiers`; add `dawnEvalsSpecifier: specifiers.dawnEvals` to the `writeTemplate` replacements in `createGeneratedApp`.
+
+- [ ] **Step 4: Build the touched packages.**
+
+Run: `pnpm --filter create-dawn-ai-app --filter @dawn-ai/devkit build`
+Expected: success (the new replacement key compiles; `writeTemplate` accepts it once the template uses `{{dawnEvalsSpecifier}}` — added in Task 8, but the replacement object can carry an unused key now).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add test/harness/scaffold-packaging.ts test/harness/scaffold-packaging.test.ts packages/create-dawn-app/src/index.ts packages/devkit/src/testing/generated-app.ts
+git commit -m "feat(scaffold): thread @dawn-ai/evals specifier + add to SCAFFOLD_PACKAGES"
+```
+
+---
+
+## Task 8: Add the evals sample to the template
+
+**Files:**
+- Modify: `packages/devkit/templates/app-basic/package.json.template`
+- Create: `packages/devkit/templates/app-basic/src/app/(public)/hello/[tenant]/evals/smoke.eval.ts.template`
+
+- [ ] **Step 1: Update `package.json.template`.** Add `"@dawn-ai/evals": "{{dawnEvalsSpecifier}}"` to `devDependencies` (alphabetical, after `@dawn-ai/config-typescript`) and `"eval": "dawn eval"` to `scripts` (after `"check"`).
+
+- [ ] **Step 2: Inspect the existing test sample** `packages/devkit/templates/app-basic/test/agent.test.ts.template` to copy its route key (`/hello/[tenant]#agent`) and the exact reply text its `script()` fixture uses, so the eval's fixture is deterministic against the same route.
+
+- [ ] **Step 3: Create `…/hello/[tenant]/evals/smoke.eval.ts.template`** (use the SAME input + reply as the agent test sample so it passes deterministically — adjust the literals to match what Step 2 found):
+
+```typescript
+import { contains, defineEval } from "@dawn-ai/evals"
+import { script } from "@dawn-ai/testing"
+
+export default defineEval({
+  name: "greets the tenant",
+  dataset: [
+    {
+      name: "hello",
+      input: "Say hello",
+      fixtures: script().user("Say hello").replies("Hello from Acme!"),
+    },
+  ],
+  scorers: [contains("Hello", { threshold: 1 })],
+  threshold: 1,
+})
+```
+
+- [ ] **Step 4: Sanity-generate locally (internal mode) and run `dawn eval`.**
+
+```bash
+pnpm --filter create-dawn-ai-app build
+node packages/create-dawn-app/dist/bin.js /tmp/evals-tmpl-check --mode internal
+cd /tmp/evals-tmpl-check && pnpm install && pnpm exec dawn eval ; echo "exit=$?" ; cd - ; rm -rf /tmp/evals-tmpl-check
+```
+Expected: `dawn eval` prints `PASS` and `exit=0`. (If the reply/scorer don't match, align the eval's fixture/scorer to the route's real behavior.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add "packages/devkit/templates/app-basic/package.json.template" "packages/devkit/templates/app-basic/src/app/(public)/hello/[tenant]/evals/smoke.eval.ts.template"
+git commit -m "feat(scaffold): scaffold a sample @dawn-ai/evals eval in new apps"
+```
+
+---
+
+## Task 9: Update scaffold assertions + generated-app fixtures
+
+**Files:**
+- Modify: `packages/create-dawn-app/test/create-app.test.ts`
+- Modify: `packages/devkit/test/generated-app.test.ts`
+- Modify: `test/generated/fixtures/basic.expected.json`
+- Modify: `test/generated/fixtures/custom-app-dir.expected.json`
+
+- [ ] **Step 1: Update `create-app.test.ts`.** Read it; mirror the existing `@dawn-ai/testing` / `test/agent.test.ts` assertions. In both the external-mode and internal-mode scenarios add assertions that the generated app: contains `src/app/(public)/hello/[tenant]/evals/smoke.eval.ts` (via the existing `assertExists` helper), has `@dawn-ai/evals` in devDependencies (matching the same `not.toMatch(/^file:/)` / `toBe("next")` pattern used for `@dawn-ai/testing` externally, and the `toMatch(/^file:/)` pattern internally), and `packageJson.scripts.eval === "dawn eval"`.
+
+- [ ] **Step 2: Update devkit `generated-app.test.ts`.** Mirror the `@dawn-ai/testing` assertions: assert the generated `package.json` contains `"@dawn-ai/evals": "workspace:*"`, `"eval": "dawn eval"`, and that `evals/smoke.eval.ts` exists.
+
+- [ ] **Step 3: Regenerate the two fixtures.** The `run-generated-app` snapshots now need the `@dawn-ai/evals` devDep (`<tarball:@dawn-ai/evals>`), the `eval` script, and the `@dawn-ai/evals` override entry. Run the framework lane to get the exact expected diff, then update `basic.expected.json` and `custom-app-dir.expected.json` to match the produced normalized output:
+
+```bash
+pnpm verify:harness:framework 2>&1 | grep -E "passed=|failed:|status:"
+```
+On failure, read the preserved artifact's actual normalized result (the harness prints the artifact path) and update both fixtures' `packageJson` blocks: add `"eval": "dawn eval"` to `scripts`, `"@dawn-ai/evals": "<tarball:@dawn-ai/evals>"` to `devDependencies`, and `"@dawn-ai/evals": "<tarball:@dawn-ai/evals>"` to `pnpm.overrides`. Re-run until `status: passed`.
+
+- [ ] **Step 4: Run the scaffold unit tests + framework lane.**
+
+Run: `pnpm --filter create-dawn-ai-app --filter @dawn-ai/devkit test` → all pass.
+Run: `pnpm verify:harness:framework 2>&1 | grep -E "passed=|status:"` → `status: passed`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/create-dawn-app/test/create-app.test.ts packages/devkit/test/generated-app.test.ts test/generated/fixtures/basic.expected.json test/generated/fixtures/custom-app-dir.expected.json
+git commit -m "test(scaffold): assert scaffolded eval + update generated-app fixtures"
+```
+
+---
+
+## Task 10: Docs, changeset, full validation
+
+**Files:**
+- Modify: `apps/web/content/docs/evals.mdx`
+- Create: `.changeset/scaffold-evals.md`
+
+- [ ] **Step 1: Add a scaffold note to `evals.mdx`.** A short section: "your scaffolded app already has an eval" — `create-dawn-ai-app` generates `evals/smoke.eval.ts` + an `eval` script; run `dawn eval`. Mirror the equivalent note in `testing-agents.mdx`. Do NOT use banned phrases (`byte-identical`, "What works locally works in production", etc. — see `scripts/check-docs.mjs`).
+
+- [ ] **Step 2: Write `.changeset/scaffold-evals.md`:**
+
+```markdown
+---
+"create-dawn-ai-app": minor
+"@dawn-ai/devkit": patch
+---
+
+`create-dawn-ai-app` now scaffolds a sample `@dawn-ai/evals` eval (`evals/smoke.eval.ts`) plus an `eval` script in new apps, alongside the existing `@dawn-ai/testing` sample test, so a freshly scaffolded app can run `dawn eval` out of the box.
+```
+
+- [ ] **Step 3: Full validation.**
+
+```
+pnpm install
+pnpm lint
+pnpm build
+pnpm typecheck
+pnpm test
+node scripts/check-docs.mjs
+pnpm verify:harness:framework
+pnpm verify:harness:runtime
+pnpm verify:harness:smoke
+```
+Expected: all green (macOS `/private/tmp` caveat applies only to local runtime-contract; CI Linux is clean). Fix anything that breaks.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/web/content/docs/evals.mdx .changeset/scaffold-evals.md
+git commit -m "docs(scaffold): evals scaffold note + changeset"
+```
+
+---
+
+## Self-Review (completed by plan author)
+
+**Spec coverage:** shared helper + SCAFFOLD_PACKAGES + data-driven rewrite (T1); migrate all 5 lanes / 9 lists (T2–T6, incl. the named-PackedTarballs removal in T5/T6 and fixture-normalizer genericization in T6); add evals to SCAFFOLD_PACKAGES + specifier threading (T7); template devDep/script/sample (T8); assertions + fixtures (T9); docs + changeset + full validate across all three harness lanes (T10). Out-of-scope items (template-parsing, dep-agnostic fixtures, new dawn-eval-in-generated-app lane) are honored — none are tasks.
+
+**Placeholder scan:** the migration tasks (T2–T6) intentionally say "read the current file" because they transform existing per-file code into a shared call with EXACTLY specified options (extra/remove deps given verbatim per lane) — the variable part (each lane's options) is fully specified; the surrounding wiring is read, not invented. No TBDs.
+
+**Type consistency:** `rewriteGeneratedAppDependencies({ appRoot, tarballs, extraDependencies?, removeDependencies? })` and `SCAFFOLD_PACKAGES` are defined once (T1) and used identically in T2–T7; `tarballs` becomes `Readonly<Record<string,string>>` everywhere (the named `PackedTarballs` type is deleted in T5/T6); `dawnEvalsSpecifier`/`dawnEvals` mirror the existing `dawnTestingSpecifier`/`dawnTesting` names.

--- a/docs/superpowers/specs/2026-06-07-harness-packaging-consolidation-design.md
+++ b/docs/superpowers/specs/2026-06-07-harness-packaging-consolidation-design.md
@@ -1,0 +1,115 @@
+# Harness-packaging consolidation + `@dawn-ai/evals` scaffold (Design)
+
+**Status:** Approved for planning
+**Date:** 2026-06-07
+**Context:** Follows eval-authoring ([PR #202]). Two coupled goals: (1) remove the generated-app harness "packaging trap" that makes adding a scaffold-template dependency error-prone, then (2) add `@dawn-ai/evals` to the `create-dawn-app` template so new apps get an eval out of the box.
+
+## Problem
+
+The generated-app verification lanes simulate a real end-user install: they `pnpm pack` each workspace package to a `.tgz`, then rewrite a generated app's `package.json` so its `@dawn-ai/*` deps point at those tarballs (offline "published" install). Two things are hardcoded per lane:
+
+- **which packages to pack** — a `packageNames` array, and
+- **how to rewrite the generated `package.json`** — a `rewriteDependenciesToTarballs` function with a ~20-line hardcoded `@dawn-ai/*` override block (deps + devDeps + `pnpm.overrides`).
+
+This pair is **copy-pasted across 5 files (9 `packageNames` lists total)**: `test/generated/harness.ts`, `test/generated/run-generated-app.test.ts`, `test/runtime/run-agent-protocol.test.ts` (×4 lists), `test/runtime/run-runtime-contract.test.ts`, `test/smoke/run-smoke.test.ts`. Adding one scaffold dep means editing all of them correctly; miss one and **that lane fails silently with a cryptic cold-cache 404** (`ERR_PNPM_NO_MATCHING_VERSION @pkg@next`) or `ERR_PNPM_WORKSPACE_PKG_NOT_FOUND`. This actually cost three CI cycles during eval-authoring (fix `run-generated-app` → red on `run-runtime-contract` → red on `run-smoke`).
+
+Goal: collapse the duplication so adding a scaffold dependency is a near-template-only change, then add `@dawn-ai/evals`.
+
+**Scope decision (deliberately right-sized, not gold-plated):** consolidate the rewrite + package list into one shared, data-driven helper. **Out of scope** (cut as over-engineering): deriving the package set by parsing `package.json.template` (a shared constant is simpler), and making the `run-generated-app` expected fixtures dep-agnostic (that snapshot fails loudly/obviously; a one-file update when adding a dep is acceptable).
+
+## Verified facts (against current code)
+
+- `test/harness/packaged-app.ts` `createPackagedInstaller({ packageNames })` already prepends `@dawn-ai/devkit` + `create-dawn-ai-app` and dedupes, packs each via `pnpm pack`, returns `{ installerDir, tarballs: Record<string,string> }` keyed by package name.
+- The 5 `rewriteDependenciesToTarballs` copies all take `{ appRoot, tarballs }`; `run-agent-protocol`/`run-runtime-contract`/`run-smoke` already use the string-keyed `Record<string,string>` form; `run-generated-app.test.ts` and `harness.ts` additionally maintain a named `PackedTarballs` interface + `toPackedTarballs` mapper (used by `run-generated-app`'s fixture normalizer for `<tarball:@dawn-ai/X>` placeholders).
+- Lane-specific deviations to preserve (the plan MUST read each lane's current `rewriteDependenciesToTarballs` to capture its exact behavior, not trust this summary): at least `run-agent-protocol` adds `@langchain/langgraph: "1.3.0"`, and the runtime lanes `delete` `langchain` + `@langchain/openai`. Each lane's exact delete/extra set is translated into `removeDependencies`/`extraDependencies` options.
+- `run-generated-app` compares the generated app's full normalized `package.json` against `test/generated/fixtures/{basic,custom-app-dir}.expected.json` via `normalizeForFixture` (tarball paths → `<tarball:@dawn-ai/X>`) and `normalizeForInternalFixture` (file: edges → `<repo:@dawn-ai/X>`).
+- The scaffold template `packages/devkit/templates/app-basic/` integrates `@dawn-ai/testing` only: `test/agent.test.ts.template`, `@dawn-ai/testing` + `vitest` devDeps, `"test": "vitest run"`. `create-dawn-app` threads `dawnTestingSpecifier` through `createTemplateReplacements` (internal file: + external dist-tag) + `applyInternalModePackageOverrides`; devkit `generated-app.ts` exposes `dawnTesting` in `GeneratedAppSpecifiers`/`normalizeSpecifiers` and writes `dawnTestingSpecifier`.
+- `@dawn-ai/evals@1.0.0` and `@dawn-ai/testing@3.0.0` are published; the published `dawn eval` works in a fresh app (verified). The scaffold route is `hello/[tenant]`, key `/hello/[tenant]#agent`.
+
+## Architecture
+
+### Part 1 — shared packaging helper
+
+New module **`test/harness/scaffold-packaging.ts`**:
+
+```ts
+/** Canonical set of @dawn-ai/* workspace packages a generated app may depend on. */
+export const SCAFFOLD_PACKAGES: readonly string[] = [
+  "@dawn-ai/cli",
+  "@dawn-ai/config-typescript",
+  "@dawn-ai/core",
+  "@dawn-ai/evals",
+  "@dawn-ai/langchain",
+  "@dawn-ai/langgraph",
+  "@dawn-ai/permissions",
+  "@dawn-ai/sdk",
+  "@dawn-ai/sqlite-storage",
+  "@dawn-ai/testing",
+  "@dawn-ai/workspace",
+]
+
+export interface RewriteGeneratedAppDepsOptions {
+  readonly appRoot: string
+  readonly tarballs: Readonly<Record<string, string>>
+  /** Extra non-workspace deps to force (e.g. { "@langchain/langgraph": "1.3.0" }). */
+  readonly extraDependencies?: Readonly<Record<string, string>>
+  /** Dep keys to delete before rewriting (e.g. ["langchain", "@langchain/openai"]). */
+  readonly removeDependencies?: readonly string[]
+}
+
+/**
+ * Data-driven rewrite: for every dep/devDep key present in `tarballs`, point it at
+ * the tarball; rebuild pnpm.overrides from the same map. Adding a new packed package
+ * needs no change here.
+ */
+export async function rewriteGeneratedAppDependencies(
+  options: RewriteGeneratedAppDepsOptions,
+): Promise<void>
+```
+
+Behavior:
+1. Read `<appRoot>/package.json`.
+2. Delete each key in `removeDependencies` from `dependencies`/`devDependencies`.
+3. For each of `dependencies` and `devDependencies`, replace the value of any key that exists in `tarballs` with `tarballs[key]` (leaves unknown keys, e.g. `zod`, untouched).
+4. Merge `extraDependencies` into `dependencies`.
+5. Set `pnpm.overrides` = (existing overrides) merged with `{ name: tarballs[name] }` for **every** `tarballs` key that the app references in deps/devDeps (i.e. only packages the app actually uses), so the override set tracks the app. (Simplest correct rule; matches today's behavior where overrides list the workspace deps.)
+6. Write back, pretty-printed + trailing newline (match current format).
+
+All five lanes replace their local `rewriteDependenciesToTarballs` with a call to this; `run-agent-protocol`/`run-runtime-contract` pass `removeDependencies: ["langchain", "@langchain/openai"]` and `extraDependencies: { "@langchain/langgraph": "1.3.0" }`. All `packageNames: [ ...long list ]` become `packageNames: [...SCAFFOLD_PACKAGES]` (or rely on a helper default).
+
+Delete: the 5 local `rewriteDependenciesToTarballs`, the 2 `PackedTarballs` interfaces, the 2 `toPackedTarballs` mappers, the 9 inline lists.
+
+`run-generated-app`'s fixture normalizer stops using named `PackedTarballs` fields and instead iterates the `tarballs` record (keys ∈ `SCAFFOLD_PACKAGES` ∪ {`create-dawn-ai-app`,`@dawn-ai/devkit`}) to emit `[tarballPath, "<tarball:" + name + ">"]` replacement pairs; the internal-mode normalizer similarly iterates for `<repo:...>` edges. Fixtures themselves are unchanged by the refactor (no dep added yet).
+
+### Part 2 — add `@dawn-ai/evals` to the scaffold
+
+With Part 1 done, `@dawn-ai/evals` is already in `SCAFFOLD_PACKAGES` (added above), so every lane packs + overrides it automatically. Remaining, all template/scaffold side:
+
+- **devkit template** `packages/devkit/templates/app-basic/`:
+  - `package.json.template`: add `"@dawn-ai/evals": "{{dawnEvalsSpecifier}}"` to devDependencies and `"eval": "dawn eval"` to scripts.
+  - New `test/`-sibling sample: `src/app/(public)/hello/[tenant]/evals/smoke.eval.ts.template` — `defineEval` with one inline-`script()`-fixture case + a `contains(...)` scorer + `threshold`, targeting the `hello/[tenant]` route. (Confirm the reply text the sample asserts matches the existing `agent.test.ts.template` fixture style so it passes deterministically.)
+- **create-dawn-app** `src/index.ts`: add `dawnEvalsSpecifier` to `createTemplateReplacements` (internal file: → `packages/evals`; external → dist-tag) and to `applyInternalModePackageOverrides`.
+- **devkit** `src/testing/generated-app.ts`: add `dawnEvals` to `GeneratedAppSpecifiers`, `normalizeSpecifiers` (default `workspace:*`), and write `dawnEvalsSpecifier` in `createGeneratedApp` replacements.
+- **Assertions:** update `create-dawn-app/test/create-app.test.ts` and devkit `test/generated-app.test.ts` to assert the generated app has `evals/smoke.eval.ts`, the `@dawn-ai/evals` devDep, and the `eval` script (mirroring the existing `agent.test.ts`/testing assertions). Update the two `run-generated-app` fixtures (`basic`, `custom-app-dir`) to include the new `@dawn-ai/evals` devDep + `eval` script + override entry (the accepted loud diff).
+- **Docs:** extend `apps/web/content/docs/evals.mdx` with a short "your scaffolded app already has an eval" note (no banned phrases per `check-docs.mjs`).
+
+## Error handling / edge cases
+
+- `rewriteGeneratedAppDependencies` with a dep key not in `tarballs` → left untouched (correct: e.g. `zod`, `@types/node`, `typescript`, `vitest`).
+- A lane whose generated app does not reference a packed package → that package simply isn't added to overrides (overrides track app usage), which is fine.
+- `extraDependencies`/`removeDependencies` default to none → lanes that don't need them call with neither.
+- Format drift: write with `JSON.stringify(pkg, null, 2) + "\n"` to match the existing fixture format and avoid spurious diffs.
+
+## Testing
+
+- **Refactor is behavior-preserving:** the existing `verify:harness:framework` / `:runtime` / `:smoke` lanes are the regression test and must stay green (run all three; macOS-local `/private/tmp` notes still apply). Per-task, run the touched lane.
+- **New unit test** `test/harness/scaffold-packaging.test.ts`: `rewriteGeneratedAppDependencies` on a synthetic temp `package.json` — swaps a known dep + devDep to tarball values, leaves an unknown dep (`zod`) untouched, applies `extraDependencies`, deletes `removeDependencies`, and writes overrides only for referenced packages.
+- **Evals scaffold:** `create-app.test.ts` + devkit `generated-app.test.ts` assert the scaffolded eval file/devDep/script; the generated-app lanes prove the generated app still installs + builds cold with `@dawn-ai/evals` packed.
+- Full `pnpm lint && build && typecheck && test && node scripts/check-docs.mjs` before PR.
+
+## Out of scope (explicit)
+
+- Parsing `package.json.template` as the package-set source (shared constant instead).
+- Dep-agnostic `run-generated-app` fixtures (accept the one-file snapshot update when a dep is added).
+- A new lane that executes `dawn eval` inside a generated app (covered by the published-prod smoke + the `examples/chat` dogfood).
+- Touching `cli-testing-export.test.ts`'s own packageNames (it builds a bespoke installer for a different purpose and is not part of the generated-app rewrite duplication).

--- a/packages/create-dawn-app/src/index.ts
+++ b/packages/create-dawn-app/src/index.ts
@@ -176,6 +176,7 @@ function createTemplateReplacements(
   readonly dawnCliSpecifier: string
   readonly dawnConfigTypescriptSpecifier: string
   readonly dawnCoreSpecifier: string
+  readonly dawnEvalsSpecifier: string
   readonly dawnLangchainSpecifier: string
   readonly dawnLanggraphSpecifier: string
   readonly dawnPermissionsSpecifier: string
@@ -192,6 +193,7 @@ function createTemplateReplacements(
         resolve(repoRoot, "packages/config-typescript"),
       ),
       dawnCoreSpecifier: createAbsoluteFileSpecifier(resolve(repoRoot, "packages/core")),
+      dawnEvalsSpecifier: createAbsoluteFileSpecifier(resolve(repoRoot, "packages/evals")),
       dawnLangchainSpecifier: createAbsoluteFileSpecifier(resolve(repoRoot, "packages/langchain")),
       dawnLanggraphSpecifier: createAbsoluteFileSpecifier(resolve(repoRoot, "packages/langgraph")),
       dawnPermissionsSpecifier: createAbsoluteFileSpecifier(
@@ -211,6 +213,7 @@ function createTemplateReplacements(
     dawnCliSpecifier: options.distTag,
     dawnConfigTypescriptSpecifier: options.distTag,
     dawnCoreSpecifier: options.distTag,
+    dawnEvalsSpecifier: options.distTag,
     dawnLangchainSpecifier: options.distTag,
     dawnLanggraphSpecifier: options.distTag,
     dawnPermissionsSpecifier: options.distTag,
@@ -241,6 +244,7 @@ async function applyInternalModePackageOverrides(
       "@dawn-ai/cli": replacements.dawnCliSpecifier,
       "@dawn-ai/config-typescript": replacements.dawnConfigTypescriptSpecifier,
       "@dawn-ai/core": replacements.dawnCoreSpecifier,
+      "@dawn-ai/evals": replacements.dawnEvalsSpecifier,
       "@dawn-ai/langchain": replacements.dawnLangchainSpecifier,
       "@dawn-ai/langgraph": replacements.dawnLanggraphSpecifier,
       "@dawn-ai/permissions": replacements.dawnPermissionsSpecifier,

--- a/packages/create-dawn-app/test/create-app.test.ts
+++ b/packages/create-dawn-app/test/create-app.test.ts
@@ -82,6 +82,7 @@ describe("create-dawn-ai-app", () => {
     await assertExists(join(targetDir, "src/app/(public)/hello/[tenant]/state.ts"))
     await assertExists(join(targetDir, "src/app/(public)/hello/[tenant]/tools/greet.ts"))
     await assertExists(join(targetDir, "test/agent.test.ts"))
+    await assertExists(join(targetDir, "src/app/(public)/hello/[tenant]/evals/smoke.eval.ts"))
 
     const packageJson = JSON.parse(await readFile(join(targetDir, "package.json"), "utf8")) as {
       readonly name: string
@@ -93,17 +94,20 @@ describe("create-dawn-ai-app", () => {
     expect(packageJson.name).toBe("hello-dawn")
     expect(packageJson.scripts.build).toBe("tsc -p tsconfig.json")
     expect(packageJson.scripts.test).toBe("vitest run")
+    expect(packageJson.scripts.eval).toBe("dawn eval")
     expect(packageJson.scripts.typecheck).toBe("tsc --noEmit")
     expect(packageJson.dependencies["@dawn-ai/core"]).not.toMatch(/^file:/)
     expect(packageJson.dependencies["@dawn-ai/cli"]).not.toMatch(/^file:/)
     expect(packageJson.dependencies["@dawn-ai/langchain"]).not.toMatch(/^file:/)
     expect(packageJson.devDependencies["@dawn-ai/config-typescript"]).not.toMatch(/^file:/)
     expect(packageJson.devDependencies["@dawn-ai/testing"]).not.toMatch(/^file:/)
+    expect(packageJson.devDependencies["@dawn-ai/evals"]).not.toMatch(/^file:/)
     expect(packageJson.dependencies["@dawn-ai/core"]).toBe("next")
     expect(packageJson.dependencies["@dawn-ai/cli"]).toBe("next")
     expect(packageJson.dependencies["@dawn-ai/langchain"]).toBe("next")
     expect(packageJson.devDependencies["@dawn-ai/config-typescript"]).toBe("next")
     expect(packageJson.devDependencies["@dawn-ai/testing"]).toBe("next")
+    expect(packageJson.devDependencies["@dawn-ai/evals"]).toBe("next")
     await expect(access(join(targetDir, ".npmrc"), constants.F_OK)).rejects.toThrow()
   })
 
@@ -144,15 +148,18 @@ describe("create-dawn-ai-app", () => {
 
     expect(packageJson.scripts.build).toBe("tsc -p tsconfig.json")
     expect(packageJson.scripts.test).toBe("vitest run")
+    expect(packageJson.scripts.eval).toBe("dawn eval")
     expect(packageJson.dependencies["@dawn-ai/core"]).toMatch(/^file:/)
     expect(packageJson.dependencies["@dawn-ai/cli"]).toMatch(/^file:/)
     expect(packageJson.dependencies["@dawn-ai/langchain"]).toMatch(/^file:/)
     expect(packageJson.devDependencies["@dawn-ai/config-typescript"]).toMatch(/^file:/)
     expect(packageJson.devDependencies["@dawn-ai/testing"]).toMatch(/^file:/)
+    expect(packageJson.devDependencies["@dawn-ai/evals"]).toMatch(/^file:/)
     await assertExists(join(targetDir, "src/app/(public)/hello/[tenant]/index.ts"))
     await assertExists(join(targetDir, "src/app/(public)/hello/[tenant]/state.ts"))
     await assertExists(join(targetDir, "src/app/(public)/hello/[tenant]/tools/greet.ts"))
     await assertExists(join(targetDir, "test/agent.test.ts"))
+    await assertExists(join(targetDir, "src/app/(public)/hello/[tenant]/evals/smoke.eval.ts"))
     await assertExists(join(targetDir, ".npmrc"))
   })
 

--- a/packages/devkit/src/testing/generated-app.ts
+++ b/packages/devkit/src/testing/generated-app.ts
@@ -9,6 +9,7 @@ export interface GeneratedAppSpecifiers {
   readonly dawnCli: string
   readonly dawnConfigTypescript: string
   readonly dawnCore: string
+  readonly dawnEvals: string
   readonly dawnLangchain: string
   readonly dawnSdk: string
   readonly dawnTesting: string
@@ -46,6 +47,7 @@ export async function createGeneratedApp(
       dawnCliSpecifier: specifiers.dawnCli,
       dawnConfigTypescriptSpecifier: specifiers.dawnConfigTypescript,
       dawnCoreSpecifier: specifiers.dawnCore,
+      dawnEvalsSpecifier: specifiers.dawnEvals,
       dawnLangchainSpecifier: specifiers.dawnLangchain,
       dawnSdkSpecifier: specifiers.dawnSdk,
       dawnTestingSpecifier: specifiers.dawnTesting,
@@ -71,6 +73,7 @@ function normalizeSpecifiers(
     dawnCli: specifiers?.dawnCli ?? "workspace:*",
     dawnConfigTypescript: specifiers?.dawnConfigTypescript ?? "workspace:*",
     dawnCore: specifiers?.dawnCore ?? "workspace:*",
+    dawnEvals: specifiers?.dawnEvals ?? "workspace:*",
     dawnLangchain: specifiers?.dawnLangchain ?? "workspace:*",
     dawnSdk: specifiers?.dawnSdk ?? "workspace:*",
     dawnTesting: specifiers?.dawnTesting ?? "workspace:*",

--- a/packages/devkit/templates/app-basic/package.json.template
+++ b/packages/devkit/templates/app-basic/package.json.template
@@ -4,6 +4,7 @@
   "type": "module",
   "scripts": {
     "check": "dawn check",
+    "eval": "dawn eval",
     "build": "tsc -p tsconfig.json",
     "test": "vitest run",
     "typecheck": "tsc --noEmit"
@@ -17,6 +18,7 @@
   },
   "devDependencies": {
     "@dawn-ai/config-typescript": "{{dawnConfigTypescriptSpecifier}}",
+    "@dawn-ai/evals": "{{dawnEvalsSpecifier}}",
     "@dawn-ai/testing": "{{dawnTestingSpecifier}}",
     "@types/node": "25.6.0",
     "typescript": "6.0.2",

--- a/packages/devkit/templates/app-basic/src/app/(public)/hello/[tenant]/evals/smoke.eval.ts.template
+++ b/packages/devkit/templates/app-basic/src/app/(public)/hello/[tenant]/evals/smoke.eval.ts.template
@@ -1,0 +1,15 @@
+import { contains, defineEval } from "@dawn-ai/evals"
+import { script } from "@dawn-ai/testing"
+
+export default defineEval({
+  name: "greets the tenant",
+  dataset: [
+    {
+      name: "hello",
+      input: "Say hello",
+      fixtures: script().user("Say hello").replies("Hello from Acme!"),
+    },
+  ],
+  scorers: [contains("Hello", { threshold: 1 })],
+  threshold: 1,
+})

--- a/packages/devkit/test/generated-app.test.ts
+++ b/packages/devkit/test/generated-app.test.ts
@@ -39,9 +39,17 @@ describe("generated app helper", () => {
       expect(packageJson).toContain('"@dawn-ai/sdk": "workspace:*"')
       expect(packageJson).toContain('"@dawn-ai/config-typescript": "workspace:*"')
       expect(packageJson).toContain('"@dawn-ai/testing": "workspace:*"')
+      expect(packageJson).toContain('"@dawn-ai/evals": "workspace:*"')
       expect(packageJson).toContain('"test": "vitest run"')
+      expect(packageJson).toContain('"eval": "dawn eval"')
       await expect(
         access(resolve(generatedApp.appRoot, "test/agent.test.ts"), constants.F_OK),
+      ).resolves.toBeUndefined()
+      await expect(
+        access(
+          resolve(generatedApp.appRoot, "src/app/(public)/hello/[tenant]/evals/smoke.eval.ts"),
+          constants.F_OK,
+        ),
       ).resolves.toBeUndefined()
     } finally {
       await rm(baseDir, { force: true, recursive: true })

--- a/test/generated/fixtures/basic.expected.json
+++ b/test/generated/fixtures/basic.expected.json
@@ -5,6 +5,7 @@
     "type": "module",
     "scripts": {
       "check": "dawn check",
+      "eval": "dawn eval",
       "build": "tsc -p tsconfig.json",
       "test": "vitest run",
       "typecheck": "tsc --noEmit"
@@ -19,6 +20,7 @@
     },
     "devDependencies": {
       "@dawn-ai/config-typescript": "<tarball:@dawn-ai/config-typescript>",
+      "@dawn-ai/evals": "<tarball:@dawn-ai/evals>",
       "@dawn-ai/testing": "<tarball:@dawn-ai/testing>",
       "@types/node": "<version:@types/node>",
       "typescript": "<version:typescript>",
@@ -29,6 +31,7 @@
         "@dawn-ai/cli": "<tarball:@dawn-ai/cli>",
         "@dawn-ai/config-typescript": "<tarball:@dawn-ai/config-typescript>",
         "@dawn-ai/core": "<tarball:@dawn-ai/core>",
+        "@dawn-ai/evals": "<tarball:@dawn-ai/evals>",
         "@dawn-ai/langchain": "<tarball:@dawn-ai/langchain>",
         "@dawn-ai/langgraph": "<tarball:@dawn-ai/langgraph>",
         "@dawn-ai/permissions": "<tarball:@dawn-ai/permissions>",

--- a/test/generated/fixtures/custom-app-dir.expected.json
+++ b/test/generated/fixtures/custom-app-dir.expected.json
@@ -5,6 +5,7 @@
     "type": "module",
     "scripts": {
       "check": "dawn check",
+      "eval": "dawn eval",
       "build": "tsc -p tsconfig.json",
       "test": "vitest run",
       "typecheck": "tsc --noEmit"
@@ -19,6 +20,7 @@
     },
     "devDependencies": {
       "@dawn-ai/config-typescript": "<tarball:@dawn-ai/config-typescript>",
+      "@dawn-ai/evals": "<tarball:@dawn-ai/evals>",
       "@dawn-ai/testing": "<tarball:@dawn-ai/testing>",
       "@types/node": "<version:@types/node>",
       "typescript": "<version:typescript>",
@@ -29,6 +31,7 @@
         "@dawn-ai/cli": "<tarball:@dawn-ai/cli>",
         "@dawn-ai/config-typescript": "<tarball:@dawn-ai/config-typescript>",
         "@dawn-ai/core": "<tarball:@dawn-ai/core>",
+        "@dawn-ai/evals": "<tarball:@dawn-ai/evals>",
         "@dawn-ai/langchain": "<tarball:@dawn-ai/langchain>",
         "@dawn-ai/langgraph": "<tarball:@dawn-ai/langgraph>",
         "@dawn-ai/permissions": "<tarball:@dawn-ai/permissions>",

--- a/test/generated/harness.ts
+++ b/test/generated/harness.ts
@@ -14,6 +14,10 @@ import {
   type TrackedTempDir,
   withPackagedDevServer,
 } from "../harness/packaged-app.ts"
+import {
+  rewriteGeneratedAppDependencies,
+  SCAFFOLD_PACKAGES,
+} from "../harness/scaffold-packaging.js"
 import { startFakeAgentServer } from "../runtime/support/fake-agent-server.ts"
 
 const REPO_ROOT = resolve(import.meta.dirname, "../..")
@@ -30,21 +34,6 @@ export {
 
 export type GeneratedRuntimeFixtureName = "basic" | "custom-app-dir" | "handwritten"
 export type GeneratedScaffoldMode = "external" | "internal"
-
-interface PackedTarballs {
-  readonly cli: string
-  readonly configTypescript: string
-  readonly core: string
-  readonly createApp: string
-  readonly devkit: string
-  readonly langchain: string
-  readonly langgraph: string
-  readonly permissions: string
-  readonly sdk: string
-  readonly sqliteStorage: string
-  readonly testing: string
-  readonly workspace: string
-}
 
 interface RuntimeFixtureSpec {
   readonly expectedFixturePath: string
@@ -67,7 +56,7 @@ export interface GeneratedRuntimeApp {
   readonly appRoot: string
   readonly artifactRoot: string
   readonly fixture: RuntimeFixtureSpec
-  readonly tarballs?: PackedTarballs
+  readonly tarballs?: Readonly<Record<string, string>>
   readonly tempRoot: string
   readonly transcriptPath: string
 }
@@ -157,30 +146,19 @@ export async function prepareGeneratedRuntimeApp(options: {
 
   try {
     let installerDir: string | undefined
-    let tarballs: PackedTarballs | undefined
+    let tarballs: Readonly<Record<string, string>> | undefined
 
     if (scaffoldMode === "internal") {
       await buildLocalContributorPackages(transcriptPath)
     } else {
       const packagedInstaller = await createPackagedInstaller({
-        packageNames: [
-          "@dawn-ai/cli",
-          "@dawn-ai/config-typescript",
-          "@dawn-ai/core",
-          "@dawn-ai/langchain",
-          "@dawn-ai/langgraph",
-          "@dawn-ai/permissions",
-          "@dawn-ai/sdk",
-          "@dawn-ai/sqlite-storage",
-          "@dawn-ai/testing",
-          "@dawn-ai/workspace",
-        ],
+        packageNames: [...SCAFFOLD_PACKAGES],
         tempRoot: options.tempRoot,
         transcriptPath,
       })
 
       installerDir = packagedInstaller.installerDir
-      tarballs = toPackedTarballs(packagedInstaller.tarballs)
+      tarballs = packagedInstaller.tarballs
     }
 
     if (fixture.source === "generated") {
@@ -232,7 +210,14 @@ export async function prepareGeneratedRuntimeApp(options: {
     }
 
     if (scaffoldMode === "external" && tarballs) {
-      await rewriteDependenciesToTarballs({ appRoot, tarballs })
+      await rewriteGeneratedAppDependencies({
+        appRoot,
+        tarballs,
+        extraDependencies: {
+          "@dawn-ai/langgraph": tarballs["@dawn-ai/langgraph"]!,
+          "@dawn-ai/sqlite-storage": tarballs["@dawn-ai/sqlite-storage"]!,
+        },
+      })
     }
     await runPackagedCommand({
       args: ["install"],
@@ -436,52 +421,6 @@ async function buildLocalContributorPackages(transcriptPath: string): Promise<vo
   })
 }
 
-async function rewriteDependenciesToTarballs(options: {
-  readonly appRoot: string
-  readonly tarballs: PackedTarballs
-}): Promise<void> {
-  const packageJsonPath = join(options.appRoot, "package.json")
-  const packageJson = JSON.parse(await readFile(packageJsonPath, "utf8")) as {
-    devDependencies?: Record<string, string>
-    dependencies?: Record<string, string>
-    pnpm?: {
-      overrides?: Record<string, string>
-    }
-  }
-
-  packageJson.dependencies = {
-    ...packageJson.dependencies,
-    "@dawn-ai/cli": options.tarballs.cli,
-    "@dawn-ai/core": options.tarballs.core,
-    "@dawn-ai/langgraph": options.tarballs.langgraph,
-    "@dawn-ai/sdk": options.tarballs.sdk,
-    "@dawn-ai/sqlite-storage": options.tarballs.sqliteStorage,
-  }
-  packageJson.devDependencies = {
-    ...packageJson.devDependencies,
-    "@dawn-ai/config-typescript": options.tarballs.configTypescript,
-    "@dawn-ai/testing": options.tarballs.testing,
-  }
-  packageJson.pnpm = {
-    ...(packageJson.pnpm ?? {}),
-    overrides: {
-      ...(packageJson.pnpm?.overrides ?? {}),
-      "@dawn-ai/cli": options.tarballs.cli,
-      "@dawn-ai/config-typescript": options.tarballs.configTypescript,
-      "@dawn-ai/core": options.tarballs.core,
-      "@dawn-ai/langchain": options.tarballs.langchain,
-      "@dawn-ai/langgraph": options.tarballs.langgraph,
-      "@dawn-ai/permissions": options.tarballs.permissions,
-      "@dawn-ai/sdk": options.tarballs.sdk,
-      "@dawn-ai/sqlite-storage": options.tarballs.sqliteStorage,
-      "@dawn-ai/testing": options.tarballs.testing,
-      "@dawn-ai/workspace": options.tarballs.workspace,
-    },
-  }
-
-  await writeFile(packageJsonPath, `${JSON.stringify(packageJson, null, 2)}\n`, "utf8")
-}
-
 async function removeLangchainFromPackageJson(appRoot: string): Promise<void> {
   const packageJsonPath = join(appRoot, "package.json")
   const packageJson = JSON.parse(await readFile(packageJsonPath, "utf8")) as {
@@ -658,23 +597,6 @@ function normalizeValue(
   }
 
   return value
-}
-
-function toPackedTarballs(tarballs: Readonly<Record<string, string>>): PackedTarballs {
-  return {
-    cli: tarballs["@dawn-ai/cli"],
-    configTypescript: tarballs["@dawn-ai/config-typescript"],
-    core: tarballs["@dawn-ai/core"],
-    createApp: tarballs["create-dawn-ai-app"],
-    devkit: tarballs["@dawn-ai/devkit"],
-    langchain: tarballs["@dawn-ai/langchain"],
-    langgraph: tarballs["@dawn-ai/langgraph"],
-    permissions: tarballs["@dawn-ai/permissions"]!,
-    sdk: tarballs["@dawn-ai/sdk"],
-    sqliteStorage: tarballs["@dawn-ai/sqlite-storage"]!,
-    testing: tarballs["@dawn-ai/testing"]!,
-    workspace: tarballs["@dawn-ai/workspace"]!,
-  }
 }
 
 async function runDawnRunJson(options: {

--- a/test/generated/run-generated-app.test.ts
+++ b/test/generated/run-generated-app.test.ts
@@ -471,6 +471,7 @@ async function createExpectedInternalFixture(
       devDependencies: {
         ...expected.packageJson.devDependencies,
         "@dawn-ai/config-typescript": "<repo:@dawn-ai/config-typescript>",
+        "@dawn-ai/evals": "<repo:@dawn-ai/evals>",
         "@dawn-ai/testing": "<repo:@dawn-ai/testing>",
       },
       pnpm: {
@@ -478,6 +479,7 @@ async function createExpectedInternalFixture(
           "@dawn-ai/cli": "<repo:@dawn-ai/cli>",
           "@dawn-ai/config-typescript": "<repo:@dawn-ai/config-typescript>",
           "@dawn-ai/core": "<repo:@dawn-ai/core>",
+          "@dawn-ai/evals": "<repo:@dawn-ai/evals>",
           "@dawn-ai/langchain": "<repo:@dawn-ai/langchain>",
           "@dawn-ai/langgraph": "<repo:@dawn-ai/langgraph>",
           "@dawn-ai/permissions": "<repo:@dawn-ai/permissions>",

--- a/test/generated/run-generated-app.test.ts
+++ b/test/generated/run-generated-app.test.ts
@@ -13,6 +13,10 @@ import {
   markTrackedTempDirForPreserve,
   type TrackedTempDir,
 } from "../harness/packaged-app.ts"
+import {
+  rewriteGeneratedAppDependencies,
+  SCAFFOLD_PACKAGES,
+} from "../harness/scaffold-packaging.js"
 import { expectBasicAuthoringLane } from "./harness.ts"
 
 const REPO_ROOT = resolve(import.meta.dirname, "../..")
@@ -22,21 +26,6 @@ const CUSTOM_APP_DIR_FIXTURE_ROOT = resolve(
   "test/fixtures/contracts/valid-custom-app-dir",
 )
 const tempDirs: TrackedTempDir[] = []
-
-interface PackedTarballs {
-  readonly cli: string
-  readonly configTypescript: string
-  readonly core: string
-  readonly createApp: string
-  readonly devkit: string
-  readonly langchain: string
-  readonly langgraph: string
-  readonly permissions: string
-  readonly sdk: string
-  readonly sqliteStorage: string
-  readonly testing: string
-  readonly workspace: string
-}
 
 interface GeneratedAppScenarioResult {
   readonly packageJson: unknown
@@ -162,30 +151,19 @@ async function runGeneratedAppScenario(
   await mkdir(dirname(transcriptPath), { recursive: true })
   try {
     let installerDir: string | undefined
-    let tarballs: PackedTarballs | undefined
+    let tarballs: Readonly<Record<string, string>> | undefined
 
     if (scaffoldMode === "internal") {
       await buildLocalContributorPackages(transcriptPath)
     } else {
       const packagedInstaller = await createPackagedInstaller({
-        packageNames: [
-          "@dawn-ai/cli",
-          "@dawn-ai/config-typescript",
-          "@dawn-ai/core",
-          "@dawn-ai/langchain",
-          "@dawn-ai/langgraph",
-          "@dawn-ai/permissions",
-          "@dawn-ai/sdk",
-          "@dawn-ai/sqlite-storage",
-          "@dawn-ai/testing",
-          "@dawn-ai/workspace",
-        ],
+        packageNames: [...SCAFFOLD_PACKAGES],
         tempRoot,
         transcriptPath,
       })
 
       installerDir = packagedInstaller.installerDir
-      tarballs = toPackedTarballs(packagedInstaller.tarballs)
+      tarballs = packagedInstaller.tarballs
     }
 
     await scaffoldApp({
@@ -222,7 +200,13 @@ async function runGeneratedAppScenario(
     }
 
     if (scaffoldMode === "external" && tarballs) {
-      await rewriteDependenciesToTarballs({ appRoot, tarballs })
+      await rewriteGeneratedAppDependencies({
+        appRoot,
+        tarballs,
+        extraDependencies: {
+          "@dawn-ai/sqlite-storage": tarballs["@dawn-ai/sqlite-storage"]!,
+        },
+      })
     }
 
     const result = await runLifecycle({ appRoot, transcriptPath })
@@ -283,52 +267,6 @@ async function scaffoldApp(options: {
   await expect(
     access(join(options.appRoot, "package.json"), constants.F_OK),
   ).resolves.toBeUndefined()
-}
-
-async function rewriteDependenciesToTarballs(options: {
-  readonly appRoot: string
-  readonly tarballs: PackedTarballs
-}): Promise<void> {
-  const packageJsonPath = join(options.appRoot, "package.json")
-  const packageJson = JSON.parse(await readFile(packageJsonPath, "utf8")) as {
-    devDependencies?: Record<string, string>
-    dependencies?: Record<string, string>
-    pnpm?: {
-      overrides?: Record<string, string>
-    }
-  }
-
-  packageJson.dependencies = {
-    ...packageJson.dependencies,
-    "@dawn-ai/cli": options.tarballs.cli,
-    "@dawn-ai/core": options.tarballs.core,
-    "@dawn-ai/langchain": options.tarballs.langchain,
-    "@dawn-ai/sdk": options.tarballs.sdk,
-    "@dawn-ai/sqlite-storage": options.tarballs.sqliteStorage,
-  }
-  packageJson.devDependencies = {
-    ...packageJson.devDependencies,
-    "@dawn-ai/config-typescript": options.tarballs.configTypescript,
-    "@dawn-ai/testing": options.tarballs.testing,
-  }
-  packageJson.pnpm = {
-    ...(packageJson.pnpm ?? {}),
-    overrides: {
-      ...(packageJson.pnpm?.overrides ?? {}),
-      "@dawn-ai/cli": options.tarballs.cli,
-      "@dawn-ai/config-typescript": options.tarballs.configTypescript,
-      "@dawn-ai/core": options.tarballs.core,
-      "@dawn-ai/langchain": options.tarballs.langchain,
-      "@dawn-ai/langgraph": options.tarballs.langgraph,
-      "@dawn-ai/permissions": options.tarballs.permissions,
-      "@dawn-ai/sdk": options.tarballs.sdk,
-      "@dawn-ai/sqlite-storage": options.tarballs.sqliteStorage,
-      "@dawn-ai/testing": options.tarballs.testing,
-      "@dawn-ai/workspace": options.tarballs.workspace,
-    },
-  }
-
-  await writeFile(packageJsonPath, `${JSON.stringify(packageJson, null, 2)}\n`, "utf8")
 }
 
 async function rewriteToCustomAppDirLayout(appRoot: string): Promise<void> {
@@ -553,44 +491,20 @@ async function createExpectedInternalFixture(
   }
 }
 
-function toPackedTarballs(tarballs: Readonly<Record<string, string>>): PackedTarballs {
-  return {
-    cli: tarballs["@dawn-ai/cli"],
-    configTypescript: tarballs["@dawn-ai/config-typescript"],
-    core: tarballs["@dawn-ai/core"],
-    createApp: tarballs["create-dawn-ai-app"],
-    devkit: tarballs["@dawn-ai/devkit"],
-    langchain: tarballs["@dawn-ai/langchain"],
-    langgraph: tarballs["@dawn-ai/langgraph"],
-    permissions: tarballs["@dawn-ai/permissions"]!,
-    sdk: tarballs["@dawn-ai/sdk"],
-    sqliteStorage: tarballs["@dawn-ai/sqlite-storage"]!,
-    testing: tarballs["@dawn-ai/testing"]!,
-    workspace: tarballs["@dawn-ai/workspace"]!,
-  }
-}
-
 function normalizeForFixture(
   value: GeneratedAppScenarioResult,
-  context: { readonly appRoot: string; readonly tarballs: PackedTarballs },
+  context: { readonly appRoot: string; readonly tarballs: Readonly<Record<string, string>> },
 ): GeneratedAppScenarioResult {
+  const tarballPairs: Array<readonly [string, string]> = Object.entries(context.tarballs).map(
+    ([name, tarballPath]) => [tarballPath, `<tarball:${name}>`] as const,
+  )
+
   return normalizeValue(value, [
     [`/private${context.appRoot}`, "<app-root>"],
     [context.appRoot, "<app-root>"],
-    [context.tarballs.cli, "<tarball:@dawn-ai/cli>"],
-    [context.tarballs.configTypescript, "<tarball:@dawn-ai/config-typescript>"],
-    [context.tarballs.core, "<tarball:@dawn-ai/core>"],
-    [context.tarballs.createApp, "<tarball:create-dawn-ai-app>"],
-    [context.tarballs.devkit, "<tarball:@dawn-ai/devkit>"],
-    [context.tarballs.langchain, "<tarball:@dawn-ai/langchain>"],
-    [context.tarballs.langgraph, "<tarball:@dawn-ai/langgraph>"],
-    [context.tarballs.permissions, "<tarball:@dawn-ai/permissions>"],
-    [context.tarballs.sdk, "<tarball:@dawn-ai/sdk>"],
-    [context.tarballs.sqliteStorage, "<tarball:@dawn-ai/sqlite-storage>"],
-    [context.tarballs.testing, "<tarball:@dawn-ai/testing>"],
-    [context.tarballs.workspace, "<tarball:@dawn-ai/workspace>"],
-    [`/private${dirname(context.tarballs.cli)}`, "<packs-dir>"],
-    [dirname(context.tarballs.cli), "<packs-dir>"],
+    ...tarballPairs,
+    [`/private${dirname(context.tarballs["@dawn-ai/cli"])}`, "<packs-dir>"],
+    [dirname(context.tarballs["@dawn-ai/cli"]), "<packs-dir>"],
     ["25.6.0", "<version:@types/node>"],
     ["6.0.2", "<version:typescript>"],
     ["4.1.4", "<version:vitest>"],
@@ -601,52 +515,24 @@ function normalizeForInternalFixture(
   value: GeneratedAppScenarioResult,
   context: { readonly appRoot: string },
 ): GeneratedAppScenarioResult {
+  const repoPairs: Array<readonly [string, string]> = SCAFFOLD_PACKAGES.map(
+    (name) => [pathToRepoPackageFileSpecifier(name), `<repo:${name}>`] as const,
+  )
+
   return normalizeValue(value, [
     [`/private${context.appRoot}`, "<app-root>"],
     [context.appRoot, "<app-root>"],
-    [pathToRepoPackageFileSpecifier("@dawn-ai/cli"), "<repo:@dawn-ai/cli>"],
-    [pathToRepoPackageFileSpecifier("@dawn-ai/config-typescript"), "<repo:@dawn-ai/config-typescript>"],
-    [pathToRepoPackageFileSpecifier("@dawn-ai/core"), "<repo:@dawn-ai/core>"],
-    [pathToRepoPackageFileSpecifier("@dawn-ai/langchain"), "<repo:@dawn-ai/langchain>"],
-    [pathToRepoPackageFileSpecifier("@dawn-ai/langgraph"), "<repo:@dawn-ai/langgraph>"],
-    [pathToRepoPackageFileSpecifier("@dawn-ai/permissions"), "<repo:@dawn-ai/permissions>"],
-    [pathToRepoPackageFileSpecifier("@dawn-ai/sdk"), "<repo:@dawn-ai/sdk>"],
-    [pathToRepoPackageFileSpecifier("@dawn-ai/sqlite-storage"), "<repo:@dawn-ai/sqlite-storage>"],
-    [pathToRepoPackageFileSpecifier("@dawn-ai/testing"), "<repo:@dawn-ai/testing>"],
-    [pathToRepoPackageFileSpecifier("@dawn-ai/workspace"), "<repo:@dawn-ai/workspace>"],
+    ...repoPairs,
     ["25.6.0", "<version:@types/node>"],
     ["6.0.2", "<version:typescript>"],
     ["4.1.4", "<version:vitest>"],
   ]) as GeneratedAppScenarioResult
 }
 
-function pathToRepoPackageFileSpecifier(
-  packageName:
-    | "@dawn-ai/cli"
-    | "@dawn-ai/config-typescript"
-    | "@dawn-ai/core"
-    | "@dawn-ai/langchain"
-    | "@dawn-ai/langgraph"
-    | "@dawn-ai/permissions"
-    | "@dawn-ai/sdk"
-    | "@dawn-ai/sqlite-storage"
-    | "@dawn-ai/testing"
-    | "@dawn-ai/workspace",
-): string {
-  const packageDirByName = {
-    "@dawn-ai/cli": "packages/cli",
-    "@dawn-ai/config-typescript": "packages/config-typescript",
-    "@dawn-ai/core": "packages/core",
-    "@dawn-ai/langchain": "packages/langchain",
-    "@dawn-ai/langgraph": "packages/langgraph",
-    "@dawn-ai/permissions": "packages/permissions",
-    "@dawn-ai/sdk": "packages/sdk",
-    "@dawn-ai/sqlite-storage": "packages/sqlite-storage",
-    "@dawn-ai/testing": "packages/testing",
-    "@dawn-ai/workspace": "packages/workspace",
-  } as const
+function pathToRepoPackageFileSpecifier(packageName: string): string {
+  const packageDir = resolve(REPO_ROOT, "packages", packageName.replace("@dawn-ai/", ""))
 
-  return pathToFileURL(resolve(REPO_ROOT, packageDirByName[packageName])).toString()
+  return pathToFileURL(packageDir).toString()
 }
 
 function normalizeValue(

--- a/test/harness/scaffold-packaging.test.ts
+++ b/test/harness/scaffold-packaging.test.ts
@@ -1,0 +1,83 @@
+import { mkdtemp, readFile, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { describe, expect, it } from "vitest"
+import { rewriteGeneratedAppDependencies, SCAFFOLD_PACKAGES } from "./scaffold-packaging.js"
+
+async function makePkg(contents: unknown): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "scaffold-pkg-"))
+  await writeFile(join(dir, "package.json"), JSON.stringify(contents), "utf8")
+  return dir
+}
+// biome-ignore lint/suspicious/noExplicitAny: test helper reads arbitrary package.json shape
+async function readPkg(dir: string): Promise<any> {
+  return JSON.parse(await readFile(join(dir, "package.json"), "utf8"))
+}
+
+const tarballs = {
+  "@dawn-ai/cli": "/packs/cli.tgz",
+  "@dawn-ai/core": "/packs/core.tgz",
+  "@dawn-ai/permissions": "/packs/permissions.tgz",
+  "@dawn-ai/sqlite-storage": "/packs/sqlite.tgz",
+  "@dawn-ai/workspace": "/packs/workspace.tgz",
+  "@dawn-ai/config-typescript": "/packs/config-ts.tgz",
+  "@dawn-ai/devkit": "/packs/devkit.tgz",
+  "create-dawn-ai-app": "/packs/create.tgz",
+}
+
+describe("SCAFFOLD_PACKAGES", () => {
+  it("lists @dawn-ai workspace packages, excluding devkit/create-dawn-ai-app", () => {
+    expect(SCAFFOLD_PACKAGES).toContain("@dawn-ai/cli")
+    expect(SCAFFOLD_PACKAGES).toContain("@dawn-ai/testing")
+    expect(SCAFFOLD_PACKAGES).not.toContain("@dawn-ai/devkit")
+    expect(SCAFFOLD_PACKAGES).not.toContain("create-dawn-ai-app")
+  })
+})
+
+describe("rewriteGeneratedAppDependencies", () => {
+  it("swaps existing deps/devDeps that are in the tarball map, leaves unknown deps untouched", async () => {
+    const dir = await makePkg({
+      dependencies: { "@dawn-ai/cli": "next", "@dawn-ai/core": "next", zod: "^3.24.0" },
+      devDependencies: { "@dawn-ai/config-typescript": "next", vitest: "4.1.4" },
+    })
+    await rewriteGeneratedAppDependencies({ appRoot: dir, tarballs })
+    const pkg = await readPkg(dir)
+    expect(pkg.dependencies["@dawn-ai/cli"]).toBe("/packs/cli.tgz")
+    expect(pkg.dependencies["@dawn-ai/core"]).toBe("/packs/core.tgz")
+    expect(pkg.dependencies.zod).toBe("^3.24.0")
+    expect(pkg.devDependencies["@dawn-ai/config-typescript"]).toBe("/packs/config-ts.tgz")
+    expect(pkg.devDependencies.vitest).toBe("4.1.4")
+  })
+
+  it("sets pnpm.overrides for every packed SCAFFOLD package (not devkit/create-app)", async () => {
+    const dir = await makePkg({ dependencies: { "@dawn-ai/cli": "next" } })
+    await rewriteGeneratedAppDependencies({ appRoot: dir, tarballs })
+    const pkg = await readPkg(dir)
+    expect(pkg.pnpm.overrides["@dawn-ai/cli"]).toBe("/packs/cli.tgz")
+    expect(pkg.pnpm.overrides["@dawn-ai/permissions"]).toBe("/packs/permissions.tgz")
+    expect(pkg.pnpm.overrides["@dawn-ai/devkit"]).toBeUndefined()
+    expect(pkg.pnpm.overrides["create-dawn-ai-app"]).toBeUndefined()
+  })
+
+  it("applies extraDependencies (forced direct deps + version strings) and removeDependencies", async () => {
+    const dir = await makePkg({
+      dependencies: { "@dawn-ai/cli": "next", langchain: "0.3.0", "@langchain/openai": "0.3.0" },
+    })
+    await rewriteGeneratedAppDependencies({
+      appRoot: dir,
+      tarballs,
+      extraDependencies: {
+        "@dawn-ai/permissions": tarballs["@dawn-ai/permissions"],
+        "@dawn-ai/sqlite-storage": tarballs["@dawn-ai/sqlite-storage"],
+        "@dawn-ai/workspace": tarballs["@dawn-ai/workspace"],
+        "@langchain/langgraph": "1.3.0",
+      },
+      removeDependencies: ["langchain", "@langchain/openai"],
+    })
+    const pkg = await readPkg(dir)
+    expect(pkg.dependencies.langchain).toBeUndefined()
+    expect(pkg.dependencies["@langchain/openai"]).toBeUndefined()
+    expect(pkg.dependencies["@dawn-ai/permissions"]).toBe("/packs/permissions.tgz")
+    expect(pkg.dependencies["@langchain/langgraph"]).toBe("1.3.0")
+  })
+})

--- a/test/harness/scaffold-packaging.test.ts
+++ b/test/harness/scaffold-packaging.test.ts
@@ -28,6 +28,7 @@ const tarballs = {
 describe("SCAFFOLD_PACKAGES", () => {
   it("lists @dawn-ai workspace packages, excluding devkit/create-dawn-ai-app", () => {
     expect(SCAFFOLD_PACKAGES).toContain("@dawn-ai/cli")
+    expect(SCAFFOLD_PACKAGES).toContain("@dawn-ai/evals")
     expect(SCAFFOLD_PACKAGES).toContain("@dawn-ai/testing")
     expect(SCAFFOLD_PACKAGES).not.toContain("@dawn-ai/devkit")
     expect(SCAFFOLD_PACKAGES).not.toContain("create-dawn-ai-app")

--- a/test/harness/scaffold-packaging.ts
+++ b/test/harness/scaffold-packaging.ts
@@ -10,6 +10,7 @@ export const SCAFFOLD_PACKAGES: readonly string[] = [
   "@dawn-ai/cli",
   "@dawn-ai/config-typescript",
   "@dawn-ai/core",
+  "@dawn-ai/evals",
   "@dawn-ai/langchain",
   "@dawn-ai/langgraph",
   "@dawn-ai/permissions",

--- a/test/harness/scaffold-packaging.ts
+++ b/test/harness/scaffold-packaging.ts
@@ -1,0 +1,70 @@
+import { readFile, writeFile } from "node:fs/promises"
+import { join } from "node:path"
+
+/**
+ * Canonical set of @dawn-ai/* workspace packages a generated app may depend on.
+ * createPackagedInstaller additionally packs @dawn-ai/devkit + create-dawn-ai-app,
+ * which are deliberately NOT in this list (they are never generated-app overrides).
+ */
+export const SCAFFOLD_PACKAGES: readonly string[] = [
+  "@dawn-ai/cli",
+  "@dawn-ai/config-typescript",
+  "@dawn-ai/core",
+  "@dawn-ai/langchain",
+  "@dawn-ai/langgraph",
+  "@dawn-ai/permissions",
+  "@dawn-ai/sdk",
+  "@dawn-ai/sqlite-storage",
+  "@dawn-ai/testing",
+  "@dawn-ai/workspace",
+]
+
+export interface RewriteGeneratedAppDepsOptions {
+  readonly appRoot: string
+  readonly tarballs: Readonly<Record<string, string>>
+  /** Forced deps to add (tarball paths for @dawn pkgs, or version strings e.g. @langchain/langgraph). */
+  readonly extraDependencies?: Readonly<Record<string, string>>
+  /** Dep keys to delete from deps+devDeps before rewriting (e.g. langchain, @langchain/openai). */
+  readonly removeDependencies?: readonly string[]
+}
+
+interface MutablePackageJson {
+  dependencies?: Record<string, string>
+  devDependencies?: Record<string, string>
+  pnpm?: { overrides?: Record<string, string> }
+}
+
+export async function rewriteGeneratedAppDependencies(
+  options: RewriteGeneratedAppDepsOptions,
+): Promise<void> {
+  const packageJsonPath = join(options.appRoot, "package.json")
+  const pkg = JSON.parse(await readFile(packageJsonPath, "utf8")) as MutablePackageJson
+
+  for (const key of options.removeDependencies ?? []) {
+    if (pkg.dependencies) delete pkg.dependencies[key]
+    if (pkg.devDependencies) delete pkg.devDependencies[key]
+  }
+
+  const swap = (deps: Record<string, string> | undefined): void => {
+    if (!deps) return
+    for (const name of Object.keys(deps)) {
+      const tarball = options.tarballs[name]
+      if (tarball) deps[name] = tarball
+    }
+  }
+  swap(pkg.dependencies)
+  swap(pkg.devDependencies)
+
+  if (options.extraDependencies) {
+    pkg.dependencies = { ...pkg.dependencies, ...options.extraDependencies }
+  }
+
+  const overrides: Record<string, string> = { ...(pkg.pnpm?.overrides ?? {}) }
+  for (const name of SCAFFOLD_PACKAGES) {
+    const tarball = options.tarballs[name]
+    if (tarball) overrides[name] = tarball
+  }
+  pkg.pnpm = { ...(pkg.pnpm ?? {}), overrides }
+
+  await writeFile(packageJsonPath, `${JSON.stringify(pkg, null, 2)}\n`, "utf8")
+}

--- a/test/runtime/run-agent-protocol.test.ts
+++ b/test/runtime/run-agent-protocol.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, readFile, writeFile } from "node:fs/promises"
+import { mkdir, writeFile } from "node:fs/promises"
 import { dirname, join } from "node:path"
 
 import { afterEach, describe, expect, it } from "vitest"
@@ -10,6 +10,10 @@ import {
   markTrackedTempDirForPreserve,
   type TrackedTempDir,
 } from "../harness/packaged-app.ts"
+import {
+  rewriteGeneratedAppDependencies,
+  SCAFFOLD_PACKAGES,
+} from "../harness/scaffold-packaging.js"
 import { allocatePort, appendDevServerTranscript, startDevServer } from "./support/dev-server.ts"
 
 // ---------------------------------------------------------------------------
@@ -173,18 +177,7 @@ describe("agent protocol permission interrupt + resume", () => {
 
     try {
       const { tarballs } = await createPackagedInstaller({
-        packageNames: [
-          "@dawn-ai/cli",
-          "@dawn-ai/config-typescript",
-          "@dawn-ai/core",
-          "@dawn-ai/langchain",
-          "@dawn-ai/langgraph",
-          "@dawn-ai/permissions",
-          "@dawn-ai/sdk",
-          "@dawn-ai/sqlite-storage",
-          "@dawn-ai/testing",
-          "@dawn-ai/workspace",
-        ],
+        packageNames: [...SCAFFOLD_PACKAGES],
         tempRoot,
         transcriptPath,
       })
@@ -202,7 +195,17 @@ describe("agent protocol permission interrupt + resume", () => {
       })
 
       appRoot = generatedApp.appRoot
-      await rewriteDependenciesToTarballs({ appRoot, tarballs })
+      await rewriteGeneratedAppDependencies({
+        appRoot,
+        tarballs,
+        extraDependencies: {
+          "@dawn-ai/permissions": tarballs["@dawn-ai/permissions"]!,
+          "@dawn-ai/sqlite-storage": tarballs["@dawn-ai/sqlite-storage"]!,
+          "@dawn-ai/workspace": tarballs["@dawn-ai/workspace"]!,
+          "@langchain/langgraph": "1.3.0",
+        },
+        removeDependencies: ["langchain", "@langchain/openai"],
+      })
 
       // Write echo agent route and a workspace directory
       const routeFile = join(appRoot, "src/app/echo/index.ts")
@@ -277,18 +280,7 @@ describe("agent protocol permission interrupt + resume", () => {
 
     try {
       const { tarballs } = await createPackagedInstaller({
-        packageNames: [
-          "@dawn-ai/cli",
-          "@dawn-ai/config-typescript",
-          "@dawn-ai/core",
-          "@dawn-ai/langchain",
-          "@dawn-ai/langgraph",
-          "@dawn-ai/permissions",
-          "@dawn-ai/sdk",
-          "@dawn-ai/sqlite-storage",
-          "@dawn-ai/testing",
-          "@dawn-ai/workspace",
-        ],
+        packageNames: [...SCAFFOLD_PACKAGES],
         tempRoot,
         transcriptPath,
       })
@@ -306,7 +298,17 @@ describe("agent protocol permission interrupt + resume", () => {
       })
 
       appRoot = generatedApp.appRoot
-      await rewriteDependenciesToTarballs({ appRoot, tarballs })
+      await rewriteGeneratedAppDependencies({
+        appRoot,
+        tarballs,
+        extraDependencies: {
+          "@dawn-ai/permissions": tarballs["@dawn-ai/permissions"]!,
+          "@dawn-ai/sqlite-storage": tarballs["@dawn-ai/sqlite-storage"]!,
+          "@dawn-ai/workspace": tarballs["@dawn-ai/workspace"]!,
+          "@langchain/langgraph": "1.3.0",
+        },
+        removeDependencies: ["langchain", "@langchain/openai"],
+      })
 
       const routeFile = join(appRoot, "src/app/echo/index.ts")
       await mkdir(dirname(routeFile), { recursive: true })
@@ -394,7 +396,17 @@ describe("agent protocol permission interrupt + resume", () => {
 
         appRoot = generatedApp.appRoot
 
-        await rewriteDependenciesToTarballs({ appRoot, tarballs })
+        await rewriteGeneratedAppDependencies({
+          appRoot,
+          tarballs,
+          extraDependencies: {
+            "@dawn-ai/permissions": tarballs["@dawn-ai/permissions"]!,
+            "@dawn-ai/sqlite-storage": tarballs["@dawn-ai/sqlite-storage"]!,
+            "@dawn-ai/workspace": tarballs["@dawn-ai/workspace"]!,
+            "@langchain/langgraph": "1.3.0",
+          },
+          removeDependencies: ["langchain", "@langchain/openai"],
+        })
 
         // Write the perm-agent route overlay at src/app/perm-agent/index.ts
         const routeFile = join(appRoot, "src/app/perm-agent/index.ts")
@@ -632,18 +644,7 @@ describe("agent protocol state persistence", () => {
 
     try {
       const { tarballs } = await createPackagedInstaller({
-        packageNames: [
-          "@dawn-ai/cli",
-          "@dawn-ai/config-typescript",
-          "@dawn-ai/core",
-          "@dawn-ai/langchain",
-          "@dawn-ai/langgraph",
-          "@dawn-ai/permissions",
-          "@dawn-ai/sdk",
-          "@dawn-ai/sqlite-storage",
-          "@dawn-ai/testing",
-          "@dawn-ai/workspace",
-        ],
+        packageNames: [...SCAFFOLD_PACKAGES],
         tempRoot,
         transcriptPath,
       })
@@ -663,7 +664,17 @@ describe("agent protocol state persistence", () => {
       appRoot = generatedApp.appRoot
 
       // Rewrite dependencies to tarballs (mirrors run-runtime-contract.test.ts)
-      await rewriteDependenciesToTarballs({ appRoot, tarballs })
+      await rewriteGeneratedAppDependencies({
+        appRoot,
+        tarballs,
+        extraDependencies: {
+          "@dawn-ai/permissions": tarballs["@dawn-ai/permissions"]!,
+          "@dawn-ai/sqlite-storage": tarballs["@dawn-ai/sqlite-storage"]!,
+          "@dawn-ai/workspace": tarballs["@dawn-ai/workspace"]!,
+          "@langchain/langgraph": "1.3.0",
+        },
+        removeDependencies: ["langchain", "@langchain/openai"],
+      })
 
       // Write the echo-agent route overlay
       const routeFile = join(appRoot, "src/app/echo/index.ts")
@@ -784,59 +795,3 @@ describe("agent protocol state persistence", () => {
     }
   })
 })
-
-// ---------------------------------------------------------------------------
-// Helpers (mirrors run-runtime-contract.test.ts)
-// ---------------------------------------------------------------------------
-
-async function rewriteDependenciesToTarballs(options: {
-  readonly appRoot: string
-  readonly tarballs: Readonly<Record<string, string>>
-}): Promise<void> {
-  const packageJsonPath = join(options.appRoot, "package.json")
-  const packageJson = JSON.parse(await readFile(packageJsonPath, "utf8")) as {
-    dependencies?: Record<string, string>
-    devDependencies?: Record<string, string>
-    pnpm?: {
-      overrides?: Record<string, string>
-    }
-  }
-
-  delete packageJson.dependencies?.langchain
-  delete packageJson.dependencies?.["@langchain/openai"]
-  packageJson.dependencies = {
-    ...packageJson.dependencies,
-    "@dawn-ai/cli": options.tarballs["@dawn-ai/cli"],
-    "@dawn-ai/core": options.tarballs["@dawn-ai/core"],
-    "@dawn-ai/langchain": options.tarballs["@dawn-ai/langchain"],
-    "@dawn-ai/permissions": options.tarballs["@dawn-ai/permissions"],
-    "@dawn-ai/sdk": options.tarballs["@dawn-ai/sdk"],
-    "@dawn-ai/sqlite-storage": options.tarballs["@dawn-ai/sqlite-storage"],
-    "@dawn-ai/workspace": options.tarballs["@dawn-ai/workspace"],
-    // Required so the echo-agent route can import it directly (pnpm strict isolation)
-    "@langchain/langgraph": "1.3.0",
-  }
-  packageJson.devDependencies = {
-    ...packageJson.devDependencies,
-    "@dawn-ai/config-typescript": options.tarballs["@dawn-ai/config-typescript"],
-    "@dawn-ai/testing": options.tarballs["@dawn-ai/testing"],
-  }
-  packageJson.pnpm = {
-    ...(packageJson.pnpm ?? {}),
-    overrides: {
-      ...(packageJson.pnpm?.overrides ?? {}),
-      "@dawn-ai/cli": options.tarballs["@dawn-ai/cli"],
-      "@dawn-ai/config-typescript": options.tarballs["@dawn-ai/config-typescript"],
-      "@dawn-ai/core": options.tarballs["@dawn-ai/core"],
-      "@dawn-ai/langchain": options.tarballs["@dawn-ai/langchain"],
-      "@dawn-ai/langgraph": options.tarballs["@dawn-ai/langgraph"],
-      "@dawn-ai/permissions": options.tarballs["@dawn-ai/permissions"],
-      "@dawn-ai/sdk": options.tarballs["@dawn-ai/sdk"],
-      "@dawn-ai/sqlite-storage": options.tarballs["@dawn-ai/sqlite-storage"],
-      "@dawn-ai/testing": options.tarballs["@dawn-ai/testing"],
-      "@dawn-ai/workspace": options.tarballs["@dawn-ai/workspace"],
-    },
-  }
-
-  await writeFile(packageJsonPath, `${JSON.stringify(packageJson, null, 2)}\n`, "utf8")
-}

--- a/test/runtime/run-runtime-contract.test.ts
+++ b/test/runtime/run-runtime-contract.test.ts
@@ -5,12 +5,12 @@ import { basename, dirname, join, resolve } from "node:path"
 import { afterEach, describe, expect, test } from "vitest"
 
 import { executeRoute } from "../../packages/cli/src/lib/runtime/execute-route.ts"
-import { createRouteAssistantId } from "../../packages/cli/src/lib/runtime/route-identity.ts"
 import type {
   RuntimeExecutionErrorKind,
   RuntimeExecutionMode,
   RuntimeExecutionResult,
 } from "../../packages/cli/src/lib/runtime/result.ts"
+import { createRouteAssistantId } from "../../packages/cli/src/lib/runtime/route-identity.ts"
 import {
   createArtifactRoot,
   createGeneratedApp,
@@ -26,6 +26,10 @@ import {
   type TrackedTempDir,
 } from "../harness/packaged-app.ts"
 import {
+  rewriteGeneratedAppDependencies,
+  SCAFFOLD_PACKAGES,
+} from "../harness/scaffold-packaging.js"
+import {
   appendDevServerTranscript,
   invokeRunsWait,
   postRunsWait,
@@ -37,7 +41,13 @@ const RUNTIME_ROOT = resolve(import.meta.dirname)
 const HARNESS_RUNTIME_ARTIFACT_BASE_DIR_ENV = "DAWN_RUNTIME_ARTIFACT_BASE_DIR"
 const tempDirs: TrackedTempDir[] = []
 
-type RuntimeFixtureName = "agent-basic" | "agent-failure" | "graph-basic" | "graph-failure" | "workflow-basic" | "workflow-failure"
+type RuntimeFixtureName =
+  | "agent-basic"
+  | "agent-failure"
+  | "graph-basic"
+  | "graph-failure"
+  | "workflow-basic"
+  | "workflow-failure"
 
 interface RuntimeOverlay {
   readonly deleteFiles?: readonly string[]
@@ -476,18 +486,7 @@ async function withRuntimeScenario(
     const overlay = await readOverlay(fixtureName)
     const { tarballs } = await recordPhase(phases, "packaged-installer", async () => {
       return await createPackagedInstaller({
-        packageNames: [
-          "@dawn-ai/cli",
-          "@dawn-ai/config-typescript",
-          "@dawn-ai/core",
-          "@dawn-ai/langchain",
-          "@dawn-ai/langgraph",
-          "@dawn-ai/permissions",
-          "@dawn-ai/sdk",
-          "@dawn-ai/sqlite-storage",
-          "@dawn-ai/testing",
-          "@dawn-ai/workspace",
-        ],
+        packageNames: [...SCAFFOLD_PACKAGES],
         tempRoot,
         transcriptPath,
       })
@@ -504,9 +503,15 @@ async function withRuntimeScenario(
       template: "basic",
     })
 
-    await rewriteDependenciesToTarballs({
+    await rewriteGeneratedAppDependencies({
       appRoot: generatedApp.appRoot,
       tarballs,
+      extraDependencies: {
+        "@dawn-ai/permissions": tarballs["@dawn-ai/permissions"]!,
+        "@dawn-ai/sqlite-storage": tarballs["@dawn-ai/sqlite-storage"]!,
+        "@dawn-ai/workspace": tarballs["@dawn-ai/workspace"]!,
+      },
+      removeDependencies: ["langchain", "@langchain/openai"],
     })
     await applyOverlay({ appRoot: generatedApp.appRoot, overlay })
 
@@ -694,56 +699,6 @@ async function applyOverlay(options: {
       await writeFile(outputPath, source, "utf8")
     }),
   )
-}
-
-async function rewriteDependenciesToTarballs(options: {
-  readonly appRoot: string
-  readonly tarballs: Readonly<Record<string, string>>
-}): Promise<void> {
-  const packageJsonPath = join(options.appRoot, "package.json")
-  const packageJson = JSON.parse(await readFile(packageJsonPath, "utf8")) as {
-    dependencies?: Record<string, string>
-    devDependencies?: Record<string, string>
-    pnpm?: {
-      overrides?: Record<string, string>
-    }
-  }
-
-  delete packageJson.dependencies?.langchain
-  delete packageJson.dependencies?.["@langchain/openai"]
-  packageJson.dependencies = {
-    ...packageJson.dependencies,
-    "@dawn-ai/cli": options.tarballs["@dawn-ai/cli"],
-    "@dawn-ai/core": options.tarballs["@dawn-ai/core"],
-    "@dawn-ai/langchain": options.tarballs["@dawn-ai/langchain"],
-    "@dawn-ai/permissions": options.tarballs["@dawn-ai/permissions"],
-    "@dawn-ai/sdk": options.tarballs["@dawn-ai/sdk"],
-    "@dawn-ai/sqlite-storage": options.tarballs["@dawn-ai/sqlite-storage"],
-    "@dawn-ai/workspace": options.tarballs["@dawn-ai/workspace"],
-  }
-  packageJson.devDependencies = {
-    ...packageJson.devDependencies,
-    "@dawn-ai/config-typescript": options.tarballs["@dawn-ai/config-typescript"],
-    "@dawn-ai/testing": options.tarballs["@dawn-ai/testing"],
-  }
-  packageJson.pnpm = {
-    ...(packageJson.pnpm ?? {}),
-    overrides: {
-      ...(packageJson.pnpm?.overrides ?? {}),
-      "@dawn-ai/cli": options.tarballs["@dawn-ai/cli"],
-      "@dawn-ai/config-typescript": options.tarballs["@dawn-ai/config-typescript"],
-      "@dawn-ai/core": options.tarballs["@dawn-ai/core"],
-      "@dawn-ai/langchain": options.tarballs["@dawn-ai/langchain"],
-      "@dawn-ai/langgraph": options.tarballs["@dawn-ai/langgraph"],
-      "@dawn-ai/permissions": options.tarballs["@dawn-ai/permissions"],
-      "@dawn-ai/sdk": options.tarballs["@dawn-ai/sdk"],
-      "@dawn-ai/sqlite-storage": options.tarballs["@dawn-ai/sqlite-storage"],
-      "@dawn-ai/testing": options.tarballs["@dawn-ai/testing"],
-      "@dawn-ai/workspace": options.tarballs["@dawn-ai/workspace"],
-    },
-  }
-
-  await writeFile(packageJsonPath, `${JSON.stringify(packageJson, null, 2)}\n`, "utf8")
 }
 
 async function recordPhase<T>(

--- a/test/smoke/run-smoke.test.ts
+++ b/test/smoke/run-smoke.test.ts
@@ -17,6 +17,10 @@ import {
   markTrackedTempDirForPreserve,
   type TrackedTempDir,
 } from "../harness/packaged-app.ts"
+import {
+  rewriteGeneratedAppDependencies,
+  SCAFFOLD_PACKAGES,
+} from "../harness/scaffold-packaging.js"
 
 const SMOKE_ROOT = resolve(import.meta.dirname)
 const tempDirs: TrackedTempDir[] = []
@@ -153,18 +157,7 @@ async function runSmokeScenario(fixtureName: SmokeFixtureName): Promise<HarnessL
     const overlay = await readOverlay(fixtureName)
     const { tarballs } = await recordPhase(phases, "packaged-installer", async () => {
       return await createPackagedInstaller({
-        packageNames: [
-          "@dawn-ai/cli",
-          "@dawn-ai/config-typescript",
-          "@dawn-ai/core",
-          "@dawn-ai/langchain",
-          "@dawn-ai/langgraph",
-          "@dawn-ai/permissions",
-          "@dawn-ai/sdk",
-          "@dawn-ai/sqlite-storage",
-          "@dawn-ai/testing",
-          "@dawn-ai/workspace",
-        ],
+        packageNames: [...SCAFFOLD_PACKAGES],
         tempRoot,
         transcriptPath,
       })
@@ -181,9 +174,15 @@ async function runSmokeScenario(fixtureName: SmokeFixtureName): Promise<HarnessL
       template: "basic",
     })
 
-    await rewriteDependenciesToTarballs({
+    await rewriteGeneratedAppDependencies({
       appRoot: generatedApp.appRoot,
       tarballs,
+      extraDependencies: {
+        "@dawn-ai/permissions": tarballs["@dawn-ai/permissions"]!,
+        "@dawn-ai/sqlite-storage": tarballs["@dawn-ai/sqlite-storage"]!,
+        "@dawn-ai/workspace": tarballs["@dawn-ai/workspace"]!,
+      },
+      removeDependencies: ["langchain", "@langchain/openai"],
     })
     await applyOverlay({ appRoot: generatedApp.appRoot, overlay })
 
@@ -294,56 +293,6 @@ async function applyOverlay(options: {
       await writeFile(outputPath, source, "utf8")
     }),
   )
-}
-
-async function rewriteDependenciesToTarballs(options: {
-  readonly appRoot: string
-  readonly tarballs: Readonly<Record<string, string>>
-}): Promise<void> {
-  const packageJsonPath = join(options.appRoot, "package.json")
-  const packageJson = JSON.parse(await readFile(packageJsonPath, "utf8")) as {
-    dependencies?: Record<string, string>
-    devDependencies?: Record<string, string>
-    pnpm?: {
-      overrides?: Record<string, string>
-    }
-  }
-
-  delete packageJson.dependencies?.langchain
-  delete packageJson.dependencies?.["@langchain/openai"]
-  packageJson.dependencies = {
-    ...packageJson.dependencies,
-    "@dawn-ai/cli": options.tarballs["@dawn-ai/cli"],
-    "@dawn-ai/core": options.tarballs["@dawn-ai/core"],
-    "@dawn-ai/langchain": options.tarballs["@dawn-ai/langchain"],
-    "@dawn-ai/permissions": options.tarballs["@dawn-ai/permissions"],
-    "@dawn-ai/sdk": options.tarballs["@dawn-ai/sdk"],
-    "@dawn-ai/sqlite-storage": options.tarballs["@dawn-ai/sqlite-storage"],
-    "@dawn-ai/workspace": options.tarballs["@dawn-ai/workspace"],
-  }
-  packageJson.devDependencies = {
-    ...packageJson.devDependencies,
-    "@dawn-ai/config-typescript": options.tarballs["@dawn-ai/config-typescript"],
-    "@dawn-ai/testing": options.tarballs["@dawn-ai/testing"],
-  }
-  packageJson.pnpm = {
-    ...(packageJson.pnpm ?? {}),
-    overrides: {
-      ...(packageJson.pnpm?.overrides ?? {}),
-      "@dawn-ai/cli": options.tarballs["@dawn-ai/cli"],
-      "@dawn-ai/config-typescript": options.tarballs["@dawn-ai/config-typescript"],
-      "@dawn-ai/core": options.tarballs["@dawn-ai/core"],
-      "@dawn-ai/langchain": options.tarballs["@dawn-ai/langchain"],
-      "@dawn-ai/langgraph": options.tarballs["@dawn-ai/langgraph"],
-      "@dawn-ai/permissions": options.tarballs["@dawn-ai/permissions"],
-      "@dawn-ai/sdk": options.tarballs["@dawn-ai/sdk"],
-      "@dawn-ai/sqlite-storage": options.tarballs["@dawn-ai/sqlite-storage"],
-      "@dawn-ai/testing": options.tarballs["@dawn-ai/testing"],
-      "@dawn-ai/workspace": options.tarballs["@dawn-ai/workspace"],
-    },
-  }
-
-  await writeFile(packageJsonPath, `${JSON.stringify(packageJson, null, 2)}\n`, "utf8")
 }
 
 async function discoverRoutes(options: {


### PR DESCRIPTION
Fixes the generated-app harness "packaging trap" (the PR #198/eval-authoring pain), then adds `@dawn-ai/evals` to the scaffold — the latter now a near-template-only change.

Spec: `docs/superpowers/specs/2026-06-07-harness-packaging-consolidation-design.md` · Plan: `docs/superpowers/plans/2026-06-07-harness-packaging-consolidation.md`

## The fix (consolidation)
Adding a scaffold dependency used to require editing **9 inline `packageNames` lists + 5 copy-pasted `rewriteDependenciesToTarballs` functions + 2 `PackedTarballs` types** across 5 harness files; miss one and that lane failed silently with a cryptic cold-cache 404.

Now a single `test/harness/scaffold-packaging.ts` exports:
- **`SCAFFOLD_PACKAGES`** — the canonical workspace-package set (replaces the 9 lists).
- **`rewriteGeneratedAppDependencies`** — data-driven: swaps any dep present in the packed-tarball map, sets `pnpm.overrides` for every packed `SCAFFOLD_PACKAGES` entry, applies per-lane `extraDependencies`/`removeDependencies` (the only genuinely per-lane bits — runtime/smoke force `permissions`/`sqlite-storage`/`workspace` direct deps + delete `langchain`/`@langchain/openai`; agent-protocol also adds `@langchain/langgraph`).

All five lanes migrated; the 2 named `PackedTarballs` types + `toPackedTarballs` deleted; `run-generated-app`'s fixture normalizers made generic over the tarball map. Behavior-preserving — proven by all three harness lanes staying green.

## The payoff (evals scaffold)
Adding `@dawn-ai/evals` was then: add it to `SCAFFOLD_PACKAGES` (one line → packed + overridden everywhere, **zero per-lane edits**) + thread the specifier through `create-dawn-app`/`devkit` (mirroring `@dawn-ai/testing`) + a template `evals/smoke.eval.ts.template` + `eval` script + devDep. New apps now get a passing `dawn eval` out of the box (verified end-to-end on a freshly-generated app).

## Verification
- New unit test for `rewriteGeneratedAppDependencies` (4 cases).
- All three harness lanes green: `verify:harness:framework`, `:runtime`, `:smoke`.
- Scaffold tests assert the eval file/devDep/`eval` script; generated-app fixtures updated.
- Full suite green: lint, build, typecheck, `pnpm test`, `check-docs`.

Built via subagent-driven development (the two API-overload interruptions on the fixtures task were finished inline). Out of scope by design: template-parsing source-of-truth, dep-agnostic fixtures, a `dawn eval`-in-generated-app lane.

Note: `create-dawn-ai-app` is in the changeset `fixed` group, so this queues a Version PR (group bump + `@dawn-ai/devkit`); no publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)