### PR TITLE
docs: fix retired dawn-ai.org domain references

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,7 +1,7 @@
 blank_issues_enabled: false
 contact_links:
   - name: Documentation
-    url: https://dawn-ai.org/docs/getting-started
+    url: https://dawnai.org/docs/getting-started
     about: Read Dawn's public documentation.
   - name: Discussions
     url: https://github.com/cacheplane/dawnai/discussions
@@ -10,5 +10,5 @@ contact_links:
     url: https://github.com/cacheplane/dawnai/security/advisories/new
     about: Report vulnerabilities privately.
   - name: Brand assets
-    url: https://dawn-ai.org/brand
+    url: https://dawnai.org/brand
     about: Download Dawn logos and media assets.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -6,7 +6,7 @@ Use GitHub Discussions for usage questions, design discussions, and integration 
 
 https://github.com/cacheplane/dawnai/discussions
 
-The public documentation is available at https://dawn-ai.org/docs/getting-started.
+The public documentation is available at https://dawnai.org/docs/getting-started.
 
 ## Bugs
 


### PR DESCRIPTION
## Summary

Follow-up to the README GTM refresh (#214). A repo-wide sweep found the retired `dawn-ai.org` domain still referenced outside the READMEs:

- `SUPPORT.md` — documentation link
- `.github/ISSUE_TEMPLATE/config.yml` — the "Documentation" and "Brand assets" links in GitHub's New Issue chooser (user-facing)

All updated to the live `dawnai.org`. `scripts/check-docs.mjs` explicitly flags `dawn-ai.org` as retired; the only remaining references are that detector string and historical plan docs (both intentional).

No `packages/*` files touched, so no changeset is required.

## Test Plan

- [ ] No retired `dawn-ai.org` references remain outside `check-docs.mjs` and `docs/superpowers/plans/*`
- [ ] Issue-template chooser links resolve to dawnai.org

🤖 Generated with [Claude Code](https://claude.com/claude-code)