### PR TITLE
fix(devkit): scaffold zod@^4 — fresh apps fail npm install against published sdk

### DIFF
--- a/.changeset/scaffold-zod4.md
+++ b/.changeset/scaffold-zod4.md
@@ -1,0 +1,6 @@
+---
+"@dawn-ai/devkit": patch
+"create-dawn-ai-app": patch
+---
+
+Fix fresh scaffolds failing `npm install`: the app templates pinned `zod@^3.24.0` while `@dawn-ai/sdk` declares an optional peer of `zod@^4`, which npm's strict peer resolution rejects (ERESOLVE) on every new app. Templates now scaffold `zod@^4.0.0` (the template code uses only APIs present in both majors, and `@langchain/core` accepts `^3.25.76 || ^4`).

--- a/packages/devkit/templates/app-basic/package.json.template
+++ b/packages/devkit/templates/app-basic/package.json.template
@@ -14,7 +14,7 @@
     "@dawn-ai/cli": "{{dawnCliSpecifier}}",
     "@dawn-ai/langchain": "{{dawnLangchainSpecifier}}",
     "@dawn-ai/sdk": "{{dawnSdkSpecifier}}",
-    "zod": "^3.24.0"
+    "zod": "^4.0.0"
   },
   "devDependencies": {
     "@dawn-ai/config-typescript": "{{dawnConfigTypescriptSpecifier}}",

--- a/packages/devkit/templates/app-research/package.json.template
+++ b/packages/devkit/templates/app-research/package.json.template
@@ -14,7 +14,7 @@
     "@dawn-ai/cli": "{{dawnCliSpecifier}}",
     "@dawn-ai/langchain": "{{dawnLangchainSpecifier}}",
     "@dawn-ai/sdk": "{{dawnSdkSpecifier}}",
-    "zod": "^3.24.0"
+    "zod": "^4.0.0"
   },
   "devDependencies": {
     "@dawn-ai/config-typescript": "{{dawnConfigTypescriptSpecifier}}",

--- a/test/generated/fixtures/basic.expected.json
+++ b/test/generated/fixtures/basic.expected.json
@@ -15,7 +15,7 @@
       "@dawn-ai/cli": "latest",
       "@dawn-ai/langchain": "latest",
       "@dawn-ai/sdk": "latest",
-      "zod": "^3.24.0"
+      "zod": "^4.0.0"
     },
     "devDependencies": {
       "@dawn-ai/config-typescript": "latest",

--- a/test/generated/fixtures/custom-app-dir.expected.json
+++ b/test/generated/fixtures/custom-app-dir.expected.json
@@ -15,7 +15,7 @@
       "@dawn-ai/cli": "latest",
       "@dawn-ai/langchain": "latest",
       "@dawn-ai/sdk": "latest",
-      "zod": "^3.24.0"
+      "zod": "^4.0.0"
     },
     "devDependencies": {
       "@dawn-ai/config-typescript": "latest",


### PR DESCRIPTION
## What

**P0 found by production smoke:** every fresh \`npm create dawn-ai-app\` + \`npm install\` fails with ERESOLVE. The app templates pin \`zod@^3.24.0\`, but published \`@dawn-ai/sdk\` (0.8.5) declares \`peerOptional zod@^4.0.0\` — npm's strict peer resolution rejects the tree. \`--legacy-peer-deps\` is not an escape hatch (it skips peer installs → \`@langchain/core\` unresolvable at runtime).

**Why CI never saw it:** the generated-app harness installs with pnpm, which tolerates unmet optional peers. The break only manifests with npm against the real registry — exactly the new-user path.

**Fix:** templates scaffold \`zod@^4.0.0\` (research + basic), harness fixtures updated. Template code uses only \`z.object\`/\`z.string\` (both majors); \`@langchain/core\` accepts \`^3.25.76 || ^4\`. Validated manually against the real registry: with \`^4\` the strict npm install succeeds and \`dawn check\`/\`dev\` run.

## Tests

- create-dawn-ai-app 5/5, devkit 9/9, full generated-app lane 15/15 (scaffold-tree comparisons + publish-lifecycle via test registry).

## Follow-up (separate)

Consider widening sdk's peer to \`^3.25.76 || ^4\` for existing zod-3 apps — this PR fixes the broken new-user funnel without touching published semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)