### PR TITLE
fix(core): reference sqlite-storage for cold composite builds

### DIFF
--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -5,5 +5,10 @@
     "outDir": "dist",
     "rootDir": "src"
   },
-  "include": ["src/**/*.ts"]
+  "include": ["src/**/*.ts"],
+  "references": [
+    {
+      "path": "../sqlite-storage"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
Main's CI is red since #213: `core` now imports `@dawn-ai/sqlite-storage`, but `core/tsconfig.json` had no project reference to it. `create-dawn-ai-app#build` runs `tsc -b ../core/tsconfig.json …`, and since neither `create-dawn-ai-app` nor `devkit` has a package dependency on `sqlite-storage`, turbo can schedule that build before `sqlite-storage` emits its `dist` → cold `TS2307 Cannot find module '@dawn-ai/sqlite-storage'` (exactly the #196 gotcha class).

Fix: add the project reference so `tsc -b` builds `sqlite-storage` first.

## Validation
- Deterministic repro before fix: `rm -rf packages/sqlite-storage/dist packages/core/dist` + tsbuildinfo, `pnpm --filter create-dawn-ai-app build` → the exact CI TS2307s. After fix: passes.
- Fully clean `pnpm build` (all dist/tsbuildinfo purged): green.

No changeset: tsconfig-only build ordering, no published-package behavior change — will add an empty changeset if the gate requires it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)