### PR TITLE
docs(cli): invoke the dawn bin (monorepo invocation note)

### DIFF
--- a/.changeset/monorepo-dawn-invocation-docs.md
+++ b/.changeset/monorepo-dawn-invocation-docs.md
@@ -1,0 +1,4 @@
+---
+---
+
+Docs-only: add a "Running the CLI" note to the CLI reference — always invoke the `dawn` bin (`pnpm exec dawn …`), and in a hoisted monorepo don't point Node at `node_modules/@dawn-ai/cli/dist/index.js` directly (the cli hoists to the workspace root and the path won't resolve). No package changes.

--- a/apps/web/content/docs/cli.mdx
+++ b/apps/web/content/docs/cli.mdx
@@ -2,6 +2,14 @@
 
 Dawn ships a single `dawn` binary with nine commands: `build`, `check`, `dev`, `eval`, `routes`, `run`, `test`, `typegen`, and `verify`. Most commands read `dawn.config.ts` from the current working directory or from `--cwd <path>`; `dawn dev` currently uses the current working directory and exposes only its own server flags.
 
+## Running the CLI
+
+Always invoke Dawn through the `dawn` **bin** — `pnpm exec dawn <command>` (or `npx dawn …` / a `package.json` script). The bin is what `@dawn-ai/cli` installs into `node_modules/.bin`, and it resolves correctly regardless of where the package physically lives.
+
+<Callout type="warn" title="Monorepos: use the bin, not a direct path">
+  In an npm/pnpm-hoisted monorepo, `@dawn-ai/cli` typically hoists to the workspace root, so a hardcoded path like `node node_modules/@dawn-ai/cli/dist/index.js` from a sub-package will fail to resolve. Run `pnpm exec dawn …` (which finds the bin via the workspace's `node_modules/.bin`) instead of pointing Node at the package's `dist/` directly.
+</Callout>
+
 ## `dawn check`
 
 Validates the app structure and configuration.


### PR DESCRIPTION
## Summary

Backlog #7 (the last dogfooding-friction item). Documents how to invoke the CLI — always via the `dawn` **bin** (`pnpm exec dawn …`) — with a callout for the monorepo gotcha: in a hoisted workspace, `@dawn-ai/cli` lands at the root, so a hardcoded `node node_modules/@dawn-ai/cli/dist/index.js` from a sub-package fails to resolve. Adds a "Running the CLI" section to the CLI reference.

Docs-only; no package changes (empty changeset).

## Test plan
- [x] `pnpm --filter @dawn-ai/web build` — compiles, 54 pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)