### PR TITLE
test(harness): provide @dawn-ai/workspace tarball to generated apps (release gate fix)

### DIFF
--- a/test/generated/fixtures/basic.expected.json
+++ b/test/generated/fixtures/basic.expected.json
@@ -16,6 +16,7 @@
       "@dawn-ai/langchain": "<tarball:@dawn-ai/langchain>",
       "@dawn-ai/sdk": "<tarball:@dawn-ai/sdk>",
       "@dawn-ai/sqlite-storage": "<tarball:@dawn-ai/sqlite-storage>",
+      "@dawn-ai/workspace": "<tarball:@dawn-ai/workspace>",
       "zod": "^3.24.0"
     },
     "devDependencies": {

--- a/test/generated/fixtures/custom-app-dir.expected.json
+++ b/test/generated/fixtures/custom-app-dir.expected.json
@@ -16,6 +16,7 @@
       "@dawn-ai/langchain": "<tarball:@dawn-ai/langchain>",
       "@dawn-ai/sdk": "<tarball:@dawn-ai/sdk>",
       "@dawn-ai/sqlite-storage": "<tarball:@dawn-ai/sqlite-storage>",
+      "@dawn-ai/workspace": "<tarball:@dawn-ai/workspace>",
       "zod": "^3.24.0"
     },
     "devDependencies": {

--- a/test/generated/harness.ts
+++ b/test/generated/harness.ts
@@ -216,6 +216,11 @@ export async function prepareGeneratedRuntimeApp(options: {
         extraDependencies: {
           "@dawn-ai/langgraph": tarballs["@dawn-ai/langgraph"]!,
           "@dawn-ai/sqlite-storage": tarballs["@dawn-ai/sqlite-storage"]!,
+          // workspace is a transitive-only dep (via core + langchain); a pnpm
+          // override alone does not resolve a local tarball for a non-direct
+          // dep, so it must be promoted to a direct dep like the other forced
+          // packages, or install falls back to the (unpublished) registry version.
+          "@dawn-ai/workspace": tarballs["@dawn-ai/workspace"]!,
         },
       })
     }

--- a/test/generated/run-generated-app.test.ts
+++ b/test/generated/run-generated-app.test.ts
@@ -205,6 +205,11 @@ async function runGeneratedAppScenario(
         tarballs,
         extraDependencies: {
           "@dawn-ai/sqlite-storage": tarballs["@dawn-ai/sqlite-storage"]!,
+          // workspace is a transitive-only dep (via core + langchain); a pnpm
+          // override alone does not resolve a local tarball for a non-direct
+          // dep, so it must be promoted to a direct dep like the other forced
+          // packages, or install falls back to the (unpublished) registry version.
+          "@dawn-ai/workspace": tarballs["@dawn-ai/workspace"]!,
         },
       })
     }
@@ -464,8 +469,10 @@ async function createExpectedInternalFixture(
           "@dawn-ai/langchain": "<repo:@dawn-ai/langchain>",
           "@dawn-ai/sdk": "<repo:@dawn-ai/sdk>",
         }
-        // sqlite-storage is only in overrides for internal mode, not in direct deps
+        // sqlite-storage and workspace are only in overrides for internal mode,
+        // not in direct deps (external mode promotes them via extraDependencies)
         delete deps["@dawn-ai/sqlite-storage"]
+        delete deps["@dawn-ai/workspace"]
         return deps
       })(),
       devDependencies: {


### PR DESCRIPTION
## Why

The 0.8.2 release was blocked: the `Release` workflow's `pnpm verify:harness` **Framework verification** lane failed with:

```
ERR_PNPM_NO_MATCHING_VERSION  No matching version found for @dawn-ai/workspace@0.8.2
while fetching it from https://registry.npmjs.org/
```

This reproduces locally on `main` (`fa81a68`) — it is a real release-time bug, not a CI flake.

## Root cause

The generated-app publish/runtime harnesses pack local `@dawn-ai/*` tarballs and pin scaffolded apps to them so `pnpm install` resolves offline. `@dawn-ai/workspace` is a **transitive-only** dependency (via `@dawn-ai/core` + `@dawn-ai/langchain`), so the harness only listed it in `pnpm.overrides`. A pnpm file-path override is **not honored for a package that isn't also a direct dependency**, so install fell back to the public registry.

On every PR the pinned version equals the last published one (`0.8.1`), so the registry fallback silently succeeds and masks the gap. Only at release time — when versions are bumped to the not-yet-published `0.8.2` — does the fallback 404 and fail the gate. The runtime and smoke lanes already promote `@dawn-ai/workspace` to a direct dep via `extraDependencies`; the two **framework-lane** scaffolders were the only sites missing it.

## Fix

- Add `@dawn-ai/workspace` to `extraDependencies` in the two framework-lane scaffolders (`run-generated-app.test.ts`, `harness.ts`) — same pattern as `langgraph`/`sqlite-storage`.
- Update the recorded `basic`/`custom-app-dir` fixtures to include the new direct dep.
- Delete `@dawn-ai/workspace` from the internal-mode expectation (internal mode keeps it in overrides only, like `sqlite-storage`).

## Verification

`pnpm verify:harness` → **all 3 lanes pass** (framework/runtime/smoke). `pnpm lint`, `pnpm typecheck`, `pnpm verify:harness:self-test` all green. Test-infra only — no source/package change, no changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)