### PR TITLE
chore: default research scaffold to gpt-5-mini

### DIFF
--- a/.changeset/research-default-gpt5-mini.md
+++ b/.changeset/research-default-gpt5-mini.md
@@ -1,0 +1,6 @@
+---
+"create-dawn-ai-app": patch
+"@dawn-ai/devkit": patch
+---
+
+The research scaffold template now defaults to the `gpt-5-mini` model (was `gpt-4o-mini`) for its coordinator, researcher subagent, and eval judge.

--- a/packages/devkit/templates/app-research/src/app/research/evals/research-quality.eval.ts.template
+++ b/packages/devkit/templates/app-research/src/app/research/evals/research-quality.eval.ts.template
@@ -39,7 +39,7 @@ export default defineEval({
       name: "cites-source",
       threshold: 1,
     }),
-    llmJudge({ criteria: JUDGE_CRITERIA, model: "gpt-4o-mini", threshold: 0.7 }),
+    llmJudge({ criteria: JUDGE_CRITERIA, model: "gpt-5-mini", threshold: 0.7 }),
   ],
   gate: gate.all(gate.passRate(1), gate.perScorer()),
 })

--- a/packages/devkit/templates/app-research/src/app/research/index.ts
+++ b/packages/devkit/templates/app-research/src/app/research/index.ts
@@ -1,7 +1,7 @@
 import { agent } from "@dawn-ai/sdk"
 
 export default agent({
-  model: "gpt-4o-mini",
+  model: "gpt-5-mini",
   description:
     "A deep-research assistant: plans sub-questions, dispatches researchers, and writes a cited report.",
   systemPrompt: `You are a deep-research coordinator. Given a question:

--- a/packages/devkit/templates/app-research/src/app/research/subagents/researcher/index.ts
+++ b/packages/devkit/templates/app-research/src/app/research/subagents/researcher/index.ts
@@ -1,7 +1,7 @@
 import { agent } from "@dawn-ai/sdk"
 
 export default agent({
-  model: "gpt-4o-mini",
+  model: "gpt-5-mini",
   description:
     "Researches one sub-question against the bundled corpus and returns a focused, cited answer.",
   systemPrompt: `You are a research specialist. Answer the single sub-question you are given using the corpus.


### PR DESCRIPTION
## Summary

- Updates the research starter template to use `gpt-5-mini` instead of `gpt-4o-mini` in three places: the coordinator agent (`src/app/research/index.ts`), the researcher subagent (`src/app/research/subagents/researcher/index.ts`), and the `llmJudge` scorer in the eval template (`src/app/research/evals/research-quality.eval.ts.template`).
- Aligns the research scaffold's default with the chat example, which already uses `gpt-5-mini` for its subagents.
- `@dawn-ai/devkit` build passes cleanly. The scaffold's offline tests and evals run in REPLAY mode (mocked model), so the model id change does not affect their pass/fail.

## Test plan

- [x] `pnpm --filter @dawn-ai/devkit build` — passes
- [x] `grep -rn "gpt-4o-mini" packages/devkit/templates/app-research/` — returns nothing
- [x] `grep -rn "gpt-5-mini" packages/devkit/templates/app-research/` — shows all 3 changed lines
- [x] `pnpm --filter create-dawn-ai-app test` — 3 scaffold/file-existence tests pass; 2 "packaged bin" tests fail on the same missing `@dawn-ai/workspace` type declarations as on unmodified `main` (pre-existing, unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)