### PR TITLE
docs: rewrite memory page for shipped feature + accuracy audit fixes

### DIFF
--- a/apps/web/content/docs/api.mdx
+++ b/apps/web/content/docs/api.mdx
@@ -211,6 +211,72 @@ See [Middleware](/docs/middleware).
 
 ---
 
+### Memory
+
+Functions and types for declaring a route's typed long-term memory. See [Memory](/docs/memory).
+
+### `defineMemory(def)`
+
+```ts
+export function defineMemory<S extends z.ZodTypeAny>(def: {
+  kind: "semantic" | "episodic" | "procedural" | "reflection"
+  scope: readonly MemoryScopeDimension[]
+  schema: S
+  identity?: readonly string[]
+}): DefinedMemory<S>
+```
+
+Declares a route's typed long-term memory. Place the call as the default export of a `memory.ts` file next to the route's `index.ts` — that file's presence is what activates the `recall`/`remember` tools. `kind` selects the memory category. `scope` lists the namespace dimensions the memory is partitioned by. `schema` is a [zod](https://zod.dev) schema validating each stored record. `identity` names the fields used for write reconciliation; it defaults to `["subject", "predicate"]`.
+
+```ts
+import { defineMemory } from "@dawn-ai/sdk"
+import { z } from "zod"
+
+export default defineMemory({
+  kind: "semantic",
+  scope: ["workspace", "user"],
+  schema: z.object({
+    subject: z.string(),
+    predicate: z.string(),
+    object: z.string(),
+  }),
+})
+```
+
+See [Memory](/docs/memory) and the [`memory`](/docs/configuration#memory) config key.
+
+### `DefinedMemory`
+
+```ts
+export interface DefinedMemory<S extends z.ZodTypeAny = z.ZodTypeAny> {
+  readonly kind: "semantic" | "episodic" | "procedural" | "reflection"
+  readonly scope: readonly MemoryScopeDimension[]
+  readonly schema: S
+  readonly identity?: readonly string[]
+}
+```
+
+The descriptor returned by `defineMemory()`. Carry it as a route's `memory.ts` default export; do not construct it manually.
+
+See [Memory](/docs/memory).
+
+### `MemoryScopeDimension`
+
+```ts
+export type MemoryScopeDimension =
+  | "workspace"
+  | "route"
+  | "tenant"
+  | "user"
+  | "agent"
+```
+
+The namespace dimensions a memory can be partitioned by, used in `DefinedMemory.scope`. `workspace` and `route` are derived automatically; `tenant`, `user`, and `agent` come from the config-level `memory.resolveScope` callback.
+
+See [Memory](/docs/memory).
+
+---
+
 ### Route configuration
 
 Types that shape route-level behaviour. See [Routes](/docs/routes).
@@ -306,6 +372,35 @@ A map of tool name to `RuntimeTool`. Used as the constraint on `RuntimeContext`'
 
 See [Tools](/docs/tools).
 
+### `DawnToolContext`
+
+```ts
+export interface DawnToolContext {
+  readonly signal: AbortSignal
+  readonly middleware?: Readonly<Record<string, unknown>>
+  readonly fs: WorkspaceFs
+}
+```
+
+The context argument Dawn passes to a route tool's function. `signal` is aborted when the client disconnects. `middleware` carries any context injected by `allow(...)` for the current request. `fs` is a sandboxed [`WorkspaceFs`](#workspacefs) handle scoped to the route's `workspace/` directory.
+
+See [Tools](/docs/tools) and [Workspace Filesystem](/docs/workspace).
+
+### `WorkspaceFs`
+
+```ts
+export interface WorkspaceFs {
+  readFile(path: string, opts?: { readonly maxBytes?: number }): Promise<string>
+  readBinaryFile(path: string, opts?: { readonly maxBytes?: number }): Promise<Uint8Array>
+  writeFile(path: string, content: string): Promise<{ readonly bytesWritten: number }>
+  listDir(path?: string): Promise<readonly string[]>
+}
+```
+
+A sandboxed filesystem handle scoped to the route's `workspace/` directory, available as `ctx.fs` on `DawnToolContext`. Relative paths resolve against the workspace root; paths inside `workspace/` are always allowed, while paths outside consult the permissions store. `readBinaryFile` throws when the configured filesystem backend does not implement binary reads.
+
+See [Workspace Filesystem](/docs/workspace).
+
 ---
 
 ### Models
@@ -380,6 +475,62 @@ export type XaiModelId = "grok-4.3"
 ```
 
 String literals for supported xAI models. The built-in `agent()` route infers the xAI provider for `grok-*` model IDs.
+
+### `inferProvider(model)`
+
+```ts
+export function inferProvider(model: string): BuiltInModelProviderId | undefined
+```
+
+Infers a built-in provider id from a model string for the known families, returning `undefined` when none match. Matches OpenAI (`gpt-*`, `o3*`, `o4*`), Anthropic (`claude-*`), Google (`gemini-*`), Mistral (`mistral-*`, `mixtral-*`, `codestral-*`), and xAI (`grok-*`). This is the same inference the built-in `agent()` path uses when `AgentConfig.provider` is omitted.
+
+### `SUPPORTED_AGENT_PROVIDERS`
+
+```ts
+export const SUPPORTED_AGENT_PROVIDERS: readonly BuiltInModelProviderId[]
+// ["openai", "anthropic", "google", "mistral", "groq", "ollama", "xai", "openrouter"]
+```
+
+The runtime array of built-in provider ids the `agent()` path can materialize. The corresponding type is `BuiltInModelProviderId`.
+
+### `validateModelId(opts)`
+
+```ts
+export function validateModelId(opts: {
+  readonly model: string
+  readonly provider?: string
+}): ModelIdValidation
+```
+
+Advisory check of a model id against the curated per-provider lists ([`CURATED_MODEL_IDS`](#curated_model_ids)). When `provider` is omitted it is inferred via `inferProvider`. Returns `{ ok: true }` for curated ids — and silently for uncurated or unresolvable providers — so consumers warn rather than hard-fail. On a miss it returns the resolved `provider` plus up to three nearest curated id `suggestions`.
+
+### `ModelIdValidation`
+
+```ts
+export type ModelIdValidation =
+  | { readonly ok: true }
+  | {
+      readonly ok: false
+      readonly provider: string
+      readonly suggestions: readonly string[]
+    }
+```
+
+The result of `validateModelId`. The `ok: false` branch carries the resolved `provider` and the nearest curated id `suggestions` (closest first, max 3).
+
+### Model id constants
+
+```ts
+export const CURATED_MODEL_IDS: Readonly<
+  Partial<Record<BuiltInModelProviderId, readonly string[]>>
+>
+export const OPENAI_MODEL_IDS: readonly string[]
+export const GOOGLE_MODEL_IDS: readonly string[]
+export const ANTHROPIC_MODEL_IDS: readonly string[]
+export const XAI_MODEL_IDS: readonly string[]
+```
+
+The runtime arrays backing the model-id literal types. Each per-provider constant (`OPENAI_MODEL_IDS`, `GOOGLE_MODEL_IDS`, `ANTHROPIC_MODEL_IDS`, `XAI_MODEL_IDS`) holds the same ids as its corresponding `*ModelId` type. `CURATED_MODEL_IDS` maps each curated provider id to its list and is consumed by `validateModelId`.
 
 ---
 

--- a/apps/web/content/docs/cli.mdx
+++ b/apps/web/content/docs/cli.mdx
@@ -1,6 +1,6 @@
 # CLI Reference
 
-Dawn ships a single `dawn` binary with nine commands: `build`, `check`, `dev`, `eval`, `routes`, `run`, `test`, `typegen`, and `verify`. Most commands read `dawn.config.ts` from the current working directory or from `--cwd <path>`; `dawn dev` currently uses the current working directory and exposes only its own server flags.
+Dawn ships a single `dawn` binary with ten commands: `build`, `check`, `dev`, `eval`, `memory`, `routes`, `run`, `test`, `typegen`, and `verify`. Most commands read `dawn.config.ts` from the current working directory or from `--cwd <path>`; `dawn dev` currently uses the current working directory and exposes only its own server flags.
 
 ## Running the CLI
 

--- a/apps/web/content/docs/configuration.mdx
+++ b/apps/web/content/docs/configuration.mdx
@@ -53,6 +53,16 @@ export default {
     // model: "gpt-5-mini",  // defaults to the route's own model
   },
 
+  // Long-term memory governance. A route opts in by adding a memory.ts; the
+  // keys below tune how those typed memories are stored, recalled, and written.
+  // Defaults apply to every route with a memory.ts even when this key is absent.
+  memory: {
+    writes: "candidate",   // default — writes land for review, hidden from recall
+    indexMaxEntries: 20,   // default — cap on memories injected into the prompt index
+    // store: myMemoryStore,  // default: SQLite at .dawn/memory.sqlite
+    // resolveScope: ({ routePath, appRoot }) => ({ tenant: "acme" }),
+  },
+
   // SQLite persistence is on by default — no config needed.
   // Threads survive a restart. Override only if you need a custom backend.
   // checkpointer: myCheckpointer,
@@ -186,6 +196,30 @@ Configures conversation summarization. When enabled, Dawn compresses older messa
 | `model` | `string` | Route's model | Model used for the summary LLM call. Defaults to the same model the route uses. |
 | `tokenCounter` | `(text: string) => number \| Promise<number>` | Lazy `gpt-tokenizer` (o200k_base) | Custom token counting function. |
 | `summarize` | `(args) => Promise<string>` | Built-in single-LLM-call summarizer | Custom summary generator. Receives `messages`, `model`, `previousSummary`, and `signal`. |
+
+---
+
+### `memory`
+
+Configures long-term memory governance. A route opts into memory by adding a `memory.ts` next to its `index.ts` (see [`defineMemory`](/docs/api#definememory) in the [Memory](/docs/memory) reference) — that file's presence is what activates the `recall`/`remember` tools and the memory-index prompt fragment. The keys below tune how those typed memories are stored, recalled, and written. They apply to every memory-enabled route even when the `memory` config key is omitted.
+
+```ts
+memory?: {
+  store?: MemoryStore
+  writes?: "off" | "candidate" | "auto"
+  indexMaxEntries?: number
+  resolveScope?: (ctx: { routePath: string; appRoot: string }) => Record<string, string>
+}
+```
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `store` | `MemoryStore` | SQLite at `.dawn/memory.sqlite` | The memory store backend. Defaults to an SQLite-backed store at `<appRoot>/.dawn/memory.sqlite`. Override to plug in a custom backend. |
+| `writes` | `"off" \| "candidate" \| "auto"` | `"candidate"` | Write governance for the `remember` tool. `off` — recall-only; the `remember` tool is not exposed. `candidate` — writes land as candidates for review, hidden from `recall` until promoted with `dawn memory approve`. `auto` — writes are active immediately, with inline identity reconciliation (idempotent updates and supersede-on-conflict). |
+| `indexMaxEntries` | `number` | `20` | Cap on how many in-scope memories are injected into the prompt memory index. |
+| `resolveScope` | `(ctx: { routePath; appRoot }) => Record<string, string>` | — | Supplies runtime namespace dimensions (e.g. `tenant`, `user`, `agent`) for the memory namespace. Only the dimensions a route declares in its `memory.ts` scope are applied. |
+
+See [Memory](/docs/memory) for the full long-term-memory model and the [`dawn memory`](/docs/cli#dawn-memory) CLI for reviewing candidate writes.
 
 ---
 

--- a/apps/web/content/docs/evals.mdx
+++ b/apps/web/content/docs/evals.mdx
@@ -4,7 +4,7 @@ Scenario tests and `@dawn-ai/testing` pin down behaviour: given this input and t
 
 Use evals when you want a quality bar that survives prompt edits, model swaps, and refactors: a number that goes up or down across a dataset, with an optional threshold that fails CI when quality regresses.
 
-Evals are deterministic and CI-safe by default. Like `@dawn-ai/testing`, each case replays pre-written **aimock** fixtures — your tools, prompts, capabilities, and state run normally; only the LLM is replaced. A separate `dawn eval --live` mode runs the real model locally when you want to measure against actual model output.
+Evals are deterministic and CI-safe by default. Like `@dawn-ai/testing`, each case replays pre-written **aimock** fixtures, so only the LLM is replaced while your tools, prompts, capabilities, and state run normally. A separate `dawn eval --live` mode runs the real model locally when you want to measure against actual model output.
 
 ## Install
 
@@ -134,7 +134,9 @@ If you set neither `gate` nor `threshold`, the eval is **informational**: it alw
 
 ## Execution: replay vs live
 
-By default `dawn eval` runs in **replay** mode: each case replays its `fixtures` through aimock, so no real model is called. Fixtures come from a `script()` builder inline on the case, or from committed fixture files — the same deterministic, CI-safe path `@dawn-ai/testing` uses. This is the only mode that should run in CI.
+Evals use the same aimock fixture system as agent tests — see [Testing Agents](/docs/testing-agents) for how fixtures, `script()`, and replay-vs-live mode work, and why live runs must never touch CI.
+
+By default `dawn eval` runs in **replay** mode: each case replays its `fixtures` (a `script()` builder inline on the case, or a committed fixture file) through aimock, so no real model is called. This is the only mode that should run in CI.
 
 ```bash
 dawn eval

--- a/apps/web/content/docs/memory.mdx
+++ b/apps/web/content/docs/memory.mdx
@@ -1,21 +1,18 @@
 # Memory
 
-Memory lets every Dawn agent route read the same workspace-level facts without adding a database or a custom prompt loader.
+Dawn has three coexisting memory mechanisms; pick by scope and shape. Two are flat profile text a human edits (`workspace/AGENTS.md` and a route-local `memory.md`); the third is a typed, discrete collection the *agent* writes to and recalls across sessions (`memory.ts`). All three are opt-in by presence — no registration call in your route — and all three compose into the same system prompt.
 
-It is intentionally simple: if `workspace/AGENTS.md` exists and has content, Dawn injects that content into the agent system prompt on every model turn.
+| | `workspace/AGENTS.md` (L1) | `memory.md` (L2) | `memory.ts` (L3) |
+|---|---|---|---|
+| **Scope** | Whole app (every route) | One route | Namespaced per declared scope |
+| **Format** | Free-form Markdown | Free-form Markdown | Typed records (Zod schema) |
+| **Who writes** | The agent (via `writeFile`) or you | You (human) | The agent (via `remember`) |
+| **Persistence** | A file, re-read every turn | A file, re-read every turn | SQLite store, queried per turn |
+| **When to use** | Stable facts shared across all routes | Stable facts for one route | Discrete facts the agent accumulates over time |
 
-Use memory for stable, project-level context that should follow all agent routes: repository conventions, product facts, user preferences, account assumptions for a local workspace, or anything else that should be visible before the model chooses tools.
+## Workspace profile (`AGENTS.md`)
 
-## Quick start
-
-Create a workspace memory file:
-
-```text
-workspace/
-  AGENTS.md
-```
-
-Add concise instructions:
+If `workspace/AGENTS.md` exists and has content, Dawn injects it into the agent system prompt on every model turn under a `# Memory` heading. Use it for stable, app-level context that should follow *all* routes: repository conventions, product facts, account assumptions for a local workspace.
 
 ```md title="workspace/AGENTS.md"
 # Workspace Memory
@@ -25,65 +22,22 @@ Add concise instructions:
 - Escalate billing exceptions to the finance queue.
 ```
 
-Run any `agent()` route. Dawn adds a `# Memory` prompt fragment after the route's `systemPrompt` and before the current conversation messages.
+You do not import anything to enable this — the presence of the file is the opt-in. Behavior:
 
-You do not import anything in the route to enable this. The presence of the file is the opt-in.
+- The path is `workspace/AGENTS.md` under the app root (`context.appRoot`), which equals the project directory under `dawn dev`.
+- The capability is `createAgentsMdMarker()`; it always participates for agent routes but renders an empty fragment unless the file exists and has content.
+- The file is re-read when the fragment renders, so a later turn sees an edited file without rebuilding the route.
+- Empty files and unreadable files are skipped. Files larger than **64 KiB** are not loaded; the prompt notes the file exceeded the limit.
 
-## What Dawn injects
+Because `AGENTS.md` is workspace-level, it is shared by every agent route in the same running app — it is not route-local.
 
-Dawn renders memory like this:
+### Updating it
 
-```text
-# Memory
-
-The block below is the live contents of `workspace/AGENTS.md`, re-read on every turn.
-...
-
----
-
-<trimmed file contents>
-```
-
-The exact instructional text is owned by Dawn, but the important behavior is stable:
-
-- The file path is `workspace/AGENTS.md` under the app root (`context.appRoot`), which equals the project directory under `dawn dev`.
-- The feature applies to `agent()` routes during route preparation.
-- Empty files are skipped.
-- Files larger than 64 KiB are not loaded; the prompt says the file exceeded the limit.
-- Files that cannot be read are skipped.
-- The file is re-read when the prompt fragment renders, so a later model turn can see an updated file.
-
-Because the memory file is workspace-level, it is shared by all agent routes in the same running app. It is not route-local.
-
-If you run Dawn from a different working directory while pointing at an app root explicitly, remember that memory follows `context.appRoot`, not the test runner's working directory. In-process test harnesses that pass an explicit `appRoot` activate memory relative to that root.
-
-## Updating memory
-
-When a `workspace/` directory exists, the [workspace tools](/docs/workspace) capability provides a `writeFile` tool that is path-jailed to that directory. Dawn's injected system-prompt instruction already tells the agent to update memory by calling `writeFile({ path: "AGENTS.md", content: "..." })` — no extra tooling is required.
-
-Because memory is workspace-level, an update affects every agent route in the same running app. Keep write access intentional and the content concise.
-
-If your app does not use a `workspace/` directory, you can expose a narrow custom tool that writes the file. Prefer the workspace capability whenever possible; it handles path safety automatically.
-
-## Under the hood
-
-The runtime applies built-in agent behavior in `prepareRouteExecution` before invoking an agent route. For memory, Dawn registers `createAgentsMdMarker()`.
-
-That marker always participates for agent routes, but its rendered prompt fragment returns an empty string unless the file exists and has usable content.
-
-When `@dawn-ai/langchain` materializes an `agent()` descriptor, it uses a function-form prompt if any prompt fragments exist. That function calls every fragment renderer with the current state before each model call, then builds:
-
-```ts
-[{ role: "system", content: composedSystemPrompt }, ...messages]
-```
-
-Memory is one of those prompt fragments. That is why the file can be re-read across turns without rebuilding the route.
+When a `workspace/` directory exists, the [workspace tools](/docs/workspace) capability provides a path-jailed `writeFile` tool. Dawn's injected instruction already tells the agent to update its memory by calling `writeFile({ path: "AGENTS.md", content: "..." })` — no extra tooling required. Because the update affects every route in the app, keep write access intentional and the content concise.
 
 ## Route memory (`memory.md`)
 
-The workspace `AGENTS.md` above is shared by every route. When you want stable
-context that applies to one route only, add a `memory.md` next to that route's
-`index.ts`:
+When you want stable context that applies to **one route only**, add a `memory.md` next to that route's `index.ts`:
 
 ```text
 src/app/research/
@@ -91,11 +45,7 @@ src/app/research/
   memory.md
 ```
 
-Dawn injects its trimmed contents under a `# Route Memory` heading, placed
-*after* the workspace `AGENTS.md` fragment, so the route file refines — never
-replaces — the workspace-wide facts. Like `AGENTS.md`, the file is opt-in by
-presence and re-read on every turn, so an edit is visible to the next model call
-without restarting the route.
+Dawn injects its trimmed contents under a `# Route Memory` heading via `createMemoryMdMarker()`, placed *after* the workspace `AGENTS.md` fragment, so the route file refines — never replaces — the workspace-wide facts.
 
 ```md title="src/app/research/memory.md"
 # Research Route Memory
@@ -104,15 +54,11 @@ without restarting the route.
 - Prefer primary sources; flag anything you could not verify.
 ```
 
-Route memory is plain, human-editable profile text — not a store. Files larger
-than 32 KiB are skipped (the prompt notes the file exceeded the limit), and
-empty files contribute nothing.
+Like `AGENTS.md`, it is opt-in by presence and re-read on every turn. It is a prompt fragment only — not a store, and nothing writes it but you. Empty files contribute nothing, and files larger than **32 KiB** are skipped (the prompt notes the file exceeded the limit).
 
-## Long-term memory (`memory.ts`)
+## Long-term collection (`memory.ts`)
 
-`AGENTS.md` and `memory.md` are flat text a human edits. Long-term memory is a
-typed, discrete collection the *agent* writes to and reads back across sessions.
-Declare it by adding a `memory.ts` next to a route's `index.ts`:
+`AGENTS.md` and `memory.md` are flat text. Long-term memory is a typed, discrete collection the agent writes to and reads back across sessions, backed by `@dawn-ai/memory` on `node:sqlite`. Declare it with a `memory.ts` next to a route's `index.ts`:
 
 ```ts title="src/app/research/memory.ts"
 import { defineMemory } from "@dawn-ai/sdk"
@@ -129,67 +75,165 @@ export default defineMemory({
 })
 ```
 
-When a route has a `memory.ts`, Dawn generates two tools for it:
+`defineMemory({ kind, scope, schema, identity? })`:
 
-- `remember` — store a typed fact. The payload is validated against your
-  `schema` before it is written.
-- `recall` — fetch in-scope memories by keyword, kind, or tags.
+- **`kind`** — `"semantic" | "episodic" | "procedural" | "reflection"`. Only `"semantic"` is wired end-to-end today; the other three are typed but deferred.
+- **`scope`** — a subset of `["workspace", "route", "tenant", "user", "agent"]`. The dimensions a memory is partitioned by; `["workspace", "route"]` namespaces records to the app *and* the specific route, so two routes never read each other's memories.
+- **`schema`** — a Zod schema describing your fact shape.
+- **`identity?`** — the keys used for write reconciliation (in `auto` mode). Defaults to `["subject", "predicate"]`.
 
-Recall is deterministic: a keyword + recency search over a SQLite-backed store
-(`@dawn-ai/memory`, on `node:sqlite`). There is no embedding model or network
-call in the path, so the same query returns the same rows — which keeps evals
-and fixtures stable. A short index of the most recent in-scope memories is also
-injected into the prompt so the agent knows what is available to recall.
+<Callout type="info" title="Deterministic recall">
+  Recall is a tokenized keyword match ordered by recency over a SQLite store — there is no FTS5, embedding model, or network call in the path. The same query returns the same rows, which keeps evals and fixtures stable (and replayable under aimock).
+</Callout>
 
-### Scope and namespaces
+### Generated tools
 
-`scope` lists the dimensions a memory is partitioned by. `["workspace", "route"]`
-namespaces records to the workspace *and* the specific route, so two routes do
-not read each other's memories, and an app may supply further namespace
-dimensions (e.g. tenant or user) at runtime. The `schema` is your fact shape;
-for the `semantic` kind, records are reconciled by an identity key that defaults
-to `["subject", "predicate"]` (override with `identity`).
+Typegen emits two typed tools for any route with a `memory.ts` into `.dawn/dawn.generated.d.ts`:
 
-### Writes and governance
+- **`recall`** — fetch in-scope memories by keyword, kind, or tags.
+- **`remember`** — store a typed fact (omitted entirely when `writes` is `"off"`).
 
-Writes default to a review queue rather than landing live. Control this with the
-`memory` config in `dawn.config.ts`:
+<Callout type="warn" title="remember.data is loosely typed in v1">
+  Typegen types `remember`'s `data` as `Record<string, unknown>`, not your Zod schema. The schema is still enforced at *runtime* — `remember` validates `data` against it and rejects on failure — but you do not yet get compile-time field types on the write path. Schema-typed `remember.data` is deferred.
+</Callout>
 
-```ts title="dawn.config.ts"
-export default defineConfig({
-  memory: { writes: "candidate" }, // "off" | "candidate" | "auto"
-})
+**`recall({ query?, kind?, tags?, limit? })`** searches the store. It defaults `status` to `"active"` and `limit` to `8`, and returns one `id: content` line per match, or `(no memories found)` when empty.
+
+**`remember({ data, content?, tags?, confidence? })`** validates `data` against the schema, then writes a record. The id is **data-derived** — `memory_` + the first 16 hex chars of `sha1(namespace | JSON(data))` — so a contradicting value (same identity, different data) gets a distinct id and can coexist with the old row. `content` defaults to `JSON.stringify(data)`, `confidence` to `1`, `tags` to `[]`.
+
+### The injected index
+
+Dawn also injects an index of the in-scope memories the agent can recall, so it knows what is available without a blind `recall`. It lists up to `indexMaxEntries` (default **20**) active in-scope records, each truncated to 80 chars, under a `# Long-Term Memory` heading placed after the user prompt:
+
+```text
+# Long-Term Memory
+
+These memories are available — call `recall({ query })` to load full details before relying on them.
+
+- memory_a1b2c3d4e5f6a7b8: acme prefers invoices net-30
+- memory_0f1e2d3c4b5a6978: primary contact is jordan@acme.test
 ```
 
-- `off` — the `remember` tool is not generated; the agent can only `recall`.
-- `candidate` (default) — `remember` writes land as `candidate` records that are
-  not surfaced to `recall` until a human promotes them.
-- `auto` — `remember` writes land as `active` immediately.
+The default store lives at `<appRoot>/.dawn/memory.sqlite`.
 
-Promote, inspect, or remove candidates with the [`dawn memory`](/docs/cli#dawn-memory)
-CLI (`list`, `search`, `inspect`, `approve`, `reject`, `forget`). When a new
-fact contradicts an existing one (same identity, different value), Dawn
-*supersedes* the old record rather than deleting it, so history is preserved.
+## Write governance
 
-### What's deferred
+The `memory.writes` mode in `dawn.config.ts` controls what `remember` does. It defaults to `"candidate"`.
 
-Long-term memory ships with the `semantic` kind and deterministic keyword +
-recency recall. Vector / embedding-based recall, the `episodic` and `procedural`
-kinds, and a dev-server inspector UI are planned but not yet implemented. Use
-`memory.md` for stable profile text and `memory.ts` for facts the agent should
-accumulate over time.
+| Mode | `remember` tool | Where writes land | Reconciliation |
+|---|---|---|---|
+| `off` | Not generated (recall-only) | — | — |
+| `candidate` *(default)* | Generated | `candidate` — hidden from `recall` until approved | None |
+| `auto` | Generated | `active` immediately | Inline (see below) |
 
-## What memory is not
+In **`auto`** mode each write reconciles inline against existing active records with the same identity key:
 
-Memory is not a vector store, retrieval system, or per-user profile service. It is not automatically summarized. It is not scoped by tenant, route, or session.
+- **Same identity + same data** → idempotent `UPDATE` (refreshes content/tags/timestamp).
+- **Same identity, different value** → **supersede**: a new active row is written and the old row flips to `superseded` (history preserved, not deleted).
+- **No matching identity** → add a new active row.
 
-If you need tenant-specific or user-specific memory, keep that in your own storage and expose it through route-local tools. Use `workspace/AGENTS.md` for facts that are safe and useful across the whole workspace.
+<Callout type="warn" title="Supersession only fires in auto mode">
+  In the default `candidate` mode there is **no** reconciliation or supersession. A `remember` call simply writes a hidden candidate; `dawn memory approve` only flips its status to `active`. Contradicting facts are *not* reconciled when approved — that logic runs only on `auto` writes. If you rely on contradiction-handling, you must opt into `auto`.
+</Callout>
+
+<Callout type="warn" title="auto writes are not gated by permissions">
+  The design specced a permissions HITL flow (Once / Always / Deny) to gate `auto` writes, but that was **not shipped**. `auto` writes land active immediately and do **not** pass through `@dawn-ai/permissions`. Treat `auto` as fully trusting the agent's writes; use `candidate` when a human should review first.
+</Callout>
+
+## Reviewing candidates
+
+In the default `candidate` mode, the agent's writes queue up for review. Manage them with the [`dawn memory`](/docs/cli) CLI (`--cwd <path>` points at the app root; defaults to the current directory):
+
+<CodeGroup>
+```bash title="list all candidates"
+dawn memory list
+```
+
+```bash title="approve a candidate (→ active)"
+dawn memory approve memory_a1b2c3d4e5f6a7b8
+```
+
+```bash title="reject a candidate (hard delete)"
+dawn memory reject memory_a1b2c3d4e5f6a7b8
+```
+</CodeGroup>
+
+Records print as `${id} [${status}] ${namespace} — ${content}`. The subcommands:
+
+- **`list`** — every candidate across all namespaces.
+- **`search <q>`** — candidates whose content or namespace contains `<q>`.
+- **`inspect <id>`** — the full record as JSON.
+- **`approve <id>`** — flip a candidate to `active`. (Errors if the record is not a candidate.)
+- **`reject <id>`** — hard-delete the record.
+- **`forget <id>`** — also a hard delete; it differs from `reject` only in the printed message.
+
+<Callout type="warn" title="search is a substring filter, not recall">
+  `dawn memory search` is a plain case-insensitive substring filter over candidate content and namespace — it is *not* the tokenized keyword recall the agent uses, and it only sees candidates (not active or superseded records).
+</Callout>
+
+## Configuration
+
+The `memory` block in `dawn.config.ts` configures L3 across the app:
+
+```ts title="dawn.config.ts"
+export default {
+  memory: {
+    // store?       — defaults to a SQLite store at <appRoot>/.dawn/memory.sqlite
+    writes: "candidate", // "off" | "candidate" | "auto" (default "candidate")
+    indexMaxEntries: 20, // index size cap (default 20)
+    // Supply tenant/user/agent dimensions at runtime for namespacing.
+    resolveScope: ({ routePath, appRoot }) => ({
+      tenant: process.env.TENANT_ID ?? "default",
+      user: process.env.USER_ID ?? "anon",
+    }),
+  },
+} satisfies import("@dawn-ai/core").DawnConfig
+```
+
+`resolveScope` runs per request and fills in the `tenant` / `user` / `agent` dimensions a route declared in its `scope`. The `workspace` and `route` dimensions are derived automatically (from the app-root basename and the route path); only dimensions a route lists in `scope` end up in its namespace.
+
+<Callout type="info" title="enabled is not read for memory">
+  `DawnConfig.memory` carries an `enabled` field for historical reasons, but the runtime never reads it. L3 activation is purely the presence of a `memory.ts` next to a route's `index.ts` — setting `enabled: false` does **not** disable it.
+</Callout>
+
+## Testing
+
+Seed memory rows directly in tests with `seedMemory` from `@dawn-ai/testing`. Pass a store instance or a `{ path }`, plus partial records (sensible defaults fill the rest):
+
+```ts
+import { seedMemory } from "@dawn-ai/testing"
+
+const store = await seedMemory(
+  { path: ":memory:" },
+  [
+    {
+      id: "memory_seed1",
+      namespace: "workspace=app|route=/research",
+      content: "acme prefers invoices net-30",
+      status: "active",
+    },
+  ],
+)
+```
+
+## What's deferred
+
+Long-term memory ships with the `semantic` kind and deterministic keyword + recency recall. The following are typed or designed but **not** implemented:
+
+- The `episodic`, `procedural`, and `reflection` kinds.
+- Vector / embedding recall, FTS5 / BM25 ranking, and a memory graph.
+- A dev-server Memory Inspector UI.
+- Postgres / pgvector store adapters.
+- Schema-typed `remember.data` (typed loosely as `Record<string, unknown>` today).
+- Permissions HITL gating for `auto` writes (see the warning above).
+
+For anything beyond the semantic collection, use `memory.md` for stable profile text and `memory.ts` for facts the agent should accumulate over time.
 
 ## Related
 
 <RelatedCards items={[
-  { href: "/docs/agents", title: "Agents", subtitle: "agent descriptors and prompt composition" },
-  { href: "/docs/tools", title: "Tools", subtitle: "add an explicit memory writer when needed" },
-  { href: "/docs/planning", title: "Planning", subtitle: "route-local plan state for multi-step work" },
-  { href: "/docs/skills", title: "Skills", subtitle: "load long instructions only when needed" },
+  { href: "/docs/configuration", title: "Configuration", subtitle: "the dawn.config.ts memory block" },
+  { href: "/docs/cli", title: "CLI", subtitle: "the dawn memory review workflow" },
+  { href: "/docs/workspace", title: "Workspace", subtitle: "the writeFile tool that edits AGENTS.md" },
+  { href: "/docs/testing-agents", title: "Testing agents", subtitle: "seedMemory and deterministic recall" },
 ]} />

--- a/apps/web/content/docs/migrating-from-langgraph.mdx
+++ b/apps/web/content/docs/migrating-from-langgraph.mdx
@@ -10,7 +10,7 @@ The migration is mostly *moving code*, not rewriting it.
 
 ## tl;dr
 
-- Your `StateGraph` does not change. Default-export it as a `graph` route.
+- Your `StateGraph` does not change. Export it as a named `graph` route.
 - Your tools become co-located TypeScript files. The hand-written Zod schemas go away.
 - Your typed state moves into a sibling `state.ts`. Dynamic path segments populate fields by name.
 - Your `langgraph.json` is replaced by `dawn build`. The output is still a `langgraph.json`.
@@ -102,7 +102,7 @@ import type state from "./state.js"
 
 type SupportState = z.infer<typeof state>
 
-export default new StateGraph<SupportState>({
+export const graph = new StateGraph<SupportState>({
   channels: {
     messages: { reducer: (a, b) => [...a, ...b], default: () => [] },
     orderId: null,

--- a/apps/web/content/docs/observability.mdx
+++ b/apps/web/content/docs/observability.mdx
@@ -22,7 +22,7 @@ Open any run in the LangSmith UI. The hierarchy follows the LangGraph execution 
 - **Root run** — the full agent turn. Status is `success` when the turn completes normally.
 - **LLM runs** — one per model call, with the full prompt, sampled output, token usage, and latency.
 - **Tool runs** — one per tool call, with input and output. Subagent tool runs appear nested under the subagent's run.
-- **Subagent runs** — each `subagent()` dispatch appears as a child of the root run.
+- **Subagent runs** — each `task({ subagent, input })` dispatch appears as a child of the root run.
 
 ### Human-in-the-loop interrupts in LangSmith
 

--- a/apps/web/content/docs/reasoning-effort.mdx
+++ b/apps/web/content/docs/reasoning-effort.mdx
@@ -12,7 +12,7 @@ Set `reasoning.effort` on an `agent()` descriptor:
 import { agent } from "@dawn-ai/sdk"
 
 export default agent({
-  model: "gpt-5.1",
+  model: "gpt-5-mini",
   reasoning: { effort: "high" },
   systemPrompt: "You are a careful support assistant.",
 })
@@ -94,14 +94,14 @@ If a parent and child route need different budgets, set them separately:
 ```ts
 // parent
 export default agent({
-  model: "gpt-5.1",
+  model: "gpt-5-mini",
   reasoning: { effort: "low" },
   systemPrompt: "Coordinate the work.",
 })
 
 // child
 export default agent({
-  model: "gpt-5.1",
+  model: "gpt-5-mini",
   reasoning: { effort: "high" },
   systemPrompt: "Analyze the evidence carefully.",
 })

--- a/apps/web/content/docs/recipes/stream-output.mdx
+++ b/apps/web/content/docs/recipes/stream-output.mdx
@@ -84,7 +84,7 @@ Every frame is `event: <type>\ndata: <json>\n\n`. Parse the `event:` line to rou
 | `chunk` | `{ content: string }` | Streamed text fragment from the LLM. |
 | `tool_call` | `{ name: string, input: unknown }` | LLM is calling a tool. |
 | `tool_result` | `{ name: string, output: unknown }` | Tool returned a result. |
-| `plan_update` | plan object | Emitted when [Planning](/docs/planning) updates `plan.md`. |
+| `plan_update` | plan object | Emitted after a [Planning](/docs/planning) `writeTodos` result updates the route's todo state. (Does not write back to `plan.md`.) |
 | `interrupt` | interrupt object | Emitted when the agent hits a HITL interrupt point. |
 | `subagent.start` | `{ name, routeId, depth, call_id }` | A subagent started. |
 | `subagent.tool_call` | `{ call_id, name, input }` | Tool call inside a subagent. |

--- a/apps/web/content/docs/testing-agents.mdx
+++ b/apps/web/content/docs/testing-agents.mdx
@@ -133,19 +133,6 @@ expectState(run).field("todos").toEqual([{ content: "ship it", status: "pending"
 
 `run.state` is the full agent state after the run — the same object a checkpointer would persist.
 
-## Record-first workflow
-
-For complex conversations you don't want to hand-write, record a real provider interaction locally:
-
-```ts
-import { record } from "@dawn-ai/testing"
-
-// Run once locally — requires OPENAI_API_KEY in env. Never run in CI.
-record({ out: "test/fixtures/my-scenario.json" })
-```
-
-Then hand-trim the JSON to keep only the turns that matter, commit it, and replay in CI. CI replays strict and read-only — it never re-records. Add a `git diff --exit-code test/fixtures/` guard in CI to catch uncommitted fixture edits.
-
 ## The three execution modes
 
 `createAgentHarness` supports three modes via the `mode` option (default: `"in-process"`):

--- a/apps/web/content/docs/tools.mdx
+++ b/apps/web/content/docs/tools.mdx
@@ -16,6 +16,24 @@ That's it. Dawn extracts the input and output types at build time using the Type
   Every `.ts` file in a route's `tools/` directory is automatically discovered. Drop a file in, save, and the type appears in `ctx.tools` on the next `dawn typegen` or `dawn dev` reload.
 </Callout>
 
+## Shared tools
+
+Tools resolve from two locations. Each route gets its own `tools/` directory for tools that belong to that route, and there's a shared `src/tools/` directory for tools reused across routes:
+
+```text
+src/
+├── tools/                  ← shared across every route
+│   ├── lookupOrder.ts
+│   └── escalate.ts
+└── app/
+    └── support/
+        ├── index.ts
+        └── tools/          ← route-local to /support
+            └── escalate.ts
+```
+
+Both sets are merged into the route's `ctx.tools`. When the same tool name exists in both, **the route-local tool shadows the shared one** — in the tree above, `/support` sees its own `escalate` and the shared `lookupOrder`. Put a tool in `src/tools/` when more than one route needs it; keep it in the route's `tools/` when it's specific to that route or you want to override a shared one.
+
 ## The runtime signature
 
 The full runtime signature accepted by tool discovery is `(input, ctx) => ...`, where `ctx` is `DawnToolContext` from `@dawn-ai/sdk` — carrying `signal`, `middleware?`, and `fs`:

--- a/apps/web/content/docs/workspace.mdx
+++ b/apps/web/content/docs/workspace.mdx
@@ -189,7 +189,7 @@ export async function workflow(
 
 ## Research scaffold example
 
-The `research` template (`create-dawn-app --template research`) shows how these tools fit together:
+The `research` template (`create-dawn-ai-app --template research`) shows how these tools fit together:
 
 ```text
 workspace/

--- a/docs/superpowers/specs/2026-06-19-docs-memory-and-audit-design.md
+++ b/docs/superpowers/specs/2026-06-19-docs-memory-and-audit-design.md
@@ -1,0 +1,135 @@
+# Docs: long-term memory update + accuracy audit fixes
+
+Date: 2026-06-19
+Status: Approved (design)
+Branch: blove/optimistic-brahmagupta-92c3e5
+
+## Goal
+
+Bring the Dawn docs website (`apps/web/content/docs/`) into alignment with the
+shipped state of the codebase, with a focus on the new long-term memory feature
+(PR #250, `@dawn-ai/memory`). Two outcomes:
+
+1. The memory documentation accurately describes the three coexisting memory
+   mechanisms and the shipped behavior (no false promises).
+2. A batch of verified accuracy/clarity fixes across the rest of the docs.
+
+This is a documentation-only change. No package source is modified.
+
+## Ground truth (verified against source)
+
+Dawn has **three coexisting memory mechanisms**:
+
+- **L1 — `workspace/AGENTS.md`** (pre-existing): global, always-injected profile
+  blob, shared by every route, re-read each turn, agent-edited via the workspace
+  `writeFile` tool. Capability `createAgentsMdMarker()`. Injected heading
+  `# Memory`. 64 KiB cap.
+- **L2 — route-local `memory.md`** (new): route-scoped profile text, opt-in by
+  presence, re-read each turn, prompt-fragment-only. Capability
+  `createMemoryMdMarker()`. Injected heading `# Route Memory`. 32 KiB cap.
+- **L3 — typed collection via `memory.ts` + `defineMemory`** (new, the core):
+  many discrete typed namespace-scoped records the agent writes/recalls across
+  sessions. Backed by `@dawn-ai/memory` on `node:sqlite` (no FTS5 → tokenized
+  keyword match + recency ordering; deterministic, replayable under aimock).
+  Capability `createMemoryMarker()` contributes `remember`/`recall` tools plus an
+  auto-injected index fragment headed `# Long-Term Memory`.
+
+L3 specifics:
+- `defineMemory({ kind, scope, schema, identity? })` from `@dawn-ai/sdk`.
+  - `kind`: `"semantic" | "episodic" | "procedural" | "reflection"` — only
+    `semantic` is wired end-to-end; the other three are typed-but-deferred.
+  - `scope`: subset of `["workspace","route","tenant","user","agent"]`.
+  - `schema`: a zod schema; `identity?` defaults to `["subject","predicate"]`.
+- Typegen emits typed `remember`/`recall` into `.dawn/dawn.generated.d.ts`.
+  Caveat: `remember`'s `data` is typed loosely as `Record<string, unknown>` in
+  v1 (not the zod schema).
+- `recall({ query?, kind?, tags?, limit? })` → `store.search`; defaults
+  `status="active"`, `limit=8`.
+- `remember({ data, content?, tags?, confidence? })` → validates `data` against
+  the zod schema; id is data-derived (`memory_` + sha1(namespace|JSON(data))).
+- Injected index: up to `indexMaxEntries` (default 20) active in-scope memories,
+  each truncated to 80 chars, heading `# Long-Term Memory`.
+- Default store path: `<appRoot>/.dawn/memory.sqlite`.
+
+Write governance (`memory.writes`, default `"candidate"`):
+- `off` — no `remember` tool (recall-only).
+- `candidate` (default) — writes land as `candidate`, hidden from recall until
+  approved. **No reconciliation/supersession happens.** `dawn memory approve`
+  only flips status to `active`.
+- `auto` — writes land `active` immediately with inline reconciliation
+  (idempotent UPDATE / SUPERSEDE / ADD via `classifyWrite`).
+
+CLI (`dawn memory <sub> [--cwd]`): `list`, `search <q>` (substring filter over
+candidates, NOT tokenized recall), `inspect <id>`, `approve <id>`,
+`reject <id>` (hard delete), `forget <id>` (also hard delete; differs only in
+message).
+
+Config (`DawnConfig.memory`): `store`, `writes`, `indexMaxEntries`,
+`resolveScope(ctx) => Record<string,string>` (supplies tenant/user/agent dims at
+runtime). Note: `enabled` exists in the type but is not read by the runtime
+(activation is presence-of-`memory.ts`).
+
+Testing: `seedMemory(target, records)` from `@dawn-ai/testing`.
+
+Deferred / not shipped: episodic/procedural/reflection kinds, vector/embedding
+recall, FTS5/BM25, memory graph, dev-server Memory Inspector, Postgres/pgvector
+adapters, schema-typed `remember.data`, and — importantly — the spec'd
+permissions HITL gating for `auto` writes was NOT shipped (auto writes are not
+gated through `@dawn-ai/permissions`).
+
+## Changes
+
+### A. `memory.mdx` — full restructure around the 3-layer model
+
+Sections:
+1. Intro + comparison table (AGENTS.md / `memory.md` / `memory.ts`: scope,
+   format, who writes, persistence, when to use).
+2. L1 Workspace profile (`AGENTS.md`).
+3. L2 Route memory (`memory.md`), `# Route Memory`.
+4. L3 Long-term collection: `defineMemory` config (full scope set), typegen'd
+   tools, `remember`/`recall` inputs + defaults, data-derived id, injected
+   `# Long-Term Memory` index (20 / 80-char), default `.dawn/memory.sqlite`,
+   node:sqlite tokenized+recency.
+5. Write governance table (off/candidate/auto). **Fix supersession claim**:
+   reconciliation only in `auto`; candidate default = review-then-activate.
+6. Reviewing candidates: `dawn memory` workflow; reject/forget both hard-delete;
+   `search` is substring-over-candidates.
+7. Configuration: `memory` block incl. `resolveScope` example (tenant/user).
+8. Testing: `seedMemory`.
+9. What's deferred — accurate list replacing the contradictory "what it's not"
+   section; `<Callout type="warn">` that auto-mode permissions HITL gating is not
+   shipped.
+
+### B. Memory-adjacent reference fixes
+- `configuration.mdx`: add the `memory` config key.
+- `cli.mdx`: "nine" → "ten" commands; add `memory` to inline list.
+- `api.mdx`: add reference entries for `defineMemory`, `DefinedMemory`,
+  `MemoryScopeDimension`, `DawnToolContext`, `WorkspaceFs`, `inferProvider`,
+  `SUPPORTED_AGENT_PROVIDERS`, `validateModelId`, `ModelIdValidation`, and the
+  model-id constants.
+
+### C. Broader audit fixes
+- `migrating-from-langgraph.mdx`: graph route → named `export const graph`; fix
+  tl;dr (line 13) and line 140 wording to agree (named export, not default).
+- `tools.mdx`: document shared `src/tools/` discovery (route-local shadows
+  shared).
+- `workspace.mdx`: `create-dawn-app` → `create-dawn-ai-app`.
+- `reasoning-effort.mdx`: `gpt-5.1` → curated `gpt-5-mini`.
+- `observability.mdx`: `subagent()` → `task()`.
+- `stream-output.mdx`: correct `plan_update` description (fires on `writeTodos`
+  results, not on `plan.md` writes).
+- Light dedup: `evals.mdx` links to `testing-agents.mdx` for shared
+  aimock/fixture mechanics instead of restating; remove the repeated
+  record-workflow block in `testing-agents.mdx`.
+
+## Non-goals
+- No package/source code changes.
+- No nav restructure (memory page stays in Concepts).
+- No new doc pages.
+- Not fixing the underlying code divergences (e.g. shipping auto-mode HITL
+  gating) — only documenting reality.
+
+## Verification
+- Re-grep each changed claim against `packages/*` source before marking done.
+- `apps/web` typecheck/build so MDX still compiles.
+- Confirm nav/search unaffected.


### PR DESCRIPTION
## Summary

Brings the docs site into alignment with the shipped state of the codebase, focused on the new long-term memory feature ([#250](https://github.com/cacheplane/dawnai/pull/250)), plus a batch of verified accuracy/clarity fixes found during a full docs audit.

Design spec: `docs/superpowers/specs/2026-06-19-docs-memory-and-audit-design.md`

### Memory feature
- **Rewrote `memory.mdx`** around the three coexisting mechanisms (workspace `AGENTS.md` → route `memory.md` → typed `memory.ts` collection) with a comparison table.
- **Fixed the headline accuracy bug:** the old page claimed contradicting facts get *superseded* as default behavior. Reconciliation/supersession only runs in `writes: "auto"`; the default `candidate` mode just queues a hidden candidate that `dawn memory approve` activates. Now stated plainly.
- Documented previously-missing reality: full `scope` dimension set, `recall`/`remember` inputs + defaults, data-derived ids, the injected `# Long-Term Memory` index, default store path, `resolveScope`, `seedMemory`, and that the specced auto-write permissions HITL gating was **not** shipped.
- `configuration.mdx`: added the `memory` config key.
- `cli.mdx`: nine → ten commands; added `memory` to the list.
- `api.mdx`: added `defineMemory`, `DawnToolContext`, `WorkspaceFs`, `inferProvider`, `validateModelId`, and the model-id constants.

### Audit fixes
- `migrating-from-langgraph.mdx`: graph route must be a **named** export, not `export default` (discovery never recognizes a default-exported `StateGraph`).
- `tools.mdx`: document shared `src/tools/` discovery (route-local shadows shared).
- `workspace.mdx`: `create-dawn-app` → `create-dawn-ai-app`.
- `reasoning-effort.mdx`: uncurated `gpt-5.1` → `gpt-5-mini`.
- `observability.mdx`: `subagent()` → `task()`.
- `recipes/stream-output.mdx`: correct the `plan_update` event source.
- `evals.mdx` / `testing-agents.mdx`: dedup the shared aimock/fixture explanation.

## Test plan
- `pnpm --filter @dawn-ai/web build` — compiles, all 55 pages prerendered.
- `pnpm --filter @dawn-ai/web lint` — clean (112 files).
- Every claim source-verified against `packages/*`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)