### PR TITLE
ci: skip Claude review on dependabot PRs

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -14,6 +14,10 @@ permissions:
 
 jobs:
   review:
+    # Dependabot-triggered runs cannot read repo secrets, so the Claude review
+    # action always fails with a red X on dependabot PRs. Skip them (same
+    # convention as scripts/check-changesets.mjs).
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     timeout-minutes: 25
     permissions:


### PR DESCRIPTION
## Summary

Dependabot-triggered workflow runs cannot read repo secrets, so the advisory Claude-review job fails in ~10s with a red X on every dependabot PR (all 7 current ones show it). Skip the job for `dependabot[bot]` — same convention as `scripts/check-changesets.mjs`. The job is advisory (not a required check), so this only removes noise.

## Test Plan

- [x] YAML valid; one-line job-level `if:` guard
- [ ] Next dependabot PR shows the review job skipped instead of failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)