### PR TITLE
docs(cli): document the `dawn docs` command (fixes main Docs Check)

### DIFF
--- a/apps/web/content/docs/cli.mdx
+++ b/apps/web/content/docs/cli.mdx
@@ -202,6 +202,24 @@ Subcommands:
 Flags:
 - `--cwd <path>` — operate on a different app root.
 
+## `dawn docs`
+
+Prints the **bundled, version-matched** Dawn docs that ship inside the installed
+CLI — so a coding agent (or you) can read the docs for the exact version in use
+without a network round-trip. With no topic it lists the available topics and the
+index; with a topic it prints that doc to stdout.
+
+```
+dawn docs
+dawn docs README
+dawn docs cli
+```
+
+The optional positional `[topic]` selects a single doc by slug (with or without
+the `.md` suffix); an unknown topic exits non-zero and lists the available
+topics. Running from a source checkout requires the CLI to be built first
+(`pnpm --filter @dawn-ai/cli build`) so the bundled docs exist.
+
 ## Exit codes
 
 | Code | Meaning |

--- a/apps/web/content/docs/cli.mdx
+++ b/apps/web/content/docs/cli.mdx
@@ -1,6 +1,6 @@
 # CLI Reference
 
-Dawn ships a single `dawn` binary with ten commands: `build`, `check`, `dev`, `eval`, `memory`, `routes`, `run`, `test`, `typegen`, and `verify`. Most commands read `dawn.config.ts` from the current working directory or from `--cwd <path>`; `dawn dev` currently uses the current working directory and exposes only its own server flags.
+Dawn ships a single `dawn` binary with eleven commands: `build`, `check`, `dev`, `docs`, `eval`, `memory`, `routes`, `run`, `test`, `typegen`, and `verify`. Most commands read `dawn.config.ts` from the current working directory or from `--cwd <path>`; `dawn dev` currently uses the current working directory and exposes only its own server flags.
 
 ## Running the CLI
 


### PR DESCRIPTION
## Problem

`main` is currently **failing CI for every PR** at the **Docs Check** step:

```
Docs completeness check failed.
- apps/web/content/docs/cli.mdx is missing reference to command `dawn docs`
```

[#263](https://github.com/cacheplane/dawnai/pull/263) added the `dawn docs` command (`packages/cli/src/commands/docs.ts`) but didn't document it in `cli.mdx`. `scripts/check-docs.mjs` enumerates commands from the **built** CLI, so the gap is invisible until a fresh `pnpm build` — which is why #263's own CI passed (turbo build cache served a stale dist) yet every PR opened since fails: #257, #265, #266, #267 all blocked on this.

## Fix

Add a `## \`dawn docs\`` section to `cli.mdx` describing the command (prints the bundled, version-matched docs; optional `[topic]`).

## Verification

```
pnpm --filter @dawn-ai/cli build && node scripts/check-docs.mjs
→ Docs completeness check passed.
```

Docs-only change → no changeset. Merging this unblocks main and the four stuck PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)