### PR TITLE
chore: release accumulated fixes as patch 0.8.1

### DIFF
--- a/.changeset/import-diagnostics.md
+++ b/.changeset/import-diagnostics.md
@@ -1,5 +1,5 @@
 ---
-"@dawn-ai/cli": minor
+"@dawn-ai/cli": patch
 "@dawn-ai/sqlite-storage": patch
 ---
 

--- a/.changeset/symlink-path-jail.md
+++ b/.changeset/symlink-path-jail.md
@@ -1,10 +1,10 @@
 ---
-"@dawn-ai/workspace": minor
-"@dawn-ai/core": minor
+"@dawn-ai/workspace": patch
+"@dawn-ai/core": patch
 ---
 
 Harden the workspace path jail against symlink escapes. `FilesystemBackend` gains a required `realPath(path, ctx)` method; `localFilesystem` implements it (resolving symlinks via the deepest existing ancestor so not-yet-created write targets work), and `createWorkspaceFs` canonicalizes both the candidate path and the workspace root before the permission gate. A symlink inside `workspace/` that points outside is now correctly gated instead of being silently classified as inside.
 
-**Breaking for custom `FilesystemBackend` implementations:** add a `realPath` method — return the path unchanged (`async (p) => p`) if your backend has no symlink semantics.
+**Action for custom `FilesystemBackend` implementations:** add a `realPath` method — return the path unchanged (`async (p) => p`) if your backend has no symlink semantics. (Shipped as a patch since `localFilesystem`, the only built-in backend, already implements it; custom backends are not expected at this 0.x stage.)
 
 **Behavior note:** allow rules for paths outside the workspace are now matched against the canonical (symlink-resolved) path. If your workspace or an allowed target lives under a symlink, express allow-rule paths in canonical form; rules written against a non-canonical alias will fail closed. (No effect when your paths contain no symlinks.)


### PR DESCRIPTION
Downgrades two changesets from `minor` to `patch` so the next release is a true **0.8.1** patch rather than an accidental **1.0.0**.

**Why 1.0.0 would otherwise happen:** all 15 public packages share one changesets `fixed` group, which disables 0.x dampening — so a single `minor` changeset bumps the entire group across the 1.0 boundary. The only achievable outcomes in this config are all-patch → `0.8.1` or any-minor → `1.0.0`.

**Changes:**
- `import-diagnostics`: `@dawn-ai/cli` minor → patch
- `symlink-path-jail`: `@dawn-ai/workspace` + `@dawn-ai/core` minor → patch; reword the backend note from *Breaking* to *Action* (localFilesystem, the only built-in backend, already implements `realPath`; no custom backends expected at 0.x)

After merge, the changesets bot regenerates the Version Packages PR to 0.8.1, which then publishes via OIDC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)