### PR TITLE
chore(release): patch-only bump (0.8.2), not 1.0.0

### DIFF
--- a/.changeset/testing-api-dx.md
+++ b/.changeset/testing-api-dx.md
@@ -1,5 +1,5 @@
 ---
-"@dawn-ai/testing": minor
+"@dawn-ai/testing": patch
 ---
 
 Consistent lifecycle API. Every harness/handle is now created with a `create*` factory and torn down with `close()` (plus `[Symbol.asyncDispose]`, so `await using` works everywhere). **Breaking renames:** `startAimock` → `createAimock` (type `AimockHandle` → `Aimock`, `.stop()` → `.close()`); `startSubprocessApp` → `createSubprocessApp` (`.stop()` → `.close()`); `injectAgentProtocol` → `createAgentProtocolInjector`. The `create*Harness` helpers and pure fixture functions are unchanged.

--- a/.changeset/testing-unit-harnesses.md
+++ b/.changeset/testing-unit-harnesses.md
@@ -1,5 +1,5 @@
 ---
-"@dawn-ai/testing": minor
+"@dawn-ai/testing": patch
 ---
 
 Unit-test harnesses for tools, middleware, and the workspace. `createToolHarness(tool)` invokes a route tool against a real, temp-backed `ctx.fs` (reusable `invoke()` for cumulative-state assertions); `createMiddlewareHarness(mw)` exercises a `FilesystemMiddleware` over a temp `localFilesystem` and offers `assertForwardsAll()` to catch dropped backend methods; `createWorkspaceHarness()` is the shared temp-`WorkspaceFs` fixture, also usable to test `ctx.fs` code directly. All are async `create*Harness` factories with `.close()` and `[Symbol.asyncDispose]` (for `await using`), matching `createAgentHarness`. Adds `@dawn-ai/workspace` and `@dawn-ai/sdk` as peer dependencies.


### PR DESCRIPTION
## Summary

Downgrades the two pending `@dawn-ai/testing` changesets from `minor` to `patch` so the next release is a **0.x patch (0.8.2)**, not the `1.0.0` that the minor-level changesets were escalating to in the fixed-version group.

`changeset status` after this change: all fixed-group packages bump at **patch** (NO minor, NO major). Once merged, the Version Packages PR (#231) regenerates as 0.8.2.

Note: the testing-helper renames (`startAimock`→`createAimock`, etc.) are breaking, but permissible under 0.x semver; we're deferring the 1.0 signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)