### PR TITLE
chore(scaffold): default examples to gpt-5-mini; pre-approve esbuild build in templates

### DIFF
--- a/.changeset/scaffold-gpt5-pnpm.md
+++ b/.changeset/scaffold-gpt5-pnpm.md
@@ -1,0 +1,5 @@
+---
+"@dawn-ai/evals": patch
+---
+
+Default example/scaffold model is now `gpt-5-mini` (the basic scaffold template, README/package-README examples, landing snippets, AGENTS.md template, prompts, and the `llmJudge` default) — finishing the move off `gpt-4o-mini`. Scaffold templates also pre-approve esbuild's build script (`pnpm.onlyBuiltDependencies`) so `pnpm install` works non-interactively in CI and Docker.

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ const greet = tool(async ({ name }) => `Hello, ${name}!`, {
   schema: z.object({ name: z.string() }),
 })
 
-const model = new ChatOpenAI({ model: "gpt-4o-mini" }).bindTools([greet])
+const model = new ChatOpenAI({ model: "gpt-5-mini" }).bindTools([greet])
 const tools = new ToolNode([greet])
 
 async function callModel(state: typeof MessagesAnnotation.State) {
@@ -82,7 +82,7 @@ export const graph = new StateGraph(MessagesAnnotation)
 import { agent } from "@dawn-ai/sdk"
 
 export default agent({
-  model: "gpt-4o-mini",
+  model: "gpt-5-mini",
   systemPrompt: "You are a helpful assistant for the {tenant} organization.",
 })
 ```
@@ -131,7 +131,7 @@ Dawn routes live under `src/app` and export one runtime entry. New agent routes 
 import { agent } from "@dawn-ai/sdk"
 
 export default agent({
-  model: "gpt-4o-mini",
+  model: "gpt-5-mini",
   systemPrompt: "You are a helpful assistant for the {tenant} organization.",
   retry: { maxAttempts: 3, baseDelay: 250 },
 })

--- a/apps/web/app/components/landing/FeatureRouting.tsx
+++ b/apps/web/app/components/landing/FeatureRouting.tsx
@@ -6,7 +6,7 @@ const ROUTE_CODE = `// src/app/(public)/support/index.ts
 import { agent } from "@dawn-ai/sdk"
 
 export default agent({
-  model: "gpt-4o-mini",
+  model: "gpt-5-mini",
   systemPrompt: "Answer for {tenant}.",
 })
 

--- a/apps/web/app/components/landing/Hero.tsx
+++ b/apps/web/app/components/landing/Hero.tsx
@@ -8,7 +8,7 @@ import { Eyebrow } from "../ui/Eyebrow"
 const ROUTE_CODE = `import { agent } from "@dawn-ai/sdk"
 
 export default agent({
-  model: "gpt-4o-mini",
+  model: "gpt-5-mini",
   systemPrompt: "Answer for {tenant}.",
 })`
 

--- a/apps/web/content/prompts/index.ts
+++ b/apps/web/content/prompts/index.ts
@@ -125,7 +125,7 @@ const WRITE_A_ROUTE = `Help me add a new route to an existing Dawn app. Routes a
    import { agent } from "@dawn-ai/sdk"
 
    export default agent({
-     model: "gpt-4o-mini",
+     model: "gpt-5-mini",
      systemPrompt: "You are a helpful assistant.",
    })
    \`\`\`

--- a/apps/web/content/templates/AGENTS.md
+++ b/apps/web/content/templates/AGENTS.md
@@ -34,7 +34,7 @@ Example: `src/app/(public)/hello/[tenant]/index.ts` → pathname `/hello/[tenant
 import { agent } from "@dawn-ai/sdk"
 
 export default agent({
-  model: "gpt-4o-mini",
+  model: "gpt-5-mini",
   systemPrompt:
     "You are a helpful assistant for the {tenant} organization.",
   // Optional retry policy:

--- a/packages/devkit/templates/app-basic/package.json.template
+++ b/packages/devkit/templates/app-basic/package.json.template
@@ -23,5 +23,8 @@
     "@types/node": "25.6.0",
     "typescript": "6.0.2",
     "vitest": "4.1.4"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": ["esbuild"]
   }
 }

--- a/packages/devkit/templates/app-basic/src/app/(public)/hello/[tenant]/index.ts
+++ b/packages/devkit/templates/app-basic/src/app/(public)/hello/[tenant]/index.ts
@@ -1,7 +1,7 @@
 import { agent } from "@dawn-ai/sdk"
 
 export default agent({
-  model: "gpt-4o-mini",
+  model: "gpt-5-mini",
   systemPrompt:
     "You are a helpful assistant for the {tenant} organization. Answer questions about the tenant.",
 })

--- a/packages/devkit/templates/app-research/package.json.template
+++ b/packages/devkit/templates/app-research/package.json.template
@@ -23,5 +23,8 @@
     "@types/node": "25.6.0",
     "typescript": "6.0.2",
     "vitest": "4.1.4"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": ["esbuild"]
   }
 }

