### PR TITLE
fix(workspace): writeFile creates missing parent directories

### DIFF
--- a/.changeset/workspace-writefile-mkdir.md
+++ b/.changeset/workspace-writefile-mkdir.md
@@ -1,0 +1,7 @@
+---
+"@dawn-ai/workspace": patch
+---
+
+`localFilesystem` `writeFile` now creates missing parent directories before
+writing. Previously, an agent writing to a nested workspace path (e.g.
+`reports/result.md`) failed with `ENOENT` unless the directory already existed.

--- a/packages/workspace/src/local-filesystem.ts
+++ b/packages/workspace/src/local-filesystem.ts
@@ -1,4 +1,5 @@
 import { mkdir as mkdirFs, readdir, readFile, rm, stat, utimes, writeFile } from "node:fs/promises"
+import { dirname } from "node:path"
 import type { BackendContext, FilesystemBackend } from "./types.js"
 
 const DEFAULT_MAX_FILE_BYTES = 256 * 1024
@@ -44,6 +45,10 @@ export function localFilesystem(opts: LocalFilesystemOptions = {}): FilesystemBa
       content: string,
       _ctx: BackendContext,
     ): Promise<{ readonly bytesWritten: number }> {
+      // Create missing parent directories so writing to a nested workspace
+      // path (e.g. "reports/result.md") succeeds without a separate mkdir.
+      // `path` is already resolved and path-jailed inside the workspace root.
+      await mkdirFs(dirname(path), { recursive: true })
       await writeFile(path, content, "utf8")
       return { bytesWritten: Buffer.byteLength(content, "utf8") }
     },

--- a/packages/workspace/test/local-filesystem.test.ts
+++ b/packages/workspace/test/local-filesystem.test.ts
@@ -35,6 +35,14 @@ describe("localFilesystem", () => {
     expect(res.bytesWritten).toBe(3)
   })
 
+  it("writeFile creates missing parent directories", async () => {
+    const fs = localFilesystem()
+    const nested = join(root, "reports", "2026", "result.md")
+    const res = await fs.writeFile(nested, "hello", ctx(root))
+    expect(res.bytesWritten).toBe(5)
+    expect(await fs.readFile(nested, ctx(root))).toBe("hello")
+  })
+
   it("listDir returns directory entries (leaf names only)", async () => {
     writeFileSync(join(root, "a.txt"), "", "utf8")
     mkdirSync(join(root, "sub"))


### PR DESCRIPTION
## Summary
`localFilesystem` `writeFile` now `mkdir -p`'s the parent directory before writing. Previously, an agent writing to a nested workspace path (e.g. `reports/result.md`) failed with `ENOENT` unless the directory already existed.

## How it was found
A **live smoke** (real model) of the newly-merged Deep Research starter (#206): the agent correctly planned, dispatched researcher subagents, searched the corpus, and composed a properly cited report — but `writeFile({ path: "reports/<slug>.md" })` failed `ENOENT` because `reports/` didn't exist, derailing the run into `listDir`/`runBash("mkdir -p reports")`. Offline replay tests can't catch this (their fixtures don't execute `writeFile`).

## Fix + validation
- `packages/workspace/src/local-filesystem.ts`: `writeFile` creates the parent dir (`mkdir(dirname(path), { recursive: true })`). The path is already resolved + path-jailed inside the workspace root, so this stays within the jail.
- Added a regression test: `writeFile` to a nested path creates parents and round-trips.
- `@dawn-ai/workspace` tests: 29/29 green.
- **Re-ran the live smoke on the fixed build** (driven through Chrome): coordinator → 3 researcher subagents → `writeFile` **succeeded**, report saved to `workspace/reports/common-agent-architectures.md`, clean final answer. No ENOENT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)