### PR TITLE
docs: add OpenSSF Best Practices passing badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 
 [![CI](https://github.com/cacheplane/dawnai/actions/workflows/ci.yml/badge.svg)](https://github.com/cacheplane/dawnai/actions/workflows/ci.yml)
 [![OpenSSF Scorecard](https://github.com/cacheplane/dawnai/actions/workflows/scorecard.yml/badge.svg)](https://github.com/cacheplane/dawnai/actions/workflows/scorecard.yml)
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13317/badge)](https://www.bestpractices.dev/projects/13317)
 [![License: MIT](https://img.shields.io/badge/license-MIT-111827.svg)](./LICENSE)
 
 The TypeScript meta-framework for LangGraph. Author AI agents and workflows as filesystem routes, get end-to-end types and a local dev server for free, and deploy to LangSmith with one command.


### PR DESCRIPTION
## Summary
Adds the **OpenSSF Best Practices passing badge** ([project 13317](https://www.bestpractices.dev/projects/13317), 100%) to the README badge row. The BadgeApp listing (repo URL registered) also feeds Scorecard's `CII-Best-Practices` check, taking it from 0 → credited on the next recompute.

## Test Plan
- [x] Badge renders; links to the project page