--- a/packages/evals/src/llm-judge.ts
+++ b/packages/evals/src/llm-judge.ts
@@ -20,7 +20,7 @@ function interpolate(template: string, vars: Record<string, string>): string {
 }
 
 export function llmJudge(opts: LlmJudgeOptions): Scorer {
-  const model = opts.model ?? "gpt-4o-mini"
+  const model = opts.model ?? "gpt-5-mini"
   return {
     name: opts.name ?? "llmJudge",
     ...(opts.threshold !== undefined ? { threshold: opts.threshold } : {}),

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -35,7 +35,7 @@ A Dawn route's `index.ts` exports an `agent()` descriptor. The `model` field is 
 import { agent } from "@dawn-ai/sdk"
 
 export default agent({
-  model: "gpt-4o-mini",
+  model: "gpt-5-mini",
   systemPrompt: "You are a helpful assistant.",
   retry: { maxAttempts: 3, baseDelay: 250 },
 })

--- a/test/generated/fixtures/basic.expected.json
+++ b/test/generated/fixtures/basic.expected.json
@@ -24,6 +24,11 @@
       "@types/node": "<version:@types/node>",
       "typescript": "<version:typescript>",
       "vitest": "<version:vitest>"
+    },
+    "pnpm": {
+      "onlyBuiltDependencies": [
+        "esbuild"
+      ]
     }
   },
   "verifyJson": {
@@ -48,8 +53,14 @@
         "status": "passed"
       },
       {
-        "missingEnvVars": ["OPENAI_API_KEY"],
-        "missingPackages": ["@langchain/core", "@langchain/openai", "@langchain/langgraph"],
+        "missingEnvVars": [
+          "OPENAI_API_KEY"
+        ],
+        "missingPackages": [
+          "@langchain/core",
+          "@langchain/openai",
+          "@langchain/langgraph"
+        ],
         "name": "deps",
         "status": "warning"
       }

--- a/test/generated/fixtures/custom-app-dir.expected.json
+++ b/test/generated/fixtures/custom-app-dir.expected.json
@@ -24,6 +24,11 @@
       "@types/node": "<version:@types/node>",
       "typescript": "<version:typescript>",
       "vitest": "<version:vitest>"
+    },
+    "pnpm": {
+      "onlyBuiltDependencies": [
+        "esbuild"
+      ]
     }
   },
   "verifyJson": {
@@ -48,8 +53,14 @@
         "status": "passed"
       },
       {
-        "missingEnvVars": ["OPENAI_API_KEY"],
-        "missingPackages": ["@langchain/core", "@langchain/openai", "@langchain/langgraph"],
+        "missingEnvVars": [
+          "OPENAI_API_KEY"
+        ],
+        "missingPackages": [
+          "@langchain/core",
+          "@langchain/openai",
+          "@langchain/langgraph"
+        ],
         "name": "deps",
         "status": "warning"
       }

--- a/test/generated/run-generated-app.test.ts
+++ b/test/generated/run-generated-app.test.ts
@@ -478,6 +478,7 @@ async function createExpectedInternalFixture(
         "@dawn-ai/testing": "<repo:@dawn-ai/testing>",
       },
       pnpm: {
+        onlyBuiltDependencies: ["esbuild"],
         overrides: repoOverrides,
       },
     },


### PR DESCRIPTION
## Summary

Post-smoke-test cleanup (2 of 2 follow-up PRs). Finishes the move off `gpt-4o-mini` for **user-facing examples** and fixes the scaffold's non-interactive `pnpm install`.

- **Model → `gpt-5-mini`** (the project's canonical default — the research template already uses it) in: the **basic scaffold template** route, root `README.md` (the raw-LangGraph + With-Dawn + 30-second snippets), `@dawn-ai/sdk` README, the landing `Hero`/`FeatureRouting` snippets, `content/templates/AGENTS.md`, `content/prompts`, and the `@dawn-ai/evals` `llmJudge` default.
- **Deliberately NOT swept:** the known-ids registry, model-validation tests, recorded aimock fixtures (`gpt-4o-mini-2024-07-18`), `api.mdx` type-union, frozen superpowers plans, CHANGELOGs, and dated blog posts — those keep `gpt-4o` intentionally.
- **Scaffold `pnpm.onlyBuiltDependencies: ["esbuild"]`** in both template `package.json.template` files — fixes `ERR_PNPM_IGNORED_BUILDS: esbuild` that breaks `pnpm install` non-interactively in CI/Docker (found while smoke-testing the docker blueprint).

## Test Plan

- [x] `pnpm build` / `typecheck` / `lint` clean
- [x] `@dawn-ai/devkit` (9) + `create-dawn-ai-app` (5) tests pass
- [x] `check-docs` + `pack:check` pass; changeset gate passes
- [x] `grep gpt-4o` over the migrated dirs is empty; only the 10 intended files changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)