### PR TITLE
fix(testing): reset() isolates fixtures across scenarios (HITL interrupt bug)

### DIFF
--- a/.changeset/harness-reset-fixture-isolation.md
+++ b/.changeset/harness-reset-fixture-isolation.md
@@ -1,0 +1,15 @@
+---
+"@dawn-ai/testing": patch
+"create-dawn-ai-app": patch
+"@dawn-ai/devkit": patch
+---
+
+Fix test-harness scenario isolation. `createAgentHarness().reset()` now clears
+the accumulated aimock fixtures (restoring the constructor baseline) instead of
+only swapping the thread id. Previously fixtures were registered additively and
+aimock's matcher is first-match-in-array-order, so a loosely-matched fixture
+from an earlier scenario (a raw `FixtureSet` without a `userMessage`, e.g. the
+offload pattern) could shadow a later run's first model call. This surfaced as a
+HITL permission interrupt that "only fired on the first run." The research
+scaffold's HITL test now shares one harness with `reset()` between tests instead
+of constructing a dedicated one.

--- a/apps/web/content/docs/testing-agents.mdx
+++ b/apps/web/content/docs/testing-agents.mdx
@@ -339,7 +339,7 @@ it("searches the corpus and writes a cited answer", async () => {
 }, 60_000)
 ```
 
-The remaining three tests cover: researcher subagent dispatch (`expectSubagent`); offloading of a large `readDoc` result (`expectOffloaded`); and the HITL permission gate for `runBash` with resume (`expectInterrupt` + `harness.resume`) — the last uses its own dedicated harness so the interrupt is clean.
+The remaining three tests cover: researcher subagent dispatch (`expectSubagent`); offloading of a large `readDoc` result (`expectOffloaded`); and the HITL permission gate for `runBash` with resume (`expectInterrupt` + `harness.resume`). All four share one harness and call `h.reset()` per test — `reset()` starts a fresh thread and clears the previous scenario's fixtures, so the tests stay isolated.
 
 Grow it by:
 

--- a/apps/web/next-env.d.ts
+++ b/apps/web/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/packages/devkit/templates/app-research/test/research.test.ts.template
+++ b/packages/devkit/templates/app-research/test/research.test.ts.template
@@ -71,23 +71,17 @@ it("offloads a large readDoc result", async () => {
 }, 60_000)
 
 it("gates the external fetch behind a permission prompt, then resumes", async () => {
-  // A permission interrupt is captured on a harness's first run, so this test
-  // uses its own harness rather than the shared one above.
-  const hitl = await createAgentHarness({ appRoot, route: "/research#agent" })
-  try {
-    const run = await hitl.run({
-      input: "Fetch external context on context windows",
-      fixtures: script()
-        .user("Fetch external context on context windows")
-        .callsTool("runBash", { command: "node scripts/fetch-source.mjs context windows" })
-        .replies("Fetched external context."),
-    })
-    expectInterrupt(run).ofKind("command").withDetail({
-      command: "node scripts/fetch-source.mjs context windows",
-    })
-    const resumed = await hitl.resume({ decision: "once" })
-    expectToolCalled(resumed, "runBash")
-  } finally {
-    await hitl.close()
-  }
+  h.reset()
+  const run = await h.run({
+    input: "Fetch external context on context windows",
+    fixtures: script()
+      .user("Fetch external context on context windows")
+      .callsTool("runBash", { command: "node scripts/fetch-source.mjs context windows" })
+      .replies("Fetched external context."),
+  })
+  expectInterrupt(run).ofKind("command").withDetail({
+    command: "node scripts/fetch-source.mjs context windows",
+  })
+  const resumed = await h.resume({ decision: "once" })
+  expectToolCalled(resumed, "runBash")
 }, 60_000)

--- a/packages/testing/src/aimock-runner.ts
+++ b/packages/testing/src/aimock-runner.ts
@@ -7,6 +7,8 @@ export interface AimockHandle {
   readonly baseUrl: string
   /** Append more fixtures onto the live mock without restarting it. */
   addFixtures(fixtures: readonly AimockFixture[]): void
+  /** Remove all registered fixtures (the mock keeps running). */
+  clearFixtures(): void
   /** All requests the mock has received (aimock's journal). */
   getRequests(): ReadonlyArray<{
     body: { messages?: Array<{ role: string; content: unknown }> } | null
@@ -40,6 +42,9 @@ export async function startAimock(opts: {
       if (fixtures.length > 0) {
         mock.addFixturesFromJSON(fixtures as never)
       }
+    },
+    clearFixtures() {
+      mock.clearFixtures()
     },
     getRequests() {
       return mock.getRequests() as ReadonlyArray<{

--- a/packages/testing/src/harness.ts
+++ b/packages/testing/src/harness.ts
@@ -167,6 +167,17 @@ export async function createAgentHarness(options: AgentHarnessOptions): Promise<
     },
     reset() {
       threadId = randomUUID()
+      // Start each scenario from a clean fixture set. Fixtures are registered
+      // additively per run() and findFixture is first-match-in-array-order, so
+      // without this a loosely-matched fixture from a prior scenario (e.g. a raw
+      // FixtureSet with no `userMessage`) would shadow the next run's turn-0
+      // call. Live mode proxies to the real upstream and registers no fixtures.
+      if (!live) {
+        aimock.clearFixtures()
+        if (options.fixtures && options.fixtures.length > 0) {
+          aimock.addFixtures(options.fixtures)
+        }
+      }
     },
     async close() {
       if (closed) return

--- a/packages/testing/test/harness-fixtures.test.ts
+++ b/packages/testing/test/harness-fixtures.test.ts
@@ -38,6 +38,30 @@ it("supports a second run() with new fixtures on the same persistent aimock (mul
   expect(run2.finalMessage).toContain("Found 0")
 }, 60_000)
 
+it("reset() isolates fixtures across scenarios — a wildcard fixture does not leak", async () => {
+  // Run 1 registers a wildcard turn-0 fixture (no userMessage) — mirrors a raw
+  // FixtureSet like the offload pattern. Before the fix, addFixtures() only
+  // appended and reset() only swapped the threadId, so this fixture stayed
+  // registered and shadowed every later run's turn-0 call (findFixture is
+  // first-match-in-array-order with no specificity preference).
+  h.reset()
+  const run1 = await h.run({
+    input: "alpha",
+    fixtures: [
+      { match: { turnIndex: 0, hasToolResult: false }, response: { content: "RUN_1_WILDCARD" } },
+    ],
+  })
+  expect(run1.finalMessage).toBe("RUN_1_WILDCARD")
+
+  h.reset()
+  const run2 = await h.run({
+    input: "bravo",
+    fixtures: script().user("bravo").replies("RUN_2_OWN"),
+  })
+  // The run-1 wildcard must NOT serve this run; reset() clears it.
+  expect(run2.finalMessage).toBe("RUN_2_OWN")
+}, 60_000)
+
 it("captures the system prompt the model received", async () => {
   h.reset()
   const run = await h.run({


### PR DESCRIPTION
## Summary
Fixes the long-standing "HITL permission interrupt only fires on the harness's first `run()`" report — which turned out **not** to be a permission/interrupt bug at all.

## Root cause (systematic-debugging, with an instrumented repro)
`createAgentHarness` registered fixtures **additively** (`addFixtures` only appends) and `reset()` only swapped `threadId`. `@copilotkit/aimock`'s `findFixture` is **first-match-in-array-order with no specificity preference**. So a loosely-matched fixture from an earlier scenario — a raw `FixtureSet` with no `userMessage` (the offload test's `{ turnIndex: 0, hasToolResult: false }`) — stayed registered and **shadowed every later run's turn-0 call**. In the research suite the HITL run then "called `readDoc`" instead of `runBash`, so no permission gate fired and no interrupt was captured.

Instrumented proof: run 1 registers `{turnIndex:0,hasToolResult:false} → "RUN_1_WILDCARD"`; run 2 (after `reset()`, distinct user, its own fixture) returned **`RUN_1_WILDCARD`**.

## Fix
`reset()` now `clearFixtures()` + restores the constructor baseline, so each scenario starts clean. `LLMock.clearFixtures()` already exists. Live mode (proxy, no fixtures) is unaffected; `run → resume` still shares fixtures (resume doesn't reset).

## Verification
- New regression test in `harness-fixtures.test.ts` (wildcard does not leak across `reset()`). Full `@dawn-ai/testing` suite: 75 passed.
- **End-to-end:** scaffolded a research app against the fixed package, switched its HITL test to the **shared** harness, ran the suite → **4/4 pass**, interrupt fires as the 4th run after the offload (wildcard) test. The dedicated-harness workaround is no longer needed, so the research template + testing-agents doc are updated to use the shared harness.
- `pnpm ci:validate` green (build, typecheck, lint, tests, docs, pack, all 3 harness lanes).

Closes the harness-`reset()` interrupt issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)