### PR TITLE
feat: per-route/per-subagent tool scoping

### DIFF
--- a/.changeset/tool-scoping.md
+++ b/.changeset/tool-scoping.md
@@ -1,0 +1,10 @@
+---
+"@dawn-ai/sdk": minor
+"@dawn-ai/core": minor
+"@dawn-ai/cli": minor
+"@dawn-ai/testing": minor
+---
+
+Tool scoping: `agent({ tools: { allow, deny } })` restricts which tools a route's agent may call. `deny` revokes a tool; `allow` grants a withheld capability tool; deny wins.
+
+**Behavior change (pre-1.0):** subagents are now least-privilege by default — a subagent gets only its own route-local `tools/*.ts`; ambient capability tools (`writeFile`, `runBash`, `task`, `writeTodos`, `remember`/`recall`, …) are withheld unless named in `tools.allow`. A subagent that relied on inheriting these must add `tools: { allow: [...] }`. `dawn check` validates scope names. This scopes the tool surface, not execution (not a sandbox).

--- a/apps/web/content/docs/subagents.mdx
+++ b/apps/web/content/docs/subagents.mdx
@@ -43,6 +43,10 @@ task({
 
 The parent receives the child's final text as the tool result.
 
+<Callout type="info" title="Subagents are least-privilege by default">
+  A child route does not inherit the parent's capability tools. By default it sees only its own `tools/*.ts`; ambient tools like `writeFile`, `runBash`, and `task` are withheld unless granted via `tools: { allow: [...] }`. See [Scoping a route's tools](/docs/tools#scoping-a-routes-tools).
+</Callout>
+
 ## Convention discovery
 
 Dawn discovers immediate child routes at:

--- a/apps/web/content/docs/tools.mdx
+++ b/apps/web/content/docs/tools.mdx
@@ -34,6 +34,36 @@ src/
 
 Both sets are merged into the route's `ctx.tools`. When the same tool name exists in both, **the route-local tool shadows the shared one** — in the tree above, `/support` sees its own `escalate` and the shared `lookupOrder`. Put a tool in `src/tools/` when more than one route needs it; keep it in the route's `tools/` when it's specific to that route or you want to override a shared one.
 
+## Scoping a route's tools
+
+By default a top route's agent sees every tool available to it — its own `tools/*.ts`, the shared `src/tools/`, and every capability-contributed tool (`writeFile`, `runBash`, `task`, `writeTodos`, `readSkill`, `remember`/`recall`, …). You can narrow that surface per route by passing `tools: { allow, deny }` to `agent()`:
+
+- **`deny`** revokes a tool — it is never offered to the model.
+- **`allow`** grants a withheld capability tool back into the set.
+- **`deny` wins** when a name appears in both.
+- Omitting `tools` entirely keeps the current behavior (all available tools).
+
+```ts title="src/app/research/index.ts"
+// src/app/research/index.ts — top route: everything except shell
+export default agent({ model: "gpt-5", systemPrompt: "…", tools: { deny: ["runBash"] } })
+```
+
+Scope is enforced at composition time: a withheld tool is never wired into the generated entry, so the model cannot call it. `dawn check` validates the names you reference — an unknown tool name (absent from the route's available set) is a build-time error, so typos fail loud.
+
+### Subagents are least-privilege by default
+
+A subagent does **not** inherit the parent's capability tools. By default it gets only its own route-local `tools/*.ts`; the ambient capability tools (`writeFile`, `runBash`, `task`, `writeTodos`, `remember`/`recall`, …) are withheld unless you name them in `allow`. Grant back exactly what the worker needs:
+
+```ts title="src/app/research/subagents/researcher/index.ts"
+// src/app/research/subagents/researcher/index.ts — read-only worker
+// keeps its own tools/*.ts; writeFile/runBash/task withheld by default; grant readFile:
+export default agent({ model: "gpt-5-mini", systemPrompt: "…", tools: { allow: ["readFile"] } })
+```
+
+<Callout type="warn" title="This scopes the surface, not execution">
+  Tool scoping controls which tools the model can *call* — it does not constrain what an allowed tool may *do* once invoked. A granted `writeFile` can still write anywhere its implementation permits. This is a capability boundary on the tool surface, not a sandbox.
+</Callout>
+
 ## The runtime signature
 
 The full runtime signature accepted by tool discovery is `(input, ctx) => ...`, where `ctx` is `DawnToolContext` from `@dawn-ai/sdk` — carrying `signal`, `middleware?`, and `fs`:

--- a/docs/superpowers/plans/2026-06-20-tool-scoping.md
+++ b/docs/superpowers/plans/2026-06-20-tool-scoping.md
@@ -1,0 +1,667 @@
+# Tool Scoping Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let a route's agent descriptor scope which tools its agent may call — `agent({ tools: { allow?, deny? } })` — and make subagents least-privilege by default (their own route-local tools only; ambient capability tools withheld unless granted).
+
+**Architecture:** A pure `resolveToolScope()` filter in `@dawn-ai/core` runs at the route's tool-composition seam in `execute-route.ts`, after capability + authored tools merge and before the agent/graph is materialized. Tool origin (authored vs capability) is derived from the existing `filePath` marker (`<capability:NAME>`). An `isSubagent` flag threaded through the route-prep path makes the subagent default least-privilege. Enforcement is compose-time (a withheld tool is never offered to the model).
+
+**Tech Stack:** TypeScript (no semicolons, double quotes, 2-space, ESM `.js` import specifiers), pnpm 10.33, Vitest, Biome, changesets. Deterministic agent e2e via `@copilotkit/aimock` (`@dawn-ai/testing`).
+
+**Spec:** `docs/superpowers/specs/2026-06-20-tool-scoping-design.md`
+
+**Conventions:** `pnpm -r build` once at the start. Run `pnpm -r --if-present typecheck` before declaring a task done. `pyenv: cannot rehash` output is harmless. Never run a bare `biome check --write` (mass-reformats) — scope biome to changed files with `--config-path packages/config-biome/biome.json <files>`. Branch `feat/tool-scoping` is already checked out.
+
+**Semantics recap (from the spec):**
+- Base tool set per route: **top route** → all (authored + capability); **subagent** → authored only (capability withheld).
+- `allow` GRANTS named tools into the set (how a subagent opts into a capability tool). `deny` REVOKES named tools. **deny wins.**
+- Unknown names (not in the full available set) throw at composition time so typos fail loud.
+- This scopes the tool *surface*, not execution — not a sandbox.
+
+---
+
+### Task 1: `ToolScope` type on the agent descriptor (`@dawn-ai/sdk`)
+
+**Files:**
+- Modify: `packages/sdk/src/agent.ts`
+- Test: `packages/sdk/test/agent.test.ts` (create if absent; else add a test)
+
+- [ ] **Step 1: Write the failing test.**
+
+Add to `packages/sdk/test/agent.test.ts` (create the file with this content if it doesn't exist):
+
+```ts
+import { describe, expect, test } from "vitest"
+
+import { agent } from "../src/agent.js"
+
+describe("agent() tool scope", () => {
+  test("carries a tools scope through to the descriptor", () => {
+    const a = agent({
+      model: "gpt-5",
+      systemPrompt: "x",
+      tools: { allow: ["readFile"], deny: ["runBash"] },
+    })
+    expect(a.tools).toEqual({ allow: ["readFile"], deny: ["runBash"] })
+  })
+
+  test("omits tools when not provided", () => {
+    const a = agent({ model: "gpt-5", systemPrompt: "x" })
+    expect("tools" in a).toBe(false)
+  })
+})
+```
+
+- [ ] **Step 2: Run it to verify it fails.**
+
+Run: `pnpm --filter @dawn-ai/sdk exec vitest run test/agent.test.ts`
+Expected: FAIL — `tools` is not on the descriptor (type error / `a.tools` undefined and `"tools" in a` already false makes test 2 pass but test 1 fails).
+
+- [ ] **Step 3: Add the type + wire the factory.**
+
+In `packages/sdk/src/agent.ts`, add the `ToolScope` interface (near the other config interfaces, e.g. after `ReasoningConfig`):
+
+```ts
+export interface ToolScope {
+  readonly allow?: readonly string[]
+  readonly deny?: readonly string[]
+}
+```
+
+Add `readonly tools?: ToolScope` to BOTH `DawnAgent` (after `subagents`) and `AgentConfig` (after `subagents`). Then in the `agent()` factory, add the spread alongside the existing optional spreads (e.g. after the `subagents` line):
+
+```ts
+    ...(config.tools !== undefined ? { tools: config.tools } : {}),
+```
+
+Export `ToolScope` from `packages/sdk/src/index.ts` next to the existing `agent`/`isDawnAgent` export:
+
+```ts
+export type { ToolScope } from "./agent.js"
+```
+
+- [ ] **Step 4: Run the test to verify it passes.**
+
+Run: `pnpm --filter @dawn-ai/sdk exec vitest run test/agent.test.ts`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add packages/sdk/src/agent.ts packages/sdk/src/index.ts packages/sdk/test/agent.test.ts
+git commit -m "feat(sdk): tools scope on the agent descriptor"
+```
+
+---
+
+### Task 2: `resolveToolScope` pure function + origin helper (`@dawn-ai/core`, TDD)
+
+**Files:**
+- Create: `packages/core/src/tool-scope.ts`
+- Create: `packages/core/test/tool-scope.test.ts`
+- Modify: `packages/core/src/index.ts` (export)
+
+- [ ] **Step 1: Write the failing tests.**
+
+Create `packages/core/test/tool-scope.test.ts`:
+
+```ts
+import { describe, expect, test } from "vitest"
+
+import { resolveToolScope, toolOrigin } from "../src/tool-scope.js"
+
+const A = (name: string) => ({ name, origin: "authored" as const })
+const C = (name: string) => ({ name, origin: "capability" as const })
+
+describe("toolOrigin", () => {
+  test("capability filePath marker → capability", () => {
+    expect(toolOrigin({ filePath: "<capability:runBash>" })).toBe("capability")
+  })
+  test("real path → authored", () => {
+    expect(toolOrigin({ filePath: "/app/src/app/research/tools/search.ts" })).toBe("authored")
+  })
+})
+
+describe("resolveToolScope", () => {
+  const tools = [A("search"), A("writeNote"), C("readFile"), C("writeFile"), C("runBash"), C("task")]
+
+  test("top route, no scope → all tools", () => {
+    const keep = resolveToolScope(tools, undefined, { isSubagent: false, routeId: "/r" })
+    expect([...keep].sort()).toEqual(["readFile", "runBash", "search", "task", "writeFile", "writeNote"])
+  })
+
+  test("subagent, no scope → authored only (capabilities withheld)", () => {
+    const keep = resolveToolScope(tools, undefined, { isSubagent: true, routeId: "/r" })
+    expect([...keep].sort()).toEqual(["search", "writeNote"])
+  })
+
+  test("subagent allow grants a capability tool, keeps authored", () => {
+    const keep = resolveToolScope(tools, { allow: ["readFile"] }, { isSubagent: true, routeId: "/r" })
+    expect([...keep].sort()).toEqual(["readFile", "search", "writeNote"])
+  })
+
+  test("top route deny revokes", () => {
+    const keep = resolveToolScope(tools, { deny: ["runBash"] }, { isSubagent: false, routeId: "/r" })
+    expect(keep.has("runBash")).toBe(false)
+    expect(keep.has("readFile")).toBe(true)
+  })
+
+  test("deny wins over allow", () => {
+    const keep = resolveToolScope(
+      tools,
+      { allow: ["readFile"], deny: ["readFile"] },
+      { isSubagent: true, routeId: "/r" },
+    )
+    expect(keep.has("readFile")).toBe(false)
+  })
+
+  test("subagent deny can drop an authored tool", () => {
+    const keep = resolveToolScope(tools, { deny: ["writeNote"] }, { isSubagent: true, routeId: "/r" })
+    expect([...keep].sort()).toEqual(["search"])
+  })
+
+  test("unknown name throws with available list", () => {
+    expect(() =>
+      resolveToolScope(tools, { allow: ["serch"] }, { isSubagent: true, routeId: "/research" }),
+    ).toThrow(/unknown tool\(s\): serch/)
+  })
+})
+```
+
+- [ ] **Step 2: Run to verify failure.**
+
+Run: `pnpm --filter @dawn-ai/core exec vitest run test/tool-scope.test.ts`
+Expected: FAIL — module `../src/tool-scope.js` does not exist.
+
+- [ ] **Step 3: Implement `tool-scope.ts`.**
+
+Create `packages/core/src/tool-scope.ts`:
+
+```ts
+import type { ToolScope } from "@dawn-ai/sdk"
+
+export type ToolOrigin = "authored" | "capability"
+
+/**
+ * Capability-contributed tools are tagged with a synthetic filePath
+ * `<capability:NAME>` at composition (see execute-route.ts). Everything else
+ * is authored from the route's tools/*.ts.
+ */
+export function toolOrigin(tool: { readonly filePath: string }): ToolOrigin {
+  return tool.filePath.startsWith("<capability:") ? "capability" : "authored"
+}
+
+export interface ScopeInput {
+  readonly name: string
+  readonly origin: ToolOrigin
+}
+
+/**
+ * Resolve which tool names survive a route's scope.
+ *
+ * Base set: top route → all tools; subagent → authored only (capability
+ * tools withheld). Then `allow` GRANTS named tools into the set, `deny`
+ * REVOKES named tools, and deny wins. Unknown names (absent from the full
+ * available set) throw so authoring typos fail loud at composition time.
+ */
+export function resolveToolScope(
+  tools: readonly ScopeInput[],
+  scope: ToolScope | undefined,
+  context: { readonly isSubagent: boolean; readonly routeId: string },
+): ReadonlySet<string> {
+  const available = new Set(tools.map((t) => t.name))
+  const unknown = [...(scope?.allow ?? []), ...(scope?.deny ?? [])].filter((n) => !available.has(n))
+  if (unknown.length > 0) {
+    throw new Error(
+      `Route "${context.routeId}" tool scope references unknown tool(s): ${unknown.join(", ")}. ` +
+        `Available: ${[...available].sort().join(", ")}.`,
+    )
+  }
+
+  const allow = new Set(scope?.allow ?? [])
+  const deny = new Set(scope?.deny ?? [])
+
+  const keep = new Set<string>()
+  for (const t of tools) {
+    const inBase = context.isSubagent ? t.origin === "authored" : true
+    if (inBase || allow.has(t.name)) keep.add(t.name)
+  }
+  for (const name of deny) keep.delete(name)
+  return keep
+}
+```
+
+Add to `packages/core/src/index.ts` (with the other exports):
+
+```ts
+export { resolveToolScope, toolOrigin } from "./tool-scope.js"
+export type { ScopeInput, ToolOrigin } from "./tool-scope.js"
+```
+
+- [ ] **Step 4: Run to verify pass.**
+
+Run: `pnpm --filter @dawn-ai/core build && pnpm --filter @dawn-ai/core exec vitest run test/tool-scope.test.ts`
+Expected: PASS (9 tests).
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add packages/core/src/tool-scope.ts packages/core/src/index.ts packages/core/test/tool-scope.test.ts
+git commit -m "feat(core): resolveToolScope pure filter + tool origin helper"
+```
+
+---
+
+### Task 3: Thread `isSubagent` through the route-prep path (plumbing, no behavior change)
+
+**Files:**
+- Modify: `packages/cli/src/lib/runtime/execute-route.ts`
+
+Goal: make `prepareRouteExecution` know whether the route is being materialized as a subagent. No filtering yet — pure plumbing, all existing tests stay green.
+
+- [ ] **Step 1: Read the current signatures.**
+
+Read `packages/cli/src/lib/runtime/execute-route.ts`. Locate the option types/signatures of `executeResolvedRoute` (~245), `streamResolvedRoute` (~675), and the internal `prepareRouteExecution` (the function containing the `applyCapabilities` call ~538 and the `tools = [...tools, ...filteredCapTools]` merge ~613). Note their exact option-object shapes.
+
+- [ ] **Step 2: Add an optional `isSubagent` field to each.**
+
+Add `readonly isSubagent?: boolean` to the options interfaces of `executeResolvedRoute`, `streamResolvedRoute`, and `prepareRouteExecution`. Thread it:
+- `executeResolvedRoute` passes `isSubagent: options.isSubagent ?? false` into its `prepareRouteExecution(...)` call.
+- `streamResolvedRoute` does the same.
+- `prepareRouteExecution` receives it (default `false`) and holds it in scope near the tool merge (used in Task 4). For now it is unused — that is expected.
+
+- [ ] **Step 3: Set the flag at the subagent dispatch site.**
+
+In `buildSubagentResolver`, the `graph.invoke` calls `executeResolvedRoute({...})` and `graph.dawnStream` calls `streamResolvedRoute({...})`. Add `isSubagent: true` to BOTH option objects:
+
+```ts
+const result = await executeResolvedRoute({
+  appRoot,
+  input,
+  isSubagent: true,
+  routeFile: route.entryFile,
+  routeId: route.id,
+  routePath: route.pathname,
+})
+```
+```ts
+for await (const chunk of streamResolvedRoute({
+  appRoot,
+  input,
+  isSubagent: true,
+  routeFile: route.entryFile,
+  routeId: route.id,
+  routePath: route.pathname,
+})) {
+```
+
+- [ ] **Step 4: Verify build + existing tests unaffected.**
+
+Run: `pnpm --filter @dawn-ai/cli build && pnpm -r --if-present typecheck`
+Then: `pnpm --filter @dawn-ai/cli exec vitest run test/execute-route*.test.ts test/dev-command.test.ts 2>&1 | tail -5` (or the nearest existing route/runtime tests)
+Expected: build + typecheck clean; existing tests still pass (no behavior change yet).
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add packages/cli/src/lib/runtime/execute-route.ts
+git commit -m "refactor(cli): thread isSubagent through route prep (no behavior change)"
+```
+
+---
+
+### Task 4: Apply scoping at the composition seam + subagent-scoping e2e (the keystone)
+
+**Files:**
+- Modify: `packages/cli/src/lib/runtime/execute-route.ts` (apply the filter after the tool merge ~613)
+- Modify: `packages/testing/src/aimock-runner.ts` (surface offered tool names in `getRequests()`)
+- Create: `test/runtime/fixtures/tool-scope-app/` (fixture app with a scoped subagent) — mirror an existing `test/runtime/fixtures/*` app
+- Create/Modify: `test/runtime/run-tool-scope.test.ts` (aimock e2e)
+
+- [ ] **Step 1: Apply the scope filter in `prepareRouteExecution`.**
+
+Immediately AFTER the line `tools = [...tools, ...filteredCapTools]` (~613), insert:
+
+```ts
+// Scope the final tool surface by the route descriptor's tools: { allow, deny }.
+// Subagents are least-privilege by default (authored tools only; capability
+// tools withheld unless granted). Throws on unknown names (typos fail loud).
+const scopeInputs = tools.map((t) => ({ name: t.name, origin: toolOrigin(t) }))
+const keptToolNames = resolveToolScope(scopeInputs, descriptor?.tools, {
+  isSubagent: isSubagent ?? false,
+  routeId,
+})
+tools = tools.filter((t) => keptToolNames.has(t.name))
+```
+
+Add the import at the top of the file (with the other `@dawn-ai/core` imports):
+
+```ts
+import { resolveToolScope, toolOrigin } from "@dawn-ai/core"
+```
+
+Notes: `descriptor` is the loaded `DawnAgent | undefined` already in scope (~500). `routeId` is in scope (~381). `isSubagent` comes from Task 3. `tools` entries are `DiscoveredToolDefinition` (have `filePath`), so `toolOrigin(t)` works directly. The `resolveToolScope` throw will surface through the existing `prepareRouteExecution` error handling (it returns `{ ok: false, message }` on thrown errors, OR — verify the surrounding try/catch; if there is none around this block, wrap the three lines in try/catch and `return { ok: false, message: formatErrorMessage(e) }` to match the capability-error pattern at ~548).
+
+- [ ] **Step 2: Surface offered tool names in the aimock journal type.**
+
+In `packages/testing/src/aimock-runner.ts`, widen the `getRequests()` return type so tests can read the tools offered to the model. Change the body type from `{ messages?: ... } | null` to also include `tools`:
+
+```ts
+getRequests(): ReadonlyArray<{
+  body: {
+    messages?: Array<{ role: string; content: unknown }>
+    tools?: Array<{ type?: string; function?: { name?: string } }>
+  } | null
+}>
+```
+
+(The underlying LLMock journal already records the full OpenAI request body including `tools`; this only widens the TS type — no runtime change. Verify the wrapped object actually returns `body.tools` by logging once during Step 5; if the wrapper strips it, return the raw journal entry's body instead.)
+
+- [ ] **Step 3: Create the fixture app.**
+
+Create `test/runtime/fixtures/tool-scope-app/` mirroring the structure of an existing runtime fixture (copy `dawn.config.ts`, `package.json`, `tsconfig.json` from a sibling under `test/runtime/fixtures/`). It needs:
+- A `workspace/` directory (so the workspace capability activates and contributes `readFile/writeFile/listDir/runBash`).
+- A top route `src/app/research/index.ts`:
+```ts
+import { agent } from "@dawn-ai/sdk"
+import researcher from "./subagents/researcher/index.js"
+
+export default agent({
+  model: "gpt-4o-mini",
+  systemPrompt: "Research coordinator.",
+  subagents: [researcher],
+})
+```
+- A subagent `src/app/research/subagents/researcher/index.ts`:
+```ts
+import { agent } from "@dawn-ai/sdk"
+
+export default agent({
+  model: "gpt-4o-mini",
+  systemPrompt: "RESEARCHER_SUBAGENT_MARKER read-only researcher.",
+  tools: { allow: ["readFile"] },
+})
+```
+- A route-local tool for the subagent `src/app/research/subagents/researcher/tools/search.ts` (mirror an existing `tools/*.ts` default-export tool with a zod schema).
+
+- [ ] **Step 4: Write the e2e test.**
+
+Create `test/runtime/run-tool-scope.test.ts`. Model the setup on the existing aimock e2e (`test/runtime/run-aimock-e2e.test.ts`) — start aimock, point the app at `OPENAI_BASE_URL`, script a parent turn that calls `task({ subagent: "researcher", input: "find X" })` and a subagent turn that replies. Then assert on the subagent's offered tools:
+
+```ts
+test("subagent is offered only its route-local tools + allowed readFile", async () => {
+  // ...drive the run via the harness so the parent dispatches the researcher subagent...
+  const reqs = aimock.getRequests()
+  // The subagent's request is identifiable by its system prompt marker.
+  const subReq = reqs.find((r) =>
+    r.body?.messages?.some(
+      (m) => m.role === "system" && String(m.content).includes("RESEARCHER_SUBAGENT_MARKER"),
+    ),
+  )
+  expect(subReq).toBeDefined()
+  const offered = (subReq?.body?.tools ?? []).map((t) => t.function?.name).filter(Boolean).sort()
+  expect(offered).toEqual(["readFile", "search"])
+  // The dangerous ambient tools are NOT offered to the least-privilege subagent:
+  expect(offered).not.toContain("writeFile")
+  expect(offered).not.toContain("runBash")
+  expect(offered).not.toContain("task")
+})
+```
+
+If reading offered tools from the journal proves brittle, fall back to asserting behavior: script the subagent to attempt a `writeFile` tool call and assert the run does not execute a write (the tool isn't in its registry) — but prefer the offered-tools assertion above.
+
+- [ ] **Step 5: Build + run the e2e.**
+
+Run: `pnpm -r build && pnpm exec vitest run --config test/runtime/vitest.config.ts test/runtime/run-tool-scope.test.ts`
+Expected: PASS — the researcher is offered exactly `["readFile", "search"]`; `writeFile`/`runBash`/`task` absent. (This proves both the compose-time filter AND the `isSubagent` plumbing end-to-end.) Also run the existing runtime lane to confirm no regression: `pnpm exec vitest run --config test/runtime/vitest.config.ts test/runtime/run-agent-protocol.test.ts 2>&1 | tail -5`.
+
+- [ ] **Step 6: Commit.**
+
+```bash
+git add packages/cli/src/lib/runtime/execute-route.ts packages/testing/src/aimock-runner.ts test/runtime/fixtures/tool-scope-app test/runtime/run-tool-scope.test.ts
+git commit -m "feat(cli): scope tools at composition; least-privilege subagents + e2e"
+```
+
+---
+
+### Task 5: `dawn check` build-time validation of scope names
+
+**Files:**
+- Create: `packages/core/src/capabilities/built-in-tool-names.ts` (static registry of built-in tool names)
+- Modify: `packages/core/src/index.ts` (export it)
+- Create: `packages/cli/src/lib/runtime/collect-tool-scope-errors.ts`
+- Modify: `packages/cli/src/commands/check.ts` (wire it in)
+- Test: `packages/cli/test/check-tool-scope.test.ts`
+
+- [ ] **Step 1: Add the built-in tool-name registry.**
+
+Create `packages/core/src/capabilities/built-in-tool-names.ts`:
+
+```ts
+/**
+ * Names of tools any built-in capability may contribute. Used by `dawn check`
+ * to validate a route's tools scope against the universe of names it could
+ * reference (route-local tools + these). Keep in sync with the built-in
+ * capability markers under capabilities/built-in/.
+ */
+export const BUILT_IN_TOOL_NAMES: readonly string[] = [
+  "readFile",
+  "writeFile",
+  "listDir",
+  "runBash",
+  "task",
+  "write_todos",
+  "readSkill",
+  "remember",
+  "recall",
+]
+```
+
+(Read the built-in marker files under `packages/core/src/capabilities/built-in/` first and make this list exact — add any tool name a marker contributes that's missing.)
+
+Export from `packages/core/src/index.ts`:
+
+```ts
+export { BUILT_IN_TOOL_NAMES } from "./capabilities/built-in-tool-names.js"
+```
+
+- [ ] **Step 2: Write the failing test.**
+
+Create `packages/cli/test/check-tool-scope.test.ts`:
+
+```ts
+import { describe, expect, test } from "vitest"
+
+import { collectToolScopeErrors } from "../src/lib/runtime/collect-tool-scope-errors.js"
+
+// Minimal fake manifest + descriptor-loader injection (mirror the model-id test's style).
+test("flags an unknown tool name in a route's scope", async () => {
+  const errors = await collectToolScopeErrors(
+    {
+      appRoot: "/app",
+      routes: [{ kind: "agent", pathname: "/research", entryFile: "/app/.../index.ts", routeDir: "/app/src/app/research" }],
+    } as never,
+    {
+      loadDescriptor: async () => ({ tools: { allow: ["serch"] } }) as never,
+      routeLocalToolNames: async () => ["search"],
+    },
+  )
+  expect(errors.join("\n")).toMatch(/\/research.*unknown tool.*serch/)
+})
+
+test("accepts a built-in capability tool name", async () => {
+  const errors = await collectToolScopeErrors(
+    {
+      appRoot: "/app",
+      routes: [{ kind: "agent", pathname: "/research", entryFile: "/app/.../index.ts", routeDir: "/app/src/app/research" }],
+    } as never,
+    {
+      loadDescriptor: async () => ({ tools: { allow: ["readFile"] } }) as never,
+      routeLocalToolNames: async () => ["search"],
+    },
+  )
+  expect(errors).toEqual([])
+})
+```
+
+- [ ] **Step 3: Run to verify failure.**
+
+Run: `pnpm --filter @dawn-ai/cli exec vitest run test/check-tool-scope.test.ts`
+Expected: FAIL — module does not exist.
+
+- [ ] **Step 4: Implement `collect-tool-scope-errors.ts`.**
+
+Create `packages/cli/src/lib/runtime/collect-tool-scope-errors.ts`. Use the injected-dependency shape above so it's unit-testable (mirror how `collectUnknownModelIdWarnings` loads descriptors via `normalizeRouteModule`, but accept `loadDescriptor`/`routeLocalToolNames` injectors with real defaults):
+
+```ts
+import { BUILT_IN_TOOL_NAMES } from "@dawn-ai/core"
+import { isDawnAgent } from "@dawn-ai/sdk"
+import type { RouteManifest } from "@dawn-ai/core"
+
+import { discoverToolDefinitions } from "./tool-discovery.js"
+import { normalizeRouteModule } from "./warn-unknown-model-ids.js" // or wherever it's exported
+
+interface Deps {
+  loadDescriptor: (entryFile: string, appRoot: string) => Promise<{ tools?: { allow?: readonly string[]; deny?: readonly string[] } } | undefined>
+  routeLocalToolNames: (appRoot: string, routeDir: string) => Promise<readonly string[]>
+}
+
+const defaultDeps: Deps = {
+  loadDescriptor: async (entryFile, appRoot) => {
+    try {
+      const m = await normalizeRouteModule(entryFile, appRoot)
+      return isDawnAgent(m.entry) ? (m.entry as { tools?: never }) : undefined
+    } catch {
+      return undefined
+    }
+  },
+  routeLocalToolNames: async (appRoot, routeDir) => {
+    const defs = await discoverToolDefinitions({ appRoot, routeDir })
+    return defs.map((d) => d.name)
+  },
+}
+
+export async function collectToolScopeErrors(
+  manifest: RouteManifest,
+  deps: Deps = defaultDeps,
+): Promise<readonly string[]> {
+  const errors: string[] = []
+  for (const route of manifest.routes) {
+    if (route.kind !== "agent") continue
+    const descriptor = await deps.loadDescriptor(route.entryFile, manifest.appRoot)
+    const scope = descriptor?.tools
+    if (!scope || (!scope.allow && !scope.deny)) continue
+    const available = new Set([
+      ...(await deps.routeLocalToolNames(manifest.appRoot, route.routeDir)),
+      ...BUILT_IN_TOOL_NAMES,
+    ])
+    const unknown = [...(scope.allow ?? []), ...(scope.deny ?? [])].filter((n) => !available.has(n))
+    if (unknown.length > 0) {
+      errors.push(
+        `✗ ${route.pathname}: tool scope references unknown tool(s): ${unknown.join(", ")}.\n` +
+          `    available: ${[...available].sort().join(", ")}`,
+      )
+    }
+  }
+  return errors
+}
+```
+
+(Adjust imports to the actual export locations — verify `normalizeRouteModule`/`RouteManifest` paths.)
+
+- [ ] **Step 5: Wire into `dawn check` and make it fail the command.**
+
+In `packages/cli/src/commands/check.ts`, after the model-id warnings loop, add:
+
+```ts
+const scopeErrors = await collectToolScopeErrors(manifest)
+if (scopeErrors.length > 0) {
+  throw new CliError(`Invalid tool scope:\n${scopeErrors.join("\n")}`)
+}
+```
+
+Import `collectToolScopeErrors` at the top.
+
+- [ ] **Step 6: Run tests.**
+
+Run: `pnpm --filter @dawn-ai/core build && pnpm --filter @dawn-ai/cli build && pnpm --filter @dawn-ai/cli exec vitest run test/check-tool-scope.test.ts && pnpm -r --if-present typecheck`
+Expected: PASS (2 tests); typecheck clean.
+
+- [ ] **Step 7: Commit.**
+
+```bash
+git add packages/core/src/capabilities/built-in-tool-names.ts packages/core/src/index.ts packages/cli/src/lib/runtime/collect-tool-scope-errors.ts packages/cli/src/commands/check.ts packages/cli/test/check-tool-scope.test.ts
+git commit -m "feat(cli): dawn check validates tool scope names"
+```
+
+---
+
+### Task 6: Docs + changeset + full verification + PR
+
+**Files:**
+- Modify: `apps/web/content/docs/tools.mdx` (or the nearest tools/subagents doc) — add a "Tool scoping" section
+- Create: `.changeset/tool-scoping.md`
+
+- [ ] **Step 1: Document the feature.**
+
+Add a "Scoping a route's tools" section to `apps/web/content/docs/tools.mdx` (and a cross-link from the subagents doc). Cover: `agent({ tools: { allow, deny } })`; `deny` revokes, `allow` grants withheld capability tools, deny wins; the **subagent least-privilege default** (route-local tools only; `writeFile`/`runBash`/`task` withheld unless allowed); and a plain caveat that this scopes the tool *surface*, not execution (not a sandbox). Include the two authoring examples from the spec. Build docs: `pnpm --filter @dawn-ai/web build` (revert any `apps/web/next-env.d.ts` churn).
+
+- [ ] **Step 2: Changeset (flag the breaking subagent behavior).**
+
+Create `.changeset/tool-scoping.md`:
+
+```md
+---
+"@dawn-ai/sdk": minor
+"@dawn-ai/core": minor
+"@dawn-ai/cli": minor
+"@dawn-ai/testing": minor
+---
+
+Tool scoping: `agent({ tools: { allow, deny } })` restricts which tools a route's agent may call. `deny` revokes a tool; `allow` grants a withheld capability tool; deny wins.
+
+**Behavior change (pre-1.0):** subagents are now least-privilege by default — a subagent gets only its own route-local `tools/*.ts`; ambient capability tools (`writeFile`, `runBash`, `task`, `write_todos`, `remember`/`recall`, …) are withheld unless named in `tools.allow`. A subagent that relied on inheriting these must add `tools: { allow: [...] }`. `dawn check` validates scope names. This scopes the tool surface, not execution (not a sandbox).
+```
+
+- [ ] **Step 3: Full verification.**
+
+Run, and report each:
+```
+pnpm -r build
+pnpm -r --if-present typecheck
+pnpm lint
+pnpm test
+pnpm verify:harness
+```
+Expected: all green. (`pnpm test` includes the new sdk/core/cli unit tests; `verify:harness` exercises the generated-app lanes — the new `@dawn-ai/core`/`@dawn-ai/sdk` changes publish to Verdaccio automatically, no harness edits needed.) Fix anything red before proceeding.
+
+- [ ] **Step 4: Commit, push, PR.**
+
+```bash
+git add apps/web/content/docs/tools.mdx .changeset/tool-scoping.md
+git commit -m "docs: tool scoping + changeset"
+git push -u origin feat/tool-scoping
+gh pr create --base main --title "feat: per-route/per-subagent tool scoping" --body "$(cat <<'EOF'
+Adds `agent({ tools: { allow, deny } })` to scope a route's tool surface, and makes **subagents least-privilege by default** (route-local tools only; ambient capability tools withheld unless granted). Compose-time enforcement via a pure `resolveToolScope` filter; `dawn check` validates scope names. Tool-surface scoping, not an execution sandbox.
+
+Spec: docs/superpowers/specs/2026-06-20-tool-scoping-design.md
+Plan: docs/superpowers/plans/2026-06-20-tool-scoping.md
+
+**Breaking (pre-1.0):** subagents relying on inherited writeFile/runBash/task must add tools.allow.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 5: Watch CI to green.**
+
+Run: `gh run watch <id> --exit-status` for the PR's CI run. Expected: `validate` green (incl. `verify:harness`). Investigate any failure; the per-merge Release run is unaffected (no publish without a Version PR).
+
+---
+
+## Self-review notes (author)
+
+- **Spec coverage:** descriptor type (T1) ✓; pure filter + origin + semantics incl. deny-wins + unknown-throws (T2) ✓; subagent least-privilege default via `isSubagent` (T3+T4) ✓; compose-time enforcement at the merge seam (T4) ✓; build-time validation (T5) ✓; honest "not a sandbox" framing (T6 docs + changeset) ✓; migration note (T6 changeset + dawn-check) ✓; e2e subagent-scoping headline test (T4) ✓.
+- **Out-of-scope** items (rate limits, approval, arg constraints, patterns/categories, MCP filtering, sandboxing) are intentionally absent.
+- **Risk to watch during execution:** (1) `prepareRouteExecution`'s exact internal name/shape — Task 3 step 1 says read it first; (2) whether the aimock wrapper actually returns `body.tools` (Task 4 step 2 has a verify-and-fallback note); (3) the `normalizeRouteModule`/`RouteManifest` import paths in Task 5 — verify before relying.

--- a/docs/superpowers/specs/2026-06-20-tool-scoping-design.md
+++ b/docs/superpowers/specs/2026-06-20-tool-scoping-design.md
@@ -1,0 +1,178 @@
+# Per-route / per-subagent tool scoping (Design)
+
+**Status:** Approved for planning
+**Date:** 2026-06-20
+**Roadmap:** Phase 4 (Richer Authoring Systems) sub-project — *richer tool policies*, first slice: **tool scoping** (which tools a route/subagent may call). Rate limits, per-tool approval, and argument constraints are explicitly deferred to later slices.
+
+## Problem
+
+Dawn auto-wires capability tools by filesystem convention, and the wiring is **app-global, not per-route**. The workspace capability decides to contribute `readFile`/`writeFile`/`listDir`/`runBash` like this (`packages/core/src/capabilities/built-in/workspace.ts:118-124`):
+
+```ts
+detect: async (_routeDir, context) => existsSync(workspaceRoot(context.appRoot)),
+//                ^^^^^^^^^^ route dir ignored — keyed on <appRoot>/workspace/
+```
+
+A **subagent is just another route** (`subagents/<name>/index.ts`). At runtime `applyCapabilities` runs **per route** over every discovered route, so a subagent independently re-detects the same app-global capabilities and ends up with the **full toolbelt** — `writeFile`, `runBash`, and `task` (it can spawn *more* subagents) — even when it's meant to be a focused, read-only worker. There is no way to give a route or subagent *less* than its conventions trigger.
+
+This is a least-privilege gap: blast radius (a confused or prompt-injected subagent can write files / run bash / recurse) and prompt bloat (every unused tool is schema + description in that agent's context).
+
+**Prior art (verified 2026-06-20 from `~/repos/eve`, `~/repos/flue`):** both leading filesystem-first agent frameworks make **subagents least-privilege by default**.
+- **eve (vercel/eve)** auto-wires tools like Dawn, but a *declared subagent inherits nothing* — its `tools/` starts empty; you grant a capability by placing a file. eve's reader verdict: eve *lacks* an "inherit-minus-X" knob and "that's a gap worth filling explicitly in Dawn." eve's real execution least-privilege is a per-agent **sandbox** (network egress policy, `/workspace` fs namespace, no host env).
+- **flue (withastro/flue)** passes tools explicitly (`createAgent(() => ({ tools: [...] }))`); a subagent profile gets **only** `profile.tools ?? []` — parent tools never flow (non-overridable harness rule).
+
+Dawn is the outlier (max-privilege-by-default subagents). Neither competitor has a declarative allow/deny for authored tools — so a declarative scope is a Dawn differentiator, and the natural lever for an *auto-wiring* framework (you can't "pass fewer tools" when tools are ambient).
+
+## Decisions (from brainstorming)
+
+1. **Scope is declared on the route's own agent descriptor** (self-scoping): `agent({ tools: { allow?, deny? } })`. Subagents scope themselves in their own `index.ts`. Uniform across top routes and subagents.
+2. **Model:** `tools: { allow?: readonly string[]; deny?: readonly string[] }`. `deny` **revokes** named tools; `allow` **grants** named capability tools the subagent default withholds; **deny wins** over allow.
+3. **Referencing:** exact tool names only (Set membership). Build-time validation rejects names that don't match any tool available to the route.
+4. **Default posture (the core change):**
+   - **Top route** — unchanged: auto-wires all capability tools + its route-local `tools/*.ts`. `tools.deny` subtracts; `tools.allow` is rarely needed (everything is already granted) and warns if used.
+   - **Subagent** — least-privilege by default: gets **only its own route-local `subagents/<name>/tools/*.ts`**. Ambient capability tools (`writeFile`, `runBash`, `listDir`, `readFile`, `task`, `write_todos`, `remember`/`recall`, …) are **withheld** unless named in `tools.allow`.
+5. **Enforcement:** compose-time filtering — the disallowed tool is never materialized into the agent/graph, so the model is never offered it. No runtime gate.
+6. **Honest scope:** this scopes the tool *surface* (what the model may name). It is **not** an execution sandbox — an allowed tool's actions (fs, network, exec) remain unbounded until Dawn ships a sandbox layer (the Phase-3 gap eve/flue both have). The spec and docs say this plainly; we do not market it as a security boundary.
+
+## Design
+
+### 1. Descriptor type (`@dawn-ai/sdk`, `packages/sdk/src/agent.ts`)
+
+```ts
+export interface ToolScope {
+  readonly allow?: readonly string[]
+  readonly deny?: readonly string[]
+}
+
+export interface DawnAgent {
+  // …existing fields (model, systemPrompt, subagents, retry, …)…
+  readonly tools?: ToolScope
+}
+```
+
+`agent()` passes `tools` through unchanged; `isDawnAgent` is unaffected.
+
+### 2. Tool origin
+
+At composition we already hold two lists: route-local tools from discovery (`DiscoveredToolDefinition`, which carries `scope: "route-local" | "shared"`) and capability tools collected into `capTools` after `applyCapabilities` (`execute-route.ts` ~518). Tag each tool with an **origin**:
+- `authored` — from the route's `tools/*.ts` (discovery; `scope` route-local or shared).
+- `capability` — contributed by a capability marker (workspace, subagents/`task`, planning, memory, …).
+
+Origin drives the subagent default (authored kept, capability withheld). We add the tag at the merge point rather than mutating the shared `DiscoveredToolDefinition` shape (a parallel `Map<name, origin>` or a thin wrapper is sufficient — the plan picks the least-invasive form).
+
+### 3. The pure policy function (`@dawn-ai/core`, new `tool-scope.ts`)
+
+```ts
+export interface ToolScope {
+  readonly allow?: readonly string[]
+  readonly deny?: readonly string[]
+}
+
+export interface ScopeInput {
+  readonly name: string
+  readonly origin: "authored" | "capability"
+}
+
+/**
+ * Filter an assembled tool set by a route's scope.
+ *
+ * Base set:
+ *   - top route  → all tools (authored + capability)
+ *   - subagent   → authored tools only; capability tools withheld
+ * Then: allow GRANTS named (capability) tools into the set; deny REVOKES named
+ * tools; deny wins. Unknown names (not in the full available set) throw so
+ * authoring typos fail loud at build time.
+ *
+ * Returns the names to keep (the caller maps back to tool objects).
+ */
+export function resolveToolScope(
+  tools: readonly ScopeInput[],
+  scope: ToolScope | undefined,
+  context: { readonly isSubagent: boolean; readonly routeId: string },
+): ReadonlySet<string> {
+  const available = new Set(tools.map((t) => t.name))
+  const unknown = [...(scope?.allow ?? []), ...(scope?.deny ?? [])].filter((n) => !available.has(n))
+  if (unknown.length > 0) {
+    throw new Error(
+      `Route "${context.routeId}" tool scope references unknown tool(s): ${unknown.join(", ")}. ` +
+        `Available: ${[...available].sort().join(", ")}.`,
+    )
+  }
+
+  const allow = new Set(scope?.allow ?? [])
+  const deny = new Set(scope?.deny ?? [])
+
+  const keep = new Set<string>()
+  for (const t of tools) {
+    const inBase = context.isSubagent ? t.origin === "authored" : true
+    if (inBase || allow.has(t.name)) keep.add(t.name)
+  }
+  for (const name of deny) keep.delete(name)
+  return keep
+}
+```
+
+Pure, no LangChain, no IO — directly unit-testable. The caller filters the real tool objects by the returned name set.
+
+### 4. Wiring (`packages/cli/src/lib/runtime/execute-route.ts`)
+
+- After `applyCapabilities` and the existing name-uniqueness merge, build the `ScopeInput[]` (authored vs capability), call `resolveToolScope(..., { isSubagent, routeId })`, and keep only the surviving tools before they are materialized into the agent/graph.
+- **`isSubagent`** is threaded through the route-prep path used by `buildSubagentResolver` (~583): a route prepared as a subagent-dispatch target gets `isSubagent: true`; a top-route prep gets `false`. (The same route file prepared as a top route vs as a subagent therefore differs — by design.)
+- The filter sits *after* capability + user-override merge, so `overridable` user-tool overrides compose predictably with scoping.
+
+### 5. Build-time validation (`dawn check` / typegen)
+
+Extend the existing descriptor-validation pass (the model-id descriptor check is the template) to run the same name-check per route: assert every `allow`/`deny` name matches a tool available to that route, applying the subagent base rule so it validates against the real per-route surface. Report cleanly:
+
+```
+✗ /research/subagents/researcher: tool scope references unknown tool "reedDoc"
+    available: readDoc, readFile, runBash, search, task, writeFile
+```
+
+Also surface, as a non-fatal **info during `dawn check`**, any subagent that newly loses capability tools under the default (migration aid — see below).
+
+## Authoring examples
+
+```ts
+// src/app/research/index.ts — top route: everything except shell
+export default agent({ model: "gpt-5", subagents: [researcher], tools: { deny: ["runBash"] } })
+```
+
+```ts
+// src/app/research/subagents/researcher/index.ts — read-only worker
+// default already withholds writeFile/runBash/task; it keeps its own tools/*.ts and we grant readFile
+export default agent({ model: "gpt-5-mini", tools: { allow: ["readFile"] } })
+```
+
+## Error handling / edge cases
+
+- **Unknown tool name** → build-time error (above); at runtime the same throw guards if validation is skipped.
+- **`allow` on a top route** → no-op (base already includes everything); emit a build-time warning ("use `deny` to restrict a top route").
+- **Empty result** (e.g. a subagent with no route-local tools and no `allow`) → a valid no-tools agent; the model simply has no tools.
+- **Deny a tool a capability prompt references** (e.g. planning active but `deny: ["write_todos"]`) → allowed; debug-gated warning; a future lint may flag it.
+- **`task` is a capability tool** → withheld from subagents by default (no recursive spawning unless `allow: ["task"]`). Intended safety property.
+
+## Testing
+
+- **Unit (`tool-scope.test.ts`):** top-route base = all; subagent base = authored-only; `allow` grants a capability into a subagent; `deny` revokes; deny-wins; unknown-name throws; empty-allow / empty-result.
+- **Build validation:** a route with a typo'd scope name fails `dawn check`.
+- **aimock e2e (deterministic, the established pattern) — the headline test:** a `/research` app where the `researcher` subagent has `tools: { allow: ["readFile"] }` — assert the tools offered to the researcher are exactly `{ its route-local tools, readFile }` and that `writeFile`/`runBash`/`task` are **absent**; assert the top route still has the full set minus any `deny`. Reuses the `getRequests()`/journal surface to read offered tools.
+
+## Migration (breaking change)
+
+Subagents that silently relied on inheriting `writeFile`/`runBash`/`task` will lose them and must add `tools: { allow: [...] }`. Dawn is pre-1.0 (AGENTS.md: prefer breaking changes), so this is acceptable. Mitigations: a changeset flagging the behavior change, a docs section, the example scaffold's subagent showing an explicit `allow`, and the `dawn check` info line listing subagents whose capability surface shrank.
+
+## Out of scope (later slices / other features)
+
+- Rate / usage limits, per-tool concurrency.
+- Per-tool approval gating (generalizing the HITL bash gate).
+- Argument-level constraints.
+- Pattern/glob or category tokens in allow/deny (exact names only for v1).
+- MCP/connection tool filtering.
+- **Execution sandboxing** (network/fs/exec isolation) — the complementary least-privilege layer eve/flue have; a separate, larger effort.
+
+## Risks
+
+- **Per-materialization `isSubagent` plumbing** must be correct so a route behaves as a top route when invoked directly and as a subagent when dispatched. Covered by the e2e and by validating the `buildSubagentResolver` path.
+- **Migration surprise** for existing apps with subagents — mitigated by the `dawn check` info line + changeset + docs.
+- **Over-claiming** — must be framed as tool-surface scoping, not a security sandbox.

--- a/packages/cli/src/commands/check.ts
+++ b/packages/cli/src/commands/check.ts
@@ -2,6 +2,7 @@ import { discoverRoutes } from "@dawn-ai/core"
 import type { Command } from "commander"
 
 import { CliError, type CommandIo, formatErrorMessage, writeLine } from "../lib/output.js"
+import { collectToolScopeErrors } from "../lib/runtime/collect-tool-scope-errors.js"
 import { discoverToolDefinitions } from "../lib/runtime/tool-discovery.js"
 import { collectUnknownModelIdWarnings } from "../lib/runtime/warn-unknown-model-ids.js"
 
@@ -40,7 +41,13 @@ export async function runCheckCommand(options: CheckOptions, io: CommandIo): Pro
     for (const warning of warnings) {
       writeLine(io.stdout, `\n${warning}`)
     }
+
+    const scopeErrors = await collectToolScopeErrors(manifest)
+    if (scopeErrors.length > 0) {
+      throw new CliError(`Invalid tool scope:\n${scopeErrors.join("\n")}`)
+    }
   } catch (error) {
+    if (error instanceof CliError) throw error
     throw new CliError(`Validation failed: ${formatErrorMessage(error)}`)
   }
 }

--- a/packages/cli/src/lib/runtime/collect-tool-scope-errors.ts
+++ b/packages/cli/src/lib/runtime/collect-tool-scope-errors.ts
@@ -1,0 +1,58 @@
+import type { RouteManifest } from "@dawn-ai/core"
+import { BUILT_IN_TOOL_NAMES } from "@dawn-ai/core"
+import { isDawnAgent } from "@dawn-ai/sdk"
+
+import { type NormalizedRouteModule, normalizeRouteModule } from "./load-route-kind.js"
+import { discoverToolDefinitions } from "./tool-discovery.js"
+
+interface ToolScopeShape {
+  readonly allow?: readonly string[]
+  readonly deny?: readonly string[]
+}
+
+interface Deps {
+  loadScope: (entryFile: string, appRoot: string) => Promise<ToolScopeShape | undefined>
+  routeLocalToolNames: (appRoot: string, routeDir: string) => Promise<readonly string[]>
+}
+
+const defaultDeps: Deps = {
+  loadScope: async (entryFile, appRoot) => {
+    let normalized: NormalizedRouteModule
+    try {
+      normalized = await normalizeRouteModule(entryFile, appRoot)
+    } catch {
+      return undefined // load failures surfaced elsewhere
+    }
+    if (!isDawnAgent(normalized.entry)) return undefined
+    const entry = normalized.entry as { tools?: ToolScopeShape }
+    return entry.tools
+  },
+  routeLocalToolNames: async (appRoot, routeDir) => {
+    const defs = await discoverToolDefinitions({ appRoot, routeDir })
+    return defs.map((d) => d.name)
+  },
+}
+
+export async function collectToolScopeErrors(
+  manifest: RouteManifest,
+  deps: Deps = defaultDeps,
+): Promise<readonly string[]> {
+  const errors: string[] = []
+  for (const route of manifest.routes) {
+    if (route.kind !== "agent") continue
+    const scope = await deps.loadScope(route.entryFile, manifest.appRoot)
+    if (!scope || (!scope.allow && !scope.deny)) continue
+    const available = new Set([
+      ...(await deps.routeLocalToolNames(manifest.appRoot, route.routeDir)),
+      ...BUILT_IN_TOOL_NAMES,
+    ])
+    const unknown = [...(scope.allow ?? []), ...(scope.deny ?? [])].filter((n) => !available.has(n))
+    if (unknown.length > 0) {
+      errors.push(
+        `✗ ${route.pathname}: unknown tool name(s) in scope: ${unknown.join(", ")}.\n` +
+          `    available: ${[...available].sort().join(", ")}`,
+      )
+    }
+  }
+  return errors
+}

--- a/packages/cli/src/lib/runtime/execute-route.ts
+++ b/packages/cli/src/lib/runtime/execute-route.ts
@@ -22,6 +22,8 @@ import {
   type RouteDefinition,
   type RouteManifest,
   resolveStateFields,
+  resolveToolScope,
+  toolOrigin,
 } from "@dawn-ai/core"
 import {
   Command,
@@ -618,9 +620,24 @@ async function prepareRouteExecution(options: {
       }
     }
 
-    // isSubagent is threaded here for TS4 which will use it to scope tools.
-    void isSubagent
     tools = [...tools, ...filteredCapTools]
+
+    // Scope the merged tool set at the composition seam. Base set: top route
+    // keeps all; a subagent keeps only authored tools (capability tools, e.g.
+    // workspace runBash/writeFile and the dispatch `task`, are withheld unless
+    // explicitly allowed). descriptor.tools.allow grants, .deny revokes, deny
+    // wins. Unknown names throw and surface as a route-prep failure.
+    const scopeInputs = tools.map((t) => ({ name: t.name, origin: toolOrigin(t) }))
+    let keptToolNames: ReadonlySet<string>
+    try {
+      keptToolNames = resolveToolScope(scopeInputs, descriptor?.tools, {
+        isSubagent: isSubagent ?? false,
+        routeId: options.routeId,
+      })
+    } catch (error) {
+      return { message: formatErrorMessage(error), ok: false }
+    }
+    tools = tools.filter((t) => keptToolNames.has(t.name))
     stateFields = stateFields ? [...stateFields, ...capStateFields] : capStateFields
     promptFragments = capPromptFragments
     streamTransformers = capStreamTransformers

--- a/packages/cli/src/lib/runtime/execute-route.ts
+++ b/packages/cli/src/lib/runtime/execute-route.ts
@@ -145,6 +145,7 @@ export async function executeRoute(options: ExecuteRouteOptions): Promise<Runtim
 export async function executeResolvedRoute(options: {
   readonly appRoot: string
   readonly input: unknown
+  readonly isSubagent?: boolean
   readonly middlewareContext?: Readonly<Record<string, unknown>>
   readonly routeFile: string
   readonly routeId: string
@@ -153,6 +154,7 @@ export async function executeResolvedRoute(options: {
 }): Promise<RuntimeExecutionResult> {
   return await executeRouteAtResolvedPath({
     ...options,
+    isSubagent: options.isSubagent ?? false,
     startedAt: Date.now(),
   })
 }
@@ -223,6 +225,7 @@ export async function invokeResolvedRoute(options: {
 export async function* streamResolvedRoute(options: {
   readonly appRoot: string
   readonly input: unknown
+  readonly isSubagent?: boolean
   readonly middlewareContext?: Readonly<Record<string, unknown>>
   /**
    * When set, the agent-adapter receives `Command({resume: resumeDecision})`
@@ -242,7 +245,10 @@ export async function* streamResolvedRoute(options: {
    */
   readonly threadId?: string
 }): AsyncGenerator<StreamChunk> {
-  const prepared = await prepareRouteExecution(options)
+  const prepared = await prepareRouteExecution({
+    ...options,
+    isSubagent: options.isSubagent ?? false,
+  })
 
   if (!prepared.ok) {
     yield { type: "done", output: { error: prepared.message } }
@@ -362,11 +368,13 @@ interface PreparedRouteError {
 
 async function prepareRouteExecution(options: {
   readonly appRoot: string
+  readonly isSubagent?: boolean
   readonly routeFile: string
   readonly routeId: string
   readonly routePath: string
   readonly signal?: AbortSignal
 }): Promise<PreparedRoute | PreparedRouteError> {
+  const { isSubagent = false } = options
   const routeDir = resolve(options.routeFile, "..")
 
   const normalized = await normalizeRouteModule(options.routeFile, options.appRoot)
@@ -610,6 +618,8 @@ async function prepareRouteExecution(options: {
       }
     }
 
+    // isSubagent is threaded here for TS4 which will use it to scope tools.
+    void isSubagent
     tools = [...tools, ...filteredCapTools]
     stateFields = stateFields ? [...stateFields, ...capStateFields] : capStateFields
     promptFragments = capPromptFragments
@@ -661,6 +671,7 @@ async function prepareRouteExecution(options: {
 async function executeRouteAtResolvedPath(options: {
   readonly appRoot: string
   readonly input: unknown
+  readonly isSubagent?: boolean
   readonly middlewareContext?: Readonly<Record<string, unknown>>
   readonly routeFile: string
   readonly routeId: string
@@ -672,7 +683,10 @@ async function executeRouteAtResolvedPath(options: {
   let mode: RuntimeExecutionMode | null = null
 
   try {
-    const prepared = await prepareRouteExecution(options)
+    const prepared = await prepareRouteExecution({
+      ...options,
+      isSubagent: options.isSubagent ?? false,
+    })
 
     if (!prepared.ok) {
       return createRuntimeFailureResult({
@@ -1013,6 +1027,7 @@ function buildSubagentResolver(args: {
         const result = await executeResolvedRoute({
           appRoot,
           input,
+          isSubagent: true,
           routeFile: route.entryFile,
           routeId: route.id,
           routePath: route.pathname,
@@ -1032,6 +1047,7 @@ function buildSubagentResolver(args: {
         for await (const chunk of streamResolvedRoute({
           appRoot,
           input,
+          isSubagent: true,
           routeFile: route.entryFile,
           routeId: route.id,
           routePath: route.pathname,

--- a/packages/cli/test/check-tool-scope.test.ts
+++ b/packages/cli/test/check-tool-scope.test.ts
@@ -1,0 +1,39 @@
+import { expect, test } from "vitest"
+
+import { collectToolScopeErrors } from "../src/lib/runtime/collect-tool-scope-errors.js"
+
+const manifest = {
+  appRoot: "/app",
+  routes: [
+    {
+      kind: "agent",
+      pathname: "/research",
+      entryFile: "/app/src/app/research/index.ts",
+      routeDir: "/app/src/app/research",
+    },
+  ],
+} as never
+
+test("flags an unknown tool name in a route's scope", async () => {
+  const errors = await collectToolScopeErrors(manifest, {
+    loadScope: async () => ({ allow: ["serch"] }),
+    routeLocalToolNames: async () => ["search"],
+  })
+  expect(errors.join("\n")).toMatch(/\/research.*unknown tool.*serch/s)
+})
+
+test("accepts a built-in capability tool name", async () => {
+  const errors = await collectToolScopeErrors(manifest, {
+    loadScope: async () => ({ allow: ["readFile"] }),
+    routeLocalToolNames: async () => ["search"],
+  })
+  expect(errors).toEqual([])
+})
+
+test("ignores routes with no scope", async () => {
+  const errors = await collectToolScopeErrors(manifest, {
+    loadScope: async () => undefined,
+    routeLocalToolNames: async () => ["search"],
+  })
+  expect(errors).toEqual([])
+})

--- a/packages/core/src/capabilities/built-in-tool-names.ts
+++ b/packages/core/src/capabilities/built-in-tool-names.ts
@@ -1,0 +1,22 @@
+/**
+ * Names of tools any built-in capability may contribute. Used by `dawn check`
+ * to validate a route's tools scope against the universe of names it could
+ * reference (route-local tools + these). Keep in sync with the built-in
+ * capability markers under capabilities/built-in/.
+ */
+export const BUILT_IN_TOOL_NAMES: readonly string[] = [
+  // workspace.ts — readFile, writeFile, listDir, runBash
+  "readFile",
+  "writeFile",
+  "listDir",
+  "runBash",
+  // subagents.ts — task
+  "task",
+  // planning.ts — writeTodos
+  "writeTodos",
+  // skills.ts — readSkill
+  "readSkill",
+  // memory.ts — recall, remember
+  "recall",
+  "remember",
+]

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,5 +1,4 @@
 export type { ThreadsStore } from "@dawn-ai/sqlite-storage"
-export { BUILT_IN_TOOL_NAMES } from "./capabilities/built-in-tool-names.js"
 export { createAgentsMdMarker } from "./capabilities/built-in/agents-md.js"
 export { createMemoryMarker } from "./capabilities/built-in/memory.js"
 export { createMemoryMdMarker } from "./capabilities/built-in/memory-md.js"
@@ -8,6 +7,7 @@ export { createPlanningMarker } from "./capabilities/built-in/planning.js"
 export { createSkillsMarker } from "./capabilities/built-in/skills.js"
 export { createSubagentsMarker } from "./capabilities/built-in/subagents.js"
 export { createWorkspaceMarker } from "./capabilities/built-in/workspace.js"
+export { BUILT_IN_TOOL_NAMES } from "./capabilities/built-in-tool-names.js"
 export type {
   AppliedContribution,
   ApplyResult,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,5 @@
 export type { ThreadsStore } from "@dawn-ai/sqlite-storage"
+export { BUILT_IN_TOOL_NAMES } from "./capabilities/built-in-tool-names.js"
 export { createAgentsMdMarker } from "./capabilities/built-in/agents-md.js"
 export { createMemoryMarker } from "./capabilities/built-in/memory.js"
 export { createMemoryMdMarker } from "./capabilities/built-in/memory-md.js"

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -39,6 +39,8 @@ export {
 } from "./discovery/route-segments.js"
 export type { ResolveStateFieldsOptions } from "./state/resolve-state-fields.js"
 export { resolveStateFields } from "./state/resolve-state-fields.js"
+export type { ScopeInput, ToolOrigin } from "./tool-scope.js"
+export { resolveToolScope, toolOrigin } from "./tool-scope.js"
 export type { ExtractToolSchemasOptions } from "./typegen/extract-tool-schema.js"
 export { extractToolSchemasForRoute } from "./typegen/extract-tool-schema.js"
 export type { ExtractToolTypesOptions } from "./typegen/extract-tool-types.js"

--- a/packages/core/src/tool-scope.ts
+++ b/packages/core/src/tool-scope.ts
@@ -1,0 +1,51 @@
+import type { ToolScope } from "@dawn-ai/sdk"
+
+export type ToolOrigin = "authored" | "capability"
+
+/**
+ * Capability-contributed tools are tagged with a synthetic filePath
+ * `<capability:NAME>` at composition (see execute-route.ts). Everything else
+ * is authored from the route's tools/*.ts.
+ */
+export function toolOrigin(tool: { readonly filePath: string }): ToolOrigin {
+  return tool.filePath.startsWith("<capability:") ? "capability" : "authored"
+}
+
+export interface ScopeInput {
+  readonly name: string
+  readonly origin: ToolOrigin
+}
+
+/**
+ * Resolve which tool names survive a route's scope.
+ *
+ * Base set: top route → all tools; subagent → authored only (capability
+ * tools withheld). Then `allow` GRANTS named tools into the set, `deny`
+ * REVOKES named tools, and deny wins. Unknown names (absent from the full
+ * available set) throw so authoring typos fail loud at composition time.
+ */
+export function resolveToolScope(
+  tools: readonly ScopeInput[],
+  scope: ToolScope | undefined,
+  context: { readonly isSubagent: boolean; readonly routeId: string },
+): ReadonlySet<string> {
+  const available = new Set(tools.map((t) => t.name))
+  const unknown = [...(scope?.allow ?? []), ...(scope?.deny ?? [])].filter((n) => !available.has(n))
+  if (unknown.length > 0) {
+    throw new Error(
+      `Route "${context.routeId}" tool scope references unknown tool(s): ${unknown.join(", ")}. ` +
+        `Available: ${[...available].sort().join(", ")}.`,
+    )
+  }
+
+  const allow = new Set(scope?.allow ?? [])
+  const deny = new Set(scope?.deny ?? [])
+
+  const keep = new Set<string>()
+  for (const t of tools) {
+    const inBase = context.isSubagent ? t.origin === "authored" : true
+    if (inBase || allow.has(t.name)) keep.add(t.name)
+  }
+  for (const name of deny) keep.delete(name)
+  return keep
+}

--- a/packages/core/test/tool-scope.test.ts
+++ b/packages/core/test/tool-scope.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, test } from "vitest"
+
+import { resolveToolScope, toolOrigin } from "../src/tool-scope.js"
+
+const A = (name: string) => ({ name, origin: "authored" as const })
+const C = (name: string) => ({ name, origin: "capability" as const })
+
+describe("toolOrigin", () => {
+  test("capability filePath marker → capability", () => {
+    expect(toolOrigin({ filePath: "<capability:runBash>" })).toBe("capability")
+  })
+  test("real path → authored", () => {
+    expect(toolOrigin({ filePath: "/app/src/app/research/tools/search.ts" })).toBe("authored")
+  })
+})
+
+describe("resolveToolScope", () => {
+  const tools = [
+    A("search"),
+    A("writeNote"),
+    C("readFile"),
+    C("writeFile"),
+    C("runBash"),
+    C("task"),
+  ]
+
+  test("top route, no scope → all tools", () => {
+    const keep = resolveToolScope(tools, undefined, { isSubagent: false, routeId: "/r" })
+    expect([...keep].sort()).toEqual([
+      "readFile",
+      "runBash",
+      "search",
+      "task",
+      "writeFile",
+      "writeNote",
+    ])
+  })
+
+  test("subagent, no scope → authored only (capabilities withheld)", () => {
+    const keep = resolveToolScope(tools, undefined, { isSubagent: true, routeId: "/r" })
+    expect([...keep].sort()).toEqual(["search", "writeNote"])
+  })
+
+  test("subagent allow grants a capability tool, keeps authored", () => {
+    const keep = resolveToolScope(
+      tools,
+      { allow: ["readFile"] },
+      { isSubagent: true, routeId: "/r" },
+    )
+    expect([...keep].sort()).toEqual(["readFile", "search", "writeNote"])
+  })
+
+  test("top route deny revokes", () => {
+    const keep = resolveToolScope(
+      tools,
+      { deny: ["runBash"] },
+      { isSubagent: false, routeId: "/r" },
+    )
+    expect(keep.has("runBash")).toBe(false)
+    expect(keep.has("readFile")).toBe(true)
+  })
+
+  test("deny wins over allow", () => {
+    const keep = resolveToolScope(
+      tools,
+      { allow: ["readFile"], deny: ["readFile"] },
+      { isSubagent: true, routeId: "/r" },
+    )
+    expect(keep.has("readFile")).toBe(false)
+  })
+
+  test("subagent deny can drop an authored tool", () => {
+    const keep = resolveToolScope(
+      tools,
+      { deny: ["writeNote"] },
+      { isSubagent: true, routeId: "/r" },
+    )
+    expect([...keep].sort()).toEqual(["search"])
+  })
+
+  test("unknown name throws with available list", () => {
+    expect(() =>
+      resolveToolScope(tools, { allow: ["serch"] }, { isSubagent: true, routeId: "/research" }),
+    ).toThrow(/unknown tool\(s\): serch/)
+  })
+})

--- a/packages/sdk/src/agent.ts
+++ b/packages/sdk/src/agent.ts
@@ -10,6 +10,11 @@ export interface RetryConfig {
   readonly baseDelay?: number
 }
 
+export interface ToolScope {
+  readonly allow?: readonly string[]
+  readonly deny?: readonly string[]
+}
+
 /**
  * Reasoning model tuning. Currently maps to OpenAI's `reasoningEffort`
  * parameter; non-reasoning models silently ignore it.
@@ -34,6 +39,7 @@ export interface DawnAgent {
   readonly reasoning?: ReasoningConfig
   readonly retry?: RetryConfig
   readonly subagents?: readonly DawnAgent[]
+  readonly tools?: ToolScope
   readonly systemPrompt: string
 }
 
@@ -44,6 +50,7 @@ export interface AgentConfig {
   readonly reasoning?: ReasoningConfig
   readonly retry?: RetryConfig
   readonly subagents?: readonly DawnAgent[]
+  readonly tools?: ToolScope
   readonly systemPrompt: string
 }
 
@@ -56,6 +63,7 @@ export function agent(config: AgentConfig): DawnAgent {
     ...(config.retry ? { retry: config.retry } : {}),
     ...(config.description !== undefined ? { description: config.description } : {}),
     ...(config.subagents !== undefined ? { subagents: config.subagents } : {}),
+    ...(config.tools !== undefined ? { tools: config.tools } : {}),
     systemPrompt: config.systemPrompt,
   } as unknown as DawnAgent
 }

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -3,6 +3,7 @@ export type {
   DawnAgent,
   ReasoningConfig,
   RetryConfig,
+  ToolScope,
 } from "./agent.js"
 export { agent, isDawnAgent } from "./agent.js"
 export type { BackendAdapter } from "./backend-adapter.js"

--- a/packages/sdk/test/agent.test.ts
+++ b/packages/sdk/test/agent.test.ts
@@ -82,3 +82,19 @@ describe("agent()", () => {
     expect(descriptor.provider).toBeUndefined()
   })
 })
+
+describe("agent() tool scope", () => {
+  test("carries a tools scope through to the descriptor", () => {
+    const a = agent({
+      model: "gpt-5",
+      systemPrompt: "x",
+      tools: { allow: ["readFile"], deny: ["runBash"] },
+    })
+    expect(a.tools).toEqual({ allow: ["readFile"], deny: ["runBash"] })
+  })
+
+  test("omits tools when not provided", () => {
+    const a = agent({ model: "gpt-5", systemPrompt: "x" })
+    expect("tools" in a).toBe(false)
+  })
+})

--- a/packages/testing/src/aimock-runner.ts
+++ b/packages/testing/src/aimock-runner.ts
@@ -15,7 +15,10 @@ export interface Aimock {
   clearFixtures(): void
   /** All requests the mock has received (aimock's journal). */
   getRequests(): ReadonlyArray<{
-    body: { messages?: Array<{ role: string; content: unknown }> } | null
+    body: {
+      messages?: Array<{ role: string; content: unknown }>
+      tools?: Array<{ type?: string; function?: { name?: string } }>
+    } | null
   }>
   /** Current count of registered fixtures (snapshot point for getRecordingsSince). */
   getFixtureCount(): number
@@ -73,7 +76,10 @@ export async function createAimock(opts: {
     if (newFixtures.length === 0) return []
     const proxyEntries = (
       mock.getRequests() as ReadonlyArray<{
-        body: { messages?: Array<{ role: string; content: unknown }> } | null
+        body: {
+          messages?: Array<{ role: string; content: unknown }>
+          tools?: Array<{ type?: string; function?: { name?: string } }>
+        } | null
         response?: { source?: string }
       }>
     )
@@ -100,7 +106,10 @@ export async function createAimock(opts: {
     },
     getRequests() {
       return mock.getRequests() as ReadonlyArray<{
-        body: { messages?: Array<{ role: string; content: unknown }> } | null
+        body: {
+          messages?: Array<{ role: string; content: unknown }>
+          tools?: Array<{ type?: string; function?: { name?: string } }>
+        } | null
       }>
     },
     getFixtureCount() {

--- a/test/runtime/fixtures/tool-scope-app/dawn.config.ts
+++ b/test/runtime/fixtures/tool-scope-app/dawn.config.ts
@@ -1,0 +1,1 @@
+export default { appDir: "src/app" }

--- a/test/runtime/fixtures/tool-scope-app/package.json
+++ b/test/runtime/fixtures/tool-scope-app/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "tool-scope-app",
+  "private": true,
+  "type": "module"
+}

--- a/test/runtime/fixtures/tool-scope-app/src/app/research/index.ts
+++ b/test/runtime/fixtures/tool-scope-app/src/app/research/index.ts
@@ -1,0 +1,10 @@
+import { agent } from "@dawn-ai/sdk"
+
+// The `researcher` subagent is discovered by convention from
+// ./subagents/researcher (mirrors examples/chat coordinator). We deliberately
+// do NOT also list it in `subagents: [...]` — that would collide with the
+// convention discovery ("duplicate leaf name") in the subagents marker.
+export default agent({
+  model: "gpt-4o-mini",
+  systemPrompt: "Research coordinator.",
+})

--- a/test/runtime/fixtures/tool-scope-app/src/app/research/subagents/researcher/index.ts
+++ b/test/runtime/fixtures/tool-scope-app/src/app/research/subagents/researcher/index.ts
@@ -1,0 +1,7 @@
+import { agent } from "@dawn-ai/sdk"
+
+export default agent({
+  model: "gpt-4o-mini",
+  systemPrompt: "RESEARCHER_SUBAGENT_MARKER read-only researcher.",
+  tools: { allow: ["readFile"] },
+})

--- a/test/runtime/fixtures/tool-scope-app/src/app/research/subagents/researcher/tools/search.ts
+++ b/test/runtime/fixtures/tool-scope-app/src/app/research/subagents/researcher/tools/search.ts
@@ -1,0 +1,4 @@
+/** Search the workspace index for a query and return matching snippets. */
+export default async function search(input: { query: string }): Promise<{ results: string[] }> {
+  return { results: [`stub result for ${input.query}`] }
+}

--- a/test/runtime/run-tool-scope.test.ts
+++ b/test/runtime/run-tool-scope.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Tool-scoping e2e — proves the composition-seam scope filter end-to-end.
+ *
+ * The `research` coordinator route dispatches a `researcher` subagent via the
+ * `task` tool. The subagent declares `tools: { allow: ["readFile"] }`. We assert
+ * the TOOLS OFFERED TO THE MODEL on the subagent's LLM call are exactly
+ * ["readFile", "search"]:
+ *   - `search`   — authored route-local tool (subagents keep authored tools)
+ *   - `readFile` — capability tool, withheld by default for subagents but
+ *                  re-granted via the descriptor's allow-list
+ *   - `writeFile`/`runBash` — capability tools, withheld (not in allow)
+ *   - `task`     — capability tool, withheld (subagents don't dispatch further)
+ *
+ * This exercises BOTH halves of TS4: the compose-time filter
+ * (resolveToolScope/toolOrigin in execute-route.ts) AND the isSubagent plumbing
+ * that flags the child run as a subagent.
+ *
+ * Assertion path: OFFERED-TOOLS (read from the aimock journal's request body
+ * `tools` array). We wire the harness internals inline (typegen → registry →
+ * aimock → streamResolvedRoute) — exactly what createAgentHarness does — so we
+ * retain the aimock handle and can inspect getRequests(). The subagent's LLM
+ * request is identified by its RESEARCHER_SUBAGENT_MARKER system prompt.
+ */
+import { fileURLToPath } from "node:url"
+
+import {
+  __resetMaterializedAgentsForTests,
+  createRuntimeRegistry,
+  runTypegen,
+  streamResolvedRoute,
+} from "@dawn-ai/cli/runtime"
+import { discoverRoutes } from "@dawn-ai/core"
+import { type Aimock, collectRunResult, createAimock, script } from "@dawn-ai/testing"
+import { afterAll, beforeAll, expect, it } from "vitest"
+
+const appRoot = fileURLToPath(new URL("./fixtures/tool-scope-app", import.meta.url))
+
+let aimock: Aimock
+let resolved: { routeFile: string; routeId: string; routePath: string }
+let prevBaseUrl: string | undefined
+let prevKey: string | undefined
+
+beforeAll(async () => {
+  prevBaseUrl = process.env.OPENAI_BASE_URL
+  prevKey = process.env.OPENAI_API_KEY
+
+  aimock = await createAimock({ fixtures: [] })
+  process.env.OPENAI_BASE_URL = aimock.baseUrl
+  process.env.OPENAI_API_KEY = process.env.OPENAI_API_KEY ?? "test-not-used"
+
+  // Generate tool schemas (dev-boot fidelity) so the authored `search` tool is
+  // offered with a schema, then resolve the top route.
+  const manifest = await discoverRoutes({ appRoot })
+  await runTypegen({ appRoot, manifest })
+  const registry = await createRuntimeRegistry(appRoot)
+  const lookup = registry.lookup("/research#agent")
+  if (!lookup) throw new Error("tool-scope-app: route /research#agent not found")
+  resolved = lookup
+}, 120_000)
+
+afterAll(async () => {
+  await aimock.close()
+  if (prevBaseUrl === undefined) delete process.env.OPENAI_BASE_URL
+  else process.env.OPENAI_BASE_URL = prevBaseUrl
+  if (prevKey === undefined) delete process.env.OPENAI_API_KEY
+  else process.env.OPENAI_API_KEY = prevKey
+  __resetMaterializedAgentsForTests()
+})
+
+it("subagents are scoped at composition: researcher offered only authored + allowed tools", async () => {
+  const parentInput = "research the workspace conventions"
+  const childQuestion = "What conventions are documented?"
+
+  // Parent dispatches the researcher subagent; researcher replies. The
+  // dispatcher seeds the child's user message with the `input` passed to
+  // task(), so the second fixture group matches on childQuestion.
+  aimock.addFixtures(
+    script()
+      .user(parentInput)
+      .callsTool("task", { subagent: "researcher", input: childQuestion })
+      .replies("Research complete.")
+      .user(childQuestion)
+      .replies("Conventions: tools are camelCase.")
+      .build(),
+  )
+
+  const stream = streamResolvedRoute({
+    appRoot,
+    input: { messages: [{ role: "user", content: parentInput }] },
+    routeFile: resolved.routeFile,
+    routeId: resolved.routeId,
+    routePath: resolved.routePath,
+    threadId: `t-tool-scope-${Date.now()}`,
+  })
+  const result = await collectRunResult(stream, "t-tool-scope")
+
+  // Sanity: the subagent actually ran (proves dispatch happened).
+  expect(result.subagents.map((s) => s.name)).toContain("researcher")
+
+  const reqs = aimock.getRequests()
+  // Identify the subagent's LLM request by its marker system prompt.
+  const subReq = reqs.find((r) =>
+    r.body?.messages?.some(
+      (m) => m.role === "system" && String(m.content).includes("RESEARCHER_SUBAGENT_MARKER"),
+    ),
+  )
+  expect(subReq).toBeDefined()
+
+  const offered = (subReq?.body?.tools ?? [])
+    .map((t) => t.function?.name)
+    .filter((n): n is string => Boolean(n))
+    .sort()
+
+  expect(offered).toEqual(["readFile", "search"])
+  expect(offered).not.toContain("writeFile")
+  expect(offered).not.toContain("runBash")
+  expect(offered).not.toContain("task")
+}, 120_000)

--- a/test/runtime/vitest.config.ts
+++ b/test/runtime/vitest.config.ts
@@ -30,6 +30,7 @@ export default defineConfig({
     include: [
       "test/runtime/run-runtime-contract.test.ts",
       "test/runtime/run-agent-protocol.test.ts",
+      "test/runtime/run-tool-scope.test.ts",
       "test/runtime/dawn-testing/agent-behavior.test.ts",
     ],
     testTimeout: 240_000,


### PR DESCRIPTION
## What

Adds **tool scoping** to the agent descriptor: `agent({ tools: { allow?, deny? } })` restricts which tools a route's agent may call. `deny` revokes a tool; `allow` grants a withheld capability tool; **deny wins**; omitting `tools` keeps today's behavior for top routes.

**Behavior change (pre-1.0): subagents are now least-privilege by default.** A subagent gets only its own route-local `subagents/<name>/tools/*.ts`; ambient capability tools (`writeFile`, `runBash`, `task`, `writeTodos`, `remember`/`recall`, …) are **withheld** unless named in `tools.allow`. Previously a subagent silently re-detected all app-global capabilities (could write files, run bash, spawn more subagents). This matches eve/flue (both least-privilege-by-default).

Enforcement is **compose-time** — a withheld tool is never offered to the model — via a pure `resolveToolScope` filter at the tool-composition seam. `dawn check` validates scope names (typos fail loud). This scopes the tool *surface*, not execution (not a sandbox).

## How

- `@dawn-ai/sdk`: `ToolScope` type on the descriptor.
- `@dawn-ai/core`: pure `resolveToolScope` + `toolOrigin` (origin derived from the `<capability:NAME>` filePath marker) + `BUILT_IN_TOOL_NAMES`.
- `@dawn-ai/cli`: `isSubagent` threaded through the route-prep path (set in `buildSubagentResolver`); the filter applied after the capability+authored tool merge; `dawn check` validation.
- `@dawn-ai/testing`: `getRequests()` widened to expose offered tool names for the e2e.

Spec: `docs/superpowers/specs/2026-06-20-tool-scoping-design.md` · Plan: `docs/superpowers/plans/2026-06-20-tool-scoping.md`

## Verification

`build`/`typecheck`/`lint` clean; `pnpm test` **885 passed**; `verify:harness` **3/3 lanes**. New unit tests for `resolveToolScope` (9) and `dawn check` (3); a subagent-scoping **aimock e2e** (researcher offered exactly `["readFile","search"]`, `writeFile`/`runBash`/`task` absent) that was false-green-checked (mutating the scope breaks it). Both subagent dispatch paths (`invoke` + `dawnStream`) verified to share the filter seam.

## Follow-ups (non-blocking, from final review)

- Capability **prompt fragments** aren't scope-filtered — a subagent that withholds `task`/`writeTodos` still gets prompt text describing them (the tool is genuinely never offered, but the model may attempt it). Worth filtering fragments to the kept set.
- `BUILT_IN_TOOL_NAMES` (used by `dawn check`) is a hand-maintained static list — a new capability tool must be added or `dawn check` would false-reject a valid scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)