### PR TITLE
feat: harden workspace path jail against symlink escapes

### DIFF
--- a/.changeset/symlink-path-jail.md
+++ b/.changeset/symlink-path-jail.md
@@ -1,0 +1,10 @@
+---
+"@dawn-ai/workspace": minor
+"@dawn-ai/core": minor
+---
+
+Harden the workspace path jail against symlink escapes. `FilesystemBackend` gains a required `realPath(path, ctx)` method; `localFilesystem` implements it (resolving symlinks via the deepest existing ancestor so not-yet-created write targets work), and `createWorkspaceFs` canonicalizes both the candidate path and the workspace root before the permission gate. A symlink inside `workspace/` that points outside is now correctly gated instead of being silently classified as inside.
+
+**Breaking for custom `FilesystemBackend` implementations:** add a `realPath` method — return the path unchanged (`async (p) => p`) if your backend has no symlink semantics.
+
+**Behavior note:** allow rules for paths outside the workspace are now matched against the canonical (symlink-resolved) path. If your workspace or an allowed target lives under a symlink, express allow-rule paths in canonical form; rules written against a non-canonical alias will fail closed. (No effect when your paths contain no symlinks.)

--- a/apps/web/content/docs/workspace.mdx
+++ b/apps/web/content/docs/workspace.mdx
@@ -15,6 +15,7 @@ There are three layers:
 | Method | Required | Notes |
 |---|---|---|
 | `readFile(path, ctx, opts?)` | Yes | UTF-8; `opts.maxBytes` overrides the default cap |
+| `realPath(path, ctx)` | Yes | Canonicalize an absolute path (resolve symlinks) so the permission gate compares real targets; backends without symlinks return the path unchanged |
 | `readBinaryFile(path, ctx, opts?)` | No | Raw bytes (`Uint8Array`); required for `ctx.fs.readBinaryFile` |
 | `writeFile(path, content, ctx)` | Yes | Returns `{ bytesWritten }` |
 | `listDir(path, ctx)` | Yes | Returns leaf names, not full paths |
@@ -231,7 +232,9 @@ Add an allow rule for "readFile" to the permissions config in dawn.config.ts.
 
 One permission model regardless of whether the LLM or your code initiates the I/O.
 
-**Path jail is lexical.** The local backend receives an already-resolved absolute path. A symlink inside `workspace/` that points to a path outside the workspace will be followed by the local filesystem — the jail does not dereference symlinks. Don't place untrusted symlinks inside `workspace/`.
+**Allow rules match canonical paths.** Because the gate compares symlink-resolved paths, an allow rule for a path outside the workspace must reference the **canonical** (symlink-resolved) path. On systems where the workspace or target lives under a symlink — e.g. macOS `/var → /private/var`, or a symlinked home or project directory — a rule written against the non-canonical alias will not match and the operation fails closed.
+
+**Symlinks are resolved before the gate.** `localFilesystem` resolves symlinks before the gate decision (via the required `realPath`), so a symlink inside `workspace/` that points outside is correctly gated — prompted or denied in interactive mode, fail-closed otherwise — rather than silently followed. Custom backends get the same protection by implementing `realPath`, which the type system now requires.
 
 <Callout type="warn" title="Interrupt-resume and side effects">
   When a permission prompt fires from inside tool code — because the tool called `ctx.fs` with a path outside `workspace/` that needs interactive approval — LangGraph pauses execution mid-tool. On resume, LangGraph **re-runs the tool body from the top**. Any side effects that ran before the `ctx.fs` call execute again.

