### PR TITLE
ci: pin npm version for OSSF Pinned-Dependencies (8→10)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,8 +41,9 @@ jobs:
 
       # Trusted publishing requires npm 11.5.1+. Node 22's bundled npm 10.x
       # doesn't fully support the OIDC trusted-publishing flow.
+      # Pinned to an exact version (not @latest) for OSSF Pinned-Dependencies.
       - name: Upgrade npm for trusted publishing
-        run: npm install --global npm@latest
+        run: npm install --global npm@11.17.0
 
       - name: Install
         run: pnpm install --frozen-lockfile


### PR DESCRIPTION
## Summary
OSSF Pinned-Dependencies scored 8 because of a single unpinned npmCommand: `npm install --global npm@latest` in `release.yml`. Pinned to `npm@11.17.0` (≥ the 11.5.1 trusted-publishing floor). Should take the check 8 → 10.

Diagnosed alongside SAST (7) and CI-Tests (8): both are config-correct and **rolling/historical** (CodeQL was just added; recent PRs all run `validate`), so they climb to 10 on their own as the sample window advances — no change applies.

## Test Plan
- [x] YAML parses
- [ ] Post-merge: Pinned-Dependencies → 10 at api.scorecard.dev