### PR TITLE
feat: sandboxed ctx.fs for route tools and workflow entries

### DIFF
--- a/.changeset/workspace-fs-context.md
+++ b/.changeset/workspace-fs-context.md
@@ -1,0 +1,7 @@
+---
+"@dawn-ai/core": minor
+"@dawn-ai/sdk": minor
+"@dawn-ai/cli": minor
+---
+
+Sandboxed `ctx.fs` for route tools and workflow/graph entries. Tools and route entries now receive a `WorkspaceFs` handle (`readFile`, `readBinaryFile`, `writeFile`, `listDir`) that resolves paths against the route's `workspace/` directory and runs the same permission gate as the agent-facing workspace tools — no more dropping to `node:fs`. The permission gate is extracted to a shared core module; in execution contexts where interactive prompts can't appear (workflow/graph entries), outside-workspace access fails closed with guidance to add an allow rule.

--- a/apps/web/app/components/docs/nav.ts
+++ b/apps/web/app/components/docs/nav.ts
@@ -30,6 +30,7 @@ export const DOCS_NAV: readonly DocsNavSection[] = [
       { label: "Subagents", href: "/docs/subagents" },
       { label: "Reasoning Effort", href: "/docs/reasoning-effort" },
       { label: "Middleware", href: "/docs/middleware" },
+      { label: "Workspace Filesystem", href: "/docs/workspace" },
       { label: "Retry", href: "/docs/retry" },
     ],
   },

--- a/apps/web/app/docs/workspace/page.tsx
+++ b/apps/web/app/docs/workspace/page.tsx
@@ -1,0 +1,9 @@
+import type { Metadata } from "next"
+import Content from "../../../content/docs/workspace.mdx"
+import { DocsPage } from "../../components/docs/DocsPage"
+
+export const metadata: Metadata = { title: "Workspace Filesystem" }
+
+export default function Page() {
+  return <DocsPage href="/docs/workspace" Content={Content} />
+}

--- a/apps/web/content/docs/tools.mdx
+++ b/apps/web/content/docs/tools.mdx
@@ -18,23 +18,27 @@ That's it. Dawn extracts the input and output types at build time using the Type
 
 ## The runtime signature
 
-The full runtime signature accepted by tool discovery is `(input, ctx) => ...`, where `ctx` is `{ signal: AbortSignal, middleware?: Readonly<Record<string, unknown>> }`:
+The full runtime signature accepted by tool discovery is `(input, ctx) => ...`, where `ctx` is `DawnToolContext` from `@dawn-ai/sdk` — carrying `signal`, `middleware?`, and `fs`:
 
 ```ts title="src/app/(public)/hello/[tenant]/tools/greet.ts"
+import type { DawnToolContext } from "@dawn-ai/sdk"
+
 export default async (
   input: { readonly tenant: string },
-  ctx: { signal: AbortSignal; middleware?: Readonly<Record<string, unknown>> },
+  ctx: DawnToolContext,
 ) => {
   // Cooperate with cancellation — the AbortSignal is always present.
   const res = await fetch(`https://example.com/hello?tenant=${input.tenant}`, {
     signal: ctx.signal,
   })
   // ctx.middleware is the readonly bag populated by allow({ ... }) in src/middleware.ts.
-  return { greeting: await res.text() }
+  // ctx.fs is a sandboxed WorkspaceFs handle for reading and writing workspace files.
+  const notes = await ctx.fs.readFile("notes.txt").catch(() => "")
+  return { greeting: await res.text(), notes }
 }
 ```
 
-The second parameter is optional but recommended for any tool that does network I/O, holds long-running work, or needs middleware-derived context. See [Middleware](/docs/middleware) for how `defineMiddleware` and `allow(context)` populate `ctx.middleware`.
+The second parameter is optional but recommended for any tool that does network I/O, holds long-running work, needs middleware-derived context, or reads/writes workspace files. See [Middleware](/docs/middleware) for how `defineMiddleware` and `allow(context)` populate `ctx.middleware`, and [Workspace Filesystem](/docs/workspace) for `ctx.fs`.
 
 ## Tool descriptions
 
@@ -152,6 +156,7 @@ Wrap the wrapped tool's output in a plain object (per the rules above) so Dawn c
 <RelatedCards items={[
   { href: "/docs/routes", title: "Routes", subtitle: "how agent routes bind tools automatically at build time" },
   { href: "/docs/middleware", title: "Middleware", subtitle: "how ctx.middleware is populated for every tool call" },
+  { href: "/docs/workspace", title: "Workspace Filesystem", subtitle: "the sandboxed ctx.fs handle and pluggable backend" },
   { href: "/docs/state", title: "State", subtitle: "the state contract that tools read and routes return" },
   { href: "/docs/planning", title: "Planning", subtitle: "writeTodos is a capability-contributed tool" },
   { href: "/docs/skills", title: "Skills", subtitle: "readSkill loads route-local instructions" },

--- a/apps/web/content/docs/workspace.mdx
+++ b/apps/web/content/docs/workspace.mdx
@@ -102,7 +102,7 @@ interface WorkspaceFs {
 }
 ```
 
