### PR TITLE
feat(cli): targeted diagnostics for tool authoring mistakes

### DIFF
--- a/.changeset/tool-authoring-diagnostics.md
+++ b/.changeset/tool-authoring-diagnostics.md
@@ -1,0 +1,5 @@
+---
+"@dawn-ai/cli": minor
+---
+
+Friendlier tool-discovery errors. Default-exporting a LangChain `tool()` (StructuredTool) from a route tool file now produces a targeted error naming the export and showing the 3-line plain-function wrapper conversion; the generic "must default export a function" error now describes what was actually exported and links the tools documentation.

--- a/apps/web/content/docs/tools.mdx
+++ b/apps/web/content/docs/tools.mdx
@@ -41,16 +41,16 @@ The second parameter is optional but recommended for any tool that does network 
 The description the LLM sees for an `agent`-route tool comes from a JSDoc comment directly above the default export:
 
 ```ts title="src/app/(public)/hello/[tenant]/tools/greet.ts"
-/** Greet a user by name in the tenant's locale. */
-export default async (input: { readonly name: string }) => {
-  return { greeting: `Hello, ${input.name}!` }
+/** Greet the tenant organization by name. */
+export default async (input: { readonly tenant: string }) => {
+  return { greeting: `Hello, ${input.tenant}!` }
 }
 ```
 
 `dawn typegen` extracts the comment into the route's `tools.json` manifest. To set it programmatically instead, export a string constant — an explicit `export const description` takes priority over the JSDoc comment:
 
 ```ts
-export const description = "Greet a user by name in the tenant's locale."
+export const description = "Greet the tenant organization by name."
 ```
 
 Tools without a description still work, but the LLM only sees the tool name — write the one-liner.

--- a/apps/web/content/docs/tools.mdx
+++ b/apps/web/content/docs/tools.mdx
@@ -36,6 +36,25 @@ export default async (
 
 The second parameter is optional but recommended for any tool that does network I/O, holds long-running work, or needs middleware-derived context. See [Middleware](/docs/middleware) for how `defineMiddleware` and `allow(context)` populate `ctx.middleware`.
 
+## Tool descriptions
+
+The description the LLM sees for an `agent`-route tool comes from a JSDoc comment directly above the default export:
+
+```ts title="src/app/(public)/hello/[tenant]/tools/greet.ts"
+/** Greet a user by name in the tenant's locale. */
+export default async (input: { readonly name: string }) => {
+  return { greeting: `Hello, ${input.name}!` }
+}
+```
+
+`dawn typegen` extracts the comment into the route's `tools.json` manifest. To set it programmatically instead, export a string constant — an explicit `export const description` takes priority over the JSDoc comment:
+
+```ts
+export const description = "Greet a user by name in the tenant's locale."
+```
+
+Tools without a description still work, but the LLM only sees the tool name — write the one-liner.
+
 ## Invoking a tool
 
 Inside a `workflow` or `graph` route, tools are invoked through `ctx.tools.<name>(...)`:
@@ -108,6 +127,17 @@ dawn typegen
 - **Database reads** — input includes the filters; output is the record(s). Keep queries cheap — tools are meant to be fast.
 - **LLM calls** — input is the prompt variables; output is the parsed model response. Defer orchestration to the route entry.
 - **Pure transformations** — no side effects, just shape-to-shape mapping. Dawn's testing makes these trivial to verify.
+- **Wrapping an existing LangChain tool** — instantiate the community tool at module scope, then expose it through a plain function with a typed input. Dawn tools are plain functions (not `tool()` wrappers) so the input/output types can be inferred from the signature:
+
+```ts title="src/app/(public)/research/tools/search.ts"
+import { TavilySearch } from "@langchain/tavily"
+
+const tavily = new TavilySearch({ maxResults: 5 })
+
+/** Search the web for current information. */
+export default async (input: { readonly query: string }) =>
+  tavily.invoke({ query: input.query })
+```
 
 ## Related
 

--- a/apps/web/content/docs/tools.mdx
+++ b/apps/web/content/docs/tools.mdx
@@ -47,10 +47,14 @@ export default async (input: { readonly tenant: string }) => {
 }
 ```
 
-`dawn typegen` extracts the comment into the route's `tools.json` manifest. To set it programmatically instead, export a string constant — an explicit `export const description` takes priority over the JSDoc comment:
+`dawn typegen` extracts the comment into the route's `tools.json` manifest. To set it programmatically instead, export a string constant alongside the default export — an explicit `export const description` takes priority over the JSDoc comment:
 
-```ts
+```ts title="src/app/(public)/hello/[tenant]/tools/greet.ts"
 export const description = "Greet the tenant organization by name."
+
+export default async (input: { readonly tenant: string }) => {
+  return { greeting: `Hello, ${input.tenant}!` }
+}
 ```
 
 Tools without a description still work, but the LLM only sees the tool name — write the one-liner.
@@ -135,9 +139,13 @@ import { TavilySearch } from "@langchain/tavily"
 const tavily = new TavilySearch({ maxResults: 5 })
 
 /** Search the web for current information. */
-export default async (input: { readonly query: string }) =>
-  tavily.invoke({ query: input.query })
+export default async (input: { readonly query: string }) => {
+  const results = await tavily.invoke({ query: input.query })
+  return { results: String(results) }
+}
 ```
+
+Wrap the wrapped tool's output in a plain object (per the rules above) so Dawn can infer the return shape — community tools often return loosely-typed values.
 
 ## Related
 

--- a/packages/cli/src/lib/runtime/tool-discovery.ts
+++ b/packages/cli/src/lib/runtime/tool-discovery.ts
@@ -155,5 +155,41 @@ async function loadToolDefinition(
     }
   }
 
-  throw new Error(`Tool file ${filePath} must default export a function`)
+  if (looksLikeLangChainTool(definition)) {
+    throw new Error(
+      `Tool file ${filePath} default-exports a LangChain tool() (StructuredTool "${definition.name}").\n` +
+        `Dawn tools are plain functions — Dawn infers the input/output types from the\n` +
+        `function signature, so there's no schema wrapper. Convert it like this:\n\n` +
+        `  const search = /* your existing tool or client */\n\n` +
+        `  /** Describe what the tool does. */\n` +
+        `  export default async (input: { readonly query: string }) =>\n` +
+        `    search.invoke({ query: input.query })\n\n` +
+        `Docs: https://dawnai.org/docs/tools`,
+    )
+  }
+
+  throw new Error(
+    `Tool file ${filePath} must default export a function (got ${describeExport(definition)}).\n` +
+      `Docs: https://dawnai.org/docs/tools`,
+  )
+}
+
+/**
+ * Structural detection of a @langchain/core StructuredTool instance —
+ * `.invoke()` plus `.name` plus a `schema` — without importing langchain.
+ */
+function looksLikeLangChainTool(value: unknown): value is { readonly name: string } {
+  return (
+    isRecord(value) &&
+    typeof value.invoke === "function" &&
+    typeof value.name === "string" &&
+    "schema" in value
+  )
+}
+
+function describeExport(value: unknown): string {
+  if (value === undefined) return "no default export"
+  if (value === null) return "null"
+  if (isRecord(value)) return `an object with keys [${Object.keys(value).join(", ")}]`
+  return `a ${typeof value}`
 }

