### PR TITLE
test(harness): real Verdaccio publish harness for generated apps

### DIFF
--- a/docs/superpowers/plans/2026-06-18-verdaccio-publish-harness.md
+++ b/docs/superpowers/plans/2026-06-18-verdaccio-publish-harness.md
@@ -1,0 +1,544 @@
+# Verdaccio Publish Harness Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the generated-app harness's `pack → pin tarballs → pnpm.overrides → fail-closed .npmrc` simulation with a real ephemeral Verdaccio registry: publish the whole workspace atomically, then install scaffolded apps from it exactly like a published npm user.
+
+**Architecture:** A per-lane programmatic Verdaccio (started in vitest `globalSetup`, `listen(0)`, temp storage, `@dawn-ai/*` local-only + npmjs uplink, anonymous publish). The workspace is published once per lane via `pnpm -r publish`. Scaffolded apps get a real `.npmrc` (`registry=<verdaccio>`) and `pnpm install` with no overrides/rewrite. The old mechanism is deleted; internal mode is untouched.
+
+**Tech Stack:** TypeScript (no semicolons, double quotes, 2-space, ESM `.js` specifiers), pnpm 10.33, Vitest 4, Verdaccio 6, Biome.
+
+**Spec:** `docs/superpowers/specs/2026-06-18-verdaccio-publish-harness-design.md`
+
+**Conventions:** Work only in this worktree. `pnpm -r build` once before running any lane. Lanes run via `pnpm verify:harness` or directly with `pnpm exec vitest run --config test/<lane>/vitest.config.ts`. `pyenv: cannot rehash` output is harmless. Root `.npmrc` has `package-manager-strict=true` — keep publish/install commands explicit.
+
+**Key facts (verified):**
+- All 17 publishable workspace packages are at one uniform version (fixed group). Private (skipped by `pnpm -r publish`): `@dawn-ai/web`, `@dawn-example/*`.
+- `create-dawn-ai-app` writes the `--dist-tag` string literally as the dep specifier (`"@dawn-ai/core": "latest"`); default tag is `latest` (`packages/create-dawn-app/src/index.ts:81`).
+- `@dawn-ai/*` packages depend on each other via `workspace:*`; `pnpm -r publish` rewrites these to the exact version on publish.
+- Lanes: framework=`test/generated/vitest.config.ts`, runtime=`test/runtime/vitest.config.ts`, smoke=`test/smoke/vitest.config.ts`, run by `scripts/harness-report.mjs`.
+
+---
+
+### Task 1: Verdaccio dependency + `local-registry.ts` (keystone, TDD)
+
+This task proves the whole approach end-to-end and validates the shared-store freshness reasoning before anything depends on it.
+
+**Files:**
+- Modify: `package.json` (root — add `verdaccio` devDependency)
+- Create: `test/harness/local-registry.ts`
+- Create: `test/harness/local-registry.test.ts`
+
+- [ ] **Step 1: Add Verdaccio.**
+
+Run: `pnpm add -D -w verdaccio@^6`
+Expected: `package.json` root `devDependencies` gains `"verdaccio": "^6.x"`; lockfile updates.
+
+- [ ] **Step 2: Write the failing integration test.**
+
+Create `test/harness/local-registry.test.ts`:
+
+```ts
+import { mkdtemp, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+import { afterAll, beforeAll, describe, expect, test } from "vitest"
+
+import { runPackagedCommand } from "./packaged-app.ts"
+import { type LocalRegistry, publishWorkspace, startLocalRegistry } from "./local-registry.ts"
+
+describe("local-registry", () => {
+  let registry: LocalRegistry
+
+  beforeAll(async () => {
+    registry = await startLocalRegistry()
+    await publishWorkspace(registry.url)
+  }, 180_000)
+
+  afterAll(async () => {
+    await registry?.stop()
+  })
+
+  test("serves a published @dawn-ai package that a real install resolves", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "dawn-reg-probe-"))
+    await writeFile(
+      join(dir, "package.json"),
+      `${JSON.stringify({ name: "probe", private: true, dependencies: { "@dawn-ai/core": "latest" } }, null, 2)}\n`,
+      "utf8",
+    )
+    await writeFile(join(dir, ".npmrc"), `registry=${registry.url}\n`, "utf8")
+
+    await runPackagedCommand({ args: ["install", "--no-frozen-lockfile"], command: "pnpm", cwd: dir })
+
+    // Resolved from Verdaccio (file under .pnpm keyed to the registry host), not npmjs.
+    const lockfile = await import("node:fs/promises").then((fs) =>
+      fs.readFile(join(dir, "pnpm-lock.yaml"), "utf8"),
+    )
+    expect(lockfile).toContain("@dawn-ai/core")
+    expect(lockfile).not.toContain("registry.npmjs.org/@dawn-ai")
+    await rm(dir, { force: true, recursive: true })
+  }, 180_000)
+
+  test("404s for an @dawn-ai package that was never published (fail-closed)", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "dawn-reg-neg-"))
+    await writeFile(
+      join(dir, "package.json"),
+      `${JSON.stringify({ name: "neg", private: true, dependencies: { "@dawn-ai/does-not-exist": "latest" } }, null, 2)}\n`,
+      "utf8",
+    )
+    await writeFile(join(dir, ".npmrc"), `registry=${registry.url}\n`, "utf8")
+
+    await expect(
+      runPackagedCommand({ args: ["install", "--no-frozen-lockfile"], command: "pnpm", cwd: dir }),
+    ).rejects.toThrow()
+    await rm(dir, { force: true, recursive: true })
+  }, 120_000)
+})
+```
+
+- [ ] **Step 3: Run it to verify it fails.**
+
+Run: `pnpm exec vitest run --config test/generated/vitest.config.ts test/harness/local-registry.test.ts`
+Expected: FAIL — `local-registry.ts` does not exist (import error).
+
+- [ ] **Step 4: Implement `local-registry.ts`.**
+
+Create `test/harness/local-registry.ts`:
+
+```ts
+import { readFile, readdir, rm } from "node:fs/promises"
+import { mkdtemp } from "node:fs/promises"
+import type { Server } from "node:http"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { fileURLToPath } from "node:url"
+
+import { runServer } from "verdaccio"
+
+import { runPackagedCommand } from "./packaged-app.ts"
+
+const REPO_ROOT = fileURLToPath(new URL("../..", import.meta.url))
+
+export interface LocalRegistry {
+  readonly url: string
+  readonly stop: () => Promise<void>
+}
+
+/** Start an ephemeral Verdaccio: random port, fresh temp storage, @dawn-ai local-only, npmjs uplink, anonymous publish. */
+export async function startLocalRegistry(): Promise<LocalRegistry> {
+  const storage = await mkdtemp(join(tmpdir(), "dawn-verdaccio-"))
+  const config = {
+    storage,
+    uplinks: { npmjs: { url: "https://registry.npmjs.org/", maxage: "30m" } },
+    packages: {
+      "@dawn-ai/*": { access: "$all", publish: "$anonymous", unpublish: "$anonymous" },
+      "**": { access: "$all", publish: "$anonymous", proxy: "npmjs" },
+    },
+    logs: { type: "stdout", format: "pretty", level: "warn" },
+  }
+
+  // verdaccio@6 runServer accepts a config object and resolves to an http server.
+  const app = (await runServer(config as never)) as Server
+  const server: Server = await new Promise((resolve) => {
+    const s = app.listen(0, "127.0.0.1", () => resolve(s))
+  })
+
+  const address = server.address()
+  if (!address || typeof address === "string") {
+    throw new Error("Verdaccio failed to bind a port")
+  }
+  const url = `http://127.0.0.1:${address.port}/`
+
+  return {
+    url,
+    stop: async () => {
+      await new Promise<void>((resolve) => server.close(() => resolve()))
+      await rm(storage, { force: true, recursive: true })
+    },
+  }
+}
+
+/** Assert every publishable package shares one version, then publish the whole workspace atomically to `url`. */
+export async function publishWorkspace(url: string): Promise<void> {
+  await assertUniformPublishableVersion()
+
+  const host = url.replace(/^https?:\/\//, "").replace(/\/$/, "")
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+    npm_config_registry: url,
+    // npm/pnpm refuse to publish without a token even when the scope allows $anonymous.
+    [`npm_config_//${host}/:_authToken`]: "fake",
+  }
+
+  await runPackagedCommand({
+    args: ["-r", "publish", "--registry", url, "--tag", "latest", "--no-git-checks"],
+    command: "pnpm",
+    cwd: REPO_ROOT,
+    env,
+  })
+}
+
+async function assertUniformPublishableVersion(): Promise<void> {
+  const packagesDir = join(REPO_ROOT, "packages")
+  const entries = await readdir(packagesDir, { withFileTypes: true })
+  const versions = new Map<string, string>()
+
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue
+    let manifest: { name?: string; version?: string; private?: boolean }
+    try {
+      manifest = JSON.parse(await readFile(join(packagesDir, entry.name, "package.json"), "utf8"))
+    } catch {
+      continue
+    }
+    if (manifest.private || !manifest.name || !manifest.version) continue
+    versions.set(manifest.name, manifest.version)
+  }
+
+  const unique = new Set(versions.values())
+  if (unique.size > 1) {
+    const detail = [...versions.entries()].map(([name, v]) => `${name}@${v}`).join(", ")
+    throw new Error(
+      `Publishable packages must share one canonical version before publishing to the test registry, found: ${detail}`,
+    )
+  }
+}
+```
+
+Note: `runPackagedCommand` must accept an optional `env`. If it does not already, add `readonly env?: NodeJS.ProcessEnv` to its options type in `test/harness/packaged-app.ts` and pass it through to `spawnProcess` (merge over `process.env`). Verify by reading `test/harness/packaged-app.ts:158-180` first; only add the field if missing.
+
+Verdaccio API note: `runServer` is the supported entry (the default export is deprecated). The exact return shape can vary by 6.x minor — the research indicates it resolves to a server you call `.listen(0)` on. If `app.listen` is not a function, log the resolved value's shape and adjust (some versions return `{ webServer }` or an already-listening server whose address you read directly). Step 5 will surface this immediately.
+
+- [ ] **Step 5: Build, then run the test to verify it passes.**
+
+Run: `pnpm -r build && pnpm exec vitest run --config test/generated/vitest.config.ts test/harness/local-registry.test.ts`
+Expected: PASS (both tests). The positive test proves shared-store freshness works (no `--store-dir` isolation); the negative test proves fail-closed. If the positive test resolves `@dawn-ai/core` from npmjs (lockfile contains `registry.npmjs.org/@dawn-ai`), the `@dawn-ai/*` scope is being proxied — re-check the config has NO `proxy:` on that pattern and that it precedes `**`.
+
+- [ ] **Step 6: Commit.**
+
+```bash
+git add package.json pnpm-lock.yaml test/harness/local-registry.ts test/harness/local-registry.test.ts test/harness/packaged-app.ts
+git commit -m "test(harness): ephemeral Verdaccio local-registry helper + integration test"
+```
+
+---
+
+### Task 2: Per-lane global setup + registry URL handoff
+
+**Files:**
+- Create: `test/harness/registry-global-setup.ts`
+- Modify: `test/harness/local-registry.ts` (add `getTestRegistryUrl()` accessor)
+- Modify: `test/generated/vitest.config.ts`, `test/runtime/vitest.config.ts`, `test/smoke/vitest.config.ts`
+- Create: `test/harness/registry-global-setup.test.ts`
+
+- [ ] **Step 1: Add the URL accessor to `local-registry.ts`.**
+
+Append to `test/harness/local-registry.ts`:
+
+```ts
+const REGISTRY_URL_ENV = "DAWN_TEST_REGISTRY_URL"
+
+/** Read the registry URL published by the lane's globalSetup. Throws if setup did not run. */
+export function getTestRegistryUrl(): string {
+  const url = process.env[REGISTRY_URL_ENV]
+  if (!url) {
+    throw new Error(
+      `${REGISTRY_URL_ENV} is not set — the lane's registry globalSetup must run before scaffolding helpers.`,
+    )
+  }
+  return url
+}
+
+export { REGISTRY_URL_ENV }
+```
+
+- [ ] **Step 2: Write the globalSetup.**
+
+Create `test/harness/registry-global-setup.ts`:
+
+```ts
+import { type LocalRegistry, publishWorkspace, REGISTRY_URL_ENV, startLocalRegistry } from "./local-registry.ts"
+
+let registry: LocalRegistry | undefined
+
+// Vitest runs globalSetup once per lane process, before workers fork. Setting the
+// env var here propagates to forked workers (vitest default pool). Workers read it
+// via getTestRegistryUrl().
+export async function setup(): Promise<void> {
+  registry = await startLocalRegistry()
+  await publishWorkspace(registry.url)
+  process.env[REGISTRY_URL_ENV] = registry.url
+}
+
+export async function teardown(): Promise<void> {
+  await registry?.stop()
+  delete process.env[REGISTRY_URL_ENV]
+}
+```
+
+- [ ] **Step 3: Write a failing test that a worker sees the registry.**
+
+Create `test/harness/registry-global-setup.test.ts`:
+
+```ts
+import { describe, expect, test } from "vitest"
+
+import { getTestRegistryUrl } from "./local-registry.ts"
+
+describe("registry globalSetup", () => {
+  test("exposes a reachable registry URL to test workers", async () => {
+    const url = getTestRegistryUrl()
+    expect(url).toMatch(/^http:\/\/127\.0\.0\.1:\d+\/$/)
+
+    const response = await fetch(new URL("/-/ping", url))
+    expect(response.ok).toBe(true)
+  })
+})
+```
+
+- [ ] **Step 4: Run it to verify it fails.**
+
+Run: `pnpm exec vitest run --config test/generated/vitest.config.ts test/harness/registry-global-setup.test.ts`
+Expected: FAIL — `DAWN_TEST_REGISTRY_URL is not set` (globalSetup not wired yet).
+
+- [ ] **Step 5: Wire `globalSetup` into all three lane configs.**
+
+In `test/generated/vitest.config.ts`, add to the `test` object: `globalSetup: ["test/harness/registry-global-setup.ts"],`
+
+In `test/smoke/vitest.config.ts`, add the same line inside `test`.
+
+In `test/runtime/vitest.config.ts`, the config has `root: resolve(rootDir, "../..")` (repo root), so the path is repo-relative: add `globalSetup: ["test/harness/registry-global-setup.ts"],` inside `test`.
+
+- [ ] **Step 6: Run to verify it passes.**
+
+Run: `pnpm exec vitest run --config test/generated/vitest.config.ts test/harness/registry-global-setup.test.ts`
+Expected: PASS — the worker reads the URL and `/-/ping` returns ok. (If the env var does not reach the worker, switch to vitest `provide`/`inject`: have `setup({ provide })` call `provide("dawnRegistryUrl", url)`, declare `interface ProvidedContext { dawnRegistryUrl: string }`, and make `getTestRegistryUrl()` fall back to `inject`. Only do this if env propagation fails.)
+
+- [ ] **Step 7: Commit.**
+
+```bash
+git add test/harness/local-registry.ts test/harness/registry-global-setup.ts test/harness/registry-global-setup.test.ts test/generated/vitest.config.ts test/runtime/vitest.config.ts test/smoke/vitest.config.ts
+git commit -m "test(harness): per-lane Verdaccio globalSetup + registry URL handoff"
+```
+
+---
+
+### Task 3: Scaffold from the registry (simplify `createPackagedInstaller` + `scaffoldApp`)
+
+**Files:**
+- Modify: `test/harness/packaged-app.ts` (`createPackagedInstaller`)
+- Modify: `test/generated/harness.ts` and `test/generated/run-generated-app.test.ts` (`scaffoldApp` external branch)
+
+- [ ] **Step 1: Read the current scaffolding code.**
+
+Read `test/harness/packaged-app.ts:66-132` (`createPackagedInstaller`) and the `scaffoldApp` functions in `test/generated/harness.ts` and `test/generated/run-generated-app.test.ts`. Identify the external-mode `create-dawn-ai-app` invocation (currently `pnpm exec create-dawn-ai-app ... --dist-tag next` run from `installerDir`).
+
+- [ ] **Step 2: Replace `createPackagedInstaller` with a registry-backed scaffolder provider.**
+
+The packing + installer-overrides logic is no longer needed (the registry holds everything). Replace `createPackagedInstaller` so external scaffolding runs `create-dawn-ai-app` from the registry. Change the external branch of each `scaffoldApp` to:
+
+```ts
+// external mode: scaffold using the published create-dawn-ai-app, resolved from the test registry
+await runPackagedCommand({
+  args: ["--registry", getTestRegistryUrl(), "dlx", "create-dawn-ai-app", appRoot, "--template", "basic"],
+  command: "pnpm",
+  cwd: REPO_ROOT,
+  transcriptPath,
+})
+```
+
+Notes:
+- Import `getTestRegistryUrl` from `../harness/local-registry.ts`.
+- Drop `--dist-tag next` (default is `latest` — faithful to a real user).
+- `pnpm dlx` resolves `create-dawn-ai-app@latest` from the registry; the unique per-run registry URL busts dlx's cache. If dlx caching serves a stale scaffolder, fall back to: `pnpm` `add create-dawn-ai-app` into a temp dir with `--registry <url>`, then `pnpm exec create-dawn-ai-app ...` from there.
+- Remove all `createPackagedInstaller` calls and its now-unused packing internals. If `createPackagedInstaller` has no remaining callers, delete it and its helpers (`packPackage`, installer-dir code) from `test/harness/packaged-app.ts`; keep `runPackagedCommand`, `spawnProcess`, `createTrackedTempDir`, `cleanupTrackedTempDirs`, `markTrackedTempDirForPreserve`.
+
+- [ ] **Step 3: Verify scaffolding compiles and a single framework test scaffolds.**
+
+Run: `pnpm exec vitest run --config test/generated/vitest.config.ts test/generated/run-generated-app.test.ts -t "scaffolds a packaged basic app"`
+Expected: The app scaffolds and installs from the registry. It will still FAIL at the fixture comparison (fixtures updated in Task 5) and possibly at the dependency-rewrite call (removed in Task 4) — that is expected at this point. Confirm the transcript shows `create-dawn-ai-app` running and `pnpm install` resolving `@dawn-ai/*` from `127.0.0.1:<port>`, with no `ERR` about tarballs.
+
+- [ ] **Step 4: Commit.**
+
+```bash
+git add test/harness/packaged-app.ts test/generated/harness.ts test/generated/run-generated-app.test.ts
+git commit -m "test(harness): scaffold generated apps from the test registry, drop packed-installer"
+```
+
+---
+
+### Task 4: Replace dependency-rewrite with a registry `.npmrc`; delete the old mechanism
+
+**Files:**
+- Modify: `test/harness/scaffold-packaging.ts` (replace `rewriteGeneratedAppDependencies` + `FAIL_CLOSED_NPMRC` with `writeRegistryNpmrc`)
+- Modify: `test/harness/scaffold-packaging.test.ts`
+- Modify: all external call sites — `test/generated/harness.ts`, `test/generated/run-generated-app.test.ts`, `test/smoke/run-smoke.test.ts`, `test/runtime/run-agent-protocol.test.ts`, `test/runtime/run-runtime-contract.test.ts`, `test/generated/cli-testing-export.test.ts`
+
+- [ ] **Step 1: Replace the body of `scaffold-packaging.ts`.**
+
+Rewrite `test/harness/scaffold-packaging.ts` to a single small helper (delete `SCAFFOLD_PACKAGES`, `FAIL_CLOSED_NPMRC`, `rewriteGeneratedAppDependencies`, `RewriteGeneratedAppDepsOptions`, and the swap/override/throw logic):
+
+```ts
+import { writeFile } from "node:fs/promises"
+import { join } from "node:path"
+
+/**
+ * Point a scaffolded app at the ephemeral test registry. Real users install from
+ * a registry; the generated app does exactly that — no overrides, no tarball pins.
+ * A genuinely missing @dawn-ai package now 404s from Verdaccio (the registry is
+ * local-only for that scope), preserving fail-closed behavior.
+ */
+export async function writeRegistryNpmrc(appRoot: string, registryUrl: string): Promise<void> {
+  const host = registryUrl.replace(/^https?:\/\//, "").replace(/\/$/, "")
+  const npmrc = [
+    `registry=${registryUrl}`,
+    // Parity with a private-registry user; harmless for read-only installs.
+    `//${host}/:_authToken="fake"`,
+    "",
+  ].join("\n")
+  await writeFile(join(appRoot, ".npmrc"), npmrc, "utf8")
+}
+```
+
+- [ ] **Step 2: Migrate every external call site.**
+
+At each site that currently calls `rewriteGeneratedAppDependencies({ appRoot, tarballs, extraDependencies: {...} })` inside an `if (scaffoldMode === "external" && tarballs)` (or equivalent) block, replace the whole block with:
+
+```ts
+await writeRegistryNpmrc(appRoot, getTestRegistryUrl())
+```
+
+Update imports: remove `rewriteGeneratedAppDependencies` / `SCAFFOLD_PACKAGES` / `FAIL_CLOSED_NPMRC` imports; add `writeRegistryNpmrc` from `../harness/scaffold-packaging.js` and `getTestRegistryUrl` from `../harness/local-registry.ts` (adjust relative path per file). Delete any now-unused `tarballs` plumbing in these scenario functions. The sites:
+- `test/generated/run-generated-app.test.ts` (the `extraDependencies` block with `sqlite-storage` + `workspace`)
+- `test/generated/harness.ts` (`extraDependencies` block with `langgraph` + `sqlite-storage` + `workspace`)
+- `test/smoke/run-smoke.test.ts` (block with `permissions` + `sqlite-storage` + `workspace`)
+- `test/runtime/run-agent-protocol.test.ts` (four blocks with `permissions` + `sqlite-storage` + `workspace` + `@langchain/langgraph`)
+- `test/runtime/run-runtime-contract.test.ts` (block with `permissions` + `sqlite-storage` + `workspace`)
+
+For sites that injected a NON-`@dawn` dep via `extraDependencies` (e.g. `"@langchain/langgraph": "1.3.0"`): if that pin is load-bearing for the scenario, keep it by writing it into the scaffolded `package.json` directly with a tiny inline `readFile`/`writeFile`, or confirm the template already includes a compatible range. Verify by reading each site; do not silently drop a non-`@dawn` pin.
+
+- [ ] **Step 3: Update `scaffold-packaging.test.ts`.**
+
+Replace the file's tests (which asserted `rewriteGeneratedAppDependencies` behavior, overrides, the fail-closed `.npmrc`, and `SCAFFOLD_PACKAGES`) with a focused test of `writeRegistryNpmrc`:
+
+```ts
+import { mkdtemp, readFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { describe, expect, it } from "vitest"
+
+import { writeRegistryNpmrc } from "./scaffold-packaging.js"
+
+describe("writeRegistryNpmrc", () => {
+  it("writes a registry-pinned .npmrc with an auth token line", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "npmrc-"))
+    await writeRegistryNpmrc(dir, "http://127.0.0.1:4873/")
+    const npmrc = await readFile(join(dir, ".npmrc"), "utf8")
+    expect(npmrc).toContain("registry=http://127.0.0.1:4873/")
+    expect(npmrc).toContain('//127.0.0.1:4873/:_authToken="fake"')
+  })
+})
+```
+
+- [ ] **Step 4: Verify unit + typecheck.**
+
+Run: `pnpm exec vitest run --config test/generated/vitest.config.ts test/harness/scaffold-packaging.test.ts && pnpm -r --if-present typecheck`
+Expected: PASS; typecheck clean (no dangling references to deleted symbols). Fix any remaining importers the typecheck flags.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add test/harness/scaffold-packaging.ts test/harness/scaffold-packaging.test.ts test/generated/harness.ts test/generated/run-generated-app.test.ts test/smoke/run-smoke.test.ts test/runtime/run-agent-protocol.test.ts test/runtime/run-runtime-contract.test.ts test/generated/cli-testing-export.test.ts
+git commit -m "test(harness): install generated apps from the registry; delete overrides/rewrite/fail-closed mechanism"
+```
+
+---
+
+### Task 5: Update fixture normalization + regenerate fixtures
+
+**Files:**
+- Modify: `test/generated/run-generated-app.test.ts` (`normalizeForFixture`)
+- Modify: `test/generated/fixtures/basic.expected.json`, `test/generated/fixtures/custom-app-dir.expected.json`
+
+- [ ] **Step 1: Update `normalizeForFixture`.**
+
+In `test/generated/run-generated-app.test.ts`, `normalizeForFixture` currently maps tarball paths → `<tarball:...>`. Remove the tarball/packs-dir replacements. Add `@dawn-ai` version normalization so the fixture is stable across releases. Read the current monorepo version once and replace it in the normalized output:
+
+```ts
+function normalizeForFixture(
+  value: GeneratedAppScenarioResult,
+  context: { readonly appRoot: string; readonly dawnVersion: string },
+): GeneratedAppScenarioResult {
+  return normalizeValue(value, [
+    [`/private${context.appRoot}`, "<app-root>"],
+    [context.appRoot, "<app-root>"],
+    [context.dawnVersion, "<dawn-version>"],
+    ["25.6.0", "<version:@types/node>"],
+    ["6.0.2", "<version:typescript>"],
+    ["4.1.4", "<version:vitest>"],
+  ]) as GeneratedAppScenarioResult
+}
+```
+
+Thread `dawnVersion` from the caller (read `packages/core/package.json` version once at the top of the scenario, or import it). The generated app's `package.json` deps will read `"@dawn-ai/core": "latest"` (the scaffolded specifier) with NO `pnpm.overrides` — so the fixture's `package.json` block becomes the plain template. Remove the `tarballs` parameter from `normalizeForFixture` and its callers.
+
+- [ ] **Step 2: Regenerate the `basic` fixture.**
+
+Run: `pnpm exec vitest run --config test/generated/vitest.config.ts test/generated/run-generated-app.test.ts -t "scaffolds a packaged basic app"`
+Expected: FAIL with a deep-equal diff. Inspect the diff (or read the preserved app's captured result). The new expected shape: `package.json.dependencies` = `{ "@dawn-ai/core": "latest", "@dawn-ai/cli": "latest", "@dawn-ai/langchain": "latest", "@dawn-ai/sdk": "latest", "zod": "^3.24.0" }`, matching devDeps, and **no `pnpm` key**. Update `test/generated/fixtures/basic.expected.json` to the actual normalized output (replace the dawn version with `<dawn-version>`). Re-run until green.
+
+- [ ] **Step 3: Regenerate the `custom-app-dir` fixture.**
+
+Run: `pnpm exec vitest run --config test/generated/vitest.config.ts test/generated/run-generated-app.test.ts -t "custom configured appDir"`
+Expected: FAIL with a diff; update `test/generated/fixtures/custom-app-dir.expected.json` the same way. Re-run until green.
+
+- [ ] **Step 4: Verify the internal-mode test still passes unchanged.**
+
+Run: `pnpm exec vitest run --config test/generated/vitest.config.ts test/generated/run-generated-app.test.ts -t "contributor-local"`
+Expected: PASS. Internal mode is untouched; its `<repo:...>` fixture and `createExpectedInternalFixture` are unaffected. If it references deleted symbols (e.g. `SCAFFOLD_PACKAGES`), update `createExpectedInternalFixture` to inline the package list it needs.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add test/generated/run-generated-app.test.ts test/generated/fixtures/basic.expected.json test/generated/fixtures/custom-app-dir.expected.json
+git commit -m "test(harness): fixtures reflect real registry install (real version ranges, no overrides)"
+```
+
+---
+
+### Task 6: All lanes green + cleanup + PR
+
+**Files:** (cleanup across `test/`), `.changeset/` (verify none needed)
+
+- [ ] **Step 1: Run the full harness.**
+
+Run: `pnpm -r build && pnpm verify:harness`
+Expected: `status: passed`, `passed=3 failed=0`. Framework, runtime, and smoke all install generated apps from Verdaccio. If a runtime/smoke fixture or assertion references a removed tarball/override, fix it the same way as Task 5.
+
+- [ ] **Step 2: Grep for dead references.**
+
+Run: `grep -rn "rewriteGeneratedAppDependencies\|FAIL_CLOSED_NPMRC\|SCAFFOLD_PACKAGES\|createPackagedInstaller\|extraDependencies" test/ | grep -v node_modules`
+Expected: no results, OR only intentional survivors (e.g. internal-mode helpers). Delete anything orphaned. Confirm `test/harness/packaged-app.ts` no longer exports unused packing helpers.
+
+- [ ] **Step 3: Lint + typecheck the changed files.**
+
+Run: `pnpm exec biome check --config-path packages/config-biome/biome.json test/harness/local-registry.ts test/harness/registry-global-setup.ts test/harness/scaffold-packaging.ts && pnpm -r --if-present typecheck`
+Expected: clean (apply any single-block formatting biome suggests manually; do not bare `biome --write` the repo). Typecheck passes.
+
+- [ ] **Step 4: Confirm no changeset is required.**
+
+Run: `BASE_REF=origin/main HEAD_REF=HEAD PR_AUTHOR=$(git config user.name) node scripts/check-changesets.mjs`
+Expected: "Changesets check skipped (no user-facing changes detected)" — all changes are under `test/` + root `package.json` devDep (not `packages/*/src/`). If it flags the root `package.json`, add an empty changeset: write `.changeset/verdaccio-harness.md` containing only `---\n---\n` plus a one-line note, and re-run.
+
+- [ ] **Step 5: Push and open the PR.**
+
+```bash
+git push -u origin feat/verdaccio-publish-harness
+gh pr create --base main --title "test(harness): real Verdaccio publish harness for generated apps" --body "Replaces pack→pin→overrides→fail-closed-.npmrc with an ephemeral Verdaccio registry: publish the whole workspace atomically, install scaffolded apps from it like a real npm user (no overrides/rewrite). All lanes migrated; internal mode untouched. Spec: docs/superpowers/specs/2026-06-18-verdaccio-publish-harness-design.md. 🤖 Generated with [Claude Code](https://claude.com/claude-code)"
+```
+
+- [ ] **Step 6: Watch CI to green.**
+
+Run: `gh run watch <id> --exit-status` for the PR's CI run.
+Expected: `validate` green (all three harness lanes pass under Verdaccio in CI). Investigate any uplink/port flake; the shared-store + random-port design should hold.

--- a/docs/superpowers/specs/2026-06-18-verdaccio-publish-harness-design.md
+++ b/docs/superpowers/specs/2026-06-18-verdaccio-publish-harness-design.md
@@ -1,0 +1,123 @@
+# Verdaccio-backed generated-app publish harness (Design)
+
+**Status:** Approved for planning
+**Date:** 2026-06-18
+**Roadmap:** Postmortem follow-up to the 0.8.2 release-gate break (PRs #237/#241). The generated-app verify lanes simulate "what a user installs from npm" via `pnpm pack → pin tarball paths → pnpm.overrides → fail-closed .npmrc`. That approximation produced two stacked silent fallbacks and a release-gate landmine. This replaces the approximation with the real thing: publish the workspace to a local registry (Verdaccio) and install the scaffolded app from it exactly as a published user would — no overrides, no tarball pinning, no fail-closed hack.
+
+## Problem
+
+Today an external-mode generated app is built like this (see `test/harness/scaffold-packaging.ts`, `test/harness/packaged-app.ts`, `test/generated/harness.ts`):
+
+1. `createPackagedInstaller` packs every `@dawn-ai/*` (+ `devkit` + `create-dawn-ai-app`) into tarballs and builds an `installer/` dir with `pnpm.overrides` pinning a couple of them.
+2. `create-dawn-ai-app --dist-tag next` scaffolds an app whose `package.json` deps are the **dist-tag string** (e.g. `"@dawn-ai/core": "next"`).
+3. `rewriteGeneratedAppDependencies` overwrites those specs with tarball paths, injects `pnpm.overrides` for the whole scaffold set, promotes transitive-only packages to direct deps via `extraDependencies`, and writes `FAIL_CLOSED_NPMRC` (`@dawn-ai:registry=http://127.0.0.1:1/`).
+4. `pnpm install` resolves `@dawn-ai/*` from local tarballs/overrides.
+
+This is a faithful-ish simulation that diverges from real npm resolution in exactly the ways that bit us:
+
+- **pnpm applies a file-path override inconsistently across a complex graph** — a transitive-only package (`@dawn-ai/workspace` via `core`/`langchain`/`testing`/`evals`) had *both* a `file:` and a registry `@dawn-ai/workspace@<v>` edge in the lockfile. The registry edge silently succeeded while the version was published and only `ERR_PNPM_NO_MATCHING_VERSION`-ed at release time (unpublished bumped version).
+- The mitigations (`extraDependencies` promotions, the dead-registry `.npmrc`, throw-on-missing-tarball) are scaffolding around an approximation, not the real resolution path.
+
+## Decisions (from brainstorming)
+
+- **Local registry = Verdaccio**, started **programmatically** (`runServer` + `listen(0)`), not CLI-spawned or Docker.
+- **Whole-registry resolution + npmjs uplink** (not per-scope): the app's `.npmrc` sets `registry=<verdaccio>`; Verdaccio serves `@dawn-ai/*` locally and proxies everything else to npmjs. One resolution path — the most faithful "real npm user" model (the Nx/changesets pattern).
+- **`@dawn-ai/*` scope is local-only** (no `proxy:` field) so freshly published versions are never shadowed/409'd by npmjs. `**` catch-all keeps `proxy: npmjs`. Pattern order: scope before catch-all.
+- **Publish the whole workspace atomically at one canonical version.** `pnpm -r publish` publishes every publishable workspace package and rewrites `workspace:*` to the exact current version. Before publishing, **assert all publishable packages share one identical version** (the fixed-group invariant) and fail loudly on any drift — never publish a skewed set. Fresh per-run storage means a mid-publish failure leaves no partial state: the run fails and the next run republishes clean. We do **not** mutate working-tree versions.
+- **Scaffold with the default `latest` dist-tag** (drop the harness's historical `next`) — a real user runs the default. Publish to Verdaccio tagged `latest`, so `@dawn-ai/core@latest` resolves to exactly the code under test.
+- **All lanes migrate at once** (framework + runtime + smoke + cli-testing-export). Delete the old mechanism entirely — no dual path, no backwards compat.
+- **Internal mode is untouched** — `buildLocalContributorPackages` + `--mode internal` (file:-linked monorepo) tests the contributor/checkout experience, a genuinely different thing.
+
+## Verified facts (against the worktree)
+
+- `packages/devkit/templates/app-basic/package.json.template` writes the dist-tag literally: `"@dawn-ai/core": "{{dawnCoreSpecifier}}"` where the specifier *is* the dist-tag string. `create-dawn-app`'s default `distTag = "latest"` (`packages/create-dawn-app/src/index.ts:81`).
+- `@dawn-ai/*` packages depend on each other via `workspace:*` (e.g. `packages/cli/package.json`), which `pnpm -r publish` rewrites to the exact version at publish time.
+- The real release publishes per-package via `pnpm pack` + `npm publish --provenance` (`scripts/release-publish.mjs`); provenance/OIDC is npmjs-specific, so the harness uses `pnpm -r publish` against Verdaccio instead (equivalent resolution result, no provenance).
+- Lanes and call sites: `createPackagedInstaller` / `rewriteGeneratedAppDependencies` are called from `test/generated/run-generated-app.test.ts`, `test/generated/harness.ts`, `test/smoke/run-smoke.test.ts`, `test/runtime/run-agent-protocol.test.ts`, `test/runtime/run-runtime-contract.test.ts`, and `test/generated/cli-testing-export.test.ts`. Lanes run via `scripts/harness-report.mjs` against `test/{generated,runtime,smoke}/vitest.config.ts`.
+
+## Architecture
+
+A **per-lane ephemeral Verdaccio**. Each lane's vitest config gains a `globalSetup` that:
+
+1. Starts Verdaccio programmatically: `runServer(config)` then `server.listen(0)`; read back the random port → `url`. Fresh `mkdtemp` storage dir. The `listen` callback is the readiness signal (no polling). Random port also **busts pnpm's per-registry metadata cache** between runs.
+2. Publishes the whole workspace once: assert uniform version → `pnpm -r publish --registry <url> --tag latest --no-git-checks` with a publish-time `.npmrc`/env carrying a throwaway `//host:port/:_authToken="fake"` (npm refuses to publish without a token even when the scope allows `$anonymous`).
+3. Exposes `url` to the lane's tests via `process.env.DAWN_TEST_REGISTRY_URL`.
+4. Returns a teardown that `server.close()`s and `rm`s the storage dir.
+
+Per scenario (external mode):
+
+- Scaffold with `create-dawn-ai-app <appRoot> --template <t>` (default `latest` dist-tag).
+- Write a real `.npmrc` into the app: `registry=<url>` (+ the fake `_authToken` line for parity; not needed for reads).
+- `pnpm install` — `@dawn-ai/*@latest` resolves from Verdaccio, everything else via its npmjs uplink. **No overrides, no rewrite.**
+- Run the existing lifecycle (`dawn verify`/`routes`/`typegen`, `typecheck`, `build`) and dev-server scenarios (runtime/smoke) unchanged.
+- Compare against fixtures.
+
+### Verdaccio config (object form)
+
+```js
+{
+  storage,                 // fresh mkdtemp dir; self_path: storage (v5 object-config requirement)
+  uplinks: { npmjs: { url: "https://registry.npmjs.org/", maxage: "30m" } },
+  packages: {
+    "@dawn-ai/*": { access: "$all", publish: "$anonymous", unpublish: "$anonymous" }, // NO proxy → local-only
+    "**":         { access: "$all", publish: "$anonymous", proxy: "npmjs" },
+  },
+  logs: { type: "stdout", format: "pretty", level: "warn" },
+}
+```
+
+## Components
+
+**New — `test/harness/local-registry.ts`**
+- `startLocalRegistry(): Promise<{ url, stop() }>` — programmatic Verdaccio on `listen(0)`, temp storage, config above.
+- `publishWorkspace(url): Promise<void>` — assert uniform version across publishable packages; `pnpm -r publish --registry url --tag latest --no-git-checks` with the fake-token `.npmrc`/env.
+- One small function each; both independently testable.
+
+**New — per-lane `globalSetup`** wiring start → publish → expose `DAWN_TEST_REGISTRY_URL` → teardown, referenced from the three lane vitest configs.
+
+**Changed — `test/harness/packaged-app.ts` (`createPackagedInstaller`)**: collapses to "make `create-dawn-ai-app` available from the registry" (install/`dlx` it against Verdaccio). The tarball-map + installer-overrides logic is removed; packing per-package for pinning is no longer needed (the registry holds everything).
+
+**Changed — scaffold-side helper**: a tiny `writeRegistryNpmrc(appRoot, url)` replaces `rewriteGeneratedAppDependencies` at every external call site. Scaffolders pass `--dist-tag latest` (or omit, since it's the default).
+
+**Changed — `normalizeForFixture`**: drop tarball-path/override normalization; add `@dawn-ai` resolved-**version** normalization (published version = current monorepo version, changes each release → `<version:@dawn-ai/...>`).
+
+**Deleted**: `rewriteGeneratedAppDependencies`, `FAIL_CLOSED_NPMRC`, all `extraDependencies` promotions (workspace/sqlite-storage/langgraph/permissions) across every lane call site, the installer-override path, and the related guard tests in `scaffold-packaging.test.ts` (tarball/override/.npmrc assertions).
+
+**Untouched**: internal mode (`buildLocalContributorPackages`, `--mode internal`, the `<repo:...>` internal fixture). The `test/harness/**` test-include wiring added in #241 stays (now covers `local-registry.ts`).
+
+## Store freshness (shared global store, no isolation)
+
+We keep the **shared global pnpm store** (fast — third-party deps stay cached) and rely on two facts for `@dawn-ai` freshness:
+
+1. **Random port → unique registry URL per run → pnpm metadata cache miss** for `@dawn-ai/*`, so resolution always re-reads Verdaccio's fresh packument.
+2. **Content-addressable store**: changed `@dawn-ai` content under the same version yields a new tarball integrity in Verdaccio's packument → store miss → fresh fetch.
+
+So same-version-different-content cannot serve stale bits. **This is verified empirically in the first implementation step**; documented fallback if it proves flaky is an isolated `--store-dir <temp>` per lane (slower, re-proxies third-party deps).
+
+## Error handling
+
+- **Readiness**: `listen` callback; no log-grep.
+- **Missing/unpublished `@dawn-ai` package**: Verdaccio 404 (local-only scope) → loud install failure. This *replaces* the dead-registry fail-closed guard.
+- **Publish-too-fast 409 / "Failed to save packument"**: fresh temp storage per run + `pnpm -r` serializes; add a bounded retry if observed flaky.
+- **Atomicity**: assert uniform version pre-publish (fail loud on drift); any publish error fails the lane; fresh storage prevents partial-state carryover.
+- **Uplink cold cache**: first run pays npmjs latency for third-party metadata (cached by `maxage`); acceptable.
+- **Teardown**: always `server.close()` + `rm` storage, even on failure.
+
+## Testing
+
+- **`local-registry.ts` unit/integration test** (runs in the framework lane via the `test/harness/**` include): start → publish → a probe `pnpm install` of a tiny app resolves `@dawn-ai/core@latest` from the registry → teardown leaves nothing listening.
+- **Negative test**: scaffold/probe an app referencing an `@dawn-ai` package that was *not* published → `pnpm install` 404s. Preserves the fail-closed property the dead-registry `.npmrc` used to give.
+- **Lane fixtures regenerated**: `basic` / `custom-app-dir` app `package.json` becomes the plain scaffolded template (`"@dawn-ai/core": "latest"`, **no `pnpm.overrides`**). `normalizeForFixture` version-normalizes `@dawn-ai` resolutions. Internal-mode fixture unchanged.
+- **All three lanes green** under `pnpm verify:harness` with the new model; no overrides/`.npmrc`-hack present in any generated app.
+
+## Out of scope
+
+- Internal/contributor-local mode (stays file:-linked).
+- The real release path (`scripts/release-publish.mjs`, OIDC/provenance) — unchanged; the harness mirrors *resolution*, not provenance.
+- Publishing real packages anywhere outside the ephemeral local registry.
+
+## Risks
+
+- **Uplink latency/availability** for third-party deps on a cold cache (first CI run slower; npmjs dependency). Mitigated by `maxage` and the warm shared store.
+- **pnpm + Verdaccio publish race** (#11454) — mitigated by fresh storage + serialized `pnpm -r`; retry if needed.
+- **Shared-store freshness reasoning** — verified empirically in step 1 before building on it; isolated store is the fallback.

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "publint": "0.3.15",
     "turbo": "2.9.18",
     "typescript": "6.0.2",
+    "verdaccio": "^6.7.2",
     "vitest": "4.1.9"
   }
 }

--- a/packages/create-dawn-app/test/create-app.test.ts
+++ b/packages/create-dawn-app/test/create-app.test.ts
@@ -7,8 +7,8 @@ import { afterEach, describe, expect, test } from "vitest"
 
 import {
   cleanupTrackedTempDirs,
-  createPackagedInstaller,
   createTrackedTempDir,
+  installPackagedScaffolder,
   type TrackedTempDir,
 } from "../../../test/harness/packaged-app.ts"
 import { run } from "../src/index.js"
@@ -64,9 +64,7 @@ describe("create-dawn-ai-app", () => {
   }, async () => {
     const tempRoot = await createTrackedTempDir("create-dawn-app-standalone-", tempDirs)
 
-    const { installerDir: installDir } = await createPackagedInstaller({
-      tempRoot,
-    })
+    const { installerDir: installDir } = await installPackagedScaffolder(tempRoot)
     const targetDir = join(tempRoot, "hello-dawn")
 
     const scaffoldResult = await runCommand(
@@ -124,9 +122,7 @@ describe("create-dawn-ai-app", () => {
   }, async () => {
     const tempRoot = await createTrackedTempDir("create-dawn-app-standalone-", tempDirs)
 
-    const { installerDir: installDir } = await createPackagedInstaller({
-      tempRoot,
-    })
+    const { installerDir: installDir } = await installPackagedScaffolder(tempRoot)
 
     const invalidInternalTargetDir = join(tempRoot, "hello-dawn-internal")
     const internalModeResult = await runCommand(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,6 +39,9 @@ importers:
       typescript:
         specifier: 6.0.2
         version: 6.0.2
+      verdaccio:
+        specifier: ^6.7.2
+        version: 6.7.2(typanion@3.14.0)
       vitest:
         specifier: 4.1.9
         version: 4.1.9(@types/node@25.6.0)(vite@6.4.3(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))
@@ -624,6 +627,10 @@ packages:
         optional: true
       vitest:
         optional: true
+
+  '@cypress/request@3.0.10':
+    resolution: {integrity: sha512-hauBrOdvu08vOsagkZ/Aju5XuiZx6ldsLfByg1htFeldhex+PeMrYauANzFsMJeAA0+dyPLbDoX2OYuvVoLDkQ==}
+    engines: {node: '>= 6'}
 
   '@emnapi/runtime@1.9.2':
     resolution: {integrity: sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==}
@@ -1321,6 +1328,9 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
+  '@pinojs/redact@0.4.0':
+    resolution: {integrity: sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==}
+
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
 
@@ -1497,6 +1507,10 @@ packages:
   '@shikijs/vscode-textmate@10.0.2':
     resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
 
+  '@sindresorhus/is@4.6.0':
+    resolution: {integrity: sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==}
+    engines: {node: '>=10'}
+
   '@stablelib/base64@1.0.1':
     resolution: {integrity: sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==}
 
@@ -1505,6 +1519,10 @@ packages:
 
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
+
+  '@szmarczak/http-timer@4.0.6':
+    resolution: {integrity: sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==}
+    engines: {node: '>=10'}
 
   '@tailwindcss/node@4.2.4':
     resolution: {integrity: sha512-Ai7+yQPxz3ddrDQzFfBKdHEVBg0w3Zl83jnjuwxnZOsnH9pGn93QHQtpU0p/8rYWxvbFZHneni6p1BSLK4DkGA==}
@@ -1672,6 +1690,9 @@ packages:
   '@types/react@19.2.14':
     resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
 
+  '@types/responselike@1.0.0':
+    resolution: {integrity: sha512-85Y2BjiufFzaMIlvJDvTTB8Fxl2xfLo4HgmHzVBz08w4wDePCTjYw66PdrolO0kzli3yam/YCgRufyo1DdQVTA==}
+
   '@types/unist@2.0.11':
     resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
 
@@ -1680,6 +1701,81 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+
+  '@verdaccio/auth@8.0.2':
+    resolution: {integrity: sha512-Qw5DhIIzNsM1ORbrnYDKQ2iA1ACWZkjWtxXrYFh577at9+H9QR45m3mMokcRVr3t2UBNFEmMb5cGTrReFa5Dzw==}
+    engines: {node: '>=18'}
+
+  '@verdaccio/config@8.1.1':
+    resolution: {integrity: sha512-N9nS1AAME02iuhC2B3v67NnKQp2MkUoN5uUQ2JoS2seWQ6Bjs8dnkWfh4B9N5QTVjUQx4ETYOb3M+UqUJDJT8A==}
+    engines: {node: '>=18'}
+
+  '@verdaccio/core@8.1.1':
+    resolution: {integrity: sha512-IIgi8PucT67ymIwxwzc+5CGQF97xAPWlqb7M2nidfIpPtlghPjURDP6xHDcBLuE57adZKcklO24kr6zFSQa7cg==}
+    engines: {node: '>=18'}
+
+  '@verdaccio/file-locking@13.0.1':
+    resolution: {integrity: sha512-SZ9uxnQKppiM+/67xTaaBP4AZ/Q+weUB22ci1gF861icYWhWFu3njA3ofYig/4yNqkYRVEKVAIwnH97BaBEYbg==}
+    engines: {node: '>=18'}
+
+  '@verdaccio/hooks@8.0.2':
+    resolution: {integrity: sha512-lneKTW6MDo28+hHqkIin08ruAafTvMake2TYUMdXWp+ah1YFI9XVzj6eo/rKHUB6sC4NxrBVajsGo1NX0OCE+A==}
+    engines: {node: '>=18'}
+
+  '@verdaccio/loaders@8.0.2':
+    resolution: {integrity: sha512-Hm2xa47EXPI+Rnl3a0oTvEa1OIngze36YDHXNvHEhN35emID9iqJk1BoD5rA4Y2AdR9Jy34wRqzdqcwg9+ftSA==}
+    engines: {node: '>=18'}
+
+  '@verdaccio/local-storage-legacy@11.3.3':
+    resolution: {integrity: sha512-F+cXs0Hy8tQsA6aE0hy0FaimgPfhqmetKbepOOZkstNlzOAhCzhue414VQaswKBJ/ylrmSgXP45HZjst+JNyjA==}
+    engines: {node: '>=18'}
+
+  '@verdaccio/logger-commons@8.0.2':
+    resolution: {integrity: sha512-PzR1+0tVWzDc6aQsPCi6LVywWTXD0bp61f97On8ia4Ihms6ahP9MZzF86Mub6laBw4mBsBo45EBFaqQfotvUoA==}
+    engines: {node: '>=18'}
+
+  '@verdaccio/logger-prettify@8.0.1':
+    resolution: {integrity: sha512-49a5LTi90TxjQPBk7rZUf0qCorAjOopq7uQzGRro6dOEFmyaZ/K2sNiOuRFJzVuC8C8jL/zPlJiln1vm5HsAMA==}
+    engines: {node: '>=18'}
+
+  '@verdaccio/logger@8.0.2':
+    resolution: {integrity: sha512-yxCVJP9Inr6qfdsDaOUCWWj0g0SzLY6J+62QkBafZLqIqng8IfI1NRe/6n2O3AH+YPThbqxhgaAJQ5MJTvBxOw==}
+    engines: {node: '>=18'}
+
+  '@verdaccio/middleware@8.0.2':
+    resolution: {integrity: sha512-CmSoXI1/5lfH25NP3Q7ic9TEUSn6gENqauU00EhYZ/RAk/jYyPCkokSJBi9RhsAsOjOUry4yM4c3vgxLdO8Iwg==}
+    engines: {node: '>=18'}
+
+  '@verdaccio/package-filter@13.0.2':
+    resolution: {integrity: sha512-y9X52mCpP9AKoAB6W/ymYS5XscBNOT7HdSfYIy3BMpNJxD4+rwMO/SwKn3uAY+2RaMAgU1N7NBUmPtQAYFGhww==}
+    engines: {node: '>=18'}
+
+  '@verdaccio/search-indexer@8.0.2':
+    resolution: {integrity: sha512-Pd2vGmb69pMuZj+WyiUMcbPU9H9Zfm0xHy0p2jDhb4PfT0rnoGgM0a7GxlmywsRuIM5obm4OCUZdhw0N8BnwYw==}
+    engines: {node: '>=18'}
+
+  '@verdaccio/signature@8.0.2':
+    resolution: {integrity: sha512-0vmv3D2SmyJsLoN0e+O+wvjYdUxu/cxsCSRbchmK3m1dFxrGNyxEdQkdBAKDyOr2sQit5xM0XSwHRIqYrmr8Lw==}
+    engines: {node: '>=18'}
+
+  '@verdaccio/streams@10.2.5':
+    resolution: {integrity: sha512-nVnTYeMJ7h131Nkv2svqZCfL5aDkJbwUvQd4OGXssbJJR5BfB2PzNq8TD45lEXIBW3EMMMFs7mVY789ds9soIA==}
+    engines: {node: '>=12', npm: '>=5'}
+
+  '@verdaccio/tarball@13.0.2':
+    resolution: {integrity: sha512-LQHoAlp7yk5Tlhv+uHWJKtExwbMDBvwTvoAsdWMq4sRjCrdJSz8KTfWEBrb0EayxEwPr0LmI0ce8mIriId9Zow==}
+    engines: {node: '>=18'}
+
+  '@verdaccio/ui-theme@9.0.0-next-9.14':
+    resolution: {integrity: sha512-0PQW6PV+sHsQdV3gnHQqAcDcVGfT75vHq1TfIeEN2QY5KuEkvli8e5vut+sTe89p+GOTahHKgTMOcL0O3BvsgA==}
+
+  '@verdaccio/url@13.0.2':
+    resolution: {integrity: sha512-dXVBJETBV5Q/jz7R/fTQxnzsTjgnDBEh2v8aOKtngwBEf7YkgzU7LrtyzkGmyRzXUvS5ZSAXWrBAKQ4DEIZ/6w==}
+    engines: {node: '>=18'}
+
+  '@verdaccio/utils@8.1.2':
+    resolution: {integrity: sha512-LTV6/Kcr8pS//iDjDitfYi1bp0AlKBUuvNoHAbI8tMnj0PLOUtRWJxId5FwuE+z3oNBeDLeOWPoXVtqKjl277Q==}
+    engines: {node: '>=18'}
 
   '@vitest/expect@3.2.6':
     resolution: {integrity: sha512-1+7q9BtaKzEmO+fmNT3kYvoNn5Y71XWAx2Q5HRim4tTVRQVRv4uJFAQ5FbK0OPUeNP/WmVCpxYxoJdvuHVjzBQ==}
@@ -1773,6 +1869,18 @@ packages:
   '@vitest/utils@4.1.9':
     resolution: {integrity: sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==}
 
+  JSONStream@1.3.5:
+    resolution: {integrity: sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==}
+    hasBin: true
+
+  abort-controller@3.0.0:
+    resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
+    engines: {node: '>=6.5'}
+
+  accepts@1.3.8:
+    resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
+    engines: {node: '>= 0.6'}
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -1783,6 +1891,13 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  agent-base@6.0.2:
+    resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
+    engines: {node: '>= 6.0.0'}
+
+  ajv@8.18.0:
+    resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
+
   ansi-colors@4.1.3:
     resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
     engines: {node: '>=6'}
@@ -1791,15 +1906,29 @@ packages:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
 
+  apache-md5@1.1.8:
+    resolution: {integrity: sha512-FCAJojipPn0bXjuEpjOOOMN8FZDkxfWWp4JGN9mifU2IhxvKyXZYqpzPHdnTSUpmPDy+tsslB6Z1g+Vg6nVbYA==}
+    engines: {node: '>=8'}
+
   argparse@1.0.10:
     resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
+  array-flatten@1.1.1:
+    resolution: {integrity: sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==}
+
   array-union@2.1.0:
     resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
     engines: {node: '>=8'}
+
+  asn1@0.2.6:
+    resolution: {integrity: sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==}
+
+  assert-plus@1.0.0:
+    resolution: {integrity: sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==}
+    engines: {node: '>=0.8'}
 
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
@@ -1809,8 +1938,43 @@ packages:
     resolution: {integrity: sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==}
     hasBin: true
 
+  async@3.2.6:
+    resolution: {integrity: sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==}
+
+  asynckit@0.4.0:
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+
+  atomic-sleep@1.0.0:
+    resolution: {integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==}
+    engines: {node: '>=8.0.0'}
+
+  aws-sign2@0.7.0:
+    resolution: {integrity: sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA==}
+
+  aws4@1.13.2:
+    resolution: {integrity: sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==}
+
+  b4a@1.8.1:
+    resolution: {integrity: sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==}
+    peerDependencies:
+      react-native-b4a: '*'
+    peerDependenciesMeta:
+      react-native-b4a:
+        optional: true
+
   bail@2.0.2:
     resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
+
+  balanced-match@1.0.2:
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
+  bare-events@2.9.1:
+    resolution: {integrity: sha512-Z0oHEHAFDZkffN8Qc39zNZjQlMDkPJRyyyZieU1VH7u8c5S+qHZ2S8ixdKIAxEjfHO7FJxXmJWgteOghVanIsg==}
+    peerDependencies:
+      bare-abort-controller: '*'
+    peerDependenciesMeta:
+      bare-abort-controller:
+        optional: true
 
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
@@ -1820,20 +1984,68 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
+  bcrypt-pbkdf@1.0.2:
+    resolution: {integrity: sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==}
+
+  bcryptjs@2.4.3:
+    resolution: {integrity: sha512-V/Hy/X9Vt7f3BbPJEi8BdVFMByHi+jNXrYkW3huaybV/kQ0KJg0Y6PkEMbn+zeT+i+SiKZ/HMqJGIIt4LZDqNQ==}
+
   better-path-resolve@1.0.0:
     resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
     engines: {node: '>=4'}
+
+  body-parser@1.20.5:
+    resolution: {integrity: sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==}
+    engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
+
+  brace-expansion@2.1.1:
+    resolution: {integrity: sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
 
+  browserify-zlib@0.1.4:
+    resolution: {integrity: sha512-19OEpq7vWgsH6WkvkBJQDFvJS1uPcbFOQ4v9CU839dO+ZZXUZO6XpE6hNCqvlIIj+4fZvRiJ6DsAQ382GwiyTQ==}
+
+  buffer-equal-constant-time@1.0.1:
+    resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
+
+  buffer-from@1.1.2:
+    resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
+
+  buffer@6.0.3:
+    resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
+
+  bytes@3.1.2:
+    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
+    engines: {node: '>= 0.8'}
+
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
 
+  cacheable-lookup@6.1.0:
+    resolution: {integrity: sha512-KJ/Dmo1lDDhmW2XDPMo+9oiy/CeqosPguPCrgcVzKyZrL6pM1gU2GmPY/xo6OQPTUaA/c0kwHuywB4E6nmT9ww==}
+    engines: {node: '>=10.6.0'}
+
+  cacheable-request@7.0.2:
+    resolution: {integrity: sha512-pouW8/FmiPQbuGpkXQ9BAPv/Mo5xDGANgSNXzTzJ8DrKGuXOssM4wIQRjfanNRh3Yu5cfYPvcorqbhg2KIJtew==}
+    engines: {node: '>=8'}
+
+  call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
+  call-bound@1.0.4:
+    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
+    engines: {node: '>= 0.4'}
+
   caniuse-lite@1.0.30001787:
     resolution: {integrity: sha512-mNcrMN9KeI68u7muanUpEejSLghOKlVhRqS/Za2IeyGllJ9I9otGpR9g3nsw7n4W378TE/LyIteA0+/FOZm4Kg==}
+
+  caseless@0.12.0:
+    resolution: {integrity: sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==}
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
@@ -1868,8 +2080,23 @@ packages:
   client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
 
+  clipanion@4.0.0-rc.4:
+    resolution: {integrity: sha512-CXkMQxU6s9GklO/1f714dkKBMu1lopS1WFF0B8o4AxPykR1hpozxSiUZ5ZUeBjfPgCWqbcNOtZVFhB8Lkfp1+Q==}
+    peerDependencies:
+      typanion: '*'
+
+  clone-response@1.0.3:
+    resolution: {integrity: sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==}
+
   collapse-white-space@2.1.0:
     resolution: {integrity: sha512-loKTxY1zCOuG4j9f6EPnuyyYkf58RnhhWTvRoZEokgB+WbdXehfjFviyOVYkqzEWz1Q5kRiZdBYS5SwxbQYwzw==}
+
+  colorette@2.0.20:
+    resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
+
+  combined-stream@1.0.8:
+    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
+    engines: {node: '>= 0.8'}
 
   comma-separated-tokens@2.0.3:
     resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
@@ -1878,12 +2105,45 @@ packages:
     resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
     engines: {node: '>=20'}
 
+  compressible@2.0.18:
+    resolution: {integrity: sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==}
+    engines: {node: '>= 0.6'}
+
+  compression@1.8.1:
+    resolution: {integrity: sha512-9mAqGPHLakhCLeNyxPkK4xVo746zQ/czLH1Ky+vkitMnWfWZps8r0qXuwhwizagCRttsL4lfG4pIOvaWLpAP0w==}
+    engines: {node: '>= 0.8.0'}
+
+  content-disposition@0.5.4:
+    resolution: {integrity: sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==}
+    engines: {node: '>= 0.6'}
+
+  content-type@1.0.5:
+    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
+    engines: {node: '>= 0.6'}
+
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  cookie-signature@1.0.7:
+    resolution: {integrity: sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==}
+
+  cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
+    engines: {node: '>= 0.6'}
 
   cookie@1.1.1:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
     engines: {node: '>=18'}
+
+  core-util-is@1.0.2:
+    resolution: {integrity: sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==}
+
+  core-util-is@1.0.3:
+    resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
+
+  cors@2.8.6:
+    resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
+    engines: {node: '>= 0.10'}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -1891,6 +2151,21 @@ packages:
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  dashdash@1.14.1:
+    resolution: {integrity: sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==}
+    engines: {node: '>=0.10'}
+
+  dayjs@1.11.18:
+    resolution: {integrity: sha512-zFBQ7WFRvVRhKcWoUh+ZA1g2HVgUbsZm9sbddh8EC5iv93sui8DVVz1Npvz+r6meo9VKfa8NyLWBsQK1VvIKPA==}
+
+  debug@2.6.9:
+    resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
 
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
@@ -1904,13 +2179,33 @@ packages:
   decode-named-character-reference@1.3.0:
     resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
 
+  decompress-response@6.0.0:
+    resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
+    engines: {node: '>=10'}
+
   deep-eql@5.0.2:
     resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
     engines: {node: '>=6'}
 
+  defer-to-connect@2.0.1:
+    resolution: {integrity: sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==}
+    engines: {node: '>=10'}
+
+  delayed-stream@1.0.0:
+    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
+    engines: {node: '>=0.4.0'}
+
+  depd@2.0.0:
+    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
+    engines: {node: '>= 0.8'}
+
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
+
+  destroy@1.2.0:
+    resolution: {integrity: sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==}
+    engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
 
   detect-indent@6.1.0:
     resolution: {integrity: sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==}
@@ -1927,6 +2222,29 @@ packages:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
     engines: {node: '>=8'}
 
+  dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
+
+  duplexify@3.7.1:
+    resolution: {integrity: sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==}
+
+  ecc-jsbn@0.1.2:
+    resolution: {integrity: sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==}
+
+  ecdsa-sig-formatter@1.0.11:
+    resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
+
+  ee-first@1.1.1:
+    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
+
+  encodeurl@2.0.0:
+    resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
+    engines: {node: '>= 0.8'}
+
+  end-of-stream@1.4.5:
+    resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
+
   enhanced-resolve@5.20.1:
     resolution: {integrity: sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==}
     engines: {node: '>=10.13.0'}
@@ -1939,11 +2257,32 @@ packages:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
     engines: {node: '>=0.12'}
 
+  envinfo@7.21.0:
+    resolution: {integrity: sha512-Lw7I8Zp5YKHFCXL7+Dz95g4CcbMEpgvqZNNq3AmlT5XAV6CgAAk6gyAMqn2zjw08K9BHfcNuKrMiCPLByGafow==}
+    engines: {node: '>=4'}
+    hasBin: true
+
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
 
   es-module-lexer@2.0.0:
     resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
+
+  es-object-atoms@1.1.2:
+    resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
+    engines: {node: '>= 0.4'}
+
+  es-set-tostringtag@2.1.0:
+    resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
+    engines: {node: '>= 0.4'}
 
   esast-util-from-estree@2.0.0:
     resolution: {integrity: sha512-4CyanoAudUSBAn5K13H4JhsMH6L9ZP7XbLVe/dKybkxMO7eDyLsT8UHl9TRNrU2Gr9nz+FovfSIjuXWJ81uVwQ==}
@@ -1960,6 +2299,9 @@ packages:
     resolution: {integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==}
     engines: {node: '>=18'}
     hasBin: true
+
+  escape-html@1.0.3:
+    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
 
   escape-string-regexp@5.0.0:
     resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
@@ -1994,11 +2336,26 @@ packages:
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
 
+  etag@1.8.1:
+    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
+    engines: {node: '>= 0.6'}
+
+  event-target-shim@5.0.1:
+    resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
+    engines: {node: '>=6'}
+
   eventemitter3@4.0.7:
     resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
 
   eventemitter3@5.0.4:
     resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
+
+  events-universal@1.0.1:
+    resolution: {integrity: sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==}
+
+  events@3.3.0:
+    resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
+    engines: {node: '>=0.8.x'}
 
   eventsource-parser@3.0.8:
     resolution: {integrity: sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==}
@@ -2007,6 +2364,13 @@ packages:
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
+
+  express-rate-limit@5.5.1:
+    resolution: {integrity: sha512-MTjE2eIbHv5DyfuFz4zLYWxpqVhEhkTiwFGuB74Q9CSou2WHO52nlE5y3Zlg6SIsiYUIPj6ifFxnkPz6O3sIUg==}
+
+  express@4.22.1:
+    resolution: {integrity: sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==}
+    engines: {node: '>= 0.10.0'}
 
   extend-shallow@2.0.1:
     resolution: {integrity: sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==}
@@ -2018,12 +2382,25 @@ packages:
   extendable-error@0.1.7:
     resolution: {integrity: sha512-UOiS2in6/Q0FK0R0q6UY9vYpQ21mr/Qn1KOnte7vsACuNJf514WvCCUHSRCPcgjPT2bAhNIJdlE6bVap1GKmeg==}
 
+  extsprintf@1.3.0:
+    resolution: {integrity: sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g==}
+    engines: {'0': node >=0.6.0}
+
+  fast-deep-equal@3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-fifo@1.3.2:
+    resolution: {integrity: sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==}
+
   fast-glob@3.3.3:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
     engines: {node: '>=8.6.0'}
 
   fast-sha256@1.3.0:
     resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
+
+  fast-uri@3.1.2:
+    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
@@ -2047,6 +2424,10 @@ packages:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
 
+  finalhandler@1.3.2:
+    resolution: {integrity: sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==}
+    engines: {node: '>= 0.8'}
+
   find-up@4.1.0:
     resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
     engines: {node: '>=8'}
@@ -2054,9 +2435,27 @@ packages:
   flatted@3.4.2:
     resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
+  forever-agent@0.6.1:
+    resolution: {integrity: sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==}
+
+  form-data-encoder@1.7.2:
+    resolution: {integrity: sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==}
+
+  form-data@4.0.6:
+    resolution: {integrity: sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==}
+    engines: {node: '>= 6'}
+
   format@0.2.2:
     resolution: {integrity: sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==}
     engines: {node: '>=0.4.x'}
+
+  forwarded@0.2.0:
+    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
+    engines: {node: '>= 0.6'}
+
+  fresh@0.5.2:
+    resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
+    engines: {node: '>= 0.6'}
 
   fs-extra@7.0.1:
     resolution: {integrity: sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==}
@@ -2071,8 +2470,34 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  fuse.js@7.3.0:
+    resolution: {integrity: sha512-plz8RVjfcDedTGfVngWH1jmJvBvAwi1v2jecfDerbEnMcmOYUEEwKFTHbNoCiYyzaK2Ws8lABkTCcRSqCY1q4w==}
+    engines: {node: '>=10'}
+
+  get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
+
+  get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
+
+  get-stream@5.2.0:
+    resolution: {integrity: sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==}
+    engines: {node: '>=8'}
+
+  get-stream@6.0.1:
+    resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
+    engines: {node: '>=10'}
+
   get-tsconfig@4.13.7:
     resolution: {integrity: sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==}
+
+  getpass@0.1.7:
+    resolution: {integrity: sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==}
 
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
@@ -2081,6 +2506,14 @@ packages:
   globby@11.1.0:
     resolution: {integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==}
     engines: {node: '>=10'}
+
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
+
+  got-cjs@12.5.4:
+    resolution: {integrity: sha512-Uas6lAsP8bRCt5WXGMhjFf/qEHTrm4v4qxGR02rLG2kdG9qedctvlkdwXVcDJ7Cs84X+r4dPU7vdwGjCaspXug==}
+    engines: {node: '>=12'}
 
   gpt-tokenizer@3.4.0:
     resolution: {integrity: sha512-wxFLnhIXTDjYebd9A9pGl3e31ZpSypbpIJSOswbgop5jLte/AsZVDvjlbEuVFlsqZixVKqbcoNmRlFDf6pz/UQ==}
@@ -2095,6 +2528,27 @@ packages:
   groq-sdk@1.2.0:
     resolution: {integrity: sha512-pMhSYXWcjiqvbOeKdv2zjci1BYjGdp04a40hnmQmJpKJyB6oa+gRndAqE128gwR0NLgYO+Wt1fIF46KNHcplsw==}
     hasBin: true
+
+  gunzip-maybe@1.4.2:
+    resolution: {integrity: sha512-4haO1M4mLO91PW57BMsDFf75UmwoRX0GkdD+Faw+Lr+r/OZrOCS0pIBwOL1xCKQqnQzbNFGgK2V2CpBUPeFNTw==}
+    hasBin: true
+
+  handlebars@4.7.9:
+    resolution: {integrity: sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==}
+    engines: {node: '>=0.4.7'}
+    hasBin: true
+
+  has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
+  has-tostringtag@1.0.2:
+    resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.4:
+    resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
+    engines: {node: '>= 0.4'}
 
   hast-util-from-html@2.0.3:
     resolution: {integrity: sha512-CUSRHXyKjzHov8yKsQjGOElXy/3EKpyX56ELnkHH34vDVw1N1XSQ1ZcAvTyAPtGqLTuKP/uxM+aLkSPqF/EtMw==}
@@ -2126,20 +2580,56 @@ packages:
   html-void-elements@3.0.0:
     resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
 
+  http-cache-semantics@4.2.0:
+    resolution: {integrity: sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==}
+
+  http-errors@2.0.1:
+    resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
+    engines: {node: '>= 0.8'}
+
+  http-signature@1.4.0:
+    resolution: {integrity: sha512-G5akfn7eKbpDN+8nPS/cb57YeA1jLTVxjpCj7tmm3QKPdyDy7T+qSC40e9ptydSWvkwjSXw1VbkpyEm39ukeAg==}
+    engines: {node: '>=0.10'}
+
+  http-status-codes@2.3.0:
+    resolution: {integrity: sha512-RJ8XvFvpPM/Dmc5SV+dC4y5PCeOhT3x1Hq0NU3rjGeg5a/CqlhZ7uudknPwZFz4aeAXDcbAyaeP7GAo9lvngtA==}
+
+  http2-wrapper@2.2.1:
+    resolution: {integrity: sha512-V5nVw1PAOgfI3Lmeaj2Exmeg7fenjhRUgz1lPSezy1CuhPYbgQtbQj4jZfEAEMlaL+vupsvhjqCyjzob0yxsmQ==}
+    engines: {node: '>=10.19.0'}
+
+  https-proxy-agent@5.0.1:
+    resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
+    engines: {node: '>= 6'}
+
   human-id@4.1.3:
     resolution: {integrity: sha512-tsYlhAYpjCKa//8rXZ9DqKEawhPoSytweBC2eNvcaDK+57RZLHGqNs3PZTQO6yekLFSuvA6AlnAfrw1uBvtb+Q==}
     hasBin: true
+
+  iconv-lite@0.4.24:
+    resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
+    engines: {node: '>=0.10.0'}
 
   iconv-lite@0.7.2:
     resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
     engines: {node: '>=0.10.0'}
 
+  ieee754@1.2.1:
+    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
+
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
 
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
   inline-style-parser@0.2.7:
     resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
+
+  ipaddr.js@1.9.1:
+    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
+    engines: {node: '>= 0.10'}
 
   is-alphabetical@2.0.1:
     resolution: {integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==}
@@ -2149,6 +2639,9 @@ packages:
 
   is-decimal@2.0.1:
     resolution: {integrity: sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==}
+
+  is-deflate@1.0.0:
+    resolution: {integrity: sha512-YDoFpuZWu1VRXlsnlYMzKyVRITXj7Ej/V9gXQ2/pAe7X1J7M/RNOqaIYi6qUn+B7nGyB9pDXrv02dsB58d2ZAQ==}
 
   is-extendable@0.1.1:
     resolution: {integrity: sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==}
@@ -2160,6 +2653,10 @@ packages:
 
   is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
+    engines: {node: '>=0.10.0'}
+
+  is-gzip@1.0.0:
+    resolution: {integrity: sha512-rcfALRIb1YewtnksfRIHGcIY93QnK8BIQ/2c9yDYcG/Y6+vRoJuTWBmmSEbyLLYtXm7q35pHOHbZFQBaLrhlWQ==}
     engines: {node: '>=0.10.0'}
 
   is-hexadecimal@2.0.1:
@@ -2177,16 +2674,28 @@ packages:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
 
+  is-promise@2.2.2:
+    resolution: {integrity: sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==}
+
   is-subdir@1.2.0:
     resolution: {integrity: sha512-2AT6j+gXe/1ueqbW6fLZJiIw3F8iXGJtt0yDrZaBhAZEG1raiTxKWU+IPqMCzQAXOUCKdA4UDMgacKH25XG2Cw==}
     engines: {node: '>=4'}
+
+  is-typedarray@1.0.0:
+    resolution: {integrity: sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==}
 
   is-windows@1.0.2:
     resolution: {integrity: sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==}
     engines: {node: '>=0.10.0'}
 
+  isarray@1.0.0:
+    resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
+
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  isstream@0.1.2:
+    resolution: {integrity: sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==}
 
   jiti@2.6.1:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
@@ -2206,12 +2715,48 @@ packages:
     resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
     hasBin: true
 
+  jsbn@0.1.1:
+    resolution: {integrity: sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==}
+
+  json-buffer@3.0.1:
+    resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
+
   json-schema-to-ts@3.1.1:
     resolution: {integrity: sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==}
     engines: {node: '>=16'}
 
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json-schema@0.4.0:
+    resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
+
+  json-stringify-safe@5.0.1:
+    resolution: {integrity: sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==}
+
   jsonfile@4.0.0:
     resolution: {integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==}
+
+  jsonparse@1.3.1:
+    resolution: {integrity: sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==}
+    engines: {'0': node >= 0.2.0}
+
+  jsonwebtoken@9.0.3:
+    resolution: {integrity: sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==}
+    engines: {node: '>=12', npm: '>=6'}
+
+  jsprim@2.0.2:
+    resolution: {integrity: sha512-gqXddjPqQ6G40VdnI6T6yObEC+pDNvyP95wdQhkWkg7crHH3km5qP1FsOXEkzEQwnz6gz5qGTn1c2Y52wP3OyQ==}
+    engines: {'0': node >=0.6.0}
+
+  jwa@2.0.1:
+    resolution: {integrity: sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==}
+
+  jws@4.0.1:
+    resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
+
+  keyv@4.5.4:
+    resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
 
   kind-of@6.0.3:
     resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==}
@@ -2318,14 +2863,53 @@ packages:
     resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
     engines: {node: '>=8'}
 
+  lockfile@1.0.4:
+    resolution: {integrity: sha512-cvbTwETRfsFh4nHsL1eGWapU1XFi5Ot9E85sWAwia7Y7EgB7vfqcZhTKZ+l7hCGxSPoushMv5GKhT5PdLv03WA==}
+
+  lodash.includes@4.3.0:
+    resolution: {integrity: sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==}
+
+  lodash.isboolean@3.0.3:
+    resolution: {integrity: sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==}
+
+  lodash.isinteger@4.0.4:
+    resolution: {integrity: sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==}
+
+  lodash.isnumber@3.0.3:
+    resolution: {integrity: sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==}
+
+  lodash.isplainobject@4.0.6:
+    resolution: {integrity: sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==}
+
+  lodash.isstring@4.0.1:
+    resolution: {integrity: sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==}
+
+  lodash.once@4.1.1:
+    resolution: {integrity: sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==}
+
   lodash.startcase@4.4.0:
     resolution: {integrity: sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==}
+
+  lodash@4.18.1:
+    resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
 
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
 
   loupe@3.2.1:
     resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
+
+  lowdb@1.0.0:
+    resolution: {integrity: sha512-2+x8esE/Wb9SQ1F9IHaYWfsC9FIecLOPrK4g17FGEayjUWH172H6nwicRovGvSE2CPZouc2MCIqCI7h9d+GftQ==}
+    engines: {node: '>=4'}
+
+  lowercase-keys@2.0.0:
+    resolution: {integrity: sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==}
+    engines: {node: '>=8'}
+
+  lru-cache@7.18.3:
+    resolution: {integrity: sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==}
+    engines: {node: '>=12'}
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
@@ -2336,6 +2920,10 @@ packages:
 
   markdown-table@3.0.4:
     resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
+
+  math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
 
   mdast-util-find-and-replace@3.0.2:
     resolution: {integrity: sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==}
@@ -2388,9 +2976,20 @@ packages:
   mdast-util-to-string@4.0.0:
     resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
 
+  media-typer@0.3.0:
+    resolution: {integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==}
+    engines: {node: '>= 0.6'}
+
+  merge-descriptors@1.0.3:
+    resolution: {integrity: sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==}
+
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
+
+  methods@1.1.2:
+    resolution: {integrity: sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==}
+    engines: {node: '>= 0.6'}
 
   micromark-core-commonmark@2.0.3:
     resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
@@ -2504,6 +3103,48 @@ packages:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
 
+  mime-db@1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+
+  mime-db@1.54.0:
+    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
+    engines: {node: '>= 0.6'}
+
+  mime@1.6.0:
+    resolution: {integrity: sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==}
+    engines: {node: '>=4'}
+    hasBin: true
+
+  mime@3.0.0:
+    resolution: {integrity: sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==}
+    engines: {node: '>=10.0.0'}
+    hasBin: true
+
+  mimic-response@1.0.1:
+    resolution: {integrity: sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==}
+    engines: {node: '>=4'}
+
+  mimic-response@3.1.0:
+    resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
+    engines: {node: '>=10'}
+
+  minimatch@7.4.9:
+    resolution: {integrity: sha512-Brg/fp/iAVDOQoHxkuN5bEYhyQlZhxddI78yWsCbeEwTHXQjlNLtiJDUsp1GIptVqMI7/gkJMz4vVAc01mpoBw==}
+    engines: {node: '>=10'}
+
+  minimist@1.2.8:
+    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+
+  mkdirp@1.0.4:
+    resolution: {integrity: sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==}
+    engines: {node: '>=10'}
+    hasBin: true
+
   mri@1.2.0:
     resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
     engines: {node: '>=4'}
@@ -2511,6 +3152,9 @@ packages:
   mrmime@2.0.1:
     resolution: {integrity: sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==}
     engines: {node: '>=10'}
+
+  ms@2.0.0:
+    resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -2523,6 +3167,17 @@ packages:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
+
+  negotiator@0.6.3:
+    resolution: {integrity: sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==}
+    engines: {node: '>= 0.6'}
+
+  negotiator@0.6.4:
+    resolution: {integrity: sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==}
+    engines: {node: '>= 0.6'}
+
+  neo-async@2.6.2:
+    resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
 
   next@16.2.9:
     resolution: {integrity: sha512-MEOJiq/UvuezAdqVSceHbqDgZt1kDw2tpGVOlsdIoJsQdbN2JY2hpVG4xnXGkbdJUOEWhnRfiu/O4Hpc9Juwww==}
@@ -2545,11 +3200,47 @@ packages:
       sass:
         optional: true
 
+  node-fetch@2.6.7:
+    resolution: {integrity: sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
+
+  normalize-url@6.1.0:
+    resolution: {integrity: sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==}
+    engines: {node: '>=10'}
+
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
+
+  object-inspect@1.13.4:
+    resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
+    engines: {node: '>= 0.4'}
+
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
 
   ollama@0.6.3:
     resolution: {integrity: sha512-KEWEhIqE5wtfzEIZbDCLH51VFZ6Z3ZSa6sIOg/E/tBV8S51flyqBOXi+bRxlOYKDf8i327zG9eSTb8IJxvm3Zg==}
+
+  on-exit-leak-free@2.1.2:
+    resolution: {integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==}
+    engines: {node: '>=14.0.0'}
+
+  on-finished@2.4.1:
+    resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
+    engines: {node: '>= 0.8'}
+
+  on-headers@1.1.0:
+    resolution: {integrity: sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==}
+    engines: {node: '>= 0.8'}
+
+  once@1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
   oniguruma-parser@0.12.2:
     resolution: {integrity: sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw==}
@@ -2571,6 +3262,10 @@ packages:
 
   outdent@0.5.0:
     resolution: {integrity: sha512-/jHxFIzoMXdqPzTaCpFzAAWhpkSjZPF4Vsn6jAfNpmbH/ymsmd7Qc6VE9BGn0L6YMj6uwpQLxCECpus4ukKS9Q==}
+
+  p-cancelable@2.1.1:
+    resolution: {integrity: sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==}
+    engines: {node: '>=8'}
 
   p-filter@2.1.0:
     resolution: {integrity: sha512-ZBxxZ5sL2HghephhpGAQdoskxplTwr7ICaehZwLIlfL6acuVgZPm8yBNuRAFBGEqtD/hmUeq9eqLg2ys9Xr/yw==}
@@ -2622,6 +3317,9 @@ packages:
   package-manager-detector@1.6.0:
     resolution: {integrity: sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==}
 
+  pako@0.2.9:
+    resolution: {integrity: sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==}
+
   parse-entities@4.0.2:
     resolution: {integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==}
 
@@ -2631,6 +3329,10 @@ packages:
   parse5@7.3.0:
     resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
 
+  parseurl@1.3.3:
+    resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
+    engines: {node: '>= 0.8'}
+
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
@@ -2638,6 +3340,9 @@ packages:
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
+
+  path-to-regexp@0.1.13:
+    resolution: {integrity: sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==}
 
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
@@ -2650,6 +3355,12 @@ packages:
     resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
     engines: {node: '>= 14.16'}
 
+  peek-stream@1.1.3:
+    resolution: {integrity: sha512-FhJ+YbOSBb9/rIl2ZeE/QHEsWn7PqNYt8ARAY3kIgNGOk13g9FGyIY6JIl/xB/3TFRVoTv5as0l11weORrTekA==}
+
+  performance-now@2.1.0:
+    resolution: {integrity: sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -2661,9 +3372,26 @@ packages:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
+  pify@3.0.0:
+    resolution: {integrity: sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==}
+    engines: {node: '>=4'}
+
   pify@4.0.1:
     resolution: {integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==}
     engines: {node: '>=6'}
+
+  pino-abstract-transport@1.2.0:
+    resolution: {integrity: sha512-Guhh8EZfPCfH+PMXAb6rKOjGQEoy0xlAIn+irODG5kgfYV+BQ0rGYYWTIel3P5mmyXqkYkPmdIkywsn6QKUR1Q==}
+
+  pino-abstract-transport@2.0.0:
+    resolution: {integrity: sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==}
+
+  pino-std-serializers@7.1.0:
+    resolution: {integrity: sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==}
+
+  pino@9.14.0:
+    resolution: {integrity: sha512-8OEwKp5juEvb/MjpIc4hjqfgCNysrS94RIOMXYvpYCdm/jglrKEiAYmiumbmGhCvs+IcInsphYDFwqrjr7398w==}
+    hasBin: true
 
   postcss@8.5.10:
     resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
@@ -2674,22 +3402,71 @@ packages:
     engines: {node: '>=10.13.0'}
     hasBin: true
 
+  process-nextick-args@2.0.1:
+    resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
+
+  process-warning@1.0.0:
+    resolution: {integrity: sha512-du4wfLyj4yCZq1VupnVSZmRsPJsNuxoDQFdCFHLaYiEbFBD7QE0a+I4D7hOxrVnh78QE/YipFAj9lXHiXocV+Q==}
+
   process-warning@4.0.1:
     resolution: {integrity: sha512-3c2LzQ3rY9d0hc1emcsHhfT9Jwz0cChib/QN89oME2R451w5fy3f0afAhERFZAwrbDU43wk12d0ORBpDVME50Q==}
 
+  process-warning@5.0.0:
+    resolution: {integrity: sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==}
+
+  process@0.11.10:
+    resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
+    engines: {node: '>= 0.6.0'}
+
   property-information@7.1.0:
     resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
+
+  proxy-addr@2.0.7:
+    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
+    engines: {node: '>= 0.10'}
 
   publint@0.3.15:
     resolution: {integrity: sha512-xPbRAPW+vqdiaKy5sVVY0uFAu3LaviaPO3pZ9FaRx59l9+U/RKR1OEbLhkug87cwiVKxPXyB4txsv5cad67u+A==}
     engines: {node: '>=18'}
     hasBin: true
 
+  pump@2.0.1:
+    resolution: {integrity: sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==}
+
+  pump@3.0.4:
+    resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
+
+  pumpify@1.5.1:
+    resolution: {integrity: sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==}
+
+  qs@6.14.2:
+    resolution: {integrity: sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==}
+    engines: {node: '>=0.6'}
+
+  qs@6.15.2:
+    resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
+    engines: {node: '>=0.6'}
+
   quansync@0.2.11:
     resolution: {integrity: sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==}
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+
+  quick-format-unescaped@4.0.4:
+    resolution: {integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==}
+
+  quick-lru@5.1.1:
+    resolution: {integrity: sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==}
+    engines: {node: '>=10'}
+
+  range-parser@1.2.1:
+    resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
+    engines: {node: '>= 0.6'}
+
+  raw-body@2.5.3:
+    resolution: {integrity: sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==}
+    engines: {node: '>= 0.8'}
 
   react-dom@19.2.0:
     resolution: {integrity: sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==}
@@ -2704,8 +3481,19 @@ packages:
     resolution: {integrity: sha512-VIMnQi/Z4HT2Fxuwg5KrY174U1VdUIASQVWXXyqtNRtxSr9IYkn1rsI6Tb6HsrHCmB7gVpNwX6JxPTHcH6IoTA==}
     engines: {node: '>=6'}
 
+  readable-stream@2.3.8:
+    resolution: {integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==}
+
+  readable-stream@4.7.0:
+    resolution: {integrity: sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
   reading-time@1.5.0:
     resolution: {integrity: sha512-onYyVhBNr4CmAxFsKS7bz+uTLRakypIe4R+5A824vBSkQy/hB3fZepoVEf8OVAxzLvK+H/jm9TzpI3ETSm64Kg==}
+
+  real-require@0.2.0:
+    resolution: {integrity: sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==}
+    engines: {node: '>= 12.13.0'}
 
   recma-build-jsx@1.0.0:
     resolution: {integrity: sha512-8GtdyqaBcDfva+GUKDr3nev3VpKAhup1+RvkMvUxURHpW7QyIvk9F5wz7Vzo06CEMSilw6uArgRqhpiUcWp8ew==}
@@ -2763,12 +3551,22 @@ packages:
   remark-stringify@11.0.0:
     resolution: {integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==}
 
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
+
+  resolve-alpn@1.2.1:
+    resolution: {integrity: sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==}
+
   resolve-from@5.0.0:
     resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
     engines: {node: '>=8'}
 
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
+  responselike@2.0.1:
+    resolution: {integrity: sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==}
 
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
@@ -2786,8 +3584,21 @@ packages:
     resolution: {integrity: sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==}
     engines: {node: '>=6'}
 
+  safe-buffer@5.1.2:
+    resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
+
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+
+  safe-stable-stringify@2.5.0:
+    resolution: {integrity: sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==}
+    engines: {node: '>=10'}
+
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  sanitize-filename@1.6.4:
+    resolution: {integrity: sha512-9ZyI08PsvdQl2r/bBIGubpVdR3RR9sY6RDiWFPreA21C/EFlQhmgo20UZlNjZMMZNubusLhAQozkA0Od5J21Eg==}
 
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
@@ -2801,8 +3612,24 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  semver@7.8.0:
+    resolution: {integrity: sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  send@0.19.2:
+    resolution: {integrity: sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==}
+    engines: {node: '>= 0.8.0'}
+
+  serve-static@1.16.3:
+    resolution: {integrity: sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==}
+    engines: {node: '>= 0.8.0'}
+
   set-cookie-parser@2.7.2:
     resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
+
+  setprototypeof@1.2.0:
+    resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
 
   sharp@0.34.5:
     resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
@@ -2820,8 +3647,27 @@ packages:
     resolution: {integrity: sha512-eAVKTMedR5ckPo4xne/PjYQYrU3qx78gtJZ+sHlXEg5IHhhoQhMfZVzetTYuaJS0L2Ef3AcCRzCHV8T0WI6nIQ==}
     engines: {node: '>=20'}
 
+  side-channel-list@1.0.1:
+    resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-map@1.0.1:
+    resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-weakmap@1.0.2:
+    resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
+    engines: {node: '>= 0.4'}
+
+  side-channel@1.1.1:
+    resolution: {integrity: sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==}
+    engines: {node: '>= 0.4'}
+
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  signal-exit@3.0.7:
+    resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
 
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
@@ -2835,8 +3681,18 @@ packages:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
 
+  sonic-boom@3.8.1:
+    resolution: {integrity: sha512-y4Z8LCDBuum+PBP3lSV7RHrXscqksve/bi0as7mhwVnBW+/wUqKT/2Kb7um8yqcFy0duYbbPxzt89Zy2nOCaxg==}
+
+  sonic-boom@4.2.1:
+    resolution: {integrity: sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  source-map@0.6.1:
+    resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
 
   source-map@0.7.6:
@@ -2849,8 +3705,17 @@ packages:
   spawndamnit@3.0.1:
     resolution: {integrity: sha512-MmnduQUuHCoFckZoWnXsTg7JaiLBJrKFj9UI2MbRPGaJeVpsLcVBu6P/IGZovziM/YBsellCmsprgNA+w0CzVg==}
 
+  split2@4.2.0:
+    resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
+    engines: {node: '>= 10.x'}
+
   sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
+
+  sshpk@1.18.0:
+    resolution: {integrity: sha512-2p2KJZTSqQ/I3+HX42EpYOa2l3f8Erv8MWKsy2I9uf4wA7yFIkXRffYdsx86y6z4vHtV8u7g+pPlr8/4ouAxsQ==}
+    engines: {node: '>=0.10.0'}
+    hasBin: true
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
@@ -2858,11 +3723,30 @@ packages:
   standardwebhooks@1.0.0:
     resolution: {integrity: sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==}
 
+  statuses@2.0.2:
+    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
+    engines: {node: '>= 0.8'}
+
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
   std-env@4.0.0:
     resolution: {integrity: sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==}
+
+  steno@0.4.4:
+    resolution: {integrity: sha512-EEHMVYHNXFHfGtgjNITnka0aHhiAlo93F7z2/Pwd+g0teG9CnM3JIINM7hVVB5/rhw9voufD7Wukwgtw2uqh6w==}
+
+  stream-shift@1.0.3:
+    resolution: {integrity: sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ==}
+
+  streamx@2.28.0:
+    resolution: {integrity: sha512-1Yowhzjf0ivGMrTIkY9hav5TxobO9qIVqUE41fiCGMGgc3CLlf4MY+9AHmZqBWgDTue0fY9zWjYFVyf6Diuobw==}
+
+  string_decoder@1.1.1:
+    resolution: {integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==}
+
+  string_decoder@1.3.0:
+    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
 
   stringify-entities@4.0.4:
     resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
@@ -2908,9 +3792,24 @@ packages:
     resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
     engines: {node: '>=6'}
 
+  tar-stream@3.1.7:
+    resolution: {integrity: sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==}
+
   term-size@2.2.1:
     resolution: {integrity: sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==}
     engines: {node: '>=8'}
+
+  text-decoder@1.2.7:
+    resolution: {integrity: sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==}
+
+  thread-stream@3.2.0:
+    resolution: {integrity: sha512-zLBvqpwr4Esa0kRjcrzGU6zL25lePWaCLMx0RQFrmteozIfeNdaMLpG5U7PeHzvlFkAWaRKA9/KVW4F60iB+qw==}
+
+  through2@2.0.5:
+    resolution: {integrity: sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==}
+
+  through@2.3.8:
+    resolution: {integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -2946,9 +3845,20 @@ packages:
     resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
     engines: {node: '>=14.0.0'}
 
+  tldts-core@6.1.86:
+    resolution: {integrity: sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==}
+
+  tldts@6.1.86:
+    resolution: {integrity: sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==}
+    hasBin: true
+
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
+
+  toidentifier@1.0.1:
+    resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
+    engines: {node: '>=0.6'}
 
   toml@3.0.0:
     resolution: {integrity: sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w==}
@@ -2957,11 +3867,21 @@ packages:
     resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
     engines: {node: '>=6'}
 
+  tough-cookie@5.1.2:
+    resolution: {integrity: sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==}
+    engines: {node: '>=16'}
+
+  tr46@0.0.3:
+    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
   trim-lines@3.0.1:
     resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
 
   trough@2.2.0:
     resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
+
+  truncate-utf8-bytes@1.0.2:
+    resolution: {integrity: sha512-95Pu1QXQvruGEhv62XCMO3Mm90GscOCClvrIUwCM0PYOXK3kaF3l3sIHxx71ThJfcbM2O5Au6SO3AWCSEfW4mQ==}
 
   ts-algebra@2.0.0:
     resolution: {integrity: sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==}
@@ -2974,9 +3894,22 @@ packages:
     engines: {node: '>=18.0.0'}
     hasBin: true
 
+  tunnel-agent@0.6.0:
+    resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
+
   turbo@2.9.18:
     resolution: {integrity: sha512-bwabv6PupzeavybzEoArBAkwq5fnzwf8OFnRtpHwnviFWuwJPFxtyH+aVp36TmIqK3aYYgtTJ3J0m2ysxxSzQg==}
     hasBin: true
+
+  tweetnacl@0.14.5:
+    resolution: {integrity: sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==}
+
+  typanion@3.14.0:
+    resolution: {integrity: sha512-ZW/lVMRabETuYCd9O9ZvMhAh8GslSqaUjxmK/JLPCh6l73CvLBiuXswj/+7LdnWOgYsQ130FqLzFz5aGT4I3Ug==}
+
+  type-is@1.6.18:
+    resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
+    engines: {node: '>= 0.6'}
 
   typescript@5.8.3:
     resolution: {integrity: sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==}
@@ -2986,6 +3919,11 @@ packages:
   typescript@6.0.2:
     resolution: {integrity: sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==}
     engines: {node: '>=14.17'}
+    hasBin: true
+
+  uglify-js@3.19.3:
+    resolution: {integrity: sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==}
+    engines: {node: '>=0.8.0'}
     hasBin: true
 
   undici-types@7.19.2:
@@ -3019,6 +3957,23 @@ packages:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
     engines: {node: '>= 4.0.0'}
 
+  unix-crypt-td-js@1.1.4:
+    resolution: {integrity: sha512-8rMeVYWSIyccIJscb9NdCfZKSRBKYTeVnwmiRYT2ulE3qd1RaDQ0xQDP+rI3ccIWbhu/zuo5cgN8z73belNZgw==}
+
+  unpipe@1.0.0:
+    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
+    engines: {node: '>= 0.8'}
+
+  utf8-byte-length@1.0.5:
+    resolution: {integrity: sha512-Xn0w3MtiQ6zoz2vFyUVruaCL53O/DwUvkEeOvj+uulMm0BkUGYWmBYVyElqZaSLhY6ZD0ulfU3aBra2aVT4xfA==}
+
+  util-deprecate@1.0.2:
+    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  utils-merge@1.0.1:
+    resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
+    engines: {node: '>= 0.4.0'}
+
   uuid@11.1.1:
     resolution: {integrity: sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==}
     hasBin: true
@@ -3026,6 +3981,31 @@ packages:
   uuid@13.0.2:
     resolution: {integrity: sha512-vzi9uRZ926x4XV73S/4qQaTwPXM2JBj6/6lI/byHH1jOpCzb0zDbfytgA9LcN/hzb2l7WQSQnxITOVx5un/wGw==}
     hasBin: true
+
+  validator@13.15.26:
+    resolution: {integrity: sha512-spH26xU080ydGggxRyR1Yhcbgx+j3y5jbNXk/8L+iRvdIEQ4uTRH2Sgf2dokud6Q4oAtsbNvJ1Ft+9xmm6IZcA==}
+    engines: {node: '>= 0.10'}
+
+  vary@1.1.2:
+    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
+    engines: {node: '>= 0.8'}
+
+  verdaccio-audit@13.0.2:
+    resolution: {integrity: sha512-J2aq4b0Q6qj/3o+r8dBPCmKNj37x+8BjSZOEoH85zjR3kihiVYQgJ1+2UxKCJpLj4Z/04SekB1p+zTBiViyoMw==}
+    engines: {node: '>=18'}
+
+  verdaccio-htpasswd@13.0.2:
+    resolution: {integrity: sha512-ObyN409utfLKQ4QdGAYyXOprVaOYz0tDvhi0WpK7U71QvL/LOjeXWleDFRJHeaEMTNNdrzPhtC/9kcpfnztabg==}
+    engines: {node: '>=18'}
+
+  verdaccio@6.7.2:
+    resolution: {integrity: sha512-o9YQonYX94RxVKQncxcUbsPtLTV26IgDSPQTbcw6rFrtQ6zb7Fx75vTNBps2O7xStMtwROblGwnLlHF7akm0jQ==}
+    engines: {node: '>=20'}
+    hasBin: true
+
+  verror@1.10.0:
+    resolution: {integrity: sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==}
+    engines: {'0': node >=0.6.0}
 
   vfile-location@5.0.3:
     resolution: {integrity: sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==}
@@ -3194,8 +4174,14 @@ packages:
   web-namespaces@2.0.1:
     resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
 
+  webidl-conversions@3.0.1:
+    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+
   whatwg-fetch@3.6.20:
     resolution: {integrity: sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==}
+
+  whatwg-url@5.0.0:
+    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
 
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
@@ -3206,6 +4192,12 @@ packages:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
     hasBin: true
+
+  wordwrap@1.0.0:
+    resolution: {integrity: sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==}
+
+  wrappy@1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
   ws@8.21.0:
     resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
@@ -3218,6 +4210,10 @@ packages:
         optional: true
       utf-8-validate:
         optional: true
+
+  xtend@4.0.2:
+    resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
+    engines: {node: '>=0.4'}
 
   yaml@2.9.0:
     resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
@@ -3431,6 +4427,27 @@ snapshots:
   '@copilotkit/aimock@1.28.0(vitest@4.1.9(@types/node@25.6.0)(vite@6.4.3(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)))':
     optionalDependencies:
       vitest: 4.1.9(@types/node@25.6.0)(vite@6.4.3(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))
+
+  '@cypress/request@3.0.10':
+    dependencies:
+      aws-sign2: 0.7.0
+      aws4: 1.13.2
+      caseless: 0.12.0
+      combined-stream: 1.0.8
+      extend: 3.0.2
+      forever-agent: 0.6.1
+      form-data: 4.0.6
+      http-signature: 1.4.0
+      is-typedarray: 1.0.0
+      isstream: 0.1.2
+      json-stringify-safe: 5.0.1
+      mime-types: 2.1.35
+      performance-now: 2.1.0
+      qs: 6.14.2
+      safe-buffer: 5.2.1
+      tough-cookie: 5.1.2
+      tunnel-agent: 0.6.0
+      uuid: 11.1.1
 
   '@emnapi/runtime@1.9.2':
     dependencies:
@@ -3958,6 +4975,8 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
 
+  '@pinojs/redact@0.4.0': {}
+
   '@polka/url@1.0.0-next.29': {}
 
   '@publint/pack@0.1.4': {}
@@ -4077,6 +5096,8 @@ snapshots:
 
   '@shikijs/vscode-textmate@10.0.2': {}
 
+  '@sindresorhus/is@4.6.0': {}
+
   '@stablelib/base64@1.0.1': {}
 
   '@standard-schema/spec@1.1.0': {}
@@ -4084,6 +5105,10 @@ snapshots:
   '@swc/helpers@0.5.15':
     dependencies:
       tslib: 2.8.1
+
+  '@szmarczak/http-timer@4.0.6':
+    dependencies:
+      defer-to-connect: 2.0.1
 
   '@tailwindcss/node@4.2.4':
     dependencies:
@@ -4217,11 +5242,177 @@ snapshots:
     dependencies:
       csstype: 3.2.3
 
+  '@types/responselike@1.0.0':
+    dependencies:
+      '@types/node': 25.6.0
+
   '@types/unist@2.0.11': {}
 
   '@types/unist@3.0.3': {}
 
   '@ungap/structured-clone@1.3.0': {}
+
+  '@verdaccio/auth@8.0.2':
+    dependencies:
+      '@verdaccio/config': 8.1.1
+      '@verdaccio/core': 8.1.1
+      '@verdaccio/loaders': 8.0.2
+      '@verdaccio/signature': 8.0.2
+      debug: 4.4.3
+      lodash: 4.18.1
+      verdaccio-htpasswd: 13.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@verdaccio/config@8.1.1':
+    dependencies:
+      '@verdaccio/core': 8.1.1
+      debug: 4.4.3
+      js-yaml: 4.2.0
+      lodash: 4.18.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@verdaccio/core@8.1.1':
+    dependencies:
+      ajv: 8.18.0
+      http-errors: 2.0.1
+      http-status-codes: 2.3.0
+      minimatch: 7.4.9
+      process-warning: 1.0.0
+      semver: 7.7.4
+
+  '@verdaccio/file-locking@13.0.1':
+    dependencies:
+      lockfile: 1.0.4
+
+  '@verdaccio/hooks@8.0.2':
+    dependencies:
+      '@verdaccio/core': 8.1.1
+      '@verdaccio/logger': 8.0.2
+      debug: 4.4.3
+      got-cjs: 12.5.4
+      handlebars: 4.7.9
+    transitivePeerDependencies:
+      - supports-color
+
+  '@verdaccio/loaders@8.0.2':
+    dependencies:
+      '@verdaccio/core': 8.1.1
+      debug: 4.4.3
+      lodash: 4.18.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@verdaccio/local-storage-legacy@11.3.3':
+    dependencies:
+      '@verdaccio/core': 8.1.1
+      '@verdaccio/file-locking': 13.0.1
+      '@verdaccio/streams': 10.2.5
+      debug: 4.4.3
+      globby: 11.1.0
+      lodash: 4.18.1
+      lowdb: 1.0.0
+      mkdirp: 1.0.4
+      sanitize-filename: 1.6.4
+    transitivePeerDependencies:
+      - supports-color
+
+  '@verdaccio/logger-commons@8.0.2':
+    dependencies:
+      '@verdaccio/core': 8.1.1
+      '@verdaccio/logger-prettify': 8.0.1
+      colorette: 2.0.20
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@verdaccio/logger-prettify@8.0.1':
+    dependencies:
+      colorette: 2.0.20
+      dayjs: 1.11.18
+      lodash: 4.18.1
+      on-exit-leak-free: 2.1.2
+      pino-abstract-transport: 1.2.0
+      sonic-boom: 3.8.1
+
+  '@verdaccio/logger@8.0.2':
+    dependencies:
+      '@verdaccio/logger-commons': 8.0.2
+      pino: 9.14.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@verdaccio/middleware@8.0.2':
+    dependencies:
+      '@verdaccio/config': 8.1.1
+      '@verdaccio/core': 8.1.1
+      '@verdaccio/url': 13.0.2
+      debug: 4.4.3
+      express: 4.22.1
+      express-rate-limit: 5.5.1
+      lodash: 4.18.1
+      lru-cache: 7.18.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@verdaccio/package-filter@13.0.2':
+    dependencies:
+      '@verdaccio/core': 8.1.1
+      debug: 4.4.3
+      semver: 7.7.4
+    transitivePeerDependencies:
+      - supports-color
+
+  '@verdaccio/search-indexer@8.0.2':
+    dependencies:
+      debug: 4.4.3
+      fuse.js: 7.3.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@verdaccio/signature@8.0.2':
+    dependencies:
+      '@verdaccio/config': 8.1.1
+      '@verdaccio/core': 8.1.1
+      debug: 4.4.3
+      jsonwebtoken: 9.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@verdaccio/streams@10.2.5': {}
+
+  '@verdaccio/tarball@13.0.2':
+    dependencies:
+      '@verdaccio/core': 8.1.1
+      '@verdaccio/url': 13.0.2
+      debug: 4.4.3
+      gunzip-maybe: 1.4.2
+      tar-stream: 3.1.7
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+      - supports-color
+
+  '@verdaccio/ui-theme@9.0.0-next-9.14':
+    dependencies:
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@verdaccio/url@13.0.2':
+    dependencies:
+      '@verdaccio/core': 8.1.1
+      debug: 4.4.3
+      validator: 13.15.26
+    transitivePeerDependencies:
+      - supports-color
+
+  '@verdaccio/utils@8.1.2':
+    dependencies:
+      '@verdaccio/core': 8.1.1
+      lodash: 4.18.1
+      minimatch: 7.4.9
 
   '@vitest/expect@3.2.6':
     dependencies:
@@ -4358,15 +5549,44 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
+  JSONStream@1.3.5:
+    dependencies:
+      jsonparse: 1.3.1
+      through: 2.3.8
+
+  abort-controller@3.0.0:
+    dependencies:
+      event-target-shim: 5.0.1
+
+  accepts@1.3.8:
+    dependencies:
+      mime-types: 2.1.35
+      negotiator: 0.6.3
+
   acorn-jsx@5.3.2(acorn@8.16.0):
     dependencies:
       acorn: 8.16.0
 
   acorn@8.16.0: {}
 
+  agent-base@6.0.2:
+    dependencies:
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  ajv@8.18.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.2
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
+
   ansi-colors@4.1.3: {}
 
   ansi-regex@5.0.1: {}
+
+  apache-md5@1.1.8: {}
 
   argparse@1.0.10:
     dependencies:
@@ -4374,29 +5594,119 @@ snapshots:
 
   argparse@2.0.1: {}
 
+  array-flatten@1.1.1: {}
+
   array-union@2.1.0: {}
+
+  asn1@0.2.6:
+    dependencies:
+      safer-buffer: 2.1.2
+
+  assert-plus@1.0.0: {}
 
   assertion-error@2.0.1: {}
 
   astring@1.9.0: {}
 
+  async@3.2.6: {}
+
+  asynckit@0.4.0: {}
+
+  atomic-sleep@1.0.0: {}
+
+  aws-sign2@0.7.0: {}
+
+  aws4@1.13.2: {}
+
+  b4a@1.8.1: {}
+
   bail@2.0.2: {}
+
+  balanced-match@1.0.2: {}
+
+  bare-events@2.9.1: {}
 
   base64-js@1.5.1: {}
 
   baseline-browser-mapping@2.10.17: {}
 
+  bcrypt-pbkdf@1.0.2:
+    dependencies:
+      tweetnacl: 0.14.5
+
+  bcryptjs@2.4.3: {}
+
   better-path-resolve@1.0.0:
     dependencies:
       is-windows: 1.0.2
+
+  body-parser@1.20.5:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 1.0.5
+      debug: 2.6.9
+      depd: 2.0.0
+      destroy: 1.2.0
+      http-errors: 2.0.1
+      iconv-lite: 0.4.24
+      on-finished: 2.4.1
+      qs: 6.15.2
+      raw-body: 2.5.3
+      type-is: 1.6.18
+      unpipe: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  brace-expansion@2.1.1:
+    dependencies:
+      balanced-match: 1.0.2
 
   braces@3.0.3:
     dependencies:
       fill-range: 7.1.1
 
+  browserify-zlib@0.1.4:
+    dependencies:
+      pako: 0.2.9
+
+  buffer-equal-constant-time@1.0.1: {}
+
+  buffer-from@1.1.2: {}
+
+  buffer@6.0.3:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
+
+  bytes@3.1.2: {}
+
   cac@6.7.14: {}
 
+  cacheable-lookup@6.1.0: {}
+
+  cacheable-request@7.0.2:
+    dependencies:
+      clone-response: 1.0.3
+      get-stream: 5.2.0
+      http-cache-semantics: 4.2.0
+      keyv: 4.5.4
+      lowercase-keys: 2.0.0
+      normalize-url: 6.1.0
+      responselike: 2.0.1
+
+  call-bind-apply-helpers@1.0.2:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+
+  call-bound@1.0.4:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      get-intrinsic: 1.3.0
+
   caniuse-lite@1.0.30001787: {}
+
+  caseless@0.12.0: {}
 
   ccount@2.0.1: {}
 
@@ -4424,15 +5734,64 @@ snapshots:
 
   client-only@0.0.1: {}
 
+  clipanion@4.0.0-rc.4(typanion@3.14.0):
+    dependencies:
+      typanion: 3.14.0
+
+  clone-response@1.0.3:
+    dependencies:
+      mimic-response: 1.0.1
+
   collapse-white-space@2.1.0: {}
+
+  colorette@2.0.20: {}
+
+  combined-stream@1.0.8:
+    dependencies:
+      delayed-stream: 1.0.0
 
   comma-separated-tokens@2.0.3: {}
 
   commander@14.0.3: {}
 
+  compressible@2.0.18:
+    dependencies:
+      mime-db: 1.54.0
+
+  compression@1.8.1:
+    dependencies:
+      bytes: 3.1.2
+      compressible: 2.0.18
+      debug: 2.6.9
+      negotiator: 0.6.4
+      on-headers: 1.1.0
+      safe-buffer: 5.2.1
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  content-disposition@0.5.4:
+    dependencies:
+      safe-buffer: 5.2.1
+
+  content-type@1.0.5: {}
+
   convert-source-map@2.0.0: {}
 
+  cookie-signature@1.0.7: {}
+
+  cookie@0.7.2: {}
+
   cookie@1.1.1: {}
+
+  core-util-is@1.0.2: {}
+
+  core-util-is@1.0.3: {}
+
+  cors@2.8.6:
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
 
   cross-spawn@7.0.6:
     dependencies:
@@ -4442,6 +5801,16 @@ snapshots:
 
   csstype@3.2.3: {}
 
+  dashdash@1.14.1:
+    dependencies:
+      assert-plus: 1.0.0
+
+  dayjs@1.11.18: {}
+
+  debug@2.6.9:
+    dependencies:
+      ms: 2.0.0
+
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
@@ -4450,9 +5819,21 @@ snapshots:
     dependencies:
       character-entities: 2.0.2
 
+  decompress-response@6.0.0:
+    dependencies:
+      mimic-response: 3.1.0
+
   deep-eql@5.0.2: {}
 
+  defer-to-connect@2.0.1: {}
+
+  delayed-stream@1.0.0: {}
+
+  depd@2.0.0: {}
+
   dequal@2.0.3: {}
+
+  destroy@1.2.0: {}
 
   detect-indent@6.1.0: {}
 
@@ -4466,6 +5847,36 @@ snapshots:
     dependencies:
       path-type: 4.0.0
 
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
+  duplexify@3.7.1:
+    dependencies:
+      end-of-stream: 1.4.5
+      inherits: 2.0.4
+      readable-stream: 2.3.8
+      stream-shift: 1.0.3
+
+  ecc-jsbn@0.1.2:
+    dependencies:
+      jsbn: 0.1.1
+      safer-buffer: 2.1.2
+
+  ecdsa-sig-formatter@1.0.11:
+    dependencies:
+      safe-buffer: 5.2.1
+
+  ee-first@1.1.1: {}
+
+  encodeurl@2.0.0: {}
+
+  end-of-stream@1.4.5:
+    dependencies:
+      once: 1.4.0
+
   enhanced-resolve@5.20.1:
     dependencies:
       graceful-fs: 4.2.11
@@ -4478,9 +5889,26 @@ snapshots:
 
   entities@6.0.1: {}
 
+  envinfo@7.21.0: {}
+
+  es-define-property@1.0.1: {}
+
+  es-errors@1.3.0: {}
+
   es-module-lexer@1.7.0: {}
 
   es-module-lexer@2.0.0: {}
+
+  es-object-atoms@1.1.2:
+    dependencies:
+      es-errors: 1.3.0
+
+  es-set-tostringtag@2.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      has-tostringtag: 1.0.2
+      hasown: 2.0.4
 
   esast-util-from-estree@2.0.0:
     dependencies:
@@ -4554,6 +5982,8 @@ snapshots:
       '@esbuild/win32-ia32': 0.28.1
       '@esbuild/win32-x64': 0.28.1
 
+  escape-html@1.0.3: {}
+
   escape-string-regexp@5.0.0: {}
 
   esprima@4.0.1: {}
@@ -4595,13 +6025,63 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.8
 
+  etag@1.8.1: {}
+
+  event-target-shim@5.0.1: {}
+
   eventemitter3@4.0.7: {}
 
   eventemitter3@5.0.4: {}
 
+  events-universal@1.0.1:
+    dependencies:
+      bare-events: 2.9.1
+    transitivePeerDependencies:
+      - bare-abort-controller
+
+  events@3.3.0: {}
+
   eventsource-parser@3.0.8: {}
 
   expect-type@1.3.0: {}
+
+  express-rate-limit@5.5.1: {}
+
+  express@4.22.1:
+    dependencies:
+      accepts: 1.3.8
+      array-flatten: 1.1.1
+      body-parser: 1.20.5
+      content-disposition: 0.5.4
+      content-type: 1.0.5
+      cookie: 0.7.2
+      cookie-signature: 1.0.7
+      debug: 2.6.9
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 1.3.2
+      fresh: 0.5.2
+      http-errors: 2.0.1
+      merge-descriptors: 1.0.3
+      methods: 1.1.2
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      path-to-regexp: 0.1.13
+      proxy-addr: 2.0.7
+      qs: 6.14.2
+      range-parser: 1.2.1
+      safe-buffer: 5.2.1
+      send: 0.19.2
+      serve-static: 1.16.3
+      setprototypeof: 1.2.0
+      statuses: 2.0.2
+      type-is: 1.6.18
+      utils-merge: 1.0.1
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
 
   extend-shallow@2.0.1:
     dependencies:
@@ -4610,6 +6090,12 @@ snapshots:
   extend@3.0.2: {}
 
   extendable-error@0.1.7: {}
+
+  extsprintf@1.3.0: {}
+
+  fast-deep-equal@3.1.3: {}
+
+  fast-fifo@1.3.2: {}
 
   fast-glob@3.3.3:
     dependencies:
@@ -4620,6 +6106,8 @@ snapshots:
       micromatch: 4.0.8
 
   fast-sha256@1.3.0: {}
+
+  fast-uri@3.1.2: {}
 
   fastq@1.20.1:
     dependencies:
@@ -4639,6 +6127,18 @@ snapshots:
     dependencies:
       to-regex-range: 5.0.1
 
+  finalhandler@1.3.2:
+    dependencies:
+      debug: 2.6.9
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.2
+      unpipe: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
+
   find-up@4.1.0:
     dependencies:
       locate-path: 5.0.0
@@ -4646,7 +6146,23 @@ snapshots:
 
   flatted@3.4.2: {}
 
+  forever-agent@0.6.1: {}
+
+  form-data-encoder@1.7.2: {}
+
+  form-data@4.0.6:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.4
+      mime-types: 2.1.35
+
   format@0.2.2: {}
+
+  forwarded@0.2.0: {}
+
+  fresh@0.5.2: {}
 
   fs-extra@7.0.1:
     dependencies:
@@ -4663,9 +6179,41 @@ snapshots:
   fsevents@2.3.3:
     optional: true
 
+  function-bind@1.1.2: {}
+
+  fuse.js@7.3.0: {}
+
+  get-intrinsic@1.3.0:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.2
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.4
+      math-intrinsics: 1.1.0
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.2
+
+  get-stream@5.2.0:
+    dependencies:
+      pump: 3.0.4
+
+  get-stream@6.0.1: {}
+
   get-tsconfig@4.13.7:
     dependencies:
       resolve-pkg-maps: 1.0.0
+
+  getpass@0.1.7:
+    dependencies:
+      assert-plus: 1.0.0
 
   glob-parent@5.1.2:
     dependencies:
@@ -4680,6 +6228,23 @@ snapshots:
       merge2: 1.4.1
       slash: 3.0.0
 
+  gopd@1.2.0: {}
+
+  got-cjs@12.5.4:
+    dependencies:
+      '@sindresorhus/is': 4.6.0
+      '@szmarczak/http-timer': 4.0.6
+      '@types/responselike': 1.0.0
+      cacheable-lookup: 6.1.0
+      cacheable-request: 7.0.2
+      decompress-response: 6.0.0
+      form-data-encoder: 1.7.2
+      get-stream: 6.0.1
+      http2-wrapper: 2.2.1
+      lowercase-keys: 2.0.0
+      p-cancelable: 2.1.1
+      responselike: 2.0.1
+
   gpt-tokenizer@3.4.0: {}
 
   graceful-fs@4.2.11: {}
@@ -4692,6 +6257,34 @@ snapshots:
       strip-bom-string: 1.0.0
 
   groq-sdk@1.2.0: {}
+
+  gunzip-maybe@1.4.2:
+    dependencies:
+      browserify-zlib: 0.1.4
+      is-deflate: 1.0.0
+      is-gzip: 1.0.0
+      peek-stream: 1.1.3
+      pumpify: 1.5.1
+      through2: 2.0.5
+
+  handlebars@4.7.9:
+    dependencies:
+      minimist: 1.2.8
+      neo-async: 2.6.2
+      source-map: 0.6.1
+      wordwrap: 1.0.0
+    optionalDependencies:
+      uglify-js: 3.19.3
+
+  has-symbols@1.1.0: {}
+
+  has-tostringtag@1.0.2:
+    dependencies:
+      has-symbols: 1.1.0
+
+  hasown@2.0.4:
+    dependencies:
+      function-bind: 1.1.2
 
   hast-util-from-html@2.0.3:
     dependencies:
@@ -4790,15 +6383,55 @@ snapshots:
 
   html-void-elements@3.0.0: {}
 
+  http-cache-semantics@4.2.0: {}
+
+  http-errors@2.0.1:
+    dependencies:
+      depd: 2.0.0
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 2.0.2
+      toidentifier: 1.0.1
+
+  http-signature@1.4.0:
+    dependencies:
+      assert-plus: 1.0.0
+      jsprim: 2.0.2
+      sshpk: 1.18.0
+
+  http-status-codes@2.3.0: {}
+
+  http2-wrapper@2.2.1:
+    dependencies:
+      quick-lru: 5.1.1
+      resolve-alpn: 1.2.1
+
+  https-proxy-agent@5.0.1:
+    dependencies:
+      agent-base: 6.0.2
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   human-id@4.1.3: {}
+
+  iconv-lite@0.4.24:
+    dependencies:
+      safer-buffer: 2.1.2
 
   iconv-lite@0.7.2:
     dependencies:
       safer-buffer: 2.1.2
 
+  ieee754@1.2.1: {}
+
   ignore@5.3.2: {}
 
+  inherits@2.0.4: {}
+
   inline-style-parser@0.2.7: {}
+
+  ipaddr.js@1.9.1: {}
 
   is-alphabetical@2.0.1: {}
 
@@ -4809,6 +6442,8 @@ snapshots:
 
   is-decimal@2.0.1: {}
 
+  is-deflate@1.0.0: {}
+
   is-extendable@0.1.1: {}
 
   is-extglob@2.1.1: {}
@@ -4816,6 +6451,8 @@ snapshots:
   is-glob@4.0.3:
     dependencies:
       is-extglob: 2.1.1
+
+  is-gzip@1.0.0: {}
 
   is-hexadecimal@2.0.1: {}
 
@@ -4825,13 +6462,21 @@ snapshots:
 
   is-plain-obj@4.1.0: {}
 
+  is-promise@2.2.2: {}
+
   is-subdir@1.2.0:
     dependencies:
       better-path-resolve: 1.0.0
 
+  is-typedarray@1.0.0: {}
+
   is-windows@1.0.2: {}
 
+  isarray@1.0.0: {}
+
   isexe@2.0.0: {}
+
+  isstream@0.1.2: {}
 
   jiti@2.6.1: {}
 
@@ -4850,14 +6495,61 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
+  jsbn@0.1.1: {}
+
+  json-buffer@3.0.1: {}
+
   json-schema-to-ts@3.1.1:
     dependencies:
       '@babel/runtime': 7.29.2
       ts-algebra: 2.0.0
 
+  json-schema-traverse@1.0.0: {}
+
+  json-schema@0.4.0: {}
+
+  json-stringify-safe@5.0.1: {}
+
   jsonfile@4.0.0:
     optionalDependencies:
       graceful-fs: 4.2.11
+
+  jsonparse@1.3.1: {}
+
+  jsonwebtoken@9.0.3:
+    dependencies:
+      jws: 4.0.1
+      lodash.includes: 4.3.0
+      lodash.isboolean: 3.0.3
+      lodash.isinteger: 4.0.4
+      lodash.isnumber: 3.0.3
+      lodash.isplainobject: 4.0.6
+      lodash.isstring: 4.0.1
+      lodash.once: 4.1.1
+      ms: 2.1.3
+      semver: 7.8.0
+
+  jsprim@2.0.2:
+    dependencies:
+      assert-plus: 1.0.0
+      extsprintf: 1.3.0
+      json-schema: 0.4.0
+      verror: 1.10.0
+
+  jwa@2.0.1:
+    dependencies:
+      buffer-equal-constant-time: 1.0.1
+      ecdsa-sig-formatter: 1.0.11
+      safe-buffer: 5.2.1
+
+  jws@4.0.1:
+    dependencies:
+      jwa: 2.0.1
+      safe-buffer: 5.2.1
+
+  keyv@4.5.4:
+    dependencies:
+      json-buffer: 3.0.1
 
   kind-of@6.0.3: {}
 
@@ -4927,11 +6619,43 @@ snapshots:
     dependencies:
       p-locate: 4.1.0
 
+  lockfile@1.0.4:
+    dependencies:
+      signal-exit: 3.0.7
+
+  lodash.includes@4.3.0: {}
+
+  lodash.isboolean@3.0.3: {}
+
+  lodash.isinteger@4.0.4: {}
+
+  lodash.isnumber@3.0.3: {}
+
+  lodash.isplainobject@4.0.6: {}
+
+  lodash.isstring@4.0.1: {}
+
+  lodash.once@4.1.1: {}
+
   lodash.startcase@4.4.0: {}
+
+  lodash@4.18.1: {}
 
   longest-streak@3.1.0: {}
 
   loupe@3.2.1: {}
+
+  lowdb@1.0.0:
+    dependencies:
+      graceful-fs: 4.2.11
+      is-promise: 2.2.2
+      lodash: 4.18.1
+      pify: 3.0.0
+      steno: 0.4.4
+
+  lowercase-keys@2.0.0: {}
+
+  lru-cache@7.18.3: {}
 
   magic-string@0.30.21:
     dependencies:
@@ -4940,6 +6664,8 @@ snapshots:
   markdown-extensions@2.0.0: {}
 
   markdown-table@3.0.4: {}
+
+  math-intrinsics@1.1.0: {}
 
   mdast-util-find-and-replace@3.0.2:
     dependencies:
@@ -5115,7 +6841,13 @@ snapshots:
     dependencies:
       '@types/mdast': 4.0.4
 
+  media-typer@0.3.0: {}
+
+  merge-descriptors@1.0.3: {}
+
   merge2@1.4.1: {}
+
+  methods@1.1.2: {}
 
   micromark-core-commonmark@2.0.3:
     dependencies:
@@ -5393,15 +7125,47 @@ snapshots:
       braces: 3.0.3
       picomatch: 2.3.2
 
+  mime-db@1.52.0: {}
+
+  mime-db@1.54.0: {}
+
+  mime-types@2.1.35:
+    dependencies:
+      mime-db: 1.52.0
+
+  mime@1.6.0: {}
+
+  mime@3.0.0: {}
+
+  mimic-response@1.0.1: {}
+
+  mimic-response@3.1.0: {}
+
+  minimatch@7.4.9:
+    dependencies:
+      brace-expansion: 2.1.1
+
+  minimist@1.2.8: {}
+
+  mkdirp@1.0.4: {}
+
   mri@1.2.0: {}
 
   mrmime@2.0.1: {}
+
+  ms@2.0.0: {}
 
   ms@2.1.3: {}
 
   mustache@4.2.0: {}
 
   nanoid@3.3.11: {}
+
+  negotiator@0.6.3: {}
+
+  negotiator@0.6.4: {}
+
+  neo-async@2.6.2: {}
 
   next@16.2.9(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
     dependencies:
@@ -5427,11 +7191,33 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
+  node-fetch@2.6.7:
+    dependencies:
+      whatwg-url: 5.0.0
+
+  normalize-url@6.1.0: {}
+
+  object-assign@4.1.1: {}
+
+  object-inspect@1.13.4: {}
+
   obug@2.1.1: {}
 
   ollama@0.6.3:
     dependencies:
       whatwg-fetch: 3.6.20
+
+  on-exit-leak-free@2.1.2: {}
+
+  on-finished@2.4.1:
+    dependencies:
+      ee-first: 1.1.1
+
+  on-headers@1.1.0: {}
+
+  once@1.4.0:
+    dependencies:
+      wrappy: 1.0.2
 
   oniguruma-parser@0.12.2: {}
 
@@ -5447,6 +7233,8 @@ snapshots:
       zod: 4.4.3
 
   outdent@0.5.0: {}
+
+  p-cancelable@2.1.1: {}
 
   p-filter@2.1.0:
     dependencies:
@@ -5492,6 +7280,8 @@ snapshots:
 
   package-manager-detector@1.6.0: {}
 
+  pako@0.2.9: {}
+
   parse-entities@4.0.2:
     dependencies:
       '@types/unist': 2.0.11
@@ -5508,9 +7298,13 @@ snapshots:
     dependencies:
       entities: 6.0.1
 
+  parseurl@1.3.3: {}
+
   path-exists@4.0.0: {}
 
   path-key@3.1.1: {}
+
+  path-to-regexp@0.1.13: {}
 
   path-type@4.0.0: {}
 
@@ -5518,13 +7312,48 @@ snapshots:
 
   pathval@2.0.1: {}
 
+  peek-stream@1.1.3:
+    dependencies:
+      buffer-from: 1.1.2
+      duplexify: 3.7.1
+      through2: 2.0.5
+
+  performance-now@2.1.0: {}
+
   picocolors@1.1.1: {}
 
   picomatch@2.3.2: {}
 
   picomatch@4.0.4: {}
 
+  pify@3.0.0: {}
+
   pify@4.0.1: {}
+
+  pino-abstract-transport@1.2.0:
+    dependencies:
+      readable-stream: 4.7.0
+      split2: 4.2.0
+
+  pino-abstract-transport@2.0.0:
+    dependencies:
+      split2: 4.2.0
+
+  pino-std-serializers@7.1.0: {}
+
+  pino@9.14.0:
+    dependencies:
+      '@pinojs/redact': 0.4.0
+      atomic-sleep: 1.0.0
+      on-exit-leak-free: 2.1.2
+      pino-abstract-transport: 2.0.0
+      pino-std-serializers: 7.1.0
+      process-warning: 5.0.0
+      quick-format-unescaped: 4.0.4
+      real-require: 0.2.0
+      safe-stable-stringify: 2.5.0
+      sonic-boom: 4.2.1
+      thread-stream: 3.2.0
 
   postcss@8.5.10:
     dependencies:
@@ -5534,9 +7363,22 @@ snapshots:
 
   prettier@2.8.8: {}
 
+  process-nextick-args@2.0.1: {}
+
+  process-warning@1.0.0: {}
+
   process-warning@4.0.1: {}
 
+  process-warning@5.0.0: {}
+
+  process@0.11.10: {}
+
   property-information@7.1.0: {}
+
+  proxy-addr@2.0.7:
+    dependencies:
+      forwarded: 0.2.0
+      ipaddr.js: 1.9.1
 
   publint@0.3.15:
     dependencies:
@@ -5545,9 +7387,46 @@ snapshots:
       picocolors: 1.1.1
       sade: 1.8.1
 
+  pump@2.0.1:
+    dependencies:
+      end-of-stream: 1.4.5
+      once: 1.4.0
+
+  pump@3.0.4:
+    dependencies:
+      end-of-stream: 1.4.5
+      once: 1.4.0
+
+  pumpify@1.5.1:
+    dependencies:
+      duplexify: 3.7.1
+      inherits: 2.0.4
+      pump: 2.0.1
+
+  qs@6.14.2:
+    dependencies:
+      side-channel: 1.1.1
+
+  qs@6.15.2:
+    dependencies:
+      side-channel: 1.1.1
+
   quansync@0.2.11: {}
 
   queue-microtask@1.2.3: {}
+
+  quick-format-unescaped@4.0.4: {}
+
+  quick-lru@5.1.1: {}
+
+  range-parser@1.2.1: {}
+
+  raw-body@2.5.3:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.1
+      iconv-lite: 0.4.24
+      unpipe: 1.0.0
 
   react-dom@19.2.0(react@19.2.0):
     dependencies:
@@ -5563,7 +7442,27 @@ snapshots:
       pify: 4.0.1
       strip-bom: 3.0.0
 
+  readable-stream@2.3.8:
+    dependencies:
+      core-util-is: 1.0.3
+      inherits: 2.0.4
+      isarray: 1.0.0
+      process-nextick-args: 2.0.1
+      safe-buffer: 5.1.2
+      string_decoder: 1.1.1
+      util-deprecate: 1.0.2
+
+  readable-stream@4.7.0:
+    dependencies:
+      abort-controller: 3.0.0
+      buffer: 6.0.3
+      events: 3.3.0
+      process: 0.11.10
+      string_decoder: 1.3.0
+
   reading-time@1.5.0: {}
+
+  real-require@0.2.0: {}
 
   recma-build-jsx@1.0.0:
     dependencies:
@@ -5687,9 +7586,17 @@ snapshots:
       mdast-util-to-markdown: 2.1.2
       unified: 11.0.5
 
+  require-from-string@2.0.2: {}
+
+  resolve-alpn@1.2.1: {}
+
   resolve-from@5.0.0: {}
 
   resolve-pkg-maps@1.0.0: {}
+
+  responselike@2.0.1:
+    dependencies:
+      lowercase-keys: 2.0.0
 
   reusify@1.1.0: {}
 
@@ -5732,7 +7639,17 @@ snapshots:
     dependencies:
       mri: 1.2.0
 
+  safe-buffer@5.1.2: {}
+
+  safe-buffer@5.2.1: {}
+
+  safe-stable-stringify@2.5.0: {}
+
   safer-buffer@2.1.2: {}
+
+  sanitize-filename@1.6.4:
+    dependencies:
+      truncate-utf8-bytes: 1.0.2
 
   scheduler@0.27.0: {}
 
@@ -5743,7 +7660,38 @@ snapshots:
 
   semver@7.7.4: {}
 
+  semver@7.8.0: {}
+
+  send@0.19.2:
+    dependencies:
+      debug: 2.6.9
+      depd: 2.0.0
+      destroy: 1.2.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 0.5.2
+      http-errors: 2.0.1
+      mime: 1.6.0
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.2.1
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  serve-static@1.16.3:
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 0.19.2
+    transitivePeerDependencies:
+      - supports-color
+
   set-cookie-parser@2.7.2: {}
+
+  setprototypeof@1.2.0: {}
 
   sharp@0.34.5:
     dependencies:
@@ -5794,7 +7742,37 @@ snapshots:
       '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.4
 
+  side-channel-list@1.0.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-map@1.0.1:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-weakmap@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-map: 1.0.1
+
+  side-channel@1.1.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.1
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
+
   siginfo@2.0.0: {}
+
+  signal-exit@3.0.7: {}
 
   signal-exit@4.1.0: {}
 
@@ -5806,7 +7784,17 @@ snapshots:
 
   slash@3.0.0: {}
 
+  sonic-boom@3.8.1:
+    dependencies:
+      atomic-sleep: 1.0.0
+
+  sonic-boom@4.2.1:
+    dependencies:
+      atomic-sleep: 1.0.0
+
   source-map-js@1.2.1: {}
+
+  source-map@0.6.1: {}
 
   source-map@0.7.6: {}
 
@@ -5817,7 +7805,21 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
+  split2@4.2.0: {}
+
   sprintf-js@1.0.3: {}
+
+  sshpk@1.18.0:
+    dependencies:
+      asn1: 0.2.6
+      assert-plus: 1.0.0
+      bcrypt-pbkdf: 1.0.2
+      dashdash: 1.14.1
+      ecc-jsbn: 0.1.2
+      getpass: 0.1.7
+      jsbn: 0.1.1
+      safer-buffer: 2.1.2
+      tweetnacl: 0.14.5
 
   stackback@0.0.2: {}
 
@@ -5826,9 +7828,34 @@ snapshots:
       '@stablelib/base64': 1.0.1
       fast-sha256: 1.3.0
 
+  statuses@2.0.2: {}
+
   std-env@3.10.0: {}
 
   std-env@4.0.0: {}
+
+  steno@0.4.4:
+    dependencies:
+      graceful-fs: 4.2.11
+
+  stream-shift@1.0.3: {}
+
+  streamx@2.28.0:
+    dependencies:
+      events-universal: 1.0.1
+      fast-fifo: 1.3.2
+      text-decoder: 1.2.7
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+
+  string_decoder@1.1.1:
+    dependencies:
+      safe-buffer: 5.1.2
+
+  string_decoder@1.3.0:
+    dependencies:
+      safe-buffer: 5.2.1
 
   stringify-entities@4.0.4:
     dependencies:
@@ -5864,7 +7891,33 @@ snapshots:
 
   tapable@2.3.3: {}
 
+  tar-stream@3.1.7:
+    dependencies:
+      b4a: 1.8.1
+      fast-fifo: 1.3.2
+      streamx: 2.28.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+
   term-size@2.2.1: {}
+
+  text-decoder@1.2.7:
+    dependencies:
+      b4a: 1.8.1
+    transitivePeerDependencies:
+      - react-native-b4a
+
+  thread-stream@3.2.0:
+    dependencies:
+      real-require: 0.2.0
+
+  through2@2.0.5:
+    dependencies:
+      readable-stream: 2.3.8
+      xtend: 4.0.2
+
+  through@2.3.8: {}
 
   tinybench@2.9.0: {}
 
@@ -5890,17 +7943,35 @@ snapshots:
 
   tinyspy@4.0.4: {}
 
+  tldts-core@6.1.86: {}
+
+  tldts@6.1.86:
+    dependencies:
+      tldts-core: 6.1.86
+
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
+
+  toidentifier@1.0.1: {}
 
   toml@3.0.0: {}
 
   totalist@3.0.1: {}
 
+  tough-cookie@5.1.2:
+    dependencies:
+      tldts: 6.1.86
+
+  tr46@0.0.3: {}
+
   trim-lines@3.0.1: {}
 
   trough@2.2.0: {}
+
+  truncate-utf8-bytes@1.0.2:
+    dependencies:
+      utf8-byte-length: 1.0.5
 
   ts-algebra@2.0.0: {}
 
@@ -5913,6 +7984,10 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
+  tunnel-agent@0.6.0:
+    dependencies:
+      safe-buffer: 5.2.1
+
   turbo@2.9.18:
     optionalDependencies:
       '@turbo/darwin-64': 2.9.18
@@ -5922,9 +7997,21 @@ snapshots:
       '@turbo/windows-64': 2.9.18
       '@turbo/windows-arm64': 2.9.18
 
+  tweetnacl@0.14.5: {}
+
+  typanion@3.14.0: {}
+
+  type-is@1.6.18:
+    dependencies:
+      media-typer: 0.3.0
+      mime-types: 2.1.35
+
   typescript@5.8.3: {}
 
   typescript@6.0.2: {}
+
+  uglify-js@3.19.3:
+    optional: true
 
   undici-types@7.19.2: {}
 
@@ -5977,9 +8064,92 @@ snapshots:
 
   universalify@0.1.2: {}
 
+  unix-crypt-td-js@1.1.4: {}
+
+  unpipe@1.0.0: {}
+
+  utf8-byte-length@1.0.5: {}
+
+  util-deprecate@1.0.2: {}
+
+  utils-merge@1.0.1: {}
+
   uuid@11.1.1: {}
 
   uuid@13.0.2: {}
+
+  validator@13.15.26: {}
+
+  vary@1.1.2: {}
+
+  verdaccio-audit@13.0.2:
+    dependencies:
+      '@verdaccio/config': 8.1.1
+      '@verdaccio/core': 8.1.1
+      express: 4.22.1
+      https-proxy-agent: 5.0.1
+      node-fetch: 2.6.7
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  verdaccio-htpasswd@13.0.2:
+    dependencies:
+      '@verdaccio/core': 8.1.1
+      '@verdaccio/file-locking': 13.0.1
+      apache-md5: 1.1.8
+      bcryptjs: 2.4.3
+      debug: 4.4.3
+      http-errors: 2.0.1
+      unix-crypt-td-js: 1.1.4
+    transitivePeerDependencies:
+      - supports-color
+
+  verdaccio@6.7.2(typanion@3.14.0):
+    dependencies:
+      '@cypress/request': 3.0.10
+      '@verdaccio/auth': 8.0.2
+      '@verdaccio/config': 8.1.1
+      '@verdaccio/core': 8.1.1
+      '@verdaccio/hooks': 8.0.2
+      '@verdaccio/loaders': 8.0.2
+      '@verdaccio/local-storage-legacy': 11.3.3
+      '@verdaccio/logger': 8.0.2
+      '@verdaccio/middleware': 8.0.2
+      '@verdaccio/package-filter': 13.0.2
+      '@verdaccio/search-indexer': 8.0.2
+      '@verdaccio/signature': 8.0.2
+      '@verdaccio/streams': 10.2.5
+      '@verdaccio/tarball': 13.0.2
+      '@verdaccio/ui-theme': 9.0.0-next-9.14
+      '@verdaccio/url': 13.0.2
+      '@verdaccio/utils': 8.1.2
+      JSONStream: 1.3.5
+      async: 3.2.6
+      clipanion: 4.0.0-rc.4(typanion@3.14.0)
+      compression: 1.8.1
+      cors: 2.8.6
+      debug: 4.4.3
+      envinfo: 7.21.0
+      express: 4.22.1
+      lodash: 4.18.1
+      lru-cache: 7.18.3
+      mime: 3.0.0
+      semver: 7.8.0
+      verdaccio-audit: 13.0.2
+      verdaccio-htpasswd: 13.0.2
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - encoding
+      - react-native-b4a
+      - supports-color
+      - typanion
+
+  verror@1.10.0:
+    dependencies:
+      assert-plus: 1.0.0
+      core-util-is: 1.0.2
+      extsprintf: 1.3.0
 
   vfile-location@5.0.3:
     dependencies:
@@ -6132,7 +8302,14 @@ snapshots:
 
   web-namespaces@2.0.1: {}
 
+  webidl-conversions@3.0.1: {}
+
   whatwg-fetch@3.6.20: {}
+
+  whatwg-url@5.0.0:
+    dependencies:
+      tr46: 0.0.3
+      webidl-conversions: 3.0.1
 
   which@2.0.2:
     dependencies:
@@ -6143,7 +8320,13 @@ snapshots:
       siginfo: 2.0.0
       stackback: 0.0.2
 
+  wordwrap@1.0.0: {}
+
+  wrappy@1.0.2: {}
+
   ws@8.21.0: {}
+
+  xtend@4.0.2: {}
 
   yaml@2.9.0: {}
 

--- a/test/generated/cli-testing-export.test.ts
+++ b/test/generated/cli-testing-export.test.ts
@@ -1,17 +1,29 @@
-import { readFile, writeFile } from "node:fs/promises"
+import { writeFile } from "node:fs/promises"
 import { join } from "node:path"
 
 import { afterEach, describe, expect, test } from "vitest"
 
 import { spawnProcess } from "../../packages/devkit/src/testing/index.ts"
+import { getTestRegistryUrl } from "../harness/local-registry.ts"
 import {
   cleanupTrackedTempDirs,
-  createPackagedInstaller,
   createTrackedTempDir,
   type TrackedTempDir,
 } from "../harness/packaged-app.ts"
+import { writeRegistryNpmrc } from "../harness/scaffold-packaging.js"
 
 const tempDirs: TrackedTempDir[] = []
+
+const CONSUMER_PACKAGES = [
+  "@dawn-ai/core",
+  "@dawn-ai/langchain",
+  "@dawn-ai/langgraph",
+  "@dawn-ai/permissions",
+  "@dawn-ai/sdk",
+  "@dawn-ai/sqlite-storage",
+  "@dawn-ai/workspace",
+  "@dawn-ai/cli",
+] as const
 
 afterEach(async () => {
   await cleanupTrackedTempDirs(tempDirs)
@@ -21,42 +33,21 @@ describe.each([
   { subpath: "@dawn-ai/sdk/testing", label: "sdk" },
   { subpath: "@dawn-ai/cli/testing", label: "cli" },
 ])("$subpath", ({ subpath, label }) => {
-  test("packed consumers can import the published testing helpers", {
-    timeout: 30_000,
+  test("registry consumers can import the published testing helpers", {
+    timeout: 60_000,
   }, async () => {
-    const tempRoot = await createTrackedTempDir(`dawn-${label}-testing-pack-`, tempDirs)
-    const { installerDir, tarballs } = await createPackagedInstaller({
-      packageNames: [
-        "@dawn-ai/core",
-        "@dawn-ai/langchain",
-        "@dawn-ai/langgraph",
-        "@dawn-ai/permissions",
-        "@dawn-ai/sdk",
-        "@dawn-ai/sqlite-storage",
-        "@dawn-ai/workspace",
-        "@dawn-ai/cli",
-      ],
-      tempRoot,
-    })
+    const consumerDir = await createTrackedTempDir(`dawn-${label}-testing-`, tempDirs)
 
-    await writeInstallerOverrides(installerDir, tarballs)
-    await runCommand(
-      "pnpm",
-      [
-        "add",
-        requiredTarball(tarballs, "@dawn-ai/core"),
-        requiredTarball(tarballs, "@dawn-ai/langchain"),
-        requiredTarball(tarballs, "@dawn-ai/langgraph"),
-        requiredTarball(tarballs, "@dawn-ai/permissions"),
-        requiredTarball(tarballs, "@dawn-ai/sdk"),
-        requiredTarball(tarballs, "@dawn-ai/sqlite-storage"),
-        requiredTarball(tarballs, "@dawn-ai/workspace"),
-        requiredTarball(tarballs, "@dawn-ai/cli"),
-      ],
-      installerDir,
+    await writeFile(
+      join(consumerDir, "package.json"),
+      `${JSON.stringify({ name: `${label}-testing-consumer`, private: true }, null, 2)}\n`,
+      "utf8",
     )
+    await writeRegistryNpmrc(consumerDir, getTestRegistryUrl())
 
-    const scriptPath = join(installerDir, "testing-check.mjs")
+    await runCommand("pnpm", ["add", ...CONSUMER_PACKAGES], consumerDir)
+
+    const scriptPath = join(consumerDir, "testing-check.mjs")
 
     await writeFile(
       scriptPath,
@@ -93,22 +84,12 @@ describe.each([
       "utf8",
     )
 
-    await expect(runCommand("node", [scriptPath], installerDir)).resolves.toMatchObject({
+    await expect(runCommand("node", [scriptPath], consumerDir)).resolves.toMatchObject({
       stderr: "",
       stdout: "",
     })
   })
 })
-
-function requiredTarball(tarballs: Readonly<Record<string, string>>, packageName: string): string {
-  const tarball = tarballs[packageName]
-
-  if (!tarball) {
-    throw new Error(`Missing tarball for ${packageName}`)
-  }
-
-  return tarball
-}
 
 async function runCommand(command: string, args: readonly string[], cwd: string) {
   const result = await spawnProcess({
@@ -129,44 +110,4 @@ async function runCommand(command: string, args: readonly string[], cwd: string)
     stderr: result.stderr,
     stdout: result.stdout,
   }
-}
-
-async function writeInstallerOverrides(
-  installerDir: string,
-  tarballs: Readonly<Record<string, string>>,
-): Promise<void> {
-  const packageJsonPath = join(installerDir, "package.json")
-  const packageJson = JSON.parse(await readFile(packageJsonPath, "utf8")) as {
-    readonly pnpm?: {
-      readonly overrides?: Record<string, string>
-    }
-  } & Record<string, unknown>
-
-  const overrides = {
-    ...(packageJson.pnpm?.overrides ?? {}),
-    "@dawn-ai/cli": requiredTarball(tarballs, "@dawn-ai/cli"),
-    "@dawn-ai/core": requiredTarball(tarballs, "@dawn-ai/core"),
-    "@dawn-ai/langchain": requiredTarball(tarballs, "@dawn-ai/langchain"),
-    "@dawn-ai/langgraph": requiredTarball(tarballs, "@dawn-ai/langgraph"),
-    "@dawn-ai/permissions": requiredTarball(tarballs, "@dawn-ai/permissions"),
-    "@dawn-ai/sdk": requiredTarball(tarballs, "@dawn-ai/sdk"),
-    "@dawn-ai/sqlite-storage": requiredTarball(tarballs, "@dawn-ai/sqlite-storage"),
-    "@dawn-ai/workspace": requiredTarball(tarballs, "@dawn-ai/workspace"),
-  }
-
-  await writeFile(
-    packageJsonPath,
-    `${JSON.stringify(
-      {
-        ...packageJson,
-        pnpm: {
-          ...(packageJson.pnpm ?? {}),
-          overrides,
-        },
-      },
-      null,
-      2,
-    )}\n`,
-    "utf8",
-  )
 }

--- a/test/generated/fixtures/basic.expected.json
+++ b/test/generated/fixtures/basic.expected.json
@@ -11,36 +11,19 @@
       "typecheck": "tsc --noEmit"
     },
     "dependencies": {
-      "@dawn-ai/core": "<tarball:@dawn-ai/core>",
-      "@dawn-ai/cli": "<tarball:@dawn-ai/cli>",
-      "@dawn-ai/langchain": "<tarball:@dawn-ai/langchain>",
-      "@dawn-ai/sdk": "<tarball:@dawn-ai/sdk>",
-      "@dawn-ai/sqlite-storage": "<tarball:@dawn-ai/sqlite-storage>",
-      "@dawn-ai/workspace": "<tarball:@dawn-ai/workspace>",
+      "@dawn-ai/core": "latest",
+      "@dawn-ai/cli": "latest",
+      "@dawn-ai/langchain": "latest",
+      "@dawn-ai/sdk": "latest",
       "zod": "^3.24.0"
     },
     "devDependencies": {
-      "@dawn-ai/config-typescript": "<tarball:@dawn-ai/config-typescript>",
-      "@dawn-ai/evals": "<tarball:@dawn-ai/evals>",
-      "@dawn-ai/testing": "<tarball:@dawn-ai/testing>",
+      "@dawn-ai/config-typescript": "latest",
+      "@dawn-ai/evals": "latest",
+      "@dawn-ai/testing": "latest",
       "@types/node": "<version:@types/node>",
       "typescript": "<version:typescript>",
       "vitest": "<version:vitest>"
-    },
-    "pnpm": {
-      "overrides": {
-        "@dawn-ai/cli": "<tarball:@dawn-ai/cli>",
-        "@dawn-ai/config-typescript": "<tarball:@dawn-ai/config-typescript>",
-        "@dawn-ai/core": "<tarball:@dawn-ai/core>",
-        "@dawn-ai/evals": "<tarball:@dawn-ai/evals>",
-        "@dawn-ai/langchain": "<tarball:@dawn-ai/langchain>",
-        "@dawn-ai/langgraph": "<tarball:@dawn-ai/langgraph>",
-        "@dawn-ai/permissions": "<tarball:@dawn-ai/permissions>",
-        "@dawn-ai/sdk": "<tarball:@dawn-ai/sdk>",
-        "@dawn-ai/sqlite-storage": "<tarball:@dawn-ai/sqlite-storage>",
-        "@dawn-ai/testing": "<tarball:@dawn-ai/testing>",
-        "@dawn-ai/workspace": "<tarball:@dawn-ai/workspace>"
-      }
     }
   },
   "verifyJson": {

--- a/test/generated/fixtures/custom-app-dir.expected.json
+++ b/test/generated/fixtures/custom-app-dir.expected.json
@@ -11,36 +11,19 @@
       "typecheck": "tsc --noEmit"
     },
     "dependencies": {
-      "@dawn-ai/core": "<tarball:@dawn-ai/core>",
-      "@dawn-ai/cli": "<tarball:@dawn-ai/cli>",
-      "@dawn-ai/langchain": "<tarball:@dawn-ai/langchain>",
-      "@dawn-ai/sdk": "<tarball:@dawn-ai/sdk>",
-      "@dawn-ai/sqlite-storage": "<tarball:@dawn-ai/sqlite-storage>",
-      "@dawn-ai/workspace": "<tarball:@dawn-ai/workspace>",
+      "@dawn-ai/core": "latest",
+      "@dawn-ai/cli": "latest",
+      "@dawn-ai/langchain": "latest",
+      "@dawn-ai/sdk": "latest",
       "zod": "^3.24.0"
     },
     "devDependencies": {
-      "@dawn-ai/config-typescript": "<tarball:@dawn-ai/config-typescript>",
-      "@dawn-ai/evals": "<tarball:@dawn-ai/evals>",
-      "@dawn-ai/testing": "<tarball:@dawn-ai/testing>",
+      "@dawn-ai/config-typescript": "latest",
+      "@dawn-ai/evals": "latest",
+      "@dawn-ai/testing": "latest",
       "@types/node": "<version:@types/node>",
       "typescript": "<version:typescript>",
       "vitest": "<version:vitest>"
-    },
-    "pnpm": {
-      "overrides": {
-        "@dawn-ai/cli": "<tarball:@dawn-ai/cli>",
-        "@dawn-ai/config-typescript": "<tarball:@dawn-ai/config-typescript>",
-        "@dawn-ai/core": "<tarball:@dawn-ai/core>",
-        "@dawn-ai/evals": "<tarball:@dawn-ai/evals>",
-        "@dawn-ai/langchain": "<tarball:@dawn-ai/langchain>",
-        "@dawn-ai/langgraph": "<tarball:@dawn-ai/langgraph>",
-        "@dawn-ai/permissions": "<tarball:@dawn-ai/permissions>",
-        "@dawn-ai/sdk": "<tarball:@dawn-ai/sdk>",
-        "@dawn-ai/sqlite-storage": "<tarball:@dawn-ai/sqlite-storage>",
-        "@dawn-ai/testing": "<tarball:@dawn-ai/testing>",
-        "@dawn-ai/workspace": "<tarball:@dawn-ai/workspace>"
-      }
     }
   },
   "verifyJson": {

--- a/test/generated/fixtures/handwritten-runtime-app/package.json
+++ b/test/generated/fixtures/handwritten-runtime-app/package.json
@@ -7,13 +7,13 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@dawn-ai/core": "next",
-    "@dawn-ai/cli": "next",
-    "@dawn-ai/langgraph": "next",
-    "@dawn-ai/sdk": "next"
+    "@dawn-ai/core": "latest",
+    "@dawn-ai/cli": "latest",
+    "@dawn-ai/langgraph": "latest",
+    "@dawn-ai/sdk": "latest"
   },
   "devDependencies": {
-    "@dawn-ai/config-typescript": "next",
+    "@dawn-ai/config-typescript": "latest",
     "@types/node": "25.6.0",
     "typescript": "6.0.2"
   }

--- a/test/generated/harness.ts
+++ b/test/generated/harness.ts
@@ -5,19 +5,16 @@ import { dirname, join, resolve } from "node:path"
 import { expect } from "vitest"
 
 import { createArtifactRoot } from "../../packages/devkit/src/testing/index.ts"
+import { getTestRegistryUrl } from "../harness/local-registry.ts"
 import {
   cleanupTrackedTempDirs,
-  createPackagedInstaller,
   createTrackedTempDir,
   markTrackedTempDirForPreserve,
   runPackagedCommand,
   type TrackedTempDir,
   withPackagedDevServer,
 } from "../harness/packaged-app.ts"
-import {
-  rewriteGeneratedAppDependencies,
-  SCAFFOLD_PACKAGES,
-} from "../harness/scaffold-packaging.js"
+import { writeRegistryNpmrc } from "../harness/scaffold-packaging.js"
 import { startFakeAgentServer } from "../runtime/support/fake-agent-server.ts"
 
 const REPO_ROOT = resolve(import.meta.dirname, "../..")
@@ -56,7 +53,6 @@ export interface GeneratedRuntimeApp {
   readonly appRoot: string
   readonly artifactRoot: string
   readonly fixture: RuntimeFixtureSpec
-  readonly tarballs?: Readonly<Record<string, string>>
   readonly tempRoot: string
   readonly transcriptPath: string
 }
@@ -145,26 +141,13 @@ export async function prepareGeneratedRuntimeApp(options: {
   await mkdir(dirname(transcriptPath), { recursive: true })
 
   try {
-    let installerDir: string | undefined
-    let tarballs: Readonly<Record<string, string>> | undefined
-
     if (scaffoldMode === "internal") {
       await buildLocalContributorPackages(transcriptPath)
-    } else {
-      const packagedInstaller = await createPackagedInstaller({
-        packageNames: [...SCAFFOLD_PACKAGES],
-        tempRoot: options.tempRoot,
-        transcriptPath,
-      })
-
-      installerDir = packagedInstaller.installerDir
-      tarballs = packagedInstaller.tarballs
     }
 
     if (fixture.source === "generated") {
       await scaffoldApp({
         appRoot,
-        installerDir,
         mode: scaffoldMode,
         transcriptPath,
       })
@@ -209,20 +192,8 @@ export async function prepareGeneratedRuntimeApp(options: {
       })
     }
 
-    if (scaffoldMode === "external" && tarballs) {
-      await rewriteGeneratedAppDependencies({
-        appRoot,
-        tarballs,
-        extraDependencies: {
-          "@dawn-ai/langgraph": tarballs["@dawn-ai/langgraph"]!,
-          "@dawn-ai/sqlite-storage": tarballs["@dawn-ai/sqlite-storage"]!,
-          // workspace is a transitive-only dep (via core + langchain); a pnpm
-          // override alone does not resolve a local tarball for a non-direct
-          // dep, so it must be promoted to a direct dep like the other forced
-          // packages, or install falls back to the (unpublished) registry version.
-          "@dawn-ai/workspace": tarballs["@dawn-ai/workspace"]!,
-        },
-      })
+    if (scaffoldMode === "external") {
+      await writeRegistryNpmrc(appRoot, getTestRegistryUrl())
     }
     await runPackagedCommand({
       args: ["install"],
@@ -235,7 +206,6 @@ export async function prepareGeneratedRuntimeApp(options: {
       appRoot,
       artifactRoot,
       fixture,
-      tarballs,
       tempRoot: options.tempRoot,
       transcriptPath,
     }
@@ -380,28 +350,33 @@ async function captureServerRequest(options: {
 
 async function scaffoldApp(options: {
   readonly appRoot: string
-  readonly installerDir?: string
   readonly mode: GeneratedScaffoldMode
   readonly transcriptPath: string
 }): Promise<void> {
   if (options.mode === "internal") {
     await runPackagedCommand({
-      args: ["packages/create-dawn-app/dist/bin.js", options.appRoot, "--mode", "internal", "--template", "basic"],
+      args: [
+        "packages/create-dawn-app/dist/bin.js",
+        options.appRoot,
+        "--mode",
+        "internal",
+        "--template",
+        "basic",
+      ],
       command: "node",
       cwd: REPO_ROOT,
       transcriptPath: options.transcriptPath,
     })
   } else {
-    if (!options.installerDir) {
-      throw new Error(
-        "Expected packaged installer directory for external generated runtime scaffolding",
-      )
-    }
-
+    // external mode: scaffold using the published create-dawn-ai-app, resolved
+    // from the test registry — exactly what a real user runs. pnpm dlx does not
+    // accept --registry, so the registry is passed via npm_config_registry; the
+    // unique per-run URL busts dlx's cache.
     await runPackagedCommand({
-      args: ["exec", "create-dawn-ai-app", options.appRoot, "--dist-tag", "next", "--template", "basic"],
+      args: ["dlx", "create-dawn-ai-app", options.appRoot, "--template", "basic"],
       command: "pnpm",
-      cwd: options.installerDir,
+      cwd: REPO_ROOT,
+      env: { npm_config_registry: getTestRegistryUrl() },
       transcriptPath: options.transcriptPath,
     })
   }

--- a/test/generated/run-generated-app.test.ts
+++ b/test/generated/run-generated-app.test.ts
@@ -6,18 +6,32 @@ import { pathToFileURL } from "node:url"
 import { afterEach, describe, expect, test } from "vitest"
 
 import { createArtifactRoot, spawnProcess } from "../../packages/devkit/src/testing/index.ts"
+import { getTestRegistryUrl } from "../harness/local-registry.ts"
 import {
   cleanupTrackedTempDirs,
-  createPackagedInstaller,
   createTrackedTempDir,
   markTrackedTempDirForPreserve,
+  runPackagedCommand,
   type TrackedTempDir,
 } from "../harness/packaged-app.ts"
-import {
-  rewriteGeneratedAppDependencies,
-  SCAFFOLD_PACKAGES,
-} from "../harness/scaffold-packaging.js"
+import { writeRegistryNpmrc } from "../harness/scaffold-packaging.js"
 import { expectBasicAuthoringLane } from "./harness.ts"
+
+// @dawn-ai workspace packages a generated app may depend on. Used only to build
+// the internal-mode <repo:...> fixture (external mode installs from the registry).
+const SCAFFOLD_PACKAGES: readonly string[] = [
+  "@dawn-ai/cli",
+  "@dawn-ai/config-typescript",
+  "@dawn-ai/core",
+  "@dawn-ai/evals",
+  "@dawn-ai/langchain",
+  "@dawn-ai/langgraph",
+  "@dawn-ai/permissions",
+  "@dawn-ai/sdk",
+  "@dawn-ai/sqlite-storage",
+  "@dawn-ai/testing",
+  "@dawn-ai/workspace",
+]
 
 const REPO_ROOT = resolve(import.meta.dirname, "../..")
 const FIXTURE_ROOT = resolve(import.meta.dirname, "fixtures")
@@ -150,25 +164,12 @@ async function runGeneratedAppScenario(
 
   await mkdir(dirname(transcriptPath), { recursive: true })
   try {
-    let installerDir: string | undefined
-    let tarballs: Readonly<Record<string, string>> | undefined
-
     if (scaffoldMode === "internal") {
       await buildLocalContributorPackages(transcriptPath)
-    } else {
-      const packagedInstaller = await createPackagedInstaller({
-        packageNames: [...SCAFFOLD_PACKAGES],
-        tempRoot,
-        transcriptPath,
-      })
-
-      installerDir = packagedInstaller.installerDir
-      tarballs = packagedInstaller.tarballs
     }
 
     await scaffoldApp({
       appRoot,
-      installerDir,
       mode: scaffoldMode,
       transcriptPath,
     })
@@ -199,26 +200,17 @@ async function runGeneratedAppScenario(
       await options.mutateApp(appRoot)
     }
 
-    if (scaffoldMode === "external" && tarballs) {
-      await rewriteGeneratedAppDependencies({
-        appRoot,
-        tarballs,
-        extraDependencies: {
-          "@dawn-ai/sqlite-storage": tarballs["@dawn-ai/sqlite-storage"]!,
-          // workspace is a transitive-only dep (via core + langchain); a pnpm
-          // override alone does not resolve a local tarball for a non-direct
-          // dep, so it must be promoted to a direct dep like the other forced
-          // packages, or install falls back to the (unpublished) registry version.
-          "@dawn-ai/workspace": tarballs["@dawn-ai/workspace"]!,
-        },
-      })
+    if (scaffoldMode === "external") {
+      await writeRegistryNpmrc(appRoot, getTestRegistryUrl())
     }
 
     const result = await runLifecycle({ appRoot, transcriptPath })
-    if (scaffoldMode === "external" && tarballs) {
+    if (scaffoldMode === "external") {
       const expected = await readExpectedFixture(options.expectedFixtureName)
 
-      expect(normalizeForFixture(result, { appRoot, tarballs })).toEqual(expected)
+      expect(
+        normalizeForFixture(result, { appRoot, dawnVersion: await readDawnVersion() }),
+      ).toEqual(expected)
     }
 
     return {
@@ -243,28 +235,33 @@ async function runGeneratedAppScenario(
 
 async function scaffoldApp(options: {
   readonly appRoot: string
-  readonly installerDir?: string
   readonly mode: "external" | "internal"
   readonly transcriptPath: string
 }): Promise<void> {
   if (options.mode === "internal") {
     await runCommand({
-      args: ["packages/create-dawn-app/dist/bin.js", options.appRoot, "--mode", "internal", "--template", "basic"],
+      args: [
+        "packages/create-dawn-app/dist/bin.js",
+        options.appRoot,
+        "--mode",
+        "internal",
+        "--template",
+        "basic",
+      ],
       command: "node",
       cwd: REPO_ROOT,
       transcriptPath: options.transcriptPath,
     })
   } else {
-    if (!options.installerDir) {
-      throw new Error(
-        "Expected packaged installer directory for external generated-app scaffolding",
-      )
-    }
-
-    await runCommand({
-      args: ["exec", "create-dawn-ai-app", options.appRoot, "--dist-tag", "next", "--template", "basic"],
+    // external mode: scaffold using the published create-dawn-ai-app, resolved
+    // from the test registry — exactly what a real user runs. pnpm dlx does not
+    // accept --registry, so the registry is passed via npm_config_registry; the
+    // unique per-run URL busts dlx's cache.
+    await runPackagedCommand({
+      args: ["dlx", "create-dawn-ai-app", options.appRoot, "--template", "basic"],
       command: "pnpm",
-      cwd: options.installerDir,
+      cwd: REPO_ROOT,
+      env: { npm_config_registry: getTestRegistryUrl() },
       transcriptPath: options.transcriptPath,
     })
   }
@@ -502,22 +499,28 @@ async function createExpectedInternalFixture(
 
 function normalizeForFixture(
   value: GeneratedAppScenarioResult,
-  context: { readonly appRoot: string; readonly tarballs: Readonly<Record<string, string>> },
+  context: { readonly appRoot: string; readonly dawnVersion: string },
 ): GeneratedAppScenarioResult {
-  const tarballPairs: Array<readonly [string, string]> = Object.entries(context.tarballs).map(
-    ([name, tarballPath]) => [tarballPath, `<tarball:${name}>`] as const,
-  )
-
   return normalizeValue(value, [
     [`/private${context.appRoot}`, "<app-root>"],
     [context.appRoot, "<app-root>"],
-    ...tarballPairs,
-    [`/private${dirname(context.tarballs["@dawn-ai/cli"])}`, "<packs-dir>"],
-    [dirname(context.tarballs["@dawn-ai/cli"]), "<packs-dir>"],
+    [context.dawnVersion, "<dawn-version>"],
     ["25.6.0", "<version:@types/node>"],
     ["6.0.2", "<version:typescript>"],
     ["4.1.4", "<version:vitest>"],
   ]) as GeneratedAppScenarioResult
+}
+
+async function readDawnVersion(): Promise<string> {
+  const corePackageJson = JSON.parse(
+    await readFile(resolve(REPO_ROOT, "packages/core/package.json"), "utf8"),
+  ) as { version?: string }
+
+  if (!corePackageJson.version) {
+    throw new Error("Could not read @dawn-ai/core version for fixture normalization")
+  }
+
+  return corePackageJson.version
 }
 
 function normalizeForInternalFixture(

--- a/test/generated/run-generated-app.test.ts
+++ b/test/generated/run-generated-app.test.ts
@@ -447,31 +447,29 @@ async function createExpectedInternalFixture(
       dependencies: Record<string, string>
       devDependencies: Record<string, string>
       name: string
-      pnpm: {
-        overrides: Record<string, string>
-      }
     }
   }
+
+  // Internal mode rewrites every dawn specifier from "latest" to a repo file: URL (normalized
+  // to <repo:...>) and adds a pnpm.overrides block covering all SCAFFOLD_PACKAGES.
+  // We build the overrides block directly from SCAFFOLD_PACKAGES rather than reading
+  // it from the external fixture (which has no pnpm key in the Verdaccio-install shape).
+  const repoOverrides = Object.fromEntries(
+    SCAFFOLD_PACKAGES.map((name) => [name, `<repo:${name}>`]),
+  )
 
   return {
     ...expected,
     packageJson: {
       ...expected.packageJson,
       name: appName,
-      dependencies: (() => {
-        const deps = {
-          ...expected.packageJson.dependencies,
-          "@dawn-ai/cli": "<repo:@dawn-ai/cli>",
-          "@dawn-ai/core": "<repo:@dawn-ai/core>",
-          "@dawn-ai/langchain": "<repo:@dawn-ai/langchain>",
-          "@dawn-ai/sdk": "<repo:@dawn-ai/sdk>",
-        }
-        // sqlite-storage and workspace are not direct deps in the generated template;
-        // internal mode references them only via overrides
-        delete deps["@dawn-ai/sqlite-storage"]
-        delete deps["@dawn-ai/workspace"]
-        return deps
-      })(),
+      dependencies: {
+        ...expected.packageJson.dependencies,
+        "@dawn-ai/cli": "<repo:@dawn-ai/cli>",
+        "@dawn-ai/core": "<repo:@dawn-ai/core>",
+        "@dawn-ai/langchain": "<repo:@dawn-ai/langchain>",
+        "@dawn-ai/sdk": "<repo:@dawn-ai/sdk>",
+      },
       devDependencies: {
         ...expected.packageJson.devDependencies,
         "@dawn-ai/config-typescript": "<repo:@dawn-ai/config-typescript>",
@@ -479,19 +477,7 @@ async function createExpectedInternalFixture(
         "@dawn-ai/testing": "<repo:@dawn-ai/testing>",
       },
       pnpm: {
-        overrides: {
-          "@dawn-ai/cli": "<repo:@dawn-ai/cli>",
-          "@dawn-ai/config-typescript": "<repo:@dawn-ai/config-typescript>",
-          "@dawn-ai/core": "<repo:@dawn-ai/core>",
-          "@dawn-ai/evals": "<repo:@dawn-ai/evals>",
-          "@dawn-ai/langchain": "<repo:@dawn-ai/langchain>",
-          "@dawn-ai/langgraph": "<repo:@dawn-ai/langgraph>",
-          "@dawn-ai/permissions": "<repo:@dawn-ai/permissions>",
-          "@dawn-ai/sdk": "<repo:@dawn-ai/sdk>",
-          "@dawn-ai/sqlite-storage": "<repo:@dawn-ai/sqlite-storage>",
-          "@dawn-ai/testing": "<repo:@dawn-ai/testing>",
-          "@dawn-ai/workspace": "<repo:@dawn-ai/workspace>",
-        },
+        overrides: repoOverrides,
       },
     },
   }

--- a/test/generated/run-generated-app.test.ts
+++ b/test/generated/run-generated-app.test.ts
@@ -466,8 +466,8 @@ async function createExpectedInternalFixture(
           "@dawn-ai/langchain": "<repo:@dawn-ai/langchain>",
           "@dawn-ai/sdk": "<repo:@dawn-ai/sdk>",
         }
-        // sqlite-storage and workspace are only in overrides for internal mode,
-        // not in direct deps (external mode promotes them via extraDependencies)
+        // sqlite-storage and workspace are not direct deps in the generated template;
+        // internal mode references them only via overrides
         delete deps["@dawn-ai/sqlite-storage"]
         delete deps["@dawn-ai/workspace"]
         return deps

--- a/test/generated/vitest.config.ts
+++ b/test/generated/vitest.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
     environment: "node",
     exclude: ["test/generated/fixtures/**"],
     fileParallelism: false,
+    globalSetup: ["test/harness/registry-global-setup.ts"],
     hookTimeout: 180_000,
     // test/harness holds the shared scaffolding helpers the framework lane
     // exercises; include their unit tests here so they actually run in CI

--- a/test/harness/local-registry.test.ts
+++ b/test/harness/local-registry.test.ts
@@ -1,0 +1,67 @@
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+import { afterAll, beforeAll, describe, expect, test } from "vitest"
+
+import { type LocalRegistry, publishWorkspace, startLocalRegistry } from "./local-registry.ts"
+import { runPackagedCommand } from "./packaged-app.ts"
+
+describe("local-registry", () => {
+  let registry: LocalRegistry
+
+  beforeAll(async () => {
+    registry = await startLocalRegistry()
+    await publishWorkspace(registry.url)
+  }, 180_000)
+
+  afterAll(async () => {
+    await registry?.stop()
+  })
+
+  test("serves a published @dawn-ai package that a real install resolves", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "dawn-reg-probe-"))
+    try {
+      await writeFile(
+        join(dir, "package.json"),
+        `${JSON.stringify({ name: "probe", private: true, dependencies: { "@dawn-ai/core": "latest" } }, null, 2)}\n`,
+        "utf8",
+      )
+      await writeFile(join(dir, ".npmrc"), `registry=${registry.url}\n`, "utf8")
+
+      await runPackagedCommand({
+        args: ["install", "--no-frozen-lockfile"],
+        command: "pnpm",
+        cwd: dir,
+      })
+
+      const lockfile = await readFile(join(dir, "pnpm-lock.yaml"), "utf8")
+      expect(lockfile).toContain("@dawn-ai/core")
+      expect(lockfile).not.toContain("registry.npmjs.org/@dawn-ai")
+    } finally {
+      await rm(dir, { force: true, recursive: true })
+    }
+  }, 180_000)
+
+  test("404s for an @dawn-ai package that was never published (fail-closed)", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "dawn-reg-neg-"))
+    try {
+      await writeFile(
+        join(dir, "package.json"),
+        `${JSON.stringify({ name: "neg", private: true, dependencies: { "@dawn-ai/does-not-exist": "latest" } }, null, 2)}\n`,
+        "utf8",
+      )
+      await writeFile(join(dir, ".npmrc"), `registry=${registry.url}\n`, "utf8")
+
+      await expect(
+        runPackagedCommand({
+          args: ["install", "--no-frozen-lockfile"],
+          command: "pnpm",
+          cwd: dir,
+        }),
+      ).rejects.toThrow()
+    } finally {
+      await rm(dir, { force: true, recursive: true })
+    }
+  }, 120_000)
+})

--- a/test/harness/local-registry.ts
+++ b/test/harness/local-registry.ts
@@ -138,6 +138,21 @@ async function readPublicPackages(): Promise<Array<{ dir: string; name: string }
   return packages.sort((a, b) => a.name.localeCompare(b.name))
 }
 
+const REGISTRY_URL_ENV = "DAWN_TEST_REGISTRY_URL"
+
+/** Read the registry URL published by the lane's globalSetup. Throws if setup did not run. */
+export function getTestRegistryUrl(): string {
+  const url = process.env[REGISTRY_URL_ENV]
+  if (!url) {
+    throw new Error(
+      `${REGISTRY_URL_ENV} is not set — the lane's registry globalSetup must run before scaffolding helpers.`,
+    )
+  }
+  return url
+}
+
+export { REGISTRY_URL_ENV }
+
 async function assertUniformPublishableVersion(): Promise<void> {
   const packagesDir = join(REPO_ROOT, "packages")
   const entries = await readdir(packagesDir, { withFileTypes: true })

--- a/test/harness/local-registry.ts
+++ b/test/harness/local-registry.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readdir, readFile, rm, writeFile } from "node:fs/promises"
+import { mkdtemp, readdir, readFile, rm } from "node:fs/promises"
 import type { Server } from "node:http"
 import { tmpdir } from "node:os"
 import { basename, join } from "node:path"
@@ -65,23 +65,39 @@ export async function publishWorkspace(url: string): Promise<void> {
 
   const host = url.replace(/^https?:\/\//, "").replace(/\/$/, "")
 
-  // Write an isolated npmrc that only declares our local registry. We pass
-  // npm_config_userconfig to npm so it reads THIS file instead of ~/.npmrc —
-  // that bypasses any global scope/registry settings that npm 10 would otherwise
-  // apply (including the default replace-registry-host=npmjs behaviour that
-  // silently redirects PUT calls back to registry.npmjs.org).
-  const packsDir = await mkdtemp(join(tmpdir(), "dawn-packs-"))
-  const npmrcPath = join(packsDir, ".npmrc")
-  await writeFile(
-    npmrcPath,
-    [`registry=${url}`, `//${host}/:_authToken=fake`, ""].join("\n"),
-    "utf8",
-  )
+  // npm config passed as env, the highest-precedence config layer after the command
+  // line. Setting these in the publish env makes them authoritative: they override
+  // any `registry`/auth inherited from ~/.npmrc, the project .npmrc, or an
+  // env-injected npm_config_registry, regardless of what the host machine carries.
+  //
+  //   - registry: the local Verdaccio (the publish target for unscoped packages once
+  //     the inherited default scope is cleared — see `--scope=` below).
+  //   - //<host>/:_authToken: Verdaccio accepts $anonymous publish but npm still
+  //     wants an auth token in the env for the target host, else ENEEDAUTH.
+  //   - replace-registry-host=never: npm 10 otherwise rewrites the PUT target host
+  //     back to the public registry; pin it so the tarball PUT stays local.
+  //
+  // ROOT CAUSE this guards against: `npm publish` resolves the *publish* registry by
+  // scope, not from the top-level `registry`. Two failure modes, both silently
+  // routing to registry.npmjs.org → ENEEDAUTH/E404 on a developer or CI machine:
+  //   1. A SCOPED package (@dawn-ai/*) uses `@<scope>:registry` and falls back to
+  //      the public registry — NOT the top-level `registry` — when that scope has no
+  //      registry. We set `npm_config_@<scope>:registry` per package below.
+  //   2. An inherited default `scope=@foo` in ~/.npmrc routes EVERY publish (even
+  //      unscoped create-dawn-ai-app) through `@foo:registry`, ignoring both
+  //      `--registry` and `npm_config_registry`. We pass `--scope=` to clear it so
+  //      unscoped publishes fall back to the top-level `registry`.
+  const baseEnv: NodeJS.ProcessEnv = {
+    npm_config_registry: url,
+    [`npm_config_//${host}/:_authToken`]: "fake",
+    npm_config_replace_registry_host: "never",
+  }
 
   // Pack each public package into a temp dir, then publish the tarball directly
-  // to the local Verdaccio using `npm publish tarball` with an isolated userconfig.
+  // to the local Verdaccio.
+  const packsDir = await mkdtemp(join(tmpdir(), "dawn-packs-"))
   try {
-    for (const { dir } of packages) {
+    for (const { dir, name } of packages) {
       const packResult = await runPackagedCommand({
         args: ["pack", "--pack-destination", packsDir],
         command: "pnpm",
@@ -97,18 +113,15 @@ export async function publishWorkspace(url: string): Promise<void> {
         throw new Error(`Could not determine tarball name from pnpm pack in ${dir}`)
       }
 
+      const scope = name.startsWith("@") ? name.slice(0, name.indexOf("/")) : undefined
       const tarballPath = join(packsDir, basename(tarballName))
       await runPackagedCommand({
-        args: ["publish", tarballPath, "--tag", "latest", "--access", "public"],
+        // `--scope=` clears any inherited default scope so the publish target comes
+        // from `registry` (for unscoped) or the package's own scope (set in env).
+        args: ["publish", tarballPath, "--tag", "latest", "--access", "public", "--scope="],
         command: "npm",
         cwd: dir,
-        env: {
-          // Point npm at our isolated npmrc so it uses the local registry URL.
-          // This is the only reliable way to override registry in npm >=10 — the
-          // --registry flag and npm_config_registry env var are both overridden by
-          // the user's ~/.npmrc when replace-registry-host=npmjs (npm 10 default).
-          npm_config_userconfig: npmrcPath,
-        },
+        env: scope ? { ...baseEnv, [`npm_config_${scope}:registry`]: url } : baseEnv,
       })
     }
   } finally {

--- a/test/harness/local-registry.ts
+++ b/test/harness/local-registry.ts
@@ -1,0 +1,165 @@
+import { mkdtemp, readdir, readFile, rm, writeFile } from "node:fs/promises"
+import type { Server } from "node:http"
+import { tmpdir } from "node:os"
+import { basename, join } from "node:path"
+import { fileURLToPath } from "node:url"
+
+import { runServer } from "verdaccio"
+
+import { runPackagedCommand } from "./packaged-app.ts"
+
+const REPO_ROOT = fileURLToPath(new URL("../..", import.meta.url))
+
+export interface LocalRegistry {
+  readonly url: string
+  readonly stop: () => Promise<void>
+}
+
+export async function startLocalRegistry(): Promise<LocalRegistry> {
+  const storage = await mkdtemp(join(tmpdir(), "dawn-verdaccio-"))
+  const config = {
+    configPath: join(storage, "config.yaml"),
+    storage,
+    uplinks: { npmjs: { url: "https://registry.npmjs.org/", maxage: "30m" } },
+    packages: {
+      // Dawn's own packages: local publish only, no npmjs proxy so versions
+      // already on the public registry don't shadow our local publish.
+      "@dawn-ai/*": { access: "$all", publish: "$anonymous", unpublish: "$anonymous" },
+      "create-dawn-ai-app": { access: "$all", publish: "$anonymous", unpublish: "$anonymous" },
+      // Everything else: proxy through npmjs for transitive deps
+      "**": { access: "$all", publish: "$anonymous", proxy: "npmjs" },
+    },
+    log: { type: "stdout", format: "pretty", level: "warn" },
+  }
+
+  try {
+    const app = (await runServer(config as never)) as Server
+    const server: Server = await new Promise((resolve) => {
+      const s = app.listen(0, "127.0.0.1", () => resolve(s))
+    })
+
+    const address = server.address()
+    if (!address || typeof address === "string") {
+      throw new Error("Verdaccio failed to bind a port")
+    }
+    const url = `http://127.0.0.1:${address.port}/`
+
+    return {
+      url,
+      stop: async () => {
+        await new Promise<void>((resolve, reject) =>
+          server.close((err) => (err ? reject(err) : resolve())),
+        )
+        await rm(storage, { force: true, recursive: true })
+      },
+    }
+  } catch (err) {
+    await rm(storage, { force: true, recursive: true })
+    throw err
+  }
+}
+
+export async function publishWorkspace(url: string): Promise<void> {
+  await assertUniformPublishableVersion()
+  const packages = await readPublicPackages()
+
+  const host = url.replace(/^https?:\/\//, "").replace(/\/$/, "")
+
+  // Write an isolated npmrc that only declares our local registry. We pass
+  // npm_config_userconfig to npm so it reads THIS file instead of ~/.npmrc —
+  // that bypasses any global scope/registry settings that npm 10 would otherwise
+  // apply (including the default replace-registry-host=npmjs behaviour that
+  // silently redirects PUT calls back to registry.npmjs.org).
+  const packsDir = await mkdtemp(join(tmpdir(), "dawn-packs-"))
+  const npmrcPath = join(packsDir, ".npmrc")
+  await writeFile(
+    npmrcPath,
+    [`registry=${url}`, `//${host}/:_authToken=fake`, ""].join("\n"),
+    "utf8",
+  )
+
+  // Pack each public package into a temp dir, then publish the tarball directly
+  // to the local Verdaccio using `npm publish tarball` with an isolated userconfig.
+  try {
+    for (const { dir } of packages) {
+      const packResult = await runPackagedCommand({
+        args: ["pack", "--pack-destination", packsDir],
+        command: "pnpm",
+        cwd: dir,
+      })
+      const tarballName = packResult.stdout
+        .split("\n")
+        .map((line) => line.trim())
+        .filter(Boolean)
+        .find((line) => line.endsWith(".tgz"))
+
+      if (!tarballName) {
+        throw new Error(`Could not determine tarball name from pnpm pack in ${dir}`)
+      }
+
+      const tarballPath = join(packsDir, basename(tarballName))
+      await runPackagedCommand({
+        args: ["publish", tarballPath, "--tag", "latest", "--access", "public"],
+        command: "npm",
+        cwd: dir,
+        env: {
+          // Point npm at our isolated npmrc so it uses the local registry URL.
+          // This is the only reliable way to override registry in npm >=10 — the
+          // --registry flag and npm_config_registry env var are both overridden by
+          // the user's ~/.npmrc when replace-registry-host=npmjs (npm 10 default).
+          npm_config_userconfig: npmrcPath,
+        },
+      })
+    }
+  } finally {
+    await rm(packsDir, { force: true, recursive: true })
+  }
+}
+
+async function readPublicPackages(): Promise<Array<{ dir: string; name: string }>> {
+  const packagesDir = join(REPO_ROOT, "packages")
+  const entries = await readdir(packagesDir, { withFileTypes: true })
+  const packages: Array<{ dir: string; name: string }> = []
+
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue
+    const dir = join(packagesDir, entry.name)
+    let manifest: { name?: string; private?: boolean }
+    try {
+      manifest = JSON.parse(await readFile(join(dir, "package.json"), "utf8"))
+    } catch {
+      continue
+    }
+    if (manifest.private || !manifest.name) continue
+    packages.push({ dir, name: manifest.name })
+  }
+
+  // Sort for deterministic publish order
+  return packages.sort((a, b) => a.name.localeCompare(b.name))
+}
+
+async function assertUniformPublishableVersion(): Promise<void> {
+  const packagesDir = join(REPO_ROOT, "packages")
+  const entries = await readdir(packagesDir, { withFileTypes: true })
+  const versions = new Map<string, string>()
+
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue
+    let manifest: { name?: string; version?: string; private?: boolean }
+    try {
+      manifest = JSON.parse(await readFile(join(packagesDir, entry.name, "package.json"), "utf8"))
+    } catch {
+      continue
+    }
+    if (manifest.private || !manifest.name || !manifest.version) continue
+    versions.set(manifest.name, manifest.version)
+  }
+
+  const unique = new Set(versions.values())
+  if (unique.size > 1) {
+    const detail = [...versions.entries()].map(([name, v]) => `${name}@${v}`).join(", ")
+    throw new Error(
+      `Publishable packages must share one canonical version before publishing to the test registry, found: ${detail}`,
+    )
+  }
+}

--- a/test/harness/packaged-app.ts
+++ b/test/harness/packaged-app.ts
@@ -1,32 +1,18 @@
 import { spawn } from "node:child_process"
-import { appendFile, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises"
+import { appendFile, mkdtemp, rm } from "node:fs/promises"
 import { tmpdir } from "node:os"
-import { basename, join, resolve } from "node:path"
+import { join } from "node:path"
 
 import { spawnProcess } from "../../packages/devkit/src/testing/index.ts"
 import {
   appendDevServerTranscript,
-  startDevServer,
   type DevServerHandle,
+  startDevServer,
 } from "../runtime/support/dev-server.ts"
-
-const REPO_ROOT = resolve(import.meta.dirname, "../..")
 
 export interface TrackedTempDir {
   path: string
   preserve: boolean
-}
-
-export interface CreatePackagedInstallerOptions {
-  readonly packageNames?: readonly string[]
-  readonly tempRoot: string
-  readonly transcriptPath?: string
-}
-
-export interface CreatePackagedInstallerResult {
-  readonly installerDir: string
-  readonly packsDir: string
-  readonly tarballs: Readonly<Record<string, string>>
 }
 
 export interface PackagedDevServerSession {
@@ -59,100 +45,10 @@ export async function cleanupTrackedTempDirs(registry: TrackedTempDir[]): Promis
       .filter((entry) => !entry.preserve)
       // maxRetries handles the ENOTEMPTY race where a just-killed dev server's
       // child flushes a SQLite WAL file into .dawn/ between readdir and rmdir.
-      .map((entry) => rm(entry.path, { force: true, maxRetries: 5, recursive: true, retryDelay: 100 })),
+      .map((entry) =>
+        rm(entry.path, { force: true, maxRetries: 5, recursive: true, retryDelay: 100 }),
+      ),
   )
-}
-
-export async function createPackagedInstaller(
-  options: CreatePackagedInstallerOptions,
-): Promise<CreatePackagedInstallerResult> {
-  const packsDir = join(options.tempRoot, "packs")
-  const installerDir = join(options.tempRoot, "installer")
-  const packageNames = ["@dawn-ai/devkit", "create-dawn-ai-app", ...(options.packageNames ?? [])].filter(
-    (value, index, allValues) => allValues.indexOf(value) === index,
-  )
-
-  await mkdir(packsDir, { recursive: true })
-  await mkdir(installerDir, { recursive: true })
-
-  await runPackagedCommand({
-    args: ["--filter", "create-dawn-ai-app", "build"],
-    command: "pnpm",
-    cwd: REPO_ROOT,
-    transcriptPath: options.transcriptPath,
-  })
-
-  const tarballs = Object.fromEntries(
-    await Promise.all(
-      packageNames.map(async (packageName) => [
-        packageName,
-        await packPackage(packageName, { packsDir, transcriptPath: options.transcriptPath }),
-      ]),
-    ),
-  )
-
-  await writeFile(
-    join(installerDir, "package.json"),
-    `${JSON.stringify(
-      {
-        name: "installer",
-        private: true,
-        packageManager: "pnpm@10.33.0",
-        pnpm: {
-          overrides: {
-            "@dawn-ai/devkit": tarballs["@dawn-ai/devkit"],
-            "@dawn-ai/langchain": tarballs["@dawn-ai/langchain"],
-          },
-        },
-      },
-      null,
-      2,
-    )}\n`,
-    "utf8",
-  )
-
-  await runPackagedCommand({
-    args: ["add", tarballs["@dawn-ai/devkit"]],
-    command: "pnpm",
-    cwd: installerDir,
-    transcriptPath: options.transcriptPath,
-  })
-  await runPackagedCommand({
-    args: ["add", tarballs["create-dawn-ai-app"]],
-    command: "pnpm",
-    cwd: installerDir,
-    transcriptPath: options.transcriptPath,
-  })
-
-  return {
-    installerDir,
-    packsDir,
-    tarballs,
-  }
-}
-
-async function packPackage(
-  packageName: string,
-  options: { readonly packsDir: string; readonly transcriptPath?: string },
-): Promise<string> {
-  const packResult = await runPackagedCommand({
-    args: ["--filter", packageName, "pack", "--pack-destination", options.packsDir],
-    command: "pnpm",
-    cwd: REPO_ROOT,
-    transcriptPath: options.transcriptPath,
-  })
-
-  const tarballName = packResult.stdout
-    .split("\n")
-    .map((line) => line.trim())
-    .filter(Boolean)
-    .find((line) => line.endsWith(".tgz"))
-
-  if (!tarballName) {
-    throw new Error(`Could not determine tarball name for ${packageName}`)
-  }
-
-  return join(options.packsDir, basename(tarballName))
 }
 
 export async function runPackagedCommand(options: {

--- a/test/harness/packaged-app.ts
+++ b/test/harness/packaged-app.ts
@@ -1,7 +1,7 @@
 import { spawn } from "node:child_process"
-import { appendFile, mkdtemp, rm } from "node:fs/promises"
+import { appendFile, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
-import { join } from "node:path"
+import { basename, join, resolve } from "node:path"
 
 import { spawnProcess } from "../../packages/devkit/src/testing/index.ts"
 import {
@@ -9,6 +9,8 @@ import {
   type DevServerHandle,
   startDevServer,
 } from "../runtime/support/dev-server.ts"
+
+const REPO_ROOT = resolve(import.meta.dirname, "../..")
 
 export interface TrackedTempDir {
   path: string
@@ -49,6 +51,65 @@ export async function cleanupTrackedTempDirs(registry: TrackedTempDir[]): Promis
         rm(entry.path, { force: true, maxRetries: 5, recursive: true, retryDelay: 100 }),
       ),
   )
+}
+
+/**
+ * Pack the CURRENT create-dawn-ai-app source and install it into a temp installer
+ * dir, returning that dir. Lets a standalone test run `pnpm exec create-dawn-ai-app`
+ * with the local build (not the published npmjs version). Self-contained: no registry.
+ */
+export async function installPackagedScaffolder(
+  tempRoot: string,
+): Promise<{ installerDir: string }> {
+  const packsDir = join(tempRoot, "packs")
+  const installerDir = join(tempRoot, "installer")
+
+  await mkdir(packsDir, { recursive: true })
+  await mkdir(installerDir, { recursive: true })
+
+  // 1. Build create-dawn-ai-app
+  await runPackagedCommand({
+    args: ["--filter", "create-dawn-ai-app", "build"],
+    command: "pnpm",
+    cwd: REPO_ROOT,
+  })
+
+  // 2. Pack create-dawn-ai-app into packsDir
+  const packResult = await runPackagedCommand({
+    args: ["--filter", "create-dawn-ai-app", "pack", "--pack-destination", packsDir],
+    command: "pnpm",
+    cwd: REPO_ROOT,
+  })
+
+  const tarballName = packResult.stdout
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .find((line) => line.endsWith(".tgz"))
+
+  if (!tarballName) {
+    throw new Error(
+      `Could not determine tarball name for create-dawn-ai-app from pnpm pack stdout:\n${packResult.stdout}`,
+    )
+  }
+
+  const tarballPath = join(packsDir, basename(tarballName))
+
+  // 3. Write a minimal package.json in installerDir
+  await writeFile(
+    join(installerDir, "package.json"),
+    `${JSON.stringify({ name: "installer", private: true }, null, 2)}\n`,
+    "utf8",
+  )
+
+  // 4. Install the tarball into installerDir
+  await runPackagedCommand({
+    args: ["add", tarballPath],
+    command: "pnpm",
+    cwd: installerDir,
+  })
+
+  return { installerDir }
 }
 
 export async function runPackagedCommand(options: {

--- a/test/harness/packaged-app.ts
+++ b/test/harness/packaged-app.ts
@@ -159,6 +159,7 @@ export async function runPackagedCommand(options: {
   readonly args: readonly string[]
   readonly command: string
   readonly cwd: string
+  readonly env?: NodeJS.ProcessEnv
   readonly stdin?: string
   readonly transcriptPath?: string
 }) {
@@ -172,6 +173,7 @@ export async function runPackagedCommand(options: {
             // Suppress Node.js experimental-feature warnings (e.g. node:sqlite)
             // so the harness does not treat non-empty stderr as a failure.
             NODE_NO_WARNINGS: "1",
+            ...options.env,
           },
         })
       : await spawnWithStdin(options)

--- a/test/harness/registry-global-setup.test.ts
+++ b/test/harness/registry-global-setup.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, test } from "vitest"
+
+import { getTestRegistryUrl } from "./local-registry.ts"
+
+describe("registry globalSetup", () => {
+  test("exposes a reachable registry URL to test workers", async () => {
+    const url = getTestRegistryUrl()
+    expect(url).toMatch(/^http:\/\/127\.0\.0\.1:\d+\/$/)
+
+    const response = await fetch(new URL("/-/ping", url))
+    expect(response.ok).toBe(true)
+  })
+})

--- a/test/harness/registry-global-setup.ts
+++ b/test/harness/registry-global-setup.ts
@@ -1,0 +1,28 @@
+import {
+  type LocalRegistry,
+  publishWorkspace,
+  REGISTRY_URL_ENV,
+  startLocalRegistry,
+} from "./local-registry.ts"
+
+let registry: LocalRegistry | undefined
+
+// Vitest runs globalSetup once per lane process, before workers fork. Setting the
+// env var here propagates to forked workers (vitest default pool). Workers read it
+// via getTestRegistryUrl().
+export async function setup(): Promise<void> {
+  registry = await startLocalRegistry()
+  try {
+    await publishWorkspace(registry.url)
+  } catch (err) {
+    await registry.stop()
+    registry = undefined
+    throw err
+  }
+  process.env[REGISTRY_URL_ENV] = registry.url
+}
+
+export async function teardown(): Promise<void> {
+  await registry?.stop()
+  delete process.env[REGISTRY_URL_ENV]
+}

--- a/test/harness/scaffold-packaging.test.ts
+++ b/test/harness/scaffold-packaging.test.ts
@@ -1,119 +1,16 @@
-import { mkdtemp, readFile, writeFile } from "node:fs/promises"
+import { mkdtemp, readFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { describe, expect, it } from "vitest"
-import {
-  FAIL_CLOSED_NPMRC,
-  rewriteGeneratedAppDependencies,
-  SCAFFOLD_PACKAGES,
-} from "./scaffold-packaging.js"
 
-async function makePkg(contents: unknown): Promise<string> {
-  const dir = await mkdtemp(join(tmpdir(), "scaffold-pkg-"))
-  await writeFile(join(dir, "package.json"), JSON.stringify(contents), "utf8")
-  return dir
-}
-// biome-ignore lint/suspicious/noExplicitAny: test helper reads arbitrary package.json shape
-async function readPkg(dir: string): Promise<any> {
-  return JSON.parse(await readFile(join(dir, "package.json"), "utf8"))
-}
+import { writeRegistryNpmrc } from "./scaffold-packaging.js"
 
-// Mirrors createPackagedInstaller: a tarball for every SCAFFOLD_PACKAGES entry
-// plus devkit + create-dawn-ai-app. The fail-loud override loop requires the
-// full set, so an incomplete map would (correctly) throw.
-const tarballs = {
-  "@dawn-ai/cli": "/packs/cli.tgz",
-  "@dawn-ai/config-typescript": "/packs/config-ts.tgz",
-  "@dawn-ai/core": "/packs/core.tgz",
-  "@dawn-ai/evals": "/packs/evals.tgz",
-  "@dawn-ai/langchain": "/packs/langchain.tgz",
-  "@dawn-ai/langgraph": "/packs/langgraph.tgz",
-  "@dawn-ai/permissions": "/packs/permissions.tgz",
-  "@dawn-ai/sdk": "/packs/sdk.tgz",
-  "@dawn-ai/sqlite-storage": "/packs/sqlite.tgz",
-  "@dawn-ai/testing": "/packs/testing.tgz",
-  "@dawn-ai/workspace": "/packs/workspace.tgz",
-  "@dawn-ai/devkit": "/packs/devkit.tgz",
-  "create-dawn-ai-app": "/packs/create.tgz",
-}
-
-describe("SCAFFOLD_PACKAGES", () => {
-  it("lists @dawn-ai workspace packages, excluding devkit/create-dawn-ai-app", () => {
-    expect(SCAFFOLD_PACKAGES).toContain("@dawn-ai/cli")
-    expect(SCAFFOLD_PACKAGES).toContain("@dawn-ai/evals")
-    expect(SCAFFOLD_PACKAGES).toContain("@dawn-ai/testing")
-    expect(SCAFFOLD_PACKAGES).not.toContain("@dawn-ai/devkit")
-    expect(SCAFFOLD_PACKAGES).not.toContain("create-dawn-ai-app")
-  })
-})
-
-describe("rewriteGeneratedAppDependencies", () => {
-  it("swaps existing deps/devDeps that are in the tarball map, leaves unknown deps untouched", async () => {
-    const dir = await makePkg({
-      dependencies: { "@dawn-ai/cli": "next", "@dawn-ai/core": "next", zod: "^3.24.0" },
-      devDependencies: { "@dawn-ai/config-typescript": "next", vitest: "4.1.4" },
-    })
-    await rewriteGeneratedAppDependencies({ appRoot: dir, tarballs })
-    const pkg = await readPkg(dir)
-    expect(pkg.dependencies["@dawn-ai/cli"]).toBe("/packs/cli.tgz")
-    expect(pkg.dependencies["@dawn-ai/core"]).toBe("/packs/core.tgz")
-    expect(pkg.dependencies.zod).toBe("^3.24.0")
-    expect(pkg.devDependencies["@dawn-ai/config-typescript"]).toBe("/packs/config-ts.tgz")
-    expect(pkg.devDependencies.vitest).toBe("4.1.4")
-  })
-
-  it("sets pnpm.overrides for every packed SCAFFOLD package (not devkit/create-app)", async () => {
-    const dir = await makePkg({ dependencies: { "@dawn-ai/cli": "next" } })
-    await rewriteGeneratedAppDependencies({ appRoot: dir, tarballs })
-    const pkg = await readPkg(dir)
-    expect(pkg.pnpm.overrides["@dawn-ai/cli"]).toBe("/packs/cli.tgz")
-    expect(pkg.pnpm.overrides["@dawn-ai/permissions"]).toBe("/packs/permissions.tgz")
-    expect(pkg.pnpm.overrides["@dawn-ai/devkit"]).toBeUndefined()
-    expect(pkg.pnpm.overrides["create-dawn-ai-app"]).toBeUndefined()
-  })
-
-  it("applies extraDependencies (forced direct deps + version strings) and removeDependencies", async () => {
-    const dir = await makePkg({
-      dependencies: { "@dawn-ai/cli": "next", langchain: "0.3.0", "@langchain/openai": "0.3.0" },
-    })
-    await rewriteGeneratedAppDependencies({
-      appRoot: dir,
-      tarballs,
-      extraDependencies: {
-        "@dawn-ai/permissions": tarballs["@dawn-ai/permissions"],
-        "@dawn-ai/sqlite-storage": tarballs["@dawn-ai/sqlite-storage"],
-        "@dawn-ai/workspace": tarballs["@dawn-ai/workspace"],
-        "@langchain/langgraph": "1.3.0",
-      },
-      removeDependencies: ["langchain", "@langchain/openai"],
-    })
-    const pkg = await readPkg(dir)
-    expect(pkg.dependencies.langchain).toBeUndefined()
-    expect(pkg.dependencies["@langchain/openai"]).toBeUndefined()
-    expect(pkg.dependencies["@dawn-ai/permissions"]).toBe("/packs/permissions.tgz")
-    expect(pkg.dependencies["@langchain/langgraph"]).toBe("1.3.0")
-  })
-
-  it("writes the fail-closed .npmrc pinning @dawn-ai to an unreachable registry", async () => {
-    const dir = await makePkg({ dependencies: { "@dawn-ai/cli": "next" } })
-    await rewriteGeneratedAppDependencies({ appRoot: dir, tarballs })
+describe("writeRegistryNpmrc", () => {
+  it("writes a registry-pinned .npmrc with an auth token line", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "npmrc-"))
+    await writeRegistryNpmrc(dir, "http://127.0.0.1:4873/")
     const npmrc = await readFile(join(dir, ".npmrc"), "utf8")
-    expect(npmrc).toBe(FAIL_CLOSED_NPMRC)
-    expect(npmrc).toContain("@dawn-ai:registry=http://127.0.0.1:1/")
-  })
-
-  it("throws when a SCAFFOLD package has no packed tarball (silent override skip → loud)", async () => {
-    const { "@dawn-ai/workspace": _omitted, ...incomplete } = tarballs
-    const dir = await makePkg({ dependencies: { "@dawn-ai/cli": "next" } })
-    await expect(
-      rewriteGeneratedAppDependencies({ appRoot: dir, tarballs: incomplete }),
-    ).rejects.toThrow(/@dawn-ai\/workspace/)
-  })
-
-  it("throws when a direct @dawn-ai dependency has no packed tarball", async () => {
-    const dir = await makePkg({ dependencies: { "@dawn-ai/not-packed": "next" } })
-    await expect(rewriteGeneratedAppDependencies({ appRoot: dir, tarballs })).rejects.toThrow(
-      /@dawn-ai\/not-packed/,
-    )
+    expect(npmrc).toContain("registry=http://127.0.0.1:4873/")
+    expect(npmrc).toContain('//127.0.0.1:4873/:_authToken="fake"')
   })
 })

--- a/test/harness/scaffold-packaging.ts
+++ b/test/harness/scaffold-packaging.ts
@@ -2,6 +2,23 @@ import { writeFile } from "node:fs/promises"
 import { join } from "node:path"
 
 /**
+ * Version specifiers for all @dawn-ai packages that the scaffold templates declare.
+ * Every dep resolves from the test registry at the `latest` dist-tag, exactly what
+ * a real `npm install` does against the Verdaccio uplink.
+ */
+export function registryLatestSpecifiers() {
+  return {
+    dawnCli: "latest",
+    dawnConfigTypescript: "latest",
+    dawnCore: "latest",
+    dawnEvals: "latest",
+    dawnLangchain: "latest",
+    dawnSdk: "latest",
+    dawnTesting: "latest",
+  }
+}
+
+/**
  * Point a scaffolded app at the ephemeral test registry. Real users install from
  * a registry; the generated app does exactly that — no overrides, no tarball pins.
  * A genuinely missing @dawn-ai package now 404s from Verdaccio (the registry is

--- a/test/harness/scaffold-packaging.ts
+++ b/test/harness/scaffold-packaging.ts
@@ -1,108 +1,19 @@
-import { readFile, writeFile } from "node:fs/promises"
+import { writeFile } from "node:fs/promises"
 import { join } from "node:path"
 
 /**
- * Canonical set of @dawn-ai/* workspace packages a generated app may depend on.
- * createPackagedInstaller additionally packs @dawn-ai/devkit + create-dawn-ai-app,
- * which are deliberately NOT in this list (they are never generated-app overrides).
+ * Point a scaffolded app at the ephemeral test registry. Real users install from
+ * a registry; the generated app does exactly that — no overrides, no tarball pins.
+ * A genuinely missing @dawn-ai package now 404s from Verdaccio (the registry is
+ * local-only for that scope), preserving fail-closed behavior.
  */
-export const SCAFFOLD_PACKAGES: readonly string[] = [
-  "@dawn-ai/cli",
-  "@dawn-ai/config-typescript",
-  "@dawn-ai/core",
-  "@dawn-ai/evals",
-  "@dawn-ai/langchain",
-  "@dawn-ai/langgraph",
-  "@dawn-ai/permissions",
-  "@dawn-ai/sdk",
-  "@dawn-ai/sqlite-storage",
-  "@dawn-ai/testing",
-  "@dawn-ai/workspace",
-]
-
-/**
- * `.npmrc` written into every externally-packaged generated app. A generated
- * app under test must resolve every `@dawn-ai/*` package from the locally
- * packed tarballs (direct deps + pnpm overrides), NEVER the public registry.
- *
- * Pinning the scope to an unreachable registry enforces that invariant: any
- * edge the local wiring fails to cover (a missing tarball, or a transitive dep
- * pnpm declines to apply an override to) fails loudly with an `@dawn-ai`
- * meta-fetch error on EVERY run, instead of silently fetching whatever happens
- * to be published. That silent registry fallback is exactly what hid the
- * missing `@dawn-ai/workspace` direct dep until it broke a release (see the
- * release-harness postmortem). Non-`@dawn-ai` deps still use the real registry.
- */
-export const FAIL_CLOSED_NPMRC = [
-  "# Test harness: @dawn-ai/* must resolve from local tarballs only. Pinning the",
-  "# scope to an unreachable registry makes any missing local wiring fail loudly",
-  "# instead of silently falling back to the public registry.",
-  "@dawn-ai:registry=http://127.0.0.1:1/",
-  "",
-].join("\n")
-
-export interface RewriteGeneratedAppDepsOptions {
-  readonly appRoot: string
-  readonly tarballs: Readonly<Record<string, string>>
-  /** Forced deps to add (tarball paths for @dawn pkgs, or version strings e.g. @langchain/langgraph). */
-  readonly extraDependencies?: Readonly<Record<string, string>>
-  /** Dep keys to delete from deps+devDeps before rewriting (e.g. langchain, @langchain/openai). */
-  readonly removeDependencies?: readonly string[]
-}
-
-interface MutablePackageJson {
-  dependencies?: Record<string, string>
-  devDependencies?: Record<string, string>
-  pnpm?: { overrides?: Record<string, string> }
-}
-
-export async function rewriteGeneratedAppDependencies(
-  options: RewriteGeneratedAppDepsOptions,
-): Promise<void> {
-  const packageJsonPath = join(options.appRoot, "package.json")
-  const pkg = JSON.parse(await readFile(packageJsonPath, "utf8")) as MutablePackageJson
-
-  for (const key of options.removeDependencies ?? []) {
-    if (pkg.dependencies) delete pkg.dependencies[key]
-    if (pkg.devDependencies) delete pkg.devDependencies[key]
-  }
-
-  // Fail loud, not silent: a `@dawn-ai/*` dependency with no packed tarball is a
-  // harness wiring bug. Leaving it as a registry version spec is what let the
-  // gap reach a release; throw here so it surfaces on the introducing change.
-  const swap = (deps: Record<string, string> | undefined): void => {
-    if (!deps) return
-    for (const name of Object.keys(deps)) {
-      const tarball = options.tarballs[name]
-      if (tarball) {
-        deps[name] = tarball
-      } else if (name.startsWith("@dawn-ai/")) {
-        throw new Error(
-          `No packed tarball provided for @dawn-ai dependency "${name}". Every @dawn-ai/* dependency of a generated app must be pinned to a local tarball (add it to the createPackagedInstaller package set).`,
-        )
-      }
-    }
-  }
-  swap(pkg.dependencies)
-  swap(pkg.devDependencies)
-
-  if (options.extraDependencies) {
-    pkg.dependencies = { ...pkg.dependencies, ...options.extraDependencies }
-  }
-
-  const overrides: Record<string, string> = { ...(pkg.pnpm?.overrides ?? {}) }
-  for (const name of SCAFFOLD_PACKAGES) {
-    const tarball = options.tarballs[name]
-    if (!tarball) {
-      throw new Error(
-        `No packed tarball for scaffold package "${name}". createPackagedInstaller must pack every SCAFFOLD_PACKAGES entry so its override pins to a local tarball.`,
-      )
-    }
-    overrides[name] = tarball
-  }
-  pkg.pnpm = { ...(pkg.pnpm ?? {}), overrides }
-
-  await writeFile(packageJsonPath, `${JSON.stringify(pkg, null, 2)}\n`, "utf8")
-  // Enforce local-only @dawn-ai resolution (see FAIL_CLOSED_NPMRC).
-  await writeFile(join(options.appRoot, ".npmrc"), FAIL_CLOSED_NPMRC, "utf8")
+export async function writeRegistryNpmrc(appRoot: string, registryUrl: string): Promise<void> {
+  const host = registryUrl.replace(/^https?:\/\//, "").replace(/\/$/, "")
+  const npmrc = [
+    `registry=${registryUrl}`,
+    // Parity with a private-registry user; harmless for read-only installs.
+    `//${host}/:_authToken="fake"`,
+    "",
+  ].join("\n")
+  await writeFile(join(appRoot, ".npmrc"), npmrc, "utf8")
 }

--- a/test/runtime/run-agent-protocol.test.ts
+++ b/test/runtime/run-agent-protocol.test.ts
@@ -1,19 +1,16 @@
-import { mkdir, writeFile } from "node:fs/promises"
+import { mkdir, readFile, writeFile } from "node:fs/promises"
 import { dirname, join } from "node:path"
 
 import { afterEach, describe, expect, it } from "vitest"
 import { createGeneratedApp } from "../../packages/devkit/src/testing/index.ts"
+import { getTestRegistryUrl } from "../harness/local-registry.ts"
 import {
   cleanupTrackedTempDirs,
-  createPackagedInstaller,
   createTrackedTempDir,
   markTrackedTempDirForPreserve,
   type TrackedTempDir,
 } from "../harness/packaged-app.ts"
-import {
-  rewriteGeneratedAppDependencies,
-  SCAFFOLD_PACKAGES,
-} from "../harness/scaffold-packaging.js"
+import { writeRegistryNpmrc } from "../harness/scaffold-packaging.js"
 import { allocatePort, appendDevServerTranscript, startDevServer } from "./support/dev-server.ts"
 
 // ---------------------------------------------------------------------------
@@ -81,6 +78,43 @@ async function collectSseEvents(response: Response, stopOn?: string): Promise<Ss
 
 const HARNESS_RUNTIME_ARTIFACT_BASE_DIR_ENV = "DAWN_RUNTIME_ARTIFACT_BASE_DIR"
 const tempDirs: TrackedTempDir[] = []
+
+// Every template @dawn-ai dep resolves from the test registry at its published
+// `latest` tag — exactly what a real `npm install` does.
+function registryLatestSpecifiers() {
+  return {
+    dawnCli: "latest",
+    dawnConfigTypescript: "latest",
+    dawnCore: "latest",
+    dawnEvals: "latest",
+    dawnLangchain: "latest",
+    dawnSdk: "latest",
+    dawnTesting: "latest",
+  }
+}
+
+/**
+ * Add the direct deps the agent-protocol overlays import but the base template
+ * does not declare: the echo route imports @dawn-ai/sqlite-storage and
+ * @langchain/langgraph directly, and the workspace/permissions capabilities need
+ * their packages. @dawn-ai/* resolve from the registry at `latest`; the
+ * @langchain/langgraph pin is load-bearing (the overlay compiles a StateGraph
+ * against this major) so it is preserved verbatim.
+ */
+async function addAgentProtocolDependencies(appRoot: string): Promise<void> {
+  const packageJsonPath = join(appRoot, "package.json")
+  const pkg = JSON.parse(await readFile(packageJsonPath, "utf8")) as {
+    dependencies?: Record<string, string>
+  }
+  pkg.dependencies = {
+    ...pkg.dependencies,
+    "@dawn-ai/permissions": "latest",
+    "@dawn-ai/sqlite-storage": "latest",
+    "@dawn-ai/workspace": "latest",
+    "@langchain/langgraph": "1.3.0",
+  }
+  await writeFile(packageJsonPath, `${JSON.stringify(pkg, null, 2)}\n`, "utf8")
+}
 
 afterEach(async () => {
   await cleanupTrackedTempDirs(tempDirs)
@@ -176,36 +210,16 @@ describe("agent protocol permission interrupt + resume", () => {
     let appRoot: string
 
     try {
-      const { tarballs } = await createPackagedInstaller({
-        packageNames: [...SCAFFOLD_PACKAGES],
-        tempRoot,
-        transcriptPath,
-      })
-
       const generatedApp = await createGeneratedApp({
         appName: "resume-neg",
         artifactRoot: tempRoot,
-        specifiers: {
-          dawnCli: tarballs["@dawn-ai/cli"],
-          dawnConfigTypescript: tarballs["@dawn-ai/config-typescript"],
-          dawnCore: tarballs["@dawn-ai/core"],
-          dawnLangchain: tarballs["@dawn-ai/langchain"],
-        },
+        specifiers: registryLatestSpecifiers(),
         template: "basic",
       })
 
       appRoot = generatedApp.appRoot
-      await rewriteGeneratedAppDependencies({
-        appRoot,
-        tarballs,
-        extraDependencies: {
-          "@dawn-ai/permissions": tarballs["@dawn-ai/permissions"]!,
-          "@dawn-ai/sqlite-storage": tarballs["@dawn-ai/sqlite-storage"]!,
-          "@dawn-ai/workspace": tarballs["@dawn-ai/workspace"]!,
-          "@langchain/langgraph": "1.3.0",
-        },
-        removeDependencies: ["langchain", "@langchain/openai"],
-      })
+      await addAgentProtocolDependencies(appRoot)
+      await writeRegistryNpmrc(appRoot, getTestRegistryUrl())
 
       // Write echo agent route and a workspace directory
       const routeFile = join(appRoot, "src/app/echo/index.ts")
@@ -279,36 +293,16 @@ describe("agent protocol permission interrupt + resume", () => {
     let appRoot: string
 
     try {
-      const { tarballs } = await createPackagedInstaller({
-        packageNames: [...SCAFFOLD_PACKAGES],
-        tempRoot,
-        transcriptPath,
-      })
-
       const generatedApp = await createGeneratedApp({
         appName: "resume-404",
         artifactRoot: tempRoot,
-        specifiers: {
-          dawnCli: tarballs["@dawn-ai/cli"],
-          dawnConfigTypescript: tarballs["@dawn-ai/config-typescript"],
-          dawnCore: tarballs["@dawn-ai/core"],
-          dawnLangchain: tarballs["@dawn-ai/langchain"],
-        },
+        specifiers: registryLatestSpecifiers(),
         template: "basic",
       })
 
       appRoot = generatedApp.appRoot
-      await rewriteGeneratedAppDependencies({
-        appRoot,
-        tarballs,
-        extraDependencies: {
-          "@dawn-ai/permissions": tarballs["@dawn-ai/permissions"]!,
-          "@dawn-ai/sqlite-storage": tarballs["@dawn-ai/sqlite-storage"]!,
-          "@dawn-ai/workspace": tarballs["@dawn-ai/workspace"]!,
-          "@langchain/langgraph": "1.3.0",
-        },
-        removeDependencies: ["langchain", "@langchain/openai"],
-      })
+      await addAgentProtocolDependencies(appRoot)
+      await writeRegistryNpmrc(appRoot, getTestRegistryUrl())
 
       const routeFile = join(appRoot, "src/app/echo/index.ts")
       await mkdir(dirname(routeFile), { recursive: true })
@@ -365,48 +359,17 @@ describe("agent protocol permission interrupt + resume", () => {
       let appRoot: string
 
       try {
-        const { tarballs } = await createPackagedInstaller({
-          packageNames: [
-            "@dawn-ai/cli",
-            "@dawn-ai/config-typescript",
-            "@dawn-ai/core",
-            "@dawn-ai/langchain",
-            "@dawn-ai/langgraph",
-            "@dawn-ai/permissions",
-            "@dawn-ai/sdk",
-            "@dawn-ai/sqlite-storage",
-            "@dawn-ai/testing",
-            "@dawn-ai/workspace",
-          ],
-          tempRoot,
-          transcriptPath,
-        })
-
         const generatedApp = await createGeneratedApp({
           appName: "ap-perm",
           artifactRoot: artifactBaseDir,
-          specifiers: {
-            dawnCli: tarballs["@dawn-ai/cli"],
-            dawnConfigTypescript: tarballs["@dawn-ai/config-typescript"],
-            dawnCore: tarballs["@dawn-ai/core"],
-            dawnLangchain: tarballs["@dawn-ai/langchain"],
-          },
+          specifiers: registryLatestSpecifiers(),
           template: "basic",
         })
 
         appRoot = generatedApp.appRoot
 
-        await rewriteGeneratedAppDependencies({
-          appRoot,
-          tarballs,
-          extraDependencies: {
-            "@dawn-ai/permissions": tarballs["@dawn-ai/permissions"]!,
-            "@dawn-ai/sqlite-storage": tarballs["@dawn-ai/sqlite-storage"]!,
-            "@dawn-ai/workspace": tarballs["@dawn-ai/workspace"]!,
-            "@langchain/langgraph": "1.3.0",
-          },
-          removeDependencies: ["langchain", "@langchain/openai"],
-        })
+        await addAgentProtocolDependencies(appRoot)
+        await writeRegistryNpmrc(appRoot, getTestRegistryUrl())
 
         // Write the perm-agent route overlay at src/app/perm-agent/index.ts
         const routeFile = join(appRoot, "src/app/perm-agent/index.ts")
@@ -643,38 +606,19 @@ describe("agent protocol state persistence", () => {
     let appRoot: string
 
     try {
-      const { tarballs } = await createPackagedInstaller({
-        packageNames: [...SCAFFOLD_PACKAGES],
-        tempRoot,
-        transcriptPath,
-      })
-
       const generatedApp = await createGeneratedApp({
         appName: "ap-persist",
         artifactRoot: artifactBaseDir,
-        specifiers: {
-          dawnCli: tarballs["@dawn-ai/cli"],
-          dawnConfigTypescript: tarballs["@dawn-ai/config-typescript"],
-          dawnCore: tarballs["@dawn-ai/core"],
-          dawnLangchain: tarballs["@dawn-ai/langchain"],
-        },
+        specifiers: registryLatestSpecifiers(),
         template: "basic",
       })
 
       appRoot = generatedApp.appRoot
 
-      // Rewrite dependencies to tarballs (mirrors run-runtime-contract.test.ts)
-      await rewriteGeneratedAppDependencies({
-        appRoot,
-        tarballs,
-        extraDependencies: {
-          "@dawn-ai/permissions": tarballs["@dawn-ai/permissions"]!,
-          "@dawn-ai/sqlite-storage": tarballs["@dawn-ai/sqlite-storage"]!,
-          "@dawn-ai/workspace": tarballs["@dawn-ai/workspace"]!,
-          "@langchain/langgraph": "1.3.0",
-        },
-        removeDependencies: ["langchain", "@langchain/openai"],
-      })
+      // Install @dawn-ai/* + @langchain/langgraph from the registry, mirroring a
+      // real user (see run-runtime-contract.test.ts).
+      await addAgentProtocolDependencies(appRoot)
+      await writeRegistryNpmrc(appRoot, getTestRegistryUrl())
 
       // Write the echo-agent route overlay
       const routeFile = join(appRoot, "src/app/echo/index.ts")

--- a/test/runtime/run-agent-protocol.test.ts
+++ b/test/runtime/run-agent-protocol.test.ts
@@ -10,7 +10,7 @@ import {
   markTrackedTempDirForPreserve,
   type TrackedTempDir,
 } from "../harness/packaged-app.ts"
-import { writeRegistryNpmrc } from "../harness/scaffold-packaging.js"
+import { registryLatestSpecifiers, writeRegistryNpmrc } from "../harness/scaffold-packaging.js"
 import { allocatePort, appendDevServerTranscript, startDevServer } from "./support/dev-server.ts"
 
 // ---------------------------------------------------------------------------
@@ -78,20 +78,6 @@ async function collectSseEvents(response: Response, stopOn?: string): Promise<Ss
 
 const HARNESS_RUNTIME_ARTIFACT_BASE_DIR_ENV = "DAWN_RUNTIME_ARTIFACT_BASE_DIR"
 const tempDirs: TrackedTempDir[] = []
-
-// Every template @dawn-ai dep resolves from the test registry at its published
-// `latest` tag — exactly what a real `npm install` does.
-function registryLatestSpecifiers() {
-  return {
-    dawnCli: "latest",
-    dawnConfigTypescript: "latest",
-    dawnCore: "latest",
-    dawnEvals: "latest",
-    dawnLangchain: "latest",
-    dawnSdk: "latest",
-    dawnTesting: "latest",
-  }
-}
 
 /**
  * Add the direct deps the agent-protocol overlays import but the base template
@@ -596,7 +582,7 @@ describe("agent protocol permission interrupt + resume", () => {
 describe("agent protocol state persistence", () => {
   it("state survives server kill + restart on a new port", { timeout: 300_000 }, async () => {
     // ------------------------------------------------------------------
-    // 1. Build a packed app with the echo-agent overlay
+    // 1. Scaffold the echo-agent app from the test registry
     // ------------------------------------------------------------------
     const tempRoot = await createTrackedTempDir("dap-", tempDirs)
     const artifactBaseDir = process.env[HARNESS_RUNTIME_ARTIFACT_BASE_DIR_ENV] ?? tempRoot

--- a/test/runtime/run-runtime-contract.test.ts
+++ b/test/runtime/run-runtime-contract.test.ts
@@ -18,17 +18,14 @@ import {
   type HarnessPhaseResult,
   spawnProcess,
 } from "../../packages/devkit/src/testing/index.ts"
+import { getTestRegistryUrl } from "../harness/local-registry.ts"
 import {
   cleanupTrackedTempDirs,
-  createPackagedInstaller,
   createTrackedTempDir,
   markTrackedTempDirForPreserve,
   type TrackedTempDir,
 } from "../harness/packaged-app.ts"
-import {
-  rewriteGeneratedAppDependencies,
-  SCAFFOLD_PACKAGES,
-} from "../harness/scaffold-packaging.js"
+import { writeRegistryNpmrc } from "../harness/scaffold-packaging.js"
 import {
   appendDevServerTranscript,
   invokeRunsWait,
@@ -40,6 +37,20 @@ import {
 const RUNTIME_ROOT = resolve(import.meta.dirname)
 const HARNESS_RUNTIME_ARTIFACT_BASE_DIR_ENV = "DAWN_RUNTIME_ARTIFACT_BASE_DIR"
 const tempDirs: TrackedTempDir[] = []
+
+// Every template @dawn-ai dep resolves from the test registry at its published
+// `latest` tag — exactly what a real `npm install` does.
+function registryLatestSpecifiers() {
+  return {
+    dawnCli: "latest",
+    dawnConfigTypescript: "latest",
+    dawnCore: "latest",
+    dawnEvals: "latest",
+    dawnLangchain: "latest",
+    dawnSdk: "latest",
+    dawnTesting: "latest",
+  }
+}
 
 type RuntimeFixtureName =
   | "agent-basic"
@@ -82,7 +93,6 @@ describe("runtime contract harness", () => {
       status: "passed",
     })
     expect(result.phases.map((phase) => phase.name)).toEqual([
-      "packaged-installer",
       "install",
       "execute-direct",
       "execute-cli",
@@ -103,7 +113,6 @@ describe("runtime contract harness", () => {
       status: "passed",
     })
     expect(result.phases.map((phase) => phase.name)).toEqual([
-      "packaged-installer",
       "install",
       "execute-direct",
       "execute-cli",
@@ -124,7 +133,6 @@ describe("runtime contract harness", () => {
       status: "passed",
     })
     expect(result.phases.map((phase) => phase.name)).toEqual([
-      "packaged-installer",
       "install",
       "execute-direct",
       "execute-cli",
@@ -145,7 +153,6 @@ describe("runtime contract harness", () => {
       status: "passed",
     })
     expect(result.phases.map((phase) => phase.name)).toEqual([
-      "packaged-installer",
       "install",
       "execute-direct",
       "execute-cli",
@@ -166,7 +173,6 @@ describe("runtime contract harness", () => {
       status: "passed",
     })
     expect(result.phases.map((phase) => phase.name)).toEqual([
-      "packaged-installer",
       "install",
       "execute-direct",
       "execute-cli",
@@ -187,7 +193,6 @@ describe("runtime contract harness", () => {
       status: "passed",
     })
     expect(result.phases.map((phase) => phase.name)).toEqual([
-      "packaged-installer",
       "install",
       "execute-direct",
       "execute-cli",
@@ -484,35 +489,14 @@ async function withRuntimeScenario(
 
   try {
     const overlay = await readOverlay(fixtureName)
-    const { tarballs } = await recordPhase(phases, "packaged-installer", async () => {
-      return await createPackagedInstaller({
-        packageNames: [...SCAFFOLD_PACKAGES],
-        tempRoot,
-        transcriptPath,
-      })
-    })
     const generatedApp = await createGeneratedApp({
       appName: fixtureName,
       artifactRoot,
-      specifiers: {
-        dawnCli: tarballs["@dawn-ai/cli"],
-        dawnConfigTypescript: tarballs["@dawn-ai/config-typescript"],
-        dawnCore: tarballs["@dawn-ai/core"],
-        dawnLangchain: tarballs["@dawn-ai/langchain"],
-      },
+      specifiers: registryLatestSpecifiers(),
       template: "basic",
     })
 
-    await rewriteGeneratedAppDependencies({
-      appRoot: generatedApp.appRoot,
-      tarballs,
-      extraDependencies: {
-        "@dawn-ai/permissions": tarballs["@dawn-ai/permissions"]!,
-        "@dawn-ai/sqlite-storage": tarballs["@dawn-ai/sqlite-storage"]!,
-        "@dawn-ai/workspace": tarballs["@dawn-ai/workspace"]!,
-      },
-      removeDependencies: ["langchain", "@langchain/openai"],
-    })
+    await writeRegistryNpmrc(generatedApp.appRoot, getTestRegistryUrl())
     await applyOverlay({ appRoot: generatedApp.appRoot, overlay })
 
     await recordPhase(phases, "install", async () => {

--- a/test/runtime/run-runtime-contract.test.ts
+++ b/test/runtime/run-runtime-contract.test.ts
@@ -25,7 +25,7 @@ import {
   markTrackedTempDirForPreserve,
   type TrackedTempDir,
 } from "../harness/packaged-app.ts"
-import { writeRegistryNpmrc } from "../harness/scaffold-packaging.js"
+import { registryLatestSpecifiers, writeRegistryNpmrc } from "../harness/scaffold-packaging.js"
 import {
   appendDevServerTranscript,
   invokeRunsWait,
@@ -37,20 +37,6 @@ import {
 const RUNTIME_ROOT = resolve(import.meta.dirname)
 const HARNESS_RUNTIME_ARTIFACT_BASE_DIR_ENV = "DAWN_RUNTIME_ARTIFACT_BASE_DIR"
 const tempDirs: TrackedTempDir[] = []
-
-// Every template @dawn-ai dep resolves from the test registry at its published
-// `latest` tag — exactly what a real `npm install` does.
-function registryLatestSpecifiers() {
-  return {
-    dawnCli: "latest",
-    dawnConfigTypescript: "latest",
-    dawnCore: "latest",
-    dawnEvals: "latest",
-    dawnLangchain: "latest",
-    dawnSdk: "latest",
-    dawnTesting: "latest",
-  }
-}
 
 type RuntimeFixtureName =
   | "agent-basic"

--- a/test/runtime/vitest.config.ts
+++ b/test/runtime/vitest.config.ts
@@ -25,7 +25,8 @@ export default defineConfig({
     // runner causes server-boot timeouts and port/disk contention. Serialize
     // them — integration parity is the goal here, not raw speed.
     fileParallelism: false,
-    hookTimeout: 60_000,
+    globalSetup: ["test/harness/registry-global-setup.ts"],
+    hookTimeout: 180_000,
     include: [
       "test/runtime/run-runtime-contract.test.ts",
       "test/runtime/run-agent-protocol.test.ts",

--- a/test/smoke/run-smoke.test.ts
+++ b/test/smoke/run-smoke.test.ts
@@ -17,24 +17,10 @@ import {
   markTrackedTempDirForPreserve,
   type TrackedTempDir,
 } from "../harness/packaged-app.ts"
-import { writeRegistryNpmrc } from "../harness/scaffold-packaging.js"
+import { registryLatestSpecifiers, writeRegistryNpmrc } from "../harness/scaffold-packaging.js"
 
 const SMOKE_ROOT = resolve(import.meta.dirname)
 const tempDirs: TrackedTempDir[] = []
-
-// Every template @dawn-ai dep resolves from the test registry at its published
-// `latest` tag — exactly what a real `npm install` does.
-function registryLatestSpecifiers() {
-  return {
-    dawnCli: "latest",
-    dawnConfigTypescript: "latest",
-    dawnCore: "latest",
-    dawnEvals: "latest",
-    dawnLangchain: "latest",
-    dawnSdk: "latest",
-    dawnTesting: "latest",
-  }
-}
 
 type SmokeRouteKind = "agent" | "chain" | "graph" | "workflow"
 type SmokeFixtureName = "agent-basic" | "graph-basic" | "workflow-basic"

--- a/test/smoke/run-smoke.test.ts
+++ b/test/smoke/run-smoke.test.ts
@@ -10,20 +10,31 @@ import {
   type HarnessPhaseResult,
   spawnProcess,
 } from "../../packages/devkit/src/testing/index.ts"
+import { getTestRegistryUrl } from "../harness/local-registry.ts"
 import {
   cleanupTrackedTempDirs,
-  createPackagedInstaller,
   createTrackedTempDir,
   markTrackedTempDirForPreserve,
   type TrackedTempDir,
 } from "../harness/packaged-app.ts"
-import {
-  rewriteGeneratedAppDependencies,
-  SCAFFOLD_PACKAGES,
-} from "../harness/scaffold-packaging.js"
+import { writeRegistryNpmrc } from "../harness/scaffold-packaging.js"
 
 const SMOKE_ROOT = resolve(import.meta.dirname)
 const tempDirs: TrackedTempDir[] = []
+
+// Every template @dawn-ai dep resolves from the test registry at its published
+// `latest` tag — exactly what a real `npm install` does.
+function registryLatestSpecifiers() {
+  return {
+    dawnCli: "latest",
+    dawnConfigTypescript: "latest",
+    dawnCore: "latest",
+    dawnEvals: "latest",
+    dawnLangchain: "latest",
+    dawnSdk: "latest",
+    dawnTesting: "latest",
+  }
+}
 
 type SmokeRouteKind = "agent" | "chain" | "graph" | "workflow"
 type SmokeFixtureName = "agent-basic" | "graph-basic" | "workflow-basic"
@@ -67,7 +78,6 @@ describe("runtime smoke harness", () => {
       status: "passed",
     })
     expect(result.phases.map((phase) => phase.name)).toEqual([
-      "packaged-installer",
       "install",
       "discover-routes",
       "typegen",
@@ -95,7 +105,6 @@ describe("runtime smoke harness", () => {
       status: "passed",
     })
     expect(result.phases.map((phase) => phase.name)).toEqual([
-      "packaged-installer",
       "install",
       "discover-routes",
       "typegen",
@@ -123,7 +132,6 @@ describe("runtime smoke harness", () => {
       status: "passed",
     })
     expect(result.phases.map((phase) => phase.name)).toEqual([
-      "packaged-installer",
       "install",
       "discover-routes",
       "typegen",
@@ -155,35 +163,14 @@ async function runSmokeScenario(fixtureName: SmokeFixtureName): Promise<HarnessL
 
   try {
     const overlay = await readOverlay(fixtureName)
-    const { tarballs } = await recordPhase(phases, "packaged-installer", async () => {
-      return await createPackagedInstaller({
-        packageNames: [...SCAFFOLD_PACKAGES],
-        tempRoot,
-        transcriptPath,
-      })
-    })
     const generatedApp = await createGeneratedApp({
       appName: fixtureName,
       artifactRoot,
-      specifiers: {
-        dawnCli: tarballs["@dawn-ai/cli"],
-        dawnConfigTypescript: tarballs["@dawn-ai/config-typescript"],
-        dawnCore: tarballs["@dawn-ai/core"],
-        dawnLangchain: tarballs["@dawn-ai/langchain"],
-      },
+      specifiers: registryLatestSpecifiers(),
       template: "basic",
     })
 
-    await rewriteGeneratedAppDependencies({
-      appRoot: generatedApp.appRoot,
-      tarballs,
-      extraDependencies: {
-        "@dawn-ai/permissions": tarballs["@dawn-ai/permissions"]!,
-        "@dawn-ai/sqlite-storage": tarballs["@dawn-ai/sqlite-storage"]!,
-        "@dawn-ai/workspace": tarballs["@dawn-ai/workspace"]!,
-      },
-      removeDependencies: ["langchain", "@langchain/openai"],
-    })
+    await writeRegistryNpmrc(generatedApp.appRoot, getTestRegistryUrl())
     await applyOverlay({ appRoot: generatedApp.appRoot, overlay })
 
     await recordPhase(phases, "install", async () => {

--- a/test/smoke/vitest.config.ts
+++ b/test/smoke/vitest.config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from "vitest/config"
 export default defineConfig({
   test: {
     environment: "node",
+    globalSetup: ["test/harness/registry-global-setup.ts"],
     include: ["test/smoke/**/*.test.ts"],
   },
 })


### PR DESCRIPTION
## Why

The generated-app verify lanes faked "what an npm user installs" via `pnpm pack` → `pnpm.overrides` → a fail-closed `.npmrc`. That approximation diverged from real pnpm resolution in exactly the ways that broke the 0.8.2 release ([#237](https://github.com/cacheplane/dawnai/pull/237)/[#241](https://github.com/cacheplane/dawnai/pull/241)): an override applied inconsistently across the graph and a transitive `@dawn-ai` edge silently fell back to the public registry. This replaces the approximation with the real thing.

## What

A per-lane **ephemeral Verdaccio** registry (programmatic, `listen(0)`, temp storage), started in a vitest `globalSetup`. `@dawn-ai/*` + `create-dawn-ai-app` are served **local-only** (no proxy); everything else proxies to npmjs via an uplink. The whole workspace is published to it (one canonical version, asserted), then scaffolded apps are created with the default `latest` dist-tag, given a real registry-pinned `.npmrc`, and `pnpm install` **exactly like a real user — no overrides, no rewrite, no fail-closed hack**. A missing `@dawn-ai` package now 404s from Verdaccio (local-only scope), preserving fail-closed.

The old mechanism is **deleted**: `createPackagedInstaller`/`packPackage`, `rewriteGeneratedAppDependencies`, the central `SCAFFOLD_PACKAGES`, `FAIL_CLOSED_NPMRC`, and the `extraDependencies` transitive-dep promotions. Net **−228 lines** in `test/` while the model gets *more* faithful. Internal/contributor mode (file:-linked) is untouched.

Spec: `docs/superpowers/specs/2026-06-18-verdaccio-publish-harness-design.md` · Plan: `docs/superpowers/plans/2026-06-18-verdaccio-publish-harness.md`

## Notable

- **Publish targets the local registry authoritatively.** `npm publish` resolves the publish registry by *scope*, not the top-level `registry`; a scoped pkg falls back to the public registry and an inherited default `scope` in `~/.npmrc` routes everything to npmjs. `publishWorkspace` sets per-scope `@<scope>:registry`, `--scope=`, the host auth token, and `replace-registry-host=never` in the env so publishes always hit Verdaccio regardless of host/CI npm config.
- **Shared pnpm store stays correct + fast**: the random per-run registry URL busts pnpm's metadata cache and the store is content-addressed by integrity, so `@dawn-ai` is always fetched fresh without isolating the store.

## Verification

`pnpm verify:harness` → **`status: passed`, 3/3 lanes** (framework, runtime, smoke), no npmjs in transcripts. `pnpm lint` 16/16, `pnpm typecheck` 17/17. New `local-registry` integration test (publish→install round-trip) + negative 404 test. Test-infra only — all changes under `test/` + a root devDep; no changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)