--- a/docs/superpowers/plans/2026-06-16-symlink-path-jail.md
+++ b/docs/superpowers/plans/2026-06-16-symlink-path-jail.md
@@ -1,0 +1,227 @@
+# Symlink-Hardened Workspace Path Jail Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close the workspace path-jail symlink escape — a symlink inside `workspace/` pointing outside is currently classified as inside and accessed silently.
+
+**Architecture:** One PR off `feat/symlink-path-jail` (spec: `docs/superpowers/specs/2026-06-16-symlink-path-jail-design.md`). Add a REQUIRED `realPath` to `FilesystemBackend`; `localFilesystem` resolves symlinks (deepest-existing-ancestor); `createWorkspaceFs.gate()` canonicalizes both the candidate path and the workspace root before the (unchanged) `gatePathOp`. Three tasks: S1 introduces `realPath` and keeps the whole monorepo compiling; S2 makes the gate use it + proves the escape is caught; S3 docs + changeset + PR.
+
+**Tech Stack:** TypeScript (no semicolons, double quotes, 2-space, ESM `.js` specifiers), pnpm, Vitest, Biome, changesets.
+
+**Conventions:** `pnpm -r build` once at start; rebuild a package after editing it when another package's tests consume its `dist` (workspace → core/langchain). Run `pnpm -r --if-present typecheck` before declaring done. `pyenv: cannot rehash` output is harmless noise. No `console.*` in CLI output paths (n/a here).
+
+---
+
+### Task S1: Required `realPath` on the backend + `localFilesystem` impl + keep everything green (TDD)
+
+**Files:**
+- Modify: `packages/workspace/src/types.ts` (add required `realPath`)
+- Modify: `packages/workspace/src/local-filesystem.ts` (implement)
+- Modify: `packages/workspace/src/with-logging.ts` (forward it)
+- Test: `packages/workspace/test/local-filesystem.test.ts` (new `realPath` tests)
+- Modify (conformance, mechanical): every inline `FilesystemBackend` literal in tests across the monorepo — add `realPath: async (p) => p`. Known sites: `packages/workspace/test/with-logging.test.ts`, `packages/workspace/test/compose.test.ts` (if it builds a literal), `packages/core/test/capabilities/workspace-fs.test.ts`, and any `FilesystemBackend` literal in `packages/langchain/test/offload-*.test.ts`. **Let TypeScript find them all** — after the interface change, `pnpm -r build && pnpm -r --if-present typecheck` will flag each missing one.
+
+- [ ] **Step 1: Write the failing `realPath` tests** in `packages/workspace/test/local-filesystem.test.ts` (follow the file's existing temp-dir idiom — `mkdtempSync`/`writeFileSync`/`symlinkSync` from `node:fs`):
+
+```ts
+it("realPath resolves a symlink to its real target", async () => {
+  const fs = localFilesystem()
+  const real = join(root, "real.txt")
+  writeFileSync(real, "x", "utf8")
+  const link = join(root, "link.txt")
+  symlinkSync(real, link)
+  // realpath both to normalize any symlinked tmp ancestor (e.g. macOS /var)
+  expect(await fs.realPath(link, ctx(root))).toBe(realpathSync(real))
+})
+
+it("realPath resolves an escaping symlink to the outside real path", async () => {
+  const fs = localFilesystem()
+  const outside = mkdtempSync(join(tmpdir(), "dawn-outside-"))
+  const target = join(outside, "secret.txt")
+  writeFileSync(target, "s", "utf8")
+  const link = join(root, "escape")
+  symlinkSync(target, link)
+  expect(await fs.realPath(link, ctx(root))).toBe(realpathSync(target))
+  rmSync(outside, { recursive: true, force: true })
+})
+
+it("realPath tolerates a non-existent target (write case): resolves deepest existing ancestor", async () => {
+  const fs = localFilesystem()
+  // root exists; the file does not
+  const want = join(realpathSync(root), "new-dir", "new.md")
+  expect(await fs.realPath(join(root, "new-dir", "new.md"), ctx(root))).toBe(want)
+})
+
+it("realPath returns the canonical path for an ordinary existing file", async () => {
+  const fs = localFilesystem()
+  const p = join(root, "plain.txt")
+  writeFileSync(p, "x", "utf8")
+  expect(await fs.realPath(p, ctx(root))).toBe(realpathSync(p))
+})
+```
+
+Add `symlinkSync`, `realpathSync` to the `node:fs` import in the test; reuse the file's existing `ctx(root)` helper and `root` temp dir (read the top of the file to match exact helper names).
+
+- [ ] **Step 2: Run to verify failure:** `pnpm --filter @dawn-ai/workspace test -- local-filesystem` → FAIL (`fs.realPath` is not a function / TS error).
+
+- [ ] **Step 3: Add the required method to the interface** (`packages/workspace/src/types.ts`), after `listDir` (keep it grouped with the required methods, before the optional `statFile?`):
+
+```ts
+  /**
+   * Canonicalize an already-resolved absolute path — resolving symlinks and
+   * `..` to a real target location — so the permission gate compares true
+   * locations, not lexical strings. Must tolerate a path that does not exist
+   * yet (e.g. a writeFile target): resolve the deepest existing ancestor and
+   * re-append the non-existent tail. Backends with no symlink concept
+   * (in-memory, remote) may return the path unchanged.
+   */
+  realPath(path: string, ctx: BackendContext): Promise<string>
+```
+
+- [ ] **Step 4: Implement in `localFilesystem`** (`packages/workspace/src/local-filesystem.ts`). Extend the `node:fs/promises` import with `realpath`; extend the `node:path` import with `basename`, `join` (it already imports `dirname`). Add the method to the returned object:
+
+```ts
+async realPath(path: string, _ctx: BackendContext): Promise<string> {
+  const tail: string[] = []
+  let current = path
+  for (;;) {
+    try {
+      const resolved = await realpath(current)
+      return tail.length === 0 ? resolved : join(resolved, ...tail)
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error
+      const parent = dirname(current)
+      if (parent === current) return path
+      tail.unshift(basename(current))
+      current = parent
+    }
+  }
+}
+```
+
+- [ ] **Step 5: Forward `realPath` in `withFilesystemLogging`** (`packages/workspace/src/with-logging.ts`). It's required, so add it to the always-built `wrapped` object alongside `readFile`/`writeFile`/`listDir` (NOT the conditional optional block). Passthrough without logging (it is internal canonicalization, not a user-facing read/write event):
+
+```ts
+realPath: (path, ctx) => next.realPath(path, ctx),
+```
+
+(Place it in the initial `wrapped` literal so a wrapped backend always satisfies the required interface.)
+
+- [ ] **Step 6: Verify the workspace package green:** `pnpm --filter @dawn-ai/workspace build && pnpm --filter @dawn-ai/workspace test && pnpm --filter @dawn-ai/workspace lint`.
+
+- [ ] **Step 7: Restore monorepo green — add identity `realPath` to every flagged test double.** Rebuild workspace so downstream sees the new type: `pnpm --filter @dawn-ai/workspace build`, then `pnpm -r build && pnpm -r --if-present typecheck`. For each `FilesystemBackend` literal the compiler flags as missing `realPath`, add `realPath: async (p) => p` (identity — these doubles don't exercise symlinks). Re-run until `pnpm -r build` and `pnpm -r --if-present typecheck` are both green. Then run the affected suites: `pnpm --filter @dawn-ai/core test && pnpm --filter @dawn-ai/langchain test`.
+
+- [ ] **Step 8: Commit:**
+```bash
+git add packages/workspace packages/core/test packages/langchain/test
+git commit -m "feat(workspace): required realPath on FilesystemBackend; localFilesystem resolves symlinks"
+```
+(Adjust the `git add` set to exactly the files you changed — include only the test files that actually needed a double update.)
+
+### Task S2: Canonicalize in the gate + prove the escape is caught (TDD)
+
+**Files:**
+- Modify: `packages/core/src/capabilities/workspace-fs.ts` (`gate()`)
+- Test: `packages/core/test/capabilities/workspace-fs.test.ts` (security + regression)
+
+- [ ] **Step 1: Write the failing security test** in `packages/core/test/capabilities/workspace-fs.test.ts`. Use the file's existing helpers (real `createPermissionsStore`, temp `workspaceRoot`, `localFilesystem()`; read the top of the file for exact helper names). Add to the permission-gating describe block:
+
+```ts
+it("gates a symlink that escapes the workspace (caught, not silently allowed)", async () => {
+  const outside = mkdtempSync(join(tmpdir(), "dawn-escape-"))
+  writeFileSync(join(outside, "secret.txt"), "top secret", "utf8")
+  symlinkSync(join(outside, "secret.txt"), join(workspaceRoot, "escape"))
+  const permissions = await makeStore("non-interactive") // copy the file's store-construction pattern
+  const fs = createWorkspaceFs({
+    workspaceRoot, backend: localFilesystem(), permissions, signal, interruptCapable: false,
+  })
+  await expect(fs.readFile("escape")).rejects.toThrow(/fail-closed/)
+  rmSync(outside, { recursive: true, force: true })
+})
+
+it("still allows a legitimate inside path when the workspace root is reached via a symlink", async () => {
+  // Canonicalizing only the candidate (not the root) would misclassify this as outside.
+  const realDir = mkdtempSync(join(tmpdir(), "dawn-realroot-"))
+  const linkedRoot = join(mkdtempSync(join(tmpdir(), "dawn-linkroot-")), "ws")
+  symlinkSync(realDir, linkedRoot)
+  writeFileSync(join(realDir, "notes.md"), "hello", "utf8")
+  const permissions = await makeStore("non-interactive")
+  const fs = createWorkspaceFs({
+    workspaceRoot: linkedRoot, backend: localFilesystem(), permissions, signal, interruptCapable: false,
+  })
+  expect(await fs.readFile("notes.md")).toBe("hello")
+  rmSync(realDir, { recursive: true, force: true })
+})
+```
+
+Add `symlinkSync` (+ `mkdtempSync`, `writeFileSync`, `rmSync` if not already imported) to the test's `node:fs` import. Match the actual store-helper name in the file (the plan calls it `makeStore` — use whatever the file defines).
+
+- [ ] **Step 2: Run to verify failure:** `pnpm --filter @dawn-ai/core test -- workspace-fs` → the escape test FAILS (currently the symlink is lexically inside → silently allowed → `readFile` resolves instead of rejecting). The "linked root" test may already pass or fail depending on tmp symlinks — it must pass after Step 3 regardless.
+
+- [ ] **Step 3: Canonicalize both sides in `gate()`** (`packages/core/src/capabilities/workspace-fs.ts`):
+
+```ts
+async function gate(operation: PathOperation, path: string): Promise<string> {
+  const absPath = resolve(opts.workspaceRoot, path)
+  const canonicalPath = await opts.backend.realPath(absPath, bctx)
+  const canonicalRoot = await opts.backend.realPath(opts.workspaceRoot, bctx)
+  const result = await gatePathOp(opts.permissions, operation, canonicalPath, canonicalRoot, {
+    interruptCapable: opts.interruptCapable,
+  })
+  if (!result.allowed) throw new Error(result.reason)
+  return absPath
+}
+```
+
+Only `gate()` changes — the method bodies (`readFile`/`readBinaryFile`/`writeFile`/`listDir`) still call `await gate(...)` and pass the returned original `absPath` to the backend. `gatePathOp` and `permission-gate.ts` are NOT touched.
+
+- [ ] **Step 4: Verify green:** `pnpm --filter @dawn-ai/core build && pnpm --filter @dawn-ai/core test` — new tests pass; ALL existing gating tests (inside silent-allow, outside fail-closed, allow-rule, interrupt-suppression, bypass, binary, maxBytes, the `..` traversal + sibling-prefix tests from PR #213) still pass. `pnpm --filter @dawn-ai/core lint`.
+
+- [ ] **Step 5: Commit:**
+```bash
+git add packages/core/src/capabilities/workspace-fs.ts packages/core/test/capabilities/workspace-fs.test.ts
+git commit -m "feat(core): canonicalize symlinks before the workspace permission gate"
+```
+
+### Task S3: Docs + changeset + full verification + PR
+
+**Files:**
+- Modify: `apps/web/content/docs/workspace.mdx`
+- Create: `.changeset/symlink-path-jail.md`
+
+- [ ] **Step 1: Docs.** In `apps/web/content/docs/workspace.mdx`:
+  - Add `realPath` to the `FilesystemBackend` method table: `| `realPath(path, ctx)` | Yes | Canonicalize an absolute path (resolve symlinks); return it unchanged for backends without symlinks |`.
+  - Find the **"Path jail is lexical"** caveat (added in PR #213, in the Permissions section) and rewrite it: `localFilesystem` now resolves symlinks before the gate decision, so a symlink inside `workspace/` pointing outside is correctly gated (prompted/denied), not silently followed. Custom backends get the same protection by implementing `realPath` — which the type system now requires.
+  - Build: `pnpm --filter @dawn-ai/web build` (revert `apps/web/next-env.d.ts` churn with `git checkout --` if it appears).
+
+- [ ] **Step 2: Changeset** `.changeset/symlink-path-jail.md`:
+```md
+---
+"@dawn-ai/workspace": minor
+"@dawn-ai/core": minor
+---
+
+Harden the workspace path jail against symlink escapes. `FilesystemBackend` gains a required `realPath(path, ctx)` method; `localFilesystem` implements it (resolving symlinks via the deepest existing ancestor so not-yet-created write targets work), and `createWorkspaceFs` canonicalizes both the candidate path and the workspace root before the permission gate. A symlink inside `workspace/` that points outside is now correctly gated instead of being silently classified as inside. **Breaking for custom `FilesystemBackend` implementations:** add a `realPath` method — return the path unchanged (`async (p) => p`) if your backend has no symlink semantics.
+```
+
+- [ ] **Step 3: Full verification (report each):**
+```
+pnpm -r build
+pnpm -r --if-present typecheck
+pnpm --filter @dawn-ai/workspace test
+pnpm --filter @dawn-ai/core test
+pnpm --filter @dawn-ai/langchain test
+pnpm --filter @dawn-ai/workspace lint && pnpm --filter @dawn-ai/core lint
+pnpm --filter @dawn-ai/web build
+```
+All green; lint exits 0 (pre-existing warnings only). Revert any `next-env.d.ts` churn.
+
+- [ ] **Step 4: Commit, push, PR:**
+```bash
+git add apps/web/content/docs/workspace.mdx .changeset/symlink-path-jail.md
+git commit -m "docs: symlink-hardened path jail; changeset"
+git push -u origin feat/symlink-path-jail
+gh pr create --base main --title "feat: harden workspace path jail against symlink escapes" \
+  --body "Spec: docs/superpowers/specs/2026-06-16-symlink-path-jail-design.md. Required FilesystemBackend.realPath; localFilesystem resolves symlinks (deepest-existing-ancestor); createWorkspaceFs canonicalizes both candidate path and workspace root before gatePathOp. Closes the lexical-jail symlink escape documented in the workspace docs."
+```
+Then enable auto-merge: `gh pr merge <branch> --auto --squash` (report the outcome — it may say admin required or auto-merge enabled).

--- a/docs/superpowers/specs/2026-06-16-symlink-path-jail-design.md
+++ b/docs/superpowers/specs/2026-06-16-symlink-path-jail-design.md
@@ -1,0 +1,138 @@
+# Symlink-hardened workspace path jail (Design)
+
+**Status:** Approved for planning
+**Date:** 2026-06-16
+**Roadmap:** Security hardening follow-up captured during the `ctx.fs` review (PR #213) and documented as a known limitation in `apps/web/content/docs/workspace.mdx`. The workspace permission gate's inside-vs-outside decision is purely lexical, so a symlink **inside** `workspace/` pointing **outside** is classified as inside and read/written silently — an escape from the path jail.
+
+## Problem
+
+`gatePathOp` (`packages/core/src/capabilities/permission-gate.ts:21`) decides whether a path is inside the workspace with a string compare:
+
+```ts
+const insideWorkspace = absPath === workspaceRoot || absPath.startsWith(workspaceRoot + sep)
+```
+
+`createWorkspaceFs.gate()` (the sole production caller) feeds it `resolve(workspaceRoot, relPath)`, which normalizes `..` but does **not** resolve symlinks. So `workspace/escape -> /etc/passwd` resolves to `<root>/escape`, lexically passes the inside check, and `localFilesystem` (which uses `node:fs`, following symlinks) reads `/etc/passwd` — no permission prompt, no deny. The agent can create such a link itself via `runBash` (`ln -s`).
+
+## Decisions (from brainstorming)
+
+- **Mechanism: a `realPath` method on `FilesystemBackend`** (Option B). The backend that follows symlinks owns the canonicalization; the gate stays a pure policy function; the pluggable-backend abstraction holds (a remote/in-memory backend canonicalizes its own way — identity if it has no symlinks). Rejected: hardcoding `node:fs` in the gate (couples policy to local FS, leaks for remote backends); per-method defense inside `localFilesystem` (duplicates the jail, bypasses the allow/deny/prompt decision).
+- **`realPath` is REQUIRED, not optional.** The only audience that must implement it is custom-backend authors (advanced work); the default `localFilesystem` ships it, so `create-dawn-app`/getting-started is hardened secure-by-default with zero friction. Required eliminates any silent-gap path — every backend canonicalizes, so the gate always compares real targets. (No back-compat constraint; `FilesystemBackend` is pre-1.0 under fixed versioning.)
+- **Canonicalize BOTH the candidate path and the workspace root** before the inside check. Realpath'ing only the candidate would misclassify legitimate inside paths as outside wherever the root itself sits under a symlink — notably macOS temp dirs (`/var → /private/var`, `/tmp → /private/tmp`), which the test suite uses heavily.
+- **`gatePathOp` is unchanged** — its lexical compare is correct once inputs are canonical.
+
+## Verified facts (against main @ `407303f`)
+
+- `gatePathOp` (permission-gate.ts) is called for path ops by exactly one production site: `createWorkspaceFs.gate()` (`packages/core/src/capabilities/workspace-fs.ts:30`). All other references are in `permission-gate.test.ts`. The agent-facing workspace tools delegate to `createWorkspaceFs` (refactored in PR #213), so there is no second path.
+- `createWorkspaceFs` holds the backend (`opts.backend`) and a `BackendContext` (`bctx`), so it is the natural place to canonicalize.
+- `FilesystemBackend` (`packages/workspace/src/types.ts`): `readFile`/`writeFile`/`listDir` are required; `readBinaryFile?`/`statFile?`/`removeFile?`/`touchFile?`/`mkdir?` optional.
+- `localFilesystem` (`packages/workspace/src/local-filesystem.ts`) uses `node:fs/promises` throughout; `writeFile` creates missing parent dirs (PR #208), so write targets often do not exist at gate time → a naive `fs.realpath(absPath)` would throw `ENOENT`.
+- `withFilesystemLogging` (`packages/workspace/src/with-logging.ts`) forwards required methods and conditionally forwards the optional ones; it will need to forward the new required `realPath`.
+- Inline `FilesystemBackend` test doubles exist in: `packages/core/test/capabilities/workspace-fs.test.ts`, `packages/workspace/test/with-logging.test.ts`, and any offload tests that construct a backend literal — each must gain a `realPath` once it's required (TypeScript flags them).
+
+## Design
+
+### 1. `FilesystemBackend.realPath` (required) — `@dawn-ai/workspace`
+
+In `packages/workspace/src/types.ts`:
+
+```ts
+export interface FilesystemBackend {
+  readFile(path: string, ctx: BackendContext, opts?: { readonly maxBytes?: number }): Promise<string>
+  // ...existing methods...
+  /**
+   * Canonicalize an already-resolved absolute path — resolving symlinks and
+   * `..` to a real target location — so the permission gate compares true
+   * locations, not lexical strings. Must tolerate paths that do not exist yet
+   * (e.g. a writeFile target): resolve the deepest existing ancestor and
+   * re-append the non-existent tail. Backends with no symlink concept
+   * (in-memory, remote) may return the path unchanged.
+   */
+  realPath(path: string, ctx: BackendContext): Promise<string>
+}
+```
+
+`ctx` is included for signature consistency with the other methods and to give remote backends the `signal`/`workspaceRoot`; `localFilesystem` ignores it.
+
+### 2. `localFilesystem.realPath` — deepest-existing-ancestor resolution
+
+`node:fs.realpath` throws `ENOENT` on a non-existent path, so walk up to the deepest existing ancestor, realpath that, and re-append the remainder:
+
+```ts
+import { realpath } from "node:fs/promises"
+import { basename, dirname, join } from "node:path"
+
+async realPath(path: string, _ctx: BackendContext): Promise<string> {
+  const tail: string[] = []
+  let current = path
+  for (;;) {
+    try {
+      const resolved = await realpath(current)
+      return tail.length === 0 ? resolved : join(resolved, ...tail)
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error
+      const parent = dirname(current)
+      if (parent === current) return path // reached FS root, nothing resolved
+      tail.unshift(basename(current))
+      current = parent
+    }
+  }
+}
+```
+
+Non-ENOENT errors propagate (a genuine I/O/permission failure should surface, not be masked).
+
+### 3. `createWorkspaceFs.gate()` canonicalizes both sides — `@dawn-ai/core`
+
+```ts
+async function gate(operation: PathOperation, path: string): Promise<string> {
+  const absPath = resolve(opts.workspaceRoot, path)
+  const canonicalPath = await opts.backend.realPath(absPath, bctx)
+  const canonicalRoot = await opts.backend.realPath(opts.workspaceRoot, bctx)
+  const result = await gatePathOp(opts.permissions, operation, canonicalPath, canonicalRoot, {
+    interruptCapable: opts.interruptCapable,
+  })
+  if (!result.allowed) throw new Error(result.reason)
+  return absPath // the backend op uses the original path; the OS resolves the link
+}
+```
+
+The backend op still receives the original `absPath` (the OS resolves the symlink at open time); canonicalization exists only to make the *security decision* on the real target. `gatePathOp` is untouched.
+
+### 4. `withFilesystemLogging` forwards `realPath`
+
+Add `realPath` to the always-forwarded set (it's required). It is path-only data; log it like `readFile` (path argument) or treat as passthrough without logging — match the existing required-method forwarding style; do not log it as noise if the existing reads/writes are the interesting events (implementer's call, but it MUST be forwarded so a wrapped backend stays valid).
+
+### 5. Update `FilesystemBackend` test doubles
+
+Every inline `FilesystemBackend` literal in tests gains a `realPath`. For doubles that don't exercise symlinks, identity is correct: `realPath: async (p) => p`. TypeScript will flag each missing one at build/typecheck.
+
+## Testing
+
+- **`packages/workspace/test/local-filesystem.test.ts`** — `realPath`:
+  - resolves a symlink to its real target (create a file, a symlink to it, assert `realPath(link)` === realpath of the target);
+  - resolves a symlink **escaping** a dir to the outside real path;
+  - for a non-existent target under an existing dir (write case), returns `<realdir>/<tail>` without throwing;
+  - returns an unchanged real path for an ordinary existing file;
+  - propagates non-ENOENT errors (optional — only if cheaply simulable).
+- **`packages/core/test/capabilities/workspace-fs.test.ts`** — the security assertion:
+  - a symlink at `workspace/escape -> <outside dir>` makes `fs.readFile("escape")` go through the gate as an **outside** path → with a non-interactive store it rejects `/fail-closed/` (proves the escape is caught, not silently allowed);
+  - **regression / macOS:** a normal inside path still resolves as inside and is allowed even when the workspace root is itself reached via a symlinked ancestor (simulate by creating the temp workspace under a symlinked dir, or rely on the macOS `/var` symlink) — proves canonicalizing both sides doesn't misclassify legit paths;
+  - existing gating tests (inside silent-allow, outside fail-closed, allow-rule, bypass, binary) still pass.
+- Full `@dawn-ai/core` + `@dawn-ai/workspace` suites green after the test-double updates.
+
+## Docs
+
+Update `apps/web/content/docs/workspace.mdx`:
+- Add `realPath` to the `FilesystemBackend` method table (required; one-line description; "identity for backends without symlinks").
+- Replace the **"Path jail is lexical"** caveat: `localFilesystem` now resolves symlinks before the gate decision, so a symlink inside `workspace/` pointing outside is correctly gated; custom backends must implement `realPath` to get the same protection (and the type system requires it).
+
+## Changeset
+
+`@dawn-ai/workspace` minor (new required `realPath` on `FilesystemBackend` + `localFilesystem` impl) and `@dawn-ai/core` minor (`createWorkspaceFs` canonicalization). Fixed versioning bumps all `@dawn-ai/*` together. The changeset note must call out that `FilesystemBackend` gains a **required** `realPath` method — custom backend implementations must add it (identity, `async (p) => p`, if the backend has no symlink semantics).
+
+## Out of scope
+
+- TOCTOU hardening (a symlink swapped between gate and open) — inherent to realpath-then-open; not addressed.
+- `gateBashOp` / `runBash` — operates on commands, not paths; unaffected.
+- Changing what the backend op receives (still the original path).

--- a/packages/core/src/capabilities/workspace-fs.ts
+++ b/packages/core/src/capabilities/workspace-fs.ts
@@ -27,7 +27,9 @@ export function createWorkspaceFs(opts: CreateWorkspaceFsOptions): WorkspaceFs {
 
   async function gate(operation: PathOperation, path: string): Promise<string> {
     const absPath = resolve(opts.workspaceRoot, path)
-    const result = await gatePathOp(opts.permissions, operation, absPath, opts.workspaceRoot, {
+    const canonicalPath = await opts.backend.realPath(absPath, bctx)
+    const canonicalRoot = await opts.backend.realPath(opts.workspaceRoot, bctx)
+    const result = await gatePathOp(opts.permissions, operation, canonicalPath, canonicalRoot, {
       interruptCapable: opts.interruptCapable,
     })
     if (!result.allowed) throw new Error(result.reason)

--- a/packages/core/test/capabilities/workspace-fs.test.ts
+++ b/packages/core/test/capabilities/workspace-fs.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { mkdirSync, mkdtempSync, realpathSync, rmSync, symlinkSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { createPermissionsStore } from "@dawn-ai/permissions"
@@ -101,7 +101,10 @@ describe("createWorkspaceFs permission gating", () => {
   const signal = new AbortController().signal
 
   beforeEach(() => {
-    root = mkdtempSync(join(tmpdir(), "dawn-wsfs-gate-"))
+    // Canonicalize the temp root: on macOS tmpdir() is /var -> /private/var, and
+    // the gate now compares canonical paths, so allow-rule patterns (and the
+    // workspace root) must be expressed in canonical form to match.
+    root = realpathSync(mkdtempSync(join(tmpdir(), "dawn-wsfs-gate-")))
     workspaceRoot = join(root, "workspace")
     mkdirSync(workspaceRoot, { recursive: true })
     outsideDir = join(root, "shared")
@@ -203,5 +206,50 @@ describe("createWorkspaceFs permission gating", () => {
     await permissions.load()
     const fs = makeGated(permissions)
     expect(await fs.readFile(outsideFile)).toBe("secret")
+  })
+
+  it("gates a symlink that escapes the workspace (caught, not silently allowed)", async () => {
+    const outside = mkdtempSync(join(tmpdir(), "dawn-escape-"))
+    writeFileSync(join(outside, "secret.txt"), "top secret", "utf8")
+    symlinkSync(join(outside, "secret.txt"), join(workspaceRoot, "escape"))
+    const permissions = createPermissionsStore({
+      appRoot: root,
+      config: undefined,
+      mode: "non-interactive",
+    })
+    await permissions.load()
+    const fs = createWorkspaceFs({
+      workspaceRoot,
+      backend: localFilesystem(),
+      permissions,
+      signal,
+      interruptCapable: false,
+    })
+    await expect(fs.readFile("escape")).rejects.toThrow(/fail-closed/)
+    rmSync(outside, { recursive: true, force: true })
+  })
+
+  it("still allows a legitimate inside path when the workspace root is reached via a symlink", async () => {
+    const realDir = mkdtempSync(join(tmpdir(), "dawn-realroot-"))
+    const linkParent = mkdtempSync(join(tmpdir(), "dawn-linkroot-"))
+    const linkedRoot = join(linkParent, "ws")
+    symlinkSync(realDir, linkedRoot)
+    writeFileSync(join(realDir, "notes.md"), "hello", "utf8")
+    const permissions = createPermissionsStore({
+      appRoot: root,
+      config: undefined,
+      mode: "non-interactive",
+    })
+    await permissions.load()
+    const fs = createWorkspaceFs({
+      workspaceRoot: linkedRoot,
+      backend: localFilesystem(),
+      permissions,
+      signal,
+      interruptCapable: false,
+    })
+    expect(await fs.readFile("notes.md")).toBe("hello")
+    rmSync(realDir, { recursive: true, force: true })
+    rmSync(linkParent, { recursive: true, force: true })
   })
 })

--- a/packages/core/test/capabilities/workspace.test.ts
+++ b/packages/core/test/capabilities/workspace.test.ts
@@ -95,6 +95,7 @@ describe("createWorkspaceMarker — load", () => {
       readFile: vi.fn().mockResolvedValue("hi"),
       writeFile: vi.fn(),
       listDir: vi.fn(),
+      realPath: async (p: string) => p,
     }
     const contribution = await createWorkspaceMarker().load(
       routeDir,
@@ -212,6 +213,7 @@ describe("createWorkspaceMarker — load", () => {
       readFile: async () => "data",
       writeFile: async () => ({ bytesWritten: 4 }),
       listDir: async () => [],
+      realPath: async (p: string) => p,
       touchFile: async (p: string) => {
         touched.push(p)
       },
@@ -232,6 +234,7 @@ describe("createWorkspaceMarker — load", () => {
       readFile: async () => "hello",
       writeFile: async () => ({ bytesWritten: 5 }),
       listDir: async () => [],
+      realPath: async (p: string) => p,
       touchFile: async (p: string) => {
         touched.push(p)
       },
@@ -254,6 +257,7 @@ describe("createWorkspaceMarker — load", () => {
       },
       writeFile: async () => ({ bytesWritten: 0 }),
       listDir: async () => [],
+      realPath: async (p: string) => p,
     }
     const contribution = await createWorkspaceMarker().load(
       routeDir,

--- a/packages/workspace/src/local-filesystem.ts
+++ b/packages/workspace/src/local-filesystem.ts
@@ -1,5 +1,14 @@
-import { mkdir as mkdirFs, readdir, readFile, rm, stat, utimes, writeFile } from "node:fs/promises"
-import { dirname } from "node:path"
+import {
+  mkdir as mkdirFs,
+  readdir,
+  readFile,
+  realpath,
+  rm,
+  stat,
+  utimes,
+  writeFile,
+} from "node:fs/promises"
+import { basename, dirname, join } from "node:path"
 import type { BackendContext, FilesystemBackend } from "./types.js"
 
 const DEFAULT_MAX_FILE_BYTES = 256 * 1024
@@ -51,6 +60,22 @@ export function localFilesystem(opts: LocalFilesystemOptions = {}): FilesystemBa
       await mkdirFs(dirname(path), { recursive: true })
       await writeFile(path, content, "utf8")
       return { bytesWritten: Buffer.byteLength(content, "utf8") }
+    },
+    async realPath(path: string, _ctx: BackendContext): Promise<string> {
+      const tail: string[] = []
+      let current = path
+      for (;;) {
+        try {
+          const resolved = await realpath(current)
+          return tail.length === 0 ? resolved : join(resolved, ...tail)
+        } catch (error) {
+          if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error
+          const parent = dirname(current)
+          if (parent === current) return path
+          tail.unshift(basename(current))
+          current = parent
+        }
+      }
     },
     async listDir(path: string, _ctx: BackendContext): Promise<readonly string[]> {
       return await readdir(path)

--- a/packages/workspace/src/types.ts
+++ b/packages/workspace/src/types.ts
@@ -56,6 +56,16 @@ export interface FilesystemBackend {
   /** List entries in a directory. Returns leaf names (not full paths). */
   listDir(path: string, ctx: BackendContext): Promise<readonly string[]>
 
+  /**
+   * Canonicalize an already-resolved absolute path — resolving symlinks and
+   * `..` to a real target location — so the permission gate compares true
+   * locations, not lexical strings. Must tolerate a path that does not exist
+   * yet (e.g. a writeFile target): resolve the deepest existing ancestor and
+   * re-append the non-existent tail. Backends with no symlink concept
+   * (in-memory, remote) may return the path unchanged.
+   */
+  realPath(path: string, ctx: BackendContext): Promise<string>
+
   /** Stat a file. Optional — backends that omit it disable offload GC. */
   statFile?(
     path: string,

--- a/packages/workspace/src/with-logging.ts
+++ b/packages/workspace/src/with-logging.ts
@@ -38,6 +38,8 @@ export function withFilesystemLogging(opts: LoggingOptions = {}): FilesystemMidd
         emit(opts, "listDir", [path])
         return next.listDir(path, ctx)
       },
+      // Required; internal canonicalization, not a user-facing read/write — passthrough, no log.
+      realPath: (path, ctx) => next.realPath(path, ctx),
     }
 
     // Forward binary read with PATH-ONLY logging — never serialize the bytes.

--- a/packages/workspace/test/compose.test.ts
+++ b/packages/workspace/test/compose.test.ts
@@ -6,6 +6,7 @@ const base: FilesystemBackend = {
   async readFile() { return "BASE" },
   async writeFile() { return { bytesWritten: 0 } },
   async listDir() { return [] },
+  async realPath(p) { return p },
 }
 
 describe("compose", () => {

--- a/packages/workspace/test/local-filesystem.test.ts
+++ b/packages/workspace/test/local-filesystem.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, beforeEach, afterEach } from "vitest"
-import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from "node:fs"
+import { mkdtempSync, realpathSync, rmSync, symlinkSync, writeFileSync, mkdirSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { localFilesystem } from "../src/local-filesystem.js"
@@ -27,6 +27,39 @@ describe("localFilesystem", () => {
     writeFileSync(join(root, "big.txt"), "x".repeat(2048), "utf8")
     const fs = localFilesystem({ maxFileBytes: 1024 })
     await expect(fs.readFile(join(root, "big.txt"), ctx(root))).rejects.toThrow(/too large/i)
+  })
+
+  it("realPath resolves a symlink to its real target", async () => {
+    const fs = localFilesystem()
+    const real = join(root, "real.txt")
+    writeFileSync(real, "x", "utf8")
+    const link = join(root, "link.txt")
+    symlinkSync(real, link)
+    expect(await fs.realPath(link, ctx(root))).toBe(realpathSync(real))
+  })
+
+  it("realPath resolves an escaping symlink to the outside real path", async () => {
+    const fs = localFilesystem()
+    const outside = mkdtempSync(join(tmpdir(), "dawn-outside-"))
+    const target = join(outside, "secret.txt")
+    writeFileSync(target, "s", "utf8")
+    const link = join(root, "escape")
+    symlinkSync(target, link)
+    expect(await fs.realPath(link, ctx(root))).toBe(realpathSync(target))
+    rmSync(outside, { recursive: true, force: true })
+  })
+
+  it("realPath tolerates a non-existent target (write case): resolves deepest existing ancestor", async () => {
+    const fs = localFilesystem()
+    const want = join(realpathSync(root), "new-dir", "new.md")
+    expect(await fs.realPath(join(root, "new-dir", "new.md"), ctx(root))).toBe(want)
+  })
+
+  it("realPath returns the canonical path for an ordinary existing file", async () => {
+    const fs = localFilesystem()
+    const p = join(root, "plain.txt")
+    writeFileSync(p, "x", "utf8")
+    expect(await fs.realPath(p, ctx(root))).toBe(realpathSync(p))
   })
 
   it("writeFile returns the byte count", async () => {

--- a/packages/workspace/test/with-logging.test.ts
+++ b/packages/workspace/test/with-logging.test.ts
@@ -6,6 +6,7 @@ const base: FilesystemBackend = {
   async readFile() { return "ok" },
   async writeFile() { return { bytesWritten: 5 } },
   async listDir() { return ["a"] },
+  async realPath(p) { return p },
 }
 
 const ctx = { signal: new AbortController().signal, workspaceRoot: "/r" }


### PR DESCRIPTION
## Summary

Closes the workspace path-jail symlink escape documented as a known limitation in the workspace docs. The permission gate's inside-vs-outside decision was purely lexical, so a symlink inside `workspace/` pointing outside (e.g. `ln -s /etc/passwd workspace/escape`) was classified as inside and read/written silently.

- **`FilesystemBackend.realPath` (required)** — `localFilesystem` resolves symlinks via the deepest existing ancestor (so a not-yet-created `writeFile` target doesn't ENOENT). Backends without symlink semantics return the path unchanged (`async (p) => p`).
- **`createWorkspaceFs.gate()` canonicalizes both the candidate path and the workspace root** before `gatePathOp` (canonicalizing the root too keeps macOS `/var → /private/var` temp dirs from being misclassified). `gatePathOp` itself is unchanged — its lexical compare is correct on canonical inputs.
- Spec: docs/superpowers/specs/2026-06-16-symlink-path-jail-design.md.

**Breaking:** custom `FilesystemBackend` implementations must add `realPath`. **Behavior note:** allow rules for outside paths now match against the canonical (symlink-resolved) path.

## Test plan

- [x] TDD: localFilesystem.realPath unit tests (symlink, escaping symlink, non-existent write target, plain file); createWorkspaceFs security test (escaping symlink → fail-closed, revert-proven) + linked-root regression (both-sides canonicalization)
- [x] Full suites green: workspace 33, core 169, langchain 161; `pnpm -r build` + typecheck clean; docs build
- [x] Per-task spec + quality subagent reviews

🤖 Generated with [Claude Code](https://claude.com/claude-code)