--- a/packages/cli/test/tool-discovery-errors.test.ts
+++ b/packages/cli/test/tool-discovery-errors.test.ts
@@ -1,0 +1,71 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import { discoverToolDefinitions } from "../src/lib/runtime/tool-discovery.js"
+
+describe("tool discovery error messages", () => {
+  let appRoot: string
+  let toolsDir: string
+
+  beforeEach(() => {
+    appRoot = mkdtempSync(join(tmpdir(), "dawn-tooldisc-"))
+    toolsDir = join(appRoot, "route", "tools")
+    mkdirSync(toolsDir, { recursive: true })
+  })
+  afterEach(() => {
+    rmSync(appRoot, { recursive: true, force: true })
+  })
+
+  function writeTool(name: string, source: string): void {
+    writeFileSync(join(toolsDir, name), source, "utf8")
+  }
+
+  async function discover() {
+    return discoverToolDefinitions({ appRoot, routeDir: join(appRoot, "route") })
+  }
+
+  it("names a LangChain StructuredTool-shaped default export and shows the wrapper fix", async () => {
+    writeTool(
+      "search.ts",
+      `export default {
+        name: "web_search",
+        schema: {},
+        invoke: async () => "results",
+      }`,
+    )
+    await expect(discover()).rejects.toThrow(
+      /default-exports a LangChain tool\(\) \(StructuredTool "web_search"\)/,
+    )
+    await expect(discover()).rejects.toThrow(/export default async/)
+    await expect(discover()).rejects.toThrow(/dawnai\.org\/docs\/tools/)
+  })
+
+  it("describes a plain-object default export by its keys", async () => {
+    writeTool("config.ts", `export default { apiKey: "x", region: "us" }`)
+    await expect(discover()).rejects.toThrow(/an object with keys \[apiKey, region\]/)
+    await expect(discover()).rejects.toThrow(/dawnai\.org\/docs\/tools/)
+  })
+
+  it("describes a missing default export", async () => {
+    writeTool("nothing.ts", `export const helper = 1`)
+    await expect(discover()).rejects.toThrow(/no default export/)
+  })
+
+  it("describes a primitive default export by type", async () => {
+    writeTool("oops.ts", `export default "just a string"`)
+    await expect(discover()).rejects.toThrow(/a string/)
+  })
+
+  it("still accepts a plain default-exported function", async () => {
+    writeTool("greet.ts", `export default async (input: { name: string }) => input.name`)
+    const tools = await discover()
+    expect(tools.map((t) => t.name)).toEqual(["greet"])
+  })
+
+  it("still accepts an object with a run function", async () => {
+    writeTool("runner.ts", `export default { run: async () => "ok" }`)
+    const tools = await discover()
+    expect(tools.map((t) => t.name)).toEqual(["runner"])
+  })
+})


### PR DESCRIPTION
## Summary

Part A of the tool-authoring + workspace-fs design (backlog #1; spec: `docs/superpowers/specs/2026-06-11-tool-authoring-and-workspace-fs-design.md` on the upcoming Part B branch).

- **Targeted StructuredTool diagnostic:** default-exporting a LangChain `tool()` from a route tool file now produces an error that names the export (`StructuredTool "web_search"`), explains why Dawn wants a plain function (static type inference from the signature), shows the 3-line wrapper conversion, and links the docs. Detection is structural (`invoke` + `name` + `schema`) — no `@langchain/core` import, and it runs after the `{ run }` acceptance so hybrid objects still work.
- **Descriptive generic error:** `must default export a function (got an object with keys [apiKey, region])` etc., with docs link.
- **Docs:** tools.mdx gains the previously-undocumented JSDoc-description convention (incl. `export const description` priority) and a "Wrapping an existing LangChain tool" pattern with an inferrable-output example.

## Test plan

- [x] 6 new tests in `packages/cli/test/tool-discovery-errors.test.ts` (TDD — watched the 4 error-path tests fail first)
- [x] Full cli suite 190/190; lint clean (5 pre-existing warnings in untouched files)
- [x] `pnpm -r build` clean; docs site builds (48/48 pages)
- [x] Spec-compliance + code-quality subagent reviews passed (review fixes folded in)

🤖 Generated with [Claude Code](https://claude.com/claude-code)