### PR TITLE
test(harness): pin lane installs to the test registry (unblock 0.8.3 publish)

### DIFF
--- a/test/harness/local-registry.test.ts
+++ b/test/harness/local-registry.test.ts
@@ -33,6 +33,11 @@ describe("local-registry", () => {
         args: ["install", "--no-frozen-lockfile"],
         command: "pnpm",
         cwd: dir,
+        // Pin the install onto this registry via npm_config_registry (highest
+        // precedence). The .npmrc alone leaks transitive @dawn-ai/* resolution
+        // to npmjs, which fails mid-release when the candidate is partially
+        // published there.
+        env: { npm_config_registry: registry.url },
       })
 
       const lockfile = await readFile(join(dir, "pnpm-lock.yaml"), "utf8")
@@ -58,6 +63,7 @@ describe("local-registry", () => {
           args: ["install", "--no-frozen-lockfile"],
           command: "pnpm",
           cwd: dir,
+          env: { npm_config_registry: registry.url },
         }),
       ).rejects.toThrow()
     } finally {

--- a/test/harness/registry-global-setup.ts
+++ b/test/harness/registry-global-setup.ts
@@ -20,9 +20,21 @@ export async function setup(): Promise<void> {
     throw err
   }
   process.env[REGISTRY_URL_ENV] = registry.url
+  // Pin every install spawned by this lane onto the test registry. The
+  // scaffolded .npmrc (writeRegistryNpmrc) sets only the default `registry=`,
+  // which pnpm bypasses when resolving transitive @dawn-ai/* deps — letting them
+  // leak to npmjs. That is fatal mid-release: while a candidate version is only
+  // partially published to npmjs, the leaked resolution fails (ERR_PNPM_NO_MATCHING_VERSION)
+  // and deadlocks the very release that would make npmjs whole. npm_config_registry
+  // is the highest-precedence npm config, so it forces ALL resolution (direct and
+  // transitive) onto Verdaccio. Spawned installs inherit it via process.env. A
+  // test that manages its own registry (local-registry.test.ts) overrides this
+  // per-command with its own URL.
+  process.env.npm_config_registry = registry.url
 }
 
 export async function teardown(): Promise<void> {
   await registry?.stop()
   delete process.env[REGISTRY_URL_ENV]
+  delete process.env.npm_config_registry
 }


### PR DESCRIPTION
## Problem

The 0.8.3 release published 9/16 packages then fail-fast-stopped, leaving npmjs **internally inconsistent** (core@0.8.3 needs sdk@0.8.3, but sdk is still 0.8.2). Re-running the release fails `validate` deterministically: the generated/runtime/smoke harness lanes install a scaffolded app and **leak transitive `@dawn-ai/*` resolution to npmjs**:

```
ERR_PNPM_NO_MATCHING_VERSION  No matching version found for @dawn-ai/sdk@0.8.3
  (installing dependencies of @dawn-ai/core@0.8.3) — latest sdk is "0.8.2"
```

This is a **deadlock**: publishing the remaining 7 would make npmjs whole, but `validate` (which gates publish) can't pass until they're published. It also turns CI red for every PR meanwhile.

**Root cause:** `writeRegistryNpmrc` sets only the default `registry=` in the app's `.npmrc`. pnpm honors that for the *direct* install target but bypasses it when resolving *transitive* `@dawn-ai/*` deps, falling back to npmjs. Invisible while npmjs is consistent; fatal during a partial publish.

## Fix

The lane's registry `globalSetup` now also exports **`npm_config_registry`** (the highest-precedence npm config), forcing *all* resolution — direct and transitive — onto the ephemeral Verdaccio registry. Spawned installs inherit it via `process.env`. `local-registry.test.ts` manages its own registry, so it overrides this per-command with its own URL.

One central fix (the globalSetup) instead of patching every install site, so future install sites are covered automatically.

## Verification

Full `pnpm verify:harness` (framework + runtime + smoke) — **all three green** against the *current* partially-published npmjs state, which previously failed all three lanes. Lint clean. CI-only change (no `packages/*/src`) → no changeset.

## Why this unblocks the release

With the harness isolated from npmjs, `validate` passes regardless of npmjs's partial state → the OIDC release publishes the remaining 7 (sdk, permissions, …) **with provenance** → npmjs becomes consistent → CI green again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)