### PR TITLE
feat(memory): smarter recall — IDF-weighted relevance ranking

### DIFF
--- a/.changeset/smarter-recall.md
+++ b/.changeset/smarter-recall.md
@@ -1,0 +1,13 @@
+---
+"@dawn-ai/memory": patch
+"@dawn-ai/core": patch
+"@dawn-ai/cli": patch
+---
+
+Smarter recall: long-term-memory `recall` now ranks results by IDF-weighted
+relevance blended with recency decay and stored confidence, instead of pure
+recency — a six-week-old fact that actually answers the query outranks
+yesterday's marginal match. Deterministic (no clock, no network, no new deps;
+same store + same query → same order), zero-config (tune via
+`DawnConfig.memory.recall` only if needed), and query-less searches (the
+injected index, `dawn memory list`) keep their recency order.

--- a/apps/web/content/docs/memory.mdx
+++ b/apps/web/content/docs/memory.mdx
@@ -111,8 +111,9 @@ Ranked recall (any call with a `query`) orders results by a weighted blend:
 | Recency | 0.3 | Exponential decay; the boost halves every 14 days |
 | Confidence | 0.1 | The `confidence` stored with the memory |
 
-Ties break by `updatedAt` (newest first), then `id`. Query-less searches (the
-injected index, `dawn memory list`) keep pure recency order.
+Ties break by `updatedAt` (newest first), then `id`. Query-less searches (like
+the injected index) keep pure recency order, and `dawn memory list` (which
+lists candidates, not active memories) is likewise unaffected.
 
 Tune it in `dawn.config.ts` (all fields optional and defaulted):
 
@@ -258,7 +259,7 @@ For deterministic coverage the aimock harness scripts exact tool arguments — w
 Long-term memory ships with the `semantic` kind and deterministic ranked recall (IDF-weighted relevance blended with recency and confidence). The following are typed or designed but **not** implemented:
 
 - The `episodic`, `procedural`, and `reflection` kinds.
-- Vector / embedding recall, FTS5 / BM25 ranking, and a memory graph.
+- Vector / embedding recall, full BM25 (term-frequency / length-normalized) ranking via FTS5, and a memory graph.
 - A dev-server Memory Inspector UI.
 - Postgres / pgvector store adapters.
 - Schema-typed `remember.data` (typed loosely as `Record<string, unknown>` today).