-Paths are **workspace-relative** — `"images/logo.png"` resolves to `<appRoot>/workspace/images/logo.png`. The handle resolves and jails paths before calling the backend; you never deal with absolute paths.
+Paths are **workspace-relative** — `"images/logo.png"` resolves to `<appRoot>/workspace/images/logo.png`. The handle resolves relative paths against the workspace root and permission-gates anything that lands outside it (see [Permissions](#permissions) below).
 
 **Example: a route tool reading a binary file**
 

--- a/apps/web/content/docs/workspace.mdx
+++ b/apps/web/content/docs/workspace.mdx
@@ -1,12 +1,12 @@
 # Workspace Filesystem
 
-Every Dawn route gets a sandboxed `workspace/` directory at the app root. All file I/O in the runtime flows through one permission gate, whether the request comes from the LLM calling an agent-facing tool or from your own code calling `ctx.fs`.
+A Dawn app's sandboxed file area is the `workspace/` directory at the app root. All file I/O in the runtime flows through one permission gate, whether the request comes from the LLM calling an agent-facing tool or from your own code calling `ctx.fs`.
 
 There are three layers:
 
 - **The pluggable backend** (`@dawn-ai/workspace`) — a plain-object interface that reads, writes, and lists files. `localFilesystem()` ships as the default; you can substitute any backend in `dawn.config.ts`.
-- **Agent-facing workspace tools** — `readFile`, `writeFile`, `listDir`, and `runBash` wired into every agent route. The LLM calls these by name; they gate through the permission system before touching the backend.
-- **`ctx.fs`** — the `WorkspaceFs` handle available on `DawnToolContext` (route tools) and `RuntimeContext` (workflow/graph entries). Same gate, same backend, but your code drives it.
+- **Agent-facing workspace tools** — `readFile`, `writeFile`, `listDir`, and `runBash`, wired into agent routes when a `workspace/` directory exists at the app root. The LLM calls these by name; they gate through the permission system before touching the backend.
+- **`ctx.fs`** — the `WorkspaceFs` handle available on `DawnToolContext` (route tools) and `RuntimeContext` (workflow/graph entries). Same gate, same backend, but your code drives it. Always present on the context; reads simply surface `ENOENT` if the `workspace/` directory doesn't exist yet.
 
 ## The pluggable backend
 
@@ -31,14 +31,13 @@ There are three layers:
 Configure a custom backend in `dawn.config.ts`:
 
 ```ts title="dawn.config.ts"
-import { defineConfig } from "@dawn-ai/sdk"
 import { myRemoteBackend } from "./backends/remote.js"
 
-export default defineConfig({
+export default {
   backends: {
     filesystem: myRemoteBackend(),
   },
-})
+}
 ```
 
 ## Middleware
@@ -46,20 +45,17 @@ export default defineConfig({
 `FilesystemMiddleware` is `(next: FilesystemBackend) => FilesystemBackend`. Wrap the default backend with `compose()` to add cross-cutting behavior:
 
 ```ts title="dawn.config.ts"
-import { defineConfig } from "@dawn-ai/sdk"
 import { compose, localFilesystem, withFilesystemLogging } from "@dawn-ai/workspace"
 
-export default defineConfig({
+export default {
   backends: {
-    filesystem: compose(
-      withFilesystemLogging(),
-      localFilesystem(),
-    ),
+    // compose(...) takes middlewares and returns a wrapper; apply it to the base backend.
+    filesystem: compose(withFilesystemLogging())(localFilesystem()),
   },
-})
+}
 ```
 
-`withFilesystemLogging` writes method names and paths to `stderr` by default. Supply a `destination` function for structured output:
+`withFilesystemLogging` writes method names and arguments to `stderr` by default — note that for `writeFile` this includes the full file content, so route logs accordingly. Supply a `destination` function for structured output:
 
 ```ts
 withFilesystemLogging({

--- a/apps/web/content/docs/workspace.mdx
+++ b/apps/web/content/docs/workspace.mdx
@@ -1,0 +1,189 @@
+# Workspace Filesystem
+
+Every Dawn route gets a sandboxed `workspace/` directory at the app root. All file I/O in the runtime flows through one permission gate, whether the request comes from the LLM calling an agent-facing tool or from your own code calling `ctx.fs`.
+
+There are three layers:
+
+- **The pluggable backend** (`@dawn-ai/workspace`) — a plain-object interface that reads, writes, and lists files. `localFilesystem()` ships as the default; you can substitute any backend in `dawn.config.ts`.
+- **Agent-facing workspace tools** — `readFile`, `writeFile`, `listDir`, and `runBash` wired into every agent route. The LLM calls these by name; they gate through the permission system before touching the backend.
+- **`ctx.fs`** — the `WorkspaceFs` handle available on `DawnToolContext` (route tools) and `RuntimeContext` (workflow/graph entries). Same gate, same backend, but your code drives it.
+
+## The pluggable backend
+
+`FilesystemBackend` is the contract every backend must satisfy:
+
+| Method | Required | Notes |
+|---|---|---|
+| `readFile(path, ctx, opts?)` | Yes | UTF-8; `opts.maxBytes` overrides the default cap |
+| `readBinaryFile(path, ctx, opts?)` | No | Raw bytes (`Uint8Array`); required for `ctx.fs.readBinaryFile` |
+| `writeFile(path, content, ctx)` | Yes | Returns `{ bytesWritten }` |
+| `listDir(path, ctx)` | Yes | Returns leaf names, not full paths |
+| `statFile(path, ctx)` | No | Required for offload GC |
+| `removeFile(path, ctx)` | No | Required for offload GC eviction |
+| `touchFile(path, ctx)` | No | Used by LRU-by-access offload tracking |
+| `mkdir(path, ctx)` | No | Used to create the `tool-outputs/` directory |
+
+`localFilesystem()` implements all of them. Its defaults:
+
+- **256 KiB read cap** per call. Override per-call with `opts.maxBytes` (e.g. `Number.POSITIVE_INFINITY` for uncapped reads).
+- **`writeFile` creates missing parent directories** — writing to `reports/result.md` works without a separate `mkdir` call.
+
+Configure a custom backend in `dawn.config.ts`:
+
+```ts title="dawn.config.ts"
+import { defineConfig } from "@dawn-ai/sdk"
+import { myRemoteBackend } from "./backends/remote.js"
+
+export default defineConfig({
+  backends: {
+    filesystem: myRemoteBackend(),
+  },
+})
+```
+
+## Middleware
+
+`FilesystemMiddleware` is `(next: FilesystemBackend) => FilesystemBackend`. Wrap the default backend with `compose()` to add cross-cutting behavior:
+
+```ts title="dawn.config.ts"
+import { defineConfig } from "@dawn-ai/sdk"
+import { compose, localFilesystem, withFilesystemLogging } from "@dawn-ai/workspace"
+
+export default defineConfig({
+  backends: {
+    filesystem: compose(
+      withFilesystemLogging(),
+      localFilesystem(),
+    ),
+  },
+})
+```
+
+`withFilesystemLogging` writes method names and paths to `stderr` by default. Supply a `destination` function for structured output:
+
+```ts
+withFilesystemLogging({
+  destination: ({ method, args }) => {
+    structuredLogger.debug("workspace", { method, args })
+  },
+})
+```
+
+`readBinaryFile` is logged with the **path only** — the bytes are never serialized into the log entry.
+
+<Callout type="warn" title="Forward optional methods">
+  A middleware that returns only `{ readFile, writeFile, listDir }` silently drops `readBinaryFile`, `statFile`, `removeFile`, `touchFile`, and `mkdir`. Dropping `statFile`/`removeFile` disables offload GC; dropping `readBinaryFile` disables `ctx.fs.readBinaryFile`. Use a conditional spread to preserve methods you don't need to intercept:
+
+  ```ts
+  return (next: FilesystemBackend) => ({
+    readFile: async (path, ctx, opts) => {
+      // ... your logic
+      return next.readFile(path, ctx, opts)
+    },
+    writeFile: (path, content, ctx) => next.writeFile(path, content, ctx),
+    listDir: (path, ctx) => next.listDir(path, ctx),
+    ...(next.readBinaryFile && { readBinaryFile: (p, c, o) => next.readBinaryFile!(p, c, o) }),
+    ...(next.statFile && { statFile: (p, c) => next.statFile!(p, c) }),
+    ...(next.removeFile && { removeFile: (p, c) => next.removeFile!(p, c) }),
+    ...(next.touchFile && { touchFile: (p, c) => next.touchFile!(p, c) }),
+    ...(next.mkdir && { mkdir: (p, c) => next.mkdir!(p, c) }),
+  })
+  ```
+
+  `withFilesystemLogging` does this correctly and is safe to use as a reference.
+</Callout>
+
+## ctx.fs for tools and routes
+
+`ctx.fs` is a `WorkspaceFs` handle — a narrower, workspace-relative surface over the backend:
+
+```ts
+interface WorkspaceFs {
+  readFile(path: string, opts?: { readonly maxBytes?: number }): Promise<string>
+  readBinaryFile(path: string, opts?: { readonly maxBytes?: number }): Promise<Uint8Array>
+  writeFile(path: string, content: string): Promise<{ readonly bytesWritten: number }>
+  listDir(path?: string): Promise<readonly string[]>
+}
+```
+
+Paths are **workspace-relative** — `"images/logo.png"` resolves to `<appRoot>/workspace/images/logo.png`. The handle resolves and jails paths before calling the backend; you never deal with absolute paths.
+
+**Example: a route tool reading a binary file**
+
+```ts title="src/app/(public)/describe/tools/describeImage.ts"
+import type { DawnToolContext } from "@dawn-ai/sdk"
+
+export const description = "Describe an image stored in the workspace."
+
+export default async (
+  input: { readonly path: string },
+  ctx: DawnToolContext,
+) => {
+  const bytes = await ctx.fs.readBinaryFile(input.path)
+  const dataUrl = `data:image/png;base64,${Buffer.from(bytes).toString("base64")}`
+  // Pass dataUrl to a vision model call, return the description, etc.
+  return { dataUrl }
+}
+```
+
+`Buffer.from(bytes).toString("base64")` converts the `Uint8Array` to a base64 string. If the configured backend does not implement `readBinaryFile`, the call throws with a message naming the fix.
+
+**Example: a workflow entry listing and reading files**
+
+```ts title="src/app/(public)/report/index.ts"
+import type { RuntimeContext } from "@dawn-ai/sdk"
+import type { RouteTools } from "dawn:routes"
+
+export async function workflow(
+  state: { readonly topic: string },
+  ctx: RuntimeContext<RouteTools<"/report">>,
+) {
+  const entries = await ctx.fs.listDir("drafts")
+  const first = entries[0]
+  if (!first) return { ...state, summary: "no drafts found" }
+  const content = await ctx.fs.readFile(`drafts/${first}`)
+  return { ...state, summary: content.slice(0, 500) }
+}
+```
+
+`listDir()` with no argument defaults to the workspace root. Both `readFile` and `listDir` run through the permission gate before touching the backend.
+
+## Permissions
+
+All file I/O — whether initiated by the LLM calling a workspace tool or by your code calling `ctx.fs` — goes through the same permission gate.
+
+| Path | Decision |
+|---|---|
+| Inside `workspace/` | Always allowed silently |
+| Outside `workspace/` — allow rule matches | Allowed |
+| Outside `workspace/` — deny rule matches | Denied |
+| Outside `workspace/` — no rule (unknown), interactive mode, agent-route tool | Interactive prompt shown; user approves or denies |
+| Outside `workspace/` — no rule (unknown), non-interactive mode | Fail-closed |
+| Outside `workspace/` — no rule (unknown), workflow/graph entry | Fail-closed with guidance |
+| `bypass` mode | Everything allowed (dev only) |
+
+**Non-interactive and workflow/graph entries fail closed.** Workflow and graph entries run outside the LangGraph graph, where the interrupt mechanism is not available. If a path outside `workspace/` hits an unknown permission, the gate returns an error telling you to add an allow rule:
+
+```
+Permission denied: /etc/hosts is outside the workspace and interactive
+permission prompts are not available in this execution context.
+Add an allow rule for "readFile" to the permissions config in dawn.config.ts.
+```
+
+One permission model regardless of whether the LLM or your code initiates the I/O.
+
+**Path jail is lexical.** The local backend receives an already-resolved absolute path. A symlink inside `workspace/` that points to a path outside the workspace will be followed by the local filesystem — the jail does not dereference symlinks. Don't place untrusted symlinks inside `workspace/`.
+
+<Callout type="warn" title="Interrupt-resume and side effects">
+  When a permission prompt fires from inside tool code — because the tool called `ctx.fs` with a path outside `workspace/` that needs interactive approval — LangGraph pauses execution mid-tool. On resume, LangGraph **re-runs the tool body from the top**. Any side effects that ran before the `ctx.fs` call execute again.
+
+  Keep side effects idempotent around gated `fs` calls, or move them after the call so they only run once the permission is resolved.
+</Callout>
+
+## Related
+
+<RelatedCards items={[
+  { href: "/docs/tools", title: "Tools", subtitle: "the full tool authoring contract, including DawnToolContext" },
+  { href: "/docs/middleware", title: "Middleware", subtitle: "route request middleware — authentication and ctx.middleware" },
+  { href: "/docs/agents", title: "Agents", subtitle: "agent routes and the workspace tools the LLM calls" },
+]} />

--- a/docs/superpowers/plans/2026-06-11-tool-authoring-and-workspace-fs.md
+++ b/docs/superpowers/plans/2026-06-11-tool-authoring-and-workspace-fs.md
@@ -1,0 +1,1034 @@
+# Tool Authoring Diagnostics + Sandboxed `ctx.fs` Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Route-tool authors get a targeted error when they default-export a LangChain `tool()`, and a sandboxed, permission-gated `ctx.fs` filesystem handle on every tool and workflow/graph context.
+
+**Architecture:** Two PRs from one spec (`docs/superpowers/specs/2026-06-11-tool-authoring-and-workspace-fs-design.md`). **Part A** (Tasks 1–3, PR 1) touches only `@dawn-ai/cli` tool discovery + docs. **Part B** (Tasks 4–13, PR 2) extracts the permission gate from the built-in workspace capability into a shared core module, adds a `createWorkspaceFs` factory, declares `WorkspaceFs`/`DawnToolContext` in the sdk, and injects the handle once in `prepareRouteExecution` by wrapping tool definitions — `@dawn-ai/langchain` is untouched.
+
+**Tech Stack:** TypeScript (no semicolons, double quotes, 2-space indent, ESM `.js` specifiers), pnpm workspace, Vitest, Biome, changesets.
+
+**Conventions you MUST follow:**
+- Build before testing: `pnpm -r build` once at start; after editing a package that another package's tests consume via `dist/`, rebuild that package (`pnpm --filter <pkg> build`).
+- Tests live in `packages/<pkg>/test/*.test.ts`. Run one package: `pnpm --filter @dawn-ai/cli test`.
+- Lint after each task: `pnpm --filter <pkg> lint`. Biome forbids non-null assertions (`!.`) in src — bind optionals to locals instead.
+- Part A is branch `feat/tool-authoring-diagnostics` off `main`; Part B continues on `feat/tool-authoring-workspace-fs` (already exists, contains the spec). Do not start Part B's code before Part A's PR is opened.
+
+---
+
+## Part A — authoring diagnostics + docs (PR 1: `@dawn-ai/cli`)
+
+### Task 1: StructuredTool detection + descriptive generic error in tool discovery
+
+**Files:**
+- Modify: `packages/cli/src/lib/runtime/tool-discovery.ts` (the `loadToolDefinition` function, currently ends at the generic `throw` around line 158)
+- Test: `packages/cli/test/tool-discovery-errors.test.ts` (create)
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `packages/cli/test/tool-discovery-errors.test.ts`:
+
+```ts
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import { discoverToolDefinitions } from "../src/lib/runtime/tool-discovery.js"
+
+describe("tool discovery error messages", () => {
+  let appRoot: string
+  let toolsDir: string
+
+  beforeEach(() => {
+    appRoot = mkdtempSync(join(tmpdir(), "dawn-tooldisc-"))
+    toolsDir = join(appRoot, "route", "tools")
+    mkdirSync(toolsDir, { recursive: true })
+  })
+  afterEach(() => {
+    rmSync(appRoot, { recursive: true, force: true })
+  })
+
+  function writeTool(name: string, source: string): void {
+    writeFileSync(join(toolsDir, name), source, "utf8")
+  }
+
+  async function discover() {
+    return discoverToolDefinitions({ appRoot, routeDir: join(appRoot, "route") })
+  }
+
+  it("names a LangChain StructuredTool-shaped default export and shows the wrapper fix", async () => {
+    writeTool(
+      "search.ts",
+      `export default {
+        name: "web_search",
+        schema: {},
+        invoke: async () => "results",
+      }`,
+    )
+    await expect(discover()).rejects.toThrow(
+      /default-exports a LangChain tool\(\) \(StructuredTool "web_search"\)/,
+    )
+    await expect(discover()).rejects.toThrow(/export default async/)
+    await expect(discover()).rejects.toThrow(/dawnai\.org\/docs\/tools/)
+  })
+
+  it("describes a plain-object default export by its keys", async () => {
+    writeTool("config.ts", `export default { apiKey: "x", region: "us" }`)
+    await expect(discover()).rejects.toThrow(/an object with keys \[apiKey, region\]/)
+    await expect(discover()).rejects.toThrow(/dawnai\.org\/docs\/tools/)
+  })
+
+  it("describes a missing default export", async () => {
+    writeTool("nothing.ts", `export const helper = 1`)
+    await expect(discover()).rejects.toThrow(/no default export/)
+  })
+
+  it("describes a primitive default export by type", async () => {
+    writeTool("oops.ts", `export default "just a string"`)
+    await expect(discover()).rejects.toThrow(/a string/)
+  })
+
+  it("still accepts a plain default-exported function", async () => {
+    writeTool("greet.ts", `export default async (input: { name: string }) => input.name`)
+    const tools = await discover()
+    expect(tools.map((t) => t.name)).toEqual(["greet"])
+  })
+
+  it("still accepts an object with a run function", async () => {
+    writeTool("runner.ts", `export default { run: async () => "ok" }`)
+    const tools = await discover()
+    expect(tools.map((t) => t.name)).toEqual(["runner"])
+  })
+})
+```
+
+- [ ] **Step 2: Run tests to verify the new ones fail**
+
+Run: `pnpm --filter @dawn-ai/cli test -- tool-discovery-errors`
+Expected: the four error-message tests FAIL (current error is the generic `must default export a function`); the two acceptance tests PASS.
+
+- [ ] **Step 3: Implement detection and descriptive errors**
+
+In `packages/cli/src/lib/runtime/tool-discovery.ts`, replace the final `throw` in `loadToolDefinition` and add two helpers below it:
+
+```ts
+  if (looksLikeLangChainTool(definition)) {
+    throw new Error(
+      `Tool file ${filePath} default-exports a LangChain tool() (StructuredTool "${definition.name}").\n` +
+        `Dawn tools are plain functions — Dawn infers the input/output types from the\n` +
+        `function signature, so there's no schema wrapper. Convert it like this:\n\n` +
+        `  const search = /* your existing tool or client */\n\n` +
+        `  /** Describe what the tool does. */\n` +
+        `  export default async (input: { readonly query: string }) =>\n` +
+        `    search.invoke({ query: input.query })\n\n` +
+        `Docs: https://dawnai.org/docs/tools`,
+    )
+  }
+
+  throw new Error(
+    `Tool file ${filePath} must default export a function (got ${describeExport(definition)}).\n` +
+      `Docs: https://dawnai.org/docs/tools`,
+  )
+}
+
+/**
+ * Structural detection of a @langchain/core StructuredTool instance —
+ * `.invoke()` plus `.name` plus a `schema` — without importing langchain.
+ */
+function looksLikeLangChainTool(value: unknown): value is { readonly name: string } {
+  return (
+    isRecord(value) &&
+    typeof value.invoke === "function" &&
+    typeof value.name === "string" &&
+    "schema" in value
+  )
+}
+
+function describeExport(value: unknown): string {
+  if (value === undefined) return "no default export"
+  if (value === null) return "null"
+  if (isRecord(value)) return `an object with keys [${Object.keys(value).join(", ")}]`
+  return `a ${typeof value}`
+}
+```
+
+(`isRecord` is already imported at the top of the file.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pnpm --filter @dawn-ai/cli test -- tool-discovery-errors`
+Expected: all 6 PASS.
+
+- [ ] **Step 5: Lint and run the full cli suite**
+
+Run: `pnpm --filter @dawn-ai/cli lint && pnpm --filter @dawn-ai/cli test`
+Expected: lint clean; all cli tests pass (no existing test asserts the old generic message — `tool-name-uniqueness.test.ts` tests a different error).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/cli/src/lib/runtime/tool-discovery.ts packages/cli/test/tool-discovery-errors.test.ts
+git commit -m "feat(cli): targeted diagnostic for LangChain tool() default exports"
+```
+
+### Task 2: Document the JSDoc-description convention + LangChain wrapper pattern
+
+**Files:**
+- Modify: `apps/web/content/docs/tools.mdx`
+
+- [ ] **Step 1: Add a "Tool descriptions" section** after the existing "The runtime signature" section (after its closing paragraph, before "## Invoking a tool"):
+
+```mdx
+## Tool descriptions
+
+The description the LLM sees for an `agent`-route tool comes from a JSDoc comment directly above the default export:
+
+```ts title="src/app/(public)/hello/[tenant]/tools/greet.ts"
+/** Greet a user by name in the tenant's locale. */
+export default async (input: { readonly name: string }) => {
+  return { greeting: `Hello, ${input.name}!` }
+}
+```
+
+`dawn typegen` extracts the comment into the route's `tools.json` manifest. To set it programmatically instead, export a string constant — an explicit `export const description` takes priority over the JSDoc comment:
+
+```ts
+export const description = "Greet a user by name in the tenant's locale."
+```
+
+Tools without a description still work, but the LLM only sees the tool name — write the one-liner.
+```
+
+- [ ] **Step 2: Add a "Using an existing LangChain tool" entry** under `## Common patterns` (append to the bullet list):
+
+```mdx
+- **Wrapping an existing LangChain tool** — instantiate the community tool at module scope, then expose it through a plain function with a typed input. Dawn tools are plain functions (not `tool()` wrappers) so the input/output types can be inferred from the signature:
+
+  ```ts title="src/app/(public)/research/tools/search.ts"
+  import { TavilySearch } from "@langchain/tavily"
+
+  const tavily = new TavilySearch({ maxResults: 5 })
+
+  /** Search the web for current information. */
+  export default async (input: { readonly query: string }) =>
+    tavily.invoke({ query: input.query })
+  ```
+```
+
+- [ ] **Step 3: Verify the docs site builds**
+
+Run: `pnpm --filter @dawn-ai/web build`
+Expected: `✓ Compiled successfully`, static pages generated.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/web/content/docs/tools.mdx
+git commit -m "docs: JSDoc description convention + LangChain wrapper pattern in tools doc"
+```
+
+### Task 3: Part A changeset + PR
+
+- [ ] **Step 1: Write the changeset** to `.changeset/tool-authoring-diagnostics.md`:
+
+```md
+---
+"@dawn-ai/cli": minor
+---
+
+Friendlier tool-discovery errors. Default-exporting a LangChain `tool()` (StructuredTool) from a route tool file now produces a targeted error naming the export and showing the 3-line plain-function wrapper conversion; the generic "must default export a function" error now describes what was actually exported and links the tools documentation.
+```
+
+- [ ] **Step 2: Full verification**
+
+Run: `pnpm -r build && pnpm --filter @dawn-ai/cli test && pnpm --filter @dawn-ai/cli lint`
+Expected: all green.
+
+- [ ] **Step 3: Commit, push, open PR**
+
+```bash
+git add .changeset/tool-authoring-diagnostics.md
+git commit -m "chore: changeset for tool-discovery diagnostics"
+git push -u origin feat/tool-authoring-diagnostics
+gh pr create --base main --title "feat(cli): targeted diagnostics for tool authoring mistakes" \
+  --body "Part A of docs/superpowers/specs/2026-06-11-tool-authoring-and-workspace-fs-design.md (backlog #1). StructuredTool detection + descriptive generic error + tools.mdx additions."
+```
+
+---
+
+## Part B — sandboxed `ctx.fs` (PR 2: core + sdk + cli)
+
+> Branch: `feat/tool-authoring-workspace-fs`. If Part A merged first, rebase onto `main`.
+
+### Task 4: Extract the permission gate into a shared core module (pure move)
+
+**Files:**
+- Create: `packages/core/src/capabilities/permission-gate.ts`
+- Modify: `packages/core/src/capabilities/built-in/workspace.ts`
+- Test: existing `packages/core/test/capabilities/workspace.test.ts` (must pass unchanged)
+
+- [ ] **Step 1: Create `permission-gate.ts`** by MOVING (cut, not copy) `GateResult`, `gatePathOp`, `gateBashOp`, `InterruptArgs`, and `emitPermissionInterrupt` from `built-in/workspace.ts`, verbatim except for exports and imports:
+
+```ts
+import type { PermissionsStore } from "@dawn-ai/permissions"
+import { suggestedCommandPattern, suggestedPathPattern } from "@dawn-ai/permissions"
+import { interrupt } from "@langchain/langgraph"
+import { sep } from "node:path"
+
+export type GateResult = { allowed: true } | { allowed: false; reason: string }
+
+export type PathOperation = "readFile" | "writeFile" | "listDir"
+
+export async function gatePathOp(
+  permissions: PermissionsStore | undefined,
+  operation: PathOperation,
+  absPath: string,
+  workspaceRoot: string,
+): Promise<GateResult> {
+  // ...body moved verbatim from built-in/workspace.ts...
+}
+
+export async function gateBashOp(
+  permissions: PermissionsStore | undefined,
+  command: string,
+): Promise<GateResult> {
+  // ...body moved verbatim...
+}
+
+// InterruptArgs + emitPermissionInterrupt moved verbatim (not exported beyond
+// what gatePathOp/gateBashOp need — keep emitPermissionInterrupt module-private).
+```
+
+The `"readFile" | "writeFile" | "listDir"` union becomes the exported `PathOperation` alias; update the moved bodies to use it. Node import order per Biome (node builtins group as in existing files — check the file header pattern of `built-in/workspace.ts`).
+
+- [ ] **Step 2: Update `built-in/workspace.ts`** to import from the new module:
+
+```ts
+import { gateBashOp, gatePathOp } from "../permission-gate.js"
+```
+
+and delete the moved code (also remove the now-unused `interrupt`, `suggestedCommandPattern`, `suggestedPathPattern` imports and, if no longer referenced, `sep`; keep `sep` if `readFile`'s tool-outputs check still uses it — it does).
+
+- [ ] **Step 3: Build + regression**
+
+Run: `pnpm --filter @dawn-ai/core build && pnpm --filter @dawn-ai/core test`
+Expected: build clean; ALL core tests pass unchanged (especially `test/capabilities/workspace.test.ts`).
+
+- [ ] **Step 4: Lint and commit**
+
+Run: `pnpm --filter @dawn-ai/core lint`
+
+```bash
+git add packages/core/src/capabilities/permission-gate.ts packages/core/src/capabilities/built-in/workspace.ts
+git commit -m "refactor(core): extract workspace permission gate into shared module"
+```
+
+### Task 5: `gatePathOp` interrupt-suppression option
+
+**Files:**
+- Modify: `packages/core/src/capabilities/permission-gate.ts`
+- Test: `packages/core/test/capabilities/permission-gate.test.ts` (create)
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { describe, expect, it } from "vitest"
+import { gatePathOp } from "../../src/capabilities/permission-gate.js"
+
+function storeStub(mode: "interactive" | "non-interactive" | "bypass") {
+  return {
+    mode,
+    match: () => "unknown" as const,
+    addAllow: async () => {},
+    load: async () => {},
+  } as never
+}
+
+describe("gatePathOp interrupt suppression", () => {
+  it("fails closed with guidance when interactive but interrupts unavailable", async () => {
+    const result = await gatePathOp(storeStub("interactive"), "readFile", "/outside/x", "/ws", {
+      interruptCapable: false,
+    })
+    expect(result.allowed).toBe(false)
+    if (!result.allowed) {
+      expect(result.reason).toMatch(/allow rule/)
+      expect(result.reason).toMatch(/dawn\.config/)
+    }
+  })
+
+  it("still allows inside-workspace paths without consulting the store", async () => {
+    const result = await gatePathOp(storeStub("interactive"), "readFile", "/ws/notes.md", "/ws", {
+      interruptCapable: false,
+    })
+    expect(result.allowed).toBe(true)
+  })
+})
+```
+
+(If the store stub's shape drifts from `PermissionsStore`, build a minimal real store via `@dawn-ai/permissions` `createPermissionsStore` the way `packages/core/test/capabilities/workspace.test.ts` does — copy its pattern.)
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `pnpm --filter @dawn-ai/core test -- permission-gate`
+Expected: FAIL — `gatePathOp` doesn't accept a 5th argument; interactive+unknown path tries to `interrupt()` and throws a LangGraph error instead of failing closed.
+
+- [ ] **Step 3: Implement the option**
+
+In `gatePathOp`, add the parameter and the branch (before the interactive-interrupt path):
+
+```ts
+export async function gatePathOp(
+  permissions: PermissionsStore | undefined,
+  operation: PathOperation,
+  absPath: string,
+  workspaceRoot: string,
+  opts?: { readonly interruptCapable?: boolean },
+): Promise<GateResult> {
+  // ...unchanged until the `decision === "unknown"` handling...
+  if (permissions.mode === "non-interactive") {
+    return { allowed: false, reason: `Permission denied (fail-closed): ${absPath}` }
+  }
+  if (opts?.interruptCapable === false) {
+    return {
+      allowed: false,
+      reason:
+        `Permission denied: ${absPath} is outside the workspace and interactive ` +
+        `permission prompts are not available in this execution context. ` +
+        `Add an allow rule for "${operation}" to the permissions config in dawn.config.ts.`,
+    }
+  }
+  // ...existing interrupt path unchanged (default: interrupts allowed)...
+```
+
+- [ ] **Step 4: Verify green + regression**
+
+Run: `pnpm --filter @dawn-ai/core test`
+Expected: new tests PASS, all existing tests still pass (omitted option preserves behavior).
+
+- [ ] **Step 5: Lint + commit**
+
+```bash
+git add packages/core/src/capabilities/permission-gate.ts packages/core/test/capabilities/permission-gate.test.ts
+git commit -m "feat(core): gatePathOp can fail closed where interrupts are unavailable"
+```
+
+### Task 6: `WorkspaceFs` + `DawnToolContext` types in `@dawn-ai/sdk`
+
+**Files:**
+- Create: `packages/sdk/src/workspace-fs.ts`
+- Modify: `packages/sdk/src/runtime-context.ts`, `packages/sdk/src/index.ts`
+
+- [ ] **Step 1: Create `packages/sdk/src/workspace-fs.ts`:**
+
+```ts
+/**
+ * Sandboxed filesystem handle scoped to the route's workspace/ directory.
+ *
+ * Relative paths resolve against the workspace root. Every call is
+ * permission-gated with the same rules as the agent-facing workspace tools:
+ * paths inside workspace/ are always allowed; paths outside consult the
+ * permissions store (interactive prompt where available, fail-closed
+ * otherwise).
+ */
+export interface WorkspaceFs {
+  /** Read a UTF-8 file. */
+  readFile(path: string, opts?: { readonly maxBytes?: number }): Promise<string>
+  /**
+   * Read raw bytes (images, PDFs, …). Throws a descriptive error when the
+   * configured filesystem backend does not implement binary reads.
+   */
+  readBinaryFile(path: string, opts?: { readonly maxBytes?: number }): Promise<Uint8Array>
+  /** Write a UTF-8 file. localFilesystem creates missing parent directories. */
+  writeFile(path: string, content: string): Promise<{ readonly bytesWritten: number }>
+  /** List entries (leaf names). Defaults to the workspace root. */
+  listDir(path?: string): Promise<readonly string[]>
+}
+
+/** The context argument Dawn passes to a route tool's function. */
+export interface DawnToolContext {
+  readonly signal: AbortSignal
+  readonly middleware?: Readonly<Record<string, unknown>>
+  readonly fs: WorkspaceFs
+}
+```
+
+- [ ] **Step 2: Add `fs` to `RuntimeContext`** in `packages/sdk/src/runtime-context.ts`:
+
+```ts
+import type { WorkspaceFs } from "./workspace-fs.js"
+
+export interface RuntimeContext<TTools extends ToolRegistry = ToolRegistry> {
+  readonly signal: AbortSignal
+  readonly tools: TTools
+  readonly fs: WorkspaceFs
+}
+```
+
+- [ ] **Step 3: Export from `packages/sdk/src/index.ts`** — add `DawnToolContext` and `WorkspaceFs` to the type-export block (alphabetical position within the existing `export type {...}` lists).
+
+- [ ] **Step 4: Build the workspace + check downstream**
+
+Run: `pnpm --filter @dawn-ai/sdk build && pnpm -r build`
+Expected: sdk builds. **Downstream `pnpm -r build` may fail** where `RuntimeContext` objects are constructed without `fs` (cli `createDawnContext`) — that is expected mid-feature; note the failures, they are fixed in Task 9. If the breakage blocks unrelated packages, temporarily mark `fs` optional is NOT allowed — instead proceed directly to Task 9 before committing, or commit sdk + cli wiring together at Task 9. Use one commit at the end of Task 9 if needed.
+
+- [ ] **Step 5: Commit (alone if downstream still builds, else fold into Task 9's commit)**
+
+```bash
+git add packages/sdk/src/workspace-fs.ts packages/sdk/src/runtime-context.ts packages/sdk/src/index.ts
+git commit -m "feat(sdk): WorkspaceFs and DawnToolContext types; fs on RuntimeContext"
+```
+
+### Task 7: `createWorkspaceFs` factory in core (TDD)
+
+**Files:**
+- Create: `packages/core/src/capabilities/workspace-fs.ts`
+- Modify: `packages/core/src/index.ts` (export it)
+- Test: `packages/core/test/capabilities/workspace-fs.test.ts` (create)
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { localFilesystem } from "@dawn-ai/workspace"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import { createWorkspaceFs } from "../../src/capabilities/workspace-fs.js"
+
+describe("createWorkspaceFs", () => {
+  let root: string
+  let workspaceRoot: string
+  const signal = new AbortController().signal
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "dawn-wsfs-"))
+    workspaceRoot = join(root, "workspace")
+    mkdirSync(workspaceRoot, { recursive: true })
+  })
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true })
+  })
+
+  function make(backend = localFilesystem()) {
+    return createWorkspaceFs({
+      workspaceRoot,
+      backend,
+      permissions: undefined,
+      signal,
+      interruptCapable: false,
+    })
+  }
+
+  it("resolves relative paths against the workspace root", async () => {
+    writeFileSync(join(workspaceRoot, "notes.md"), "hello", "utf8")
+    const fs = make()
+    expect(await fs.readFile("notes.md")).toBe("hello")
+  })
+
+  it("round-trips writeFile/readFile and listDir", async () => {
+    const fs = make()
+    const res = await fs.writeFile("reports/out.md", "data")
+    expect(res.bytesWritten).toBe(4)
+    expect(await fs.readFile("reports/out.md")).toBe("data")
+    expect([...(await fs.listDir("reports"))]).toEqual(["out.md"])
+    expect([...(await fs.listDir())]).toContain("reports")
+  })
+
+  it("reads binary files as Uint8Array", async () => {
+    const bytes = Uint8Array.from([0x89, 0x50, 0x4e, 0x47])
+    writeFileSync(join(workspaceRoot, "img.png"), bytes)
+    const fs = make()
+    const out = await fs.readBinaryFile("img.png")
+    expect(out).toBeInstanceOf(Uint8Array)
+    expect([...out]).toEqual([...bytes])
+  })
+
+  it("throws a descriptive error when the backend lacks readBinaryFile", async () => {
+    const textOnly = {
+      readFile: async () => "x",
+      writeFile: async () => ({ bytesWritten: 1 }),
+      listDir: async () => [],
+    }
+    const fs = createWorkspaceFs({
+      workspaceRoot,
+      backend: textOnly,
+      permissions: undefined,
+      signal,
+      interruptCapable: false,
+    })
+    await expect(fs.readBinaryFile("img.png")).rejects.toThrow(
+      /does not support binary reads \(readBinaryFile\)/,
+    )
+  })
+
+  it("allows everything silently when no permissions store is provided", async () => {
+    const outside = join(root, "outside.txt")
+    writeFileSync(outside, "secret", "utf8")
+    const fs = make()
+    expect(await fs.readFile(outside)).toBe("secret")
+  })
+
+  it("forwards maxBytes to the backend", async () => {
+    writeFileSync(join(workspaceRoot, "big.txt"), "x".repeat(100), "utf8")
+    const fs = createWorkspaceFs({
+      workspaceRoot,
+      backend: localFilesystem({ maxFileBytes: 10 }),
+      permissions: undefined,
+      signal,
+      interruptCapable: false,
+    })
+    await expect(fs.readFile("big.txt")).rejects.toThrow(/too large/)
+    expect(await fs.readFile("big.txt", { maxBytes: 1000 })).toBe("x".repeat(100))
+  })
+})
+
+describe("createWorkspaceFs permission gating", () => {
+  // Copy the permissions-store construction pattern from
+  // packages/core/test/capabilities/workspace.test.ts (createPermissionsStore
+  // from @dawn-ai/permissions with mode + config), then assert:
+  // - non-interactive store + outside path -> rejects /fail-closed/
+  // - non-interactive store with allow rule for the path -> resolves
+  // - interactive store + outside path + interruptCapable:false -> rejects /allow rule/
+  // - writeFile outside -> gated with operation "writeFile"
+  // - bypass-mode store + outside path -> resolves (no gating)
+})
+```
+
+Fill in the second describe block by copying the exact store-construction pattern found in `packages/core/test/capabilities/workspace.test.ts` — read that file first; do not invent a stub shape.
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `pnpm --filter @dawn-ai/core test -- workspace-fs`
+Expected: FAIL — module `../../src/capabilities/workspace-fs.js` does not exist.
+
+- [ ] **Step 3: Implement `packages/core/src/capabilities/workspace-fs.ts`:**
+
+```ts
+import { resolve } from "node:path"
+import type { PermissionsStore } from "@dawn-ai/permissions"
+import type { WorkspaceFs } from "@dawn-ai/sdk"
+import type { FilesystemBackend } from "@dawn-ai/workspace"
+import { gatePathOp, type PathOperation } from "./permission-gate.js"
+
+export interface CreateWorkspaceFsOptions {
+  readonly workspaceRoot: string
+  readonly backend: FilesystemBackend
+  readonly permissions: PermissionsStore | undefined
+  readonly signal: AbortSignal
+  /**
+   * Whether this execution context can surface the interactive LangGraph
+   * permission interrupt (true inside agent-route tool execution; false for
+   * workflow/graph entries, which run outside the graph).
+   */
+  readonly interruptCapable: boolean
+}
+
+/**
+ * Build the author-facing sandboxed filesystem handle (`ctx.fs`). Paths are
+ * workspace-relative; every call runs the same permission gate as the
+ * agent-facing workspace tools.
+ */
+export function createWorkspaceFs(opts: CreateWorkspaceFsOptions): WorkspaceFs {
+  const bctx = { signal: opts.signal, workspaceRoot: opts.workspaceRoot }
+
+  async function gate(operation: PathOperation, path: string): Promise<string> {
+    const absPath = resolve(opts.workspaceRoot, path)
+    const result = await gatePathOp(opts.permissions, operation, absPath, opts.workspaceRoot, {
+      interruptCapable: opts.interruptCapable,
+    })
+    if (!result.allowed) throw new Error(result.reason)
+    return absPath
+  }
+
+  return {
+    async readFile(path, readOpts) {
+      return opts.backend.readFile(await gate("readFile", path), bctx, readOpts)
+    },
+    async readBinaryFile(path, readOpts) {
+      const absPath = await gate("readFile", path)
+      const { readBinaryFile } = opts.backend
+      if (!readBinaryFile) {
+        throw new Error(
+          "The configured filesystem backend does not support binary reads (readBinaryFile). " +
+            "localFilesystem supports it; custom backends must implement it.",
+        )
+      }
+      return readBinaryFile.call(opts.backend, absPath, bctx, readOpts)
+    },
+    async writeFile(path, content) {
+      return opts.backend.writeFile(await gate("writeFile", path), content, bctx)
+    },
+    async listDir(path = ".") {
+      return [...(await opts.backend.listDir(await gate("listDir", path), bctx))]
+    },
+  }
+}
+```
+
+Export from `packages/core/src/index.ts`: add `export { createWorkspaceFs, type CreateWorkspaceFsOptions } from "./capabilities/workspace-fs.js"` in the existing export block.
+
+- [ ] **Step 4: Verify green**
+
+Run: `pnpm --filter @dawn-ai/core build && pnpm --filter @dawn-ai/core test -- workspace-fs`
+Expected: all PASS.
+
+- [ ] **Step 5: Lint + commit**
+
+```bash
+git add packages/core/src/capabilities/workspace-fs.ts packages/core/src/index.ts packages/core/test/capabilities/workspace-fs.test.ts
+git commit -m "feat(core): createWorkspaceFs sandboxed filesystem handle"
+```
+
+### Task 8: Refactor the agent-facing workspace tools onto the handle
+
+**Files:**
+- Modify: `packages/core/src/capabilities/built-in/workspace.ts` (`buildWorkspaceTools`)
+- Test: existing `packages/core/test/capabilities/workspace.test.ts` must pass unchanged
+
+- [ ] **Step 1: Rewrite the four tool bodies** to construct the handle per call (`interruptCapable: true` — agent tools run inside the graph) and delegate. `readFile` keeps the `tool-outputs/` special case in the tool layer:
+
+```ts
+const readFile: OverridableTool = {
+  name: "readFile",
+  description: "Read a UTF-8 file from the workspace.",
+  schema: READ_FILE_INPUT,
+  overridable: true,
+  run: async (input, ctx) => {
+    const { path } = READ_FILE_INPUT.parse(input)
+    const handle = createWorkspaceFs({
+      workspaceRoot,
+      backend: fs,
+      permissions,
+      signal: ctx.signal,
+      interruptCapable: true,
+    })
+    const absPath = resolve(workspaceRoot, path)
+    const rel = relative(workspaceRoot, absPath)
+    // NOTE: must match SUBDIR ("tool-outputs") in @dawn-ai/langchain offload-store.ts
+    const isToolOutput = rel === "tool-outputs" || rel.startsWith(`tool-outputs${sep}`)
+    const data = await handle.readFile(
+      path,
+      isToolOutput ? { maxBytes: Number.POSITIVE_INFINITY } : undefined,
+    )
+    if (isToolOutput && fs.touchFile) {
+      try {
+        await fs.touchFile(absPath, { signal: ctx.signal, workspaceRoot })
+      } catch {
+        /* touch is best-effort; never fail a read because of it */
+      }
+    }
+    return data
+  },
+}
+```
+
+`writeFile` / `listDir` / `runBash`: `writeFile` and `listDir` delegate to the handle (preserving their current return shapes: the `wrote N bytes to <path>` string and the mutable array copy); `runBash` keeps using `gateBashOp` + `exec` directly (no change beyond the Task 4 import move).
+
+- [ ] **Step 2: Regression**
+
+Run: `pnpm --filter @dawn-ai/core test`
+Expected: ALL pass unchanged — this is a pure internal refactor; permission behavior, messages, and return shapes are identical.
+
+- [ ] **Step 3: Lint + commit**
+
+```bash
+git add packages/core/src/capabilities/built-in/workspace.ts
+git commit -m "refactor(core): workspace agent tools delegate to createWorkspaceFs"
+```
+
+### Task 9: Thread `fs` through the cli (context types, createDawnContext, prepareRouteExecution)
+
+**Files:**
+- Modify: `packages/core/src/capabilities/types.ts` (`DawnToolDefinition.run` context)
+- Modify: `packages/cli/src/lib/runtime/tool-discovery.ts` (`DiscoveredToolDefinition.run` context)
+- Modify: `packages/cli/src/lib/runtime/dawn-context.ts`
+- Modify: `packages/cli/src/lib/runtime/execute-route.ts`
+- Test: `packages/cli/test/dawn-context.test.ts` (create); existing suites as regression
+
+- [ ] **Step 1: Write the failing test** (`packages/cli/test/dawn-context.test.ts`):
+
+```ts
+import { describe, expect, it } from "vitest"
+import type { WorkspaceFs } from "@dawn-ai/sdk"
+import { createDawnContext } from "../src/lib/runtime/dawn-context.js"
+
+const fakeFs: WorkspaceFs = {
+  readFile: async () => "content",
+  readBinaryFile: async () => Uint8Array.from([1]),
+  writeFile: async () => ({ bytesWritten: 1 }),
+  listDir: async () => [],
+}
+
+describe("createDawnContext fs threading", () => {
+  it("exposes fs on the route context", () => {
+    const context = createDawnContext({ tools: [], fs: fakeFs })
+    expect(context.fs).toBe(fakeFs)
+  })
+
+  it("passes fs to tool run contexts", async () => {
+    let seenFs: WorkspaceFs | undefined
+    const context = createDawnContext({
+      fs: fakeFs,
+      tools: [
+        {
+          filePath: "/x/tools/probe.ts",
+          name: "probe",
+          scope: "route-local",
+          run: (_input, ctx) => {
+            seenFs = ctx.fs
+            return "ok"
+          },
+        },
+      ],
+    })
+    await context.tools.probe?.({})
+    expect(seenFs).toBe(fakeFs)
+  })
+})
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `pnpm --filter @dawn-ai/cli test -- dawn-context`
+Expected: FAIL — `createDawnContext` has no `fs` option.
+
+- [ ] **Step 3: Implement the type + context changes**
+
+`packages/core/src/capabilities/types.ts` — `DawnToolDefinition.run`'s context gains the optional member:
+
+```ts
+import type { DawnAgent, WorkspaceFs } from "@dawn-ai/sdk"
+// ...
+  readonly run: (
+    input: unknown,
+    context: {
+      readonly middleware?: Readonly<Record<string, unknown>>
+      readonly signal: AbortSignal
+      readonly fs?: WorkspaceFs
+    },
+  ) => Promise<unknown> | unknown
+```
+
+`packages/cli/src/lib/runtime/tool-discovery.ts` — same addition to `DiscoveredToolDefinition.run`'s context type (import `type { WorkspaceFs } from "@dawn-ai/sdk"`).
+
+`packages/cli/src/lib/runtime/dawn-context.ts`:
+
+```ts
+import type { WorkspaceFs } from "@dawn-ai/sdk"
+import type { DiscoveredToolDefinition } from "./tool-discovery.js"
+
+export interface DawnRouteContext {
+  readonly middleware?: Readonly<Record<string, unknown>>
+  readonly signal: AbortSignal
+  readonly tools: Record<string, (input: unknown) => Promise<unknown>>
+  readonly fs: WorkspaceFs
+}
+
+export function createDawnContext(options: {
+  readonly middleware?: Readonly<Record<string, unknown>>
+  readonly signal?: AbortSignal
+  readonly tools: readonly DiscoveredToolDefinition[]
+  readonly fs: WorkspaceFs
+}): DawnRouteContext {
+  const signal = options.signal ?? new AbortController().signal
+  const middleware = options.middleware
+  const tools = Object.fromEntries(
+    options.tools.map((tool) => [
+      tool.name,
+      async (input: unknown) =>
+        await tool.run(input, {
+          ...(middleware ? { middleware } : {}),
+          signal,
+          fs: options.fs,
+        }),
+    ]),
+  )
+
+  const context: DawnRouteContext = { signal, tools, fs: options.fs }
+  if (middleware) {
+    return { ...context, middleware }
+  }
+  return context
+}
+```
+
+- [ ] **Step 4: Wire `prepareRouteExecution`** in `packages/cli/src/lib/runtime/execute-route.ts`:
+
+1. **Hoist permissions-store creation** out of the `if (normalized.kind === "agent")` block: move the `envMode`/`mode` resolution and `createPermissionsStore` + `await permissionsStore.load()` lines to just after the `threadsStore` assignment, so all route kinds have the store. The agent branch keeps using the hoisted `permissionsStore` variable in `applyCapabilities`.
+2. **Build the handle** right after the hoisted store (import `createWorkspaceFs` from `@dawn-ai/core` and `localFilesystem` from `@dawn-ai/workspace` — check whether execute-route already imports `localFilesystem`; `buildOffload` may — reuse the import):
+
+```ts
+const workspaceFs = createWorkspaceFs({
+  workspaceRoot: join(options.appRoot, "workspace"),
+  backend: configBackends?.filesystem ?? localFilesystem(),
+  permissions: permissionsStore,
+  signal: options.signal ?? new AbortController().signal,
+  interruptCapable: normalized.kind === "agent",
+})
+```
+
+3. **Wrap the assembled tools** immediately before `prepareRouteExecution` returns them (after the capability-tool merge):
+
+```ts
+// Inject ctx.fs once here so every downstream invoker (createDawnContext,
+// the langchain tool converter/loop) hands tools the sandboxed handle.
+tools = tools.map((t) => ({
+  ...t,
+  run: (input: unknown, ctx: { middleware?: Readonly<Record<string, unknown>>; signal: AbortSignal }) =>
+    t.run(input, { ...ctx, fs: workspaceFs }),
+}))
+```
+
+4. **Return `workspaceFs` in the prepared result** (add to the prepared object's type and both `return` sites) and **pass it at both `createDawnContext` call sites** (`fs: workspaceFs` — destructure `workspaceFs` alongside `tools` at both `prepared` destructuring sites).
+
+- [ ] **Step 5: Build + full cli regression**
+
+Run: `pnpm -r build && pnpm --filter @dawn-ai/cli test && pnpm --filter @dawn-ai/core test`
+Expected: build clean (this completes the `RuntimeContext.fs` consumers from Task 6); dawn-context tests PASS; full cli + core suites pass. If any existing cli test constructs `createDawnContext` directly, give it a stub fs (the `fakeFs` from Step 1).
+
+- [ ] **Step 6: Lint + commit**
+
+```bash
+git add packages/core/src/capabilities/types.ts packages/cli/src/lib/runtime/tool-discovery.ts packages/cli/src/lib/runtime/dawn-context.ts packages/cli/src/lib/runtime/execute-route.ts packages/cli/test/dawn-context.test.ts
+git commit -m "feat(cli): inject sandboxed ctx.fs into tool and route contexts"
+```
+
+(If Task 6's commit was deferred, include the sdk files here.)
+
+### Task 10: End-to-end integration test (fixture route using `ctx.fs`)
+
+**Files:**
+- Test: `packages/cli/test/workspace-fs-integration.test.ts` (create)
+
+- [ ] **Step 1: Study an existing in-process fixture test** — read `packages/cli/test/run-command.test.ts` (or `offload-exempt.test.ts`) and copy its scaffold pattern: how it creates a temp app dir with `src/app/<route>/index.ts`, a `workspace/` dir, sets `DAWN_PERMISSIONS_MODE`, and invokes the route in-process.
+
+- [ ] **Step 2: Write the test** — a workflow route whose entry and tool both use `ctx.fs`:
+
+Fixture files (written by the test into a temp app):
+
+```ts
+// src/app/(public)/notes/index.ts
+export async function workflow(state: { readonly name: string }, ctx) {
+  await ctx.tools.stash({ name: state.name })
+  const listed = await ctx.fs.listDir("stash")
+  return { ...state, files: listed }
+}
+```
+
+```ts
+// src/app/(public)/notes/tools/stash.ts
+export default async (input: { readonly name: string }, ctx) => {
+  await ctx.fs.writeFile(`stash/${input.name}.txt`, `stashed ${input.name}`)
+  return { ok: true }
+}
+```
+
+Assertions (with `DAWN_PERMISSIONS_MODE=non-interactive` set for the test):
+- executing the route with input `{ name: "alpha" }` succeeds;
+- the returned state's `files` equals `["alpha.txt"]`;
+- the file physically exists at `<appRoot>/workspace/stash/alpha.txt` with content `stashed alpha`;
+- a second fixture tool that calls `ctx.fs.readFile("../outside.txt")` (escaping the workspace) rejects, and the route output surfaces an error matching `/Permission denied/`.
+
+Exact scaffold code: follow the studied pattern from Step 1 — same helpers, same execute entry point (`executeRouteInProcess`/equivalent exported runner the existing tests use).
+
+- [ ] **Step 3: Run it**
+
+Run: `pnpm --filter @dawn-ai/cli test -- workspace-fs-integration`
+Expected: PASS (everything was implemented in Tasks 4–9; this validates the seam end-to-end). If it fails, debug the wiring — do not weaken the assertions.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/cli/test/workspace-fs-integration.test.ts
+git commit -m "test(cli): end-to-end ctx.fs integration coverage"
+```
+
+### Task 11: Docs — `workspace.mdx` page + tools.mdx context update
+
+**Files:**
+- Create: `apps/web/content/docs/workspace.mdx`
+- Modify: `apps/web/app/components/docs/nav.ts` (add `{ label: "Workspace Filesystem", href: "/docs/workspace" }` to the "Concepts" section after "Middleware")
+- Modify: `apps/web/content/docs/tools.mdx` ("The runtime signature" section)
+
+- [ ] **Step 1: Write `workspace.mdx`** with this structure (write real prose, not placeholders):
+
+```mdx
+# Workspace Filesystem
+
+[intro: every route gets a sandboxed workspace/ directory; three layers: pluggable backend, agent-facing tools, ctx.fs for authors]
+
+## The pluggable backend
+[FilesystemBackend interface summary: readFile/readBinaryFile/writeFile/listDir + optional methods; localFilesystem defaults — 256 KiB cap, writeFile creates parents; configuring a custom backend via dawn.config.ts backends.filesystem]
+
+## Middleware
+[compose() + FilesystemMiddleware; withFilesystemLogging example with destination option; note that middleware must forward optional methods]
+
+## ctx.fs for tools and routes
+[the WorkspaceFs surface with a tool example (readBinaryFile → base64) and a workflow example; relative paths resolve against workspace/]
+
+## Permissions
+[table: inside workspace = silent allow; outside = store consultation; interactive prompt (agent-route tools only) / fail-closed (non-interactive, and workflow/graph contexts where prompts can't appear — add allow rules to dawn.config.ts); bypass mode]
+
+## Interrupt-resume caveat
+[a permission prompt fired from inside tool code re-runs the tool body on resume; keep side effects around gated fs calls idempotent]
+```
+
+Use the code examples from the spec (`docs/superpowers/specs/2026-06-11-tool-authoring-and-workspace-fs-design.md` §B2 and the appendix of the binary-read spec) as the basis for the `ctx.fs` section.
+
+- [ ] **Step 2: Update tools.mdx "The runtime signature"** — change the signature description and example so `ctx` is `DawnToolContext` (signal, middleware?, fs) imported from `@dawn-ai/sdk`, and link the new page:
+
+```ts
+import type { DawnToolContext } from "@dawn-ai/sdk"
+
+export default async (input: { readonly tenant: string }, ctx: DawnToolContext) => {
+  const greeting = await ctx.fs.readFile("greeting-template.md")
+  // ...
+}
+```
+
+Add to the Related cards: `{ href: "/docs/workspace", title: "Workspace Filesystem", subtitle: "the sandboxed ctx.fs handle and pluggable backend" }`.
+
+- [ ] **Step 3: Build the docs site**
+
+Run: `pnpm --filter @dawn-ai/web build`
+Expected: compiles, page count increases by one.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/web/content/docs/workspace.mdx apps/web/app/components/docs/nav.ts apps/web/content/docs/tools.mdx
+git commit -m "docs: workspace filesystem page; ctx.fs in tools runtime signature"
+```
+
+### Task 12: Part B changeset + full verification
+
+- [ ] **Step 1: Write `.changeset/workspace-fs-context.md`:**
+
+```md
+---
+"@dawn-ai/core": minor
+"@dawn-ai/sdk": minor
+"@dawn-ai/cli": minor
+---
+
+Sandboxed `ctx.fs` for route tools and workflow/graph entries. Tools and route entries now receive a `WorkspaceFs` handle (`readFile`, `readBinaryFile`, `writeFile`, `listDir`) that resolves paths against the route's `workspace/` directory and runs the same permission gate as the agent-facing workspace tools — no more dropping to `node:fs`. The permission gate is extracted to a shared core module; in execution contexts where interactive prompts can't appear (workflow/graph entries), outside-workspace access fails closed with guidance to add an allow rule.
+```
+
+- [ ] **Step 2: Full verification**
+
+Run: `pnpm -r build && pnpm --filter @dawn-ai/workspace test && pnpm --filter @dawn-ai/core test && pnpm --filter @dawn-ai/langchain test && pnpm --filter @dawn-ai/cli test && pnpm --filter @dawn-ai/core lint && pnpm --filter @dawn-ai/cli lint && pnpm --filter @dawn-ai/sdk lint`
+Expected: everything green.
+
+- [ ] **Step 3: Commit + push + PR**
+
+```bash
+git add .changeset/workspace-fs-context.md
+git commit -m "chore: changeset for sandboxed ctx.fs"
+git push -u origin feat/tool-authoring-workspace-fs
+gh pr create --base main --title "feat: sandboxed ctx.fs for route tools and workflow entries" \
+  --body "Part B of docs/superpowers/specs/2026-06-11-tool-authoring-and-workspace-fs-design.md (backlog #3). Gate extraction, createWorkspaceFs, sdk types, cli threading, workspace.mdx docs."
+```
+
+### Task 13: Post-merge housekeeping
+
+- [ ] After both PRs merge: verify the changesets "Version Packages" PR includes both entries; confirm `examples/chat/server` still builds in CI (it exercises the full pipeline).

--- a/docs/superpowers/specs/2026-06-11-tool-authoring-and-workspace-fs-design.md
+++ b/docs/superpowers/specs/2026-06-11-tool-authoring-and-workspace-fs-design.md
@@ -1,0 +1,140 @@
+# Tool authoring diagnostics + sandboxed `ctx.fs` (Design)
+
+**Status:** Approved for planning
+**Date:** 2026-06-11
+**Roadmap:** Dogfooding-friction backlog items #1 (tool authoring convention) and #3 (sandboxed filesystem handle for route tools), designed together because they share the same surface: what a Dawn route tool is and what its `context` argument carries. Builds on the binary-read primitive shipped in [PR #207](https://github.com/cacheplane/dawnai/pull/207) (spec: `2026-06-09-workspace-binary-read-design.md`, whose appendix sketched this design). One spec, **two implementation PRs** (Part A: cli + docs; Part B: core + sdk + cli).
+
+## Problem
+
+Two related frictions surfaced building Dawn's first external consumer:
+
+1. **The tool authoring convention trips up every newcomer.** The natural ecosystem instinct — wrap in `@langchain/core`'s `tool()` and default-export the `StructuredTool` — fails with the generic `"Tool file <path> must default export a function"` (`packages/cli/src/lib/runtime/tool-discovery.ts`). The error names neither what the user exported nor the fix, and links no docs. Separately, the JSDoc-description convention (`/** description */` above the default export, extracted by typegen) is documented nowhere — `apps/web/content/docs/tools.mdx` covers the signature and type-inference rules but never mentions descriptions.
+
+2. **Route tools have no sandboxed filesystem access.** A tool's `run(input, context)` receives only `{ middleware?, signal }` (`packages/cli/src/lib/runtime/dawn-context.ts`). Any file work — text or binary — drops to `node:fs`, bypassing the workspace path-jail and permission gate entirely. PR #207 gave the *backend* a binary read; nothing yet hands tool authors a safe way to call it.
+
+## Decisions (from brainstorming)
+
+- **Dawn stays opinionated: no native LangChain `tool()` acceptance, and no `fromLangChainTool()` escape hatch.** The plain-function convention powers static type inference (Dawn's headline feature: tool I/O types extracted from the function signature via the TS compiler API → `ctx.tools` IntelliSense + `tools.json`). A `StructuredTool` carries only a runtime Zod schema, which would force a second, degraded path through typegen and blur the framework's opinion. The ecosystem/migration benefit is adequately served by a 3-line wrapper, which the diagnostic and docs will teach. An adapter helper can ship later in a minor if real demand appears.
+- **`ctx.fs` uses the exact same permission gate as the agent-facing workspace tools.** Inside `workspace/`: silent allow. Outside: consult the permissions store; interactive mode can emit the LangGraph permission interrupt (same prompt UX); non-interactive fails closed; `bypass` allows all. One permission model regardless of whether the LLM or tool code initiates the I/O.
+- **Surface: `readFile`, `readBinaryFile`, `writeFile`, `listDir`** — the operations the gate already has vocabulary for, plus the binary primitive. No `statFile`/`removeFile`/`touchFile`/`mkdir` (removal from tool code wants its own permission story), no `writeBinaryFile` (YAGNI).
+- **Reach: tool context AND workflow/graph `RuntimeContext`.** Anywhere Dawn hands authors a `ctx`, `ctx.fs` is present — one rule, no second context shape to learn.
+- **Always present, honest errors.** `ctx.fs` is non-optional in the types. If `workspace/` doesn't exist, operations surface natural ENOENT (no auto-create magic, matching `localFilesystem` semantics — except `writeFile`, which creates missing parent directories per [PR #208](https://github.com/cacheplane/dawnai/pull/208)). `readBinaryFile` on a backend lacking the optional method throws an error naming the fix.
+- **Name: `ctx.fs`** (not `ctx.workspace`).
+
+## Verified facts (against main @ `fa8bdd4`)
+
+- Tool discovery accepts a default-exported function or an object with a `.run` function; optional `export const description` / `export const schema`; generic failure at `tool-discovery.ts` line ~158. (`packages/cli/src/lib/runtime/tool-discovery.ts`)
+- Tool context today is `{ middleware?, signal }`, built in `createDawnContext`. (`packages/cli/src/lib/runtime/dawn-context.ts`)
+- `DawnToolDefinition.run`'s context type in core duplicates the same shape. (`packages/core/src/capabilities/types.ts`)
+- The path-jail + permission gate (`gatePathOp`, `emitPermissionInterrupt`) live inside the built-in workspace capability alongside the agent-facing tools. (`packages/core/src/capabilities/built-in/workspace.ts`)
+- `FilesystemBackend.readBinaryFile?` exists as of PR #207; `localFilesystem` implements it; `localFilesystem.writeFile` creates missing parent dirs as of PR #208. (`packages/workspace/src/`)
+- The docs site is `https://dawnai.org`; tools doc at `/docs/tools`. tools.mdx documents the `(input, ctx)` signature and type-inference rules but not JSDoc descriptions and no LangChain-wrapper pattern. (`apps/web/content/docs/tools.mdx`)
+- No docs-site page documents the pluggable `@dawn-ai/workspace` backend API (`FilesystemBackend` / `localFilesystem` / `compose` / middleware).
+
+---
+
+## Part A — authoring diagnostics + docs (PR 1: `@dawn-ai/cli` + docs)
+
+### A1. Targeted StructuredTool diagnostic
+
+In `loadToolDefinition`, after the existing function / `{ run }` checks fail, detect a LangChain-tool-shaped export **structurally** (no `@langchain/core` import):
+
+```ts
+function looksLikeLangChainTool(value: unknown): value is { readonly name: string } {
+  return (
+    isRecord(value) &&
+    typeof value.invoke === "function" &&
+    typeof value.name === "string" &&
+    "schema" in value
+  )
+}
+```
+
+When it matches, throw a multi-line error naming the export (`StructuredTool "<name>"`), explaining *why* Dawn wants a plain function (type inference from the signature), showing the 3-line wrapper conversion, and linking `https://dawnai.org/docs/tools`.
+
+### A2. Better generic error
+
+The fallback error names what was found via a `describeExport(value)` helper (`"no default export"`, `"a string"`, `"an object with keys [a, b]"`, …) and links the docs page.
+
+### A3. Docs (tools.mdx)
+
+- New subsection documenting the **JSDoc description convention** (where the LLM-facing tool description comes from; `export const description` as the override).
+- New **"Using an existing LangChain tool"** entry under Common patterns: instantiate the community tool at module scope, wrap in a plain function with a typed input.
+
+### Part A testing
+
+- Unit tests in `packages/cli/test/` for `loadToolDefinition`: a fake StructuredTool-shaped export produces the targeted error (asserting it names the tool and contains the docs link); `undefined` / string / plain-object defaults produce the described-export generic error; existing accepted shapes unaffected.
+
+---
+
+## Part B — sandboxed `ctx.fs` (PR 2: `@dawn-ai/core` + `@dawn-ai/sdk` + `@dawn-ai/cli`)
+
+### B1. Gate extraction (refactor, no behavior change)
+
+Move `gatePathOp`, `gateBashOp`, and `emitPermissionInterrupt` from `capabilities/built-in/workspace.ts` into a shared core module (`packages/core/src/capabilities/permission-gate.ts`), exported for internal use. The built-in workspace capability imports them; existing tests must pass unchanged.
+
+### B2. `WorkspaceFs` + `DawnToolContext` types in `@dawn-ai/sdk`
+
+```ts
+export interface WorkspaceFs {
+  /** Read a UTF-8 file. Relative paths resolve against the route's workspace/. */
+  readFile(path: string, opts?: { readonly maxBytes?: number }): Promise<string>
+  /** Read raw bytes (images, PDFs, …). Throws a clear error if the configured
+      backend doesn't implement readBinaryFile. */
+  readBinaryFile(path: string, opts?: { readonly maxBytes?: number }): Promise<Uint8Array>
+  /** Write a UTF-8 file. localFilesystem creates missing parent directories. */
+  writeFile(path: string, content: string): Promise<{ readonly bytesWritten: number }>
+  /** List entries (leaf names). Defaults to the workspace root. */
+  listDir(path?: string): Promise<readonly string[]>
+}
+
+export interface DawnToolContext {
+  readonly signal: AbortSignal
+  readonly middleware?: Readonly<Record<string, unknown>>
+  readonly fs: WorkspaceFs
+}
+```
+
+`RuntimeContext` (workflow/graph entries) gains `readonly fs: WorkspaceFs`.
+
+### B3. `createWorkspaceFs` factory in core
+
+`packages/core/src/capabilities/workspace-fs.ts`: closes over `{ workspaceRoot, backend, permissions, signal }`; each method resolves the (workspace-relative) path, runs the shared gate (`readFile` op for both text and binary reads; `writeFile`; `listDir`), then delegates to the backend. `readBinaryFile` throws `"The configured filesystem backend does not support binary reads (readBinaryFile). localFilesystem supports it; custom backends must implement it."` when the backend lacks the optional method.
+
+### B4. Agent-facing tools refactor onto the handle
+
+`buildWorkspaceTools` constructs the handle and routes its tool bodies through it, so the LLM-facing tools and `ctx.fs` share one gated code path. The `tool-outputs/` special case (uncapped read + best-effort `touchFile`) is preserved — it stays in the agent-tool layer (it is offload plumbing, not part of the author-facing `WorkspaceFs` contract).
+
+### B5. Threading
+
+- cli `createDawnContext` builds the handle once per run and passes it in each `tool.run(input, { middleware?, signal, fs })`; `DiscoveredToolDefinition`'s and core `DawnToolDefinition`'s context types gain `fs`.
+- `execute-route` provides `fs` on the workflow/graph `RuntimeContext`.
+- Backend/permissions sources are the same ones the workspace capability uses (`context.backends?.filesystem ?? localFilesystem()`, `context.permissions`); `workspaceRoot` is `<appRoot>/workspace` regardless of whether the directory exists (honest ENOENT at call time).
+- Capability-contributed tools (planning, skills, subagents, workspace itself) receive the same context shape; they simply ignore `fs` today.
+
+### B6. Interrupt-resume caveat (documented, inherited)
+
+A permission interrupt fired from inside tool code pauses mid-tool-execution; on resume LangGraph re-runs the node body, so the tool function executes again from the top. This is existing interrupt semantics, not new behavior — but `ctx.fs` makes it reachable from author code, so the docs must call it out: keep side effects before/around gated `fs` calls idempotent.
+
+### B7. Docs
+
+New docs-site page (**"Workspace filesystem"**, `apps/web/content/docs/workspace.mdx`) telling the complete story: the pluggable backend (`FilesystemBackend`, `localFilesystem`, `compose`, `FilesystemMiddleware`, `withFilesystemLogging`) → the agent-facing workspace tools → `ctx.fs` for tool/route authors (with the permission table and the interrupt-resume note). Closes the missing-backend-docs gap deferred from PR #207. tools.mdx's runtime-signature section updates to show `ctx.fs` and link the new page.
+
+### Part B testing
+
+- **core unit tests** (`packages/core/test/`): factory — relative-path jail resolution; inside-workspace silent allow; outside-workspace deny (non-interactive fail-closed) and store-allow; `writeFile`/`listDir` gating; binary read delegation; backend-lacks-binary error; `bypass` mode.
+- **cli integration** (`packages/cli/test/`): a fixture route tool that uses `ctx.fs.readFile`/`writeFile` end-to-end; workflow entry receiving `ctx.fs`.
+- **Regression:** existing workspace-capability tests pass unchanged after B1/B4.
+
+---
+
+## Out of scope (follow-ups)
+
+- `@dawn-ai/testing` support for `ctx.fs` (harness-provided `WorkspaceFs` over a temp dir) — belongs to backlog #6's spec.
+- `fromLangChainTool()` adapter — only if demand appears.
+- `statFile`/`removeFile`/`touchFile`/`mkdir`/`writeBinaryFile` on `WorkspaceFs`.
+- `dawn check` lint warning on raw `node:fs` imports in tool files — attractive once `ctx.fs` exists, but a separate increment.
+
+## Changesets
+
+Two PRs, one changeset each: PR 1 `"@dawn-ai/cli": minor`; PR 2 `"@dawn-ai/core": minor`, `"@dawn-ai/sdk": minor`, `"@dawn-ai/cli": minor` (fixed versioning bumps all together regardless).

--- a/docs/superpowers/specs/2026-06-11-tool-authoring-and-workspace-fs-design.md
+++ b/docs/superpowers/specs/2026-06-11-tool-authoring-and-workspace-fs-design.md
@@ -107,10 +107,21 @@ export interface DawnToolContext {
 
 ### B5. Threading
 
-- cli `createDawnContext` builds the handle once per run and passes it in each `tool.run(input, { middleware?, signal, fs })`; `DiscoveredToolDefinition`'s and core `DawnToolDefinition`'s context types gain `fs`.
-- `execute-route` provides `fs` on the workflow/graph `RuntimeContext`.
-- Backend/permissions sources are the same ones the workspace capability uses (`context.backends?.filesystem ?? localFilesystem()`, `context.permissions`); `workspaceRoot` is `<appRoot>/workspace` regardless of whether the directory exists (honest ENOENT at call time).
-- Capability-contributed tools (planning, skills, subagents, workspace itself) receive the same context shape; they simply ignore `fs` today.
+Tool `run` is invoked from multiple sites — cli `createDawnContext` (workflow/graph `ctx.tools`), and `@dawn-ai/langchain`'s `tool-converter.ts` / `tool-loop.ts` (agent routes). Rather than threading `fs` through every caller, **`prepareRouteExecution` (cli) injects it once by wrapping the assembled tool definitions**:
+
+```ts
+tools = tools.map((t) => ({ ...t, run: (input, ctx) => t.run(input, { ...ctx, fs }) }))
+```
+
+so `@dawn-ai/langchain` requires **no changes** (its locally-declared structural tool type still matches). Additionally:
+
+- `prepareRouteExecution` hoists permissions-store creation out of the agent-only branch (workflow/graph routes need the store's allow/deny rules too) and builds the handle from the same sources the workspace capability uses (`config.backends?.filesystem ?? localFilesystem()`, `<appRoot>/workspace` regardless of whether the directory exists — honest ENOENT at call time).
+- `createDawnContext` gains an `fs` option and exposes it on the workflow/graph `RuntimeContext`.
+- `DiscoveredToolDefinition`'s and core `DawnToolDefinition`'s run-context types gain `readonly fs?: WorkspaceFs` (optional at the definition layer; the author-facing `DawnToolContext` declares it required since the cli always injects it). Capability-contributed tools receive and ignore it.
+
+### B5a. Interrupt reachability (discovered during planning recon)
+
+The interactive permission interrupt is LangGraph machinery — it only works inside a graph node. **Agent-route tools** run inside the generated graph (`DynamicStructuredTool`), so the full interactive prompt works there. **Workflow/graph entries and their `ctx.tools` calls run as plain functions** (`invokeEntry`), where `interrupt()` would throw. Therefore `createWorkspaceFs` takes an `interruptCapable` flag (set from the route kind): when an outside-workspace path is `unknown` in interactive mode and interrupts are not available, the gate **fails closed** with a message telling the user to add an allow rule to `dawn.config.ts` permissions. The extracted `gatePathOp` gains an option to suppress interrupting (default preserves current behavior).
 
 ### B6. Interrupt-resume caveat (documented, inherited)
 

--- a/packages/cli/src/lib/runtime/dawn-context.ts
+++ b/packages/cli/src/lib/runtime/dawn-context.ts
@@ -1,15 +1,19 @@
+import type { WorkspaceFs } from "@dawn-ai/sdk"
+
 import type { DiscoveredToolDefinition } from "./tool-discovery.js"
 
 export interface DawnRouteContext {
   readonly middleware?: Readonly<Record<string, unknown>>
   readonly signal: AbortSignal
   readonly tools: Record<string, (input: unknown) => Promise<unknown>>
+  readonly fs: WorkspaceFs
 }
 
 export function createDawnContext(options: {
   readonly middleware?: Readonly<Record<string, unknown>>
   readonly signal?: AbortSignal
   readonly tools: readonly DiscoveredToolDefinition[]
+  readonly fs: WorkspaceFs
 }): DawnRouteContext {
   const signal = options.signal ?? new AbortController().signal
   const middleware = options.middleware
@@ -20,11 +24,12 @@ export function createDawnContext(options: {
         await tool.run(input, {
           ...(middleware ? { middleware } : {}),
           signal,
+          fs: options.fs,
         }),
     ]),
   )
 
-  const context: DawnRouteContext = { signal, tools }
+  const context: DawnRouteContext = { signal, tools, fs: options.fs }
   if (middleware) {
     return { ...context, middleware }
   }

--- a/packages/cli/src/lib/runtime/execute-route.ts
+++ b/packages/cli/src/lib/runtime/execute-route.ts
@@ -10,6 +10,7 @@ import {
   createPlanningMarker,
   createSkillsMarker,
   createSubagentsMarker,
+  createWorkspaceFs,
   createWorkspaceMarker,
   type DawnConfig,
   discoverRoutes,
@@ -37,7 +38,7 @@ import {
   type PermissionMode,
   type PermissionsStore,
 } from "@dawn-ai/permissions"
-import { type DawnAgent, isDawnAgent } from "@dawn-ai/sdk"
+import { type DawnAgent, isDawnAgent, type WorkspaceFs } from "@dawn-ai/sdk"
 import { createThreadsStore, sqliteCheckpointer, type ThreadsStore } from "@dawn-ai/sqlite-storage"
 import type { ExecBackend, FilesystemBackend } from "@dawn-ai/workspace"
 import { localFilesystem } from "@dawn-ai/workspace"
@@ -249,12 +250,14 @@ export async function* streamResolvedRoute(options: {
     checkpointer,
     offload,
     summarization,
+    workspaceFs,
   } = prepared
 
   if (normalized.kind !== "agent") {
     // Non-agent routes don't support incremental streaming — execute and emit done
     const context = createDawnContext({
       ...(options.middlewareContext ? { middleware: options.middlewareContext } : {}),
+      fs: workspaceFs,
       tools,
       ...(options.signal ? { signal: options.signal } : {}),
     })
@@ -340,6 +343,7 @@ interface PreparedRoute {
     NonNullable<CapabilityContribution["streamTransformers"]>[number]
   >
   readonly subagentResolver?: SubagentResolver
+  readonly workspaceFs: WorkspaceFs
 }
 
 interface PreparedRouteError {
@@ -442,6 +446,33 @@ async function prepareRouteExecution(options: {
     configThreadsStore ??
     createThreadsStore({ path: join(options.appRoot, ".dawn/threads.sqlite") })
 
+  const envMode = process.env.DAWN_PERMISSIONS_MODE
+  const mode: PermissionMode =
+    envMode === "interactive" || envMode === "non-interactive" || envMode === "bypass"
+      ? envMode
+      : (permissionsConfig?.mode ?? "interactive")
+
+  const permissionsStore: PermissionsStore = createPermissionsStore({
+    appRoot: options.appRoot,
+    config: permissionsConfig
+      ? {
+          version: 1,
+          allow: permissionsConfig.allow ?? {},
+          deny: permissionsConfig.deny ?? {},
+        }
+      : undefined,
+    mode,
+  })
+  await permissionsStore.load()
+
+  const workspaceFs = createWorkspaceFs({
+    workspaceRoot: join(options.appRoot, "workspace"),
+    backend: configBackends?.filesystem ?? localFilesystem(),
+    permissions: permissionsStore,
+    signal: options.signal ?? new AbortController().signal,
+    interruptCapable: normalized.kind === "agent",
+  })
+
   if (normalized.kind === "agent") {
     const registry = createCapabilityRegistry([
       createPlanningMarker(),
@@ -462,25 +493,6 @@ async function prepareRouteExecution(options: {
     // requests in production (one manifest per CLI invocation), naturally
     // invalidated in dev when the runtime rebuilds the manifest.
     const descriptorRouteMap = await getCachedDescriptorRouteMap(routeManifest)
-
-    const envMode = process.env.DAWN_PERMISSIONS_MODE
-    const mode: PermissionMode =
-      envMode === "interactive" || envMode === "non-interactive" || envMode === "bypass"
-        ? envMode
-        : (permissionsConfig?.mode ?? "interactive")
-
-    const permissionsStore: PermissionsStore = createPermissionsStore({
-      appRoot: options.appRoot,
-      config: permissionsConfig
-        ? {
-            version: 1,
-            allow: permissionsConfig.allow ?? {},
-            deny: permissionsConfig.deny ?? {},
-          }
-        : undefined,
-      mode,
-    })
-    await permissionsStore.load()
 
     const applied = await applyCapabilities(registry, routeDir, {
       routeManifest,
@@ -575,6 +587,19 @@ async function prepareRouteExecution(options: {
     }
   }
 
+  // Inject ctx.fs once here so every downstream invoker (createDawnContext,
+  // the langchain tool converter/loop) hands tools the sandboxed handle.
+  tools = tools.map((t) => ({
+    ...t,
+    run: (
+      input: unknown,
+      ctx: {
+        readonly middleware?: Readonly<Record<string, unknown>>
+        readonly signal: AbortSignal
+      },
+    ) => t.run(input, { ...ctx, fs: workspaceFs }),
+  }))
+
   return {
     normalized,
     ok: true,
@@ -587,6 +612,7 @@ async function prepareRouteExecution(options: {
     ...(streamTransformers.length > 0 ? { streamTransformers } : {}),
     ...(subagentResolver ? { subagentResolver } : {}),
     tools,
+    workspaceFs,
   }
 }
 
@@ -629,11 +655,13 @@ async function executeRouteAtResolvedPath(options: {
       checkpointer,
       offload,
       summarization,
+      workspaceFs,
     } = prepared
     mode = normalized.kind
 
     const context = createDawnContext({
       ...(options.middlewareContext ? { middleware: options.middlewareContext } : {}),
+      fs: workspaceFs,
       tools,
       ...(options.signal ? { signal: options.signal } : {}),
     })

--- a/packages/cli/src/lib/runtime/execute-route.ts
+++ b/packages/cli/src/lib/runtime/execute-route.ts
@@ -446,6 +446,9 @@ async function prepareRouteExecution(options: {
     configThreadsStore ??
     createThreadsStore({ path: join(options.appRoot, ".dawn/threads.sqlite") })
 
+  // Deliberately outside the agent-only branch below: every route kind needs
+  // the loaded store for ctx.fs permission gating, and createWorkspaceFs
+  // requires it loaded. The agent branch reuses this store in applyCapabilities.
   const envMode = process.env.DAWN_PERMISSIONS_MODE
   const mode: PermissionMode =
     envMode === "interactive" || envMode === "non-interactive" || envMode === "bypass"

--- a/packages/cli/src/lib/runtime/tool-discovery.ts
+++ b/packages/cli/src/lib/runtime/tool-discovery.ts
@@ -18,6 +18,9 @@ export interface DiscoveredToolDefinition {
     context: {
       readonly middleware?: Readonly<Record<string, unknown>>
       readonly signal: AbortSignal
+      // Optional here because pre-wrap invokers (langchain tool-converter/loop)
+      // omit it; the prepareRouteExecution wrapper guarantees it at runtime,
+      // which is why the author-facing DawnToolContext declares it required.
       readonly fs?: WorkspaceFs
     },
   ) => Promise<unknown> | unknown

--- a/packages/cli/src/lib/runtime/tool-discovery.ts
+++ b/packages/cli/src/lib/runtime/tool-discovery.ts
@@ -2,6 +2,8 @@ import { readdir } from "node:fs/promises"
 import { basename, join } from "node:path"
 import { pathToFileURL } from "node:url"
 
+import type { WorkspaceFs } from "@dawn-ai/sdk"
+
 import { registerTsxLoader } from "./register-tsx-loader.js"
 import { isRecord } from "./utils.js"
 
@@ -16,6 +18,7 @@ export interface DiscoveredToolDefinition {
     context: {
       readonly middleware?: Readonly<Record<string, unknown>>
       readonly signal: AbortSignal
+      readonly fs?: WorkspaceFs
     },
   ) => Promise<unknown> | unknown
   readonly schema?: unknown

--- a/packages/cli/test/dawn-context.test.ts
+++ b/packages/cli/test/dawn-context.test.ts
@@ -1,0 +1,38 @@
+import type { WorkspaceFs } from "@dawn-ai/sdk"
+import { describe, expect, it } from "vitest"
+
+import { createDawnContext } from "../src/lib/runtime/dawn-context.js"
+
+const fakeFs: WorkspaceFs = {
+  readFile: async () => "content",
+  readBinaryFile: async () => Uint8Array.from([1]),
+  writeFile: async () => ({ bytesWritten: 1 }),
+  listDir: async () => [],
+}
+
+describe("createDawnContext fs threading", () => {
+  it("exposes fs on the route context", () => {
+    const context = createDawnContext({ tools: [], fs: fakeFs })
+    expect(context.fs).toBe(fakeFs)
+  })
+
+  it("passes fs to tool run contexts", async () => {
+    let seenFs: WorkspaceFs | undefined
+    const context = createDawnContext({
+      fs: fakeFs,
+      tools: [
+        {
+          filePath: "/x/tools/probe.ts",
+          name: "probe",
+          scope: "route-local",
+          run: (_input, ctx) => {
+            seenFs = ctx.fs
+            return "ok"
+          },
+        },
+      ],
+    })
+    await context.tools.probe?.({})
+    expect(seenFs).toBe(fakeFs)
+  })
+})

--- a/packages/cli/test/workspace-fs-integration.test.ts
+++ b/packages/cli/test/workspace-fs-integration.test.ts
@@ -1,0 +1,158 @@
+import { readFileSync } from "node:fs"
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { dirname, join } from "node:path"
+
+import { afterEach, beforeEach, describe, expect, test } from "vitest"
+
+import { run } from "../src/index.js"
+
+const tempDirs: string[] = []
+let savedPermissionsMode: string | undefined
+
+beforeEach(() => {
+  savedPermissionsMode = process.env.DAWN_PERMISSIONS_MODE
+  process.env.DAWN_PERMISSIONS_MODE = "non-interactive"
+})
+
+afterEach(async () => {
+  if (savedPermissionsMode === undefined) {
+    delete process.env.DAWN_PERMISSIONS_MODE
+  } else {
+    process.env.DAWN_PERMISSIONS_MODE = savedPermissionsMode
+  }
+
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { force: true, recursive: true })))
+})
+
+describe("ctx.fs end-to-end", () => {
+  test("workflow entry and route tool share the sandboxed workspace handle", async () => {
+    const appRoot = await createFixtureApp({
+      "package.json": "{}\n",
+      "dawn.config.ts": "export default {};\n",
+      "src/app/(public)/notes/index.ts": `import type { RuntimeContext } from "@dawn-ai/sdk"
+export const workflow = async (
+  state: { readonly name: string },
+  ctx: RuntimeContext,
+) => {
+  await ctx.tools.stash({ name: state.name })
+  const files = await ctx.fs.listDir("stash")
+  return { ...state, files }
+}
+`,
+      "src/app/(public)/notes/tools/stash.ts": `import type { DawnToolContext } from "@dawn-ai/sdk"
+export default async (input: { readonly name: string }, ctx: DawnToolContext) => {
+  await ctx.fs.writeFile(\`stash/\${input.name}.txt\`, \`stashed \${input.name}\`)
+  return { ok: true }
+}
+`,
+    })
+
+    const result = await invoke(["run", "/notes", "--cwd", appRoot], {
+      stdin: JSON.stringify({ name: "alpha" }),
+    })
+
+    expect(result.exitCode).toBe(0)
+    expect(result.stderr).toBe("")
+    const payload = JSON.parse(result.stdout) as Record<string, unknown>
+
+    expect(payload).toMatchObject({
+      appRoot,
+      executionSource: "in-process",
+      mode: "workflow",
+      output: {
+        files: ["alpha.txt"],
+        name: "alpha",
+      },
+      routeId: "/notes",
+      routePath: "src/app/(public)/notes/index.ts",
+      status: "passed",
+    })
+
+    const onDisk = readFileSync(join(appRoot, "workspace", "stash", "alpha.txt"), "utf8")
+    expect(onDisk).toBe("stashed alpha")
+  })
+
+  test("tool ctx.fs reads escaping the workspace fail closed in non-interactive mode", async () => {
+    const appRoot = await createFixtureApp({
+      "package.json": "{}\n",
+      "dawn.config.ts": "export default {};\n",
+      "src/app/(public)/leaky/index.ts": `import type { RuntimeContext } from "@dawn-ai/sdk"
+export const workflow = async (
+  _state: unknown,
+  ctx: RuntimeContext,
+) => {
+  return await ctx.tools.escape({})
+}
+`,
+      "src/app/(public)/leaky/tools/escape.ts": `import type { DawnToolContext } from "@dawn-ai/sdk"
+export default async (_input: unknown, ctx: DawnToolContext) => {
+  return await ctx.fs.readFile("../outside.txt")
+}
+`,
+    })
+    await writeFile(join(appRoot, "outside.txt"), "secrets", "utf8")
+
+    const result = await invoke(["run", "/leaky", "--cwd", appRoot], {
+      stdin: JSON.stringify({}),
+    })
+
+    expect(result.exitCode).toBe(1)
+    expect(result.stderr).toBe("")
+    const payload = JSON.parse(result.stdout) as Record<string, unknown>
+
+    expect(payload).toMatchObject({
+      appRoot,
+      executionSource: "in-process",
+      error: {
+        kind: "execution_error",
+        message: expect.stringMatching(/Permission denied/),
+      },
+      routeId: "/leaky",
+      routePath: "src/app/(public)/leaky/index.ts",
+      status: "failed",
+    })
+  })
+})
+
+async function createFixtureApp(files: Readonly<Record<string, string>>) {
+  const appRoot = await mkdtemp(join(tmpdir(), "dawn-cli-workspace-fs-"))
+  tempDirs.push(appRoot)
+
+  await Promise.all(
+    Object.entries(files).map(async ([relativePath, source]) => {
+      const filePath = join(appRoot, relativePath)
+      await mkdir(dirname(filePath), { recursive: true })
+      await writeFile(filePath, source, "utf8")
+    }),
+  )
+  await mkdir(join(appRoot, "workspace"), { recursive: true })
+
+  return appRoot
+}
+
+async function invoke(
+  argv: readonly string[],
+  options: {
+    readonly stdin: string
+  },
+) {
+  const stdout: string[] = []
+  const stderr: string[] = []
+
+  const exitCode = await run([...argv], {
+    stderr: (message: string) => {
+      stderr.push(message)
+    },
+    stdin: async () => options.stdin,
+    stdout: (message: string) => {
+      stdout.push(message)
+    },
+  })
+
+  return {
+    exitCode,
+    stderr: stderr.join(""),
+    stdout: stdout.join(""),
+  }
+}

--- a/packages/core/src/capabilities/built-in/workspace.ts
+++ b/packages/core/src/capabilities/built-in/workspace.ts
@@ -1,12 +1,11 @@
 import { existsSync } from "node:fs"
 import { join, relative, resolve, sep } from "node:path"
 import type { PermissionsStore } from "@dawn-ai/permissions"
-import { suggestedCommandPattern, suggestedPathPattern } from "@dawn-ai/permissions"
 import type { BackendContext, ExecBackend, FilesystemBackend } from "@dawn-ai/workspace"
 import { localExec, localFilesystem } from "@dawn-ai/workspace"
-import { interrupt } from "@langchain/langgraph"
 import { z } from "zod"
 
+import { gateBashOp, gatePathOp } from "../permission-gate.js"
 import type { CapabilityMarker, DawnToolDefinition } from "../types.js"
 
 const WORKSPACE_DIRNAME = "workspace"
@@ -28,108 +27,6 @@ const RUN_BASH_INPUT = z.object({ command: z.string().min(1) })
 
 function backendContext(workspaceRoot: string, signal: AbortSignal): BackendContext {
   return { signal, workspaceRoot }
-}
-
-type GateResult = { allowed: true } | { allowed: false; reason: string }
-
-async function gatePathOp(
-  permissions: PermissionsStore | undefined,
-  operation: "readFile" | "writeFile" | "listDir",
-  absPath: string,
-  workspaceRoot: string,
-): Promise<GateResult> {
-  // If permissions store is absent, allow (legacy behavior — capability used without permissions context).
-  if (!permissions) return { allowed: true }
-  if (permissions.mode === "bypass") return { allowed: true }
-
-  const insideWorkspace = absPath === workspaceRoot || absPath.startsWith(workspaceRoot + sep)
-
-  // Inside workspace: always allow silently.
-  if (insideWorkspace) return { allowed: true }
-
-  // Outside workspace: consult the store.
-  const decision = permissions.match(operation, absPath)
-  if (decision === "allow") return { allowed: true }
-  if (decision === "deny") {
-    return { allowed: false, reason: `Permission denied by user: ${absPath}` }
-  }
-  // decision === "unknown"
-  if (permissions.mode === "non-interactive") {
-    return { allowed: false, reason: `Permission denied (fail-closed): ${absPath}` }
-  }
-  // Interactive: emit LangGraph interrupt and await user decision.
-  const result = await emitPermissionInterrupt({
-    kind: "path",
-    operation,
-    path: absPath,
-    permissions,
-  })
-  if (result === "deny") {
-    return { allowed: false, reason: `Permission denied by user: ${absPath}` }
-  }
-  return { allowed: true }
-}
-
-async function gateBashOp(
-  permissions: PermissionsStore | undefined,
-  command: string,
-): Promise<GateResult> {
-  if (!permissions) return { allowed: true }
-  if (permissions.mode === "bypass") return { allowed: true }
-
-  const decision = permissions.match("bash", command)
-  if (decision === "allow") return { allowed: true }
-  if (decision === "deny") {
-    return { allowed: false, reason: `Permission denied by user: ${command}` }
-  }
-  if (permissions.mode === "non-interactive") {
-    return { allowed: false, reason: `Permission denied (fail-closed): ${command}` }
-  }
-  const result = await emitPermissionInterrupt({
-    kind: "command",
-    command,
-    permissions,
-  })
-  if (result === "deny") {
-    return { allowed: false, reason: `Permission denied by user: ${command}` }
-  }
-  return { allowed: true }
-}
-
-interface InterruptArgs {
-  kind: "command" | "path"
-  command?: string
-  operation?: "readFile" | "writeFile" | "listDir"
-  path?: string
-  permissions: PermissionsStore
-}
-
-async function emitPermissionInterrupt(args: InterruptArgs): Promise<"allow" | "deny"> {
-  const interruptId = `perm-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
-  const suggestedPattern =
-    args.kind === "command"
-      ? suggestedCommandPattern(args.command ?? "")
-      : suggestedPathPattern(args.path ?? "")
-  const payload = {
-    interruptId,
-    type: "permission-request" as const,
-    kind: args.kind,
-    detail:
-      args.kind === "command"
-        ? { command: args.command ?? "", suggestedPattern }
-        : {
-            operation: args.operation ?? "readFile",
-            path: args.path ?? "",
-            suggestedPattern,
-          },
-  }
-  const decision = interrupt(payload) as "once" | "always" | "deny"
-  if (decision === "deny") return "deny"
-  if (decision === "always") {
-    const tool = args.kind === "command" ? "bash" : (args.operation ?? "readFile")
-    await args.permissions.addAllow(tool, suggestedPattern)
-  }
-  return "allow"
 }
 
 interface OverridableTool extends DawnToolDefinition {

--- a/packages/core/src/capabilities/built-in/workspace.ts
+++ b/packages/core/src/capabilities/built-in/workspace.ts
@@ -5,8 +5,9 @@ import type { BackendContext, ExecBackend, FilesystemBackend } from "@dawn-ai/wo
 import { localExec, localFilesystem } from "@dawn-ai/workspace"
 import { z } from "zod"
 
-import { gateBashOp, gatePathOp } from "../permission-gate.js"
+import { gateBashOp } from "../permission-gate.js"
 import type { CapabilityMarker, DawnToolDefinition } from "../types.js"
+import { createWorkspaceFs } from "../workspace-fs.js"
 
 const WORKSPACE_DIRNAME = "workspace"
 
@@ -39,6 +40,17 @@ function buildWorkspaceTools(
   exec: ExecBackend,
   permissions: PermissionsStore | undefined,
 ): readonly OverridableTool[] {
+  // Agent tools run inside the graph, so the handle may surface the
+  // interactive LangGraph permission interrupt.
+  function handleFor(signal: AbortSignal) {
+    return createWorkspaceFs({
+      workspaceRoot,
+      backend: fs,
+      permissions,
+      signal,
+      interruptCapable: true,
+    })
+  }
   const readFile: OverridableTool = {
     name: "readFile",
     description: "Read a UTF-8 file from the workspace.",
@@ -46,23 +58,18 @@ function buildWorkspaceTools(
     overridable: true,
     run: async (input, ctx) => {
       const { path } = READ_FILE_INPUT.parse(input)
+      const handle = handleFor(ctx.signal)
       const absPath = resolve(workspaceRoot, path)
-      const gate = await gatePathOp(permissions, "readFile", absPath, workspaceRoot)
-      if (!gate.allowed) {
-        throw new Error(gate.reason)
-      }
-      const bctx = backendContext(workspaceRoot, ctx.signal)
       const rel = relative(workspaceRoot, absPath)
       // NOTE: must match SUBDIR ("tool-outputs") in @dawn-ai/langchain offload-store.ts
       const isToolOutput = rel === "tool-outputs" || rel.startsWith(`tool-outputs${sep}`)
-      const data = await fs.readFile(
-        absPath,
-        bctx,
+      const data = await handle.readFile(
+        path,
         isToolOutput ? { maxBytes: Number.POSITIVE_INFINITY } : undefined,
       )
       if (isToolOutput && fs.touchFile) {
         try {
-          await fs.touchFile(absPath, bctx)
+          await fs.touchFile(absPath, backendContext(workspaceRoot, ctx.signal))
         } catch {
           /* touch is best-effort; never fail a read because of it */
         }
@@ -77,12 +84,7 @@ function buildWorkspaceTools(
     overridable: true,
     run: async (input, ctx) => {
       const { path, content } = WRITE_FILE_INPUT.parse(input)
-      const absPath = resolve(workspaceRoot, path)
-      const gate = await gatePathOp(permissions, "writeFile", absPath, workspaceRoot)
-      if (!gate.allowed) {
-        throw new Error(gate.reason)
-      }
-      const result = await fs.writeFile(absPath, content, backendContext(workspaceRoot, ctx.signal))
+      const result = await handleFor(ctx.signal).writeFile(path, content)
       return `wrote ${result.bytesWritten} bytes to ${path}`
     },
   }
@@ -93,13 +95,7 @@ function buildWorkspaceTools(
     overridable: true,
     run: async (input, ctx) => {
       const { path } = LIST_DIR_INPUT.parse(input)
-      const absPath = resolve(workspaceRoot, path)
-      const gate = await gatePathOp(permissions, "listDir", absPath, workspaceRoot)
-      if (!gate.allowed) {
-        throw new Error(gate.reason)
-      }
-      const entries = await fs.listDir(absPath, backendContext(workspaceRoot, ctx.signal))
-      return [...entries]
+      return [...(await handleFor(ctx.signal).listDir(path))]
     },
   }
   const runBash: OverridableTool = {

--- a/packages/core/src/capabilities/permission-gate.ts
+++ b/packages/core/src/capabilities/permission-gate.ts
@@ -12,6 +12,7 @@ export async function gatePathOp(
   operation: PathOperation,
   absPath: string,
   workspaceRoot: string,
+  opts?: { readonly interruptCapable?: boolean },
 ): Promise<GateResult> {
   // If permissions store is absent, allow (legacy behavior — capability used without permissions context).
   if (!permissions) return { allowed: true }
@@ -31,6 +32,15 @@ export async function gatePathOp(
   // decision === "unknown"
   if (permissions.mode === "non-interactive") {
     return { allowed: false, reason: `Permission denied (fail-closed): ${absPath}` }
+  }
+  if (opts?.interruptCapable === false) {
+    return {
+      allowed: false,
+      reason:
+        `Permission denied: ${absPath} is outside the workspace and interactive ` +
+        `permission prompts are not available in this execution context. ` +
+        `Add an allow rule for "${operation}" to the permissions config in dawn.config.ts.`,
+    }
   }
   // Interactive: emit LangGraph interrupt and await user decision.
   const result = await emitPermissionInterrupt({

--- a/packages/core/src/capabilities/permission-gate.ts
+++ b/packages/core/src/capabilities/permission-gate.ts
@@ -1,0 +1,108 @@
+import { sep } from "node:path"
+import type { PermissionsStore } from "@dawn-ai/permissions"
+import { suggestedCommandPattern, suggestedPathPattern } from "@dawn-ai/permissions"
+import { interrupt } from "@langchain/langgraph"
+
+export type PathOperation = "readFile" | "writeFile" | "listDir"
+
+export type GateResult = { allowed: true } | { allowed: false; reason: string }
+
+export async function gatePathOp(
+  permissions: PermissionsStore | undefined,
+  operation: PathOperation,
+  absPath: string,
+  workspaceRoot: string,
+): Promise<GateResult> {
+  // If permissions store is absent, allow (legacy behavior — capability used without permissions context).
+  if (!permissions) return { allowed: true }
+  if (permissions.mode === "bypass") return { allowed: true }
+
+  const insideWorkspace = absPath === workspaceRoot || absPath.startsWith(workspaceRoot + sep)
+
+  // Inside workspace: always allow silently.
+  if (insideWorkspace) return { allowed: true }
+
+  // Outside workspace: consult the store.
+  const decision = permissions.match(operation, absPath)
+  if (decision === "allow") return { allowed: true }
+  if (decision === "deny") {
+    return { allowed: false, reason: `Permission denied by user: ${absPath}` }
+  }
+  // decision === "unknown"
+  if (permissions.mode === "non-interactive") {
+    return { allowed: false, reason: `Permission denied (fail-closed): ${absPath}` }
+  }
+  // Interactive: emit LangGraph interrupt and await user decision.
+  const result = await emitPermissionInterrupt({
+    kind: "path",
+    operation,
+    path: absPath,
+    permissions,
+  })
+  if (result === "deny") {
+    return { allowed: false, reason: `Permission denied by user: ${absPath}` }
+  }
+  return { allowed: true }
+}
+
+export async function gateBashOp(
+  permissions: PermissionsStore | undefined,
+  command: string,
+): Promise<GateResult> {
+  if (!permissions) return { allowed: true }
+  if (permissions.mode === "bypass") return { allowed: true }
+
+  const decision = permissions.match("bash", command)
+  if (decision === "allow") return { allowed: true }
+  if (decision === "deny") {
+    return { allowed: false, reason: `Permission denied by user: ${command}` }
+  }
+  if (permissions.mode === "non-interactive") {
+    return { allowed: false, reason: `Permission denied (fail-closed): ${command}` }
+  }
+  const result = await emitPermissionInterrupt({
+    kind: "command",
+    command,
+    permissions,
+  })
+  if (result === "deny") {
+    return { allowed: false, reason: `Permission denied by user: ${command}` }
+  }
+  return { allowed: true }
+}
+
+interface InterruptArgs {
+  kind: "command" | "path"
+  command?: string
+  operation?: PathOperation
+  path?: string
+  permissions: PermissionsStore
+}
+
+async function emitPermissionInterrupt(args: InterruptArgs): Promise<"allow" | "deny"> {
+  const interruptId = `perm-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+  const suggestedPattern =
+    args.kind === "command"
+      ? suggestedCommandPattern(args.command ?? "")
+      : suggestedPathPattern(args.path ?? "")
+  const payload = {
+    interruptId,
+    type: "permission-request" as const,
+    kind: args.kind,
+    detail:
+      args.kind === "command"
+        ? { command: args.command ?? "", suggestedPattern }
+        : {
+            operation: args.operation ?? "readFile",
+            path: args.path ?? "",
+            suggestedPattern,
+          },
+  }
+  const decision = interrupt(payload) as "once" | "always" | "deny"
+  if (decision === "deny") return "deny"
+  if (decision === "always") {
+    const tool = args.kind === "command" ? "bash" : (args.operation ?? "readFile")
+    await args.permissions.addAllow(tool, suggestedPattern)
+  }
+  return "allow"
+}

--- a/packages/core/src/capabilities/types.ts
+++ b/packages/core/src/capabilities/types.ts
@@ -24,6 +24,9 @@ export interface DawnToolDefinition {
     context: {
       readonly middleware?: Readonly<Record<string, unknown>>
       readonly signal: AbortSignal
+      // Optional here because pre-wrap invokers (langchain tool-converter/loop)
+      // omit it; the cli's prepareRouteExecution wrapper guarantees it at
+      // runtime, which is why the author-facing DawnToolContext requires it.
       readonly fs?: WorkspaceFs
     },
   ) => Promise<unknown> | unknown

--- a/packages/core/src/capabilities/types.ts
+++ b/packages/core/src/capabilities/types.ts
@@ -1,5 +1,5 @@
 import type { PermissionsStore } from "@dawn-ai/permissions"
-import type { DawnAgent } from "@dawn-ai/sdk"
+import type { DawnAgent, WorkspaceFs } from "@dawn-ai/sdk"
 import type { ExecBackend, FilesystemBackend } from "@dawn-ai/workspace"
 import type { ResolvedStateField, RouteManifest } from "../types.js"
 
@@ -24,6 +24,7 @@ export interface DawnToolDefinition {
     context: {
       readonly middleware?: Readonly<Record<string, unknown>>
       readonly signal: AbortSignal
+      readonly fs?: WorkspaceFs
     },
   ) => Promise<unknown> | unknown
   readonly schema?: unknown

--- a/packages/core/src/capabilities/workspace-fs.ts
+++ b/packages/core/src/capabilities/workspace-fs.ts
@@ -1,0 +1,59 @@
+import { resolve } from "node:path"
+import type { PermissionsStore } from "@dawn-ai/permissions"
+import type { WorkspaceFs } from "@dawn-ai/sdk"
+import type { FilesystemBackend } from "@dawn-ai/workspace"
+import { gatePathOp, type PathOperation } from "./permission-gate.js"
+
+export interface CreateWorkspaceFsOptions {
+  readonly workspaceRoot: string
+  readonly backend: FilesystemBackend
+  readonly permissions: PermissionsStore | undefined
+  readonly signal: AbortSignal
+  /**
+   * Whether this execution context can surface the interactive LangGraph
+   * permission interrupt (true inside agent-route tool execution; false for
+   * workflow/graph entries, which run outside the graph).
+   */
+  readonly interruptCapable: boolean
+}
+
+/**
+ * Build the author-facing sandboxed filesystem handle (`ctx.fs`). Paths are
+ * workspace-relative; every call runs the same permission gate as the
+ * agent-facing workspace tools.
+ */
+export function createWorkspaceFs(opts: CreateWorkspaceFsOptions): WorkspaceFs {
+  const bctx = { signal: opts.signal, workspaceRoot: opts.workspaceRoot }
+
+  async function gate(operation: PathOperation, path: string): Promise<string> {
+    const absPath = resolve(opts.workspaceRoot, path)
+    const result = await gatePathOp(opts.permissions, operation, absPath, opts.workspaceRoot, {
+      interruptCapable: opts.interruptCapable,
+    })
+    if (!result.allowed) throw new Error(result.reason)
+    return absPath
+  }
+
+  return {
+    async readFile(path, readOpts) {
+      return opts.backend.readFile(await gate("readFile", path), bctx, readOpts)
+    },
+    async readBinaryFile(path, readOpts) {
+      const absPath = await gate("readFile", path)
+      const { readBinaryFile } = opts.backend
+      if (!readBinaryFile) {
+        throw new Error(
+          "The configured filesystem backend does not support binary reads (readBinaryFile). " +
+            "localFilesystem supports it; custom backends must implement it.",
+        )
+      }
+      return readBinaryFile.call(opts.backend, absPath, bctx, readOpts)
+    },
+    async writeFile(path, content) {
+      return opts.backend.writeFile(await gate("writeFile", path), content, bctx)
+    },
+    async listDir(path = ".") {
+      return [...(await opts.backend.listDir(await gate("listDir", path), bctx))]
+    },
+  }
+}

--- a/packages/core/src/capabilities/workspace-fs.ts
+++ b/packages/core/src/capabilities/workspace-fs.ts
@@ -39,7 +39,8 @@ export function createWorkspaceFs(opts: CreateWorkspaceFsOptions): WorkspaceFs {
       return opts.backend.readFile(await gate("readFile", path), bctx, readOpts)
     },
     async readBinaryFile(path, readOpts) {
-      const absPath = await gate("readFile", path)
+      // Check backend capability before gating so users are never prompted to
+      // approve a read that will immediately fail.
       const { readBinaryFile } = opts.backend
       if (!readBinaryFile) {
         throw new Error(
@@ -47,6 +48,7 @@ export function createWorkspaceFs(opts: CreateWorkspaceFsOptions): WorkspaceFs {
             "localFilesystem supports it; custom backends must implement it.",
         )
       }
+      const absPath = await gate("readFile", path)
       return readBinaryFile.call(opts.backend, absPath, bctx, readOpts)
     },
     async writeFile(path, content) {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -22,6 +22,8 @@ export type {
   StreamTransformerInput,
   StreamTransformerOutput,
 } from "./capabilities/types.js"
+export type { CreateWorkspaceFsOptions } from "./capabilities/workspace-fs.js"
+export { createWorkspaceFs } from "./capabilities/workspace-fs.js"
 export { loadDawnConfig } from "./config.js"
 export { discoverRoutes } from "./discovery/discover-routes.js"
 export { assertDawnRoutesDir, findDawnApp } from "./discovery/find-dawn-app.js"

--- a/packages/core/test/capabilities/permission-gate.test.ts
+++ b/packages/core/test/capabilities/permission-gate.test.ts
@@ -1,0 +1,53 @@
+import { mkdtempSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { createPermissionsStore } from "@dawn-ai/permissions"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+
+import { gatePathOp } from "../../src/capabilities/permission-gate.js"
+
+describe("gatePathOp interrupt suppression", () => {
+  let appRoot: string
+
+  beforeEach(() => {
+    appRoot = mkdtempSync(join(tmpdir(), "dawn-gate-test-"))
+  })
+
+  afterEach(() => {
+    rmSync(appRoot, { recursive: true, force: true })
+  })
+
+  it("fails closed with guidance when interactive but interrupts unavailable", async () => {
+    // Interactive mode with no config => match() returns "unknown" for outside paths.
+    // Without interruptCapable:false the gate would call interrupt() and throw a LangGraph error.
+    const permissions = createPermissionsStore({
+      appRoot,
+      config: undefined,
+      mode: "interactive",
+    })
+    await permissions.load()
+
+    const result = await gatePathOp(permissions, "readFile", "/outside/x", "/ws", {
+      interruptCapable: false,
+    })
+    expect(result.allowed).toBe(false)
+    if (!result.allowed) {
+      expect(result.reason).toMatch(/allow rule/)
+      expect(result.reason).toMatch(/dawn\.config/)
+    }
+  })
+
+  it("still allows inside-workspace paths without consulting the store", async () => {
+    const permissions = createPermissionsStore({
+      appRoot,
+      config: undefined,
+      mode: "interactive",
+    })
+    await permissions.load()
+
+    const result = await gatePathOp(permissions, "readFile", "/ws/notes.md", "/ws", {
+      interruptCapable: false,
+    })
+    expect(result.allowed).toBe(true)
+  })
+})

--- a/packages/core/test/capabilities/workspace-fs.test.ts
+++ b/packages/core/test/capabilities/workspace-fs.test.ts
@@ -169,6 +169,31 @@ describe("createWorkspaceFs permission gating", () => {
     await expect(fs.writeFile(join(outsideDir, "new.txt"), "data")).rejects.toThrow(/fail-closed/)
   })
 
+  it("gates relative ../ traversal out of the workspace", async () => {
+    const permissions = createPermissionsStore({
+      appRoot: root,
+      config: undefined,
+      mode: "non-interactive",
+    })
+    await permissions.load()
+    const fs = makeGated(permissions)
+    await expect(fs.readFile(join("..", "shared", "outside.txt"))).rejects.toThrow(/fail-closed/)
+  })
+
+  it("does not treat a sibling dir sharing the workspace prefix as inside", async () => {
+    const evil = `${workspaceRoot}-evil`
+    mkdirSync(evil, { recursive: true })
+    writeFileSync(join(evil, "x.txt"), "evil", "utf8")
+    const permissions = createPermissionsStore({
+      appRoot: root,
+      config: undefined,
+      mode: "non-interactive",
+    })
+    await permissions.load()
+    const fs = makeGated(permissions)
+    await expect(fs.readFile(join(evil, "x.txt"))).rejects.toThrow(/fail-closed/)
+  })
+
   it("skips gating entirely for a bypass-mode store", async () => {
     const permissions = createPermissionsStore({
       appRoot: root,

--- a/packages/core/test/capabilities/workspace-fs.test.ts
+++ b/packages/core/test/capabilities/workspace-fs.test.ts
@@ -1,0 +1,182 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { createPermissionsStore } from "@dawn-ai/permissions"
+import { localFilesystem } from "@dawn-ai/workspace"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import { createWorkspaceFs } from "../../src/capabilities/workspace-fs.js"
+
+describe("createWorkspaceFs", () => {
+  let root: string
+  let workspaceRoot: string
+  const signal = new AbortController().signal
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "dawn-wsfs-"))
+    workspaceRoot = join(root, "workspace")
+    mkdirSync(workspaceRoot, { recursive: true })
+  })
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true })
+  })
+
+  function make(backend = localFilesystem()) {
+    return createWorkspaceFs({
+      workspaceRoot,
+      backend,
+      permissions: undefined,
+      signal,
+      interruptCapable: false,
+    })
+  }
+
+  it("resolves relative paths against the workspace root", async () => {
+    writeFileSync(join(workspaceRoot, "notes.md"), "hello", "utf8")
+    const fs = make()
+    expect(await fs.readFile("notes.md")).toBe("hello")
+  })
+
+  it("round-trips writeFile/readFile and listDir", async () => {
+    const fs = make()
+    const res = await fs.writeFile("reports/out.md", "data")
+    expect(res.bytesWritten).toBe(4)
+    expect(await fs.readFile("reports/out.md")).toBe("data")
+    expect([...(await fs.listDir("reports"))]).toEqual(["out.md"])
+    expect([...(await fs.listDir())]).toContain("reports")
+  })
+
+  it("reads binary files as Uint8Array", async () => {
+    const bytes = Uint8Array.from([0x89, 0x50, 0x4e, 0x47])
+    writeFileSync(join(workspaceRoot, "img.png"), bytes)
+    const fs = make()
+    const out = await fs.readBinaryFile("img.png")
+    expect(out).toBeInstanceOf(Uint8Array)
+    expect([...out]).toEqual([...bytes])
+  })
+
+  it("throws a descriptive error when the backend lacks readBinaryFile", async () => {
+    const textOnly = {
+      readFile: async () => "x",
+      writeFile: async () => ({ bytesWritten: 1 }),
+      listDir: async () => [],
+    }
+    const fs = createWorkspaceFs({
+      workspaceRoot,
+      backend: textOnly,
+      permissions: undefined,
+      signal,
+      interruptCapable: false,
+    })
+    await expect(fs.readBinaryFile("img.png")).rejects.toThrow(
+      /does not support binary reads \(readBinaryFile\)/,
+    )
+  })
+
+  it("allows everything silently when no permissions store is provided", async () => {
+    const outside = join(root, "outside.txt")
+    writeFileSync(outside, "secret", "utf8")
+    const fs = make()
+    expect(await fs.readFile(outside)).toBe("secret")
+  })
+
+  it("forwards maxBytes to the backend", async () => {
+    writeFileSync(join(workspaceRoot, "big.txt"), "x".repeat(100), "utf8")
+    const fs = createWorkspaceFs({
+      workspaceRoot,
+      backend: localFilesystem({ maxFileBytes: 10 }),
+      permissions: undefined,
+      signal,
+      interruptCapable: false,
+    })
+    await expect(fs.readFile("big.txt")).rejects.toThrow(/too large/)
+    expect(await fs.readFile("big.txt", { maxBytes: 1000 })).toBe("x".repeat(100))
+  })
+})
+
+describe("createWorkspaceFs permission gating", () => {
+  let root: string
+  let workspaceRoot: string
+  let outsideDir: string
+  let outsideFile: string
+  const signal = new AbortController().signal
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "dawn-wsfs-gate-"))
+    workspaceRoot = join(root, "workspace")
+    mkdirSync(workspaceRoot, { recursive: true })
+    outsideDir = join(root, "shared")
+    mkdirSync(outsideDir, { recursive: true })
+    outsideFile = join(outsideDir, "outside.txt")
+    writeFileSync(outsideFile, "secret", "utf8")
+  })
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true })
+  })
+
+  function makeGated(permissions: Parameters<typeof createWorkspaceFs>[0]["permissions"]) {
+    return createWorkspaceFs({
+      workspaceRoot,
+      backend: localFilesystem(),
+      permissions,
+      signal,
+      interruptCapable: false,
+    })
+  }
+
+  it("fails closed for outside paths with a non-interactive store", async () => {
+    const permissions = createPermissionsStore({
+      appRoot: root,
+      config: undefined,
+      mode: "non-interactive",
+    })
+    await permissions.load()
+    const fs = makeGated(permissions)
+    await expect(fs.readFile(outsideFile)).rejects.toThrow(/fail-closed/)
+  })
+
+  it("allows outside reads when a config allow rule matches the path", async () => {
+    // Prefix-match pattern shaped like suggestedPathPattern: parent dir + "/"
+    const permissions = createPermissionsStore({
+      appRoot: root,
+      config: { version: 1, allow: { readFile: [`${outsideDir}/`] }, deny: {} },
+      mode: "non-interactive",
+    })
+    await permissions.load()
+    const fs = makeGated(permissions)
+    expect(await fs.readFile(outsideFile)).toBe("secret")
+  })
+
+  it("rejects with allow-rule guidance when interactive but interrupts unavailable", async () => {
+    const permissions = createPermissionsStore({
+      appRoot: root,
+      config: undefined,
+      mode: "interactive",
+    })
+    await permissions.load()
+    const fs = makeGated(permissions)
+    await expect(fs.readFile(outsideFile)).rejects.toThrow(/allow rule/)
+  })
+
+  it("gates outside writes under the writeFile operation, not readFile", async () => {
+    // Allow rule covers readFile only — a write to the same outside dir must still fail.
+    const permissions = createPermissionsStore({
+      appRoot: root,
+      config: { version: 1, allow: { readFile: [`${outsideDir}/`] }, deny: {} },
+      mode: "non-interactive",
+    })
+    await permissions.load()
+    const fs = makeGated(permissions)
+    await expect(fs.writeFile(join(outsideDir, "new.txt"), "data")).rejects.toThrow(/fail-closed/)
+  })
+
+  it("skips gating entirely for a bypass-mode store", async () => {
+    const permissions = createPermissionsStore({
+      appRoot: root,
+      config: undefined,
+      mode: "bypass",
+    })
+    await permissions.load()
+    const fs = makeGated(permissions)
+    expect(await fs.readFile(outsideFile)).toBe("secret")
+  })
+})

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -31,3 +31,4 @@ export type {
   ToolRegistry,
 } from "./runtime-context.js"
 export type { Prettify } from "./types.js"
+export type { DawnToolContext, WorkspaceFs } from "./workspace-fs.js"

--- a/packages/sdk/src/runtime-context.ts
+++ b/packages/sdk/src/runtime-context.ts
@@ -1,3 +1,5 @@
+import type { WorkspaceFs } from "./workspace-fs.js"
+
 export type RuntimeTool<TInput = unknown, TOutput = unknown> = (
   input: TInput,
 ) => Promise<TOutput> | TOutput
@@ -7,4 +9,5 @@ export type ToolRegistry = Record<string, RuntimeTool<never, unknown>>
 export interface RuntimeContext<TTools extends ToolRegistry = ToolRegistry> {
   readonly signal: AbortSignal
   readonly tools: TTools
+  readonly fs: WorkspaceFs
 }

--- a/packages/sdk/src/workspace-fs.ts
+++ b/packages/sdk/src/workspace-fs.ts
@@ -1,0 +1,29 @@
+/**
+ * Sandboxed filesystem handle scoped to the route's workspace/ directory.
+ *
+ * Relative paths resolve against the workspace root. Every call is
+ * permission-gated with the same rules as the agent-facing workspace tools:
+ * paths inside workspace/ are always allowed; paths outside consult the
+ * permissions store (interactive prompt where available, fail-closed
+ * otherwise).
+ */
+export interface WorkspaceFs {
+  /** Read a UTF-8 file. */
+  readFile(path: string, opts?: { readonly maxBytes?: number }): Promise<string>
+  /**
+   * Read raw bytes (images, PDFs, …). Throws a descriptive error when the
+   * configured filesystem backend does not implement binary reads.
+   */
+  readBinaryFile(path: string, opts?: { readonly maxBytes?: number }): Promise<Uint8Array>
+  /** Write a UTF-8 file. localFilesystem creates missing parent directories. */
+  writeFile(path: string, content: string): Promise<{ readonly bytesWritten: number }>
+  /** List entries (leaf names). Defaults to the workspace root. */
+  listDir(path?: string): Promise<readonly string[]>
+}
+
+/** The context argument Dawn passes to a route tool's function. */
+export interface DawnToolContext {
+  readonly signal: AbortSignal
+  readonly middleware?: Readonly<Record<string, unknown>>
+  readonly fs: WorkspaceFs
+}

--- a/packages/sdk/test/runtime-context.contract.ts
+++ b/packages/sdk/test/runtime-context.contract.ts
@@ -1,4 +1,4 @@
-import type { RuntimeContext, RuntimeTool, ToolRegistry } from "@dawn-ai/sdk"
+import type { RuntimeContext, RuntimeTool, ToolRegistry, WorkspaceFs } from "@dawn-ai/sdk"
 
 const _registry: ToolRegistry = {}
 void _registry
@@ -8,6 +8,13 @@ const _tool: RuntimeTool<{ name: string }, { greeting: string }> = async (input)
 })
 void _tool
 
+const _fs: WorkspaceFs = {
+  readFile: async () => "",
+  readBinaryFile: async () => Uint8Array.from([]),
+  writeFile: async () => ({ bytesWritten: 0 }),
+  listDir: async () => [],
+}
+
 const _context: RuntimeContext<{
   readonly greet: RuntimeTool<{ readonly name: string }, { readonly greeting: string }>
 }> = {
@@ -15,5 +22,6 @@ const _context: RuntimeContext<{
   tools: {
     greet: async (input) => ({ greeting: `hi ${input.name}` }),
   },
+  fs: _fs,
 }
 void _context


### PR DESCRIPTION
## Summary

Part B of [the tool-authoring + workspace-fs design](docs/superpowers/specs/2026-06-11-tool-authoring-and-workspace-fs-design.md) (backlog #3; Part A is #211). Route tools and workflow/graph entries get a sandboxed, permission-gated filesystem handle — closing the gap where any tool file I/O meant dropping to raw `node:fs` and bypassing the workspace sandbox.

- **`ctx.fs: WorkspaceFs`** (`readFile`, `readBinaryFile`, `writeFile`, `listDir`) on `DawnToolContext` and `RuntimeContext` — workspace-relative paths, jailed + gated per call. Builds on the binary-read primitive from #207.
- **Gate extraction:** `gatePathOp`/`gateBashOp`/`emitPermissionInterrupt` moved to a shared `permission-gate.ts`; the agent-facing workspace tools refactored onto the same `createWorkspaceFs` handle — one gated code path whether the LLM or author code initiates I/O.
- **Interrupt reachability:** agent-route tools (inside the LangGraph graph) keep the full interactive permission prompt; workflow/graph entries (outside the graph, where `interrupt()` can't fire) fail closed with guidance to add an allow rule.
- **One injection point:** `prepareRouteExecution` wraps the assembled tool definitions to inject `fs` — `@dawn-ai/langchain` needed zero changes.
- **Docs:** new [Workspace Filesystem](apps/web/content/docs/workspace.mdx) page (pluggable backend → middleware → `ctx.fs` → permissions, incl. interrupt-resume and lexical-jail caveats — closing the backend-docs gap deferred from #207); tools.mdx runtime signature now shows `DawnToolContext`.

## Test plan

- [x] TDD throughout: 22 new tests (core permission-gate 2, workspace-fs factory 13 incl. path-boundary regressions verified via weaken-then-revert, cli dawn-context 2, e2e integration 2 through the real `dawn run` path, +3 review-driven)
- [x] Full suites green post-rebase: workspace 29, core 167, langchain 159 (zero changes, zero regressions), cli 188
- [x] `pnpm -r build` clean; docs site 49/49 pages
- [x] Per-task spec-compliance + code-quality subagent reviews; review findings (guard comments, docs accuracy fixes, boundary tests, readBinaryFile gate ordering) folded in

🤖 Generated with [Claude Code](https://claude.com/claude-code)