### PR TITLE
chore(release): downgrade tool-scoping changeset to patch (release 0.8.3, not 1.0.0)

### DIFF
--- a/.changeset/tool-scoping.md
+++ b/.changeset/tool-scoping.md
@@ -1,8 +1,8 @@
 ---
-"@dawn-ai/sdk": minor
-"@dawn-ai/core": minor
-"@dawn-ai/cli": minor
-"@dawn-ai/testing": minor
+"@dawn-ai/sdk": patch
+"@dawn-ai/core": patch
+"@dawn-ai/cli": patch
+"@dawn-ai/testing": patch
 ---
 
 Tool scoping: `agent({ tools: { allow, deny } })` restricts which tools a route's agent may call. `deny` revokes a tool; `allow` grants a withheld capability tool; deny wins.


### PR DESCRIPTION
## Why

The pending **Version Packages** PR [#255](https://github.com/cacheplane/dawnai/pull/255) computes **`1.0.0`** for the whole fixed group because the `tool-scoping` changeset is `minor`, and this repo's `fixed` 0.x group escalates any `minor` straight to `1.0.0` (no clean `0.9.0` path). Current published is `0.8.2`. We don't want to declare 1.0 stability mid-Phase-4.

## Change

Downgrade the `tool-scoping` changeset from `minor` → `patch` for all four packages (`@dawn-ai/sdk`/`core`/`cli`/`testing`). After this merges, the changesets action regenerates #255 to compute **`0.8.3`**.

The subagent least-privilege **behavior change still ships** and stays documented in the changeset body. Pre-1.0 this is acceptable (AGENTS.md: prefer breaking changes while < 1.0).

## Next

Merge this → #255 recomputes to 0.8.3 → merge #255 → publish → verify the Release run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)