--- a/apps/web/content/docs/memory.mdx
+++ b/apps/web/content/docs/memory.mdx
@@ -83,7 +83,7 @@ export default defineMemory({
 - **`identity?`** — the keys used for write reconciliation (in `auto` mode). Defaults to `["subject", "predicate"]`.
 
 <Callout type="info" title="Deterministic recall">
-  Recall is a tokenized keyword match ordered by recency over a SQLite store — there is no FTS5, embedding model, or network call in the path. The same query returns the same rows, which keeps evals and fixtures stable (and replayable under aimock).
+  Recall is deterministic: an IDF-weighted keyword match blended with recency and confidence, over a SQLite store — no FTS5, embedding model, or network call in the path. The same query against the same store returns the same rows in the same order, which keeps evals and fixtures stable (and replayable under aimock).
 </Callout>
 
 ### Generated tools
@@ -100,6 +100,39 @@ Typegen emits two typed tools for any route with a `memory.ts` into `.dawn/dawn.
 **`recall({ query?, kind?, tags?, limit? })`** searches the store. It defaults `status` to `"active"` and `limit` to `8`, and returns one `id: content` line per match, or `(no memories found)` when empty.
 
 **`remember({ data, content?, tags?, confidence? })`** validates `data` against the schema, then writes a record. The id is **data-derived** — `memory_` + the first 16 hex chars of `sha1(namespace | JSON(data))` — so a contradicting value (same identity, different data) gets a distinct id and can coexist with the old row. `content` defaults to `JSON.stringify(data)`, `confidence` to `1`, `tags` to `[]`.
+
+### How recall ranks
+
+Ranked recall (any call with a `query`) orders results by a weighted blend:
+
+| Signal | Default weight | Meaning |
+|---|---|---|
+| Relevance | 0.6 | IDF-weighted overlap — matching rare, specific words counts far more than ubiquitous ones |
+| Recency | 0.3 | Exponential decay; the boost halves every 14 days |
+| Confidence | 0.1 | The `confidence` stored with the memory |
+
+Ties break by `updatedAt` (newest first), then `id`. Query-less searches (the
+injected index, `dawn memory list`) keep pure recency order.
+
+Tune it in `dawn.config.ts` (all fields optional and defaulted):
+
+```ts title="dawn.config.ts"
+export default {
+  memory: {
+    recall: {
+      weights: { relevance: 0.6, recency: 0.3, confidence: 0.1 },
+      recencyHalfLifeMs: 14 * 24 * 60 * 60 * 1000,
+      candidatePool: 256, // ranked searches score at most this many newest token-matches
+    },
+  },
+} satisfies import("@dawn-ai/core").DawnConfig
+```
+
+<Callout type="info" title="No stemming">
+  Matching is exact-token: "escalation" and "escalates" are different tokens.
+  Specific, consistent wording in remembered `content` gives the ranker better
+  signal — vague summaries rank vaguely.
+</Callout>
 
 ### The injected index
 
@@ -222,7 +255,7 @@ For deterministic coverage the aimock harness scripts exact tool arguments — w
 
 ## What's deferred
 
-Long-term memory ships with the `semantic` kind and deterministic keyword + recency recall. The following are typed or designed but **not** implemented:
+Long-term memory ships with the `semantic` kind and deterministic ranked recall (IDF-weighted relevance blended with recency and confidence). The following are typed or designed but **not** implemented:
 
 - The `episodic`, `procedural`, and `reflection` kinds.
 - Vector / embedding recall, FTS5 / BM25 ranking, and a memory graph.

--- a/docs/dev/memory-system.md
+++ b/docs/dev/memory-system.md
@@ -1,0 +1,275 @@
+# Long-term memory — developer walkthrough
+
+> Draft developer documentation. A full, code-grounded walkthrough of Dawn's
+> long-term memory system as it exists on `main` (post-PR #250 + #257). Written
+> to help assess the current design and guide the "smarter recall" follow-up.
+> Reflects `main` @ #275 **plus** the `feat/memory-recall-ranking` branch
+> (smarter recall — ranked `search()`, shipped; see §4 and §14).
+
+## 1. Mental model: three layers, one overloaded word
+
+"Memory" in Dawn means three distinct things. Only the third is a queryable store.
+
+| Layer | What it is | Mechanism | Source |
+|---|---|---|---|
+| **L1 — workspace profile** | Global facts true across the whole app | Whole `workspace/AGENTS.md` spliced into the system prompt every turn | `core/.../built-in/agents-md.ts` |
+| **L2 — route profile** | Route-scoped prose facts | Whole route `memory.md` spliced into the prompt (32 KiB cap) | `core/.../built-in/memory-md.ts` |
+| **L3 — typed collection** | A namespaced database of discrete typed facts the agent reads/writes via tools | `recall`/`remember` tools + an injected index, backed by SQLite | `@dawn-ai/memory` + `core/.../built-in/memory.ts` |
+
+L1/L2 are **text injection** — no ranking, no queries, re-read each turn. L3 is the
+real subsystem: records, namespaces, write governance, recall. Everything below is L3
+unless stated. "Smarter recall" touches exactly one function inside L3.
+
+## 2. File map (where everything lives)
+
+**`@dawn-ai/memory`** — storage engine, no deps but `node:sqlite`:
+- `types.ts` — `MemoryRecord`, `MemoryStore`, `MemoryQuery`, `MemoryKind`, `MemoryStatus`.
+- `sqlite-store.ts` — `sqliteMemoryStore()`: schema/migrations, tokenized index, `search()`.
+- `score.ts` — pure recall scoring: `idf()`, `scoreMemory()`, `RecallRankingOptions` + defaults.
+- `tokenize.ts` — lowercase / split / drop-1-char / **dedupe** → tokens.
+- `namespace.ts` — `serializeNamespace()` + `MemoryScopeTuple`.
+- `reconcile.ts` — `classifyWrite()` (deterministic add/update/supersede).
+- `index.ts` — barrel.
+
+**`@dawn-ai/sdk`**
+- `memory.ts` — `defineMemory({ kind, scope, schema, identity? })` (author API).
+
+**`@dawn-ai/core`**
+- `capabilities/built-in/memory.ts` — the L3 capability: contributes `recall`/`remember` tools + the memory-index prompt fragment.
+- `capabilities/built-in/memory-md.ts` — the L2 fragment.
+- `capabilities/types.ts` — `MemoryContext`, `MemoryStoreLike`, `PromptFragment` (note `cacheKey`).
+- `types.ts` — `DawnConfig.memory` config shape.
+
+**`@dawn-ai/cli`**
+- `lib/runtime/resolve-memory.ts` — `resolveMemoryStore()`, `resolveMemoryWrites()`, `buildMemoryContext()`, `routeNamespaceKey()`.
+- `lib/runtime/execute-route.ts` — registers the marker, builds `MemoryContext` per request, applies capabilities.
+- `lib/typegen/run-typegen.ts` — `MEMORY_EXTRA_TOOLS` + `hasMemory()` detection.
+- `commands/memory.ts` — the `dawn memory` CLI.
+
+**`@dawn-ai/langchain`**
+- `agent-adapter.ts` — materializes the agent; folds the fragment `cacheKey` into the materialize cache.
+
+**`@dawn-ai/testing`** — `seedMemory()`. **`@dawn-ai/evals`** — `memoryRecalled`/`memoryFresh`/`memoryIsolated` scorers.
+
+## 3. The data model
+
+```ts
+interface MemoryRecord {
+  id: string                 // data-derived: memory_ + sha1(namespace | JSON(data)).slice(16)
+  kind: "semantic" | "episodic" | "procedural" | "reflection"  // only semantic is wired
+  namespace: string          // e.g. "workspace=app|route=/research"
+  content: string            // human-readable summary (what recall prints)
+  data: Record<string, unknown>   // the typed payload, validated against the route schema
+  source: { type: "run"|"user"|"tool"|"eval"|"human"; id: string }
+  confidence: number         // 0..1 — blended into ranked recall (default weight 0.1)
+  tags: readonly string[]
+  status: "candidate" | "active" | "superseded"
+  supersedes?: readonly string[]
+  createdAt: string; updatedAt: string
+  effectiveAt?: string; expiresAt?: string   // episodic temporal fields — declared, UNUSED
+}
+```
+
+Two things to notice: the schema is **forward-looking** (all four kinds + temporal fields
+exist but only `semantic` is implemented), and **`confidence` now earns its keep** — ranked
+recall blends it into the composite score (default weight 0.1; see §4).
+
+**Status lifecycle:** `candidate` → (approve) → `active` → (contradicted) → `superseded`.
+Supersession never deletes; the old row flips status and the new row records `supersedes: [oldId]`.
+
+**The `id` is data-derived** (`sha1(namespace | JSON(data))`), so the *same fact* always
+maps to the same id (idempotent), while a *contradicting value* gets a new id and can coexist
+as `active` while the old goes `superseded`.
+
+## 4. Storage internals (`sqlite-store.ts`)
+
+Two tables (migration v1):
+
+```sql
+memories(id PK, kind, namespace, content, data, source, confidence,
+         tags, status, supersedes, created_at, updated_at, effective_at, expires_at)
+  INDEX (namespace, status, updated_at DESC)
+memory_tokens(memory_id FK→memories ON DELETE CASCADE, token)
+  INDEX (token), INDEX (memory_id)
+```
+
+`memory_tokens` holds **one row per distinct token per memory** — `tokenize()` dedupes,
+so term-frequency is not stored (every TF = 1). This is the key constraint for ranking:
+**IDF is computable** (count memories per token) but classic **BM25 TF is not**, without a
+schema migration.
+
+`reindex(record)` deletes the memory's token rows and re-inserts tokens from
+`content + tags + data values`. So recall matches against the content, the tags, and the
+stringified data — not just `content`.
+
+**`search(query)` today (ranked, this branch):**
+1. `status` defaults to `active`, `limit` to `8`. Tokenize the query.
+2. **Zero tokens** (or no `query` at all) → the original SQL path, unchanged:
+   `WHERE namespace = ? AND status = ?` [`AND kind = ?`], `ORDER BY updated_at DESC, id ASC LIMIT ?`.
+   The index fragment, `listCandidates`, and `dawn memory list` all live here — query-less
+   consumers keep pure recency.
+3. **≥ 1 token** → **candidate pool**: same SQL filter plus the token-overlap `IN` subquery,
+   ordered `updated_at DESC, id ASC`, capped at `candidatePool` (default **256**) instead of
+   the caller's `limit`.
+4. **Live corpus stats** — one `COUNT` for `N` (rows matching the base filter) and one
+   grouped count for per-token `df`, computed fresh per search. Nothing is precomputed, so
+   there are no stats to drift.
+5. **Score** each candidate with the pure `scoreMemory()` (`score.ts`): IDF-weighted overlap
+   fraction (weight 0.6) + exponential recency decay (0.3, half-life 14 days) + stored
+   `confidence` (0.1).
+6. **Sort** `score DESC, updated_at DESC, id ASC` (codepoint compare, matching SQLite BINARY
+   collation), apply the caller's `limit`, then the optional tag filter in JS (unchanged).
+
+So the *filter* and the *ranking* are both token-aware now: a six-week-old memory matching
+the query's rare tokens outranks yesterday's marginal one-token match. Tuning lives in
+`DawnConfig.memory.recall` (`weights` / `recencyHalfLifeMs` / `candidatePool`; non-positive
+or non-finite half-life/pool values fall back to defaults); a custom `config.memory.store`
+bypasses it entirely. Matching is still exact-token — no stemming.
+
+**`classifyWrite()` (`reconcile.ts`)** decides add/update/supersede deterministically by
+comparing the incoming record's identity key (default `["subject","predicate"]`) against
+existing active records — no LLM. The capability uses this logic in `auto` mode.
+
+## 5. The author contract
+
+A route opts into L3 by adding `memory.ts` next to `index.ts`:
+
+```ts
+// src/app/research/memory.ts
+import { defineMemory } from "@dawn-ai/sdk"
+import { z } from "zod"
+export default defineMemory({
+  kind: "semantic",
+  scope: ["workspace", "route"],            // namespace dimensions
+  schema: z.object({ subject: z.string(), predicate: z.string(), value: z.string() }),
+  // identity?: ["subject","predicate"]      // defaults for semantic
+})
+```
+
+`scope` decides isolation: `["workspace","route"]` → namespace `workspace=app|route=/research`,
+so two routes (and two apps) never read each other's memories. `schema` is the zod shape of a
+fact's `data`, enforced at write time. (L2 is even simpler: drop a `memory.md` file; its text
+is injected. No declaration needed.)
+
+## 6. Typegen
+
+`run-typegen.ts` checks `hasMemory(routeDir)` (does `memory.ts` exist?) and, if so, appends
+`MEMORY_EXTRA_TOOLS` to the route's generated `.dawn/dawn.generated.d.ts` — typed `recall`
+and `remember`. Caveat: generated `remember.data` is typed `Record<string, unknown>`, not the
+route's zod schema — compile-time field types on the write path are deferred. (The schema *is*
+enforced at runtime.)
+
+## 7. The L3 capability (`built-in/memory.ts`)
+
+`detect`: active iff the CLI built a `context.memory` (i.e. the route has `memory.ts`).
+`load(context)` returns a `CapabilityContribution` with:
+
+- **`recall` tool** — schema `{ query?, kind?, tags?, limit? }`; calls `store.search()`; prints `id: content` lines or `(no memories found)`.
+- **`remember` tool** (omitted when `writes: "off"`) — schema `{ data: <route schema>, content?, tags?, confidence? }`; `validate(data)` → `store.put()` as `active` (auto) or `candidate`; auto mode runs add/update/supersede inline.
+- **`promptFragment`** — the memory index: up to `indexMaxEntries` (default 20) active records, content sliced to 80 chars, under a `# Long-Term Memory` heading, `placement: "after_user_prompt"`.
+
+> The `recall`/`remember` **input schemas** are the #257 fix. Before it, the tools shipped
+> with no schema, so a real model called them with empty/invalid args and every write was
+> rejected by `validate()` — memory was unusable by an actual agent. `remember.data` is now
+> the route's own `defineMemory()` schema, threaded through `MemoryContext.schema`.
+
+**The index `cacheKey` (the #257 staleness fix):** the index is computed once at `load()`
+time and the fragment's `render()` closes over that snapshot. The fragment now also exposes
+`cacheKey = sha1(indexEntries.map(id@updatedAt))`. `agent-adapter` computes a
+`fragmentFingerprint` over all fragments' `cacheKey`s and folds it into the per-descriptor
+materialize cache. When a memory is written, the fingerprint changes, so the next run
+re-materializes the agent with a fresh index instead of serving the stale snapshot. (The
+`recall` tool was always live; this fixed the *hint* specifically.)
+
+## 8. CLI runtime wiring (`resolve-memory.ts` + `execute-route.ts`)
+
+Per request, `execute-route` builds a `MemoryContext` via `buildMemoryContext()`:
+
+- **store** — `resolveMemoryStore(appRoot)`: `config.memory.store` if set, else `sqliteMemoryStore({ path: <appRoot>/.dawn/memory.sqlite })`.
+- **namespace** — derive `{ workspace: basename(appRoot), route: routeNamespaceKey(routePath), ...resolveScope?.() }`, restrict to the dimensions the route declared in `scope`, then `serializeNamespace()`. `routeNamespaceKey()` normalizes a file path (`src/app/research/index.ts`) to a clean route id (`/research`) — regex-free (a CodeQL-ReDoS-driven choice).
+- **writes** — `resolveMemoryWrites(appRoot)`: `config.memory.writes ?? "candidate"`.
+- **schema / validate** — the route's zod schema + a `validate(data)` wrapper.
+- **now** — request timestamp (lib code is deterministic — no `Date.now()` inside `@dawn-ai/memory`; the capability takes `context.memory.now`).
+
+`execute-route` then runs `applyCapabilities`, which calls `memory.load(context)` and merges
+its tools + prompt fragment into the route.
+
+## 9. Request lifecycle (end to end)
+
+1. HTTP run (`POST /threads/:id/runs/wait`) → `execute-route`.
+2. `buildMemoryContext` (store, namespace, writes, schema, now).
+3. `applyCapabilities` → `memory.load()` → searches the store for the index, returns `recall`/`remember` + the index fragment.
+4. `agent-adapter.materializeAgent` → prompt = `systemPrompt` + fragments (fingerprint-keyed cache); toolset includes `recall`/`remember`.
+5. Model turn:
+   - `recall({ query })` → `store.search(namespace, query)` → rows. **← smarter recall lives here.**
+   - `remember({ data })` → `validate` → `store.put` (+ reconcile in auto mode).
+
+## 10. Write governance
+
+`DawnConfig.memory.writes` (default `candidate`):
+
+| Mode | `remember` tool | Write lands as | Reconciliation |
+|---|---|---|---|
+| `off` | not generated (recall-only) | — | — |
+| `candidate` *(default)* | generated | `candidate` (hidden from recall) | none |
+| `auto` | generated | `active` immediately | inline add/update/supersede |
+
+Candidates are managed out-of-band with the `dawn memory` CLI:
+`list` / `search <q>` (substring filter over candidates, **not** the agent's tokenized recall) /
+`inspect <id>` / `approve <id>` (→ active) / `reject <id>` (hard delete) / `forget <id>` (hard
+delete). Note: supersession/reconciliation runs only on `auto` writes — approving a candidate
+just flips its status; it does not reconcile contradictions. Permission-gated `auto` writes
+were specced but not shipped (auto writes are not gated by `@dawn-ai/permissions`).
+
+## 11. Config surface (`DawnConfig.memory`)
+
+```ts
+memory?: {
+  enabled?: boolean        // NOT read — L3 activates purely on memory.ts presence
+  store?: MemoryStoreLike  // default: sqlite at .dawn/memory.sqlite
+  writes?: "off" | "candidate" | "auto"   // default "candidate"
+  indexMaxEntries?: number // default 20
+  resolveScope?: (ctx) => Record<string,string>   // fill tenant/user/agent per request
+}
+```
+
+## 12. Testing surfaces
+
+- **Unit** (`@dawn-ai/memory`): store, tokenize, namespace, reconcile.
+- **Capability** (`@dawn-ai/core`): tool behavior + index fragment.
+- **`seedMemory`** (`@dawn-ai/testing`): insert rows directly in tests.
+- **Scorers** (`@dawn-ai/evals`): `memoryRecalled` / `memoryFresh` / `memoryIsolated`.
+- **Deterministic e2e** (aimock, CI-safe): cross-thread remember→recall; `memory-index-refresh.test.ts` (mid-process index refresh).
+- **Gated live smoke** (`memory-live.smoke.test.ts`, `skipIf(!OPENAI_API_KEY)`): real-model remember/recall/supersession/isolation/index/candidate flow. Skips in CI.
+
+## 13. Current limitations & deferred roadmap
+
+Shipped: the `semantic` kind with ranked recall — IDF-weighted relevance blended with
+recency decay and stored confidence (shipped in this branch; was pure recency through #275).
+Explicitly deferred (spec §"Out of scope"):
+
+- `episodic` / `procedural` / `reflection` kinds; episodic-from-traces; background consolidation.
+- Vector / embedding recall; BM25/FTS5 (term frequency is not stored).
+- Memory graph (edges/relations).
+- Dev-server Memory Inspector UI (no dev UI host exists today).
+- Postgres / pgvector adapters (the `MemoryStore` interface leaves room).
+- Schema-typed `remember.data` in typegen.
+
+## 14. Where "smarter recall" plugged in (DONE — this branch)
+
+It landed exactly where §4 describes: one function, `search()` in `sqlite-store.ts`, now
+runs pool → live df/N stats → pure `scoreMemory()` (`score.ts`) → sort → limit for ranked
+queries. Everything upstream (capability, tools, context-building, prompt index) was left
+untouched, and no-query searches (the index, `listCandidates`) kept pure-recency behavior.
+Determinism held: all-arithmetic scoring + the stable `updated_at, id` tiebreak kept aimock
+fixtures and eval scorers green. The next natural step, vector / embedding recall, plugs
+into the same `score.ts` seam — another signal blended into the composite score rather than
+a new code path.
+
+## 15. Glossary
+
+- **namespace** — the isolation key, `dim=value|...` over `workspace,route,tenant,user,agent`.
+- **identity key** — the fields (default `subject,predicate`) that decide whether a new write updates/supersedes an existing fact.
+- **index / index hint** — the `# Long-Term Memory` block injected into the prompt listing recallable memories. A hint; the source of truth is the `recall` tool.
+- **candidate** — a written-but-unapproved memory, hidden from recall until promoted.
+- **reconciliation** — deterministic add/update/supersede classification on write (`auto` mode only).

--- a/docs/dev/smarter-recall-dx.md
+++ b/docs/dev/smarter-recall-dx.md
@@ -1,0 +1,142 @@
+# Smarter recall — DX draft
+
+> Draft developer-experience narrative for the smarter-recall feature
+> (spec: `docs/superpowers/specs/2026-07-05-smarter-recall-design.md`).
+> Written from the seat of a Dawn app developer. The acceptance bar at the
+> bottom is the DX contract the implementation must meet.
+
+## Where you start (nothing new to learn)
+
+You already have a route with memory:
+
+```ts
+// src/app/support/memory.ts
+import { defineMemory } from "@dawn-ai/sdk"
+import { z } from "zod"
+export default defineMemory({
+  kind: "semantic",
+  scope: ["workspace", "route"],
+  schema: z.object({ subject: z.string(), predicate: z.string(), value: z.string() }),
+})
+```
+
+Your agent has been running for weeks. It has remembered ~30 facts about
+`acme`: billing thresholds, contacts, preferences, an escalation policy, a
+note about invoice formatting.
+
+## The sharp edge you'd hit today
+
+A user asks: "what's acme's billing escalation threshold?" The agent calls:
+
+```ts
+recall({ query: "acme billing escalation threshold" })
+```
+
+Today the store finds every memory sharing any word with that query — then
+returns the most recently written ones. If yesterday the agent stored "acme's
+contact prefers Slack," that fact outranks the six-week-old billing threshold,
+because recency is the only ranking signal. With `limit: 8` and 30 acme facts,
+the right answer can fall off the page entirely. Nobody files this as a bug
+against their own code — it reads as "my agent's memory is flaky."
+
+## What changes: nothing — and that's the point
+
+No changes to `memory.ts`, no config, no re-index. After upgrading, the same
+`recall` call ranks by a blend:
+
+| Signal | Weight | What it means for your facts |
+|---|---|---|
+| Relevance | 0.6 | Matching rare, specific words ("threshold", "escalation") counts far more than ubiquitous ones ("acme", present in all 30 facts, decides nothing) |
+| Recency | 0.3 | Newer facts get a nudge; the boost halves every 14 days |
+| Confidence | 0.1 | The `confidence` the agent stored finally matters |
+
+The six-week-old billing threshold now wins because it matches the query's
+informative words. The Slack-preference fact still surfaces instantly when
+someone asks about contact preferences — that's when its words are the rare
+ones.
+
+## The one behavior shift worth knowing: confidence is live
+
+`remember({ data, confidence: 0.6 })` used to be decorative. Now a hedged fact
+ranks slightly below a certain one, all else equal. If the route's system
+prompt tells the agent to store guesses with low confidence, "best answer
+first" falls out for free. At 10% weight it breaks ties — it will not bury a
+relevant fact.
+
+## Tuning — only if you need it
+
+```ts
+// dawn.config.ts — every field optional, all defaulted
+export default {
+  memory: {
+    recall: {
+      weights: { relevance: 0.6, recency: 0.3, confidence: 0.1 },
+      recencyHalfLifeMs: 14 * 24 * 60 * 60 * 1000,
+      candidatePool: 256,
+    },
+  },
+} satisfies import("@dawn-ai/core").DawnConfig
+```
+
+When to touch each knob:
+
+- **Fast-moving domains** (facts stale in days): shorten `recencyHalfLifeMs`
+  or bump `weights.recency`.
+- **Archival domains** (old facts stay true): drop recency toward 0 — ranking
+  becomes almost purely best-match.
+- **Huge namespaces** (thousands of facts per route): raise `candidatePool` —
+  only the 256 most recent token-matches are scored by default.
+
+A custom `memory.store` bypasses all of this — it owns its own ranking.
+
+## What you can rely on not changing
+
+- The prompt index (`# Long-Term Memory` hint) — still the most recent 20.
+  A table of contents, not a search result.
+- `dawn memory` CLI — candidate review unchanged.
+- Determinism — same store contents + same query → same order, every run.
+  aimock fixtures and `dawn eval` replays do not churn. No clock in the
+  library: recall uses the request timestamp; direct store calls fall back to
+  data-derived time.
+- Cross-route isolation, write governance, supersession — untouched.
+
+## Testing recall quality in your app
+
+Deterministic, no live model:
+
+```ts
+import { seedMemory } from "@dawn-ai/testing"
+
+await seedMemory({ path: ".dawn/memory.sqlite" }, [
+  { id: "m_thresh",  namespace: "workspace=app|route=/support",
+    content: "acme escalates billing above 500 dollars", status: "active" },
+  { id: "m_contact", namespace: "workspace=app|route=/support",
+    content: "acme contact jordan prefers slack", status: "active" },
+])
+// eval: query the threshold, expect m_thresh ranked first
+// scorer: memoryRecalled(["m_thresh"])
+```
+
+## Debugging: "why did recall return X above Y?"
+
+Three questions, in order:
+
+1. **Which query words are rare in this namespace?** They decide relevance.
+   If every fact mentions "acme", the word "acme" decides nothing.
+2. **How old is each fact?** A 14-day-old fact carries half the recency boost
+   of one written today.
+3. **What confidence was stored?** `dawn memory inspect <id>`.
+
+If the wrong fact still wins, the usual root cause is the memory's *content* —
+a vague `content` string ("note about acme billing stuff") gives the ranker
+vague tokens. Better remembered summaries → better recall. That prompt-side
+lever already existed; ranking makes it pay off.
+
+## DX summary / acceptance bar
+
+**Recall goes from "most recent match" to "best answer" with zero config,
+zero migration, zero test churn — knobs exist only for the day you need
+them.**
+
+If a developer has to do anything to benefit, or any existing fixture breaks,
+the implementation has missed the DX target.

--- a/docs/superpowers/plans/2026-07-05-smarter-recall.md
+++ b/docs/superpowers/plans/2026-07-05-smarter-recall.md
@@ -1,0 +1,1174 @@
+# Smarter Recall Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace pure-recency ordering in long-term-memory recall with deterministic IDF-weighted relevance ranking (+ recency decay + confidence), per the approved spec `docs/superpowers/specs/2026-07-05-smarter-recall-design.md`.
+
+**Architecture:** A new pure scoring module in `@dawn-ai/memory` (`score.ts`); `sqliteMemoryStore.search()` gains a ranked path for tokenized queries (candidate pool + live df/N stats + JS scoring) while the query-less path stays byte-for-byte unchanged; `MemoryQuery` gains optional `now`; the core capability passes `context.memory.now`; `DawnConfig.memory.recall` threads tuning options via `resolveMemoryStore`.
+
+**Tech Stack:** TypeScript, `node:sqlite`, vitest, aimock harness (`@dawn-ai/testing`). No new dependencies. Branch: `feat/memory-recall-ranking` (already created; spec committed).
+
+**Working directory:** `/Users/blove/repos/dawn` (the primary checkout, already on the branch). All commands run from there. Use the repo lint script pattern (`pnpm exec biome check --config-path packages/config-biome/biome.json <files>`) — NEVER bare `biome check --write` (it mass-reformats with wrong defaults).
+
+**Deviation from spec (approved rationale):** The spec's "eval dogfood in the research template" is DEFERRED — the template has no evals today and adding `@dawn-ai/evals` to a scaffold template destabilizes the generated-app verify lanes (known SCAFFOLD_PACKAGES hazard). The aimock before/after e2e (Task 5) is the deterministic quality gate instead. Task 7 amends the spec to record this.
+
+---
+
+## File structure
+
+| File | Responsibility |
+|---|---|
+| `packages/memory/src/score.ts` (create) | Pure scoring: `idf()`, `scoreMemory()`, `RecallWeights`, `RecallRankingOptions`, defaults |
+| `packages/memory/src/types.ts` (modify) | `MemoryQuery.now?: string` |
+| `packages/memory/src/sqlite-store.ts` (modify) | `sqliteMemoryStore({ path, recall? })`; ranked path in `search()` |
+| `packages/memory/src/index.ts` (modify) | Barrel exports for score module |
+| `packages/memory/test/score.test.ts` (create) | Score unit tests |
+| `packages/memory/test/sqlite-store.test.ts` (modify) | Ranked-ordering store tests |
+| `packages/core/src/capabilities/types.ts` (modify) | `MemoryStoreLike.search` gains `now?` |
+| `packages/core/src/types.ts` (modify) | `DawnConfig.memory.recall` (structural, no import of @dawn-ai/memory) |
+| `packages/core/src/capabilities/built-in/memory.ts` (modify) | recall tool passes `now: mem.now` |
+| `packages/core/test/memory-capability-recall.test.ts` (create) | now-plumbing test via fake store |
+| `packages/cli/src/lib/runtime/resolve-memory.ts` (modify) | thread `config.memory.recall` into `sqliteMemoryStore` |
+| `packages/cli/test/resolve-memory.test.ts` (modify) | recall-options threading test |
+| `packages/testing/test/memory-ranking-e2e.test.ts` (create) | aimock before/after e2e (headline) |
+| `packages/testing/test/memory-live.smoke.test.ts` (modify) | gated live ranking scenario |
+| `apps/web/content/docs/memory.mdx` (modify) | "How recall ranks" docs |
+| `docs/dev/memory-system.md` (modify+commit) | §4/§13/§14 updates (file currently untracked — commit it) |
+| `docs/dev/smarter-recall-dx.md` (commit) | DX draft (currently untracked) |
+| `.changeset/smarter-recall.md` (create) | patch: memory, core, cli |
+
+---
+
+### Task 1: Pure scoring module (`score.ts`)
+
+**Files:**
+- Create: `packages/memory/src/score.ts`
+- Create: `packages/memory/test/score.test.ts`
+- Modify: `packages/memory/src/index.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `packages/memory/test/score.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest"
+import {
+  DEFAULT_CANDIDATE_POOL,
+  DEFAULT_RECENCY_HALF_LIFE_MS,
+  idf,
+  scoreMemory,
+} from "../src/score.js"
+
+const NOW = "2026-07-05T00:00:00.000Z"
+const DAY = 24 * 60 * 60 * 1000
+function ago(ms: number): string {
+  return new Date(Date.parse(NOW) - ms).toISOString()
+}
+
+describe("idf", () => {
+  it("is monotonically decreasing in df and always positive", () => {
+    const n = 10
+    const values = [0, 1, 5, 10].map((df) => idf(df, n))
+    expect(values[0]).toBeGreaterThan(values[1]!)
+    expect(values[1]).toBeGreaterThan(values[2]!)
+    expect(values[2]).toBeGreaterThan(values[3]!)
+    for (const v of values) expect(v).toBeGreaterThan(0) // smoothed: df=N still > 0
+  })
+  it("clamps df above corpusSize instead of going negative", () => {
+    expect(idf(12, 10)).toBeGreaterThan(0)
+  })
+})
+
+describe("scoreMemory", () => {
+  const base = {
+    corpusSize: 6,
+    updatedAt: NOW,
+    confidence: 1,
+    referenceNow: NOW,
+  }
+  it("rare-token match outranks common-token match (IDF dominance)", () => {
+    const df = new Map([
+      ["acme", 6], // in every memory — uninformative
+      ["threshold", 1], // rare — informative
+    ])
+    const queryTokens = ["acme", "threshold"]
+    const matchesRare = scoreMemory({
+      ...base,
+      memoryTokens: new Set(["threshold"]),
+      queryTokens,
+      dfByToken: df,
+    })
+    const matchesCommon = scoreMemory({
+      ...base,
+      memoryTokens: new Set(["acme"]),
+      queryTokens,
+      dfByToken: df,
+    })
+    expect(matchesRare).toBeGreaterThan(matchesCommon)
+  })
+  it("matching more query tokens scores higher (overlap fraction)", () => {
+    const df = new Map([
+      ["billing", 2],
+      ["threshold", 2],
+    ])
+    const queryTokens = ["billing", "threshold"]
+    const two = scoreMemory({
+      ...base,
+      memoryTokens: new Set(["billing", "threshold"]),
+      queryTokens,
+      dfByToken: df,
+    })
+    const one = scoreMemory({
+      ...base,
+      memoryTokens: new Set(["billing"]),
+      queryTokens,
+      dfByToken: df,
+    })
+    expect(two).toBeGreaterThan(one)
+    expect(two).toBeCloseTo(0.6 * 1 + 0.3 * 1 + 0.1 * 1, 10) // full match, age 0, conf 1
+  })
+  it("recency component halves at exactly one half-life", () => {
+    const df = new Map([["x", 1]])
+    const args = {
+      memoryTokens: new Set(["x"]),
+      queryTokens: ["x"],
+      dfByToken: df,
+      corpusSize: 1,
+      confidence: 1,
+      referenceNow: NOW,
+      options: { weights: { relevance: 0, recency: 1, confidence: 0 } },
+    }
+    const fresh = scoreMemory({ ...args, updatedAt: NOW })
+    const halfLife = scoreMemory({ ...args, updatedAt: ago(DEFAULT_RECENCY_HALF_LIFE_MS) })
+    expect(fresh).toBeCloseTo(1, 10)
+    expect(halfLife).toBeCloseTo(0.5, 10)
+  })
+  it("confidence is clamped to [0,1]", () => {
+    const df = new Map([["x", 1]])
+    const args = {
+      memoryTokens: new Set(["x"]),
+      queryTokens: ["x"],
+      dfByToken: df,
+      corpusSize: 1,
+      updatedAt: NOW,
+      referenceNow: NOW,
+      options: { weights: { relevance: 0, recency: 0, confidence: 1 } },
+    }
+    expect(scoreMemory({ ...args, confidence: 1.5 })).toBeCloseTo(1, 10)
+    expect(scoreMemory({ ...args, confidence: -0.2 })).toBeCloseTo(0, 10)
+  })
+  it("invalid timestamps degrade to age 0 (recency 1), never throw", () => {
+    const df = new Map([["x", 1]])
+    const score = scoreMemory({
+      memoryTokens: new Set(["x"]),
+      queryTokens: ["x"],
+      dfByToken: df,
+      corpusSize: 1,
+      updatedAt: "not-a-date",
+      confidence: 1,
+      referenceNow: "also-not-a-date",
+      options: { weights: { relevance: 0, recency: 1, confidence: 0 } },
+    })
+    expect(score).toBeCloseTo(1, 10)
+  })
+  it("weight overrides merge with defaults (partial weights allowed)", () => {
+    const df = new Map([["x", 1]])
+    const score = scoreMemory({
+      memoryTokens: new Set(["x"]),
+      queryTokens: ["x"],
+      dfByToken: df,
+      corpusSize: 1,
+      updatedAt: NOW,
+      confidence: 0,
+      referenceNow: NOW,
+      options: { weights: { confidence: 0.5 } }, // relevance/recency keep defaults 0.6/0.3
+    })
+    expect(score).toBeCloseTo(0.6 + 0.3 + 0, 10)
+  })
+  it("exposes the documented defaults", () => {
+    expect(DEFAULT_RECENCY_HALF_LIFE_MS).toBe(14 * DAY)
+    expect(DEFAULT_CANDIDATE_POOL).toBe(256)
+  })
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm --filter @dawn-ai/memory exec vitest run test/score.test.ts`
+Expected: FAIL — `Cannot find module '../src/score.js'`
+
+- [ ] **Step 3: Implement `score.ts`**
+
+Create `packages/memory/src/score.ts`:
+
+```ts
+// Pure recall scoring — no I/O, no clock, no randomness. Deterministic by
+// construction so aimock fixtures and eval replays stay stable. See
+// docs/superpowers/specs/2026-07-05-smarter-recall-design.md.
+
+export interface RecallWeights {
+  readonly relevance?: number
+  readonly recency?: number
+  readonly confidence?: number
+}
+
+export interface RecallRankingOptions {
+  readonly weights?: RecallWeights
+  readonly recencyHalfLifeMs?: number
+  readonly candidatePool?: number
+}
+
+export const DEFAULT_RECALL_WEIGHTS = {
+  relevance: 0.6,
+  recency: 0.3,
+  confidence: 0.1,
+} as const
+
+export const DEFAULT_RECENCY_HALF_LIFE_MS = 14 * 24 * 60 * 60 * 1000
+export const DEFAULT_CANDIDATE_POOL = 256
+
+/**
+ * BM25-smoothed inverse document frequency. Always positive — a token present
+ * in every memory (df = corpusSize) still carries a small weight rather than
+ * zeroing out or going negative (as unsmoothed idf would).
+ */
+export function idf(df: number, corpusSize: number): number {
+  const d = Math.max(0, df)
+  const n = Math.max(d, corpusSize)
+  return Math.log(1 + (n - d + 0.5) / (d + 0.5))
+}
+
+function clamp01(v: number): number {
+  return v < 0 ? 0 : v > 1 ? 1 : v
+}
+
+/** Parse an ISO timestamp; NaN (invalid/missing) degrades to null, never throws. */
+function parseMs(iso: string): number | null {
+  const ms = Date.parse(iso)
+  return Number.isNaN(ms) ? null : ms
+}
+
+/**
+ * Composite recall score: wRel·relevance + wRec·recency + wConf·confidence.
+ *
+ * relevance = Σ idf(matched query tokens) / Σ idf(all query tokens) — the
+ * fraction of the query's information this memory matches (0..1). Query
+ * tokens matching nothing inflate only the shared denominator, so relative
+ * ordering is unaffected.
+ *
+ * recency = 2^(−age / halfLife), age measured from `referenceNow` back to
+ * `updatedAt`, clamped ≥ 0. Invalid timestamps degrade to age 0.
+ */
+export function scoreMemory(args: {
+  readonly memoryTokens: ReadonlySet<string>
+  readonly queryTokens: readonly string[]
+  readonly dfByToken: ReadonlyMap<string, number>
+  readonly corpusSize: number
+  readonly updatedAt: string
+  readonly confidence: number
+  readonly referenceNow: string
+  readonly options?: RecallRankingOptions
+}): number {
+  const weights = { ...DEFAULT_RECALL_WEIGHTS, ...args.options?.weights }
+  const halfLife = args.options?.recencyHalfLifeMs ?? DEFAULT_RECENCY_HALF_LIFE_MS
+
+  let matchedIdf = 0
+  let totalIdf = 0
+  for (const t of args.queryTokens) {
+    const w = idf(args.dfByToken.get(t) ?? 0, args.corpusSize)
+    totalIdf += w
+    if (args.memoryTokens.has(t)) matchedIdf += w
+  }
+  const relevance = totalIdf > 0 ? matchedIdf / totalIdf : 0
+
+  const ref = parseMs(args.referenceNow)
+  const upd = parseMs(args.updatedAt)
+  const ageMs = ref !== null && upd !== null ? Math.max(0, ref - upd) : 0
+  const recency = 2 ** (-ageMs / halfLife)
+
+  const confidence = clamp01(args.confidence)
+
+  return weights.relevance * relevance + weights.recency * recency + weights.confidence * confidence
+}
+```
+
+- [ ] **Step 4: Export from the barrel**
+
+In `packages/memory/src/index.ts`, add (keeping alphabetical grouping with the existing exports):
+
+```ts
+export {
+  DEFAULT_CANDIDATE_POOL,
+  DEFAULT_RECALL_WEIGHTS,
+  DEFAULT_RECENCY_HALF_LIFE_MS,
+  idf,
+  type RecallRankingOptions,
+  type RecallWeights,
+  scoreMemory,
+} from "./score.js"
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `pnpm --filter @dawn-ai/memory exec vitest run test/score.test.ts`
+Expected: PASS (8 tests)
+
+- [ ] **Step 6: Lint + commit**
+
+```bash
+cd /Users/blove/repos/dawn
+pnpm exec biome check --config-path packages/config-biome/biome.json packages/memory/src/score.ts packages/memory/src/index.ts packages/memory/test/score.test.ts
+git add packages/memory/src/score.ts packages/memory/src/index.ts packages/memory/test/score.test.ts
+git commit -m "feat(memory): pure IDF-weighted recall scoring module"
+```
+
+---
+
+### Task 2: Ranked path in `sqliteMemoryStore.search()`
+
+**Files:**
+- Modify: `packages/memory/src/types.ts` (MemoryQuery)
+- Modify: `packages/memory/src/sqlite-store.ts`
+- Modify: `packages/memory/test/sqlite-store.test.ts`
+
+- [ ] **Step 1: Add `now` to `MemoryQuery`**
+
+In `packages/memory/src/types.ts`, change the `MemoryQuery` interface to:
+
+```ts
+export interface MemoryQuery {
+  readonly namespace: string
+  readonly query?: string
+  readonly kind?: MemoryKind
+  readonly tags?: readonly string[]
+  readonly status?: MemoryStatus
+  readonly limit?: number
+  /** ISO timestamp used as the recency reference for ranked (query) searches.
+   *  Optional; when absent, recency is measured relative to the newest
+   *  candidate's updatedAt (data-derived — the library never reads a clock). */
+  readonly now?: string
+}
+```
+
+- [ ] **Step 2: Write the failing store tests**
+
+Append to `packages/memory/test/sqlite-store.test.ts` (inside the existing `describe("sqliteMemoryStore", ...)`, reusing the existing `rec()` helper):
+
+```ts
+  it("ranked recall: relevant-but-old beats recent-but-marginal (headline)", async () => {
+    const s = sqliteMemoryStore({ path: ":memory:" })
+    // Several acme memories so "acme" is common (low idf) in the namespace.
+    await s.put(rec({ id: "m1", namespace: "ns", content: "acme invoice format is pdf", updatedAt: "2026-06-30T00:00:00.000Z" }))
+    await s.put(rec({ id: "m2", namespace: "ns", content: "acme owner is jordan", updatedAt: "2026-07-01T00:00:00.000Z" }))
+    await s.put(rec({ id: "target", namespace: "ns", content: "acme billing escalation threshold is 500 dollars", updatedAt: "2026-05-20T00:00:00.000Z" }))
+    await s.put(rec({ id: "distractor", namespace: "ns", content: "acme contact jordan prefers slack", updatedAt: "2026-07-04T00:00:00.000Z" }))
+    const out = await s.search({
+      namespace: "ns",
+      query: "acme billing escalation threshold",
+      now: "2026-07-05T00:00:00.000Z",
+    })
+    // Pure recency (old behavior) would put "distractor" first; ranking must not.
+    expect(out[0]?.id).toBe("target")
+  })
+
+  it("ranked recall: same relevance ties break by recency then id", async () => {
+    const s = sqliteMemoryStore({ path: ":memory:" })
+    await s.put(rec({ id: "b_old", namespace: "ns", content: "billing threshold fact", updatedAt: "2026-07-01T00:00:00.000Z" }))
+    await s.put(rec({ id: "a_new", namespace: "ns", content: "billing threshold fact", updatedAt: "2026-07-04T00:00:00.000Z" }))
+    const out = await s.search({ namespace: "ns", query: "billing threshold", now: "2026-07-05T00:00:00.000Z" })
+    expect(out.map((r) => r.id)).toEqual(["a_new", "b_old"])
+  })
+
+  it("ranked recall: omitted `now` falls back to newest candidate (deterministic)", async () => {
+    const s = sqliteMemoryStore({ path: ":memory:" })
+    await s.put(rec({ id: "x", namespace: "ns", content: "billing threshold", updatedAt: "2026-07-04T00:00:00.000Z" }))
+    await s.put(rec({ id: "y", namespace: "ns", content: "billing note", updatedAt: "2026-07-01T00:00:00.000Z" }))
+    const a = await s.search({ namespace: "ns", query: "billing threshold" })
+    const b = await s.search({ namespace: "ns", query: "billing threshold" })
+    expect(a.map((r) => r.id)).toEqual(b.map((r) => r.id)) // same inputs → same order
+    expect(a[0]?.id).toBe("x") // matches 2/2 tokens; y matches 1/2
+  })
+
+  it("ranked recall: confidence breaks ties at equal relevance and recency", async () => {
+    const s = sqliteMemoryStore({ path: ":memory:" })
+    await s.put(rec({ id: "hedged", namespace: "ns", content: "billing threshold fact", confidence: 0.4, updatedAt: "2026-07-01T00:00:00.000Z" }))
+    await s.put(rec({ id: "sure", namespace: "ns", content: "billing threshold fact", confidence: 1, updatedAt: "2026-07-01T00:00:00.000Z" }))
+    const out = await s.search({ namespace: "ns", query: "billing threshold", now: "2026-07-05T00:00:00.000Z" })
+    expect(out[0]?.id).toBe("sure")
+  })
+
+  it("ranked recall: candidatePool caps scored candidates by recency, deterministically", async () => {
+    const s = sqliteMemoryStore({ path: ":memory:", recall: { candidatePool: 1 } })
+    await s.put(rec({ id: "older", namespace: "ns", content: "billing threshold exact", updatedAt: "2026-07-01T00:00:00.000Z" }))
+    await s.put(rec({ id: "newer", namespace: "ns", content: "billing note", updatedAt: "2026-07-04T00:00:00.000Z" }))
+    const out = await s.search({ namespace: "ns", query: "billing threshold", now: "2026-07-05T00:00:00.000Z" })
+    // Pool of 1 keeps only the NEWEST token-match; "older" never gets scored.
+    expect(out.map((r) => r.id)).toEqual(["newer"])
+  })
+
+  it("query-less search is unchanged: pure recency order", async () => {
+    const s = sqliteMemoryStore({ path: ":memory:" })
+    await s.put(rec({ id: "old", namespace: "ns", content: "billing threshold exact match", updatedAt: "2026-07-01T00:00:00.000Z" }))
+    await s.put(rec({ id: "new", namespace: "ns", content: "unrelated note", updatedAt: "2026-07-04T00:00:00.000Z" }))
+    const out = await s.search({ namespace: "ns" })
+    expect(out.map((r) => r.id)).toEqual(["new", "old"])
+  })
+```
+
+- [ ] **Step 3: Run tests to verify the new ones fail**
+
+Run: `pnpm --filter @dawn-ai/memory exec vitest run test/sqlite-store.test.ts`
+Expected: FAIL — headline test gets `distractor` first (recency order); candidatePool test fails on the `recall` option (TS error: unknown property) — if TS blocks the run entirely, that's the expected failure mode; proceed.
+
+- [ ] **Step 4: Implement the ranked path**
+
+In `packages/memory/src/sqlite-store.ts`:
+
+(a) Add imports at the top:
+
+```ts
+import {
+  DEFAULT_CANDIDATE_POOL,
+  type RecallRankingOptions,
+  scoreMemory,
+} from "./score.js"
+```
+
+(b) Change the factory signature:
+
+```ts
+export function sqliteMemoryStore(opts: {
+  path: string
+  /** Recall ranking tuning; all fields defaulted. See score.ts. */
+  recall?: RecallRankingOptions
+}): MemoryStore {
+```
+
+(c) Replace the body of `async search(q: MemoryQuery)` with:
+
+```ts
+    async search(q: MemoryQuery) {
+      const status = q.status ?? "active"
+      const limit = q.limit ?? 8
+      const terms = q.query ? tokenize(q.query) : []
+
+      // Shared base filter (namespace + status [+ kind]) — the "corpus".
+      let baseSql = `m.namespace = ? AND m.status = ?`
+      const baseParams: SQLInputValue[] = [q.namespace, status]
+      if (q.kind) {
+        baseSql += ` AND m.kind = ?`
+        baseParams.push(q.kind)
+      }
+
+      if (terms.length === 0) {
+        // Query-less path: EXACTLY the pre-ranking behavior (index fragment,
+        // listCandidates-adjacent consumers depend on pure recency order).
+        const rows = db
+          .prepare(
+            `SELECT m.* FROM memories m WHERE ${baseSql} ORDER BY m.updated_at DESC, m.id ASC LIMIT ?`,
+          )
+          .all(...baseParams, limit) as Record<string, unknown>[]
+        let records = rows.map(rowToRecord)
+        if (q.tags && q.tags.length > 0) {
+          const want = new Set(q.tags)
+          records = records.filter((r) => r.tags.some((t) => want.has(t)))
+        }
+        return records
+      }
+
+      // Ranked path — see docs/superpowers/specs/2026-07-05-smarter-recall-design.md.
+      const pool = opts.recall?.candidatePool ?? DEFAULT_CANDIDATE_POOL
+      const placeholders = terms.map(() => "?").join(",")
+
+      // 1) Candidate pool: rows matching ≥1 query token, newest first (pool
+      //    truncation by recency is deterministic).
+      const candidateRows = db
+        .prepare(
+          `SELECT m.* FROM memories m WHERE ${baseSql}
+           AND m.id IN (SELECT memory_id FROM memory_tokens WHERE token IN (${placeholders}))
+           ORDER BY m.updated_at DESC, m.id ASC LIMIT ?`,
+        )
+        .all(...baseParams, ...terms, pool) as Record<string, unknown>[]
+      const candidates = candidateRows.map(rowToRecord)
+      if (candidates.length === 0) return []
+
+      // 2) Corpus stats, computed live (nothing cached → nothing to go stale).
+      const corpusSize = (
+        db.prepare(`SELECT COUNT(*) AS n FROM memories m WHERE ${baseSql}`).get(...baseParams) as {
+          n: number
+        }
+      ).n
+      const dfRows = db
+        .prepare(
+          `SELECT t.token AS token, COUNT(DISTINCT t.memory_id) AS df
+           FROM memory_tokens t JOIN memories m ON m.id = t.memory_id
+           WHERE ${baseSql} AND t.token IN (${placeholders}) GROUP BY t.token`,
+        )
+        .all(...baseParams, ...terms) as { token: string; df: number }[]
+      const dfByToken = new Map(dfRows.map((r) => [r.token, r.df]))
+
+      // 3) Score. Candidate token sets are recomputed via the same helper
+      //    reindex() uses, so they are guaranteed consistent with the table.
+      //    Pool is updated_at-DESC ordered, so candidates[0] is the newest —
+      //    the data-derived reference when the caller supplies no clock.
+      const referenceNow = q.now ?? candidates[0]?.updatedAt ?? ""
+      const scored = candidates.map((record) => ({
+        record,
+        score: scoreMemory({
+          memoryTokens: new Set(tokensFor(record)),
+          queryTokens: terms,
+          dfByToken,
+          corpusSize,
+          updatedAt: record.updatedAt,
+          confidence: record.confidence,
+          referenceNow,
+          ...(opts.recall ? { options: opts.recall } : {}),
+        }),
+      }))
+
+      // 4) Sort (score DESC, updated_at DESC, id ASC — stable) and page.
+      scored.sort(
+        (a, b) =>
+          b.score - a.score ||
+          b.record.updatedAt.localeCompare(a.record.updatedAt) ||
+          a.record.id.localeCompare(b.record.id),
+      )
+      let records = scored.slice(0, limit).map((s) => s.record)
+
+      // 5) Tag post-filter on the returned page — today's semantics, unchanged.
+      if (q.tags && q.tags.length > 0) {
+        const want = new Set(q.tags)
+        records = records.filter((r) => r.tags.some((t) => want.has(t)))
+      }
+      return records
+    },
+```
+
+- [ ] **Step 5: Run the full memory package tests**
+
+Run: `pnpm --filter @dawn-ai/memory test`
+Expected: PASS — all new tests plus every pre-existing test (namespace, reconcile, tokenize, types, and the existing sqlite-store recency/isolation tests, which use either query-less searches or single-relevance cases that rank identically).
+
+If the pre-existing test `search matches tokenized keywords and orders by recency (updatedAt desc)` fails: inspect it — it uses two records with the SAME tokens, so equal relevance → recency tiebreak preserves its expected order. A failure there means the tiebreak is wrong; fix the comparator, not the test.
+
+- [ ] **Step 6: Lint + commit**
+
+```bash
+cd /Users/blove/repos/dawn
+pnpm exec biome check --config-path packages/config-biome/biome.json packages/memory/src packages/memory/test
+git add packages/memory/src packages/memory/test
+git commit -m "feat(memory): ranked recall path — IDF relevance + recency + confidence"
+```
+
+---
+
+### Task 3: Core types + capability passes `now`
+
+**Files:**
+- Modify: `packages/core/src/capabilities/types.ts` (MemoryStoreLike)
+- Modify: `packages/core/src/types.ts` (DawnConfig.memory.recall)
+- Modify: `packages/core/src/capabilities/built-in/memory.ts` (recall tool)
+- Create: `packages/core/test/memory-capability-recall.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/core/test/memory-capability-recall.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest"
+import { createMemoryMarker } from "../src/capabilities/built-in/memory.js"
+import type { CapabilityMarkerContext, MemoryContext } from "../src/capabilities/types.js"
+
+const NOW = "2026-07-05T12:00:00.000Z"
+
+function makeContext(captured: { query?: Record<string, unknown> }): CapabilityMarkerContext {
+  const memory: MemoryContext = {
+    store: {
+      async put() {},
+      async get() {
+        return null
+      },
+      async search(q) {
+        // The index query (query-less) also lands here; only capture ranked queries.
+        if ((q as { query?: string }).query) captured.query = q as Record<string, unknown>
+        return []
+      },
+      async update() {},
+      async supersede() {},
+    },
+    namespace: "route=/probe",
+    writes: "auto",
+    defined: { kind: "semantic", scope: ["route"] },
+    validate: () => ({ ok: true, value: {} }),
+    now: NOW,
+  }
+  return {
+    routeManifest: { tools: [], stateFields: [] } as unknown as CapabilityMarkerContext["routeManifest"],
+    descriptor: undefined,
+    appRoot: "/tmp/nowhere",
+    memory,
+  }
+}
+
+describe("memory capability recall tool", () => {
+  it("passes context.memory.now as the recency reference on ranked searches", async () => {
+    const captured: { query?: Record<string, unknown> } = {}
+    const marker = createMemoryMarker()
+    const contribution = await marker.load("/tmp/nowhere", makeContext(captured))
+    const recall = contribution.tools?.find((t) => t.name === "recall")
+    expect(recall).toBeDefined()
+    await recall?.run({ query: "billing threshold" }, { signal: new AbortController().signal })
+    expect(captured.query?.now).toBe(NOW)
+  })
+})
+```
+
+Note: if `CapabilityMarkerContext.routeManifest` rejects the cast above, mirror how the existing capability tests in `packages/core/test/` construct a minimal context (check `ls packages/core/test/` for e.g. skills/planning capability tests and copy their manifest stub).
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm --filter @dawn-ai/core exec vitest run test/memory-capability-recall.test.ts`
+Expected: FAIL — `captured.query?.now` is `undefined` (recall doesn't pass it yet). A TS error on `now` in the search arg type is the same failure; proceed.
+
+- [ ] **Step 3: Add `now` to `MemoryStoreLike.search`**
+
+In `packages/core/src/capabilities/types.ts`, change the search signature inside `MemoryStoreLike`:
+
+```ts
+  search(q: {
+    namespace: string
+    query?: string
+    kind?: string
+    tags?: readonly string[]
+    status?: string
+    limit?: number
+    /** ISO recency reference for ranked searches; stores may ignore it. */
+    now?: string
+  }): Promise<readonly MemoryRecordLike[]>
+```
+
+- [ ] **Step 4: Pass `now` from the recall tool**
+
+In `packages/core/src/capabilities/built-in/memory.ts`, in the `recall` tool's `run`, change the `mem.store.search({...})` call to include the reference timestamp:
+
+```ts
+          const rows = await mem.store.search({
+            namespace: mem.namespace,
+            ...(q.query ? { query: q.query } : {}),
+            ...(q.kind ? { kind: q.kind } : {}),
+            ...(q.tags ? { tags: q.tags } : {}),
+            limit: q.limit ?? 8,
+            // Recency reference for ranked recall — the per-request timestamp,
+            // NOT Date.now() (determinism rule; see module docblock).
+            now: mem.now,
+          })
+```
+
+- [ ] **Step 5: Add `recall` to `DawnConfig.memory`**
+
+In `packages/core/src/types.ts`, inside the `readonly memory?: { ... }` block (after `indexMaxEntries`), add:
+
+```ts
+    /** Recall ranking tuning for the default SQLite store. All fields
+     *  defaulted; omit for standard behavior. Ignored when a custom `store`
+     *  is supplied (custom stores own their own ranking). */
+    readonly recall?: {
+      readonly weights?: {
+        readonly relevance?: number
+        readonly recency?: number
+        readonly confidence?: number
+      }
+      readonly recencyHalfLifeMs?: number
+      readonly candidatePool?: number
+    }
+```
+
+(Structural on purpose — `@dawn-ai/core` must not import `@dawn-ai/memory`.)
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `pnpm --filter @dawn-ai/core test`
+Expected: PASS — the new test plus all existing core tests (the added `now` field is optional; existing fake stores ignore it).
+
+- [ ] **Step 7: Lint + commit**
+
+```bash
+cd /Users/blove/repos/dawn
+pnpm exec biome check --config-path packages/config-biome/biome.json packages/core/src packages/core/test/memory-capability-recall.test.ts
+git add packages/core/src packages/core/test/memory-capability-recall.test.ts
+git commit -m "feat(core): recall passes per-request now; DawnConfig.memory.recall tuning type"
+```
+
+---
+
+### Task 4: CLI threads `memory.recall` config into the default store
+
+**Files:**
+- Modify: `packages/cli/src/lib/runtime/resolve-memory.ts`
+- Modify: `packages/cli/test/resolve-memory.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Read `packages/cli/test/resolve-memory.test.ts` first and reuse its existing tmp-appRoot/config-file helpers. Add this test (adapt helper names to what the file actually uses):
+
+```ts
+it("threads config.memory.recall into the default sqlite store", async () => {
+  // App root with a dawn.config.ts that caps the ranked candidate pool at 1.
+  const appRoot = await makeTmpApp({
+    dawnConfig: `export default { memory: { recall: { candidatePool: 1 } } }\n`,
+  })
+  const store = await resolveMemoryStore(appRoot)
+  const base = {
+    kind: "semantic" as const,
+    namespace: "ns",
+    data: {},
+    source: { type: "run" as const, id: "r" },
+    confidence: 1,
+    tags: [],
+    status: "active" as const,
+    createdAt: "2026-07-01T00:00:00.000Z",
+  }
+  await store.put({ ...base, id: "older", content: "billing threshold exact", updatedAt: "2026-07-01T00:00:00.000Z" })
+  await store.put({ ...base, id: "newer", content: "billing note", updatedAt: "2026-07-04T00:00:00.000Z" })
+  const out = await store.search({ namespace: "ns", query: "billing threshold", now: "2026-07-05T00:00:00.000Z" })
+  // candidatePool 1 → only the newest token-match is scored/returned. With the
+  // default pool (256), "older" (2/2 token match) would win instead.
+  expect(out.map((r) => r.id)).toEqual(["newer"])
+})
+```
+
+If the existing file has no tmp-app helper, create the app root with `mkdtemp` + write `dawn.config.ts` with `writeFile`, matching whatever pattern `resolve-memory.test.ts` already uses for its `resolveMemoryWrites` config tests (it has ones — mirror them exactly).
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm --filter @dawn-ai/cli exec vitest run test/resolve-memory.test.ts`
+Expected: the new test FAILS with `["older"]` first (recall options not threaded, default pool 256 scores both, older wins on relevance).
+
+- [ ] **Step 3: Thread the option**
+
+In `packages/cli/src/lib/runtime/resolve-memory.ts`, replace `resolveMemoryStore` with:
+
+```ts
+export async function resolveMemoryStore(appRoot: string): Promise<MemoryStoreLike> {
+  let recall: Record<string, unknown> | undefined
+  try {
+    const loaded = await loadDawnConfig({ appRoot })
+    if (loaded.config.memory?.store) return loaded.config.memory.store as MemoryStoreLike
+    recall = loaded.config.memory?.recall as Record<string, unknown> | undefined
+  } catch {
+    // no dawn.config.ts / unreadable — use default
+  }
+  return sqliteMemoryStore({
+    path: join(appRoot, ".dawn", "memory.sqlite"),
+    ...(recall ? { recall } : {}),
+  }) as unknown as MemoryStoreLike
+}
+```
+
+- [ ] **Step 4: Run the CLI memory tests**
+
+Run: `pnpm --filter @dawn-ai/cli exec vitest run test/resolve-memory.test.ts test/build-memory-context.test.ts test/memory-command.test.ts`
+Expected: PASS (new test + all existing).
+
+- [ ] **Step 5: Lint + commit**
+
+```bash
+cd /Users/blove/repos/dawn
+pnpm exec biome check --config-path packages/config-biome/biome.json packages/cli/src/lib/runtime/resolve-memory.ts packages/cli/test/resolve-memory.test.ts
+git add packages/cli/src/lib/runtime/resolve-memory.ts packages/cli/test/resolve-memory.test.ts
+git commit -m "feat(cli): thread DawnConfig.memory.recall into the default memory store"
+```
+
+---
+
+### Task 5: aimock before/after e2e (the headline proof)
+
+**Files:**
+- Create: `packages/testing/test/memory-ranking-e2e.test.ts`
+
+Model: `packages/testing/test/memory-e2e.test.ts` (same probe app `/memory-chat#agent`, auto-writes mode, schema `{subject, predicate, value}`).
+
+- [ ] **Step 1: Write the test**
+
+Create `packages/testing/test/memory-ranking-e2e.test.ts`:
+
+```ts
+// Deterministic (aimock) e2e for RANKED recall: a relevant-but-old memory must
+// outrank a recent-but-marginal one. Under pure-recency (pre-ranking) recall
+// this test FAILS — it is the before/after proof for smarter recall. aimock
+// scripts only the model; runtime, capability, SQLite, tokenization, and
+// ranking are all real. Runs in CI (no API key).
+import { rmSync } from "node:fs"
+import { join } from "node:path"
+import { fileURLToPath } from "node:url"
+import { sqliteMemoryStore } from "@dawn-ai/memory"
+import { afterAll, beforeAll, expect, it } from "vitest"
+import { script } from "../src/fixture-builder.js"
+import { createAgentHarness } from "../src/harness.js"
+
+const appRoot = fileURLToPath(new URL("./fixtures/probe-app", import.meta.url))
+const dbBase = join(appRoot, ".dawn", "memory.sqlite")
+function cleanDb() {
+  for (const suffix of ["", "-wal", "-shm"]) rmSync(`${dbBase}${suffix}`, { force: true })
+}
+
+beforeAll(cleanDb)
+afterAll(cleanDb)
+
+it("ranks a relevant-but-old memory above a recent-but-marginal one", async () => {
+  // Seed the backdated relevant fact directly: writes through the remember
+  // tool always stamp the request time, so age must be seeded at the store.
+  const store = sqliteMemoryStore({ path: dbBase })
+  const sixWeeksAgo = new Date(Date.now() - 42 * 24 * 60 * 60 * 1000).toISOString()
+  await store.put({
+    id: "memory_ranktarget",
+    kind: "semantic",
+    namespace: "route=/memory-chat",
+    content: "acme billing escalation threshold is 500 dollars",
+    data: { subject: "acme", predicate: "billing-escalation-threshold", value: "500 dollars" },
+    source: { type: "tool", id: "remember" },
+    confidence: 1,
+    tags: [],
+    status: "active",
+    createdAt: sixWeeksAgo,
+    updatedAt: sixWeeksAgo,
+  })
+
+  const h = await createAgentHarness({ appRoot, route: "/memory-chat#agent" })
+  try {
+    // Fresh marginal distractor written through the REAL agent loop
+    // (tool → validate → put → reindex), auto mode → active immediately.
+    h.reset()
+    await h.run({
+      input: "Remember that the acme contact jordan prefers slack.",
+      fixtures: script()
+        .user("Remember that the acme contact jordan prefers slack.")
+        .callsTool("remember", {
+          data: { subject: "acme-contact", predicate: "prefers", value: "slack" },
+          content: "acme contact jordan prefers slack",
+        })
+        .replies("Noted."),
+    })
+
+    // Recall: aimock scripts the CALL; the tool RESULT (and its ordering) is real.
+    h.reset()
+    const r = await h.run({
+      input: "What is acme's billing escalation threshold?",
+      fixtures: script()
+        .user("What is acme's billing escalation threshold?")
+        .callsTool("recall", { query: "acme billing escalation threshold" })
+        .replies("The threshold is 500 dollars."),
+    })
+    const recall = r.toolResults.find((t) => t.name === "recall")
+    expect(recall, "recall tool must have been executed").toBeDefined()
+    const lines = String(recall?.content ?? "").split("\n")
+    // Both memories share the "acme" token, so both are in the result set;
+    // the SIX-WEEK-OLD relevant fact must be ranked FIRST. Pure recency
+    // (the pre-ranking behavior) puts the fresh distractor first instead.
+    expect(lines.length).toBeGreaterThanOrEqual(2)
+    expect(lines[0]).toContain("memory_ranktarget")
+  } finally {
+    await h.close()
+  }
+}, 60_000)
+```
+
+- [ ] **Step 2: Verify it fails against pre-ranking code (sanity of the "before" claim)**
+
+```bash
+cd /Users/blove/repos/dawn
+git stash  # stash nothing-or-WIP; the ranking commits are already in — so instead:
+```
+
+Skip the literal revert dance: the "fails before" property was locked in by Task 2's headline store test (same ordering logic). Just run it against the current build:
+
+Run: `pnpm --filter @dawn-ai/testing exec vitest run test/memory-ranking-e2e.test.ts`
+Expected: PASS. (If it fails with `lines[0]` = the distractor, the ranked path is not engaged end-to-end — check that the testing package resolves the WORKSPACE `@dawn-ai/memory` build: run `pnpm build` first; the harness consumes built dist via workspace linking.)
+
+- [ ] **Step 3: Run the neighboring memory e2es for regressions**
+
+Run: `pnpm --filter @dawn-ai/testing exec vitest run test/memory-e2e.test.ts test/memory-index-refresh.test.ts test/memory-seed.test.ts`
+Expected: PASS (their recall cases have a single matching memory — order-insensitive).
+
+- [ ] **Step 4: Lint + commit**
+
+```bash
+cd /Users/blove/repos/dawn
+pnpm exec biome check --config-path packages/config-biome/biome.json packages/testing/test/memory-ranking-e2e.test.ts
+git add packages/testing/test/memory-ranking-e2e.test.ts
+git commit -m "test(testing): ranked-recall before/after e2e — relevance beats recency"
+```
+
+---
+
+### Task 6: Live smoke ranking scenario (gated)
+
+**Files:**
+- Modify: `packages/testing/test/memory-live.smoke.test.ts`
+
+- [ ] **Step 1: Add the scenario**
+
+Append to `packages/testing/test/memory-live.smoke.test.ts` (reusing the file's existing `live`, `probeRoot`, `dbPath`, `cleanDb` helpers and its `it.skipIf(!live)` pattern):
+
+```ts
+it.skipIf(!live)(
+  "ranked recall: real model finds the relevant old fact past a fresh distractor",
+  async () => {
+    // Seed the backdated relevant fact (remember stamps request time; age must be seeded).
+    const store = sqliteMemoryStore({ path: dbPath(probeRoot) })
+    const sixWeeksAgo = new Date(Date.now() - 42 * 24 * 60 * 60 * 1000).toISOString()
+    await store.put({
+      id: "memory_live_ranktarget",
+      kind: "semantic",
+      namespace: "route=/memory-chat",
+      content: "acme billing escalation threshold is 500 dollars",
+      data: { subject: "acme", predicate: "billing-escalation-threshold", value: "500 dollars" },
+      source: { type: "tool", id: "remember" },
+      confidence: 1,
+      tags: [],
+      status: "active",
+      createdAt: sixWeeksAgo,
+      updatedAt: sixWeeksAgo,
+    })
+
+    const h = await createAgentHarness({
+      appRoot: probeRoot,
+      route: "/memory-chat#agent",
+      live: true,
+    })
+    try {
+      h.reset()
+      // Real model stores a fresh marginal distractor its own way.
+      await h.run({
+        input:
+          "Use the remember tool now. data: subject 'acme-contact', predicate 'prefers', value 'slack'.",
+      })
+      h.reset()
+      // Natural question — covers what aimock cannot: whether the model's own
+      // query phrasing is good enough for the ranker.
+      const r = await h.run({
+        input: "What is acme's billing escalation threshold?",
+      })
+      expect(r.finalMessage).toContain("500")
+    } finally {
+      await h.close()
+    }
+  },
+  150_000,
+)
+```
+
+- [ ] **Step 2: Verify it still SKIPS without a key (CI safety)**
+
+Run: `env -u OPENAI_API_KEY pnpm --filter @dawn-ai/testing exec vitest run test/memory-live.smoke.test.ts`
+Expected: all tests skipped (now 6 skipped).
+
+- [ ] **Step 3: Run the full live smoke locally (gated)**
+
+The key lives in `/Users/blove/repos/dawn/.env` — authorized for LOCAL runs only. NEVER print it, never add it to CI.
+
+```bash
+cd /Users/blove/repos/dawn
+set -a; . ./.env; set +a
+pnpm --filter @dawn-ai/testing exec vitest run test/memory-live.smoke.test.ts
+```
+
+Expected: 6 passed (5 existing + the new ranking scenario). If the new scenario fails, diagnose before touching assertions: check the recall tool result ordering in `r.toolResults` first (ranker vs model-phrasing issue).
+
+- [ ] **Step 4: Lint + commit**
+
+```bash
+cd /Users/blove/repos/dawn
+pnpm exec biome check --config-path packages/config-biome/biome.json packages/testing/test/memory-live.smoke.test.ts
+git add packages/testing/test/memory-live.smoke.test.ts
+git commit -m "test(testing): gated live ranking scenario — natural query beats fresh distractor"
+```
+
+---
+
+### Task 7: Documentation + spec amendment
+
+**Files:**
+- Modify: `apps/web/content/docs/memory.mdx`
+- Modify: `docs/dev/memory-system.md` (untracked — will be added)
+- Add: `docs/dev/smarter-recall-dx.md` (untracked — will be added)
+- Modify: `docs/superpowers/specs/2026-07-05-smarter-recall-design.md`
+
+- [ ] **Step 1: Update `memory.mdx`**
+
+(a) Find the `<Callout type="info" title="Deterministic recall">` block and replace its body text with:
+
+```text
+Recall is deterministic: an IDF-weighted keyword match blended with recency and confidence, over a SQLite store — no FTS5, embedding model, or network call in the path. The same query against the same store returns the same rows in the same order, which keeps evals and fixtures stable (and replayable under aimock).
+```
+
+(b) After the paragraph documenting **`recall({ query?, kind?, tags?, limit? })`**, add a new subsection:
+
+```mdx
+### How recall ranks
+
+Ranked recall (any call with a `query`) orders results by a weighted blend:
+
+| Signal | Default weight | Meaning |
+|---|---|---|
+| Relevance | 0.6 | IDF-weighted overlap — matching rare, specific words counts far more than ubiquitous ones |
+| Recency | 0.3 | Exponential decay; the boost halves every 14 days |
+| Confidence | 0.1 | The `confidence` stored with the memory |
+
+Ties break by `updatedAt` (newest first), then `id`. Query-less searches (the
+injected index, `dawn memory list`) keep pure recency order.
+
+Tune it in `dawn.config.ts` (all fields optional and defaulted):
+
+```ts title="dawn.config.ts"
+export default {
+  memory: {
+    recall: {
+      weights: { relevance: 0.6, recency: 0.3, confidence: 0.1 },
+      recencyHalfLifeMs: 14 * 24 * 60 * 60 * 1000,
+      candidatePool: 256, // ranked searches score at most this many newest token-matches
+    },
+  },
+} satisfies import("@dawn-ai/core").DawnConfig
+```
+
+<Callout type="info" title="No stemming">
+  Matching is exact-token: "escalation" and "escalates" are different tokens.
+  Specific, consistent wording in remembered `content` gives the ranker better
+  signal — vague summaries rank vaguely.
+</Callout>
+```
+
+(c) In the "What's deferred" list, remove/adjust the "importance-weighted ranking" clause (now shipped) while keeping vector/BM25-FTS5 deferred.
+
+- [ ] **Step 2: Update `docs/dev/memory-system.md`**
+
+- §4: replace the "`search(query)` today" steps and the "pure recency" gap paragraph with the ranked-path description (pool → live df/N stats → `scoreMemory` → sort → limit; query-less path unchanged).
+- §13: move "recall ranking is pure recency" from limitations to shipped; keep vector/episodic/graph/inspector/postgres deferred.
+- §14: retitle to reflect DONE and note vector recall plugs into `score.ts`.
+
+- [ ] **Step 3: Amend the spec (eval-dogfood deferral)**
+
+In `docs/superpowers/specs/2026-07-05-smarter-recall-design.md`, replace the `**Eval dogfood:**` bullet with:
+
+```markdown
+- **Eval dogfood: DEFERRED.** The research template ships no evals today, and
+  adding `@dawn-ai/evals` to a scaffold template destabilizes the generated-app
+  verify lanes (known SCAFFOLD_PACKAGES hazard). The aimock before/after e2e is
+  the deterministic quality gate; a template eval can follow when the template
+  grows an evals directory for other reasons.
+```
+
+- [ ] **Step 4: Docs check + commit**
+
+```bash
+cd /Users/blove/repos/dawn
+node scripts/check-docs.mjs
+git add apps/web/content/docs/memory.mdx docs/dev/memory-system.md docs/dev/smarter-recall-dx.md docs/superpowers/specs/2026-07-05-smarter-recall-design.md
+git commit -m "docs(memory): how recall ranks + dev walkthrough/DX docs + spec amendment"
+```
+
+(`check-docs.mjs` bans certain marketing phrases in source — e.g. `byte-identical`. If it flags one of the new docs, reword.)
+
+---
+
+### Task 8: Changeset, full validation, PR
+
+**Files:**
+- Create: `.changeset/smarter-recall.md`
+
+- [ ] **Step 1: Write the changeset (PATCH — fixed 0.x group; minor would bump the whole group to 1.0.0)**
+
+Create `.changeset/smarter-recall.md`:
+
+```markdown
+---
+"@dawn-ai/memory": patch
+"@dawn-ai/core": patch
+"@dawn-ai/cli": patch
+---
+
+Smarter recall: long-term-memory `recall` now ranks results by IDF-weighted
+relevance blended with recency decay and stored confidence, instead of pure
+recency — a six-week-old fact that actually answers the query outranks
+yesterday's marginal match. Deterministic (no clock, no network, no new deps;
+same store + same query → same order), zero-config (tune via
+`DawnConfig.memory.recall` only if needed), and query-less searches (the
+injected index, `dawn memory list`) keep their recency order.
+```
+
+- [ ] **Step 2: Full local validation**
+
+```bash
+cd /Users/blove/repos/dawn
+pnpm lint && pnpm build && pnpm typecheck && pnpm test
+```
+
+Expected: all green. Run `pnpm test` WITHOUT sourcing `.env` (a sourced OPENAI_API_KEY un-skips live smokes AND pollutes env-loading tests — known false-failure source).
+
+- [ ] **Step 3: Commit changeset, push, open PR**
+
+```bash
+cd /Users/blove/repos/dawn
+git add .changeset/smarter-recall.md
+git commit -m "chore: changeset for smarter recall"
+git push -u origin feat/memory-recall-ranking
+gh pr create --base main --head feat/memory-recall-ranking \
+  --title "feat(memory): smarter recall — IDF-weighted relevance ranking" \
+  --body "$(cat <<'EOF'
+## What
+
+`recall` now ranks by relevance instead of pure recency: IDF-weighted token
+overlap (0.6) + recency decay, half-life 14d (0.3) + stored confidence (0.1),
+with a stable updatedAt/id tiebreak. A six-week-old fact that answers the
+query outranks yesterday's marginal match.
+
+- New pure `score.ts` in `@dawn-ai/memory` (idf + scoreMemory + options)
+- Ranked path in `sqliteMemoryStore.search()` — candidate pool (256) + live
+  df/N corpus stats; query-less searches (index fragment, `dawn memory list`)
+  are byte-for-byte unchanged
+- `MemoryQuery.now` recency reference; capability passes `context.memory.now`
+  (no clock in the library — absent `now` falls back to newest candidate)
+- `DawnConfig.memory.recall` tuning (weights / halfLife / candidatePool),
+  threaded via `resolveMemoryStore`; custom stores unaffected
+- Docs: "How recall ranks" + dev walkthrough (`docs/dev/memory-system.md`) +
+  DX draft
+
+## Proof
+
+- `memory-ranking-e2e.test.ts` (aimock, CI-safe): relevant-but-old memory is
+  the FIRST recall result past a fresh distractor written through the real
+  agent loop — this test fails under pre-ranking pure-recency code.
+- Store-level exact-ordering tests + pure score units (IDF dominance, decay
+  half-life, clamps, tiebreaks, absent-now fallback).
+- Gated live smoke extended with a natural-phrasing ranking scenario — 6/6
+  locally against a real model (skips in CI, no key).
+
+## Notes
+
+- Deterministic end to end: no Date.now(), no network, no new dependencies.
+- Spec: docs/superpowers/specs/2026-07-05-smarter-recall-design.md (template
+  eval dogfood deferred — scaffold-lane hazard; noted in spec).
+- Patch changeset (fixed 0.x group).
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 4: Auto-merge + verify**
+
+```bash
+gh pr merge --squash --auto
+gh pr checks --watch
+```
+
+Expected: validate/CodeQL/review/changesets all green → auto-merges.
+
+---
+
+## Self-review notes (done at plan time)
+
+- **Spec coverage:** score module (T1), ranked path + pool + stats + query-less preservation (T2), `now` plumbing both type layers + capability (T3), config threading (T4), aimock before/after e2e (T5), live scenario (T6), docs + spec amendment (T7), patch changeset (T8). Eval-dogfood consciously deferred with spec amendment (T7). ✓
+- **Type consistency:** `RecallRankingOptions`/`scoreMemory` signature identical across T1 (definition), T2 (store usage), T3/T4 (structural config mirror). `MemoryQuery.now` (memory) ↔ `search(q).now` (core structural) both optional strings. ✓
+- **Known trap flags embedded:** bare-biome ban, patch-not-minor changeset, `.env` pollution of `pnpm test`, `check-docs.mjs` banned phrases, workspace build before harness e2e.

--- a/docs/superpowers/specs/2026-07-05-smarter-recall-design.md
+++ b/docs/superpowers/specs/2026-07-05-smarter-recall-design.md
@@ -1,0 +1,274 @@
+# Smarter Recall Design (Phase 4 — memory follow-up)
+
+Date: 2026-07-05
+Status: approved design, pending implementation plan
+Branch: `feat/memory-recall-ranking`
+
+## Goal
+
+Replace pure-recency ordering in long-term-memory recall with a deterministic
+relevance score, so `recall({ query })` returns the memories that best match the
+question — not merely the most recently written ones. Stay inside `node:sqlite`
+(no FTS5, no embeddings, no network, no new dependencies) and preserve byte-level
+determinism so aimock fixtures and eval scorers remain stable.
+
+## Background: what exists today
+
+`sqliteMemoryStore().search()` (`packages/memory/src/sqlite-store.ts`):
+
+1. Tokenize the query (`tokenize.ts`: lowercase, split on non-alphanumerics,
+   drop 1-char tokens, **dedupe**).
+2. SQL filter: `namespace = ? AND status = ?` [+ `kind = ?`] and, when the query
+   has tokens, `id IN (SELECT memory_id FROM memory_tokens WHERE token IN (...))`.
+3. `ORDER BY updated_at DESC, id ASC LIMIT ?` — **pure recency**.
+4. Optional tag post-filter in JS.
+
+Consequences: a memory matching one query token ranks identically to one
+matching five; the stored `confidence` field is never read during recall.
+
+Constraints inherited from the shipped system (verified in code):
+
+- `memory_tokens` holds **one row per distinct token per memory** (tokenize
+  dedupes) → term frequency is not stored; classic BM25 is impossible without a
+  schema migration.
+- `@dawn-ai/memory` library code must not call `Date.now()` (determinism rule);
+  the capability receives a per-request timestamp as `context.memory.now`.
+- Tokens are indexed from `content + tags + JSON data values` (`reindex()`), so
+  matching already spans all three.
+- The memory-index prompt fragment and `listCandidates` perform **query-less**
+  searches; their recency ordering is depended on by shipped tests
+  (`memory-index-refresh.test.ts`, live smoke) and must not change.
+
+Related prior work: PR #257 (tool input schemas + index `cacheKey` refresh),
+PR #279 (non-Zod schema guard). Both merged; this design assumes them.
+
+## Decision: IDF-weighted overlap (Option B)
+
+Three options were considered:
+
+- **A. Plain overlap count** — rank by number of matched query tokens. Rejected:
+  treats "the" and "acme" as equally informative.
+- **B. IDF-weighted overlap (chosen)** — weight each matched token by how rare it
+  is in the namespace. Computable entirely from the existing tables.
+- **C. Full BM25** — requires term frequency, hence a schema migration +
+  reindex of existing rows. Rejected (not deferred-by-accident): memories are
+  one-line facts; TF adds ~nothing for short documents, at real migration cost.
+
+**Doc-length normalization is deliberately omitted.** Because relevance is an
+overlap *fraction* bounded per query (see below), a memory with many tokens
+gains no per-query score advantage from its extra tokens; BM25's length damping
+exists to counter TF inflation, which cannot occur here. If vector recall later
+lands, the scoring seam (`score.ts`) is where such a knob would go.
+
+## Scoring model
+
+For a query that tokenizes to `Q = {q1..qn}` (n ≥ 1), against the candidate set
+described below:
+
+```
+idf(t)     = ln(1 + (N − df(t) + 0.5) / (df(t) + 0.5))
+             N     = count of memories matching the SQL base filter
+                     (namespace + status [+ kind]) — the "corpus"
+             df(t) = count of corpus memories containing token t
+
+relevance  = Σ_{t ∈ Q ∩ tokens(m)} idf(t) / Σ_{t ∈ Q} idf(t)        ∈ [0, 1]
+
+recency    = 2^(−ageMs / halfLifeMs)                                 ∈ (0, 1]
+             ageMs = reference − updated_at (clamped ≥ 0)
+             reference = query.now when provided, else the maximum
+             updated_at across the candidate set (data-derived fallback)
+             halfLifeMs default = 14 days
+
+confidence = the record's stored confidence, clamped to [0, 1]
+
+score      = wRel·relevance + wRec·recency + wConf·confidence
+             defaults: wRel = 0.6, wRec = 0.3, wConf = 0.1
+
+order      = score DESC, then updated_at DESC, then id ASC
+```
+
+Notes:
+
+- The BM25-smoothed idf is **always positive**, including when df = N (a token
+  present in every memory still contributes a small weight; no zeroing, no
+  negative values as in unsmoothed idf).
+- Query tokens with df = 0 (appearing in *no* memory) contribute their (maximal)
+  idf to the **denominator only**. This is a per-query constant, so relative
+  ordering is unaffected; it simply keeps `relevance` interpretable as
+  "fraction of the query's information matched".
+- Weights are used as given (after filling defaults); they need not sum to 1 —
+  the score is used only for ordering.
+- All arithmetic is pure; identical inputs always produce identical order. The
+  `updated_at DESC, id ASC` tiebreak keeps ordering stable when scores are
+  exactly equal.
+
+## Determinism and the `now` parameter
+
+`MemoryQuery` gains an optional field:
+
+```ts
+interface MemoryQuery {
+  // ...existing fields...
+  /** ISO timestamp used as the recency reference. Optional; when absent,
+   *  recency is measured relative to the newest candidate's updated_at. */
+  readonly now?: string
+}
+```
+
+- The **capability's `recall` tool** passes `context.memory.now` (already
+  plumbed per-request by the CLI) so recall reflects true staleness.
+- Direct store callers (tests, CLI internals) may omit it; the fallback
+  reference is the max `updated_at` among candidates — fully data-derived, so
+  the library still never reads a clock.
+- The structural `MemoryStoreLike.search()` signature in
+  `@dawn-ai/core/capabilities/types.ts` gains the same optional `now`.
+
+`Date.parse()` on the ISO strings is the only time handling; invalid or missing
+timestamps degrade to age 0 (recency = 1) rather than throwing.
+
+## Execution flow in `search()`
+
+When `q.query` tokenizes to **zero** tokens (or is absent): the existing SQL
+path runs unchanged (`ORDER BY updated_at DESC, id ASC LIMIT ?`). This preserves
+the index fragment, `listCandidates`, and every current query-less consumer
+byte-for-byte.
+
+When it tokenizes to **≥ 1** token:
+
+1. **Candidate pool** — existing SQL filter (≥ 1 token match), but ordered by
+   `updated_at DESC, id ASC` and capped at `candidatePool` (default **256**)
+   instead of the caller's `limit`. Pool truncation by recency is deterministic;
+   the cap is documented (docs page) since a silent cap can read as "searched
+   everything".
+2. **Corpus stats** — one query for `N` (count over the base filter) and one for
+   per-token `df` (`SELECT token, COUNT(DISTINCT memory_id) ... WHERE token IN
+   (...)` joined to the base filter). Small: bounded by |Q| rows.
+3. **Score** each candidate with the pure scorer. Each candidate's token set is
+   recomputed in JS via the same token-derivation helper `reindex()` uses
+   (content + tags + data values → `tokenize()`), so it is guaranteed
+   consistent with what the token table holds — no extra SQL round-trip.
+4. **Sort** by the composite order and apply the caller's `limit` (default 8).
+5. **Tag post-filter** is applied after the limit, on the returned page —
+   exactly today's semantics (including the existing under-fill caveat when
+   combining `tags` with `limit`; unchanged by this work).
+
+Perf envelope: per-namespace memory counts are small (tens to low hundreds);
+pool ≤ 256; everything is index-backed. No measurable regression expected; no
+caching added (YAGNI).
+
+## Public API and configuration
+
+New pure module `packages/memory/src/score.ts`:
+
+```ts
+export interface RecallWeights {
+  readonly relevance?: number   // default 0.6
+  readonly recency?: number     // default 0.3
+  readonly confidence?: number  // default 0.1
+}
+export interface RecallRankingOptions {
+  readonly weights?: RecallWeights
+  readonly recencyHalfLifeMs?: number   // default 14 * 24 * 60 * 60 * 1000
+  readonly candidatePool?: number       // default 256
+}
+export function idf(df: number, corpusSize: number): number
+export function scoreMemory(args: {
+  readonly memoryTokens: ReadonlySet<string>
+  readonly queryTokens: readonly string[]
+  readonly dfByToken: ReadonlyMap<string, number>
+  readonly corpusSize: number
+  readonly updatedAt: string
+  readonly confidence: number
+  readonly referenceNow: string
+  readonly options?: RecallRankingOptions
+}): number
+```
+
+Store factory:
+
+```ts
+sqliteMemoryStore({ path, recall?: RecallRankingOptions })
+```
+
+Config surface (`DawnConfig.memory` in `@dawn-ai/core/types.ts`):
+
+```ts
+memory?: {
+  // ...existing fields...
+  /** Recall ranking tuning. All fields defaulted; omit for standard behavior. */
+  readonly recall?: {
+    readonly weights?: { relevance?: number; recency?: number; confidence?: number }
+    readonly recencyHalfLifeMs?: number
+    readonly candidatePool?: number
+  }
+}
+```
+
+`resolveMemoryStore()` (`packages/cli/src/lib/runtime/resolve-memory.ts`)
+threads `config.memory.recall` into the default `sqliteMemoryStore` call.
+A custom `config.memory.store` bypasses all of this (it owns its own ranking).
+
+## Error handling / edge cases
+
+- **Empty corpus (N = 0)** — the token filter yields no candidates; empty result,
+  no division by zero (denominator path never runs without candidates).
+- **All-common token (df = N)** — smoothed idf stays a small positive number.
+- **Query tokens matching nothing** — inflate only the shared denominator;
+  ordering unaffected.
+- **Missing/invalid timestamps** — age clamps to 0 (recency 1); never throws.
+- **`confidence` outside [0,1]** — clamped defensively in the scorer.
+- **Weights all zero** — score 0 for everything; tiebreak (recency) fully
+  determines order, i.e. degrades to today's behavior rather than misbehaving.
+- **Tag filter interaction** — tags are applied as a post-filter on the ranked,
+  limited page (current behavior preserved). Documented caveat (existing):
+  combining `tags` with `limit` can under-fill the page; unchanged by this work.
+- **candidatePool exceeded** — deterministic recency truncation; noted in the
+  docs page.
+
+## Testing
+
+- **`score.test.ts` (new, pure units):** idf monotonicity + smoothing bounds;
+  rare-token dominance ("matches 1 rare term > matches 1 common term");
+  overlap-fraction behavior ("matches 2 terms > matches 1, same rarity");
+  recency decay halving at half-life; confidence weight effect; absent-`now`
+  fallback; weight-override arithmetic; clamping.
+- **Store-level ordering tests (`sqlite-store.test.ts` additions):** seed a
+  namespace and assert exact expected orderings, including: relevant-but-older
+  beats recent-but-marginal (the headline case); query-less path unchanged
+  (exact recency order); `now` passed vs omitted; candidatePool truncation;
+  kind/status filters interact correctly with corpus stats.
+- **Capability:** recall tool passes `context.memory.now` (assert via a fake
+  store capturing the query).
+- **Existing suites stay green:** `@dawn-ai/memory` units, capability tests,
+  `memory-e2e.test.ts` (cross-thread), `memory-index-refresh.test.ts`,
+  research-template eval. Any assertion that is accidentally order-sensitive
+  with a single result is unaffected by construction.
+- **Gated live smoke** (`memory-live.smoke.test.ts`) re-run locally
+  (OPENAI_API_KEY, never CI) as final verification.
+- **Eval dogfood:** add one recall-ranking case to the research template's
+  memory eval using the existing `memoryRecalled` scorer (seed two memories,
+  query for the specific one, expect the relevant id first).
+
+## Documentation
+
+- `apps/web/content/docs/memory.mdx` — update the "Deterministic recall" callout
+  and add a short "How recall ranks" subsection (IDF-weighted overlap + recency
+  + confidence; the `memory.recall` config; the candidatePool cap).
+- `docs/dev/memory-system.md` — update §4 (search internals) and §13/§14
+  (roadmap: ranking done; vector recall plugs into the scoring seam).
+
+## Packaging & release
+
+- Changed packages: `@dawn-ai/memory` (score.ts, search), `@dawn-ai/core`
+  (`DawnConfig.memory.recall`, `MemoryQuery.now` structural type),
+  `@dawn-ai/cli` (`resolveMemoryStore` threading).
+- Changeset: **patch** for all three (fixed 0.x group — patch keeps the group on
+  a patch; do not use minor, per release GOTCHA 6).
+
+## Out of scope (explicit)
+
+- Vector / embedding recall (next natural sub-project; `score.ts` is its seam).
+- Term-frequency storage / true BM25 (rejected, see Decision).
+- Doc-length normalization (omitted with rationale, see Decision).
+- Episodic/procedural/reflection kinds, memory graph, Inspector UI, Postgres.
+- Any change to write governance, supersession, or the index fragment.

--- a/docs/superpowers/specs/2026-07-05-smarter-recall-design.md
+++ b/docs/superpowers/specs/2026-07-05-smarter-recall-design.md
@@ -239,12 +239,24 @@ A custom `config.memory.store` bypasses all of this (it owns its own ranking).
   kind/status filters interact correctly with corpus stats.
 - **Capability:** recall tool passes `context.memory.now` (assert via a fake
   store capturing the query).
+- **Agent e2e (aimock, CI-safe) — the headline scenario:** seed a backdated
+  (~6 weeks) relevant fact directly via the store (writes through the
+  `remember` tool always stamp `now`, so age must be seeded), write a fresh
+  marginal distractor through the real agent loop, then drive `recall` with a
+  scripted tool call and assert the relevant memory is the FIRST line of the
+  real tool result. This test FAILS against today's pure-recency code — it is
+  the before/after proof for the feature. aimock scripts only the model; the
+  runtime, capability, SQLite, tokenization, and ranking are all real.
 - **Existing suites stay green:** `@dawn-ai/memory` units, capability tests,
   `memory-e2e.test.ts` (cross-thread), `memory-index-refresh.test.ts`,
   research-template eval. Any assertion that is accidentally order-sensitive
   with a single result is unaffected by construction.
 - **Gated live smoke** (`memory-live.smoke.test.ts`) re-run locally
-  (OPENAI_API_KEY, never CI) as final verification.
+  (OPENAI_API_KEY, never CI) as final verification, PLUS one new ranking
+  scenario: seed the backdated relevant fact, let the REAL model store a
+  distractor and then ask the question naturally; assert the final message
+  carries the relevant value. Covers what aimock cannot — whether the model's
+  own query phrasing is good enough for the ranker.
 - **Eval dogfood:** add one recall-ranking case to the research template's
   memory eval using the existing `memoryRecalled` scorer (seed two memories,
   query for the specific one, expect the relevant id first).

--- a/docs/superpowers/specs/2026-07-05-smarter-recall-design.md
+++ b/docs/superpowers/specs/2026-07-05-smarter-recall-design.md
@@ -254,12 +254,17 @@ A custom `config.memory.store` bypasses all of this (it owns its own ranking).
 - **Gated live smoke** (`memory-live.smoke.test.ts`) re-run locally
   (OPENAI_API_KEY, never CI) as final verification, PLUS one new ranking
   scenario: seed the backdated relevant fact, let the REAL model store a
-  distractor and then ask the question naturally; assert the final message
-  carries the relevant value. Covers what aimock cannot — whether the model's
+  distractor and then ask the question naturally; assert the recall tool was
+  called AND its result carries the value (finalMessage alone can false-pass:
+  the index hint can leak the answer into the system prompt — observed live),
+  with the seeded value placed past the 80-char index-hint slice so recall is
+  the only source. Covers what aimock cannot — whether the model's
   own query phrasing is good enough for the ranker.
-- **Eval dogfood:** add one recall-ranking case to the research template's
-  memory eval using the existing `memoryRecalled` scorer (seed two memories,
-  query for the specific one, expect the relevant id first).
+- **Eval dogfood: DEFERRED.** The research template ships no evals today, and
+  adding `@dawn-ai/evals` to a scaffold template destabilizes the generated-app
+  verify lanes (known SCAFFOLD_PACKAGES hazard). The aimock before/after e2e is
+  the deterministic quality gate; a template eval can follow when the template
+  grows an evals directory for other reasons.
 
 ## Documentation
 

--- a/packages/cli/src/lib/runtime/resolve-memory.ts
+++ b/packages/cli/src/lib/runtime/resolve-memory.ts
@@ -39,14 +39,17 @@ export function routeNamespaceKey(routePath: string): string {
  * `<appRoot>/.dawn/memory.sqlite`.
  */
 export async function resolveMemoryStore(appRoot: string): Promise<MemoryStoreLike> {
+  let recall: Record<string, unknown> | undefined
   try {
     const loaded = await loadDawnConfig({ appRoot })
     if (loaded.config.memory?.store) return loaded.config.memory.store as MemoryStoreLike
+    recall = loaded.config.memory?.recall as Record<string, unknown> | undefined
   } catch {
     // no dawn.config.ts / unreadable — use default
   }
   return sqliteMemoryStore({
     path: join(appRoot, ".dawn", "memory.sqlite"),
+    ...(recall ? { recall } : {}),
   }) as unknown as MemoryStoreLike
 }
 

--- a/packages/cli/src/lib/runtime/resolve-memory.ts
+++ b/packages/cli/src/lib/runtime/resolve-memory.ts
@@ -1,7 +1,7 @@
 import { basename, join } from "node:path"
 import type { MemoryContext, MemoryStoreLike } from "@dawn-ai/core"
 import { loadDawnConfig } from "@dawn-ai/core"
-import { serializeNamespace, sqliteMemoryStore } from "@dawn-ai/memory"
+import { type RecallRankingOptions, serializeNamespace, sqliteMemoryStore } from "@dawn-ai/memory"
 import type { LoadedRouteMemory } from "./load-memory.js"
 
 /**
@@ -39,11 +39,11 @@ export function routeNamespaceKey(routePath: string): string {
  * `<appRoot>/.dawn/memory.sqlite`.
  */
 export async function resolveMemoryStore(appRoot: string): Promise<MemoryStoreLike> {
-  let recall: Record<string, unknown> | undefined
+  let recall: RecallRankingOptions | undefined
   try {
     const loaded = await loadDawnConfig({ appRoot })
     if (loaded.config.memory?.store) return loaded.config.memory.store as MemoryStoreLike
-    recall = loaded.config.memory?.recall as Record<string, unknown> | undefined
+    recall = loaded.config.memory?.recall
   } catch {
     // no dawn.config.ts / unreadable — use default
   }

--- a/packages/cli/test/resolve-memory.test.ts
+++ b/packages/cli/test/resolve-memory.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, rm } from "node:fs/promises"
+import { mkdtemp, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { afterEach, describe, expect, it, test } from "vitest"
@@ -49,6 +49,48 @@ describe("resolveMemoryStore", () => {
 
     const record = await store.get("test-id-1")
     expect(record?.content).toBe("hello memory")
+  })
+
+  test("threads config.memory.recall into the default sqlite store", async () => {
+    // App root with a dawn.config.ts that caps the ranked candidate pool at 1.
+    const appRoot = await mkdtemp(join(tmpdir(), "dawn-resolve-memory-"))
+    tempDirs.push(appRoot)
+    await writeFile(
+      join(appRoot, "dawn.config.ts"),
+      `export default { memory: { recall: { candidatePool: 1 } } }\n`,
+    )
+
+    const store = await resolveMemoryStore(appRoot)
+    const base = {
+      kind: "semantic" as const,
+      namespace: "ns",
+      data: {},
+      source: { type: "run" as const, id: "r" },
+      confidence: 1,
+      tags: [],
+      status: "active" as const,
+      createdAt: "2026-07-01T00:00:00.000Z",
+    }
+    await store.put({
+      ...base,
+      id: "older",
+      content: "billing threshold exact",
+      updatedAt: "2026-07-01T00:00:00.000Z",
+    })
+    await store.put({
+      ...base,
+      id: "newer",
+      content: "billing note",
+      updatedAt: "2026-07-04T00:00:00.000Z",
+    })
+    const out = await store.search({
+      namespace: "ns",
+      query: "billing threshold",
+      now: "2026-07-05T00:00:00.000Z",
+    })
+    // candidatePool 1 → only the newest token-match is scored/returned. With the
+    // default pool (256), "older" (2/2 token match) would win instead.
+    expect(out.map((r) => r.id)).toEqual(["newer"])
   })
 })
 

--- a/packages/core/src/capabilities/built-in/memory.ts
+++ b/packages/core/src/capabilities/built-in/memory.ts
@@ -73,6 +73,9 @@ export function createMemoryMarker(): CapabilityMarker {
             ...(q.kind ? { kind: q.kind } : {}),
             ...(q.tags ? { tags: q.tags } : {}),
             limit: q.limit ?? 8,
+            // Recency reference for ranked recall — the per-request timestamp,
+            // NOT Date.now() (determinism rule; see module docblock).
+            now: mem.now,
           })
           if (rows.length === 0) return "(no memories found)"
           return rows.map((r) => `${r.id}: ${r.content}`).join("\n")

--- a/packages/core/src/capabilities/types.ts
+++ b/packages/core/src/capabilities/types.ts
@@ -28,6 +28,8 @@ export interface MemoryStoreLike {
     tags?: readonly string[]
     status?: string
     limit?: number
+    /** ISO recency reference for ranked searches; stores may ignore it. */
+    now?: string
   }): Promise<readonly MemoryRecordLike[]>
   update(id: string, patch: Partial<MemoryRecordLike>): Promise<void>
   supersede(id: string, bySupersedingId: string): Promise<void>

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -71,6 +71,18 @@ export interface DawnConfig {
     readonly writes?: "off" | "candidate" | "auto"
     /** Maximum number of entries returned by the index. */
     readonly indexMaxEntries?: number
+    /** Recall ranking tuning for the default SQLite store. All fields
+     *  defaulted; omit for standard behavior. Ignored when a custom `store`
+     *  is supplied (custom stores own their own ranking). */
+    readonly recall?: {
+      readonly weights?: {
+        readonly relevance?: number
+        readonly recency?: number
+        readonly confidence?: number
+      }
+      readonly recencyHalfLifeMs?: number
+      readonly candidatePool?: number
+    }
     /** Derive the memory namespace scope for a given route. */
     readonly resolveScope?: (ctx: {
       readonly routePath: string

--- a/packages/core/test/memory-capability-recall.test.ts
+++ b/packages/core/test/memory-capability-recall.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest"
+import { createMemoryMarker } from "../src/capabilities/built-in/memory.js"
+import type { CapabilityMarkerContext, MemoryContext } from "../src/capabilities/types.js"
+
+const NOW = "2026-07-05T12:00:00.000Z"
+
+function makeContext(captured: { query?: Record<string, unknown> }): CapabilityMarkerContext {
+  const memory: MemoryContext = {
+    store: {
+      async put() {},
+      async get() {
+        return null
+      },
+      async search(q) {
+        // The index query (query-less) also lands here; only capture ranked queries.
+        if ((q as { query?: string }).query) captured.query = q as Record<string, unknown>
+        return []
+      },
+      async update() {},
+      async supersede() {},
+    },
+    namespace: "route=/probe",
+    writes: "auto",
+    defined: { kind: "semantic", scope: ["route"] },
+    validate: () => ({ ok: true, value: {} }),
+    now: NOW,
+  }
+  return {
+    routeManifest: {} as never,
+    descriptor: undefined,
+    appRoot: "/tmp/nowhere",
+    memory,
+  }
+}
+
+describe("memory capability recall tool", () => {
+  it("passes context.memory.now as the recency reference on ranked searches", async () => {
+    const captured: { query?: Record<string, unknown> } = {}
+    const marker = createMemoryMarker()
+    const contribution = await marker.load("/tmp/nowhere", makeContext(captured))
+    const recall = contribution.tools?.find((t) => t.name === "recall")
+    expect(recall).toBeDefined()
+    await recall?.run({ query: "billing threshold" }, { signal: new AbortController().signal })
+    expect(captured.query?.now).toBe(NOW)
+  })
+})

--- a/packages/memory/src/index.ts
+++ b/packages/memory/src/index.ts
@@ -1,5 +1,14 @@
 export { type MemoryScopeTuple, serializeNamespace } from "./namespace.js"
 export { classifyWrite, type WriteOp } from "./reconcile.js"
+export {
+  DEFAULT_CANDIDATE_POOL,
+  DEFAULT_RECALL_WEIGHTS,
+  DEFAULT_RECENCY_HALF_LIFE_MS,
+  idf,
+  type RecallRankingOptions,
+  type RecallWeights,
+  scoreMemory,
+} from "./score.js"
 export { sqliteMemoryStore } from "./sqlite-store.js"
 export { tokenize } from "./tokenize.js"
 export type {

--- a/packages/memory/src/score.ts
+++ b/packages/memory/src/score.ts
@@ -35,7 +35,7 @@ export function idf(df: number, corpusSize: number): number {
 }
 
 function clamp01(v: number): number {
-  return v < 0 ? 0 : v > 1 ? 1 : v
+  return Number.isFinite(v) ? (v < 0 ? 0 : v > 1 ? 1 : v) : 0
 }
 
 /** Parse an ISO timestamp; NaN (invalid/missing) degrades to null, never throws. */
@@ -54,6 +54,8 @@ function parseMs(iso: string): number | null {
  *
  * recency = 2^(−age / halfLife), age measured from `referenceNow` back to
  * `updatedAt`, clamped ≥ 0. Invalid timestamps degrade to age 0.
+ *
+ * `queryTokens` are expected to be deduplicated, as produced by `tokenize()`.
  */
 export function scoreMemory(args: {
   readonly memoryTokens: ReadonlySet<string>
@@ -66,7 +68,11 @@ export function scoreMemory(args: {
   readonly options?: RecallRankingOptions
 }): number {
   const weights = { ...DEFAULT_RECALL_WEIGHTS, ...args.options?.weights }
-  const halfLife = args.options?.recencyHalfLifeMs ?? DEFAULT_RECENCY_HALF_LIFE_MS
+  const rawHalfLife = args.options?.recencyHalfLifeMs
+  const halfLife =
+    typeof rawHalfLife === "number" && Number.isFinite(rawHalfLife) && rawHalfLife > 0
+      ? rawHalfLife
+      : DEFAULT_RECENCY_HALF_LIFE_MS
 
   let matchedIdf = 0
   let totalIdf = 0

--- a/packages/memory/src/score.ts
+++ b/packages/memory/src/score.ts
@@ -1,0 +1,88 @@
+// Pure recall scoring — no I/O, no clock, no randomness. Deterministic by
+// construction so aimock fixtures and eval replays stay stable. See
+// docs/superpowers/specs/2026-07-05-smarter-recall-design.md.
+
+export interface RecallWeights {
+  readonly relevance?: number
+  readonly recency?: number
+  readonly confidence?: number
+}
+
+export interface RecallRankingOptions {
+  readonly weights?: RecallWeights
+  readonly recencyHalfLifeMs?: number
+  readonly candidatePool?: number
+}
+
+export const DEFAULT_RECALL_WEIGHTS = {
+  relevance: 0.6,
+  recency: 0.3,
+  confidence: 0.1,
+} as const
+
+export const DEFAULT_RECENCY_HALF_LIFE_MS = 14 * 24 * 60 * 60 * 1000
+export const DEFAULT_CANDIDATE_POOL = 256
+
+/**
+ * BM25-smoothed inverse document frequency. Always positive — a token present
+ * in every memory (df = corpusSize) still carries a small weight rather than
+ * zeroing out or going negative (as unsmoothed idf would).
+ */
+export function idf(df: number, corpusSize: number): number {
+  const d = Math.max(0, df)
+  const n = Math.max(d, corpusSize)
+  return Math.log(1 + (n - d + 0.5) / (d + 0.5))
+}
+
+function clamp01(v: number): number {
+  return v < 0 ? 0 : v > 1 ? 1 : v
+}
+
+/** Parse an ISO timestamp; NaN (invalid/missing) degrades to null, never throws. */
+function parseMs(iso: string): number | null {
+  const ms = Date.parse(iso)
+  return Number.isNaN(ms) ? null : ms
+}
+
+/**
+ * Composite recall score: wRel·relevance + wRec·recency + wConf·confidence.
+ *
+ * relevance = Σ idf(matched query tokens) / Σ idf(all query tokens) — the
+ * fraction of the query's information this memory matches (0..1). Query
+ * tokens matching nothing inflate only the shared denominator, so relative
+ * ordering is unaffected.
+ *
+ * recency = 2^(−age / halfLife), age measured from `referenceNow` back to
+ * `updatedAt`, clamped ≥ 0. Invalid timestamps degrade to age 0.
+ */
+export function scoreMemory(args: {
+  readonly memoryTokens: ReadonlySet<string>
+  readonly queryTokens: readonly string[]
+  readonly dfByToken: ReadonlyMap<string, number>
+  readonly corpusSize: number
+  readonly updatedAt: string
+  readonly confidence: number
+  readonly referenceNow: string
+  readonly options?: RecallRankingOptions
+}): number {
+  const weights = { ...DEFAULT_RECALL_WEIGHTS, ...args.options?.weights }
+  const halfLife = args.options?.recencyHalfLifeMs ?? DEFAULT_RECENCY_HALF_LIFE_MS
+
+  let matchedIdf = 0
+  let totalIdf = 0
+  for (const t of args.queryTokens) {
+    const w = idf(args.dfByToken.get(t) ?? 0, args.corpusSize)
+    totalIdf += w
+    if (args.memoryTokens.has(t)) matchedIdf += w
+  }
+  const relevance = totalIdf > 0 ? matchedIdf / totalIdf : 0
+
+  const ref = parseMs(args.referenceNow)
+  const upd = parseMs(args.updatedAt)
+  const ageMs = ref !== null && upd !== null ? Math.max(0, ref - upd) : 0
+  const recency = 2 ** (-ageMs / halfLife)
+
+  const confidence = clamp01(args.confidence)
+
+  return weights.relevance * relevance + weights.recency * recency + weights.confidence * confidence
+}

--- a/packages/memory/src/score.ts
+++ b/packages/memory/src/score.ts
@@ -53,7 +53,8 @@ function parseMs(iso: string): number | null {
  * ordering is unaffected.
  *
  * recency = 2^(−age / halfLife), age measured from `referenceNow` back to
- * `updatedAt`, clamped ≥ 0. Invalid timestamps degrade to age 0.
+ * `updatedAt`, clamped ≥ 0. Invalid timestamps degrade to age 0. A
+ * non-positive or non-finite halfLifeMs falls back to the default.
  *
  * `queryTokens` are expected to be deduplicated, as produced by `tokenize()`.
  */

--- a/packages/memory/src/sqlite-store.ts
+++ b/packages/memory/src/sqlite-store.ts
@@ -99,6 +99,11 @@ function rowToRecord(row: Record<string, unknown>): MemoryRecord {
   }
 }
 
+// Codepoint compare — matches SQLite BINARY collation, no ICU dependence.
+function cmp(a: string, b: string): number {
+  return a < b ? -1 : a > b ? 1 : 0
+}
+
 function tokensFor(rec: MemoryRecord): string[] {
   const values = Object.values(rec.data).filter((v) => typeof v === "string") as string[]
   return tokenize([rec.content, rec.tags.join(" "), values.join(" ")].join(" "))
@@ -190,7 +195,11 @@ export function sqliteMemoryStore(opts: {
       }
 
       // Ranked path — see docs/superpowers/specs/2026-07-05-smarter-recall-design.md.
-      const pool = opts.recall?.candidatePool ?? DEFAULT_CANDIDATE_POOL
+      const rawPool = opts.recall?.candidatePool
+      const pool =
+        typeof rawPool === "number" && Number.isFinite(rawPool) && rawPool > 0
+          ? Math.floor(rawPool)
+          : DEFAULT_CANDIDATE_POOL
       const placeholders = terms.map(() => "?").join(",")
 
       // 1) Candidate pool: rows matching ≥1 query token, newest first (pool
@@ -243,8 +252,8 @@ export function sqliteMemoryStore(opts: {
       scored.sort(
         (a, b) =>
           b.score - a.score ||
-          b.record.updatedAt.localeCompare(a.record.updatedAt) ||
-          a.record.id.localeCompare(b.record.id),
+          cmp(b.record.updatedAt, a.record.updatedAt) ||
+          cmp(a.record.id, b.record.id),
       )
       let records = scored.slice(0, limit).map((s) => s.record)
 

--- a/packages/memory/src/sqlite-store.ts
+++ b/packages/memory/src/sqlite-store.ts
@@ -2,6 +2,7 @@ import { mkdirSync } from "node:fs"
 import { dirname } from "node:path"
 import type { SQLInputValue } from "node:sqlite"
 import { DatabaseSync } from "node:sqlite"
+import { DEFAULT_CANDIDATE_POOL, type RecallRankingOptions, scoreMemory } from "./score.js"
 import { tokenize } from "./tokenize.js"
 import type { MemoryQuery, MemoryRecord, MemoryStore } from "./types.js"
 
@@ -107,7 +108,11 @@ function tokensFor(rec: MemoryRecord): string[] {
 // Factory
 // ---------------------------------------------------------------------------
 
-export function sqliteMemoryStore(opts: { path: string }): MemoryStore {
+export function sqliteMemoryStore(opts: {
+  path: string
+  /** Recall ranking tuning; all fields defaulted. See score.ts. */
+  recall?: RecallRankingOptions
+}): MemoryStore {
   const db = openDb(opts.path)
   runMigrations(db, MIGRATIONS)
 
@@ -159,21 +164,91 @@ export function sqliteMemoryStore(opts: { path: string }): MemoryStore {
       const status = q.status ?? "active"
       const limit = q.limit ?? 8
       const terms = q.query ? tokenize(q.query) : []
-      const params: SQLInputValue[] = [q.namespace, status]
-      let sql = `SELECT m.* FROM memories m WHERE m.namespace = ? AND m.status = ?`
+
+      // Shared base filter (namespace + status [+ kind]) — the "corpus".
+      let baseSql = `m.namespace = ? AND m.status = ?`
+      const baseParams: SQLInputValue[] = [q.namespace, status]
       if (q.kind) {
-        sql += ` AND m.kind = ?`
-        params.push(q.kind)
+        baseSql += ` AND m.kind = ?`
+        baseParams.push(q.kind)
       }
-      if (terms.length > 0) {
-        const placeholders = terms.map(() => "?").join(",")
-        sql += ` AND m.id IN (SELECT memory_id FROM memory_tokens WHERE token IN (${placeholders}))`
-        params.push(...terms)
+
+      if (terms.length === 0) {
+        // Query-less path: EXACTLY the pre-ranking behavior (index fragment,
+        // listCandidates-adjacent consumers depend on pure recency order).
+        const rows = db
+          .prepare(
+            `SELECT m.* FROM memories m WHERE ${baseSql} ORDER BY m.updated_at DESC, m.id ASC LIMIT ?`,
+          )
+          .all(...baseParams, limit) as Record<string, unknown>[]
+        let records = rows.map(rowToRecord)
+        if (q.tags && q.tags.length > 0) {
+          const want = new Set(q.tags)
+          records = records.filter((r) => r.tags.some((t) => want.has(t)))
+        }
+        return records
       }
-      sql += ` ORDER BY m.updated_at DESC, m.id ASC LIMIT ?`
-      params.push(limit)
-      const rows = db.prepare(sql).all(...params) as Record<string, unknown>[]
-      let records = rows.map(rowToRecord)
+
+      // Ranked path — see docs/superpowers/specs/2026-07-05-smarter-recall-design.md.
+      const pool = opts.recall?.candidatePool ?? DEFAULT_CANDIDATE_POOL
+      const placeholders = terms.map(() => "?").join(",")
+
+      // 1) Candidate pool: rows matching ≥1 query token, newest first (pool
+      //    truncation by recency is deterministic).
+      const candidateRows = db
+        .prepare(
+          `SELECT m.* FROM memories m WHERE ${baseSql}
+           AND m.id IN (SELECT memory_id FROM memory_tokens WHERE token IN (${placeholders}))
+           ORDER BY m.updated_at DESC, m.id ASC LIMIT ?`,
+        )
+        .all(...baseParams, ...terms, pool) as Record<string, unknown>[]
+      const candidates = candidateRows.map(rowToRecord)
+      if (candidates.length === 0) return []
+
+      // 2) Corpus stats, computed live (nothing cached → nothing to go stale).
+      const corpusSize = (
+        db.prepare(`SELECT COUNT(*) AS n FROM memories m WHERE ${baseSql}`).get(...baseParams) as {
+          n: number
+        }
+      ).n
+      const dfRows = db
+        .prepare(
+          `SELECT t.token AS token, COUNT(DISTINCT t.memory_id) AS df
+           FROM memory_tokens t JOIN memories m ON m.id = t.memory_id
+           WHERE ${baseSql} AND t.token IN (${placeholders}) GROUP BY t.token`,
+        )
+        .all(...baseParams, ...terms) as { token: string; df: number }[]
+      const dfByToken = new Map(dfRows.map((r) => [r.token, r.df]))
+
+      // 3) Score. Candidate token sets are recomputed via the same helper
+      //    reindex() uses, so they are guaranteed consistent with the table.
+      //    Pool is updated_at-DESC ordered, so candidates[0] is the newest —
+      //    the data-derived reference when the caller supplies no clock.
+      const referenceNow = q.now ?? candidates[0]?.updatedAt ?? ""
+      const scored = candidates.map((record) => ({
+        record,
+        score: scoreMemory({
+          memoryTokens: new Set(tokensFor(record)),
+          queryTokens: terms,
+          dfByToken,
+          corpusSize,
+          updatedAt: record.updatedAt,
+          confidence: record.confidence,
+          referenceNow,
+          ...(opts.recall ? { options: opts.recall } : {}),
+        }),
+      }))
+
+      // 4) Sort (score DESC, updated_at DESC, id ASC — stable) and page.
+      scored.sort(
+        (a, b) =>
+          b.score - a.score ||
+          b.record.updatedAt.localeCompare(a.record.updatedAt) ||
+          a.record.id.localeCompare(b.record.id),
+      )
+      let records = scored.slice(0, limit).map((s) => s.record)
+
+      // 5) Tag post-filter on the returned page — today's semantics, unchanged.
       if (q.tags && q.tags.length > 0) {
         const want = new Set(q.tags)
         records = records.filter((r) => r.tags.some((t) => want.has(t)))

--- a/packages/memory/src/types.ts
+++ b/packages/memory/src/types.ts
@@ -27,6 +27,10 @@ export interface MemoryQuery {
   readonly tags?: readonly string[]
   readonly status?: MemoryStatus
   readonly limit?: number
+  /** ISO timestamp used as the recency reference for ranked (query) searches.
+   *  Optional; when absent, recency is measured relative to the newest
+   *  candidate's updatedAt (data-derived — the library never reads a clock). */
+  readonly now?: string
 }
 export interface MemoryStore {
   put(rec: MemoryRecord): Promise<void>

--- a/packages/memory/test/score.test.ts
+++ b/packages/memory/test/score.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from "vitest"
+import {
+  DEFAULT_CANDIDATE_POOL,
+  DEFAULT_RECENCY_HALF_LIFE_MS,
+  idf,
+  scoreMemory,
+} from "../src/score.js"
+
+const NOW = "2026-07-05T00:00:00.000Z"
+const DAY = 24 * 60 * 60 * 1000
+function ago(ms: number): string {
+  return new Date(Date.parse(NOW) - ms).toISOString()
+}
+
+describe("idf", () => {
+  it("is monotonically decreasing in df and always positive", () => {
+    const n = 10
+    const values = [0, 1, 5, 10].map((df) => idf(df, n))
+    expect(values[0]).toBeGreaterThan(values[1]!)
+    expect(values[1]).toBeGreaterThan(values[2]!)
+    expect(values[2]).toBeGreaterThan(values[3]!)
+    for (const v of values) expect(v).toBeGreaterThan(0) // smoothed: df=N still > 0
+  })
+  it("clamps df above corpusSize instead of going negative", () => {
+    expect(idf(12, 10)).toBeGreaterThan(0)
+  })
+})
+
+describe("scoreMemory", () => {
+  const base = {
+    corpusSize: 6,
+    updatedAt: NOW,
+    confidence: 1,
+    referenceNow: NOW,
+  }
+  it("rare-token match outranks common-token match (IDF dominance)", () => {
+    const df = new Map([
+      ["acme", 6], // in every memory — uninformative
+      ["threshold", 1], // rare — informative
+    ])
+    const queryTokens = ["acme", "threshold"]
+    const matchesRare = scoreMemory({
+      ...base,
+      memoryTokens: new Set(["threshold"]),
+      queryTokens,
+      dfByToken: df,
+    })
+    const matchesCommon = scoreMemory({
+      ...base,
+      memoryTokens: new Set(["acme"]),
+      queryTokens,
+      dfByToken: df,
+    })
+    expect(matchesRare).toBeGreaterThan(matchesCommon)
+  })
+  it("matching more query tokens scores higher (overlap fraction)", () => {
+    const df = new Map([
+      ["billing", 2],
+      ["threshold", 2],
+    ])
+    const queryTokens = ["billing", "threshold"]
+    const two = scoreMemory({
+      ...base,
+      memoryTokens: new Set(["billing", "threshold"]),
+      queryTokens,
+      dfByToken: df,
+    })
+    const one = scoreMemory({
+      ...base,
+      memoryTokens: new Set(["billing"]),
+      queryTokens,
+      dfByToken: df,
+    })
+    expect(two).toBeGreaterThan(one)
+    expect(two).toBeCloseTo(0.6 * 1 + 0.3 * 1 + 0.1 * 1, 10) // full match, age 0, conf 1
+  })
+  it("recency component halves at exactly one half-life", () => {
+    const df = new Map([["x", 1]])
+    const args = {
+      memoryTokens: new Set(["x"]),
+      queryTokens: ["x"],
+      dfByToken: df,
+      corpusSize: 1,
+      confidence: 1,
+      referenceNow: NOW,
+      options: { weights: { relevance: 0, recency: 1, confidence: 0 } },
+    }
+    const fresh = scoreMemory({ ...args, updatedAt: NOW })
+    const halfLife = scoreMemory({ ...args, updatedAt: ago(DEFAULT_RECENCY_HALF_LIFE_MS) })
+    expect(fresh).toBeCloseTo(1, 10)
+    expect(halfLife).toBeCloseTo(0.5, 10)
+  })
+  it("confidence is clamped to [0,1]", () => {
+    const df = new Map([["x", 1]])
+    const args = {
+      memoryTokens: new Set(["x"]),
+      queryTokens: ["x"],
+      dfByToken: df,
+      corpusSize: 1,
+      updatedAt: NOW,
+      referenceNow: NOW,
+      options: { weights: { relevance: 0, recency: 0, confidence: 1 } },
+    }
+    expect(scoreMemory({ ...args, confidence: 1.5 })).toBeCloseTo(1, 10)
+    expect(scoreMemory({ ...args, confidence: -0.2 })).toBeCloseTo(0, 10)
+  })
+  it("invalid timestamps degrade to age 0 (recency 1), never throw", () => {
+    const df = new Map([["x", 1]])
+    const score = scoreMemory({
+      memoryTokens: new Set(["x"]),
+      queryTokens: ["x"],
+      dfByToken: df,
+      corpusSize: 1,
+      updatedAt: "not-a-date",
+      confidence: 1,
+      referenceNow: "also-not-a-date",
+      options: { weights: { relevance: 0, recency: 1, confidence: 0 } },
+    })
+    expect(score).toBeCloseTo(1, 10)
+  })
+  it("weight overrides merge with defaults (partial weights allowed)", () => {
+    const df = new Map([["x", 1]])
+    const score = scoreMemory({
+      memoryTokens: new Set(["x"]),
+      queryTokens: ["x"],
+      dfByToken: df,
+      corpusSize: 1,
+      updatedAt: NOW,
+      confidence: 0,
+      referenceNow: NOW,
+      options: { weights: { confidence: 0.5 } }, // relevance/recency keep defaults 0.6/0.3
+    })
+    expect(score).toBeCloseTo(0.6 + 0.3 + 0, 10)
+  })
+  it("exposes the documented defaults", () => {
+    expect(DEFAULT_RECENCY_HALF_LIFE_MS).toBe(14 * DAY)
+    expect(DEFAULT_CANDIDATE_POOL).toBe(256)
+  })
+})

--- a/packages/memory/test/score.test.ts
+++ b/packages/memory/test/score.test.ts
@@ -132,6 +132,59 @@ describe("scoreMemory", () => {
     })
     expect(score).toBeCloseTo(0.6 + 0.3 + 0, 10)
   })
+  it("non-positive or non-finite recencyHalfLifeMs falls back to the default", () => {
+    const df = new Map([["x", 1]])
+    const args = {
+      memoryTokens: new Set(["x"]),
+      queryTokens: ["x"],
+      dfByToken: df,
+      corpusSize: 1,
+      confidence: 1,
+      referenceNow: NOW,
+      updatedAt: ago(DEFAULT_RECENCY_HALF_LIFE_MS),
+    }
+    const weights = { relevance: 0, recency: 1, confidence: 0 }
+    const withDefault = scoreMemory({ ...args, options: { weights } })
+    const zero = scoreMemory({ ...args, options: { weights, recencyHalfLifeMs: 0 } })
+    const negative = scoreMemory({ ...args, options: { weights, recencyHalfLifeMs: -5 } })
+    expect(Number.isFinite(zero)).toBe(true)
+    expect(Number.isFinite(negative)).toBe(true)
+    expect(zero).toBeCloseTo(withDefault, 10)
+    expect(negative).toBeCloseTo(withDefault, 10)
+    // age 0 with half-life 0 would be 0/0 → NaN without the fallback
+    const freshZero = scoreMemory({
+      ...args,
+      updatedAt: NOW,
+      options: { weights, recencyHalfLifeMs: 0 },
+    })
+    expect(freshZero).toBeCloseTo(1, 10)
+  })
+  it("NaN confidence is treated as 0", () => {
+    const df = new Map([["x", 1]])
+    const score = scoreMemory({
+      memoryTokens: new Set(["x"]),
+      queryTokens: ["x"],
+      dfByToken: df,
+      corpusSize: 1,
+      updatedAt: NOW,
+      confidence: Number.NaN,
+      referenceNow: NOW,
+      options: { weights: { relevance: 0, recency: 0, confidence: 1 } },
+    })
+    expect(score).toBeCloseTo(0, 10)
+  })
+  it("empty queryTokens yields relevance 0 (score = recency + confidence terms)", () => {
+    const score = scoreMemory({
+      memoryTokens: new Set(["x"]),
+      queryTokens: [],
+      dfByToken: new Map(),
+      corpusSize: 1,
+      updatedAt: NOW,
+      confidence: 1,
+      referenceNow: NOW,
+    })
+    expect(score).toBeCloseTo(0.3 * 1 + 0.1 * 1, 10) // default weights, age 0, conf 1
+  })
   it("exposes the documented defaults", () => {
     expect(DEFAULT_RECENCY_HALF_LIFE_MS).toBe(14 * DAY)
     expect(DEFAULT_CANDIDATE_POOL).toBe(256)

--- a/packages/memory/test/sqlite-store.test.ts
+++ b/packages/memory/test/sqlite-store.test.ts
@@ -137,7 +137,7 @@ describe("sqliteMemoryStore", () => {
     })
     expect(out.map((r) => r.id)).toEqual(["a_new", "b_old"])
   })
-  it("ranked recall: omitted `now` falls back to newest candidate (deterministic)", async () => {
+  it("ranked recall: omitted `now` is accepted and produces a stable order", async () => {
     const s = sqliteMemoryStore({ path: ":memory:" })
     await s.put(
       rec({
@@ -212,6 +212,33 @@ describe("sqliteMemoryStore", () => {
     })
     // Pool of 1 keeps only the NEWEST token-match; "older" never gets scored.
     expect(out.map((r) => r.id)).toEqual(["newer"])
+  })
+  it("ranked recall: candidatePool of 0 falls back to the default (recall not silently dead)", async () => {
+    const s = sqliteMemoryStore({ path: ":memory:", recall: { candidatePool: 0 } })
+    await s.put(
+      rec({
+        id: "older",
+        namespace: "ns",
+        content: "billing threshold exact",
+        updatedAt: "2026-07-01T00:00:00.000Z",
+      }),
+    )
+    await s.put(
+      rec({
+        id: "newer",
+        namespace: "ns",
+        content: "billing note",
+        updatedAt: "2026-07-04T00:00:00.000Z",
+      }),
+    )
+    const out = await s.search({
+      namespace: "ns",
+      query: "billing threshold",
+      now: "2026-07-05T00:00:00.000Z",
+    })
+    // A 0 pool would be LIMIT 0 → always [] — the guard must default it instead,
+    // so both matches are scored and ranked (full match first).
+    expect(out.map((r) => r.id)).toEqual(["older", "newer"])
   })
   it("query-less search is unchanged: pure recency order", async () => {
     const s = sqliteMemoryStore({ path: ":memory:" })

--- a/packages/memory/test/sqlite-store.test.ts
+++ b/packages/memory/test/sqlite-store.test.ts
@@ -234,4 +234,93 @@ describe("sqliteMemoryStore", () => {
     const out = await s.search({ namespace: "ns" })
     expect(out.map((r) => r.id)).toEqual(["new", "old"])
   })
+  it("kind filter scopes corpus stats and candidates", async () => {
+    const s = sqliteMemoryStore({ path: ":memory:" })
+    await s.put(
+      rec({
+        id: "sem_full",
+        namespace: "ns",
+        kind: "semantic",
+        content: "billing threshold is 500",
+        updatedAt: "2026-07-01T00:00:00.000Z",
+      }),
+    )
+    await s.put(
+      rec({
+        id: "sem_partial",
+        namespace: "ns",
+        kind: "semantic",
+        content: "billing contact note",
+        updatedAt: "2026-07-02T00:00:00.000Z",
+      }),
+    )
+    await s.put(
+      rec({
+        id: "epi",
+        namespace: "ns",
+        kind: "episodic",
+        content: "billing threshold discussed in standup",
+        updatedAt: "2026-07-04T00:00:00.000Z",
+      }),
+    )
+    const out = await s.search({
+      namespace: "ns",
+      kind: "semantic",
+      query: "billing threshold",
+      now: "2026-07-05T00:00:00.000Z",
+    })
+    // Episodic record matches every query token but must be excluded by kind.
+    expect(out.map((r) => r.kind)).toEqual(["semantic", "semantic"])
+    expect(out.map((r) => r.id)).not.toContain("epi")
+    expect(out[0]?.id).toBe("sem_full") // full match outranks partial within the kind
+  })
+  it("id tiebreak: identical score and updatedAt orders by id ascending", async () => {
+    const s = sqliteMemoryStore({ path: ":memory:" })
+    await s.put(
+      rec({
+        id: "b",
+        namespace: "ns",
+        content: "billing threshold fact",
+        updatedAt: "2026-07-01T00:00:00.000Z",
+      }),
+    )
+    await s.put(
+      rec({
+        id: "a",
+        namespace: "ns",
+        content: "billing threshold fact",
+        updatedAt: "2026-07-01T00:00:00.000Z",
+      }),
+    )
+    const out = await s.search({
+      namespace: "ns",
+      query: "billing threshold",
+      now: "2026-07-05T00:00:00.000Z",
+    })
+    expect(out.map((r) => r.id)).toEqual(["a", "b"])
+  })
+  it("all-tokens-dropped query takes the recency path", async () => {
+    const s = sqliteMemoryStore({ path: ":memory:" })
+    await s.put(
+      rec({
+        id: "older_match",
+        namespace: "ns",
+        content: "a real billing threshold fact",
+        updatedAt: "2026-07-01T00:00:00.000Z",
+      }),
+    )
+    await s.put(
+      rec({
+        id: "newer_unrelated",
+        namespace: "ns",
+        content: "unrelated note",
+        updatedAt: "2026-07-04T00:00:00.000Z",
+      }),
+    )
+    // "a" is a 1-char token — tokenize() drops it, leaving zero query tokens.
+    const out = await s.search({ namespace: "ns", query: "a" })
+    // Zero-token queries must behave exactly like no query: pure recency,
+    // no token filter — both records come back, newest first.
+    expect(out.map((r) => r.id)).toEqual(["newer_unrelated", "older_match"])
+  })
 })

--- a/packages/memory/test/sqlite-store.test.ts
+++ b/packages/memory/test/sqlite-store.test.ts
@@ -69,4 +69,169 @@ describe("sqliteMemoryStore", () => {
     await s.supersede("old", "new")
     expect((await s.get("old"))?.status).toBe("superseded")
   })
+  it("ranked recall: relevant-but-old beats recent-but-marginal (headline)", async () => {
+    const s = sqliteMemoryStore({ path: ":memory:" })
+    // Several acme memories so "acme" is common (low idf) in the namespace.
+    await s.put(
+      rec({
+        id: "m1",
+        namespace: "ns",
+        content: "acme invoice format is pdf",
+        updatedAt: "2026-06-30T00:00:00.000Z",
+      }),
+    )
+    await s.put(
+      rec({
+        id: "m2",
+        namespace: "ns",
+        content: "acme owner is jordan",
+        updatedAt: "2026-07-01T00:00:00.000Z",
+      }),
+    )
+    await s.put(
+      rec({
+        id: "target",
+        namespace: "ns",
+        content: "acme billing escalation threshold is 500 dollars",
+        updatedAt: "2026-05-20T00:00:00.000Z",
+      }),
+    )
+    await s.put(
+      rec({
+        id: "distractor",
+        namespace: "ns",
+        content: "acme contact jordan prefers slack",
+        updatedAt: "2026-07-04T00:00:00.000Z",
+      }),
+    )
+    const out = await s.search({
+      namespace: "ns",
+      query: "acme billing escalation threshold",
+      now: "2026-07-05T00:00:00.000Z",
+    })
+    // Pure recency (old behavior) would put "distractor" first; ranking must not.
+    expect(out[0]?.id).toBe("target")
+  })
+  it("ranked recall: same relevance ties break by recency then id", async () => {
+    const s = sqliteMemoryStore({ path: ":memory:" })
+    await s.put(
+      rec({
+        id: "b_old",
+        namespace: "ns",
+        content: "billing threshold fact",
+        updatedAt: "2026-07-01T00:00:00.000Z",
+      }),
+    )
+    await s.put(
+      rec({
+        id: "a_new",
+        namespace: "ns",
+        content: "billing threshold fact",
+        updatedAt: "2026-07-04T00:00:00.000Z",
+      }),
+    )
+    const out = await s.search({
+      namespace: "ns",
+      query: "billing threshold",
+      now: "2026-07-05T00:00:00.000Z",
+    })
+    expect(out.map((r) => r.id)).toEqual(["a_new", "b_old"])
+  })
+  it("ranked recall: omitted `now` falls back to newest candidate (deterministic)", async () => {
+    const s = sqliteMemoryStore({ path: ":memory:" })
+    await s.put(
+      rec({
+        id: "x",
+        namespace: "ns",
+        content: "billing threshold",
+        updatedAt: "2026-07-04T00:00:00.000Z",
+      }),
+    )
+    await s.put(
+      rec({
+        id: "y",
+        namespace: "ns",
+        content: "billing note",
+        updatedAt: "2026-07-01T00:00:00.000Z",
+      }),
+    )
+    const a = await s.search({ namespace: "ns", query: "billing threshold" })
+    const b = await s.search({ namespace: "ns", query: "billing threshold" })
+    expect(a.map((r) => r.id)).toEqual(b.map((r) => r.id)) // same inputs → same order
+    expect(a[0]?.id).toBe("x") // matches 2/2 tokens; y matches 1/2
+  })
+  it("ranked recall: confidence breaks ties at equal relevance and recency", async () => {
+    const s = sqliteMemoryStore({ path: ":memory:" })
+    await s.put(
+      rec({
+        id: "hedged",
+        namespace: "ns",
+        content: "billing threshold fact",
+        confidence: 0.4,
+        updatedAt: "2026-07-01T00:00:00.000Z",
+      }),
+    )
+    await s.put(
+      rec({
+        id: "sure",
+        namespace: "ns",
+        content: "billing threshold fact",
+        confidence: 1,
+        updatedAt: "2026-07-01T00:00:00.000Z",
+      }),
+    )
+    const out = await s.search({
+      namespace: "ns",
+      query: "billing threshold",
+      now: "2026-07-05T00:00:00.000Z",
+    })
+    expect(out[0]?.id).toBe("sure")
+  })
+  it("ranked recall: candidatePool caps scored candidates by recency, deterministically", async () => {
+    const s = sqliteMemoryStore({ path: ":memory:", recall: { candidatePool: 1 } })
+    await s.put(
+      rec({
+        id: "older",
+        namespace: "ns",
+        content: "billing threshold exact",
+        updatedAt: "2026-07-01T00:00:00.000Z",
+      }),
+    )
+    await s.put(
+      rec({
+        id: "newer",
+        namespace: "ns",
+        content: "billing note",
+        updatedAt: "2026-07-04T00:00:00.000Z",
+      }),
+    )
+    const out = await s.search({
+      namespace: "ns",
+      query: "billing threshold",
+      now: "2026-07-05T00:00:00.000Z",
+    })
+    // Pool of 1 keeps only the NEWEST token-match; "older" never gets scored.
+    expect(out.map((r) => r.id)).toEqual(["newer"])
+  })
+  it("query-less search is unchanged: pure recency order", async () => {
+    const s = sqliteMemoryStore({ path: ":memory:" })
+    await s.put(
+      rec({
+        id: "old",
+        namespace: "ns",
+        content: "billing threshold exact match",
+        updatedAt: "2026-07-01T00:00:00.000Z",
+      }),
+    )
+    await s.put(
+      rec({
+        id: "new",
+        namespace: "ns",
+        content: "unrelated note",
+        updatedAt: "2026-07-04T00:00:00.000Z",
+      }),
+    )
+    const out = await s.search({ namespace: "ns" })
+    expect(out.map((r) => r.id)).toEqual(["new", "old"])
+  })
 })

--- a/packages/testing/test/memory-live.smoke.test.ts
+++ b/packages/testing/test/memory-live.smoke.test.ts
@@ -304,6 +304,8 @@ it.skipIf(!live)(
       const r = await h.run({
         input: "What is acme's billing escalation threshold?",
       })
+      expectToolCalled(r, "recall")
+      expect(String(r.toolResults.find((t) => t.name === "recall")?.content ?? "")).toContain("500")
       expect(r.finalMessage).toContain("500")
     } finally {
       await h.close()

--- a/packages/testing/test/memory-live.smoke.test.ts
+++ b/packages/testing/test/memory-live.smoke.test.ts
@@ -265,3 +265,49 @@ it.skipIf(!live)(
   },
   180_000,
 )
+
+it.skipIf(!live)(
+  "ranked recall: real model finds the relevant old fact past a fresh distractor",
+  async () => {
+    // Seed the backdated relevant fact (remember stamps request time; age must be seeded).
+    const store = sqliteMemoryStore({ path: dbPath(probeRoot) })
+    const sixWeeksAgo = new Date(Date.now() - 42 * 24 * 60 * 60 * 1000).toISOString()
+    await store.put({
+      id: "memory_live_ranktarget",
+      kind: "semantic",
+      namespace: "route=/memory-chat",
+      content: "acme billing escalation threshold is 500 dollars",
+      data: { subject: "acme", predicate: "billing-escalation-threshold", value: "500 dollars" },
+      source: { type: "tool", id: "remember" },
+      confidence: 1,
+      tags: [],
+      status: "active",
+      createdAt: sixWeeksAgo,
+      updatedAt: sixWeeksAgo,
+    })
+
+    const h = await createAgentHarness({
+      appRoot: probeRoot,
+      route: "/memory-chat#agent",
+      live: true,
+    })
+    try {
+      h.reset()
+      // Real model stores a fresh marginal distractor its own way.
+      await h.run({
+        input:
+          "Use the remember tool now. data: subject 'acme-contact', predicate 'prefers', value 'slack'.",
+      })
+      h.reset()
+      // Natural question — covers what aimock cannot: whether the model's own
+      // query phrasing is good enough for the ranker.
+      const r = await h.run({
+        input: "What is acme's billing escalation threshold?",
+      })
+      expect(r.finalMessage).toContain("500")
+    } finally {
+      await h.close()
+    }
+  },
+  150_000,
+)

--- a/packages/testing/test/memory-live.smoke.test.ts
+++ b/packages/testing/test/memory-live.smoke.test.ts
@@ -272,11 +272,16 @@ it.skipIf(!live)(
     // Seed the backdated relevant fact (remember stamps request time; age must be seeded).
     const store = sqliteMemoryStore({ path: dbPath(probeRoot) })
     const sixWeeksAgo = new Date(Date.now() - 42 * 24 * 60 * 60 * 1000).toISOString()
+    const seedContent =
+      "acme billing escalation threshold policy: escalate any single acme invoice or billing dispute above the amount of 500 dollars"
+    // Guard: the value must sit past the 80-char index-hint slice, else the model
+    // can answer from the injected hint without calling recall (observed live).
+    expect(seedContent.slice(0, 80)).not.toContain("500")
     await store.put({
       id: "memory_live_ranktarget",
       kind: "semantic",
       namespace: "route=/memory-chat",
-      content: "acme billing escalation threshold is 500 dollars",
+      content: seedContent,
       data: { subject: "acme", predicate: "billing-escalation-threshold", value: "500 dollars" },
       source: { type: "tool", id: "remember" },
       confidence: 1,

--- a/packages/testing/test/memory-ranking-e2e.test.ts
+++ b/packages/testing/test/memory-ranking-e2e.test.ts
@@ -1,0 +1,84 @@
+// Deterministic (aimock) e2e for RANKED recall: a relevant-but-old memory must
+// outrank a recent-but-marginal one. Under pure-recency (pre-ranking) recall
+// this test FAILS — it is the before/after proof for smarter recall. aimock
+// scripts only the model; runtime, capability, SQLite, tokenization, and
+// ranking are all real. Runs in CI (no API key).
+import { rmSync } from "node:fs"
+import { join } from "node:path"
+import { fileURLToPath } from "node:url"
+import { sqliteMemoryStore } from "@dawn-ai/memory"
+import { afterAll, beforeAll, expect, it } from "vitest"
+import { script } from "../src/fixture-builder.js"
+import { createAgentHarness } from "../src/harness.js"
+
+const appRoot = fileURLToPath(new URL("./fixtures/probe-app", import.meta.url))
+const dbBase = join(appRoot, ".dawn", "memory.sqlite")
+function cleanDb() {
+  for (const suffix of ["", "-wal", "-shm"]) rmSync(`${dbBase}${suffix}`, { force: true })
+}
+
+beforeAll(cleanDb)
+afterAll(cleanDb)
+
+it("ranks a relevant-but-old memory above a recent-but-marginal one", async () => {
+  // Seed the backdated relevant fact directly: writes through the remember
+  // tool always stamp the request time, so age must be seeded at the store.
+  const store = sqliteMemoryStore({ path: dbBase })
+  const sixWeeksAgo = new Date(Date.now() - 42 * 24 * 60 * 60 * 1000).toISOString()
+  await store.put({
+    id: "memory_ranktarget",
+    kind: "semantic",
+    namespace: "route=/memory-chat",
+    content: "acme billing escalation threshold is 500 dollars",
+    data: { subject: "acme", predicate: "billing-escalation-threshold", value: "500 dollars" },
+    source: { type: "tool", id: "remember" },
+    confidence: 1,
+    tags: [],
+    status: "active",
+    createdAt: sixWeeksAgo,
+    updatedAt: sixWeeksAgo,
+  })
+
+  const h = await createAgentHarness({ appRoot, route: "/memory-chat#agent" })
+  try {
+    // Fresh marginal distractor written through the REAL agent loop
+    // (tool → validate → put → reindex), auto mode → active immediately.
+    h.reset()
+    await h.run({
+      input: "Remember that the acme contact jordan prefers slack.",
+      fixtures: script()
+        .user("Remember that the acme contact jordan prefers slack.")
+        .callsTool("remember", {
+          data: { subject: "acme-contact", predicate: "prefers", value: "slack" },
+          content: "acme contact jordan prefers slack",
+        })
+        .replies("Noted."),
+    })
+
+    // Recall: aimock scripts the CALL; the tool RESULT (and its ordering) is real.
+    h.reset()
+    const r = await h.run({
+      input: "What is acme's billing escalation threshold?",
+      fixtures: script()
+        .user("What is acme's billing escalation threshold?")
+        .callsTool("recall", { query: "acme billing escalation threshold" })
+        .replies("The threshold is 500 dollars."),
+    })
+    const recall = r.toolResults.find((t) => t.name === "recall")
+    expect(recall, "recall tool must have been executed").toBeDefined()
+    // The runtime JSON-encodes plain (non-{result}-wrapper) tool returns into
+    // ToolMessage content (see unwrapToolResult in @dawn-ai/langchain), so the
+    // recall tool's newline-joined string arrives as a quoted JSON string with
+    // escaped newlines. Decode before splitting; assertions are unchanged.
+    const raw = String(recall?.content ?? "")
+    const text = raw.startsWith('"') ? (JSON.parse(raw) as string) : raw
+    const lines = text.split("\n")
+    // Both memories share the "acme" token, so both are in the result set;
+    // the SIX-WEEK-OLD relevant fact must be ranked FIRST. Pure recency
+    // (the pre-ranking behavior) puts the fresh distractor first instead.
+    expect(lines.length).toBeGreaterThanOrEqual(2)
+    expect(lines[0]).toContain("memory_ranktarget")
+  } finally {
+    await h.close()
+  }
+}, 60_000)


### PR DESCRIPTION
## What

`recall` now ranks by relevance instead of pure recency: IDF-weighted token
overlap (0.6) + recency decay, half-life 14d (0.3) + stored confidence (0.1),
with a stable updatedAt/id tiebreak (codepoint compare — matches SQLite BINARY,
no ICU dependence). A six-week-old fact that answers the query outranks
yesterday's marginal match.

- New pure `score.ts` in `@dawn-ai/memory` (idf + scoreMemory + options),
  hardened against NaN/Infinity from bad tuning values (half-life, pool,
  confidence all degrade to safe defaults)
- Ranked path in `sqliteMemoryStore.search()` — candidate pool (256, guarded)
  + live df/N corpus stats; query-less searches (index fragment,
  `listCandidates`) unchanged
- `MemoryQuery.now` recency reference; the capability passes
  `context.memory.now` (no clock in the library — absent `now` falls back to
  the newest candidate, data-derived)
- `DawnConfig.memory.recall` tuning (weights / halfLife / candidatePool),
  threaded via `resolveMemoryStore`; custom stores unaffected
- Docs: "How recall ranks" + dev walkthrough (`docs/dev/memory-system.md`) +
  DX acceptance bar (`docs/dev/smarter-recall-dx.md`)

## Proof

- `memory-ranking-e2e.test.ts` (aimock, CI-safe): a backdated relevant memory
  is the FIRST recall result past a fresh distractor written through the real
  agent loop — verified failing under pre-ranking code before implementation
  (`expected 'distractor' to be 'target'`)
- 37 `@dawn-ai/memory` tests (13 new ranking/ordering cases incl. kind-scoped
  corpus stats, id tiebreak, zero-token recency trigger, pool guards)
- Gated live smoke extended with a natural-phrasing ranking scenario — the
  first draft false-passed via the index hint (observed live: model answered
  without calling recall), now asserts the recall tool result AND seeds the
  value past the 80-char index slice; two consecutive 6/6 local passes
- Full validate green: 932 passed / 8 skipped (gated live smokes)

## Notes

- Deterministic end to end: no Date.now() in library code, no network, no new
  dependencies; fixtures and eval replays unaffected (zero pre-existing
  assertions changed — the DX acceptance bar)
- Spec: docs/superpowers/specs/2026-07-05-smarter-recall-design.md (template
  eval dogfood deferred — scaffold-lane hazard; recorded in spec)
- Patch changeset (fixed 0.x group)
- Follow-up chip filed separately: memory tool returns reach the model
  JSON-escaped (pre-existing #250 behavior) — wrap in {result} envelope

🤖 Generated with [Claude Code](https://claude.com/claude-code)