### PR TITLE
feat(testing): unit harnesses for tools, middleware, and the workspace

### DIFF
--- a/.changeset/testing-unit-harnesses.md
+++ b/.changeset/testing-unit-harnesses.md
@@ -1,0 +1,5 @@
+---
+"@dawn-ai/testing": minor
+---
+
+Unit-test harnesses for tools, middleware, and the workspace. `createToolHarness(tool)` invokes a route tool against a real, temp-backed `ctx.fs` (reusable `invoke()` for cumulative-state assertions); `createMiddlewareHarness(mw)` exercises a `FilesystemMiddleware` over a temp `localFilesystem` and offers `assertForwardsAll()` to catch dropped backend methods; `createWorkspaceHarness()` is the shared temp-`WorkspaceFs` fixture, also usable to test `ctx.fs` code directly. All are async `create*Harness` factories with `.close()` and `[Symbol.asyncDispose]` (for `await using`), matching `createAgentHarness`. Adds `@dawn-ai/workspace` and `@dawn-ai/sdk` as peer dependencies.

--- a/apps/web/content/docs/testing.mdx
+++ b/apps/web/content/docs/testing.mdx
@@ -132,6 +132,90 @@ Use `dawn verify` as the integrity gate (it covers app, routes, typegen, and dep
 
 `dawn verify` runs typegen and check internally, plus the deps check (missing packages, missing env vars) that bare `dawn check && dawn typegen` does not. `dawn test` exits non-zero on any failure and outputs a diff per mismatched scenario.
 
+## Unit-testing tools and middleware
+
+The scenario harness drives a whole route through the runtime. Sometimes you want to test one unit in isolation — a single route tool, a `FilesystemMiddleware`, or `ctx.fs`-using code — without standing up an agent. `@dawn-ai/testing` ships three harnesses for this. They run against the **real** `WorkspaceFs` and filesystem backend over a temp directory, so real permission gating, realpath resolution, and parent-directory creation all apply.
+
+All three are async `create*Harness` factories that return a handle with `.close()` and `[Symbol.asyncDispose]` — the same convention as `createAgentHarness`.
+
+### A tool that uses `ctx.fs`
+
+`createToolHarness(tool)` builds the `DawnToolContext` and gives you a reusable `invoke()`. Assert both the return value and what landed on disk via `h.workspace.read(...)`:
+
+```ts
+import { afterEach } from "vitest"
+import { createToolHarness } from "@dawn-ai/testing"
+import type { DawnToolContext } from "@dawn-ai/sdk"
+
+const saveNote = async (input: { name: string; body: string }, ctx: DawnToolContext) => {
+  const { bytesWritten } = await ctx.fs.writeFile(`notes/${input.name}.md`, input.body)
+  return { bytesWritten }
+}
+
+let h: Awaited<ReturnType<typeof createToolHarness>>
+afterEach(() => h.close())
+
+test("saveNote writes into the workspace", async () => {
+  h = await createToolHarness(saveNote)
+
+  const result = await h.invoke({ name: "todo", body: "ship it" })
+
+  expect(result.bytesWritten).toBe(7)
+  expect(await h.workspace.read("notes/todo.md")).toBe("ship it")
+})
+```
+
+`invoke()` is reusable and shares one workspace across calls, so you can assert cumulative state across several invocations. Pass `{ workspace }` to share a fixture you already own (the harness won't close it), or `{ permissions }` to exercise allow/deny gating instead of the permissive default.
+
+### Testing `ctx.fs` code directly
+
+`createWorkspaceHarness()` is the shared fixture the tool harness builds on. Use it directly when the code under test takes a `WorkspaceFs`. Seed the workspace with `write`, run your code against `h.fs`, and assert with `read`:
+
+```ts
+import { createWorkspaceHarness } from "@dawn-ai/testing"
+import type { WorkspaceFs } from "@dawn-ai/sdk"
+
+const appendLine = async (fs: WorkspaceFs, path: string, line: string) => {
+  const prev = await fs.readFile(path)
+  await fs.writeFile(path, `${prev}\n${line}`)
+}
+
+test("appendLine round-trips through the real WorkspaceFs", async () => {
+  await using h = await createWorkspaceHarness()
+  await h.write("log.txt", "first")
+
+  await appendLine(h.fs, "log.txt", "second")
+
+  expect(await h.read("log.txt")).toBe("first\nsecond")
+})
+```
+
+The `await using` form auto-disposes the harness (cleaning up the temp dir) at the end of the block — the modern alternative to `afterEach(() => h.close())`. It works on all three harnesses.
+
+### A filesystem middleware
+
+`createMiddlewareHarness(mw)` composes a `FilesystemMiddleware` over a temp `localFilesystem` and exposes the wrapped `backend` plus a `ctx` to call it with. `assertForwardsAll()` catches the most common middleware bug — silently dropping a backend method (required or optional) that the middleware doesn't intercept:
+
+```ts
+import { createMiddlewareHarness } from "@dawn-ai/testing"
+import type { FilesystemMiddleware } from "@dawn-ai/workspace"
+
+const uppercaseReads: FilesystemMiddleware = (next) => ({
+  ...next,
+  readFile: async (path, ctx) => (await next.readFile(path, ctx)).toUpperCase(),
+})
+
+test("uppercaseReads forwards every other backend method", async () => {
+  await using h = await createMiddlewareHarness(uppercaseReads)
+
+  await h.backend.writeFile("a.txt", "hello", h.ctx)
+  expect(await h.backend.readFile("a.txt", h.ctx)).toBe("HELLO")
+
+  // Fails loudly if the middleware forgot to spread a method like realPath.
+  h.assertForwardsAll()
+})
+```
+
 ## Related
 
 <RelatedCards items={[

--- a/docs/superpowers/plans/2026-06-16-testing-unit-harnesses.md
+++ b/docs/superpowers/plans/2026-06-16-testing-unit-harnesses.md
@@ -1,0 +1,471 @@
+# Testing Unit-Harnesses Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add three unit-test harnesses to `@dawn-ai/testing` — `createWorkspaceHarness`, `createToolHarness`, `createMiddlewareHarness` — so authors can test a route tool or a `FilesystemMiddleware` (and `ctx.fs` code) in isolation against the real `WorkspaceFs`/backend.
+
+**Architecture:** One PR off `feat/testing-unit-harnesses` (spec: `docs/superpowers/specs/2026-06-16-testing-unit-harnesses-design.md`). Async `create*Harness` factories matching the existing `createAgentHarness` convention (`.close()` teardown + `[Symbol.asyncDispose]` for optional `await using`). The workspace harness is the shared fixture the other two build on. Real `createWorkspaceFs` (core) over a temp `localFilesystem` (workspace); permissive gating by default. W1 sets up deps + the workspace fixture; W2/W3 add the tool/middleware harnesses on top; W4 docs + changeset + PR.
+
+**Tech Stack:** TypeScript (no semicolons, double quotes, 2-space, ESM `.js` specifiers), pnpm, Vitest, Biome, changesets.
+
+**Conventions:** `pnpm -r build` once at start; rebuild `@dawn-ai/testing` after edits before running its tests if they consume `dist` (they import from `../src/` so usually not needed). Run `pnpm -r --if-present typecheck` before declaring done. `pyenv: cannot rehash` output is harmless noise. The package's tests use top-level `await` + `afterAll(() => h.close())` (see `test/harness-construct.test.ts`) and import from `../src/*.js`.
+
+---
+
+### Task W1: deps + `createWorkspaceHarness` (TDD)
+
+**Files:**
+- Modify: `packages/testing/package.json` (add `@dawn-ai/workspace`, `@dawn-ai/sdk`)
+- Create: `packages/testing/src/workspace-harness.ts`
+- Modify: `packages/testing/src/index.ts` (export it)
+- Test: `packages/testing/test/workspace-harness.test.ts` (create)
+
+- [ ] **Step 1: Add dependencies.** In `packages/testing/package.json`, add `@dawn-ai/workspace` and `@dawn-ai/sdk` to BOTH `peerDependencies` and `devDependencies`, matching how `@dawn-ai/core`/`@dawn-ai/cli` are already listed (check the existing version/`workspace:*` style and mirror it exactly). Run `pnpm install` so the workspace links resolve.
+
+- [ ] **Step 2: Write the failing tests** (`packages/testing/test/workspace-harness.test.ts`):
+
+```ts
+import { existsSync, realpathSync } from "node:fs"
+import { afterEach, expect, it } from "vitest"
+import { createPermissionsStore } from "@dawn-ai/permissions"
+import { createWorkspaceHarness, type WorkspaceHarness } from "../src/workspace-harness.js"
+
+const open: WorkspaceHarness[] = []
+afterEach(async () => {
+  await Promise.all(open.splice(0).map((h) => h.close()))
+})
+async function harness(...args: Parameters<typeof createWorkspaceHarness>) {
+  const h = await createWorkspaceHarness(...args)
+  open.push(h)
+  return h
+}
+
+it("round-trips write -> fs.readFile and fs.writeFile -> read", async () => {
+  const h = await harness()
+  await h.write("notes/seed.md", "hi")
+  expect(await h.fs.readFile("notes/seed.md")).toBe("hi")
+  await h.fs.writeFile("out/result.md", "done")
+  expect(await h.read("out/result.md")).toBe("done")
+})
+
+it("exposes a realpath'd workspace dir", async () => {
+  const h = await harness()
+  expect(h.dir).toBe(realpathSync(h.dir))
+})
+
+it("close() removes the temp dir and is idempotent", async () => {
+  const h = await createWorkspaceHarness()
+  const dir = h.dir
+  await h.close()
+  await h.close() // idempotent
+  expect(existsSync(dir)).toBe(false)
+})
+
+it("supports `await using` auto-disposal", async () => {
+  let captured = ""
+  {
+    await using h = await createWorkspaceHarness()
+    captured = h.dir
+    expect(existsSync(captured)).toBe(true)
+  }
+  expect(existsSync(captured)).toBe(false)
+})
+
+it("is permissive by default (allows an outside-workspace read)", async () => {
+  const h = await harness()
+  // an absolute path outside the workspace resolves with no permissions store
+  await expect(h.fs.readFile("/etc/hostname")).resolves.toBeTypeOf("string")
+})
+
+it("fails closed for an outside path when a non-interactive store is injected", async () => {
+  const h = await harness({
+    permissions: createPermissionsStore({ appRoot: process.cwd(), mode: "non-interactive" }),
+  })
+  await expect(h.fs.readFile("/etc/hostname")).rejects.toThrow(/fail-closed/)
+})
+```
+
+(If `createPermissionsStore`'s signature differs, read `packages/core/test/capabilities/workspace-fs.test.ts` for the exact construction pattern and match it. If reading `/etc/hostname` is unavailable in the sandbox, substitute any path outside the temp workspace that exists, e.g. the repo root.)
+
+- [ ] **Step 3: Run to verify failure:** `pnpm --filter @dawn-ai/testing test -- workspace-harness` → FAIL (module missing).
+
+- [ ] **Step 4: Implement `packages/testing/src/workspace-harness.ts`:**
+
+```ts
+import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises"
+import { realpathSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { dirname, join } from "node:path"
+import { createWorkspaceFs } from "@dawn-ai/core"
+import type { PermissionsStore } from "@dawn-ai/permissions"
+import type { WorkspaceFs } from "@dawn-ai/sdk"
+import { localFilesystem } from "@dawn-ai/workspace"
+
+export interface WorkspaceHarness {
+  readonly fs: WorkspaceFs
+  readonly dir: string
+  read(path: string): Promise<string>
+  write(path: string, content: string): Promise<void>
+  close(): Promise<void>
+  [Symbol.asyncDispose](): Promise<void>
+}
+
+export interface WorkspaceHarnessOptions {
+  readonly permissions?: PermissionsStore
+}
+
+export async function createWorkspaceHarness(
+  opts?: WorkspaceHarnessOptions,
+): Promise<WorkspaceHarness> {
+  const root = await mkdtemp(join(tmpdir(), "dawn-ws-harness-"))
+  const workspaceRoot = join(root, "workspace")
+  await mkdir(workspaceRoot, { recursive: true })
+  // The symlink-hardened gate canonicalizes the root; realpath here so
+  // inside-workspace paths classify correctly (macOS /var -> /private/var).
+  const canonicalRoot = realpathSync(workspaceRoot)
+  const controller = new AbortController()
+  const fs = createWorkspaceFs({
+    workspaceRoot: canonicalRoot,
+    backend: localFilesystem(),
+    permissions: opts?.permissions,
+    signal: controller.signal,
+    interruptCapable: false,
+  })
+
+  let closed = false
+  const close = async (): Promise<void> => {
+    if (closed) return
+    closed = true
+    controller.abort()
+    await rm(root, { force: true, recursive: true })
+  }
+
+  return {
+    fs,
+    dir: canonicalRoot,
+    async read(path) {
+      return await readFile(join(canonicalRoot, path), "utf8")
+    },
+    async write(path, content) {
+      const abs = join(canonicalRoot, path)
+      await mkdir(dirname(abs), { recursive: true })
+      await writeFile(abs, content, "utf8")
+    },
+    close,
+    [Symbol.asyncDispose]: close,
+  }
+}
+```
+
+Export `createWorkspaceHarness` + the two types from `packages/testing/src/index.ts` (follow the file's existing export grouping).
+
+- [ ] **Step 5: Verify green:** `pnpm --filter @dawn-ai/testing build && pnpm --filter @dawn-ai/testing test -- workspace-harness && pnpm --filter @dawn-ai/testing lint`. Then `pnpm -r build && pnpm -r --if-present typecheck`.
+
+- [ ] **Step 6: Commit:**
+```bash
+git add packages/testing/package.json packages/testing/src/workspace-harness.ts packages/testing/src/index.ts packages/testing/test/workspace-harness.test.ts pnpm-lock.yaml
+git commit -m "feat(testing): createWorkspaceHarness — real WorkspaceFs over a temp dir"
+```
+
+### Task W2: `createToolHarness` (TDD)
+
+**Files:**
+- Create: `packages/testing/src/tool-harness.ts`
+- Modify: `packages/testing/src/index.ts`
+- Test: `packages/testing/test/tool-harness.test.ts` (create)
+
+- [ ] **Step 1: Write the failing tests:**
+
+```ts
+import { afterEach, expect, it } from "vitest"
+import type { DawnToolContext } from "@dawn-ai/sdk"
+import { createToolHarness, type ToolHarness } from "../src/tool-harness.js"
+import { createWorkspaceHarness } from "../src/workspace-harness.js"
+
+const open: Array<{ close(): Promise<void> }> = []
+afterEach(async () => {
+  await Promise.all(open.splice(0).map((h) => h.close()))
+})
+
+// fixture tool: writes a note, returns count of notes/
+const stash = async (input: { name: string }, ctx: DawnToolContext) => {
+  await ctx.fs.writeFile(`notes/${input.name}.md`, `# ${input.name}`)
+  return { count: (await ctx.fs.listDir("notes")).length }
+}
+
+it("invokes a ctx.fs tool and exposes its workspace side effects", async () => {
+  const h = await createToolHarness(stash)
+  open.push(h)
+  const result = await h.invoke({ name: "alpha" })
+  expect(result).toEqual({ count: 1 })
+  expect(await h.workspace.read("notes/alpha.md")).toContain("# alpha")
+})
+
+it("invoke() is reusable and accumulates workspace state", async () => {
+  const h = await createToolHarness(stash)
+  open.push(h)
+  await h.invoke({ name: "a" })
+  expect(await h.invoke({ name: "b" })).toEqual({ count: 2 })
+})
+
+it("passes the middleware bag to ctx.middleware", async () => {
+  let seen: unknown
+  const tool = async (_input: unknown, ctx: DawnToolContext) => {
+    seen = ctx.middleware
+    return "ok"
+  }
+  const h = await createToolHarness(tool, { middleware: { userId: "u1" } })
+  open.push(h)
+  await h.invoke({})
+  expect(seen).toEqual({ userId: "u1" })
+})
+
+it("shares a passed-in workspace and does NOT close it", async () => {
+  const ws = await createWorkspaceHarness()
+  open.push(ws)
+  const h = await createToolHarness(stash, { workspace: ws })
+  await h.invoke({ name: "x" })
+  await h.close() // must NOT remove ws
+  expect(await ws.read("notes/x.md")).toContain("# x")
+})
+```
+
+- [ ] **Step 2:** `pnpm --filter @dawn-ai/testing test -- tool-harness` → FAIL (module missing).
+
+- [ ] **Step 3: Implement `packages/testing/src/tool-harness.ts`:**
+
+```ts
+import type { DawnToolContext, WorkspaceFs } from "@dawn-ai/sdk"
+import type { PermissionsStore } from "@dawn-ai/permissions"
+import { createWorkspaceHarness, type WorkspaceHarness } from "./workspace-harness.js"
+
+export interface ToolHarness<I, O> {
+  invoke(input: I): Promise<O>
+  readonly workspace: WorkspaceHarness
+  close(): Promise<void>
+  [Symbol.asyncDispose](): Promise<void>
+}
+
+export interface ToolHarnessOptions {
+  readonly middleware?: Readonly<Record<string, unknown>>
+  readonly workspace?: WorkspaceHarness
+  readonly permissions?: PermissionsStore
+}
+
+export async function createToolHarness<I, O>(
+  tool: (input: I, ctx: DawnToolContext) => Promise<O> | O,
+  opts?: ToolHarnessOptions,
+): Promise<ToolHarness<I, O>> {
+  const ownsWorkspace = opts?.workspace === undefined
+  const workspace =
+    opts?.workspace ??
+    (await createWorkspaceHarness(opts?.permissions ? { permissions: opts.permissions } : undefined))
+  const controller = new AbortController()
+  const fs: WorkspaceFs = workspace.fs
+
+  const close = async (): Promise<void> => {
+    controller.abort()
+    if (ownsWorkspace) await workspace.close()
+  }
+
+  return {
+    async invoke(input) {
+      const ctx: DawnToolContext = {
+        signal: controller.signal,
+        fs,
+        ...(opts?.middleware ? { middleware: opts.middleware } : {}),
+      }
+      return await tool(input, ctx)
+    },
+    workspace,
+    close,
+    [Symbol.asyncDispose]: close,
+  }
+}
+```
+
+Export from `index.ts`.
+
+- [ ] **Step 4:** `pnpm --filter @dawn-ai/testing build && pnpm --filter @dawn-ai/testing test -- tool-harness && pnpm --filter @dawn-ai/testing lint`. Then `pnpm -r --if-present typecheck`.
+
+- [ ] **Step 5: Commit:**
+```bash
+git add packages/testing/src/tool-harness.ts packages/testing/src/index.ts packages/testing/test/tool-harness.test.ts
+git commit -m "feat(testing): createToolHarness — invoke a route tool against a real ctx.fs"
+```
+
+### Task W3: `createMiddlewareHarness` (TDD)
+
+**Files:**
+- Create: `packages/testing/src/middleware-harness.ts`
+- Modify: `packages/testing/src/index.ts`
+- Test: `packages/testing/test/middleware-harness.test.ts` (create)
+
+- [ ] **Step 1: Write the failing tests:**
+
+```ts
+import { afterEach, expect, it } from "vitest"
+import type { BackendContext, FilesystemBackend, FilesystemMiddleware } from "@dawn-ai/workspace"
+import { createMiddlewareHarness, type MiddlewareHarness } from "../src/middleware-harness.js"
+
+const open: MiddlewareHarness[] = []
+afterEach(async () => {
+  await Promise.all(open.splice(0).map((h) => h.close()))
+})
+
+// a complete logging middleware that forwards every method (incl. realPath)
+const withLog = (log: string[]): FilesystemMiddleware => (next) => ({
+  readFile: (p, c, o) => { log.push(`read ${p}`); return next.readFile(p, c, o) },
+  writeFile: (p, content, c) => { log.push(`write ${p}`); return next.writeFile(p, content, c) },
+  listDir: (p, c) => next.listDir(p, c),
+  realPath: (p, c) => next.realPath(p, c),
+  ...(next.readBinaryFile && { readBinaryFile: (p, c, o) => next.readBinaryFile!(p, c, o) }),
+  ...(next.statFile && { statFile: (p, c) => next.statFile!(p, c) }),
+  ...(next.removeFile && { removeFile: (p, c) => next.removeFile!(p, c) }),
+  ...(next.touchFile && { touchFile: (p, c) => next.touchFile!(p, c) }),
+  ...(next.mkdir && { mkdir: (p, c) => next.mkdir!(p, c) }),
+})
+
+it("composes the middleware over a temp backend and records calls while serving I/O", async () => {
+  const log: string[] = []
+  const h = await createMiddlewareHarness(withLog(log))
+  open.push(h)
+  const file = join(h.dir, "a.md")
+  await h.backend.writeFile(file, "hi", h.ctx)
+  expect(await h.backend.readFile(file, h.ctx)).toBe("hi")
+  expect(log).toEqual([`write ${file}`, `read ${file}`])
+})
+
+it("assertForwardsAll passes for a complete middleware", async () => {
+  const h = await createMiddlewareHarness(withLog([]))
+  open.push(h)
+  expect(() => h.assertForwardsAll()).not.toThrow()
+})
+
+it("assertForwardsAll throws for a middleware that drops realPath", async () => {
+  const incomplete: FilesystemMiddleware = (next) => ({
+    readFile: next.readFile,
+    writeFile: next.writeFile,
+    listDir: next.listDir,
+    // realPath omitted (the #207-class bug; realPath is required)
+  }) as unknown as FilesystemBackend
+  const h = await createMiddlewareHarness(incomplete)
+  open.push(h)
+  expect(() => h.assertForwardsAll()).toThrow(/realPath/)
+})
+```
+
+(Add `import { join } from "node:path"`.)
+
+- [ ] **Step 2:** `pnpm --filter @dawn-ai/testing test -- middleware-harness` → FAIL.
+
+- [ ] **Step 3: Implement `packages/testing/src/middleware-harness.ts`:**
+
+```ts
+import { mkdtemp, rm } from "node:fs/promises"
+import { realpathSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import type {
+  BackendContext,
+  FilesystemBackend,
+  FilesystemMiddleware,
+} from "@dawn-ai/workspace"
+import { localFilesystem } from "@dawn-ai/workspace"
+
+export interface MiddlewareHarness {
+  readonly backend: FilesystemBackend
+  readonly ctx: BackendContext
+  readonly dir: string
+  assertForwardsAll(): void
+  close(): Promise<void>
+  [Symbol.asyncDispose](): Promise<void>
+}
+
+export async function createMiddlewareHarness(
+  middleware: FilesystemMiddleware,
+): Promise<MiddlewareHarness> {
+  const dir = realpathSync(await mkdtemp(join(tmpdir(), "dawn-mw-harness-")))
+  const base = localFilesystem()
+  const backend = middleware(base)
+  const controller = new AbortController()
+  const ctx: BackendContext = { signal: controller.signal, workspaceRoot: dir }
+
+  let closed = false
+  const close = async (): Promise<void> => {
+    if (closed) return
+    closed = true
+    controller.abort()
+    await rm(dir, { force: true, recursive: true })
+  }
+
+  return {
+    backend,
+    ctx,
+    dir,
+    assertForwardsAll() {
+      const missing = (Object.keys(base) as Array<keyof FilesystemBackend>).filter(
+        (method) => typeof base[method] === "function" && typeof backend[method] !== "function",
+      )
+      if (missing.length > 0) {
+        throw new Error(
+          `Middleware dropped backend method(s) the base provides: ${missing.join(", ")}. ` +
+            "A FilesystemMiddleware must forward every method (required and optional) it does not intercept.",
+        )
+      }
+    },
+    close,
+    [Symbol.asyncDispose]: close,
+  }
+}
+```
+
+(Note: `Object.keys(localFilesystem())` enumerates the methods the base actually implements — `realPath`, `readBinaryFile`, `statFile`, etc. — so `assertForwardsAll` catches any the middleware fails to forward. Verify `localFilesystem()` returns a plain object whose own keys are the methods; if it uses a prototype/class, adjust to enumerate accordingly.)
+
+Export from `index.ts`.
+
+- [ ] **Step 4:** `pnpm --filter @dawn-ai/testing build && pnpm --filter @dawn-ai/testing test -- middleware-harness && pnpm --filter @dawn-ai/testing lint`. Then `pnpm -r --if-present typecheck`.
+
+- [ ] **Step 5: Commit:**
+```bash
+git add packages/testing/src/middleware-harness.ts packages/testing/src/index.ts packages/testing/test/middleware-harness.test.ts
+git commit -m "feat(testing): createMiddlewareHarness — exercise a FilesystemMiddleware + assertForwardsAll"
+```
+
+### Task W4: docs + changeset + full verification + PR
+
+**Files:**
+- Modify: `apps/web/content/docs/testing.mdx`
+- Create: `.changeset/testing-unit-harnesses.md`
+
+- [ ] **Step 1: Docs.** Add a **"Unit-testing tools and middleware"** section to `apps/web/content/docs/testing.mdx` (place it after the scenario content, before "Related" — read the file to match heading style). Cover the three harnesses with short examples: `createToolHarness` invoking a `ctx.fs` tool and asserting `workspace.read(...)`; `createWorkspaceHarness` for testing `ctx.fs` code directly; `createMiddlewareHarness` + `assertForwardsAll()`. Show both `afterEach(() => h.close())` and `await using` patterns. Note these complement (don't replace) the scenario harness. Build docs: `pnpm --filter @dawn-ai/web build` (revert `apps/web/next-env.d.ts` churn).
+
+- [ ] **Step 2: Changeset** `.changeset/testing-unit-harnesses.md`:
+
+```md
+---
+"@dawn-ai/testing": minor
+---
+
+Unit-test harnesses for tools, middleware, and the workspace. `createToolHarness(tool)` invokes a route tool against a real, temp-backed `ctx.fs` (reusable `invoke()` for cumulative-state assertions); `createMiddlewareHarness(mw)` exercises a `FilesystemMiddleware` over a temp `localFilesystem` and offers `assertForwardsAll()` to catch dropped backend methods; `createWorkspaceHarness()` is the shared temp-`WorkspaceFs` fixture, also usable to test `ctx.fs` code directly. All are async `create*Harness` factories with `.close()` and `[Symbol.asyncDispose]` (for `await using`), matching `createAgentHarness`. Adds `@dawn-ai/workspace` and `@dawn-ai/sdk` as peer dependencies.
+```
+
+- [ ] **Step 3: Full verification (report each):**
+```
+pnpm -r build
+pnpm -r --if-present typecheck
+pnpm --filter @dawn-ai/testing test
+pnpm --filter @dawn-ai/testing lint
+pnpm --filter @dawn-ai/web build
+```
+Expected green. Revert any `next-env.d.ts` churn.
+
+- [ ] **Step 4: Commit, push, PR:**
+```bash
+git add apps/web/content/docs/testing.mdx .changeset/testing-unit-harnesses.md
+git commit -m "docs: unit-testing tools and middleware; changeset"
+git push -u origin feat/testing-unit-harnesses
+gh pr create --base main --title "feat(testing): unit harnesses for tools, middleware, and the workspace" \
+  --body "Backlog #6. Spec: docs/superpowers/specs/2026-06-16-testing-unit-harnesses-design.md. createWorkspaceHarness / createToolHarness / createMiddlewareHarness — async create*Harness factories (close() + Symbol.asyncDispose) that test tools/middleware against the real WorkspaceFs/backend over a temp dir."
+```
+Then enable auto-merge: `gh pr merge feat/testing-unit-harnesses --auto --squash` (report outcome).

--- a/docs/superpowers/specs/2026-06-16-testing-unit-harnesses-design.md
+++ b/docs/superpowers/specs/2026-06-16-testing-unit-harnesses-design.md
@@ -1,0 +1,142 @@
+# Unit-test harnesses for tools, middleware, and the workspace (Design)
+
+**Status:** Approved for planning
+**Date:** 2026-06-16
+**Roadmap:** Dogfooding-friction backlog item #6 (tool/middleware unit-testing ergonomics). Audited 2026-06-16: `@dawn-ai/testing` today is entirely full-agent/scenario oriented (`createAgentHarness`, aimock, fixtures, Agent-Protocol HTTP injection, scenario matchers) with **no** way to unit-test a single route tool or a `FilesystemMiddleware` in isolation, and zero `WorkspaceFs`/`ctx.fs` awareness. The `ctx.fs` work (PR #213) made this worse: a tool that calls `ctx.fs.*` can't be unit-tested without hand-assembling a `DawnToolContext` with a real `WorkspaceFs`.
+
+## Problem
+
+To unit-test a `ctx.fs`-using tool today, an author must hand-build the context — ~15 lines reaching into two packages, knowing `createWorkspaceFs`'s exact option shape, and realpath'ing the temp root (or the symlink-hardened gate misclassifies it on macOS `/var`):
+
+```ts
+const workspaceRoot = realpathSync(mkdirSync(join(mkdtempSync(...), "workspace"), ...))
+const fs = createWorkspaceFs({ workspaceRoot, backend: localFilesystem(), permissions: undefined, signal, interruptCapable: false })
+const result = await myTool({ ... }, { signal, fs })
+// ...assert via node:fs against workspaceRoot, then rmSync
+```
+
+This is the exact friction #6 names — the original consumer "factored logic into plain exported functions" to dodge it, losing coverage of the real tool contract and its fs integration. `FilesystemMiddleware` has the same setup cost plus a sharper edge: a middleware must re-forward *all* backend methods (the PR #207 footgun — dropping optional methods silently disabled offload GC; `realPath` is now required too), and nothing helps verify that.
+
+## Decisions (from brainstorming)
+
+- **Ship all three helpers**, sharing one workspace fixture underneath: `createWorkspaceHarness`, `createToolHarness`, `createMiddlewareHarness`.
+- **Naming + lifecycle match the existing `createAgentHarness` convention**: async `create*Harness(opts): Promise<Handle>` factories, teardown via `.close()`. Additionally implement `[Symbol.asyncDispose]` (delegating to `close()`) so `await using` works — without breaking the documented `afterEach(() => h.close())` norm.
+- **`createToolHarness` exposes a reusable `invoke()`** (not a one-shot) so a test can call the tool repeatedly against one shared workspace and assert cumulative state — matching the stateful-harness model.
+- **Permissions default permissive** (`permissions: undefined` → `createWorkspaceFs` allows all), with an opt-in to inject a real store/mode for tests that exercise allow/deny/fail-closed gating.
+- **Test against the real `WorkspaceFs`/backend, not a fake** — real gating, realpath, parent-dir creation, and byte caps, exactly as in production. The value is fidelity.
+- **No back-compat constraint** (pre-1.0, fixed versioning) — drive for the cleanest surface.
+- **Deferred to a subsequent DX-audit phase** (recorded as a follow-up, NOT this PR): unify teardown/`[Symbol.asyncDispose]` across `createAgentHarness`/`startAimock`/`startSubprocessApp`, and review naming coherence (`start*` vs `create*`, `.stop()` vs `.close()`, `injectAgentProtocol`).
+
+## Verified facts (against main @ `8a2ab0b`)
+
+- `@dawn-ai/testing` exports only full-agent helpers (`index.ts`): `createAgentHarness` (→ handle with `close(): Promise<void>`), `startAimock`/`startSubprocessApp` (→ `.stop()`), `injectAgentProtocol`, `script`/`record`/`loadFixtures`/`writeFixtures`, `expect*` matchers. Teardown is manual (`afterAll(() => h.close())`). No `using`/`Symbol.asyncDispose` anywhere.
+- `@dawn-ai/testing` `package.json`: deps `@copilotkit/aimock`, `light-my-request`; **peerDependencies `@dawn-ai/cli`, `@dawn-ai/core`** (so it can already import `createWorkspaceFs`). `@dawn-ai/workspace` is NOT yet a dep — must be added (for `localFilesystem`).
+- `@dawn-ai/core` exports `createWorkspaceFs` (`index.ts:26`). Its options: `{ workspaceRoot: string; backend: FilesystemBackend; permissions: PermissionsStore | undefined; signal: AbortSignal; interruptCapable: boolean }` (`workspace-fs.ts`).
+- `@dawn-ai/sdk` exports `WorkspaceFs` and `DawnToolContext` (`{ signal; middleware?; fs }`).
+- `@dawn-ai/workspace` exports `localFilesystem`, `compose`, and the `FilesystemBackend` / `FilesystemMiddleware` / `BackendContext` types; `FilesystemBackend` requires `readFile`/`readBinaryFile?`... and (post-PR #225) a required `realPath`.
+- testing.mdx documents only scenario testing; "Mocking tools" is explicitly a tracked follow-up (a *different* concern — mocking tools the LLM calls, vs unit-testing your own tool).
+
+## Design
+
+All three live in `@dawn-ai/testing`, each in its own `src/*.ts`, exported from `index.ts`.
+
+### 1. `createWorkspaceHarness(opts?)` — shared fixture (`src/workspace-harness.ts`)
+
+```ts
+export interface WorkspaceHarness {
+  /** Real WorkspaceFs (via @dawn-ai/core createWorkspaceFs) over a temp dir. */
+  readonly fs: WorkspaceFs
+  /** The realpath'd temp workspace root. */
+  readonly dir: string
+  /** Read a workspace-relative file (assert side effects). */
+  read(path: string): Promise<string>
+  /** Seed a workspace-relative file (inputs). Creates parent dirs. */
+  write(path: string, content: string): Promise<void>
+  close(): Promise<void>
+  [Symbol.asyncDispose](): Promise<void>
+}
+
+export interface WorkspaceHarnessOptions {
+  /** Inject a permissions store to exercise gating. Default: undefined (permissive). */
+  readonly permissions?: PermissionsStore
+}
+
+export function createWorkspaceHarness(opts?: WorkspaceHarnessOptions): Promise<WorkspaceHarness>
+```
+
+Implementation: `mkdtemp` a temp dir, create `<temp>/workspace`, `realpathSync` it (symlink-hardening: the gate canonicalizes the root, so the harness root must be canonical or inside-paths misclassify), build `fs` via `createWorkspaceFs({ workspaceRoot, backend: localFilesystem(), permissions: opts?.permissions, signal: <harness AbortController>.signal, interruptCapable: false })`. `read`/`write` resolve against `dir` via `node:fs/promises` (write creates parents). `close()` aborts the signal and `rm`'s the temp dir (idempotent); `[Symbol.asyncDispose]` calls `close()`.
+
+### 2. `createToolHarness(tool, opts?)` (`src/tool-harness.ts`)
+
+```ts
+export interface ToolHarness<I, O> {
+  /** Invoke the tool with a fresh DawnToolContext; reusable across calls (shared workspace). */
+  invoke(input: I): Promise<O>
+  readonly workspace: WorkspaceHarness
+  close(): Promise<void>
+  [Symbol.asyncDispose](): Promise<void>
+}
+
+export interface ToolHarnessOptions {
+  readonly middleware?: Readonly<Record<string, unknown>>
+  readonly workspace?: WorkspaceHarness   // share an existing one; else a fresh harness is created+owned
+  readonly permissions?: PermissionsStore // ignored if `workspace` is provided
+}
+
+export function createToolHarness<I, O>(
+  tool: (input: I, ctx: DawnToolContext) => Promise<O> | O,
+  opts?: ToolHarnessOptions,
+): Promise<ToolHarness<I, O>>
+```
+
+`invoke(input)` calls `tool(input, { signal, ...(middleware ? { middleware } : {}), fs: workspace.fs })`. If `opts.workspace` is passed, the harness uses it and does NOT close it (caller owns it); otherwise it creates one and `close()` tears it down. A fresh `signal` per `invoke` (or one harness-level signal — implementer's call; harness-level is simpler and matches a single test's lifetime).
+
+### 3. `createMiddlewareHarness(middleware, opts?)` (`src/middleware-harness.ts`)
+
+```ts
+export interface MiddlewareHarness {
+  /** The middleware composed over a temp-backed localFilesystem. */
+  readonly backend: FilesystemBackend
+  /** BackendContext for backend calls: { signal, workspaceRoot: dir }. */
+  readonly ctx: BackendContext
+  readonly dir: string
+  /** Throws if the composed backend dropped any method the base backend provides
+      (the #207 footgun: middlewares must forward required + optional methods,
+      incl. the now-required realPath). */
+  assertForwardsAll(): void
+  close(): Promise<void>
+  [Symbol.asyncDispose](): Promise<void>
+}
+
+export function createMiddlewareHarness(
+  middleware: FilesystemMiddleware,
+  opts?: { readonly permissions?: PermissionsStore },
+): Promise<MiddlewareHarness>
+```
+
+Implementation: temp dir, `base = localFilesystem()`, `backend = middleware(base)`, `ctx = { signal, workspaceRoot: dir }`. `assertForwardsAll()` checks every method present on `base` is present (a function) on `backend` — catching a middleware that returns a partial object. (`permissions` is reserved for parity/future; the middleware operates on the raw backend, not the gate.)
+
+### Cross-cutting
+
+- `@dawn-ai/testing/package.json`: add `@dawn-ai/workspace` to `peerDependencies` (and devDependencies for the package's own build/tests). `@dawn-ai/sdk` may be needed for the `WorkspaceFs`/`DawnToolContext` types — add as a (type) peer/dev dep if not already resolvable transitively.
+- Export all three (+ their option/handle types) from `src/index.ts`.
+
+## Testing (the package's own suite, `packages/testing/test/`)
+
+- `workspace-harness.test.ts`: `write` then `fs.readFile` round-trips; `fs.writeFile` then `read` sees it; `dir` is realpath'd; `close()` removes the temp dir and is idempotent; `await using` auto-disposes (a scoped block leaves no temp dir); permissive default allows an outside-workspace read, and an injected non-interactive store makes it fail closed.
+- `tool-harness.test.ts`: a fixture tool that does `ctx.fs.writeFile` + `listDir` returns the expected result AND the file exists via `workspace.read`; `invoke()` twice accumulates state; a passed-in `workspace` is shared and NOT closed by the tool harness's `close()`; the `middleware` bag reaches `ctx.middleware`.
+- `middleware-harness.test.ts`: a logging middleware records calls and still serves reads/writes through the temp backend; `assertForwardsAll()` passes for `withFilesystemLogging` and **throws** for a deliberately-incomplete middleware that omits `realPath`.
+
+## Docs
+
+Add a **"Unit-testing tools and middleware"** section to `apps/web/content/docs/testing.mdx`: the three harnesses, the `await using` vs `afterEach(close)` patterns, and a `ctx.fs` tool example. Note it complements (doesn't replace) the scenario harness.
+
+## Changeset
+
+`@dawn-ai/testing` minor (new harnesses + the `@dawn-ai/workspace` peer dep). Fixed versioning bumps all `@dawn-ai/*` together.
+
+## Out of scope / follow-ups
+
+- **DX-audit phase**: unify teardown + `[Symbol.asyncDispose]` across `createAgentHarness`/`startAimock`/`startSubprocessApp`; review `start*` vs `create*` and `.stop()` vs `.close()` naming coherence.
+- A one-shot `invokeTool(fn, input)` convenience wrapper over `createToolHarness` — only if demand appears.
+- Per-scenario tool *mocking* (the existing testing.mdx follow-up) — unrelated to this item.

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -41,13 +41,17 @@
   },
   "peerDependencies": {
     "@dawn-ai/cli": "workspace:*",
-    "@dawn-ai/core": "workspace:*"
+    "@dawn-ai/core": "workspace:*",
+    "@dawn-ai/sdk": "workspace:*",
+    "@dawn-ai/workspace": "workspace:*"
   },
   "devDependencies": {
     "@dawn-ai/cli": "workspace:*",
     "@dawn-ai/config-typescript": "workspace:*",
     "@dawn-ai/core": "workspace:*",
+    "@dawn-ai/permissions": "workspace:*",
     "@dawn-ai/sdk": "workspace:*",
+    "@dawn-ai/workspace": "workspace:*",
     "@langchain/langgraph-checkpoint": "^1.0.2",
     "@types/node": "25.6.0"
   }

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -32,6 +32,10 @@ export {
   type SubagentRun,
   type Todo,
 } from "./matchers.js"
+export {
+  createMiddlewareHarness,
+  type MiddlewareHarness,
+} from "./middleware-harness.js"
 export { type RecordOptions, record } from "./record.js"
 export {
   type AgentRunResult,

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -41,3 +41,8 @@ export {
   type ObservedToolResult,
 } from "./run-result.js"
 export { type SubprocessApp, startSubprocessApp } from "./subprocess.js"
+export {
+  createWorkspaceHarness,
+  type WorkspaceHarness,
+  type WorkspaceHarnessOptions,
+} from "./workspace-harness.js"

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -42,6 +42,11 @@ export {
 } from "./run-result.js"
 export { type SubprocessApp, startSubprocessApp } from "./subprocess.js"
 export {
+  createToolHarness,
+  type ToolHarness,
+  type ToolHarnessOptions,
+} from "./tool-harness.js"
+export {
   createWorkspaceHarness,
   type WorkspaceHarness,
   type WorkspaceHarnessOptions,

--- a/packages/testing/src/middleware-harness.ts
+++ b/packages/testing/src/middleware-harness.ts
@@ -1,0 +1,53 @@
+import { realpathSync } from "node:fs"
+import { mkdtemp, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import type { BackendContext, FilesystemBackend, FilesystemMiddleware } from "@dawn-ai/workspace"
+import { localFilesystem } from "@dawn-ai/workspace"
+
+export interface MiddlewareHarness {
+  readonly backend: FilesystemBackend
+  readonly ctx: BackendContext
+  readonly dir: string
+  assertForwardsAll(): void
+  close(): Promise<void>
+  [Symbol.asyncDispose](): Promise<void>
+}
+
+export async function createMiddlewareHarness(
+  middleware: FilesystemMiddleware,
+): Promise<MiddlewareHarness> {
+  const dir = realpathSync(await mkdtemp(join(tmpdir(), "dawn-mw-harness-")))
+  const base = localFilesystem()
+  const backend = middleware(base)
+  const controller = new AbortController()
+  const ctx: BackendContext = { signal: controller.signal, workspaceRoot: dir }
+
+  let closed = false
+  const close = async (): Promise<void> => {
+    if (closed) return
+    closed = true
+    controller.abort()
+    await rm(dir, { force: true, recursive: true })
+  }
+
+  return {
+    backend,
+    ctx,
+    dir,
+    assertForwardsAll() {
+      const baseMethods = Object.keys(base) as Array<keyof FilesystemBackend>
+      const missing = baseMethods.filter(
+        (method) => typeof base[method] === "function" && typeof backend[method] !== "function",
+      )
+      if (missing.length > 0) {
+        throw new Error(
+          `Middleware dropped backend method(s) the base provides: ${missing.join(", ")}. ` +
+            "A FilesystemMiddleware must forward every method (required and optional) it does not intercept.",
+        )
+      }
+    },
+    close,
+    [Symbol.asyncDispose]: close,
+  }
+}

--- a/packages/testing/src/tool-harness.ts
+++ b/packages/testing/src/tool-harness.ts
@@ -1,0 +1,48 @@
+import type { PermissionsStore } from "@dawn-ai/permissions"
+import type { DawnToolContext } from "@dawn-ai/sdk"
+import { createWorkspaceHarness, type WorkspaceHarness } from "./workspace-harness.js"
+
+export interface ToolHarness<I, O> {
+  invoke(input: I): Promise<O>
+  readonly workspace: WorkspaceHarness
+  close(): Promise<void>
+  [Symbol.asyncDispose](): Promise<void>
+}
+
+export interface ToolHarnessOptions {
+  readonly middleware?: Readonly<Record<string, unknown>>
+  readonly workspace?: WorkspaceHarness
+  readonly permissions?: PermissionsStore
+}
+
+export async function createToolHarness<I, O>(
+  tool: (input: I, ctx: DawnToolContext) => Promise<O> | O,
+  opts?: ToolHarnessOptions,
+): Promise<ToolHarness<I, O>> {
+  const ownsWorkspace = opts?.workspace === undefined
+  const workspace =
+    opts?.workspace ??
+    (await createWorkspaceHarness(
+      opts?.permissions ? { permissions: opts.permissions } : undefined,
+    ))
+  const controller = new AbortController()
+
+  const close = async (): Promise<void> => {
+    controller.abort()
+    if (ownsWorkspace) await workspace.close()
+  }
+
+  return {
+    async invoke(input) {
+      const ctx: DawnToolContext = {
+        signal: controller.signal,
+        fs: workspace.fs,
+        ...(opts?.middleware ? { middleware: opts.middleware } : {}),
+      }
+      return await tool(input, ctx)
+    },
+    workspace,
+    close,
+    [Symbol.asyncDispose]: close,
+  }
+}

--- a/packages/testing/src/workspace-harness.ts
+++ b/packages/testing/src/workspace-harness.ts
@@ -1,0 +1,62 @@
+import { realpathSync } from "node:fs"
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { dirname, join } from "node:path"
+import { createWorkspaceFs } from "@dawn-ai/core"
+import type { PermissionsStore } from "@dawn-ai/permissions"
+import type { WorkspaceFs } from "@dawn-ai/sdk"
+import { localFilesystem } from "@dawn-ai/workspace"
+
+export interface WorkspaceHarness {
+  readonly fs: WorkspaceFs
+  readonly dir: string
+  read(path: string): Promise<string>
+  write(path: string, content: string): Promise<void>
+  close(): Promise<void>
+  [Symbol.asyncDispose](): Promise<void>
+}
+
+export interface WorkspaceHarnessOptions {
+  readonly permissions?: PermissionsStore
+}
+
+export async function createWorkspaceHarness(
+  opts?: WorkspaceHarnessOptions,
+): Promise<WorkspaceHarness> {
+  const root = await mkdtemp(join(tmpdir(), "dawn-ws-harness-"))
+  const workspaceRoot = join(root, "workspace")
+  await mkdir(workspaceRoot, { recursive: true })
+  // Gate canonicalizes the root; realpath so inside-paths classify correctly.
+  const canonicalRoot = realpathSync(workspaceRoot)
+  const controller = new AbortController()
+  const fs = createWorkspaceFs({
+    workspaceRoot: canonicalRoot,
+    backend: localFilesystem(),
+    permissions: opts?.permissions,
+    signal: controller.signal,
+    interruptCapable: false,
+  })
+
+  let closed = false
+  const close = async (): Promise<void> => {
+    if (closed) return
+    closed = true
+    controller.abort()
+    await rm(root, { force: true, recursive: true })
+  }
+
+  return {
+    fs,
+    dir: canonicalRoot,
+    async read(path) {
+      return await readFile(join(canonicalRoot, path), "utf8")
+    },
+    async write(path, content) {
+      const abs = join(canonicalRoot, path)
+      await mkdir(dirname(abs), { recursive: true })
+      await writeFile(abs, content, "utf8")
+    },
+    close,
+    [Symbol.asyncDispose]: close,
+  }
+}

--- a/packages/testing/test/middleware-harness.test.ts
+++ b/packages/testing/test/middleware-harness.test.ts
@@ -1,0 +1,58 @@
+import { join } from "node:path"
+import type { FilesystemBackend, FilesystemMiddleware } from "@dawn-ai/workspace"
+import { afterEach, expect, it } from "vitest"
+import { createMiddlewareHarness, type MiddlewareHarness } from "../src/middleware-harness.js"
+
+const open: MiddlewareHarness[] = []
+afterEach(async () => {
+  await Promise.all(open.splice(0).map((h) => h.close()))
+})
+
+const withLog =
+  (log: string[]): FilesystemMiddleware =>
+  (next) => ({
+    readFile: (p, c, o) => {
+      log.push(`read ${p}`)
+      return next.readFile(p, c, o)
+    },
+    writeFile: (p, content, c) => {
+      log.push(`write ${p}`)
+      return next.writeFile(p, content, c)
+    },
+    listDir: (p, c) => next.listDir(p, c),
+    realPath: (p, c) => next.realPath(p, c),
+    ...(next.readBinaryFile && { readBinaryFile: next.readBinaryFile.bind(next) }),
+    ...(next.statFile && { statFile: next.statFile.bind(next) }),
+    ...(next.removeFile && { removeFile: next.removeFile.bind(next) }),
+    ...(next.touchFile && { touchFile: next.touchFile.bind(next) }),
+    ...(next.mkdir && { mkdir: next.mkdir.bind(next) }),
+  })
+
+it("composes the middleware over a temp backend and records calls while serving I/O", async () => {
+  const log: string[] = []
+  const h = await createMiddlewareHarness(withLog(log))
+  open.push(h)
+  const file = join(h.dir, "a.md")
+  await h.backend.writeFile(file, "hi", h.ctx)
+  expect(await h.backend.readFile(file, h.ctx)).toBe("hi")
+  expect(log).toEqual([`write ${file}`, `read ${file}`])
+})
+
+it("assertForwardsAll passes for a complete middleware", async () => {
+  const h = await createMiddlewareHarness(withLog([]))
+  open.push(h)
+  expect(() => h.assertForwardsAll()).not.toThrow()
+})
+
+it("assertForwardsAll throws for a middleware that drops realPath", async () => {
+  const incomplete: FilesystemMiddleware = (next) =>
+    ({
+      readFile: next.readFile,
+      writeFile: next.writeFile,
+      listDir: next.listDir,
+      // realPath (and the optional methods) omitted
+    }) as unknown as FilesystemBackend
+  const h = await createMiddlewareHarness(incomplete)
+  open.push(h)
+  expect(() => h.assertForwardsAll()).toThrow(/realPath/)
+})

--- a/packages/testing/test/tool-harness.test.ts
+++ b/packages/testing/test/tool-harness.test.ts
@@ -1,0 +1,50 @@
+import type { DawnToolContext } from "@dawn-ai/sdk"
+import { afterEach, expect, it } from "vitest"
+import { createToolHarness } from "../src/tool-harness.js"
+import { createWorkspaceHarness } from "../src/workspace-harness.js"
+
+const open: Array<{ close(): Promise<void> }> = []
+afterEach(async () => {
+  await Promise.all(open.splice(0).map((h) => h.close()))
+})
+
+const stash = async (input: { name: string }, ctx: DawnToolContext) => {
+  await ctx.fs.writeFile(`notes/${input.name}.md`, `# ${input.name}`)
+  return { count: (await ctx.fs.listDir("notes")).length }
+}
+
+it("invokes a ctx.fs tool and exposes its workspace side effects", async () => {
+  const h = await createToolHarness(stash)
+  open.push(h)
+  const result = await h.invoke({ name: "alpha" })
+  expect(result).toEqual({ count: 1 })
+  expect(await h.workspace.read("notes/alpha.md")).toContain("# alpha")
+})
+
+it("invoke() is reusable and accumulates workspace state", async () => {
+  const h = await createToolHarness(stash)
+  open.push(h)
+  await h.invoke({ name: "a" })
+  expect(await h.invoke({ name: "b" })).toEqual({ count: 2 })
+})
+
+it("passes the middleware bag to ctx.middleware", async () => {
+  let seen: unknown
+  const tool = async (_input: unknown, ctx: DawnToolContext) => {
+    seen = ctx.middleware
+    return "ok"
+  }
+  const h = await createToolHarness(tool, { middleware: { userId: "u1" } })
+  open.push(h)
+  await h.invoke({})
+  expect(seen).toEqual({ userId: "u1" })
+})
+
+it("shares a passed-in workspace and does NOT close it", async () => {
+  const ws = await createWorkspaceHarness()
+  open.push(ws)
+  const h = await createToolHarness(stash, { workspace: ws })
+  await h.invoke({ name: "x" })
+  await h.close() // must NOT remove ws
+  expect(await ws.read("notes/x.md")).toContain("# x")
+})

--- a/packages/testing/test/workspace-harness.test.ts
+++ b/packages/testing/test/workspace-harness.test.ts
@@ -1,0 +1,61 @@
+import { existsSync, realpathSync } from "node:fs"
+import { createPermissionsStore } from "@dawn-ai/permissions"
+import { afterEach, expect, it } from "vitest"
+import { createWorkspaceHarness, type WorkspaceHarness } from "../src/workspace-harness.js"
+
+const open: WorkspaceHarness[] = []
+afterEach(async () => {
+  await Promise.all(open.splice(0).map((h) => h.close()))
+})
+async function harness(...args: Parameters<typeof createWorkspaceHarness>) {
+  const h = await createWorkspaceHarness(...args)
+  open.push(h)
+  return h
+}
+
+it("round-trips write -> fs.readFile and fs.writeFile -> read", async () => {
+  const h = await harness()
+  await h.write("notes/seed.md", "hi")
+  expect(await h.fs.readFile("notes/seed.md")).toBe("hi")
+  await h.fs.writeFile("out/result.md", "done")
+  expect(await h.read("out/result.md")).toBe("done")
+})
+
+it("exposes a realpath'd workspace dir", async () => {
+  const h = await harness()
+  expect(h.dir).toBe(realpathSync(h.dir))
+})
+
+it("close() removes the temp dir and is idempotent", async () => {
+  const h = await createWorkspaceHarness()
+  const dir = h.dir
+  await h.close()
+  await h.close()
+  expect(existsSync(dir)).toBe(false)
+})
+
+it("supports `await using` auto-disposal", async () => {
+  let captured = ""
+  {
+    await using h = await createWorkspaceHarness()
+    captured = h.dir
+    expect(existsSync(captured)).toBe(true)
+  }
+  expect(existsSync(captured)).toBe(false)
+})
+
+it("is permissive by default (allows an outside-workspace read)", async () => {
+  const h = await harness()
+  await expect(h.fs.readFile("/etc/hosts")).resolves.toBeTypeOf("string")
+})
+
+it("fails closed for an outside path when a non-interactive store is injected", async () => {
+  const permissions = createPermissionsStore({
+    appRoot: process.cwd(),
+    config: undefined,
+    mode: "non-interactive",
+  })
+  await permissions.load()
+  const h = await harness({ permissions })
+  await expect(h.fs.readFile("/etc/hosts")).rejects.toThrow(/fail-closed/)
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -428,9 +428,15 @@ importers:
       '@dawn-ai/core':
         specifier: workspace:*
         version: link:../core
+      '@dawn-ai/permissions':
+        specifier: workspace:*
+        version: link:../permissions
       '@dawn-ai/sdk':
         specifier: workspace:*
         version: link:../sdk
+      '@dawn-ai/workspace':
+        specifier: workspace:*
+        version: link:../workspace
       '@langchain/langgraph-checkpoint':
         specifier: ^1.0.2
         version: 1.0.2(@langchain/core@1.1.47(openai@6.37.0(ws@8.20.1)(zod@4.4.3))(ws@8.20.1))


### PR DESCRIPTION
## Summary

Backlog #6 ([spec](docs/superpowers/specs/2026-06-16-testing-unit-harnesses-design.md)). `@dawn-ai/testing` was entirely full-agent/scenario oriented — no way to unit-test a single route tool or a `FilesystemMiddleware` in isolation, and (since `ctx.fs` shipped) a `ctx.fs`-using tool couldn't be tested without hand-assembling a `DawnToolContext` with a real `WorkspaceFs`. This adds three harnesses that test against the **real** `WorkspaceFs`/backend over a temp dir:

- **`createWorkspaceHarness()`** — the shared fixture: a real `WorkspaceFs` over a realpath'd temp dir, `read`/`write` helpers, permissive gating by default (inject a permissions store to exercise allow/deny/fail-closed).
- **`createToolHarness(tool)`** — builds the `DawnToolContext` and invokes the tool; reusable `invoke()` for cumulative-state assertions; share a workspace or let it own one.
- **`createMiddlewareHarness(mw)`** — composes a `FilesystemMiddleware` over a temp `localFilesystem`; `assertForwardsAll()` catches dropped backend methods (the #207 footgun; `realPath` is required).

All are async `create*Harness` factories with `.close()` + `[Symbol.asyncDispose]` (for `await using`), matching the existing `createAgentHarness` convention. Adds `@dawn-ai/workspace` + `@dawn-ai/sdk` peer deps.

A broader testing-API DX audit (unify teardown/`asyncDispose` across `createAgentHarness`/`startAimock`/`startSubprocessApp`, naming coherence) is deferred to a follow-up phase.

## Test plan

- [x] TDD throughout: workspace-harness (6), tool-harness (4), middleware-harness (3) — round-trips, `await using` auto-dispose, permissive vs fail-closed gating, reusable invoke accumulating state, shared-vs-owned workspace close semantics, assertForwardsAll catching a dropped `realPath`
- [x] `@dawn-ai/testing` 88 pass / 1 skip; `pnpm -r build` + typecheck clean; docs build; lint exit 0 (2 pre-existing warnings, untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)