### PR TITLE
fix(ci): pass github_token to claude-code-action (skip OIDC)

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -28,6 +28,11 @@ jobs:
       - name: Claude review
         uses: anthropics/claude-code-action@806af32823ef69c8ef357086c573a902af641307 # v1
         with:
+          # Pass GITHUB_TOKEN explicitly (maps to OVERRIDE_GITHUB_TOKEN) so the
+          # action skips OIDC token exchange — that path needs `id-token: write`
+          # plus the Claude GitHub App, which this repo doesn't use. Posts as
+          # github-actions[bot] via the job's pull-requests: write scope.
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           track_progress: true
           prompt: |


### PR DESCRIPTION
## Summary

Follow-up fix to #242. The Claude review job failed on every PR with:

> Could not fetch an OIDC token. Did you remember to add `id-token: write` to your workflow permissions?

`claude-code-action` mints a GitHub App token via OIDC by default, which requires both `id-token: write` **and** the Claude GitHub App installed. This repo authenticates the model with `ANTHROPIC_API_KEY` only and doesn't use that App. The fix passes `github_token: ${{ secrets.GITHUB_TOKEN }}` (which the action maps to `OVERRIDE_GITHUB_TOKEN`), so it skips OIDC entirely and posts review comments as `github-actions[bot]` via the job's existing `pull-requests: write` scope.

The `auto-approve` workflow was unaffected (no OIDC) and already works.

## Test Plan
- [x] YAML parses
- [ ] This PR self-verifies: the `review` job should pass and Claude should post review comments on this PR