### PR TITLE
docs: positioning refresh — durable-by-default + route-shape duality (items 3+4+5)

### DIFF
--- a/.changeset/positioning-messaging-refresh.md
+++ b/.changeset/positioning-messaging-refresh.md
@@ -1,0 +1,4 @@
+---
+---
+
+Non-shipping: positioning & messaging refresh — unifies the README/npm tagline to the website hero, foregrounds durable-by-default, and surfaces the `agent`/`workflow`/`graph`/`chain` route-shape duality across the landing page, READMEs, and docs. Copy-only; the updated package READMEs publish with the next release.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![OpenSSF Scorecard](https://github.com/cacheplane/dawnai/actions/workflows/scorecard.yml/badge.svg)](https://github.com/cacheplane/dawnai/actions/workflows/scorecard.yml)
 [![License: MIT](https://img.shields.io/badge/license-MIT-111827.svg)](./LICENSE)
 
-The TypeScript meta-framework for LangGraph. Author AI agents and workflows as filesystem routes, get end-to-end types and a local dev server for free, and deploy to LangSmith with one command.
+Build LangGraph agents like Next.js apps. Dawn is the TypeScript meta-framework for LangGraph — author AI agents and workflows as filesystem routes with route-local tools, generated types, durable threads, and an HMR dev server. Keep the runtime, drop the boilerplate.
 
 <p align="center">
   <img src="docs/brand/quickstart.gif" alt="Dawn quickstart — scaffold a route and invoke it in under a minute" width="900" />
@@ -20,6 +20,8 @@ The TypeScript meta-framework for LangGraph. Author AI agents and workflows as f
 - **Filesystem-routed agents.** Filesystem routes under `src/app/` — colocate state schemas, tools, middleware, and tests next to the route they belong to. No more ad-hoc folders.
 - **A real local dev loop.** `dawn dev` runs your routes locally with LangSmith-style endpoints. Iterate in seconds, then verify the generated deployment artifact before shipping.
 - **Typed end to end (TypeScript).** Route params, state, and tool I/O are generated as TypeScript types. `dawn verify` is your pre-deploy gate.
+- **Durable by default.** Every Dawn app ships a working SQLite checkpointer and thread store — no setup. Threads survive a `dawn dev` restart, and an agent that pauses for human input resumes exactly where it left off. LangGraph defines the checkpoint interface; Dawn ships the default implementation.
+- **Two ways to drive the model.** A route exports one of `agent` (LLM picks tools at runtime, can pause for a human), `workflow` (deterministic typed async function when you own the order), `graph`, or `chain`. Same routing, same types, same dev loop — you choose who's in charge.
 
 ## Without Dawn / With Dawn
 

--- a/apps/web/app/components/CopyPromptButton.tsx
+++ b/apps/web/app/components/CopyPromptButton.tsx
@@ -39,7 +39,7 @@ export function CopyPromptButton({
       type="button"
       onClick={handleCopy}
       className={baseClass}
-      aria-label={ariaLabel ?? (copied ? "Prompt copied" : `${label} to clipboard`)}
+      aria-label={copied ? "Prompt copied" : (ariaLabel ?? `${label} to clipboard`)}
     >
       {copied ? (
         <>

--- a/apps/web/app/components/landing/DriveTheModel.tsx
+++ b/apps/web/app/components/landing/DriveTheModel.tsx
@@ -1,0 +1,59 @@
+import { Card } from "../ui/Card"
+import { Eyebrow } from "../ui/Eyebrow"
+
+const SHAPES = [
+  {
+    name: "agent",
+    tagline: "Let the model decide.",
+    body: "An LLM-driven route that picks tools at runtime and can pause for a human. Reach for it when you want the model to choose what to do.",
+  },
+  {
+    name: "workflow",
+    tagline: "You own the order.",
+    body: "A deterministic, typed async function. Reach for it when you control the sequence of operations and want predictable, step-by-step execution.",
+  },
+] as const
+
+export function DriveTheModel() {
+  return (
+    <section className="bg-surface border-b border-divider">
+      <div className="max-w-[1200px] mx-auto px-6 md:px-8 py-20 md:py-28">
+        <Eyebrow>Route shapes</Eyebrow>
+        <h2
+          className="font-display font-semibold text-ink mt-3 text-[32px] leading-[38px] md:text-[44px] md:leading-[50px] max-w-[22ch]"
+          style={{
+            fontVariationSettings: "'opsz' 144, 'SOFT' 50, 'WONK' 0",
+            letterSpacing: "-0.01em",
+          }}
+        >
+          Two ways to drive the model.
+        </h2>
+
+        <p className="mt-5 text-lg text-ink-muted leading-[30px] max-w-[60ch]">
+          Same routing, same types, same dev loop — you choose who's in charge. A route's{" "}
+          <code className="text-sm font-mono text-ink bg-page px-1.5 py-0.5 rounded border border-divider">
+            index.ts
+          </code>{" "}
+          exports exactly one shape.
+        </p>
+
+        <div className="mt-10 grid sm:grid-cols-2 gap-6">
+          {SHAPES.map((s) => (
+            <Card key={s.name} className="p-6 md:p-7">
+              <code className="text-sm font-mono font-semibold text-accent-saas">{s.name}</code>
+              <p className="mt-3 text-base font-medium text-ink">{s.tagline}</p>
+              <p className="mt-2 text-sm text-ink-muted leading-[22px]">{s.body}</p>
+            </Card>
+          ))}
+        </div>
+
+        <p className="mt-6 text-sm text-ink-dim leading-[22px] max-w-[60ch]">
+          Need raw LangGraph? Export a{" "}
+          <code className="text-xs font-mono text-ink-muted">graph</code> or{" "}
+          <code className="text-xs font-mono text-ink-muted">chain</code> and instantiate anything
+          you want.
+        </p>
+      </div>
+    </section>
+  )
+}

--- a/apps/web/app/components/landing/DurableByDefault.tsx
+++ b/apps/web/app/components/landing/DurableByDefault.tsx
@@ -1,0 +1,71 @@
+import { Card } from "../ui/Card"
+import { Eyebrow } from "../ui/Eyebrow"
+
+const PAYOFFS = [
+  "Threads survive a dawn dev restart — no lost state between edits.",
+  "Agents that pause for human input resume exactly where they left off.",
+  "A working SQLite checkpointer and thread store ship by default — zero setup.",
+] as const
+
+function CheckIcon() {
+  return (
+    <svg
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      aria-hidden="true"
+      focusable="false"
+      className="w-4 h-4 mt-1 text-accent-saas shrink-0"
+    >
+      <path d="M3 8.5l3.5 3.5L13 5" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  )
+}
+
+export function DurableByDefault() {
+  return (
+    <section className="bg-page border-b border-divider">
+      <div className="max-w-[1200px] mx-auto px-6 md:px-8 py-20 md:py-28">
+        <Eyebrow>Durability</Eyebrow>
+        <h2
+          className="font-display font-semibold text-ink mt-3 text-[32px] leading-[38px] md:text-[44px] md:leading-[50px] max-w-[20ch]"
+          style={{
+            fontVariationSettings: "'opsz' 144, 'SOFT' 50, 'WONK' 0",
+            letterSpacing: "-0.01em",
+          }}
+        >
+          Durable by default.
+        </h2>
+
+        <div className="mt-8 grid lg:grid-cols-[1.2fr_1fr] gap-10 lg:gap-16">
+          <div className="space-y-5 text-lg text-ink-muted leading-[30px] max-w-[58ch]">
+            <p>
+              Every Dawn app ships a working checkpointer and thread store — no setup. Runs
+              checkpoint to SQLite between turns, so threads survive a{" "}
+              <code className="text-sm font-mono text-ink bg-surface px-1.5 py-0.5 rounded border border-divider">
+                dawn dev
+              </code>{" "}
+              restart and an agent that pauses for human input resumes exactly where it left off.
+            </p>
+            <p>
+              LangGraph defines the checkpoint interface; Dawn ships the default implementation. So
+              durability is the path of least resistance — not a wiring task.
+            </p>
+          </div>
+
+          <Card className="p-6 md:p-7">
+            <ul className="space-y-3">
+              {PAYOFFS.map((line) => (
+                <li key={line} className="flex items-start gap-2.5 text-sm text-ink leading-[22px]">
+                  <CheckIcon />
+                  <span>{line}</span>
+                </li>
+              ))}
+            </ul>
+          </Card>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/apps/web/app/components/landing/Hero.tsx
+++ b/apps/web/app/components/landing/Hero.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link"
 import { highlightLight } from "../../../lib/shiki/highlight-light"
 import { CopyCommand } from "../CopyCommand"
+import { CopyPromptButton } from "../CopyPromptButton"
 import { CodeFrame } from "../ui/CodeFrame"
 import { Eyebrow } from "../ui/Eyebrow"
 
@@ -10,6 +11,8 @@ export default agent({
   model: "gpt-4o-mini",
   systemPrompt: "Answer for {tenant}.",
 })`
+
+const HERO_PROMPT = `Scaffold a new Dawn app and help me build an agent. Dawn is the TypeScript meta-framework for LangGraph — agents and workflows are file-system routes with route-local tools, generated types, and durable threads. Run \`pnpm create dawn-ai-app\` to scaffold, then read https://dawnai.org/AGENTS.md and https://dawnai.org/llms-full.txt for the full framework reference before writing any routes.`
 
 export async function Hero() {
   const codeHtml = await highlightLight(ROUTE_CODE, "typescript")
@@ -30,14 +33,19 @@ export async function Hero() {
               Build LangGraph agents like Next.js apps.
             </h1>
             <p className="mt-6 text-lg text-ink-muted leading-[30px] max-w-[44ch]">
-              Dawn adds file-system routing, route-local tools, generated types, and HMR to your
-              existing LangGraph.js stack.{" "}
+              Dawn adds file-system routing, route-local tools, generated types, durable threads,
+              and HMR to your existing LangGraph.js stack.{" "}
               <strong className="text-ink font-medium">
                 Keep the runtime. Drop the boilerplate.
               </strong>
             </p>
             <div className="mt-8 flex flex-wrap items-center gap-4">
               <CopyCommand command="pnpm create dawn-ai-app" />
+              <CopyPromptButton
+                prompt={HERO_PROMPT}
+                label="Copy agent prompt"
+                ariaLabel="Copy a prompt to scaffold Dawn with your coding agent"
+              />
               <Link
                 href="/docs/getting-started"
                 className="text-sm font-medium text-ink hover:text-accent-saas transition-colors inline-flex items-center gap-1.5"

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,4 +1,5 @@
 import { DriveTheModel } from "./components/landing/DriveTheModel"
+import { DurableByDefault } from "./components/landing/DurableByDefault"
 import { Ecosystem } from "./components/landing/Ecosystem"
 import { Faq } from "./components/landing/Faq"
 import { FeatureDevLoop } from "./components/landing/FeatureDevLoop"
@@ -23,6 +24,7 @@ export default function HomePage() {
       <FeatureTools />
       <FeatureTypes />
       <FeatureDevLoop />
+      <DurableByDefault />
       <KeepTheRuntime />
       <Ecosystem />
       <Quickstart />

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,3 +1,4 @@
+import { DriveTheModel } from "./components/landing/DriveTheModel"
 import { Ecosystem } from "./components/landing/Ecosystem"
 import { Faq } from "./components/landing/Faq"
 import { FeatureDevLoop } from "./components/landing/FeatureDevLoop"
@@ -17,6 +18,7 @@ export default function HomePage() {
       <Hero />
       <ProofStrip />
       <WhyDawn />
+      <DriveTheModel />
       <FeatureRouting />
       <FeatureTools />
       <FeatureTypes />

--- a/apps/web/content/docs/getting-started.mdx
+++ b/apps/web/content/docs/getting-started.mdx
@@ -4,6 +4,14 @@ Build a typed AI agent in 60 seconds. Dawn is file-system routing for agents —
 
 By the end of this guide you'll have a working deep-research assistant at `/research` that plans sub-questions, searches a local corpus, and writes cited reports — running offline out of the box, live against a real model when you opt in.
 
+<CopyPromptButton
+  variant="docs"
+  label="Copy agent prompt"
+  prompt={`Scaffold a new Dawn app and help me build an agent. Dawn is the TypeScript meta-framework for LangGraph — agents and workflows are file-system routes with route-local tools, generated types, and durable threads. Run \`pnpm create dawn-ai-app\` to scaffold, then read https://dawnai.org/AGENTS.md and https://dawnai.org/llms-full.txt for the full framework reference before writing any routes.`}
+/>
+
+Prefer to build with a coding agent? Copy the prompt above and paste it into Claude Code, Cursor, or your agent of choice.
+
 ## 1. Install
 
 ```bash

--- a/apps/web/content/docs/mental-model.mdx
+++ b/apps/web/content/docs/mental-model.mdx
@@ -25,6 +25,8 @@ A *route* is a folder under `src/app/`. The folder path becomes the agent endpoi
 
 A *route entry* is the route's default behavior. Each route has exactly one `index.ts` that exports an `agent`, a `workflow`, a `graph`, or a `chain`. Pick the shape that fits the problem; mix shapes across routes in the same project.
 
+**Two ways to drive the model.** Export an `agent` when the model should decide what to do — it picks tools at runtime and can pause for a human. Export a `workflow` when you own the order of operations — a deterministic, typed async function. Same routing, same types, same dev loop; you choose who's in charge. Drop to `graph` or `chain` for raw LangGraph anytime. See [Agents](/docs/agents) and [Routes](/docs/routes) for each shape.
+
 *Tools* are TypeScript files in a route's `tools/` directory. Each tool is a default-exported async function. Dawn reads each tool's parameter type at build time and turns it into a JSON schema. Agents call tools by name; the model picks when.
 
 *State* is an optional typed shape declared in `state.ts` next to the route. Dynamic segments — `[tenant]`, `[...rest]` — are preserved in the route id and generated route metadata; callers pass the corresponding values in the JSON input they send to the runtime.
@@ -74,6 +76,14 @@ Each arrow is real code:
 7. **Typed output.** The route returns a typed value. Dawn streams or returns it depending on the call (`runs/wait` vs `runs/stream` on the thread).
 
 Runs execute on a thread. Between turns, Dawn checkpoints the LangGraph state to SQLite under `.dawn/checkpoints.sqlite`. Threads survive a `dawn dev` restart — a run that resumes after a human-in-the-loop interrupt picks up exactly where it left off.
+
+<Callout>
+  **Durable by default.** Every Dawn app ships a working checkpointer and thread store — no
+  setup. Threads survive a `dawn dev` restart, and an `agent` route that pauses for human input
+  resumes exactly where it left off. LangGraph defines the checkpoint interface; Dawn ships the
+  default implementation (`@dawn-ai/sqlite-storage`), so durability is the path of least
+  resistance — not a wiring task.
+</Callout>
 
 ## Build vs runtime
 

--- a/apps/web/content/docs/mental-model.mdx
+++ b/apps/web/content/docs/mental-model.mdx
@@ -75,7 +75,7 @@ Each arrow is real code:
 6. **Tool calls.** Tools called by name are typechecked against the schemas Dawn generated at build time. The `searchCorpus` tool searches the bundled corpus; `readDoc` reads a document in full; the model picks when to call each.
 7. **Typed output.** The route returns a typed value. Dawn streams or returns it depending on the call (`runs/wait` vs `runs/stream` on the thread).
 
-Runs execute on a thread. Between turns, Dawn checkpoints the LangGraph state to SQLite under `.dawn/checkpoints.sqlite`. Threads survive a `dawn dev` restart — a run that resumes after a human-in-the-loop interrupt picks up exactly where it left off.
+Runs execute on a thread. Between turns, Dawn checkpoints the LangGraph state to SQLite under `.dawn/checkpoints.sqlite`.
 
 <Callout>
   **Durable by default.** Every Dawn app ships a working checkpointer and thread store — no

--- a/apps/web/mdx-components.tsx
+++ b/apps/web/mdx-components.tsx
@@ -1,4 +1,5 @@
 import type { MDXComponents } from "mdx/types"
+import { CopyPromptButton } from "./app/components/CopyPromptButton"
 import { RelatedCards } from "./app/components/docs/RelatedCards"
 import { Callout } from "./app/components/mdx/Callout"
 import { InlineCode, Pre, RehypeFigure } from "./app/components/mdx/CodeBlock"
@@ -15,6 +16,7 @@ export function useMDXComponents(components: MDXComponents): MDXComponents {
     Tabs,
     Tab,
     RelatedCards,
+    CopyPromptButton,
     h1: ({ children }) => (
       <h1
         className="font-display text-4xl md:text-5xl font-semibold text-ink mb-6 tracking-tight"

--- a/docs/superpowers/plans/2026-06-19-positioning-messaging-refresh.md
+++ b/docs/superpowers/plans/2026-06-19-positioning-messaging-refresh.md
@@ -1,0 +1,572 @@
+# Positioning & Messaging Refresh Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Unify Dawn's positioning across the README/npm, landing page, and docs — leaning into durable-by-default and surfacing the workflow/agent route duality — without changing any runtime behavior.
+
+**Architecture:** Copy + two new static landing-section React components. Four canonical messaging constants (M1–M4, from the design spec) are reused verbatim across surfaces. The website hero headline is preserved; durability and the route-shape duality are layered in as new sections + a hero subhead tweak. The unused `CopyPromptButton` is wired into the hero and registered for docs. No source/runtime code under `packages/*/src` changes.
+
+**Tech Stack:** Markdown (README/docs), MDX (`apps/web/content/docs`), React + Tailwind (Next.js `apps/web`), Biome, `next build`, `tsc --noEmit`, `node scripts/check-docs.mjs`, `pnpm pack:check`.
+
+**Design spec:** `docs/superpowers/specs/2026-06-19-positioning-messaging-refresh-design.md`
+
+**Testing note:** This is a copy/marketing-component change. There is no meaningful unit-test surface — do **not** invent render tests for static copy. Verification is: the affected workspace typechecks, lints, and builds; the docs/link gate and pack check pass; and grep guardrails confirm the accuracy constraints. Those gates are Task 6.
+
+**Canonical constants (use verbatim):**
+
+- **M4 (coding-agent scaffold prompt):**
+  `Scaffold a new Dawn app and help me build an agent. Dawn is the TypeScript meta-framework for LangGraph — agents and workflows are file-system routes with route-local tools, generated types, and durable threads. Run \`pnpm create dawn-ai-app\` to scaffold, then read https://dawnai.org/AGENTS.md and https://dawnai.org/llms-full.txt for the full framework reference before writing any routes.`
+
+---
+
+## Task 1: Root README + Tier-1 npm READMEs — unified messaging
+
+**Files:**
+- Modify: `README.md`
+- Modify: `packages/sdk/README.md`
+- Modify: `packages/cli/README.md`
+- Modify: `packages/create-dawn-app/README.md`
+- Modify: `packages/langchain/README.md`
+
+- [ ] **Step 1: Replace the root README tagline (line 11)**
+
+Replace this exact line:
+
+```md
+The TypeScript meta-framework for LangGraph. Author AI agents and workflows as filesystem routes, get end-to-end types and a local dev server for free, and deploy to LangSmith with one command.
+```
+
+with (M1):
+
+```md
+Build LangGraph agents like Next.js apps. Dawn is the TypeScript meta-framework for LangGraph — author AI agents and workflows as filesystem routes with route-local tools, generated types, durable threads, and an HMR dev server. Keep the runtime, drop the boilerplate.
+```
+
+- [ ] **Step 2: Add durability + duality to the root README "Why Dawn?" list**
+
+In `README.md`, the `## Why Dawn?` list currently has four bullets ending with the `**Typed end to end (TypeScript).**` bullet. Insert these two new bullets immediately after the `**Typed end to end (TypeScript).**` bullet:
+
+```md
+- **Durable by default.** Every Dawn app ships a working SQLite checkpointer and thread store — no setup. Threads survive a `dawn dev` restart, and an agent that pauses for human input resumes exactly where it left off. LangGraph defines the checkpoint interface; Dawn ships the default implementation.
+- **Two ways to drive the model.** A route exports one of `agent` (LLM picks tools at runtime, can pause for a human), `workflow` (deterministic typed async function when you own the order), `graph`, or `chain`. Same routing, same types, same dev loop — you choose who's in charge.
+```
+
+- [ ] **Step 3: Realign each Tier-1 package README opening sentence**
+
+Apply these exact replacements (one descriptive sentence each; do not touch the rest of these files):
+
+`packages/sdk/README.md` — replace:
+
+```md
+The author-facing TypeScript SDK for Dawn, the meta-framework for LangGraph. Use it to declare AI agent routes, define request middleware, and type the runtime context, tools, and route metadata that the Dawn CLI consumes. Ships small runtime helpers (`agent()`, `defineMiddleware()`, `allow()`, `reject()`, `isDawnAgent()`) alongside the type primitives — it is the canonical entry point for authoring Dawn routes.
+```
+
+with:
+
+```md
+The author-facing TypeScript SDK for Dawn, the meta-framework for LangGraph that lets you build LangGraph agents like Next.js apps. Use it to declare AI agent and workflow routes, define request middleware, and type the runtime context, tools, and route metadata that the Dawn CLI consumes. Ships small runtime helpers (`agent()`, `defineMiddleware()`, `allow()`, `reject()`, `isDawnAgent()`) alongside the type primitives — it is the canonical entry point for authoring Dawn routes.
+```
+
+`packages/cli/README.md` — replace:
+
+```md
+The `dawn` CLI for Dawn, the TypeScript meta-framework for LangGraph — a local development runtime, route execution, validation and typegen, and the build step that produces LangSmith deployment artifacts. It is the primary tool for working on a Dawn agent app from first scaffold through deploy.
+```
+
+with:
+
+```md
+The `dawn` CLI for Dawn, the TypeScript meta-framework for LangGraph that lets you build LangGraph agents like Next.js apps — a local HMR development runtime with durable threads, route execution, validation and typegen, and the build step that produces LangSmith deployment artifacts. It is the primary tool for working on a Dawn agent app from first scaffold through deploy.
+```
+
+`packages/create-dawn-app/README.md` — replace:
+
+```md
+Scaffold a new Dawn app — the fastest way to start building TypeScript AI agents on LangGraph. Generates a working application from the supported starter templates with Dawn's canonical `src/app` route layout, an `agent()` route, and the Dawn packages wired up for local development.
+```
+
+with:
+
+```md
+Scaffold a new Dawn app — the fastest way to start building LangGraph agents like Next.js apps. Generates a working application from the supported starter templates with Dawn's canonical `src/app` route layout, an `agent()` route, durable threads, and the Dawn packages wired up for local development.
+```
+
+`packages/langchain/README.md` — replace:
+
+```md
+LangChain backend adapters for Dawn, the TypeScript meta-framework for LangGraph. Dawn uses this package to materialize `chain` routes and provider-aware `agent` routes — handling tool conversion, streaming, and retry.
+```
+
+with:
+
+```md
+LangChain backend adapters for Dawn, the TypeScript meta-framework for LangGraph that lets you build LangGraph agents like Next.js apps. Dawn uses this package to materialize `chain` routes and provider-aware `agent` routes — handling tool conversion, streaming, and retry.
+```
+
+- [ ] **Step 4: Verify the README edits**
+
+Run: `grep -c "Build LangGraph agents like Next.js apps" README.md`
+Expected: `1`
+
+Run: `grep -c "Durable by default\|Two ways to drive the model" README.md`
+Expected: `2`
+
+Run: `grep -rl "build LangGraph agents like Next.js apps\|like Next.js apps" packages/sdk/README.md packages/cli/README.md packages/create-dawn-app/README.md packages/langchain/README.md`
+Expected: all four paths listed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add README.md packages/sdk/README.md packages/cli/README.md packages/create-dawn-app/README.md packages/langchain/README.md
+git commit -m "docs(readme): unify tagline to hero, add durable-by-default + route-shape duality"
+```
+
+---
+
+## Task 2: New landing section — "Two ways to drive the model"
+
+**Files:**
+- Create: `apps/web/app/components/landing/DriveTheModel.tsx`
+- Modify: `apps/web/app/page.tsx`
+
+- [ ] **Step 1: Create the `DriveTheModel` component**
+
+Create `apps/web/app/components/landing/DriveTheModel.tsx` with exactly:
+
+```tsx
+import { Card } from "../ui/Card"
+import { Eyebrow } from "../ui/Eyebrow"
+
+const SHAPES = [
+  {
+    name: "agent",
+    tagline: "Let the model decide.",
+    body: "An LLM-driven route that picks tools at runtime and can pause for a human. Reach for it when you want the model to choose what to do.",
+  },
+  {
+    name: "workflow",
+    tagline: "You own the order.",
+    body: "A deterministic, typed async function. Reach for it when you control the sequence of operations and want predictable, step-by-step execution.",
+  },
+] as const
+
+export function DriveTheModel() {
+  return (
+    <section className="bg-surface border-b border-divider">
+      <div className="max-w-[1200px] mx-auto px-6 md:px-8 py-20 md:py-28">
+        <Eyebrow>Route shapes</Eyebrow>
+        <h2
+          className="font-display font-semibold text-ink mt-3 text-[32px] leading-[38px] md:text-[44px] md:leading-[50px] max-w-[22ch]"
+          style={{
+            fontVariationSettings: "'opsz' 144, 'SOFT' 50, 'WONK' 0",
+            letterSpacing: "-0.01em",
+          }}
+        >
+          Two ways to drive the model.
+        </h2>
+
+        <p className="mt-5 text-lg text-ink-muted leading-[30px] max-w-[60ch]">
+          Same routing, same types, same dev loop — you choose who's in charge. A route's{" "}
+          <code className="text-sm font-mono text-ink bg-page px-1.5 py-0.5 rounded border border-divider">
+            index.ts
+          </code>{" "}
+          exports exactly one shape.
+        </p>
+
+        <div className="mt-10 grid sm:grid-cols-2 gap-6">
+          {SHAPES.map((s) => (
+            <Card key={s.name} className="p-6 md:p-7">
+              <code className="text-sm font-mono font-semibold text-accent-saas">{s.name}</code>
+              <p className="mt-3 text-base font-medium text-ink">{s.tagline}</p>
+              <p className="mt-2 text-sm text-ink-muted leading-[22px]">{s.body}</p>
+            </Card>
+          ))}
+        </div>
+
+        <p className="mt-6 text-sm text-ink-dim leading-[22px] max-w-[60ch]">
+          Need raw LangGraph? Export a{" "}
+          <code className="text-xs font-mono text-ink-muted">graph</code> or{" "}
+          <code className="text-xs font-mono text-ink-muted">chain</code> and instantiate anything
+          you want.
+        </p>
+      </div>
+    </section>
+  )
+}
+```
+
+- [ ] **Step 2: Wire it into the landing page**
+
+In `apps/web/app/page.tsx`, add the import (keep imports alphabetical):
+
+```tsx
+import { DriveTheModel } from "./components/landing/DriveTheModel"
+```
+
+Then place `<DriveTheModel />` immediately **after** `<WhyDawn />` and **before** `<FeatureRouting />` in the returned fragment:
+
+```tsx
+      <WhyDawn />
+      <DriveTheModel />
+      <FeatureRouting />
+```
+
+- [ ] **Step 3: Typecheck + lint the web app**
+
+Run: `pnpm --filter web typecheck`
+Expected: exits 0.
+
+Run: `pnpm --filter web lint`
+Expected: exits 0.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/web/app/components/landing/DriveTheModel.tsx apps/web/app/page.tsx
+git commit -m "feat(web): add 'Two ways to drive the model' landing section"
+```
+
+---
+
+## Task 3: New landing section — "Durable by default"
+
+**Files:**
+- Create: `apps/web/app/components/landing/DurableByDefault.tsx`
+- Modify: `apps/web/app/page.tsx`
+
+- [ ] **Step 1: Create the `DurableByDefault` component**
+
+Create `apps/web/app/components/landing/DurableByDefault.tsx` with exactly:
+
+```tsx
+import { Card } from "../ui/Card"
+import { Eyebrow } from "../ui/Eyebrow"
+
+const PAYOFFS = [
+  "Threads survive a dawn dev restart — no lost state between edits.",
+  "Agents that pause for human input resume exactly where they left off.",
+  "A working SQLite checkpointer and thread store ship by default — zero setup.",
+] as const
+
+function CheckIcon() {
+  return (
+    <svg
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      aria-hidden="true"
+      focusable="false"
+      className="w-4 h-4 mt-1 text-accent-saas shrink-0"
+    >
+      <path d="M3 8.5l3.5 3.5L13 5" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  )
+}
+
+export function DurableByDefault() {
+  return (
+    <section className="bg-page border-b border-divider">
+      <div className="max-w-[1200px] mx-auto px-6 md:px-8 py-20 md:py-28">
+        <Eyebrow>Durability</Eyebrow>
+        <h2
+          className="font-display font-semibold text-ink mt-3 text-[32px] leading-[38px] md:text-[44px] md:leading-[50px] max-w-[20ch]"
+          style={{
+            fontVariationSettings: "'opsz' 144, 'SOFT' 50, 'WONK' 0",
+            letterSpacing: "-0.01em",
+          }}
+        >
+          Durable by default.
+        </h2>
+
+        <div className="mt-8 grid lg:grid-cols-[1.2fr_1fr] gap-10 lg:gap-16">
+          <div className="space-y-5 text-lg text-ink-muted leading-[30px] max-w-[58ch]">
+            <p>
+              Every Dawn app ships a working checkpointer and thread store — no setup. Runs
+              checkpoint to SQLite between turns, so threads survive a{" "}
+              <code className="text-sm font-mono text-ink bg-surface px-1.5 py-0.5 rounded border border-divider">
+                dawn dev
+              </code>{" "}
+              restart and an agent that pauses for human input resumes exactly where it left off.
+            </p>
+            <p>
+              LangGraph defines the checkpoint interface; Dawn ships the default implementation. So
+              durability is the path of least resistance — not a wiring task.
+            </p>
+          </div>
+
+          <Card className="p-6 md:p-7">
+            <ul className="space-y-3">
+              {PAYOFFS.map((line) => (
+                <li key={line} className="flex items-start gap-2.5 text-sm text-ink leading-[22px]">
+                  <CheckIcon />
+                  <span>{line}</span>
+                </li>
+              ))}
+            </ul>
+          </Card>
+        </div>
+      </div>
+    </section>
+  )
+}
+```
+
+> **Accuracy guardrail (from the spec):** the "resumes after human input" line is an
+> agent-route property. Do not add copy here implying `workflow`/`graph`/`chain` routes
+> are interrupt-resumable.
+
+- [ ] **Step 2: Wire it into the landing page**
+
+In `apps/web/app/page.tsx`, add the import (keep imports alphabetical):
+
+```tsx
+import { DurableByDefault } from "./components/landing/DurableByDefault"
+```
+
+Then place `<DurableByDefault />` immediately **after** `<FeatureDevLoop />` and **before** `<KeepTheRuntime />`:
+
+```tsx
+      <FeatureDevLoop />
+      <DurableByDefault />
+      <KeepTheRuntime />
+```
+
+- [ ] **Step 3: Typecheck + lint the web app**
+
+Run: `pnpm --filter web typecheck`
+Expected: exits 0.
+
+Run: `pnpm --filter web lint`
+Expected: exits 0.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/web/app/components/landing/DurableByDefault.tsx apps/web/app/page.tsx
+git commit -m "feat(web): add 'Durable by default' landing section"
+```
+
+---
+
+## Task 4: Hero — durable-threads subhead + wire the paste-prompt CTA
+
+**Files:**
+- Modify: `apps/web/app/components/landing/Hero.tsx`
+
+- [ ] **Step 1: Add the prompt constant and import**
+
+In `apps/web/app/components/landing/Hero.tsx`, add this import alongside the existing `CopyCommand` import:
+
+```tsx
+import { CopyPromptButton } from "../CopyPromptButton"
+```
+
+Then add this constant directly below the existing `ROUTE_CODE` constant:
+
+```tsx
+const HERO_PROMPT = `Scaffold a new Dawn app and help me build an agent. Dawn is the TypeScript meta-framework for LangGraph — agents and workflows are file-system routes with route-local tools, generated types, and durable threads. Run \`pnpm create dawn-ai-app\` to scaffold, then read https://dawnai.org/AGENTS.md and https://dawnai.org/llms-full.txt for the full framework reference before writing any routes.`
+```
+
+- [ ] **Step 2: Add "durable threads" to the subhead**
+
+Replace this exact text in the subhead `<p>`:
+
+```tsx
+              Dawn adds file-system routing, route-local tools, generated types, and HMR to your
+              existing LangGraph.js stack.{" "}
+```
+
+with:
+
+```tsx
+              Dawn adds file-system routing, route-local tools, generated types, durable threads,
+              and HMR to your existing LangGraph.js stack.{" "}
+```
+
+- [ ] **Step 3: Wire the CTA button into the hero actions**
+
+Replace this exact block:
+
+```tsx
+            <div className="mt-8 flex flex-wrap items-center gap-4">
+              <CopyCommand command="pnpm create dawn-ai-app" />
+              <Link
+                href="/docs/getting-started"
+                className="text-sm font-medium text-ink hover:text-accent-saas transition-colors inline-flex items-center gap-1.5"
+              >
+                Read the docs <span aria-hidden="true">→</span>
+              </Link>
+            </div>
+```
+
+with:
+
+```tsx
+            <div className="mt-8 flex flex-wrap items-center gap-4">
+              <CopyCommand command="pnpm create dawn-ai-app" />
+              <CopyPromptButton
+                prompt={HERO_PROMPT}
+                label="Copy agent prompt"
+                ariaLabel="Copy a prompt to scaffold Dawn with your coding agent"
+              />
+              <Link
+                href="/docs/getting-started"
+                className="text-sm font-medium text-ink hover:text-accent-saas transition-colors inline-flex items-center gap-1.5"
+              >
+                Read the docs <span aria-hidden="true">→</span>
+              </Link>
+            </div>
+```
+
+- [ ] **Step 4: Typecheck + lint the web app**
+
+Run: `pnpm --filter web typecheck`
+Expected: exits 0.
+
+Run: `pnpm --filter web lint`
+Expected: exits 0.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/app/components/landing/Hero.tsx
+git commit -m "feat(web): durable-threads subhead + wire paste-prompt CTA into hero"
+```
+
+---
+
+## Task 5: Docs — register the CTA component + promote durability/duality
+
+**Files:**
+- Modify: `apps/web/mdx-components.tsx`
+- Modify: `apps/web/content/docs/getting-started.mdx`
+- Modify: `apps/web/content/docs/mental-model.mdx`
+
+- [ ] **Step 1: Register `CopyPromptButton` for MDX**
+
+In `apps/web/mdx-components.tsx`, add this import next to the other component imports at the top:
+
+```tsx
+import { CopyPromptButton } from "./app/components/CopyPromptButton"
+```
+
+Then add `CopyPromptButton,` to the object returned by `useMDXComponents`, next to the existing `RelatedCards,` entry:
+
+```tsx
+    RelatedCards,
+    CopyPromptButton,
+```
+
+- [ ] **Step 2: Add the docs CTA to Getting Started**
+
+In `apps/web/content/docs/getting-started.mdx`, insert this block immediately after the second intro paragraph (the one beginning "By the end of this guide you'll have a working deep-research assistant") and before the `## 1. Install` heading:
+
+```mdx
+<CopyPromptButton
+  variant="docs"
+  label="Copy agent prompt"
+  prompt={`Scaffold a new Dawn app and help me build an agent. Dawn is the TypeScript meta-framework for LangGraph — agents and workflows are file-system routes with route-local tools, generated types, and durable threads. Run \`pnpm create dawn-ai-app\` to scaffold, then read https://dawnai.org/AGENTS.md and https://dawnai.org/llms-full.txt for the full framework reference before writing any routes.`}
+/>
+
+Prefer to build with a coding agent? Copy the prompt above and paste it into Claude Code, Cursor, or your agent of choice.
+```
+
+- [ ] **Step 3: Add a "Durable by default" callout to the mental model**
+
+In `apps/web/content/docs/mental-model.mdx`, find the paragraph in the "## The runtime" section that begins "Runs execute on a thread. Between turns, Dawn checkpoints the LangGraph state to SQLite". Immediately after that paragraph, insert:
+
+```mdx
+<Callout>
+  **Durable by default.** Every Dawn app ships a working checkpointer and thread store — no
+  setup. Threads survive a `dawn dev` restart, and an `agent` route that pauses for human input
+  resumes exactly where it left off. LangGraph defines the checkpoint interface; Dawn ships the
+  default implementation (`@dawn-ai/sqlite-storage`), so durability is the path of least
+  resistance — not a wiring task.
+</Callout>
+```
+
+- [ ] **Step 4: Add a "Two ways to drive the model" subsection to the mental model**
+
+In `apps/web/content/docs/mental-model.mdx`, find the "## The pieces" section's paragraph that begins "A *route entry* is the route's default behavior. Each route has exactly one `index.ts` that exports an `agent`, a `workflow`, a `graph`, or a `chain`." Immediately after that paragraph, insert:
+
+```mdx
+**Two ways to drive the model.** Export an `agent` when the model should decide what to do — it
+picks tools at runtime and can pause for a human. Export a `workflow` when you own the order of
+operations — a deterministic, typed async function. Same routing, same types, same dev loop; you
+choose who's in charge. Drop to `graph` or `chain` for raw LangGraph anytime. See
+[Agents](/docs/agents) and [Routes](/docs/routes) for each shape.
+```
+
+- [ ] **Step 5: Typecheck + lint + docs gate**
+
+Run: `pnpm --filter web typecheck`
+Expected: exits 0.
+
+Run: `pnpm --filter web lint`
+Expected: exits 0.
+
+Run: `node scripts/check-docs.mjs`
+Expected: exits 0.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web/mdx-components.tsx apps/web/content/docs/getting-started.mdx apps/web/content/docs/mental-model.mdx
+git commit -m "docs(web): register paste-prompt CTA, promote durability + route-shape duality in mental model"
+```
+
+---
+
+## Task 6: Full verification gate
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Build the web app**
+
+Run: `pnpm --filter web build`
+Expected: `next build` completes successfully; the home page and `/docs/getting-started` and `/docs/mental-model` render without errors.
+
+- [ ] **Step 2: Accuracy guardrail — no over-claim on interrupt resumability**
+
+Run:
+```bash
+grep -rniE "(workflow|graph|chain) route.{0,40}(resume|interrupt)" apps/web/app/components/landing apps/web/content/docs README.md
+```
+Expected: no matches (only `agent` routes are described as interrupt-resumable).
+
+- [ ] **Step 3: Confirm the new sections are wired in order**
+
+Run:
+```bash
+grep -nE "WhyDawn|DriveTheModel|FeatureRouting|FeatureDevLoop|DurableByDefault|KeepTheRuntime" apps/web/app/page.tsx
+```
+Expected order of `<...>` usages: `WhyDawn` → `DriveTheModel` → `FeatureRouting` → … → `FeatureDevLoop` → `DurableByDefault` → `KeepTheRuntime`.
+
+- [ ] **Step 4: Confirm the CTA is wired (no longer dead code)**
+
+Run: `grep -rl "CopyPromptButton" apps/web/app/components/landing/Hero.tsx apps/web/mdx-components.tsx`
+Expected: both paths listed.
+
+- [ ] **Step 5: Pack check (packaged READMEs valid)**
+
+Run: `pnpm pack:check`
+Expected: passes. If it fails for a reason unrelated to README content, note it — this plan only touches READMEs among packaged files.
+
+- [ ] **Step 6: Final commit if any fixes were made**
+
+```bash
+git add -A
+git commit -m "docs: verification fixes for positioning & messaging refresh"
+```
+
+(If no fixes were needed, skip this step.)
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** Surface 1 (landing) → Tasks 2, 3, 4. Surface 2 (README + npm) → Task 1. Surface 3 (docs) → Task 5. Constants M1 → Task 1; M2 → Tasks 3 (section) + 5 (callout) + 1 (bullet); M3 → Tasks 2 (section) + 5 (subsection) + 1 (bullet); M4 → Tasks 4 (hero) + 5 (docs). Accuracy guardrail → Task 3 note + Task 6 Step 2. Verification → Task 6.
+- **No placeholders:** every new component is shown in full; every edit is an exact find/replace or a precisely-anchored insertion with complete content.
+- **Type/name consistency:** component names `DriveTheModel` / `DurableByDefault` and the `CopyPromptButton` props (`prompt`, `label`, `variant`, `ariaLabel`) match the existing `CopyPromptButton.tsx` signature; `Card`/`Eyebrow` props match their definitions.
+- **Out of scope (held):** no hero headline rewrite, no Tier-2 README changes, no new docs pages, no `agents.mdx`/`routes.mdx` edits, no brand/OG changes.

--- a/docs/superpowers/specs/2026-06-19-positioning-messaging-refresh-design.md
+++ b/docs/superpowers/specs/2026-06-19-positioning-messaging-refresh-design.md
@@ -1,0 +1,175 @@
+# Positioning & Messaging Refresh — Design
+
+**Date:** 2026-06-19
+**Status:** Approved (design), pending spec review
+**Scope:** Sub-project A of the eve/flue competitive-learnings sequence (items 3 + 4 + 5).
+
+## Goal
+
+Sharpen and unify Dawn's positioning across all three GTM surfaces, foreground
+durability as a headline benefit, and make the workflow-vs-agent route duality
+visible. Bring the README/npm in line with the website's stronger hero, wake the
+unused paste-prompt CTA, and add two landing sections.
+
+This is a **copy + light-component** change. No runtime/source behavior changes.
+
+## Background & grounding
+
+Three competitive learnings from eve (Vercel) and flue (Astro) — see
+`memory/project_competitors_eve_flue.md`:
+
+- **Item 3 (positioning + CTA):** the README tagline (*"The TypeScript
+  meta-framework for LangGraph…"*) is weaker than and inconsistent with the
+  website hero (*"Build LangGraph agents like Next.js apps. / Keep the runtime.
+  Drop the boilerplate."*). The `CopyPromptButton` component exists with
+  `hero`/`docs` variants but is **imported nowhere** — flue's
+  paste-prompt-to-your-coding-agent acquisition tactic is one wiring change away,
+  and `/AGENTS.md` + `llms-full.txt` routes already exist to point it at.
+- **Item 4 (durability):** flue/eve sell durability directly because they *are*
+  the runtime. Dawn deliberately says "not a runtime." Resolution (user
+  decision): **lean in harder**, but honestly. Durability is a real `Dawn owns`
+  deliverable — `mental-model.mdx` and `packages/cli/src/lib/runtime` confirm
+  Dawn ships the default SQLite checkpointer + thread store
+  (`@dawn-ai/sqlite-storage`, `.dawn/checkpoints.sqlite`, `.dawn/threads.sqlite`),
+  so threads survive a `dawn dev` restart and an agent that pauses for human
+  input resumes where it left off (`interruptCapable: kind === "agent"`). The
+  claim is "Dawn makes durability the zero-config default path," NOT "Dawn is the
+  durability runtime" — LangGraph still defines the checkpoint interface.
+- **Item 5 (workflow/agent duality):** a real, shipped route model. A route's
+  `index.ts` exports exactly one of `agent`, `workflow`, `graph`, `chain`
+  (`packages/cli/src/lib/runtime/load-route-kind.ts`). Per `agents.mdx` /
+  `routes.mdx`: **agent** = LLM-driven, picks tools at runtime, can pause for a
+  human; **workflow** = deterministic typed async function when you control the
+  order; **graph/chain** = raw-LangGraph escape hatches. This is flue's
+  Workflows-vs-Agents duality, expressed as one consistent routing/typing/dev-loop
+  model. It is currently buried in a `mental-model.mdx` tl;dr bullet and absent
+  from the landing page.
+
+## Approach
+
+**Approach A — Layer onto the winning hero** (chosen over a durability-forward or
+dual-mode hero rewrite). Keep the hero headline as the anchor; layer durability
+and the duality in as strong secondary messages; unify the README to the hero.
+This preserves existing brand equity and keeps the sharpest line
+(*"Build LangGraph agents like Next.js apps"*) intact while giving durability
+headline-adjacent prominence.
+
+## Canonical messaging constants (reused verbatim across surfaces)
+
+**M1 — Unified lead (README opening, realigned to the hero):**
+> Build LangGraph agents like Next.js apps. Dawn adds file-system routing,
+> route-local tools, generated types, durable threads, and an HMR dev server to
+> your existing LangGraph.js stack — keep the runtime, drop the boilerplate.
+
+**M2 — Durability paragraph ("Durable by default"):**
+> Every Dawn app ships a working checkpointer and thread store — no setup. Runs
+> checkpoint to SQLite between turns, so threads survive a `dawn dev` restart and
+> an agent that pauses for human input resumes exactly where it left off.
+> LangGraph defines the checkpoint interface; Dawn ships the default
+> implementation, so durability is the path of least resistance — not a wiring
+> task.
+
+**M3 — Duality paragraph ("Two ways to drive the model"):**
+> Export an `agent` when the model should decide what to do — it picks tools at
+> runtime and can pause for a human. Export a `workflow` when you own the order
+> of operations — a deterministic, typed async function. Same routing, same
+> types, same dev loop; you choose who's in charge. Drop to `graph` or `chain`
+> for raw LangGraph anytime.
+
+**M4 — Coding-agent scaffold prompt (the CTA payload):**
+> Scaffold a new Dawn app and help me build an agent. Dawn is the TypeScript
+> meta-framework for LangGraph: agents and workflows are file-system routes with
+> route-local tools, generated types, and durable threads. Run
+> `pnpm create dawn-ai-app` to start, then read https://dawnai.org/AGENTS.md and
+> https://dawnai.org/llms-full.txt for the full framework reference before
+> writing any routes.
+
+(M4 wording is finalized during implementation against the live `/AGENTS.md` and
+`llms-full.txt` content; the intent — scaffold + point the agent at the canonical
+machine docs — is fixed here.)
+
+## Surface 1 — Website landing (`apps/web`)
+
+Components live in `apps/web/app/components/landing/`; the order is set in
+`apps/web/app/page.tsx`. New sections follow the existing section conventions
+(`Eyebrow` + display `<h2>` + `text-ink-muted` body; see `WhyDawn.tsx`,
+`KeepTheRuntime.tsx`).
+
+1. **Hero subhead (`Hero.tsx`)** — add `durable threads` to the existing
+   capability list (apply M1's list). Headline unchanged. Add a **secondary CTA**:
+   wire the existing `CopyPromptButton` (`variant="hero"`) next to the
+   `CopyCommand`, copying **M4**. Keep "Read the docs" link.
+2. **New `DurableByDefault.tsx`** — eyebrow "Durability", heading
+   "Durable by default.", body **M2**. Optionally a small `Card` listing the
+   three concrete payoffs (survives dev restart / resumes after human interrupt /
+   zero-config SQLite checkpointer). Insert in `page.tsx` **after
+   `FeatureDevLoop`, before `KeepTheRuntime`** (so "what Dawn does NOT do" still
+   immediately precedes the Ecosystem/Quickstart close).
+3. **New `DriveTheModel.tsx`** — eyebrow "Route shapes", heading
+   "Two ways to drive the model.", body **M3**, with a compact two-column
+   `agent` vs `workflow` comparison and a one-line `graph`/`chain` footnote.
+   Insert in `page.tsx` **after `WhyDawn`, before `FeatureRouting`** (it frames
+   the core model choice before the authoring-feature trio).
+
+Resulting `page.tsx` order: Hero → ProofStrip → WhyDawn → **DriveTheModel** →
+FeatureRouting → FeatureTools → FeatureTypes → FeatureDevLoop →
+**DurableByDefault** → KeepTheRuntime → Ecosystem → Quickstart → Faq → FinalCta.
+
+**Accuracy guardrail:** the "resumes after human interrupt" claim is an
+**agent-route** property (`interruptCapable: kind === "agent"`). Copy must not
+imply workflow/graph/chain routes are interrupt-resumable. Between-turn
+SQLite checkpointing applies to threaded runs generally.
+
+## Surface 2 — README + npm package READMEs
+
+- **Root `README.md`:** replace the current tagline line (line 11) with **M1**.
+  Add durability to the "Why Dawn?" list (a bullet derived from M2) and a short
+  duality note (derived from M3) — either a new bullet or a one-paragraph
+  "Choose your route shape" block above/below the existing
+  "Without Dawn / With Dawn". Keep the existing CTA band, Quickstart, live
+  `dawnai.org/docs` links, and Learn-more list unchanged.
+- **Tier-1 package READMEs** (`packages/sdk`, `packages/cli`,
+  `packages/create-dawn-app`, `packages/langchain`): realign only the opening
+  descriptive sentence to the unified M1 framing (lead with the Next.js analogy
+  / keep the "meta-framework for LangGraph" anchor phrase for SEO), and mention
+  durable threads where natural. Do **not** restructure these READMEs; the
+  CTA band, links, and bodies from the prior GTM refresh stay.
+
+## Surface 3 — Docs (`apps/web/content/docs`)
+
+- **`mental-model.mdx`:** promote the buried duality. Add a short
+  "Two ways to drive the model" subsection (body **M3**) near the existing
+  route-kinds tl;dr, and expand the existing "The runtime" / "Where Dawn ends and
+  LangGraph begins" durability lines into an explicit **"Durable by default"**
+  callout (body **M2**), cross-linking `agents.mdx` and `routes.mdx` (which
+  already define the shapes — no change needed there).
+- No new docs pages; `agents.mdx` and `routes.mdx` already carry accurate
+  per-shape definitions and are the link targets.
+
+## Out of scope (YAGNI)
+
+- No hero **headline** rewrite (Approaches B/C rejected).
+- No new docs pages, no blog post (a launch post can follow separately).
+- No changes to `agents.mdx` / `routes.mdx` content (already accurate).
+- No Tier-2 package README changes.
+- No new brand assets / OG image changes.
+- The bundled-docs/SKILL.md work (item 2) and blueprints (item 1) are separate
+  sub-projects B and C.
+
+## Testing & verification
+
+- `apps/web` builds (`pnpm --filter web build` or repo build) with the two new
+  components and updated `page.tsx`.
+- `node scripts/check-docs.mjs` passes (doc links / retired-domain gate).
+- `pnpm pack:check` passes (packaged READMEs valid).
+- Manual: landing renders both new sections in the specified order; hero
+  "Copy prompt" button copies M4; README tagline matches the hero.
+- Grep guardrail: no copy claims workflow/graph/chain routes resume after a
+  human interrupt.
+
+## Risks
+
+- **Overclaim risk on durability** — mitigated by the accuracy guardrail and by
+  crediting LangGraph with the checkpoint interface in M2.
+- **Live-site copy change** — the hero headline is preserved; changes are
+  additive sections + a subhead list item, minimizing regression surface.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -4,7 +4,7 @@
 
 # @dawn-ai/cli
 
-The `dawn` CLI for Dawn, the TypeScript meta-framework for LangGraph — a local development runtime, route execution, validation and typegen, and the build step that produces LangSmith deployment artifacts. It is the primary tool for working on a Dawn agent app from first scaffold through deploy.
+The `dawn` CLI for Dawn, the TypeScript meta-framework for LangGraph that lets you build LangGraph agents like Next.js apps — a local HMR development runtime with durable threads, route execution, validation and typegen, and the build step that produces LangSmith deployment artifacts. It is the primary tool for working on a Dawn agent app from first scaffold through deploy.
 
 ## Install
 

--- a/packages/create-dawn-app/README.md
+++ b/packages/create-dawn-app/README.md
@@ -4,7 +4,7 @@
 
 # create-dawn-ai-app
 
-Scaffold a new Dawn app — the fastest way to start building TypeScript AI agents on LangGraph. Generates a working application from the supported starter templates with Dawn's canonical `src/app` route layout, an `agent()` route, and the Dawn packages wired up for local development.
+Scaffold a new Dawn app — the fastest way to start building LangGraph agents like Next.js apps. Generates a working application from the supported starter templates with Dawn's canonical `src/app` route layout, an `agent()` route, durable threads, and the Dawn packages wired up for local development.
 
 ## Usage
 

--- a/packages/langchain/README.md
+++ b/packages/langchain/README.md
@@ -4,7 +4,7 @@
 
 # @dawn-ai/langchain
 
-LangChain backend adapters for Dawn, the TypeScript meta-framework for LangGraph. Dawn uses this package to materialize `chain` routes and provider-aware `agent` routes — handling tool conversion, streaming, and retry.
+LangChain backend adapters for Dawn, the TypeScript meta-framework for LangGraph that lets you build LangGraph agents like Next.js apps. Dawn uses this package to materialize `chain` routes and provider-aware `agent` routes — handling tool conversion, streaming, and retry.
 
 `agent()` materialization resolves a LangChain chat model from the route descriptor. Dawn includes `@langchain/openai` for the default/backcompat path and lazy-loads optional provider packages when an agent selects or infers another provider.
 

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -4,7 +4,7 @@
 
 # @dawn-ai/sdk
 
-The author-facing TypeScript SDK for Dawn, the meta-framework for LangGraph. Use it to declare AI agent routes, define request middleware, and type the runtime context, tools, and route metadata that the Dawn CLI consumes. Ships small runtime helpers (`agent()`, `defineMiddleware()`, `allow()`, `reject()`, `isDawnAgent()`) alongside the type primitives — it is the canonical entry point for authoring Dawn routes.
+The author-facing TypeScript SDK for Dawn, the meta-framework for LangGraph that lets you build LangGraph agents like Next.js apps. Use it to declare AI agent and workflow routes, define request middleware, and type the runtime context, tools, and route metadata that the Dawn CLI consumes. Ships small runtime helpers (`agent()`, `defineMiddleware()`, `allow()`, `reject()`, `isDawnAgent()`) alongside the type primitives — it is the canonical entry point for authoring Dawn routes.
 
 ## Install
 


### PR DESCRIPTION
## Summary

Unifies Dawn's positioning across the README/npm, the marketing landing page, and the docs — applying three competitive learnings from eve (Vercel) and flue (Astro). All claims are grounded in shipped behavior; no runtime/source code changes.

- **Unified tagline (item 3).** Root README + Tier-1 package READMEs (`sdk`, `cli`, `create-dawn-app`, `langchain`) now lead with the website hero's line — "Build LangGraph agents like Next.js apps" — instead of the weaker, inconsistent old tagline.
- **Durable by default (item 4).** New `DurableByDefault` landing section + README bullet + a `mental-model` Callout. Honest framing: Dawn ships the default SQLite checkpointer + thread store; **LangGraph defines the checkpoint interface**. Resume-after-human-interrupt is attributed only to `agent` routes.
- **Two ways to drive the model (item 5).** New `DriveTheModel` landing section + README bullet + a `mental-model` subsection surfacing the real `agent` / `workflow` / `graph` / `chain` route-shape duality (previously buried in a tl;dr bullet).
- **Woke the dead paste-prompt CTA (item 3).** The unused `CopyPromptButton` is now wired into the hero and registered for MDX, with a "scaffold Dawn with your coding agent" prompt pointing at the existing `/AGENTS.md` + `llms-full.txt`.

Design spec: `docs/superpowers/specs/2026-06-19-positioning-messaging-refresh-design.md`
Plan: `docs/superpowers/plans/2026-06-19-positioning-messaging-refresh.md`

## Test Plan

- [x] `pnpm --filter web build` — compiles; `/`, `/docs/getting-started`, `/docs/mental-model` prerender
- [x] `pnpm --filter web typecheck` + `lint` — clean
- [x] `node scripts/check-docs.mjs` — passes
- [x] `pnpm pack:check` — passes
- [x] Accuracy guardrail: no copy claims `workflow`/`graph`/`chain` routes resume after a human interrupt (grep-verified)
- [ ] Visual spot-check of the two new landing sections + hero "Copy agent prompt" button on a preview deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)