### PR TITLE
fix(harness): disable npm provenance for local-registry publish

### DIFF
--- a/test/harness/local-registry.ts
+++ b/test/harness/local-registry.ts
@@ -91,6 +91,13 @@ export async function publishWorkspace(url: string): Promise<void> {
     npm_config_registry: url,
     [`npm_config_//${host}/:_authToken`]: "fake",
     npm_config_replace_registry_host: "never",
+    // The release workflow exports NPM_CONFIG_PROVENANCE=true (uppercase) at the
+    // job level for trusted publishing to npmjs. Inherited by this `npm publish`
+    // it fails with EUSAGE "provenance generation not supported" — Sigstore
+    // provenance can't be produced for a throwaway local registry. Override the
+    // exact (uppercase) key so it always wins over the job env; harmless on a dev
+    // machine where it is unset.
+    NPM_CONFIG_PROVENANCE: "false",
   }
 
   // Pack each public package into a temp dir, then publish the tarball directly


### PR DESCRIPTION
## Problem

After [#247](https://github.com/cacheplane/dawnai/pull/247) merged, the **Release** workflow's `Validate Release Candidate` step (`pnpm ci:validate` → `verify:harness`) fails — all three lanes error in ~3s. The PR `validate` job passed on identical content because it does **not** set the trusted-publishing env the Release job does.

Root cause (confirmed locally): the Release job exports `NPM_CONFIG_PROVENANCE=true` job-wide. The Verdaccio harness's `npm publish <tarball>` to the local registry inherits it and fails:
```
npm error code EUSAGE
npm error Automatic provenance generation not supported for provider: null
```
Sigstore provenance can't be generated for a throwaway local registry.

No publish risk occurred — this is the validate *gate*, and `Create Release Pull Request or Publish` was skipped; npm is untouched at 0.8.2. But the gate would block the next real release.

## Fix

Override `NPM_CONFIG_PROVENANCE=false` in `publishWorkspace`'s publish env (the exact uppercase key the job sets, so it wins over the inherited value; harmless on dev where it's unset).

## Verification

Reproduced the failure with `NPM_CONFIG_PROVENANCE=true pnpm exec vitest run … local-registry.test.ts` (EUSAGE), then confirmed the fix makes it pass 2/2 under the same env. Test-infra only; no changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)