### PR TITLE
feat: friendly diagnostics for opaque ESM import failures

### DIFF
--- a/.changeset/import-diagnostics.md
+++ b/.changeset/import-diagnostics.md
@@ -1,0 +1,6 @@
+---
+"@dawn-ai/cli": minor
+"@dawn-ai/sqlite-storage": patch
+---
+
+Friendlier import errors. When a route, tool, or config module fails to load with the opaque ESM error "does not provide an export named X", Dawn now identifies the offending package and explains the likely cause and fix — an older hoisted `@langchain/core` (with the installed-vs-required versions and an `npm ls` pointer) or a CommonJS dependency imported with named bindings under Dawn's ESM resolver. `CliError` now preserves the original error via `cause`. Also aligns `@dawn-ai/sqlite-storage`'s `@langchain/core` peer floor to `^1.1.47` to match the rest of the suite.

--- a/apps/web/content/docs/cli.mdx
+++ b/apps/web/content/docs/cli.mdx
@@ -18,6 +18,20 @@ Internally, `dawn check` loads `dawn.config.ts`, resolves the app root, runs `di
 
 Output is a `Dawn app is valid: N routes discovered.` line followed by a per-route `- <pathname> (<kind>)` summary. Exits non-zero on any violation with a detailed message.
 
+### Troubleshooting imports
+
+When a route, tool, or config module fails to load with the opaque ESM error `does not provide an export named X`, Dawn now prints the offending package plus a likely cause and fix instead of the raw `SyntaxError`. Two cases account for almost all of these:
+
+- **An older `@langchain/core` got hoisted.** Run `npm ls @langchain/core` to find the duplicate, then upgrade or dedupe so the installed version satisfies Dawn's peer range (`^1.1.47`).
+- **A CommonJS dependency imported with named bindings.** Under Dawn's ESM resolver a CommonJS package only has a default export, so `import { thing } from "x"` fails. Use a default import and destructure instead:
+
+  ```ts
+  import pkg from "x"
+  const { thing } = pkg
+  ```
+
+  Or import the package's ESM build if it ships one.
+
 ## `dawn verify`
 
 Runs four checks in one call (`app`, `routes`, `typegen`, `deps`) — the canonical pre-deploy integrity gate.

--- a/docs/superpowers/plans/2026-06-15-import-diagnostics.md
+++ b/docs/superpowers/plans/2026-06-15-import-diagnostics.md
@@ -1,0 +1,525 @@
+# Import-Error Diagnostics Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Turn the opaque `SyntaxError: The requested module 'X' does not provide an export named 'Y'` into an actionable diagnostic that distinguishes an old `@langchain/core` (#3) from a CommonJS-default dependency (#4).
+
+**Architecture:** One PR off `feat/import-diagnostics` (spec: `docs/superpowers/specs/2026-06-15-import-diagnostics-design.md`). A pure `diagnose(error)` utility in `@dawn-ai/cli` classifies the failure by reading the offending package's `package.json`. It's wired at the dynamic-import boundary (route + tool loaders) and as a fallback in the top-level `run()` catch. `CliError` gains a native `cause`. Zero new dependencies. Plus a one-line `@dawn-ai/sqlite-storage` peer-range tidy-up.
+
+**Tech Stack:** TypeScript (no semicolons, double quotes, 2-space, ESM `.js` specifiers), pnpm, Vitest, Biome, changesets.
+
+**Conventions:** `pnpm -r build` once at start; rebuild a package after editing it when another package's tests consume its `dist`. Run `pnpm -r --if-present typecheck` before declaring done (CI typechecks contract files build+lint miss). `pyenv: cannot rehash` output is harmless noise. CLI output is plain text routed through `CommandIo` — no `console.*`, no ANSI.
+
+---
+
+### Task 1: `diagnose()` utility (TDD)
+
+**Files:**
+- Create: `packages/cli/src/lib/diagnostics.ts`
+- Test: `packages/cli/test/diagnostics.test.ts` (create)
+
+- [ ] **Step 1: Write the failing tests.** These build temp `node_modules/<pkg>/package.json` fixtures (the repo's temp-dir idiom) and feed synthetic `SyntaxError`s with Node's exact wording.
+
+```ts
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import { diagnose } from "../src/lib/diagnostics.js"
+
+function esmError(specifier: string, name: string): SyntaxError {
+  return new SyntaxError(
+    `The requested module '${specifier}' does not provide an export named '${name}'`,
+  )
+}
+
+describe("diagnose", () => {
+  let appRoot: string
+  beforeEach(() => {
+    appRoot = mkdtempSync(join(tmpdir(), "dawn-diag-"))
+  })
+  afterEach(() => {
+    rmSync(appRoot, { recursive: true, force: true })
+  })
+
+  function installPkg(name: string, pkgJson: Record<string, unknown>): void {
+    const dir = join(appRoot, "node_modules", ...name.split("/"))
+    mkdirSync(dir, { recursive: true })
+    writeFileSync(join(dir, "package.json"), JSON.stringify(pkgJson), "utf8")
+  }
+
+  it("returns null for an unrelated error", () => {
+    expect(diagnose(new Error("boom"), { appRoot })).toBeNull()
+  })
+
+  it("classifies @langchain/core as a version-floor issue, naming installed version", () => {
+    installPkg("@langchain/core", { name: "@langchain/core", version: "1.1.40", type: "module" })
+    const d = diagnose(esmError("@langchain/core", "tool"), { appRoot })
+    expect(d).not.toBeNull()
+    expect(d?.summary).toContain("@langchain/core")
+    expect(d?.hint).toContain("1.1.40") // the installed (too-old) version
+    expect(d?.hint).toMatch(/npm ls @langchain\/core/)
+  })
+
+  it("classifies a subpath specifier to its package", () => {
+    installPkg("@langchain/core", { name: "@langchain/core", version: "1.1.40", type: "module" })
+    const d = diagnose(esmError("@langchain/core/messages", "AIMessage"), { appRoot })
+    expect(d?.summary).toContain("@langchain/core")
+  })
+
+  it("classifies a CommonJS dependency as a module-format issue", () => {
+    installPkg("legacy-dep", { name: "legacy-dep", version: "2.0.0", type: "commonjs" })
+    const d = diagnose(esmError("legacy-dep", "doThing"), { appRoot })
+    expect(d?.summary).toContain("legacy-dep")
+    expect(d?.hint).toMatch(/CommonJS/i)
+    expect(d?.hint).toContain("doThing") // suggests default-import + destructure of the name
+  })
+
+  it("treats a package with no \"type\" field as CommonJS", () => {
+    installPkg("untyped-dep", { name: "untyped-dep", version: "1.0.0" })
+    const d = diagnose(esmError("untyped-dep", "x"), { appRoot })
+    expect(d?.hint).toMatch(/CommonJS/i)
+  })
+
+  it("falls back to a generic named message for an ESM package missing the export", () => {
+    installPkg("modern-dep", { name: "modern-dep", version: "1.0.0", type: "module" })
+    const d = diagnose(esmError("modern-dep", "missingThing"), { appRoot })
+    expect(d).not.toBeNull()
+    expect(d?.summary).toContain("modern-dep")
+    expect(d?.summary).toContain("missingThing")
+    expect(d?.hint).toMatch(/version|format/i)
+  })
+
+  it("falls back to generic when the package.json can't be read", () => {
+    const d = diagnose(esmError("ghost-dep", "x"), { appRoot })
+    expect(d).not.toBeNull()
+    expect(d?.summary).toContain("ghost-dep")
+  })
+
+  it("finds the error through a cause chain", () => {
+    const wrapped = new Error("Validation failed", { cause: esmError("legacy-dep", "y") })
+    installPkg("legacy-dep", { name: "legacy-dep", version: "2.0.0", type: "commonjs" })
+    expect(diagnose(wrapped, { appRoot })?.hint).toMatch(/CommonJS/i)
+  })
+
+  it("returns null for a relative-specifier failure (no package to inspect)", () => {
+    expect(diagnose(esmError("./local.js", "x"), { appRoot })).toBeNull()
+  })
+})
+```
+
+- [ ] **Step 2: Run to verify failure.** `pnpm --filter @dawn-ai/cli test -- diagnostics` → FAIL (module missing).
+
+- [ ] **Step 3: Implement `packages/cli/src/lib/diagnostics.ts`:**
+
+```ts
+import { readFileSync } from "node:fs"
+import { createRequire } from "node:module"
+import { join } from "node:path"
+
+export interface Diagnostic {
+  readonly summary: string
+  readonly hint: string
+}
+
+const EXPORT_RE = /does not provide an export named ['"](.+?)['"]/
+const MODULE_RE = /requested module ['"](.+?)['"]/
+
+interface ExportFailure {
+  readonly specifier: string
+  readonly missingExport: string
+}
+
+function findExportFailure(error: unknown): ExportFailure | null {
+  const seen = new Set<unknown>()
+  let current: unknown = error
+  while (current instanceof Error && !seen.has(current)) {
+    seen.add(current)
+    const exportMatch = EXPORT_RE.exec(current.message)
+    if (exportMatch) {
+      const moduleMatch = MODULE_RE.exec(current.message)
+      return { specifier: moduleMatch?.[1] ?? "", missingExport: exportMatch[1] ?? "" }
+    }
+    current = (current as { cause?: unknown }).cause
+  }
+  return null
+}
+
+/** Bare/scoped package name from a specifier, or null for relative/absolute/empty. */
+function packageNameOf(specifier: string): string | null {
+  if (!specifier) return null
+  if (specifier.startsWith(".") || specifier.startsWith("/") || specifier.startsWith("file:")) {
+    return null
+  }
+  const parts = specifier.split("/")
+  if (specifier.startsWith("@")) {
+    return parts.length >= 2 ? `${parts[0]}/${parts[1]}` : null
+  }
+  return parts[0] ?? null
+}
+
+interface PackageManifest {
+  readonly version?: string
+  readonly type?: string
+}
+
+function readManifest(appRoot: string, pkg: string): PackageManifest | null {
+  try {
+    const raw = readFileSync(join(appRoot, "node_modules", ...pkg.split("/"), "package.json"), "utf8")
+    return JSON.parse(raw) as PackageManifest
+  } catch {
+    return null
+  }
+}
+
+/** Dawn's required @langchain/core range, read from @dawn-ai/langchain's peer deps. Best-effort. */
+function requiredCoreRange(): string | null {
+  try {
+    const require = createRequire(import.meta.url)
+    // @dawn-ai/langchain exposes ./package.json in its exports map (see Task note).
+    const manifestPath = require.resolve("@dawn-ai/langchain/package.json")
+    const pkg = JSON.parse(readFileSync(manifestPath, "utf8")) as {
+      peerDependencies?: Record<string, string>
+    }
+    return pkg.peerDependencies?.["@langchain/core"] ?? null
+  } catch {
+    return null
+  }
+}
+
+export function diagnose(error: unknown, opts?: { readonly appRoot?: string }): Diagnostic | null {
+  const failure = findExportFailure(error)
+  if (!failure) return null
+
+  const pkg = packageNameOf(failure.specifier)
+  if (!pkg) return null // relative/local module: no package to inspect, leave untouched
+
+  const appRoot = opts?.appRoot ?? process.cwd()
+  const manifest = readManifest(appRoot, pkg)
+
+  // #3 — LangChain ecosystem version floor.
+  if (pkg === "@langchain/core" || pkg.startsWith("@langchain/")) {
+    const installed = manifest?.version ? `${manifest.version}` : "an older version"
+    const range = requiredCoreRange()
+    const need = range ? `a version satisfying ${range}` : "a newer version"
+    return {
+      summary: `${pkg} does not provide the export "${failure.missingExport}" that Dawn's runtime imports.`,
+      hint:
+        `Your installed @langchain/core is ${installed}; Dawn needs ${need}. ` +
+        `An older @langchain/core was likely hoisted into your install. ` +
+        `Run "npm ls @langchain/core" (or your package manager's equivalent) to find the stale copy, ` +
+        `then upgrade/dedupe it.`,
+    }
+  }
+
+  // #4 — CommonJS-default dependency under the ESM resolver.
+  if (manifest && manifest.type !== "module") {
+    return {
+      summary: `Cannot import "${failure.missingExport}" from "${pkg}".`,
+      hint:
+        `"${pkg}" is a CommonJS package, and Dawn loads route/tool/config modules through Node's ` +
+        `ESM resolver, which can't always bind named exports from CommonJS. ` +
+        `Use a default import and destructure: import pkg from "${pkg}"; const { ${failure.missingExport} } = pkg. ` +
+        `If the package ships an ESM build ("type": "module"), upgrade to it.`,
+    }
+  }
+
+  // Generic — ESM package missing the export, or manifest unreadable.
+  return {
+    summary: `Module "${pkg}" does not provide an export named "${failure.missingExport}".`,
+    hint:
+      `This is usually a version mismatch (the installed "${pkg}" is older or newer than expected) ` +
+      `or a module-format issue. Check the installed version with "npm ls ${pkg}".`,
+  }
+}
+```
+
+- [ ] **Step 4: Verify green.** `pnpm --filter @dawn-ai/cli build && pnpm --filter @dawn-ai/cli test -- diagnostics` → all pass. `pnpm --filter @dawn-ai/cli lint`.
+
+- [ ] **Step 5: Commit.**
+```bash
+git add packages/cli/src/lib/diagnostics.ts packages/cli/test/diagnostics.test.ts
+git commit -m "feat(cli): diagnose() classifies opaque ESM import failures"
+```
+
+### Task 2: `@dawn-ai/langchain` exposes `./package.json`; verify `requiredCoreRange` resolves
+
+**Files:**
+- Modify: `packages/langchain/package.json` (only if its `exports` map blocks `./package.json`)
+- Test: extend `packages/cli/test/diagnostics.test.ts`
+
+- [ ] **Step 1:** Read `packages/langchain/package.json`'s `exports` field. If it is a map that does NOT already allow `./package.json`, add `"./package.json": "./package.json"`. If `exports` is absent or already permits it, make NO change (Node allows `package.json` access by default when not restricted) and note that in your report.
+
+- [ ] **Step 2: Add a test** to `diagnostics.test.ts` proving the #3 hint includes the real range when resolvable (run from the monorepo where `@dawn-ai/langchain` is installed):
+
+```ts
+it("includes Dawn's required @langchain/core range in the #3 hint when resolvable", () => {
+  // appRoot here is the temp dir; requiredCoreRange resolves @dawn-ai/langchain from the
+  // cli package's own location (createRequire(import.meta.url)), independent of appRoot.
+  installPkg("@langchain/core", { name: "@langchain/core", version: "1.1.40", type: "module" })
+  const d = diagnose(esmError("@langchain/core", "tool"), { appRoot })
+  // Range string like "^1.1.47" — assert the floor digits appear, OR the graceful fallback.
+  expect(d?.hint).toMatch(/satisfying \^?1\.1\.\d+|a newer version/)
+})
+```
+
+(The `|a newer version` alternative keeps the test honest if package.json subpath resolution isn't available in the test runner — but prefer the real range. If it falls back, investigate whether the `exports` change from Step 1 is needed and report.)
+
+- [ ] **Step 2b:** Run `pnpm --filter @dawn-ai/cli test -- diagnostics` — green, and report whether the real range or the fallback was exercised.
+
+- [ ] **Step 3: Commit** (include `packages/langchain/package.json` only if changed):
+```bash
+git add packages/cli/test/diagnostics.test.ts
+git commit -m "test(cli): diagnose surfaces the required @langchain/core range"
+```
+
+### Task 3: `CliError` carries `cause`
+
+**Files:**
+- Modify: `packages/cli/src/lib/output.ts`
+- Test: `packages/cli/test/output.test.ts` (create if absent; else extend)
+
+- [ ] **Step 1: Write the failing test.**
+
+```ts
+import { describe, expect, it } from "vitest"
+import { CliError } from "../src/lib/output.js"
+
+describe("CliError", () => {
+  it("preserves an optional cause", () => {
+    const root = new Error("root")
+    const err = new CliError("wrapped", 2, { cause: root })
+    expect(err.exitCode).toBe(2)
+    expect(err.cause).toBe(root)
+  })
+  it("defaults exitCode to 1 and has no cause when omitted", () => {
+    const err = new CliError("plain")
+    expect(err.exitCode).toBe(1)
+    expect(err.cause).toBeUndefined()
+  })
+})
+```
+
+- [ ] **Step 2:** Run → FAIL (constructor takes no 3rd arg; `cause` undefined).
+
+- [ ] **Step 3: Implement** — update the `CliError` constructor in `output.ts`:
+
+```ts
+constructor(message: string, exitCode = 1, options?: { readonly cause?: unknown }) {
+  super(message, options)
+  this.name = "CliError"
+  this.exitCode = exitCode
+}
+```
+
+- [ ] **Step 4:** `pnpm --filter @dawn-ai/cli test -- output` green; full cli suite still green (existing `new CliError(msg)` / `new CliError(msg, code)` calls unaffected). Lint.
+
+- [ ] **Step 5: Commit.**
+```bash
+git add packages/cli/src/lib/output.ts packages/cli/test/output.test.ts
+git commit -m "feat(cli): CliError preserves an optional cause"
+```
+
+### Task 4: `importModule` boundary helper + wire route/tool loaders (TDD)
+
+**Files:**
+- Create: `packages/cli/src/lib/runtime/import-module.ts`
+- Modify: `packages/cli/src/lib/runtime/load-route-kind.ts`, `packages/cli/src/lib/runtime/tool-discovery.ts`
+- Test: `packages/cli/test/import-module.test.ts` (create)
+
+- [ ] **Step 1: Write the failing test** (drives a real dynamic import of a temp CJS package with a missing named export; if cjs-module-lexer auto-detects exports on some Node versions, a guaranteed-absent name still throws):
+
+```ts
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { pathToFileURL } from "node:url"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import { CliError } from "../src/lib/output.js"
+import { importModule } from "../src/lib/runtime/import-module.js"
+
+describe("importModule", () => {
+  let appRoot: string
+  beforeEach(() => {
+    appRoot = mkdtempSync(join(tmpdir(), "dawn-importmod-"))
+  })
+  afterEach(() => {
+    rmSync(appRoot, { recursive: true, force: true })
+  })
+
+  it("returns the module on success", async () => {
+    const file = join(appRoot, "ok.mjs")
+    writeFileSync(file, "export const value = 42\n", "utf8")
+    const mod = (await importModule(pathToFileURL(file).href, { kind: "route", appRoot })) as {
+      value: number
+    }
+    expect(mod.value).toBe(42)
+  })
+
+  it("rethrows a diagnosable failure as an enriched CliError with cause + kind/path context", async () => {
+    const dep = join(appRoot, "node_modules", "legacy-dep")
+    mkdirSync(dep, { recursive: true })
+    writeFileSync(join(dep, "package.json"), JSON.stringify({ name: "legacy-dep", version: "1.0.0", type: "commonjs", main: "index.js" }), "utf8")
+    writeFileSync(join(dep, "index.js"), "module.exports = { present: 1 }\n", "utf8")
+    const route = join(appRoot, "route.mjs")
+    writeFileSync(route, "import { absent } from \"legacy-dep\"\nexport default absent\n", "utf8")
+
+    await expect(
+      importModule(pathToFileURL(route).href, { kind: "route", appRoot, sourcePath: route }),
+    ).rejects.toMatchObject({
+      name: "CliError",
+      message: expect.stringMatching(/CommonJS/i),
+    })
+    // and the original error is preserved as cause
+    const err = await importModule(pathToFileURL(route).href, { kind: "route", appRoot }).catch((e) => e)
+    expect(err).toBeInstanceOf(CliError)
+    expect((err as CliError).cause).toBeInstanceOf(Error)
+  })
+
+  it("rethrows a non-diagnosable error untouched", async () => {
+    const file = join(appRoot, "throws.mjs")
+    writeFileSync(file, "throw new Error(\"plain boom\")\n", "utf8")
+    await expect(importModule(pathToFileURL(file).href, { kind: "tool", appRoot })).rejects.toThrow(
+      /plain boom/,
+    )
+  })
+})
+```
+
+- [ ] **Step 2:** Run → FAIL (module missing).
+
+- [ ] **Step 3: Implement `packages/cli/src/lib/runtime/import-module.ts`:**
+
+```ts
+import { CliError } from "../output.js"
+import { diagnose } from "../diagnostics.js"
+
+export async function importModule(
+  href: string,
+  opts: {
+    readonly kind: "route" | "tool" | "config"
+    readonly appRoot?: string
+    readonly sourcePath?: string
+  },
+): Promise<unknown> {
+  try {
+    return await import(href)
+  } catch (error) {
+    const diag = diagnose(error, opts.appRoot ? { appRoot: opts.appRoot } : undefined)
+    if (!diag) throw error
+    const where = opts.sourcePath ? ` (loading ${opts.kind} ${opts.sourcePath})` : ` (loading a ${opts.kind})`
+    throw new CliError(`${diag.summary}${where}\n\n${diag.hint}`, 1, { cause: error })
+  }
+}
+```
+
+- [ ] **Step 4: Wire the loaders.**
+  - `load-route-kind.ts` `normalizeRouteModule`: replace `await import(pathToFileURL(routeFile).href)` with `await importModule(pathToFileURL(routeFile).href, { kind: "route", appRoot: <see note>, sourcePath: routeFile })`. `normalizeRouteModule` currently takes only `routeFile` — add an optional `appRoot` param threaded from its callers where readily available; if a caller lacks it, omit `appRoot` (diagnose falls back to cwd). Keep `registerTsxLoader()` ordering unchanged. Preserve the existing module-shape cast.
+  - `tool-discovery.ts` `loadToolDefinition`: replace the `await import(\`${pathToFileURL(filePath).href}?t=${Date.now()}\`)` with `await importModule(\`${pathToFileURL(filePath).href}?t=${Date.now()}\`, { kind: "tool", appRoot: options.appRoot, sourcePath: filePath })` — `discoverToolDefinitions` already has `appRoot`; thread it into `loadToolDefinition` (add a param). Keep the cast.
+
+- [ ] **Step 5: Verify.** `pnpm --filter @dawn-ai/cli build && pnpm --filter @dawn-ai/cli test` — new tests pass; full suite green (route/tool discovery behavior unchanged on the success path). Lint.
+
+- [ ] **Step 6: Commit.**
+```bash
+git add packages/cli/src/lib/runtime/import-module.ts packages/cli/src/lib/runtime/load-route-kind.ts packages/cli/src/lib/runtime/tool-discovery.ts packages/cli/test/import-module.test.ts
+git commit -m "feat(cli): enrich import failures at the route/tool load boundary"
+```
+
+### Task 5: `run()` fallback diagnostic pass (TDD)
+
+**Files:**
+- Modify: `packages/cli/src/index.ts`
+- Test: `packages/cli/test/run-diagnostics.test.ts` (create)
+
+- [ ] **Step 1: Write the failing test** — drive `run()` with a command path that throws a diagnosable error not wrapped by `importModule`. Simplest: a fixture app whose `dawn.config.ts` (loaded by `loadDawnConfig` in core, unwrapped) imports a missing named export. Follow `check-command.test.ts` scaffolding. Assert the enriched text appears on stderr and the exit code is non-zero. If wiring a config-import failure end-to-end proves fragile in the test, instead unit-test the extracted fallback (see Step 3) by calling it directly with a synthetic diagnosable error and asserting it returns the enriched lines — and add a smaller integration assertion. State which you did.
+
+- [ ] **Step 2:** Run → FAIL.
+
+- [ ] **Step 3: Implement.** In `run()`'s catch, before the final generic `writeLine(io.stderr, ...)`, add a diagnostic pass. Factor the message choice into a small local helper so it's unit-testable:
+
+```ts
+// in the catch, replacing the generic tail:
+const diag = diagnose(error)
+if (diag) {
+  writeLine(io.stderr, `${diag.summary}\n\n${diag.hint}`)
+  return 1
+}
+writeLine(io.stderr, error instanceof Error ? error.message : String(error))
+return 1
+```
+
+Also handle the case where a command wrapped a diagnosable failure as a `CliError` whose message is NOT already enriched: in the `error instanceof CliError` branch, if `error.cause` diagnoses to a `Diagnostic` AND `error.message` doesn't already contain `diag.summary`, print the enriched form (append the hint) instead of the bare wrapped message. Keep `error.exitCode`. Import `diagnose` from `./lib/diagnostics.js`.
+
+- [ ] **Step 4: Verify.** `pnpm --filter @dawn-ai/cli test` — green incl. the new test; confirm existing `index`/`run` tests unaffected. Lint.
+
+- [ ] **Step 5: Commit.**
+```bash
+git add packages/cli/src/index.ts packages/cli/test/run-diagnostics.test.ts
+git commit -m "feat(cli): run() enriches diagnosable errors that bypass the load boundary"
+```
+
+### Task 6: End-to-end `dawn check` integration (TDD)
+
+**Files:**
+- Test: `packages/cli/test/import-diagnostics-integration.test.ts` (create)
+
+- [ ] **Step 1: Write the test** — copy `check-command.test.ts`'s `createFixtureApp` + in-process `invoke`. Create a fixture app with a real CommonJS dep in its `node_modules` and an agent route whose `tools/<name>.ts` imports a guaranteed-absent named binding from it:
+  - `node_modules/legacy-dep/package.json`: `{ "name": "legacy-dep", "version": "1.0.0", "type": "commonjs", "main": "index.js" }`
+  - `node_modules/legacy-dep/index.js`: `module.exports = { present: 1 }`
+  - route `src/app/(public)/x/index.ts`: a valid `agent({ model: "gpt-4o-mini", systemPrompt: "..." })`
+  - tool `src/app/(public)/x/tools/load.ts`: `import { absent } from "legacy-dep"` + `export default async () => absent`
+
+  Run `["check", "--cwd", appRoot]`. Assert: exit code non-zero; stderr contains `legacy-dep` and matches `/CommonJS/i` and names the missing export `absent`. Add a control: a tool importing `present` (which exists) → check passes (exit 0), proving no false positive.
+
+  Note: if a Node version's cjs-module-lexer detects `present` as a named export, importing `absent` still fails with the target error — that's the intended trigger. If even `absent` somehow resolves, fall back to importing from an ESM fixture package missing the export and assert the generic enriched message instead; report the adjustment.
+
+- [ ] **Step 2:** Run → the bad-import test FAILS before wiring is confirmed end-to-end... it should already PASS given Tasks 4–5 are merged. Treat this as a verification test: if it fails, debug the wiring (don't weaken assertions).
+
+- [ ] **Step 3:** `pnpm --filter @dawn-ai/cli test -- import-diagnostics-integration` then full suite. Lint.
+
+- [ ] **Step 4: Commit.**
+```bash
+git add packages/cli/test/import-diagnostics-integration.test.ts
+git commit -m "test(cli): end-to-end import-diagnostic coverage via dawn check"
+```
+
+### Task 7: sqlite-storage peer tidy-up + docs + changeset + verification + PR
+
+**Files:**
+- Modify: `packages/sqlite-storage/package.json`
+- Modify: `apps/web/content/docs/faq.mdx` (or `cli.mdx` — decide by reading both)
+- Create: `.changeset/import-diagnostics.md`
+
+- [ ] **Step 1: Peer bump.** In `packages/sqlite-storage/package.json`, change `peerDependencies["@langchain/core"]` from `^1.1.44` to `^1.1.47`. Leave its `devDependencies` entry as-is.
+
+- [ ] **Step 2: Docs.** Read `apps/web/content/docs/faq.mdx` and `cli.mdx`; add a short **"Troubleshooting imports"** entry where it reads most naturally (FAQ is the likely home). Cover: the symptom (`does not provide an export named …`), that Dawn now prints a cause + fix, the two classes (old `@langchain/core` → `npm ls @langchain/core` + upgrade/dedupe; CommonJS dep → default-import-and-destructure or use an ESM build). Build the docs site: `pnpm --filter @dawn-ai/web build` (revert `apps/web/next-env.d.ts` churn with `git checkout --`).
+
+- [ ] **Step 3: Changeset** `.changeset/import-diagnostics.md`:
+
+```md
+---
+"@dawn-ai/cli": minor
+"@dawn-ai/sqlite-storage": patch
+---
+
+Friendlier import errors. When a route, tool, or config module fails to load with the opaque ESM error "does not provide an export named X", Dawn now identifies the offending package and explains the likely cause and fix — an older hoisted `@langchain/core` (with the installed-vs-required versions and an `npm ls` pointer) or a CommonJS dependency imported with named bindings under Dawn's ESM resolver. `CliError` now preserves the original error via `cause`. Also aligns `@dawn-ai/sqlite-storage`'s `@langchain/core` peer floor to `^1.1.47` to match the rest of the suite.
+```
+
+- [ ] **Step 4: Full verification.**
+```
+pnpm -r build
+pnpm -r --if-present typecheck
+pnpm --filter @dawn-ai/cli test
+pnpm --filter @dawn-ai/cli lint
+pnpm --filter @dawn-ai/web build
+```
+Expected: all green; cli suite includes the new diagnostics/import-module/run/integration tests; lint exit 0 (pre-existing warnings only). Revert `next-env.d.ts` churn.
+
+- [ ] **Step 5: Commit + push + PR.**
+```bash
+git add packages/sqlite-storage/package.json apps/web/content/docs/faq.mdx .changeset/import-diagnostics.md
+git commit -m "chore: sqlite-storage core peer floor; troubleshooting docs; changeset"
+git push -u origin feat/import-diagnostics
+gh pr create --base main --title "feat: friendly diagnostics for opaque ESM import failures" \
+  --body "Backlog #3+#4. Spec: docs/superpowers/specs/2026-06-15-import-diagnostics-design.md. diagnose() classifies @langchain/core version-floor vs CommonJS-default failures; wired at route/tool load boundary + run() fallback; CliError gains cause; sqlite-storage peer floor aligned to ^1.1.47."
+```

--- a/docs/superpowers/specs/2026-06-15-import-diagnostics-design.md
+++ b/docs/superpowers/specs/2026-06-15-import-diagnostics-design.md
@@ -1,0 +1,118 @@
+# Friendly import-error diagnostics (Design)
+
+**Status:** Approved for planning
+**Date:** 2026-06-15
+**Roadmap:** Dogfooding-friction backlog items #3 + #4, designed together because they surface as the *same* runtime failure. A consumer whose environment resolves an older hoisted `@langchain/core` (#3) or who imports a named binding from a CommonJS-default dependency (#4) gets the identical opaque ESM error — `SyntaxError: The requested module 'X' does not provide an export named 'Y'` — with no hint about cause or fix. This adds a reactive diagnostic layer that recognizes that failure shape and rewrites it into an actionable message.
+
+## Investigation: is a library-code fix required? (No.)
+
+Recorded because the scoping question was "reactive only, but verify there isn't a necessary library fix first."
+
+- **Dawn's source imports only stable public `@langchain/core` subpaths** (`/messages`, `/tools`, `/runnables`) — verified across `packages/*/src`. There is no fragile deep import (e.g. `language_models/stream`) in Dawn itself; that floor is **transitive**, pulled by `@langchain/langgraph` / `@langchain/openai`.
+- **The version floor is already declared.** `@dawn-ai/langchain` declares `peerDependencies: { "@langchain/core": "^1.1.47" }`; `@dawn-ai/cli` depends on `@dawn-ai/langchain`, so a cli consumer inherits the peer requirement and npm/pnpm emit a peer warning when the resolved core is too old. Dawn is not failing to communicate the requirement.
+- **One genuine inconsistency, not the root cause:** `@dawn-ai/sqlite-storage` peers `@langchain/core: "^1.1.44"`, below the suite's `^1.1.47` floor. For a cli consumer the peer intersection still resolves to `^1.1.47`, so it does not lower the effective floor — but it is misleading for standalone sqlite-storage users and violates the suite's uniform-versioning convention. Worth tidying; **not** what produces the cryptic error.
+
+**Conclusion:** the break is fundamentally a *consumer-environment* problem (older core hoisted despite the peer warning, or a CJS-default user dep) that peer ranges **warn about but cannot prevent**. No mandatory library fix removes it. Reactive enrichment is the correct primary feature; the sqlite-storage peer alignment rides along as tidy-up.
+
+## Verified facts (against main @ `01c3c0f`)
+
+- **Current error model:** `CliError(message, exitCode)` is the one structured error type (`packages/cli/src/lib/output.ts`). Commands catch low-level failures and re-wrap with a context prefix (`throw new CliError(\`Validation failed: ${formatErrorMessage(error)}\`)`) — ~37 sites. Top-level `run()` (`packages/cli/src/index.ts`) prints `error.message` to stderr and returns the exit code; `CommanderError` is special-cased; all else prints `.message` and returns 1. **Message-only — no `Error.cause`, no stack, no debug toggle.**
+- **IO is abstracted** via `CommandIo` (`stdout`/`stderr`/`stdin` callbacks); tests assert on captured strings, so output must stay plain text (ANSI would pollute assertions).
+- **Deps are lean:** cli runtime deps are the `@dawn-ai/*` packages plus `commander` and `tsx` only — no color/format libraries.
+- **Import sites that throw the cryptic error:**
+  - Route loader — `normalizeRouteModule` in `packages/cli/src/lib/runtime/load-route-kind.ts`: `await import(pathToFileURL(routeFile).href)`.
+  - Tool loader — `loadToolDefinition` in `packages/cli/src/lib/runtime/tool-discovery.ts:131`: `await import(\`${pathToFileURL(filePath).href}?t=${Date.now()}\`)`.
+  - Config loader — `loadDawnConfig` in `@dawn-ai/core` (`packages/core/src/config.ts`): cli cannot wrap this at the boundary, which is why a `run()` fallback is part of the design.
+- Node's failure text is stable: `The requested module '<specifier>' does not provide an export named '<name>'` (an ESM `SyntaxError` raised at the `import()` boundary).
+
+## Decisions (from brainstorming)
+
+- **Reactive only** — no proactive version-floor check beyond the sqlite-storage peer tidy-up.
+- **Enrichment inspects the offending package** (filesystem read) to classify #3 vs #4 precisely, degrading to a generic-but-named message when it can't read.
+- **Hybrid wiring** — enrich at the import boundary (most context) *and* a fallback pass in `run()` (catches config-load and anything unwrapped).
+- **Zero new runtime dependencies**; preserve the original error via native `Error.cause`.
+
+## Design
+
+### 1. `packages/cli/src/lib/diagnostics.ts` — pure `diagnose`
+
+```ts
+export interface Diagnostic {
+  /** One-line statement of what failed, naming the package + missing export. */
+  readonly summary: string
+  /** Actionable, multi-line fix guidance. */
+  readonly hint: string
+}
+
+/**
+ * Recognize a Node ESM "does not provide an export named" failure and classify
+ * it. Returns null for any error it does not recognize (callers leave those
+ * untouched). `appRoot` scopes the node_modules lookup; falls back to cwd.
+ */
+export function diagnose(error: unknown, opts?: { readonly appRoot?: string }): Diagnostic | null
+```
+
+Algorithm:
+1. Walk `error` and its `.cause` chain; on each, test the message against `/does not provide an export named ['"](.+?)['"]/` and `/requested module ['"](.+?)['"]/`. If no match anywhere → return `null`.
+2. From the specifier, resolve the **package name** (scoped `@scope/name`, bare `name`, or a subpath like `@langchain/core/messages` → `@langchain/core`; a relative/absolute path → treat as a local module, classify generic).
+3. Read `<appRoot>/node_modules/<pkg>/package.json` (best-effort; `appRoot ?? process.cwd()`). Classify:
+   - **`@langchain/*` (esp. `@langchain/core`)** → #3. Read the installed `version`; read Dawn's required floor from `@dawn-ai/langchain`'s `peerDependencies["@langchain/core"]` via `require.resolve("@dawn-ai/langchain/package.json")` (no hardcoded constant; degrade to "a newer version" if unreadable). Hint: upgrade `@langchain/core` to satisfy the range; `npm ls @langchain/core` to locate the stale copy; mention deduping/hoisting.
+   - **package.json present and not `"type": "module"`** (i.e. `"commonjs"` or absent) → #4. Hint: the dependency is CommonJS; Dawn loads route/tool/config modules through Node's ESM resolver, which can't bind named exports from some CJS modules. Use a default import then destructure (`import pkg from "X"; const { Y } = pkg`), or check for a newer ESM (`"type":"module"`) release.
+   - **otherwise** (ESM package missing the export, or package.json unreadable) → generic: name the module + missing export, note it is likely a version or module-format mismatch and suggest checking the installed version.
+
+Pure and synchronous; package.json reads via `node:fs` `readFileSync` in a try/catch.
+
+### 2. `CliError` carries `cause`
+
+Extend `CliError` with an optional third arg, stored via the native `Error` options:
+
+```ts
+constructor(message: string, exitCode = 1, options?: { cause?: unknown }) {
+  super(message, options)
+  this.name = "CliError"
+  this.exitCode = exitCode
+}
+```
+
+Behavior unchanged for existing call sites (third arg optional). Sets up a future `--debug` stack view (out of scope).
+
+### 3. Import-boundary helper
+
+`packages/cli/src/lib/runtime/import-module.ts`:
+
+```ts
+export async function importModule(
+  href: string,
+  opts: { readonly kind: "route" | "tool" | "config"; readonly appRoot?: string; readonly sourcePath?: string },
+): Promise<unknown>
+```
+
+Wraps `await import(href)` in try/catch; on failure runs `diagnose(error, { appRoot })`. If diagnosable, throw `new CliError(message, 1, { cause: error })` where `message` = a one-line context line naming the kind + `sourcePath`, then the diagnostic `summary` and `hint`. If not diagnosable, rethrow the original untouched. The route loader (`load-route-kind.ts`) and tool loader (`tool-discovery.ts`) route their dynamic imports through this helper (preserving the tool loader's `?t=` cache-buster and the existing `registerTsxLoader()` call ordering).
+
+### 4. `run()` fallback pass
+
+In `packages/cli/src/index.ts`, the generic (non-`CliError`, non-`CommanderError`) branch tries `diagnose(error)` before printing; if it returns a `Diagnostic`, print `summary` + `hint` instead of the raw `.message`. Also apply when a `CliError` wraps a diagnosable `cause` whose own message wasn't already enriched (so a command that wrapped a config-load failure as `CliError("... : <raw esm text>")` still gets enriched). Exit codes unchanged.
+
+### 5. Tidy-up
+
+`@dawn-ai/sqlite-storage` `peerDependencies["@langchain/core"]`: `^1.1.44` → `^1.1.47`.
+
+## Testing
+
+- **`diagnose` unit tests** (`packages/cli/test/diagnostics.test.ts`): synthetic `SyntaxError`s with Node's exact text over temp `node_modules/<pkg>/package.json` fixtures (the repo's temp-dir idiom) covering: `@langchain/core` old version → #3 message names installed + required; CJS package (`"type"` absent / `"commonjs"`) → #4 message; ESM package missing export → generic; unreadable/missing package.json → generic; non-matching error → `null`; `.cause`-chained match.
+- **cli integration** (`packages/cli/test/import-diagnostics.test.ts`): a fixture app whose route imports a named binding from a deliberately CJS-shaped local package (`node_modules/<pkg>` with `package.json` `"type":"commonjs"` + a `module.exports` file) → `dawn check` exits non-zero and stdout/stderr contains the #4 hint; control fixture with a clean import → no diagnostic. Follows `check-command.test.ts` scaffolding.
+- **`Error.cause` regression:** existing cli suite passes unchanged (the third `CliError` arg is optional).
+
+## Docs
+
+A short **"Troubleshooting imports"** section in `apps/web/content/docs/faq.mdx` (or `cli.mdx` — confirm during planning): the two failure classes, what the enriched message tells you, and the manual `npm ls @langchain/core` / CJS-default-import remedies. No new page.
+
+## Changeset
+
+`@dawn-ai/cli` minor (diagnostics + `CliError.cause`) and `@dawn-ai/sqlite-storage` patch/minor (peer bump). Fixed versioning bumps all `@dawn-ai/*` together regardless.
+
+## Out of scope
+
+- Proactive version checking (the "reactive only" decision).
+- `--debug` / stack-trace rendering (the `Error.cause` plumbing only prepares for it).
+- Color / boxed output and any new formatting dependency (would break the string-capturing test IO; `picocolors` is the conventional pick if revisited, as its own cross-cutting decision).

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -16,7 +16,14 @@ import { registerTestCommand } from "./commands/test.js"
 import { registerTypegenCommand } from "./commands/typegen.js"
 import { registerVerifyCommand } from "./commands/verify.js"
 import { registerDevChildCommand } from "./lib/dev/dev-child.js"
+import { diagnose } from "./lib/diagnostics.js"
 import { CliError, type CommandIo, createNodeIo, writeLine } from "./lib/output.js"
+
+export function renderError(error: unknown): string {
+  const diag = diagnose(error)
+  if (diag) return `${diag.summary}\n\n${diag.hint}`
+  return error instanceof Error ? error.message : String(error)
+}
 
 export function createProgram(io: CommandIo): Command {
   const program = new Command()
@@ -67,7 +74,7 @@ export async function run(
       return error.exitCode
     }
 
-    writeLine(io.stderr, error instanceof Error ? error.message : String(error))
+    writeLine(io.stderr, renderError(error))
     return 1
   }
 }

--- a/packages/cli/src/lib/diagnostics.ts
+++ b/packages/cli/src/lib/diagnostics.ts
@@ -1,0 +1,116 @@
+import { readFileSync } from "node:fs"
+import { createRequire } from "node:module"
+import { join } from "node:path"
+
+export interface Diagnostic {
+  readonly summary: string
+  readonly hint: string
+}
+
+const EXPORT_RE = /does not provide an export named ['"](.+?)['"]/
+const MODULE_RE = /requested module ['"](.+?)['"]/
+
+interface ExportFailure {
+  readonly specifier: string
+  readonly missingExport: string
+}
+
+function findExportFailure(error: unknown): ExportFailure | null {
+  const seen = new Set<unknown>()
+  let current: unknown = error
+  while (current instanceof Error && !seen.has(current)) {
+    seen.add(current)
+    const exportMatch = EXPORT_RE.exec(current.message)
+    if (exportMatch) {
+      const moduleMatch = MODULE_RE.exec(current.message)
+      return { specifier: moduleMatch?.[1] ?? "", missingExport: exportMatch[1] ?? "" }
+    }
+    current = (current as { cause?: unknown }).cause
+  }
+  return null
+}
+
+function packageNameOf(specifier: string): string | null {
+  if (!specifier) return null
+  if (specifier.startsWith(".") || specifier.startsWith("/") || specifier.startsWith("file:")) {
+    return null
+  }
+  const parts = specifier.split("/")
+  if (specifier.startsWith("@")) {
+    return parts.length >= 2 ? `${parts[0]}/${parts[1]}` : null
+  }
+  return parts[0] ?? null
+}
+
+interface PackageManifest {
+  readonly version?: string
+  readonly type?: string
+}
+
+function readManifest(appRoot: string, pkg: string): PackageManifest | null {
+  try {
+    const raw = readFileSync(
+      join(appRoot, "node_modules", ...pkg.split("/"), "package.json"),
+      "utf8",
+    )
+    return JSON.parse(raw) as PackageManifest
+  } catch {
+    return null
+  }
+}
+
+function requiredCoreRange(): string | null {
+  try {
+    const require = createRequire(import.meta.url)
+    const manifestPath = require.resolve("@dawn-ai/langchain/package.json")
+    const pkg = JSON.parse(readFileSync(manifestPath, "utf8")) as {
+      peerDependencies?: Record<string, string>
+    }
+    return pkg.peerDependencies?.["@langchain/core"] ?? null
+  } catch {
+    return null
+  }
+}
+
+export function diagnose(error: unknown, opts?: { readonly appRoot?: string }): Diagnostic | null {
+  const failure = findExportFailure(error)
+  if (!failure) return null
+
+  const pkg = packageNameOf(failure.specifier)
+  if (!pkg) return null
+
+  const appRoot = opts?.appRoot ?? process.cwd()
+  const manifest = readManifest(appRoot, pkg)
+
+  if (pkg === "@langchain/core" || pkg.startsWith("@langchain/")) {
+    const installed = manifest?.version ?? "an older version"
+    const range = requiredCoreRange()
+    const need = range ? `a version satisfying ${range}` : "a newer version"
+    return {
+      summary: `${pkg} does not provide the export "${failure.missingExport}" that Dawn's runtime imports.`,
+      hint:
+        `Your installed @langchain/core is ${installed}; Dawn needs ${need}. ` +
+        "An older @langchain/core was likely hoisted into your install. " +
+        'Run "npm ls @langchain/core" (or your package manager\'s equivalent) to find the stale copy, ' +
+        "then upgrade or dedupe it.",
+    }
+  }
+
+  if (manifest && manifest.type !== "module") {
+    return {
+      summary: `Cannot import "${failure.missingExport}" from "${pkg}".`,
+      hint:
+        `"${pkg}" is a CommonJS package, and Dawn loads route/tool/config modules through Node's ` +
+        "ESM resolver, which can't always bind named exports from CommonJS. " +
+        `Use a default import and destructure: import pkg from "${pkg}"; const { ${failure.missingExport} } = pkg. ` +
+        'If the package ships an ESM build ("type": "module"), upgrade to it.',
+    }
+  }
+
+  return {
+    summary: `Module "${pkg}" does not provide an export named "${failure.missingExport}".`,
+    hint:
+      `This is usually a version mismatch (the installed "${pkg}" is older or newer than expected) ` +
+      `or a module-format issue. Check the installed version with "npm ls ${pkg}".`,
+  }
+}

--- a/packages/cli/src/lib/output.ts
+++ b/packages/cli/src/lib/output.ts
@@ -7,8 +7,8 @@ export interface CommandIo {
 export class CliError extends Error {
   readonly exitCode: number
 
-  constructor(message: string, exitCode = 1) {
-    super(message)
+  constructor(message: string, exitCode = 1, options?: { readonly cause?: unknown }) {
+    super(message, options)
     this.name = "CliError"
     this.exitCode = exitCode
   }

--- a/packages/cli/src/lib/runtime/execute-route.ts
+++ b/packages/cli/src/lib/runtime/execute-route.ts
@@ -359,7 +359,7 @@ async function prepareRouteExecution(options: {
 }): Promise<PreparedRoute | PreparedRouteError> {
   const routeDir = resolve(options.routeFile, "..")
 
-  const normalized = await normalizeRouteModule(options.routeFile)
+  const normalized = await normalizeRouteModule(options.routeFile, options.appRoot)
 
   const discoveredTools = await discoverToolDefinitions({
     appRoot: options.appRoot,

--- a/packages/cli/src/lib/runtime/import-module.ts
+++ b/packages/cli/src/lib/runtime/import-module.ts
@@ -1,0 +1,22 @@
+import { diagnose } from "../diagnostics.js"
+import { CliError } from "../output.js"
+
+export async function importModule(
+  href: string,
+  opts: {
+    readonly kind: "route" | "tool" | "config"
+    readonly appRoot?: string
+    readonly sourcePath?: string
+  },
+): Promise<unknown> {
+  try {
+    return await import(href)
+  } catch (error) {
+    const diag = diagnose(error, opts.appRoot ? { appRoot: opts.appRoot } : undefined)
+    if (!diag) throw error
+    const where = opts.sourcePath
+      ? ` (loading ${opts.kind} ${opts.sourcePath})`
+      : ` (loading a ${opts.kind})`
+    throw new CliError(`${diag.summary}${where}\n\n${diag.hint}`, 1, { cause: error })
+  }
+}

--- a/packages/cli/src/lib/runtime/load-route-kind.ts
+++ b/packages/cli/src/lib/runtime/load-route-kind.ts
@@ -3,6 +3,7 @@ import type { NormalizedRouteModule } from "@dawn-ai/core"
 import type { RouteKind } from "@dawn-ai/sdk"
 import { isDawnAgent } from "@dawn-ai/sdk"
 
+import { importModule } from "./import-module.js"
 import { registerTsxLoader } from "./register-tsx-loader.js"
 
 export type { NormalizedRouteModule } from "@dawn-ai/core"
@@ -12,9 +13,16 @@ export async function loadRouteKind(routeFile: string): Promise<RouteKind> {
   return normalized.kind
 }
 
-export async function normalizeRouteModule(routeFile: string): Promise<NormalizedRouteModule> {
+export async function normalizeRouteModule(
+  routeFile: string,
+  appRoot?: string,
+): Promise<NormalizedRouteModule> {
   await registerTsxLoader()
-  const routeModule = (await import(pathToFileURL(routeFile).href)) as {
+  const routeModule = (await importModule(pathToFileURL(routeFile).href, {
+    kind: "route",
+    ...(appRoot ? { appRoot } : {}),
+    sourcePath: routeFile,
+  })) as {
     readonly agent?: unknown
     readonly chain?: unknown
     readonly config?: Record<string, unknown>

--- a/packages/cli/src/lib/runtime/tool-discovery.ts
+++ b/packages/cli/src/lib/runtime/tool-discovery.ts
@@ -4,6 +4,7 @@ import { pathToFileURL } from "node:url"
 
 import type { WorkspaceFs } from "@dawn-ai/sdk"
 
+import { importModule } from "./import-module.js"
 import { registerTsxLoader } from "./register-tsx-loader.js"
 import { isRecord } from "./utils.js"
 
@@ -35,10 +36,12 @@ export async function discoverToolDefinitions(options: {
   await registerTsxLoader()
 
   const sharedTools = await loadToolScope({
+    appRoot: options.appRoot,
     directory: join(options.appRoot, "src", "tools"),
     scope: "shared",
   })
   const routeLocalTools = await loadToolScope({
+    appRoot: options.appRoot,
     directory: join(options.routeDir, "tools"),
     scope: "route-local",
   })
@@ -57,6 +60,7 @@ export async function discoverToolDefinitions(options: {
 }
 
 async function loadToolScope(options: {
+  readonly appRoot: string
   readonly directory: string
   readonly scope: ToolScope
 }): Promise<readonly DiscoveredToolDefinition[]> {
@@ -79,7 +83,7 @@ async function loadToolScope(options: {
   const byName = new Map<string, string>()
 
   for (const filePath of files) {
-    const tool = await loadToolDefinition(filePath, options.scope)
+    const tool = await loadToolDefinition(filePath, options.scope, options.appRoot)
     const existingFile = byName.get(tool.name)
 
     if (existingFile) {
@@ -127,8 +131,13 @@ export function injectGeneratedSchemas(
 async function loadToolDefinition(
   filePath: string,
   scope: ToolScope,
+  appRoot: string,
 ): Promise<DiscoveredToolDefinition> {
-  const toolModule = (await import(`${pathToFileURL(filePath).href}?t=${Date.now()}`)) as {
+  const toolModule = (await importModule(`${pathToFileURL(filePath).href}?t=${Date.now()}`, {
+    kind: "tool",
+    appRoot,
+    sourcePath: filePath,
+  })) as {
     readonly default?: unknown
     readonly description?: unknown
     readonly schema?: unknown

--- a/packages/cli/src/lib/runtime/warn-unknown-model-ids.ts
+++ b/packages/cli/src/lib/runtime/warn-unknown-model-ids.ts
@@ -16,7 +16,7 @@ export async function collectUnknownModelIdWarnings(
     if (route.kind !== "agent") continue
     let normalized: NormalizedRouteModule
     try {
-      normalized = await normalizeRouteModule(route.entryFile)
+      normalized = await normalizeRouteModule(route.entryFile, manifest.appRoot)
     } catch {
       continue // load failures are surfaced by discovery paths, not this advisory pass
     }

--- a/packages/cli/test/diagnostics.test.ts
+++ b/packages/cli/test/diagnostics.test.ts
@@ -38,6 +38,21 @@ describe("diagnose", () => {
     expect(d?.hint).toMatch(/npm ls @langchain\/core/)
   })
 
+  it("includes Dawn's required @langchain/core range in the #3 hint", () => {
+    installPkg("@langchain/core", { name: "@langchain/core", version: "1.1.40", type: "module" })
+    const d = diagnose(esmError("@langchain/core", "tool"), { appRoot })
+    // requiredCoreRange resolves @dawn-ai/langchain from the cli package location,
+    // independent of the temp appRoot. Expect the real floor, e.g. "^1.1.47".
+    expect(d?.hint).toMatch(/satisfying \^?1\.1\.\d+/)
+  })
+
+  it("treats a CommonJS-typed @langchain package as a version issue, not a module-format issue", () => {
+    installPkg("@langchain/core", { name: "@langchain/core", version: "1.1.40", type: "commonjs" })
+    const d = diagnose(esmError("@langchain/core", "tool"), { appRoot })
+    expect(d?.hint).toMatch(/npm ls @langchain\/core/) // #3 hint
+    expect(d?.hint).not.toMatch(/default import and destructure/i) // not the #4 hint
+  })
+
   it("classifies a subpath specifier to its package", () => {
     installPkg("@langchain/core", { name: "@langchain/core", version: "1.1.40", type: "module" })
     const d = diagnose(esmError("@langchain/core/messages", "AIMessage"), { appRoot })

--- a/packages/cli/test/diagnostics.test.ts
+++ b/packages/cli/test/diagnostics.test.ts
@@ -1,0 +1,85 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import { diagnose } from "../src/lib/diagnostics.js"
+
+function esmError(specifier: string, name: string): SyntaxError {
+  return new SyntaxError(
+    `The requested module '${specifier}' does not provide an export named '${name}'`,
+  )
+}
+
+describe("diagnose", () => {
+  let appRoot: string
+  beforeEach(() => {
+    appRoot = mkdtempSync(join(tmpdir(), "dawn-diag-"))
+  })
+  afterEach(() => {
+    rmSync(appRoot, { recursive: true, force: true })
+  })
+
+  function installPkg(name: string, pkgJson: Record<string, unknown>): void {
+    const dir = join(appRoot, "node_modules", ...name.split("/"))
+    mkdirSync(dir, { recursive: true })
+    writeFileSync(join(dir, "package.json"), JSON.stringify(pkgJson), "utf8")
+  }
+
+  it("returns null for an unrelated error", () => {
+    expect(diagnose(new Error("boom"), { appRoot })).toBeNull()
+  })
+
+  it("classifies @langchain/core as a version-floor issue, naming installed version", () => {
+    installPkg("@langchain/core", { name: "@langchain/core", version: "1.1.40", type: "module" })
+    const d = diagnose(esmError("@langchain/core", "tool"), { appRoot })
+    expect(d).not.toBeNull()
+    expect(d?.summary).toContain("@langchain/core")
+    expect(d?.hint).toContain("1.1.40")
+    expect(d?.hint).toMatch(/npm ls @langchain\/core/)
+  })
+
+  it("classifies a subpath specifier to its package", () => {
+    installPkg("@langchain/core", { name: "@langchain/core", version: "1.1.40", type: "module" })
+    const d = diagnose(esmError("@langchain/core/messages", "AIMessage"), { appRoot })
+    expect(d?.summary).toContain("@langchain/core")
+  })
+
+  it("classifies a CommonJS dependency as a module-format issue", () => {
+    installPkg("legacy-dep", { name: "legacy-dep", version: "2.0.0", type: "commonjs" })
+    const d = diagnose(esmError("legacy-dep", "doThing"), { appRoot })
+    expect(d?.summary).toContain("legacy-dep")
+    expect(d?.hint).toMatch(/CommonJS/i)
+    expect(d?.hint).toContain("doThing")
+  })
+
+  it('treats a package with no "type" field as CommonJS', () => {
+    installPkg("untyped-dep", { name: "untyped-dep", version: "1.0.0" })
+    const d = diagnose(esmError("untyped-dep", "x"), { appRoot })
+    expect(d?.hint).toMatch(/CommonJS/i)
+  })
+
+  it("falls back to a generic named message for an ESM package missing the export", () => {
+    installPkg("modern-dep", { name: "modern-dep", version: "1.0.0", type: "module" })
+    const d = diagnose(esmError("modern-dep", "missingThing"), { appRoot })
+    expect(d).not.toBeNull()
+    expect(d?.summary).toContain("modern-dep")
+    expect(d?.summary).toContain("missingThing")
+    expect(d?.hint).toMatch(/version|format/i)
+  })
+
+  it("falls back to generic when the package.json can't be read", () => {
+    const d = diagnose(esmError("ghost-dep", "x"), { appRoot })
+    expect(d).not.toBeNull()
+    expect(d?.summary).toContain("ghost-dep")
+  })
+
+  it("finds the error through a cause chain", () => {
+    installPkg("legacy-dep", { name: "legacy-dep", version: "2.0.0", type: "commonjs" })
+    const wrapped = new Error("Validation failed", { cause: esmError("legacy-dep", "y") })
+    expect(diagnose(wrapped, { appRoot })?.hint).toMatch(/CommonJS/i)
+  })
+
+  it("returns null for a relative-specifier failure (no package to inspect)", () => {
+    expect(diagnose(esmError("./local.js", "x"), { appRoot })).toBeNull()
+  })
+})

--- a/packages/cli/test/import-diagnostics-integration.test.ts
+++ b/packages/cli/test/import-diagnostics-integration.test.ts
@@ -1,0 +1,152 @@
+import { spawn } from "node:child_process"
+import { chmod, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { dirname, join, resolve } from "node:path"
+import { afterEach, describe, expect, test } from "vitest"
+
+/**
+ * End-to-end coverage for Dawn's enriched import diagnostics.
+ *
+ * This MUST exercise the compiled CLI as a real Node subprocess. An in-process
+ * `run()` test does NOT reproduce the failure: vitest's Vite layer intercepts
+ * dynamic `import()` and resolves missing named imports to `undefined`, so the
+ * genuine "does not provide an export named" loader error never fires. Only the
+ * real Node/tsx loader (running in a spawned `dawn` process) produces it, which
+ * is what `diagnose()` + `importModule` classify and enrich.
+ */
+
+const tempDirs: string[] = []
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { force: true, recursive: true })))
+})
+
+async function createFixtureApp(files: Readonly<Record<string, string>>) {
+  const appRoot = await mkdtemp(join(tmpdir(), "dawn-cli-import-diag-"))
+  tempDirs.push(appRoot)
+
+  const appFiles = {
+    "package.json": '{"type":"module"}\n',
+    "dawn.config.ts": "export default {};\n",
+    // A real CommonJS dependency in the app's node_modules. The named export is
+    // written as `exports.present = ...` (not `module.exports = { present }`) so
+    // that Node's cjs-module-lexer can statically detect it — that detection is
+    // exactly what lets the control case bind `present` successfully while a
+    // genuinely-absent name still throws the opaque ESM loader error.
+    "node_modules/legacy-dep/package.json":
+      '{ "name": "legacy-dep", "version": "1.0.0", "type": "commonjs", "main": "index.js" }\n',
+    "node_modules/legacy-dep/index.js": "exports.present = 1\n",
+    // A valid workflow route. A workflow needs no runtime sdk import (the type is
+    // erased by tsx), so the spawned CLI resolves it without workspace wiring,
+    // and tool discovery still descends into the route-local `tools/` directory.
+    "src/app/x/index.ts": "export const workflow = async () => ({ ok: true })\n",
+    ...files,
+  }
+
+  await Promise.all(
+    Object.entries(appFiles).map(async ([relativePath, source]) => {
+      const filePath = join(appRoot, relativePath)
+      await mkdir(dirname(filePath), { recursive: true })
+      await writeFile(filePath, source)
+    }),
+  )
+
+  return appRoot
+}
+
+async function buildCliExecutable() {
+  const packageRoot = resolve(import.meta.dirname, "..")
+  const distEntry = join(packageRoot, "dist", "index.js")
+
+  await new Promise<void>((resolvePromise, rejectPromise) => {
+    const child = spawn("pnpm", ["exec", "tsc", "-b", "tsconfig.build.json", "--force"], {
+      cwd: packageRoot,
+      stdio: "inherit",
+    })
+
+    child.once("error", rejectPromise)
+    child.once("exit", (code) => {
+      if (code === 0) {
+        resolvePromise()
+        return
+      }
+
+      rejectPromise(new Error(`CLI build failed with exit code ${code ?? "unknown"}`))
+    })
+  })
+
+  await chmod(distEntry, 0o755)
+
+  return distEntry
+}
+
+async function executeCli(entryPath: string, args: readonly string[]) {
+  return await new Promise<{
+    readonly code: number | null
+    readonly stdout: string
+    readonly stderr: string
+  }>((resolvePromise, rejectPromise) => {
+    const child = spawn(entryPath, [...args], {
+      env: { ...process.env, NODE_NO_WARNINGS: "1" },
+      stdio: ["ignore", "pipe", "pipe"],
+    })
+
+    let stdout = ""
+    let stderr = ""
+
+    child.stdout.on("data", (chunk) => {
+      stdout += String(chunk)
+    })
+
+    child.stderr.on("data", (chunk) => {
+      stderr += String(chunk)
+    })
+
+    child.once("error", rejectPromise)
+    child.once("close", (code) => {
+      resolvePromise({ code, stderr, stdout })
+    })
+  })
+}
+
+describe("dawn check import diagnostics (subprocess)", () => {
+  test("enriches a stale/CommonJS named-import failure with package, CommonJS hint, and the missing export", {
+    timeout: 60_000,
+  }, async () => {
+    const appRoot = await createFixtureApp({
+      // A route-local tool that imports a guaranteed-absent named binding from
+      // the CommonJS dependency. The real Node/tsx loader throws the opaque
+      // "does not provide an export named" error, which Dawn enriches.
+      "src/app/x/tools/load.ts":
+        'import { absent } from "legacy-dep"\n\nexport default async () => absent\n',
+    })
+    const builtCli = await buildCliExecutable()
+
+    const result = await executeCli(builtCli, ["check", "--cwd", appRoot])
+    const combined = `${result.stdout}${result.stderr}`
+
+    expect(result.code).not.toBe(0)
+    expect(combined).toContain("legacy-dep")
+    expect(combined).toMatch(/CommonJS/i)
+    expect(combined).toContain("absent")
+  })
+
+  test("control: an existing named import from the same dependency passes with no diagnostic", {
+    timeout: 60_000,
+  }, async () => {
+    const appRoot = await createFixtureApp({
+      // Identical fixture except the tool imports `present`, which the CJS dep
+      // actually exposes. This proves the diagnostic is not a false positive.
+      "src/app/x/tools/load.ts":
+        'import { present } from "legacy-dep"\n\nexport default async () => present\n',
+    })
+    const builtCli = await buildCliExecutable()
+
+    const result = await executeCli(builtCli, ["check", "--cwd", appRoot])
+    const combined = `${result.stdout}${result.stderr}`
+
+    expect(result.code).toBe(0)
+    expect(result.stdout).toContain("Dawn app is valid")
+    expect(combined).not.toMatch(/CommonJS/i)
+  })
+})

--- a/packages/cli/test/import-module.test.ts
+++ b/packages/cli/test/import-module.test.ts
@@ -1,0 +1,67 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { pathToFileURL } from "node:url"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import { CliError } from "../src/lib/output.js"
+import { importModule } from "../src/lib/runtime/import-module.js"
+
+describe("importModule", () => {
+  let appRoot: string
+  beforeEach(() => {
+    appRoot = mkdtempSync(join(tmpdir(), "dawn-importmod-"))
+  })
+  afterEach(() => {
+    rmSync(appRoot, { recursive: true, force: true })
+  })
+
+  it("returns the module on success", async () => {
+    const file = join(appRoot, "ok.mjs")
+    writeFileSync(file, "export const value = 42\n", "utf8")
+    const mod = (await importModule(pathToFileURL(file).href, { kind: "route", appRoot })) as {
+      value: number
+    }
+    expect(mod.value).toBe(42)
+  })
+
+  it("rethrows a diagnosable failure as an enriched CliError with cause", async () => {
+    // Install a CommonJS package so diagnose() classifies the failure as a
+    // CJS-named-export problem. The module under test throws the Node-ESM-shaped
+    // SyntaxError at evaluation time — this is the exact error production hits
+    // (Node's ESM resolver / tsx) and is reproduced directly rather than relying
+    // on the test runner's CJS interop, which permissively resolves the named
+    // import to undefined instead of throwing.
+    const dep = join(appRoot, "node_modules", "legacy-dep")
+    mkdirSync(dep, { recursive: true })
+    writeFileSync(
+      join(dep, "package.json"),
+      JSON.stringify({ name: "legacy-dep", version: "1.0.0", type: "commonjs", main: "index.js" }),
+      "utf8",
+    )
+    writeFileSync(join(dep, "index.js"), "module.exports = { present: 1 }\n", "utf8")
+    const route = join(appRoot, "route.mjs")
+    writeFileSync(
+      route,
+      `throw new SyntaxError("The requested module 'legacy-dep' does not provide an export named 'absent'")\n`,
+      "utf8",
+    )
+
+    const err = await importModule(pathToFileURL(route).href, {
+      kind: "route",
+      appRoot,
+      sourcePath: route,
+    }).catch((e) => e)
+    expect(err).toBeInstanceOf(CliError)
+    expect((err as CliError).message).toMatch(/CommonJS/i)
+    expect((err as CliError).message).toContain("route")
+    expect((err as CliError).cause).toBeInstanceOf(Error)
+  })
+
+  it("rethrows a non-diagnosable error untouched", async () => {
+    const file = join(appRoot, "throws.mjs")
+    writeFileSync(file, 'throw new Error("plain boom")\n', "utf8")
+    await expect(importModule(pathToFileURL(file).href, { kind: "tool", appRoot })).rejects.toThrow(
+      /plain boom/,
+    )
+  })
+})

--- a/packages/cli/test/output.test.ts
+++ b/packages/cli/test/output.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest"
+import { CliError } from "../src/lib/output.js"
+
+describe("CliError", () => {
+  it("preserves an optional cause", () => {
+    const root = new Error("root")
+    const err = new CliError("wrapped", 2, { cause: root })
+    expect(err.exitCode).toBe(2)
+    expect(err.cause).toBe(root)
+  })
+  it("defaults exitCode to 1 and has no cause when omitted", () => {
+    const err = new CliError("plain")
+    expect(err.exitCode).toBe(1)
+    expect(err.cause).toBeUndefined()
+  })
+})

--- a/packages/cli/test/run-diagnostics.test.ts
+++ b/packages/cli/test/run-diagnostics.test.ts
@@ -1,0 +1,52 @@
+import { Command } from "commander"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import { renderError, run } from "../src/index.js"
+
+describe("renderError", () => {
+  it("enriches a raw diagnosable error using diagnose()", () => {
+    const err = new SyntaxError(
+      "The requested module '@langchain/core' does not provide an export named 'tool'",
+    )
+    const text = renderError(err)
+    expect(text).toContain("@langchain/core")
+    expect(text).toMatch(/npm ls @langchain\/core|newer version/)
+  })
+
+  it("falls back to the raw message for a non-diagnosable error", () => {
+    expect(renderError(new Error("plain boom"))).toBe("plain boom")
+  })
+
+  it("stringifies a non-Error value", () => {
+    expect(renderError("weird")).toBe("weird")
+  })
+})
+
+describe("run() generic-error branch", () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it("renders a raw diagnosable error via renderError()", async () => {
+    const rawError = new SyntaxError(
+      "The requested module '@langchain/core' does not provide an export named 'tool'",
+    )
+    // The generic branch only fires for errors that escape every command's
+    // CliError wrapper (the loadDawnConfig / unwrapped-import case). Reproduce
+    // that by making the program's parse reject with a raw error.
+    vi.spyOn(Command.prototype, "parseAsync").mockRejectedValue(rawError)
+
+    const stderr: string[] = []
+    const exitCode = await run([], {
+      stderr: (message) => {
+        stderr.push(message)
+      },
+      stdin: async () => "",
+      stdout: () => {},
+    })
+
+    expect(exitCode).toBe(1)
+    expect(stderr.join("")).toBe(`${renderError(rawError)}\n`)
+    expect(stderr.join("")).toContain("@langchain/core")
+  })
+})

--- a/packages/langchain/package.json
+++ b/packages/langchain/package.json
@@ -24,7 +24,8 @@
     ".": {
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/sqlite-storage/package.json
+++ b/packages/sqlite-storage/package.json
@@ -36,7 +36,7 @@
     "typecheck": "tsc --noEmit"
   },
   "peerDependencies": {
-    "@langchain/core": "^1.1.44",
+    "@langchain/core": "^1.1.47",
     "@langchain/langgraph-checkpoint": "^1.0.2"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

Backlog #3 + #4 ([spec](docs/superpowers/specs/2026-06-15-import-diagnostics-design.md)). An older hoisted `@langchain/core` (#3) or a named import from a CommonJS dependency (#4) both surface as the same opaque `SyntaxError: The requested module 'X' does not provide an export named 'Y'`. Dawn now recognizes that failure and rewrites it with the offending package, the likely cause, and the fix.

- **`diagnose()`** (`@dawn-ai/cli`) parses the failure, resolves the offending package, reads its `package.json`, and classifies: `@langchain/core` version-floor (reports installed vs required range + `npm ls` pointer) vs CommonJS-default (default-import-and-destructure guidance) vs a generic named fallback.
- **Hybrid wiring:** an `importModule` boundary helper enriches route/tool load failures (with the original error preserved via `CliError.cause`); a `run()` fallback enriches raw diagnosable errors (e.g. `loadDawnConfig`) that bypass the boundary.
- **Investigation recorded in the spec:** the `^1.1.47` floor is already declared via `@dawn-ai/langchain`'s peer dep — no mandatory library fix — so this is reactive enrichment plus a one-line `@dawn-ai/sqlite-storage` peer-floor alignment (`^1.1.44` → `^1.1.47`).
- Zero new dependencies.

## Test plan

- [x] TDD throughout: `diagnose` unit tests (#3/#4/generic/null/cause-chain/ordering), `importModule` boundary tests, `CliError.cause`, `run()` `renderError`, and an end-to-end `dawn check` **subprocess** test with a real CommonJS dep (the real tsx loader path, since vitest masks dynamic-import failures)
- [x] Full cli suite green; `pnpm -r build` + `pnpm -r typecheck` clean; docs site builds
- [x] Per-task spec + quality subagent reviews

🤖 Generated with [Claude Code](https://claude.com/claude-code)
