### PR TITLE
refactor(testing): unify lifecycle API on create* + close()/asyncDispose

### DIFF
--- a/.changeset/testing-api-dx.md
+++ b/.changeset/testing-api-dx.md
@@ -1,0 +1,5 @@
+---
+"@dawn-ai/testing": minor
+---
+
+Consistent lifecycle API. Every harness/handle is now created with a `create*` factory and torn down with `close()` (plus `[Symbol.asyncDispose]`, so `await using` works everywhere). **Breaking renames:** `startAimock` → `createAimock` (type `AimockHandle` → `Aimock`, `.stop()` → `.close()`); `startSubprocessApp` → `createSubprocessApp` (`.stop()` → `.close()`); `injectAgentProtocol` → `createAgentProtocolInjector`. The `create*Harness` helpers and pure fixture functions are unchanged.

--- a/apps/web/content/docs/testing-agents.mdx
+++ b/apps/web/content/docs/testing-agents.mdx
@@ -151,10 +151,10 @@ Then hand-trim the JSON to keep only the turns that matter, commit it, and repla
 `createAgentHarness` supports three modes via the `mode` option (default: `"in-process"`):
 
 - **`"in-process"`** (default) — runs your tools, prompts, capabilities, and state inside the test process via Dawn's runtime. Fastest; covers the vast majority of assertions. No port binding.
-- **`"http-inject"`** — **not yet implemented**. Passing `mode: "http-inject"` throws at harness construction time. `injectAgentProtocol` is exported as a standalone helper for advanced use, but the harness `mode` option does not support it yet.
-- **`"subprocess"`** — **not yet implemented**. Passing `mode: "subprocess"` throws at harness construction time. `startSubprocessApp` is exported as a standalone helper for advanced use, but the harness `mode` option does not support it yet.
+- **`"http-inject"`** — **not yet implemented**. Passing `mode: "http-inject"` throws at harness construction time. `createAgentProtocolInjector` is exported as a standalone factory for advanced use, but the harness `mode` option does not support it yet.
+- **`"subprocess"`** — **not yet implemented**. Passing `mode: "subprocess"` throws at harness construction time. `createSubprocessApp` is exported as a standalone factory for advanced use, but the harness `mode` option does not support it yet.
 
-For now, write all harness tests with the default `"in-process"` mode. The standalone `injectAgentProtocol` and `startSubprocessApp` exports are available for custom orchestration outside the harness API.
+For now, write all harness tests with the default `"in-process"` mode. The standalone `createAgentProtocolInjector` and `createSubprocessApp` factories are available for custom orchestration outside the harness API.
 
 ## CI setup
 

