### PR TITLE
test(harness): resolve packaged-scaffolder deps from the test registry (unblock 0.8.3 publish)

### DIFF
--- a/packages/create-dawn-app/vitest.config.ts
+++ b/packages/create-dawn-app/vitest.config.ts
@@ -13,6 +13,14 @@ export default defineConfig({
   },
   test: {
     environment: "node",
+    // The packaged-scaffolder tests install create-dawn-ai-app at the candidate
+    // version, whose @dawn-ai/* deps aren't on npmjs until this release
+    // publishes. Start an ephemeral Verdaccio registry with the whole workspace
+    // published (same globalSetup as the generated lane) so installPackagedScaffolder
+    // can resolve them locally. Absolute path: a project's globalSetup resolves
+    // relative to the project root, not the repo root.
+    globalSetup: [resolve(rootDir, "../../test/harness/registry-global-setup.ts")],
+    hookTimeout: 180_000,
     include: ["test/**/*.test.ts"],
   },
 })

--- a/test/harness/packaged-app.ts
+++ b/test/harness/packaged-app.ts
@@ -9,6 +9,7 @@ import {
   type DevServerHandle,
   startDevServer,
 } from "../runtime/support/dev-server.ts"
+import { getTestRegistryUrl } from "./local-registry.ts"
 
 const REPO_ROOT = resolve(import.meta.dirname, "../..")
 
@@ -56,7 +57,14 @@ export async function cleanupTrackedTempDirs(registry: TrackedTempDir[]): Promis
 /**
  * Pack the CURRENT create-dawn-ai-app source and install it into a temp installer
  * dir, returning that dir. Lets a standalone test run `pnpm exec create-dawn-ai-app`
- * with the local build (not the published npmjs version). Self-contained: no registry.
+ * with the local build (not the published npmjs version).
+ *
+ * The scaffolder declares `@dawn-ai/devkit` as a runtime dep at the candidate
+ * version, which is NOT on npmjs until AFTER the release publishes — so the
+ * install resolves `@dawn-ai/*` from the ephemeral Verdaccio test registry
+ * (where the lane's globalSetup published the whole workspace), exactly like the
+ * generated lane's external scaffolds. Requires the registry globalSetup to have
+ * run (DAWN_TEST_REGISTRY_URL set); getTestRegistryUrl() throws otherwise.
  */
 export async function installPackagedScaffolder(
   tempRoot: string,
@@ -102,11 +110,14 @@ export async function installPackagedScaffolder(
     "utf8",
   )
 
-  // 4. Install the tarball into installerDir
+  // 4. Install the tarball into installerDir, resolving the scaffolder's
+  //    @dawn-ai/* deps from the ephemeral test registry (the candidate version
+  //    isn't on npmjs until this release publishes).
   await runPackagedCommand({
     args: ["add", tarballPath],
     command: "pnpm",
     cwd: installerDir,
+    env: { npm_config_registry: getTestRegistryUrl() },
   })
 
   return { installerDir }


### PR DESCRIPTION
## Problem

The 0.8.3 Release run (post-#255) failed in **Validate Release Candidate** — `pnpm test` → `packages/create-dawn-app/test/create-app.test.ts`:

```
pnpm add .../create-dawn-ai-app-0.8.3.tgz
ERR_PNPM_NO_MATCHING_VERSION  No matching version found for @dawn-ai/devkit@0.8.3
  The latest release of @dawn-ai/devkit is "0.8.2".
```

`installPackagedScaffolder` (comment: *"Self-contained: no registry"*) installed the candidate-version scaffolder from **real npmjs**, which pulls its lone workspace dep `@dawn-ai/devkit@0.8.3` — **not published until after this very release**. So pre-publish validation can never pass on a version-bump commit. Latent since #247 (the Verdaccio rearchitecture) touched this file; **0.8.3 is the first publish to hit it on a bump commit** (at 0.8.2 the deps already existed on npm).

**Nothing was published** — the gate did its job; npm is still cleanly at 0.8.2.

## Fix

Mirror the generated lane, which already scaffolds external-mode "resolved from the test registry — exactly what a real user runs":

1. Wire the registry `globalSetup` (`test/harness/registry-global-setup.ts`) into the `create-dawn-app` vitest project — starts an ephemeral Verdaccio and publishes the whole workspace at the candidate version.
2. `installPackagedScaffolder` passes `npm_config_registry=<verdaccio>` to the install, so `@dawn-ai/*` resolves locally.

Keeps both tests and all their assertions (the `--dist-tag next` specifier rewriting + internal-mode rejection).

## Verification

`node scripts/test.mjs --project create-dawn-ai-app` → **5/5 pass** (was 2 failed). The install resolves `@dawn-ai/devkit@0.8.3` from Verdaccio — a real fix, since that version isn't on npmjs. Lint + typecheck clean.

## Release note

CI-only change (no `packages/*/src` edit) → no changeset by design, so main stays changeset-free and merging this triggers the Release workflow to **publish 0.8.3** (rather than re-opening a Version PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)