### PR TITLE
fix(ci): raise Claude review turn/time budget so it completes

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -15,7 +15,7 @@ permissions:
 jobs:
   review:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 25
     permissions:
       contents: read
       pull-requests: write
@@ -52,5 +52,5 @@ jobs:
             they affect correctness. If the PR looks good, say so briefly.
           claude_args: |
             --model claude-sonnet-4-6
-            --max-turns 15
+            --max-turns 40
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"


### PR DESCRIPTION
## Problem

The advisory **Claude Review** action (#242) errored on every non-trivial PR — e.g. on [#247](https://github.com/cacheplane/dawnai/pull/247) it posted *"Claude encountered an error"* and **no findings**. The job log shows the cause:

```
"subtype": "error_max_turns"
##[error]Execution failed: Reached maximum number of turns (15)
```

It's **not** a token/auth issue (the `github_token` OIDC-skip fix already landed). The bot spends its 15 turns reading `gh pr view` + `gh pr diff` and reasoning, then runs out before it can post the summary + inline comments — so the review silently never completes on real PRs.

## Fix

- `--max-turns 15 → 40` — headroom to read the diff, reason, and post a summary + several inline comments.
- `timeout-minutes 15 → 25` — so the longer run isn't wall-clock-capped.

Still advisory (`pull_request`, never a required check); never blocks merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)