--- a/apps/web/content/docs/testing.mdx
+++ b/apps/web/content/docs/testing.mdx
@@ -136,7 +136,7 @@ Use `dawn verify` as the integrity gate (it covers app, routes, typegen, and dep
 
 The scenario harness drives a whole route through the runtime. Sometimes you want to test one unit in isolation — a single route tool, a `FilesystemMiddleware`, or `ctx.fs`-using code — without standing up an agent. `@dawn-ai/testing` ships three harnesses for this. They run against the **real** `WorkspaceFs` and filesystem backend over a temp directory, so real permission gating, realpath resolution, and parent-directory creation all apply.
 
-All three are async `create*Harness` factories that return a handle with `.close()` and `[Symbol.asyncDispose]` — the same convention as `createAgentHarness`.
+All three are async `create*Harness` factories that return a handle with `.close()` and `[Symbol.asyncDispose]` — the same convention as `createAgentHarness`. Across `@dawn-ai/testing`, every harness/handle is created with a `create*` factory and torn down with `close()` (or `await using`).
 
 ### A tool that uses `ctx.fs`
 

--- a/docs/superpowers/plans/2026-06-17-testing-api-dx.md
+++ b/docs/superpowers/plans/2026-06-17-testing-api-dx.md
@@ -1,0 +1,116 @@
+# `@dawn-ai/testing` API Consistency Pass Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Unify `@dawn-ai/testing`'s lifecycle surface — one factory verb (`create*`), one teardown (`close()` + `[Symbol.asyncDispose]`) on every handle.
+
+**Architecture:** One PR off `feat/testing-api-dx` (spec: `docs/superpowers/specs/2026-06-17-testing-api-dx-design.md`). Mechanical renames + additive `[Symbol.asyncDispose]`, fully contained to `@dawn-ai/testing` (src + its own tests) and one docs file. No behavior change. Two tasks: X1 renames+dispose+tests (package green); X2 docs+changeset+PR.
+
+**Tech Stack:** TypeScript (no semicolons, double quotes, 2-space, ESM `.js` specifiers), pnpm, Vitest, Biome, changesets.
+
+**Conventions:** `pnpm -r build` once at start. Run `pnpm -r --if-present typecheck` before declaring done. `pyenv: cannot rehash` output is harmless noise. The renames break the package's own tests immediately, so src + tests are updated together in X1 to keep the package green.
+
+**The rename map (apply consistently):**
+| Old | New |
+|---|---|
+| `startAimock` | `createAimock` |
+| `AimockHandle` (type) | `Aimock` |
+| `AimockHandle.stop()` | `.close()` |
+| `startSubprocessApp` | `createSubprocessApp` |
+| `SubprocessApp.stop()` | `.close()` |
+| `injectAgentProtocol` | `createAgentProtocolInjector` |
+
+`SubprocessApp`, `AgentProtocolInjector`, `InjectResult`, `AgentHarness` type names unchanged. The `create*Harness` trio (workspace/tool/middleware) already conformant.
+
+**asyncDispose insertion pattern:** each lifecycle return-object is an object literal. Add this method (it references the object's own `close`):
+```ts
+[Symbol.asyncDispose](): Promise<void> {
+  return this.close()
+}
+```
+Add the matching `[Symbol.asyncDispose](): Promise<void>` line to each handle's exported interface.
+
+---
+
+### Task X1: renames + unified teardown + asyncDispose (package green)
+
+**Files (src):** `packages/testing/src/aimock-runner.ts`, `subprocess.ts`, `http-inject.ts`, `harness.ts`, `index.ts`
+**Files (tests):** `packages/testing/test/aimock-runner.test.ts`, `subprocess.test.ts`, `http-inject.test.ts`, `restart-persistence.test.ts` (+ any harness test that wants an `await using` assertion)
+
+- [ ] **Step 1 — `aimock-runner.ts`:**
+  - Rename the interface `AimockHandle` → `Aimock`; rename `startAimock` → `createAimock`.
+  - In the interface: rename `stop(): Promise<void>` → `close(): Promise<void>` and add `[Symbol.asyncDispose](): Promise<void>`.
+  - In the returned object (line ~38): rename `async stop()` → `async close()`, and add `[Symbol.asyncDispose](): Promise<void> { return this.close() }`.
+  - Internal note: the body that calls the underlying `mock.stop()` (the `@copilotkit/aimock` server's own stop) stays — only Dawn's wrapper method is renamed.
+
+- [ ] **Step 2 — `subprocess.ts`:**
+  - Rename `startSubprocessApp` → `createSubprocessApp`. Keep `SubprocessApp` type name.
+  - Interface: `stop()` → `close()`; add `[Symbol.asyncDispose](): Promise<void>`.
+  - Returned object (line ~97): `async stop()` → `async close()`; add the asyncDispose method.
+
+- [ ] **Step 3 — `http-inject.ts`:**
+  - Rename `injectAgentProtocol` → `createAgentProtocolInjector`. Keep `AgentProtocolInjector` / `InjectResult` type names.
+  - `AgentProtocolInjector` already has `close()`. Add `[Symbol.asyncDispose](): Promise<void>` to the interface and `[Symbol.asyncDispose](): Promise<void> { return this.close() }` to the returned object (line ~42). (The inner `return {` at line ~50 is the per-inject `InjectResult` — do NOT add dispose there; only the injector handle.)
+
+- [ ] **Step 4 — `harness.ts`:**
+  - `createAgentHarness` / `AgentHarness` names unchanged. Add `[Symbol.asyncDispose](): Promise<void>` to the `AgentHarness` interface and `[Symbol.asyncDispose](): Promise<void> { return this.close() }` to the returned object (near the `async close()` at line ~182).
+  - Update the two internal `aimock.stop()` calls (lines ~103, ~185) → `aimock.close()` (the wrapper method was renamed in Step 1).
+
+- [ ] **Step 5 — `index.ts`:** update the re-exports: `startAimock`→`createAimock`, type `AimockHandle`→`Aimock`; `injectAgentProtocol`→`createAgentProtocolInjector`; `startSubprocessApp`→`createSubprocessApp`. Keep `AgentProtocolInjector`/`InjectResult`/`SubprocessApp` type exports.
+
+- [ ] **Step 6 — update the package's own tests** to the new names + teardown:
+  - `aimock-runner.test.ts`: `startAimock`→`createAimock`, `.stop()`→`.close()`.
+  - `subprocess.test.ts`: `startSubprocessApp`→`createSubprocessApp`, `.stop()`→`.close()`.
+  - `http-inject.test.ts`: `injectAgentProtocol`→`createAgentProtocolInjector`.
+  - `restart-persistence.test.ts`: whichever of the above it uses.
+  - Grep the test dir for any remaining `startAimock|startSubprocessApp|injectAgentProtocol|AimockHandle|\.stop()` on these handles and fix all.
+
+- [ ] **Step 7 — add `await using` dispose coverage.** Add one assertion per newly-disposable handle proving `[Symbol.asyncDispose]` tears down (place in the most natural existing test file for each):
+  - `createAimock`: `await using m = await createAimock({ fixtures: [] })` in a block; after the block, the server URL is no longer reachable (a `fetch` rejects) — or simpler, assert no throw and that a second explicit `close()` is idempotent. Prefer the reachability check if cheap; else the idempotency assertion.
+  - `createSubprocessApp`: `await using` block; after exit, `app`'s process has exited (reuse whatever the existing stop test asserts).
+  - `createAgentProtocolInjector`: `await using` block; no throw + idempotent close.
+  - `createAgentHarness`: `await using h = await createAgentHarness({...})`; after the block, a follow-up `h.close()` (or aimock reachability) confirms closed. Mirror the existing `workspace-harness.test.ts` `await using` test.
+  - Keep these minimal — the dispose just delegates to `close()`; the point is proving the delegation is wired.
+
+- [ ] **Step 8 — verify:** `pnpm --filter @dawn-ai/testing build && pnpm --filter @dawn-ai/testing test && pnpm --filter @dawn-ai/testing lint`. Then `pnpm -r build && pnpm -r --if-present typecheck` (no other package consumes the renamed symbols, but confirm). All green; the only failures during iteration should be the renamed-symbol references you then fix.
+
+- [ ] **Step 9 — commit:**
+```bash
+git add packages/testing/src packages/testing/test
+git commit -m "refactor(testing): unify on create* factories + close()/asyncDispose"
+```
+
+### Task X2: docs + changeset + verification + PR
+
+**Files:** `apps/web/content/docs/testing-agents.mdx`, `apps/web/content/docs/testing.mdx` (conditional), `.changeset/testing-api-dx.md`
+
+- [ ] **Step 1 — docs renames.** In `apps/web/content/docs/testing-agents.mdx` (lines ~154-157): `injectAgentProtocol` → `createAgentProtocolInjector`, `startSubprocessApp` → `createSubprocessApp`. Grep `testing.mdx` for `startAimock`/`startSubprocessApp`/`injectAgentProtocol`; rename any hits to the new names. Optionally add a one-line convention note in testing.mdx: "Every harness/handle is `create*` and tears down with `close()` (or `await using`)." Build docs: `pnpm --filter @dawn-ai/web build` (revert `apps/web/next-env.d.ts` churn).
+
+- [ ] **Step 2 — changeset** `.changeset/testing-api-dx.md`:
+```md
+---
+"@dawn-ai/testing": minor
+---
+
+Consistent lifecycle API. Every harness/handle is now created with a `create*` factory and torn down with `close()` (plus `[Symbol.asyncDispose]`, so `await using` works everywhere). **Breaking renames:** `startAimock` → `createAimock` (type `AimockHandle` → `Aimock`, `.stop()` → `.close()`); `startSubprocessApp` → `createSubprocessApp` (`.stop()` → `.close()`); `injectAgentProtocol` → `createAgentProtocolInjector`. The `create*Harness` helpers and pure fixture functions are unchanged.
+```
+
+- [ ] **Step 3 — full verification (report each):**
+```
+pnpm -r build
+pnpm -r --if-present typecheck
+pnpm --filter @dawn-ai/testing test
+pnpm --filter @dawn-ai/testing lint
+pnpm --filter @dawn-ai/web build
+```
+All green; testing lint exit 0 (2 pre-existing warnings only). Revert `next-env.d.ts` churn.
+
+- [ ] **Step 4 — commit, push, PR:**
+```bash
+git add apps/web/content/docs/testing-agents.mdx apps/web/content/docs/testing.mdx .changeset/testing-api-dx.md
+git commit -m "docs: rename testing helpers to the create*/close convention; changeset"
+git push -u origin feat/testing-api-dx
+gh pr create --base main --title "refactor(testing): unify lifecycle API on create* + close()/asyncDispose" \
+  --body "DX-audit follow-up. Spec: docs/superpowers/specs/2026-06-17-testing-api-dx-design.md. One factory verb (create*), one teardown (close() + Symbol.asyncDispose) across @dawn-ai/testing. Renames: startAimock->createAimock (AimockHandle->Aimock, stop->close), startSubprocessApp->createSubprocessApp (stop->close), injectAgentProtocol->createAgentProtocolInjector. Contained to the testing package + docs; no external consumers."
+```
+Then enable auto-merge: `gh pr merge feat/testing-api-dx --auto --squash` (report outcome).

--- a/docs/superpowers/specs/2026-06-17-testing-api-dx-design.md
+++ b/docs/superpowers/specs/2026-06-17-testing-api-dx-design.md
@@ -1,0 +1,85 @@
+# `@dawn-ai/testing` API consistency pass (Design)
+
+**Status:** Approved for planning
+**Date:** 2026-06-17
+**Roadmap:** DX-audit follow-up phase requested during backlog #6 (testing unit harnesses, PR #230). With three new `create*Harness` helpers landed, the testing surface mixed two factory verbs and two teardown methods and had `[Symbol.asyncDispose]` on only the newest handles. This unifies the surface so every lifecycle object is created and disposed the same way.
+
+## Problem
+
+Audit of `@dawn-ai/testing`'s public surface:
+
+| Export | Handle | Teardown | `asyncDispose` |
+|---|---|---|---|
+| `createAgentHarness` | `AgentHarness` | `close()` | ❌ |
+| `createWorkspaceHarness` / `createToolHarness` / `createMiddlewareHarness` | `*Harness` | `close()` | ✅ |
+| `injectAgentProtocol` | `AgentProtocolInjector` | `close()` | ❌ |
+| `startAimock` | `AimockHandle` | `stop()` | ❌ |
+| `startSubprocessApp` | `SubprocessApp` | `stop()` | ❌ |
+| `script` / `record` / `loadFixtures` / `writeFixtures` / `expect*` | — (pure fns) | — | — |
+
+Three inconsistencies: two factory verbs (`create*` vs `start*` vs `inject*`), two teardown methods (`close()` vs `stop()`), and `[Symbol.asyncDispose]` on only 3 of 5 disposable handles (so `await using` works unevenly).
+
+## Decisions (from brainstorming)
+
+- **Full rename pass** for a single uniform scheme (user choice; no back-compat constraint — pre-1.0, fixed versioning).
+- **One factory verb: `create*`.** One teardown: **`close()` + `[Symbol.asyncDispose]`** on every lifecycle handle.
+- **Type names stay descriptive** (not forced to a uniform `*Harness` suffix): `Aimock`, `SubprocessApp`, `AgentProtocolInjector`, and the `*Harness` types each name a genuinely different thing.
+- Pure fixture functions (`script`, `record`, `loadFixtures`, `writeFixtures`) and matchers keep their verbs — no lifecycle to unify.
+- **Accepted tradeoff:** `start*`/`stop()` signaled "spawns an external process"; collapsing to `create*`/`close()` loses that call-site cue, but the descriptive type names (`Aimock`, `SubprocessApp`) still carry it.
+
+## Verified facts (against main @ `1241d21`)
+
+- Renamed exports are consumed ONLY within `@dawn-ai/testing` (src + its own tests) and one docs file. No `examples/chat` / eval-fixture / other-package consumers. The `.stop()` in `packages/cli/test/dev-command.test.ts` is the unrelated `DevProcessHandle` — leave it.
+- `harness.ts` internally calls `aimock.stop()` at lines 103 and 185 — these must become `aimock.close()` after the AimockHandle rename.
+- `apps/web/content/docs/testing-agents.mdx` references `injectAgentProtocol` and `startSubprocessApp` (lines 154-157) — must update to the new names.
+- `apps/web/content/docs/testing.mdx`'s unit-harness section already uses `create*` + `await using`/`close()` — no rename needed there.
+- Index exports (`packages/testing/src/index.ts`): `startAimock`/`AimockHandle`, `injectAgentProtocol`/`AgentProtocolInjector`/`InjectResult`, `startSubprocessApp`/`SubprocessApp` — update to the renamed symbols.
+
+## Design — the renames
+
+### 1. `aimock-runner.ts`
+- `startAimock` → **`createAimock`**.
+- `AimockHandle` → **`Aimock`**.
+- `stop()` → **`close()`**; add `[Symbol.asyncDispose]` delegating to `close()`.
+
+### 2. `subprocess.ts`
+- `startSubprocessApp` → **`createSubprocessApp`**.
+- `SubprocessApp` keeps its name (it is a spawned app).
+- `stop()` → **`close()`**; add `[Symbol.asyncDispose]`.
+
+### 3. `http-inject.ts`
+- `injectAgentProtocol` → **`createAgentProtocolInjector`**.
+- `AgentProtocolInjector` / `InjectResult` keep names; `close()` already present; add `[Symbol.asyncDispose]`.
+
+### 4. `harness.ts`
+- `createAgentHarness` / `AgentHarness` keep names; `close()` keeps; add `[Symbol.asyncDispose]`.
+- Update the two internal `aimock.stop()` calls → `aimock.close()`.
+
+### 5. `index.ts`
+- Re-export the renamed symbols (`createAimock`/`Aimock`, `createSubprocessApp`, `createAgentProtocolInjector`).
+
+The new trio (`createWorkspaceHarness`/`createToolHarness`/`createMiddlewareHarness`) is already conformant — no change.
+
+### Net public surface after this pass
+Every lifecycle object: `create<Noun>(…): Promise<Noun>` + `noun.close()` + `await using`. Disposable handles: `AgentHarness`, `WorkspaceHarness`, `ToolHarness`, `MiddlewareHarness`, `AgentProtocolInjector`, `Aimock`, `SubprocessApp`.
+
+## Testing
+
+- Update the package's own tests to the new names/teardown: `aimock-runner.test.ts` (`createAimock`, `.close()`), `subprocess.test.ts` (`createSubprocessApp`, `.close()`), `http-inject.test.ts` (`createAgentProtocolInjector`), `restart-persistence.test.ts` (whichever it uses).
+- Add a focused `[Symbol.asyncDispose]` assertion for each newly-disposable handle (`createAgentHarness`, `createAimock`, `createSubprocessApp`, `createAgentProtocolInjector`) — an `await using` scope leaves the resource closed (e.g. aimock server no longer reachable / subprocess exited). Mirror the workspace-harness `await using` test.
+- Full `@dawn-ai/testing` suite green after renames; no behavior change beyond method/symbol names + the additive dispose.
+
+## Docs
+
+- `apps/web/content/docs/testing-agents.mdx`: rename `injectAgentProtocol` → `createAgentProtocolInjector` and `startSubprocessApp` → `createSubprocessApp` (lines ~154-157).
+- `apps/web/content/docs/testing.mdx`: if it references `startAimock` anywhere, rename to `createAimock`; otherwise no change. Consider a one-line note stating the convention: "every harness/handle is `create*` + `close()` (or `await using`)."
+
+## Changeset
+
+`@dawn-ai/testing` minor (fixed versioning bumps all). The changeset MUST flag the breaking renames explicitly: `startAimock`→`createAimock` (+ `AimockHandle`→`Aimock`, `.stop()`→`.close()`), `startSubprocessApp`→`createSubprocessApp` (`.stop()`→`.close()`), `injectAgentProtocol`→`createAgentProtocolInjector`; plus `[Symbol.asyncDispose]` added to all lifecycle handles.
+
+## Out of scope
+
+- Renaming the pure fixture functions/matchers (no lifecycle).
+- Forcing a uniform `*Harness` type suffix (rejected — descriptive names chosen).
+- Any runtime/behavior change — this is naming + additive dispose only.

--- a/packages/testing/src/aimock-runner.ts
+++ b/packages/testing/src/aimock-runner.ts
@@ -1,7 +1,7 @@
 import { LLMock } from "@copilotkit/aimock"
 import type { AimockFixture } from "./fixture-builder.js"
 
-export interface AimockHandle {
+export interface Aimock {
   readonly port: number
   /** Base URL with the `/v1` suffix the OpenAI SDK expects. */
   readonly baseUrl: string
@@ -13,14 +13,15 @@ export interface AimockHandle {
   getRequests(): ReadonlyArray<{
     body: { messages?: Array<{ role: string; content: unknown }> } | null
   }>
-  stop(): Promise<void>
+  close(): Promise<void>
+  [Symbol.asyncDispose](): Promise<void>
 }
 
-export async function startAimock(opts: {
+export async function createAimock(opts: {
   readonly fixtures: readonly AimockFixture[]
   /** When set, proxy unmatched requests to the given upstream providers. */
   readonly proxy?: { openai: string }
-}): Promise<AimockHandle> {
+}): Promise<Aimock> {
   const mock = new LLMock(
     opts.proxy
       ? {
@@ -35,7 +36,7 @@ export async function startAimock(opts: {
   }
   await mock.start()
   let stopped = false
-  return {
+  const handle: Aimock = {
     port: mock.port,
     baseUrl: `${mock.url}/v1`,
     addFixtures(fixtures: readonly AimockFixture[]) {
@@ -51,10 +52,14 @@ export async function startAimock(opts: {
         body: { messages?: Array<{ role: string; content: unknown }> } | null
       }>
     },
-    async stop() {
+    async close() {
       if (stopped) return
       stopped = true
       await mock.stop()
     },
+    [Symbol.asyncDispose](): Promise<void> {
+      return this.close()
+    },
   }
+  return handle
 }

--- a/packages/testing/src/harness.ts
+++ b/packages/testing/src/harness.ts
@@ -6,7 +6,7 @@ import {
   streamResolvedRoute,
 } from "@dawn-ai/cli/runtime"
 import { discoverRoutes } from "@dawn-ai/core"
-import { type AimockHandle, startAimock } from "./aimock-runner.js"
+import { type Aimock, createAimock } from "./aimock-runner.js"
 import type { FixtureSet, ScriptBuilder } from "./fixture-builder.js"
 import { type AgentRunResult, collectRunResult } from "./run-result.js"
 
@@ -55,6 +55,7 @@ export interface AgentHarness {
   }): Promise<AgentRunResult>
   reset(): void
   close(): Promise<void>
+  [Symbol.asyncDispose](): Promise<void>
 }
 
 export async function createAgentHarness(options: AgentHarnessOptions): Promise<AgentHarness> {
@@ -77,9 +78,9 @@ export async function createAgentHarness(options: AgentHarnessOptions): Promise<
 
   // Start aimock once — port (and thus the cached agent's baseURL) stays stable for the harness lifetime.
   // In live mode: proxy all requests through to the real OpenAI upstream.
-  const aimock: AimockHandle = live
-    ? await startAimock({ fixtures: [], proxy: { openai: "https://api.openai.com" } })
-    : await startAimock({ fixtures: options.fixtures ?? [] })
+  const aimock: Aimock = live
+    ? await createAimock({ fixtures: [], proxy: { openai: "https://api.openai.com" } })
+    : await createAimock({ fixtures: options.fixtures ?? [] })
   process.env.OPENAI_BASE_URL = aimock.baseUrl
   // Only inject a dummy key in mock mode; in live mode the real key is already set.
   if (!live) {
@@ -100,7 +101,7 @@ export async function createAgentHarness(options: AgentHarnessOptions): Promise<
     }
   } catch (err) {
     // Unified cleanup: stop aimock and restore env vars before re-throwing.
-    await aimock.stop()
+    await aimock.close()
     if (prevBaseUrl === undefined) delete process.env.OPENAI_BASE_URL
     else process.env.OPENAI_BASE_URL = prevBaseUrl
     if (prevKey === undefined) delete process.env.OPENAI_API_KEY
@@ -182,7 +183,7 @@ export async function createAgentHarness(options: AgentHarnessOptions): Promise<
     async close() {
       if (closed) return
       closed = true
-      await aimock.stop()
+      await aimock.close()
       // restore env to avoid cross-test bleed
       if (prevBaseUrl === undefined) delete process.env.OPENAI_BASE_URL
       else process.env.OPENAI_BASE_URL = prevBaseUrl
@@ -194,6 +195,9 @@ export async function createAgentHarness(options: AgentHarnessOptions): Promise<
       // (ESM module cache returns the same export) would reuse an LLM already
       // bound to the previous (stopped) aimock server.
       __resetMaterializedAgentsForTests()
+    },
+    [Symbol.asyncDispose](): Promise<void> {
+      return this.close()
     },
   }
   return harness

--- a/packages/testing/src/http-inject.ts
+++ b/packages/testing/src/http-inject.ts
@@ -32,14 +32,15 @@ export interface AgentProtocolInjector {
     headers?: Record<string, string>
   }): Promise<InjectResult>
   close(): Promise<void>
+  [Symbol.asyncDispose](): Promise<void>
 }
 
-export async function injectAgentProtocol(options: {
+export async function createAgentProtocolInjector(options: {
   appRoot: string
 }): Promise<AgentProtocolInjector> {
   const { listener, close } = await createRuntimeRequestListener({ appRoot: options.appRoot })
 
-  return {
+  const injector: AgentProtocolInjector = {
     async inject(opts) {
       const res = await lmrInject(listener, {
         method: opts.method,
@@ -54,5 +55,9 @@ export async function injectAgentProtocol(options: {
       }
     },
     close,
+    [Symbol.asyncDispose](): Promise<void> {
+      return this.close()
+    },
   }
+  return injector
 }

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -1,4 +1,4 @@
-export { type AimockHandle, startAimock } from "./aimock-runner.js"
+export { type Aimock, createAimock } from "./aimock-runner.js"
 export {
   type AimockFixture,
   type AimockResponse,
@@ -11,8 +11,8 @@ export { loadFixtures, writeFixtures } from "./fixture-file.js"
 export { type AgentHarness, type AgentHarnessOptions, createAgentHarness } from "./harness.js"
 export {
   type AgentProtocolInjector,
+  createAgentProtocolInjector,
   type InjectResult,
-  injectAgentProtocol,
 } from "./http-inject.js"
 export {
   expectFinalMessage,
@@ -44,7 +44,7 @@ export {
   type ObservedToolCall,
   type ObservedToolResult,
 } from "./run-result.js"
-export { type SubprocessApp, startSubprocessApp } from "./subprocess.js"
+export { createSubprocessApp, type SubprocessApp } from "./subprocess.js"
 export {
   createToolHarness,
   type ToolHarness,

--- a/packages/testing/src/subprocess.ts
+++ b/packages/testing/src/subprocess.ts
@@ -6,7 +6,8 @@ import { fileURLToPath } from "node:url"
 
 export interface SubprocessApp {
   readonly baseUrl: string
-  stop(): Promise<void>
+  close(): Promise<void>
+  [Symbol.asyncDispose](): Promise<void>
 }
 
 /** Bind to port 0, read the OS-assigned port, release it. */
@@ -60,7 +61,7 @@ function resolveDawnCliEntry(): string {
   return resolve(pkgRoot, "node_modules", "@dawn-ai", "cli", "dist", "index.js")
 }
 
-export async function startSubprocessApp(opts: {
+export async function createSubprocessApp(opts: {
   readonly appRoot: string
   readonly env?: Record<string, string>
   readonly port?: number
@@ -94,9 +95,9 @@ export async function startSubprocessApp(opts: {
   }
 
   let stopped = false
-  return {
+  const app: SubprocessApp = {
     baseUrl,
-    async stop() {
+    async close() {
       if (stopped) return
       stopped = true
       if (child.pid) {
@@ -107,5 +108,9 @@ export async function startSubprocessApp(opts: {
         }
       }
     },
+    [Symbol.asyncDispose](): Promise<void> {
+      return this.close()
+    },
   }
+  return app
 }

--- a/packages/testing/test/aimock-runner.test.ts
+++ b/packages/testing/test/aimock-runner.test.ts
@@ -1,8 +1,8 @@
 import { expect, it } from "vitest"
-import { startAimock } from "../src/aimock-runner.js"
+import { createAimock } from "../src/aimock-runner.js"
 
 it("boots an aimock server on an OS-assigned port and serves the /v1 base url", async () => {
-  const mock = await startAimock({ fixtures: [{ match: {}, response: { content: "ok" } }] })
+  const mock = await createAimock({ fixtures: [{ match: {}, response: { content: "ok" } }] })
   try {
     expect(mock.port).toBeGreaterThan(0)
     expect(mock.baseUrl).toMatch(/\/v1$/)
@@ -13,28 +13,39 @@ it("boots an aimock server on an OS-assigned port and serves the /v1 base url", 
     })
     expect(res.status).toBe(200)
   } finally {
-    await mock.stop()
+    await mock.close()
   }
 })
 
 it("accepts a proxy option and exposes the journal", async () => {
-  const mock = await startAimock({ fixtures: [], proxy: { openai: "https://api.openai.com" } })
+  const mock = await createAimock({ fixtures: [], proxy: { openai: "https://api.openai.com" } })
   try {
     expect(mock.baseUrl).toMatch(/\/v1$/)
     expect(Array.isArray(mock.getRequests())).toBe(true)
   } finally {
-    await mock.stop()
+    await mock.close()
   }
 })
 
-it("stop() is idempotent", async () => {
-  const mock = await startAimock({ fixtures: [] })
-  await mock.stop()
-  await mock.stop()
+it("close() is idempotent", async () => {
+  const mock = await createAimock({ fixtures: [] })
+  await mock.close()
+  await mock.close()
+})
+
+it("disposes via `await using` and leaves the mock unreachable", async () => {
+  let baseUrl: string
+  {
+    await using mock = await createAimock({ fixtures: [] })
+    baseUrl = mock.baseUrl
+    expect(mock.port).toBeGreaterThan(0)
+  }
+  // After the block, the server has been stopped — the URL is no longer reachable.
+  await expect(fetch(`${baseUrl}/models`)).rejects.toThrow()
 })
 
 it("exposes received requests via getRequests()", async () => {
-  const mock = await startAimock({ fixtures: [{ match: {}, response: { content: "ok" } }] })
+  const mock = await createAimock({ fixtures: [{ match: {}, response: { content: "ok" } }] })
   try {
     await fetch(new URL("/v1/chat/completions", mock.baseUrl.replace(/\/v1$/, "")), {
       method: "POST",
@@ -58,6 +69,6 @@ it("exposes received requests via getRequests()", async () => {
       .join("\n")
     expect(sys).toContain("SYS-MARKER")
   } finally {
-    await mock.stop()
+    await mock.close()
   }
 })

--- a/packages/testing/test/harness-construct.test.ts
+++ b/packages/testing/test/harness-construct.test.ts
@@ -10,3 +10,13 @@ it("constructs: boots aimock, runs typegen, resolves the route", () => {
   expect(h.baseUrl).toMatch(/\/v1$/)
   expect(process.env.OPENAI_BASE_URL).toBe(h.baseUrl)
 })
+
+it("disposes via `await using` (no-throw, idempotent close)", async () => {
+  const harness = await createAgentHarness({ appRoot, route: "/chat#agent" })
+  {
+    await using disposable = harness
+    expect(disposable.baseUrl).toMatch(/\/v1$/)
+  }
+  // Dispose delegated to close(); a second explicit close must be a safe no-op.
+  await expect(harness.close()).resolves.toBeUndefined()
+})

--- a/packages/testing/test/http-inject.test.ts
+++ b/packages/testing/test/http-inject.test.ts
@@ -1,18 +1,18 @@
 import { fileURLToPath } from "node:url"
 import { expect, it } from "vitest"
-import { startAimock } from "../src/aimock-runner.js"
+import { createAimock } from "../src/aimock-runner.js"
 import { script } from "../src/fixture-builder.js"
-import { injectAgentProtocol } from "../src/http-inject.js"
+import { createAgentProtocolInjector } from "../src/http-inject.js"
 
 const appRoot = fileURLToPath(new URL("./fixtures/probe-app", import.meta.url))
 
 it("creates a thread + runs/wait over the in-process AP pipeline (no port)", async () => {
-  const mock = await startAimock({ fixtures: script().user("hello").replies("hi there").build() })
+  const mock = await createAimock({ fixtures: script().user("hello").replies("hi there").build() })
   const prevBaseUrl = process.env.OPENAI_BASE_URL
   const prevKey = process.env.OPENAI_API_KEY
   process.env.OPENAI_BASE_URL = mock.baseUrl
   process.env.OPENAI_API_KEY = "test-not-used"
-  const ap = await injectAgentProtocol({ appRoot })
+  const ap = await createAgentProtocolInjector({ appRoot })
   try {
     const created = await ap.inject({ method: "POST", url: "/threads", payload: {} })
     expect(created.statusCode).toBe(200)
@@ -28,10 +28,20 @@ it("creates a thread + runs/wait over the in-process AP pipeline (no port)", asy
     expect(run.body).toContain("hi there")
   } finally {
     await ap.close()
-    await mock.stop()
+    await mock.close()
     if (prevBaseUrl === undefined) delete process.env.OPENAI_BASE_URL
     else process.env.OPENAI_BASE_URL = prevBaseUrl
     if (prevKey === undefined) delete process.env.OPENAI_API_KEY
     else process.env.OPENAI_API_KEY = prevKey
   }
+}, 60_000)
+
+it("disposes the injector via `await using` (no-throw, idempotent close)", async () => {
+  const ap = await createAgentProtocolInjector({ appRoot })
+  {
+    await using disposable = ap
+    expect(typeof disposable.inject).toBe("function")
+  }
+  // Dispose delegated to close(); a second explicit close must be a safe no-op.
+  await expect(ap.close()).resolves.toBeUndefined()
 }, 60_000)

--- a/packages/testing/test/restart-persistence.test.ts
+++ b/packages/testing/test/restart-persistence.test.ts
@@ -1,17 +1,17 @@
 import { fileURLToPath } from "node:url"
 import { expect, it } from "vitest"
-import { script, startAimock, startSubprocessApp } from "../src/index.js"
+import { createAimock, createSubprocessApp, script } from "../src/index.js"
 
 const appRoot = fileURLToPath(new URL("./fixtures/probe-app", import.meta.url))
 
 it("persists thread state across a real dawn dev process restart (Layer C)", async () => {
-  const mock = await startAimock({
+  const mock = await createAimock({
     fixtures: script().user("remember the number 42").replies("Got it, 42.").build(),
   })
   const env = { OPENAI_BASE_URL: mock.baseUrl, OPENAI_API_KEY: "test-not-used" }
 
   // --- process #1: create a thread and run one turn ---
-  const app1 = await startSubprocessApp({ appRoot, env })
+  const app1 = await createSubprocessApp({ appRoot, env })
   let threadId: string
   try {
     const created = await fetch(new URL("/threads", app1.baseUrl), {
@@ -30,11 +30,11 @@ it("persists thread state across a real dawn dev process restart (Layer C)", asy
     })
     expect(run.status, await run.clone().text()).toBe(200)
   } finally {
-    await app1.stop()
+    await app1.close()
   }
 
   // --- process #2: fresh process, same appRoot/sqlite — state must survive ---
-  const app2 = await startSubprocessApp({ appRoot, env })
+  const app2 = await createSubprocessApp({ appRoot, env })
   try {
     const stateRes = await fetch(new URL(`/threads/${threadId}/state`, app2.baseUrl))
     expect(stateRes.status).toBe(200)
@@ -51,7 +51,7 @@ it("persists thread state across a real dawn dev process restart (Layer C)", asy
       `expected the turn-1 human message to persist; got: ${JSON.stringify(messages).slice(0, 400)}`,
     ).toBeGreaterThanOrEqual(1)
   } finally {
-    await app2.stop()
-    await mock.stop()
+    await app2.close()
+    await mock.close()
   }
 }, 180_000)

--- a/packages/testing/test/subprocess.test.ts
+++ b/packages/testing/test/subprocess.test.ts
@@ -1,13 +1,13 @@
 import { fileURLToPath } from "node:url"
 import { expect, it } from "vitest"
-import { startAimock } from "../src/aimock-runner.js"
-import { startSubprocessApp } from "../src/subprocess.js"
+import { createAimock } from "../src/aimock-runner.js"
+import { createSubprocessApp } from "../src/subprocess.js"
 
 const appRoot = fileURLToPath(new URL("./fixtures/probe-app", import.meta.url))
 
 it("boots a real dawn dev subprocess and serves the AP", async () => {
-  const mock = await startAimock({ fixtures: [{ match: {}, response: { content: "ok" } }] })
-  const app = await startSubprocessApp({
+  const mock = await createAimock({ fixtures: [{ match: {}, response: { content: "ok" } }] })
+  const app = await createSubprocessApp({
     appRoot,
     env: { OPENAI_BASE_URL: mock.baseUrl, OPENAI_API_KEY: "test-not-used" },
   })
@@ -21,7 +21,27 @@ it("boots a real dawn dev subprocess and serves the AP", async () => {
     const body = (await res.json()) as { thread_id?: string }
     expect(body.thread_id).toBeTruthy()
   } finally {
-    await app.stop()
-    await mock.stop()
+    await app.close()
+    await mock.close()
+  }
+}, 120_000)
+
+it("disposes the subprocess via `await using` and leaves it unreachable", async () => {
+  const mock = await createAimock({ fixtures: [{ match: {}, response: { content: "ok" } }] })
+  let baseUrl: string
+  try {
+    {
+      await using app = await createSubprocessApp({
+        appRoot,
+        env: { OPENAI_BASE_URL: mock.baseUrl, OPENAI_API_KEY: "test-not-used" },
+      })
+      baseUrl = app.baseUrl
+      const res = await fetch(new URL("/healthz", app.baseUrl))
+      expect(res.ok).toBe(true)
+    }
+    // After the block the child process has been killed — the port is gone.
+    await expect(fetch(new URL("/healthz", baseUrl))).rejects.toThrow()
+  } finally {
+    await mock.close()
   }
 }, 120_000)


### PR DESCRIPTION
## Summary

DX-audit follow-up to backlog #6. Unifies `@dawn-ai/testing`'s lifecycle surface: one factory verb (`create*`), one teardown (`close()` + `[Symbol.asyncDispose]`, so `await using` works everywhere). Spec: docs/superpowers/specs/2026-06-17-testing-api-dx-design.md.

**Breaking renames** (pre-1.0, fixed versioning):
- `startAimock` → `createAimock` (type `AimockHandle` → `Aimock`, `.stop()` → `.close()`)
- `startSubprocessApp` → `createSubprocessApp` (`.stop()` → `.close()`)
- `injectAgentProtocol` → `createAgentProtocolInjector`

`[Symbol.asyncDispose]` added to `AgentHarness`, `Aimock`, `SubprocessApp`, `AgentProtocolInjector`. The `create*Harness` trio and pure fixture functions are unchanged. Type names stay descriptive (no forced `*Harness` suffix). Fully contained to `@dawn-ai/testing` + docs — no external consumers.

## Test plan

- [x] `@dawn-ai/testing` 92 tests (1 skip), incl. an `await using` dispose assertion per newly-disposable handle
- [x] `pnpm -r build` + typecheck clean; docs build; lint exit 0 (2 pre-existing warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
