### PR TITLE
feat(memory): writes:"ask" — HITL gate for belief contradictions

### DIFF
--- a/.changeset/memory-ask-mode.md
+++ b/.changeset/memory-ask-mode.md
@@ -1,0 +1,7 @@
+---
+"@dawn-ai/core": patch
+"@dawn-ai/permissions": patch
+"@dawn-ai/cli": patch
+---
+
+New memory write-governance mode `writes: "ask"`: memory supersedes (belief contradictions) prompt a HITL Once/Always/Deny interrupt with old-vs-new detail; ADDs and idempotent updates flow silently; headless behaves as `auto`. New `kind: "memory"` permission interrupt, `gateMemorySupersede`, `suggestedMemoryPattern`, and a `dawn check` warning for the `ask` + `approve: ["remember"]` double-gate overlap.

--- a/apps/web/content/docs/configuration.mdx
+++ b/apps/web/content/docs/configuration.mdx
@@ -57,7 +57,7 @@ export default {
   // keys below tune how those typed memories are stored, recalled, and written.
   // Defaults apply to every route with a memory.ts even when this key is absent.
   memory: {
-    writes: "candidate",   // default — writes land for review, hidden from recall
+    writes: "candidate",   // "off" | "candidate" | "auto" | "ask" — default "candidate"
     indexMaxEntries: 20,   // default — cap on memories injected into the prompt index
     // store: myMemoryStore,  // default: SQLite at .dawn/memory.sqlite
     // resolveScope: ({ routePath, appRoot }) => ({ tenant: "acme" }),
@@ -218,7 +218,7 @@ Configures long-term memory governance. A route opts into memory by adding a `me
 ```ts
 memory?: {
   store?: MemoryStore
-  writes?: "off" | "candidate" | "auto"
+  writes?: "off" | "candidate" | "auto" | "ask"
   indexMaxEntries?: number
   resolveScope?: (ctx: { routePath: string; appRoot: string }) => Record<string, string>
 }
@@ -227,11 +227,11 @@ memory?: {
 | Key | Type | Default | Description |
 |---|---|---|---|
 | `store` | `MemoryStore` | SQLite at `.dawn/memory.sqlite` | The memory store backend. Defaults to an SQLite-backed store at `<appRoot>/.dawn/memory.sqlite`. Override to plug in a custom backend. |
-| `writes` | `"off" \| "candidate" \| "auto"` | `"candidate"` | Write governance for the `remember` tool. `off` — recall-only; the `remember` tool is not exposed. `candidate` — writes land as candidates for review, hidden from `recall` until promoted with `dawn memory approve`. `auto` — writes are active immediately, with inline identity reconciliation (idempotent updates and supersede-on-conflict). |
+| `writes` | `"off" \| "candidate" \| "auto" \| "ask"` | `"candidate"` | Write governance for the `remember` tool. `off` — recall-only; the `remember` tool is not exposed. `candidate` — writes land as candidates for review, hidden from `recall` until promoted with `dawn memory approve`. `auto` — writes are active immediately, with inline identity reconciliation (idempotent updates and supersede-on-conflict). `ask` — same as `auto`, except a supersede (belief contradiction) interrupts for human Once/Always/Deny approval when running interactively; headless behaves exactly like `auto`. |
 | `indexMaxEntries` | `number` | `20` | Cap on how many in-scope memories are injected into the prompt memory index. |
 | `resolveScope` | `(ctx: { routePath; appRoot }) => Record<string, string>` | — | Supplies runtime namespace dimensions (e.g. `tenant`, `user`, `agent`) for the memory namespace. Only the dimensions a route declares in its `memory.ts` scope are applied. |
 
-See [Memory](/docs/memory) for the full long-term-memory model and the [`dawn memory`](/docs/cli#dawn-memory) CLI for reviewing candidate writes.
+See [Memory](/docs/memory) for the full long-term-memory model and [Permissions](/docs/permissions#memory-write-approval-writes-ask) for the `ask`-mode HITL flow, plus the [`dawn memory`](/docs/cli#dawn-memory) CLI for reviewing candidate writes.
 
 ---
 

--- a/apps/web/content/docs/memory.mdx
+++ b/apps/web/content/docs/memory.mdx
@@ -146,7 +146,7 @@ In **`auto`** mode each write reconciles inline against existing active records 
 - Decisions persist under the `memory` key in `.dawn/permissions.json` as namespace prefixes, e.g. `{ "allow": { "memory": ["workspace=app|route=/support|"] } }` (keep the trailing `|` — it prevents sibling-route prefix collisions).
 
 <Callout type="info" title="Gating writes: ask mode vs tools.approve">
-  Two gates exist, at different granularities. `writes: "ask"` (below) prompts **only when the agent contradicts an existing memory** — a supersede-level gate inside `remember`. `tools: { approve: ["remember"] }` (see [per-tool approval](/docs/permissions)) prompts on **every** `remember` call. Prefer `ask` for memory; combining both draws a `dawn check` warning (double prompt). `auto` remains fully trusting.
+  Two gates exist, at different granularities. `writes: "ask"` (see above) prompts **only when the agent contradicts an existing memory** — a supersede-level gate inside `remember`. `tools: { approve: ["remember"] }` (see [per-tool approval](/docs/permissions)) prompts on **every** `remember` call. Prefer `ask` for memory; combining both draws a `dawn check` warning (double prompt). `auto` remains fully trusting.
 </Callout>
 
 ## Reviewing candidates

--- a/apps/web/content/docs/memory.mdx
+++ b/apps/web/content/docs/memory.mdx
@@ -125,6 +125,7 @@ The `memory.writes` mode in `dawn.config.ts` controls what `remember` does. It d
 | `off` | Not generated (recall-only) | — | — |
 | `candidate` *(default)* | Generated | `candidate` — hidden from `recall` until approved | None |
 | `auto` | Generated | `active` immediately | Inline (see below) |
+| `ask` | Generated | `active` immediately | Inline — supersedes prompt first |
 
 In **`auto`** mode each write reconciles inline against existing active records with the same identity key:
 
@@ -136,8 +137,16 @@ In **`auto`** mode each write reconciles inline against existing active records 
   In the default `candidate` mode there is **no** reconciliation or supersession. A `remember` call simply writes a hidden candidate; `dawn memory approve` only flips its status to `active`. Contradicting facts are *not* reconciled when approved — that logic runs only on `auto` writes. If you rely on contradiction-handling, you must opt into `auto`.
 </Callout>
 
-<Callout type="warn" title="auto writes are not gated by permissions">
-  The design specced a permissions HITL flow (Once / Always / Deny) to gate `auto` writes, but that was **not shipped**. `auto` writes land active immediately and do **not** pass through `@dawn-ai/permissions`. Treat `auto` as fully trusting the agent's writes; use `candidate` when a human should review first.
+### `ask` mode
+
+`ask` shares `auto`'s write semantics exactly — same reconciliation, same statuses — with one difference: a **SUPERSEDE** (same identity, different value) asks a human first. The prompt shows the old and new values with Once / Always / Deny; **Always** persists a rule for the whole route, so future overwrites in that route proceed silently. ADDs and idempotent updates never prompt.
+
+- **Deny** keeps the old record active; nothing is written; the agent is told which memory was kept.
+- **Headless** (non-interactive mode, CI, evals, deployed servers): `ask` behaves exactly as `auto` — the supersede proceeds. `ask` is a *supervision affordance for interactive development*, not a security boundary. Explicit `deny` rules in the permissions config are still honored headless.
+- Decisions persist under the `memory` key in `.dawn/permissions.json` as namespace prefixes, e.g. `{ "allow": { "memory": ["workspace=app|route=/support|"] } }` (keep the trailing `|` — it prevents sibling-route prefix collisions).
+
+<Callout type="info" title="Gating writes: ask mode vs tools.approve">
+  Two gates exist, at different granularities. `writes: "ask"` (below) prompts **only when the agent contradicts an existing memory** — a supersede-level gate inside `remember`. `tools: { approve: ["remember"] }` (see [per-tool approval](/docs/permissions)) prompts on **every** `remember` call. Prefer `ask` for memory; combining both draws a `dawn check` warning (double prompt). `auto` remains fully trusting.
 </Callout>
 
 ## Reviewing candidates
@@ -179,7 +188,7 @@ The `memory` block in `dawn.config.ts` configures L3 across the app:
 export default {
   memory: {
     // store?       — defaults to a SQLite store at <appRoot>/.dawn/memory.sqlite
-    writes: "candidate", // "off" | "candidate" | "auto" (default "candidate")
+    writes: "candidate", // "off" | "candidate" | "auto" | "ask" (default "candidate")
     indexMaxEntries: 20, // index size cap (default 20)
     // Supply tenant/user/agent dimensions at runtime for namespacing.
     resolveScope: ({ routePath, appRoot }) => ({
@@ -229,7 +238,6 @@ Long-term memory ships with the `semantic` kind and deterministic keyword + rece
 - A dev-server Memory Inspector UI.
 - Postgres / pgvector store adapters.
 - Schema-typed `remember.data` (typed loosely as `Record<string, unknown>` today).
-- Permissions HITL gating for `auto` writes (see the warning above).
 
 For anything beyond the semantic collection, use `memory.md` for stable profile text and `memory.ts` for facts the agent should accumulate over time.
 

--- a/apps/web/content/docs/permissions.mdx
+++ b/apps/web/content/docs/permissions.mdx
@@ -119,6 +119,18 @@ export default {
   Listing `"task"` in `approve` does not gate subagent dispatch: the subagent dispatch bridge replaces the `task` tool's run after the approval wrap, so the approval never takes effect. Gating subagent dispatch is not yet supported. `dawn check` warns if you list `task` in `approve`.
 </Callout>
 
+## Memory write approval (`writes: "ask"`)
+
+Routes with [long-term memory](/docs/memory) can gate belief *changes*: with `memory: { writes: "ask" }` in `dawn.config.ts`, a `remember` call that would **supersede** an existing active memory interrupts with the old and new values. New facts and idempotent refreshes never prompt.
+
+- **Once** — this supersede proceeds.
+- **Always** — persists the route's namespace prefix under the `memory` key; all future overwrites in the route proceed silently.
+- **Deny** — the old memory stays active; the agent is told which memory was kept.
+
+Unlike bash/path/tool gates, `ask` **allows through** when no human can answer (non-interactive mode): headless, `ask` ≡ `auto`. It is a supervision affordance, not a security boundary. Explicit `deny` entries are honored in every mode except `bypass`.
+
+Hand-authored patterns should keep the trailing `|` terminator: `"workspace=app|route=/a|"` cannot collide with `route=/ab`.
+
 ## The interrupt payload
 
 When a command or path is "unknown" in interactive mode, the agent run pauses and the runtime emits an SSE event. The `kind` field tells you which gate fired.

--- a/docs/superpowers/plans/2026-07-06-memory-ask-mode.md
+++ b/docs/superpowers/plans/2026-07-06-memory-ask-mode.md
@@ -1,0 +1,1055 @@
+# Memory `ask` Mode Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `memory.writes: "ask"` — a supervision mode where memory SUPERSEDEs (belief contradictions) prompt a HITL Once/Always/Deny interrupt, while ADDs and idempotent UPDATEs flow silently; headless behaves exactly as `auto`.
+
+**Architecture:** A new `gateMemorySupersede` in core's permission-gate (sibling of `gateToolOp`), called from *inside* the memory capability's `remember` tool at the supersede branch — the only place the old record is in hand. A new interrupt `kind: "memory"` with an old-vs-new `MemoryDetail` payload. Persistence uses a reserved `"memory"` key with native prefix matching made collision-safe by a `|` terminator on the candidate. Spec: `docs/superpowers/specs/2026-07-06-memory-ask-mode-design.md`.
+
+**Tech Stack:** TypeScript, vitest, LangGraph `interrupt()`, `@dawn-ai/permissions`, aimock e2e harness (`@dawn-ai/testing`), pnpm monorepo.
+
+**Conventions:** Run all commands from the repo root. Use the repo lint script (`pnpm lint`) — NEVER bare `biome check --write`. All new code follows the exact patterns of the #291 per-tool-approval implementation.
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|---|---|---|
+| `packages/core/src/capabilities/types.ts` | Modify | `MemoryWritesMode` alias; widen `MemoryContext.writes` |
+| `packages/core/src/types.ts` | Modify | Widen `DawnConfig.memory.writes` |
+| `packages/cli/src/lib/runtime/resolve-memory.ts` | Modify | Widen `resolveMemoryWrites` + `buildMemoryContext` |
+| `packages/permissions/src/types.ts` | Modify | `MemoryDetail`; widen `PermissionRequest` |
+| `packages/permissions/src/suggested-pattern.ts` | Modify | `suggestedMemoryPattern()` |
+| `packages/permissions/src/index.ts` | Modify | Export both |
+| `packages/permissions/test/suggested-pattern.test.ts` | Modify | Pattern unit tests |
+| `packages/permissions/test/pattern-matching.test.ts` | Modify | Terminator collision-safety tests |
+| `packages/core/src/capabilities/permission-gate.ts` | Modify | `gateMemorySupersede` + `InterruptArgs` + emit cases |
+| `packages/core/src/capabilities/built-in/memory.ts` | Modify | `ask` semantics + gate call at supersede branch |
+| `packages/core/test/capabilities/permission-gate.test.ts` | Modify | Gate ladder tests |
+| `packages/core/test/capabilities/memory.test.ts` | Modify | ask-mode capability tests |
+| `packages/cli/src/lib/runtime/collect-tool-scope-errors.ts` | Modify | ask+approve overlap warning |
+| `packages/cli/src/commands/check.ts` | Modify | Pass memoryWrites to validation |
+| `examples/chat/web/app/page.tsx` | Modify | Render `kind: "memory"` interrupts |
+| `packages/testing/test/fixtures/probe-app-memory-ask/**` | Create | e2e fixture app (`writes: "ask"`) |
+| `packages/testing/test/memory-ask.e2e.test.ts` | Create | aimock e2e (4 scenarios) |
+| `apps/web/content/docs/{memory,permissions,configuration}.mdx` | Modify | Docs |
+| `.changeset/memory-ask-mode.md` | Create | Patch changeset |
+
+---
+
+### Task 1: Widen the writes-mode types to include `"ask"`
+
+Type-only change; verified by typecheck. `"ask"` must be accepted everywhere `"auto"` is.
+
+**Files:**
+- Modify: `packages/core/src/capabilities/types.ts` (~line 36-39)
+- Modify: `packages/core/src/types.ts` (~line 72)
+- Modify: `packages/cli/src/lib/runtime/resolve-memory.ts` (lines 58, 71)
+
+- [ ] **Step 1: Add the `MemoryWritesMode` alias and widen `MemoryContext.writes`**
+
+In `packages/core/src/capabilities/types.ts`, directly above `export interface MemoryContext {`:
+
+```ts
+/**
+ * Memory write-governance mode. "ask" = auto's exact write semantics, except
+ * SUPERSEDEs (same identity, different value) pass a HITL gate first — a
+ * supervision affordance, not a security boundary (headless ≡ auto).
+ */
+export type MemoryWritesMode = "off" | "candidate" | "auto" | "ask"
+```
+
+Change `MemoryContext`'s field `readonly writes: "off" | "candidate" | "auto"` to:
+
+```ts
+  readonly writes: MemoryWritesMode
+```
+
+- [ ] **Step 2: Widen `DawnConfig.memory.writes`**
+
+In `packages/core/src/types.ts` (~line 72), replace the `writes` line and its doc comment:
+
+```ts
+  /** Write-governance mode. "off" — never write; "candidate" — write as candidate (default); "auto" — write and auto-promote; "ask" — auto, but supersedes require HITL approval when interactive. */
+  readonly writes?: "off" | "candidate" | "auto" | "ask"
+```
+
+- [ ] **Step 3: Widen the CLI resolver and builder**
+
+In `packages/cli/src/lib/runtime/resolve-memory.ts`:
+- Line 58: change the return type of `resolveMemoryWrites` from `Promise<"off" | "candidate" | "auto">` to `Promise<import("@dawn-ai/core").MemoryWritesMode>` (or add `MemoryWritesMode` to the existing `@dawn-ai/core` import at line 2 and use it directly).
+- Line 71 (`buildMemoryContext` args): change `writes: "off" | "candidate" | "auto"` to `writes: MemoryWritesMode`.
+
+Verify `MemoryWritesMode` is exported from `@dawn-ai/core`'s barrel (`packages/core/src/index.ts`) — capabilities/types.ts types are re-exported there; if the barrel uses named exports, add `MemoryWritesMode`.
+
+- [ ] **Step 4: Typecheck**
+
+Run: `pnpm --filter @dawn-ai/core --filter @dawn-ai/cli build && pnpm typecheck`
+Expected: clean (no behavior change anywhere — `"ask"` currently falls into the candidate else-branch in memory.ts, which Task 4 fixes).
+
+Note: typegen needs NO change — `run-typegen.ts` has no writes-mode conditioning (`remember`/`recall` are always emitted when `memory.ts` exists), verified 2026-07-06.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/core/src/capabilities/types.ts packages/core/src/types.ts packages/cli/src/lib/runtime/resolve-memory.ts packages/core/src/index.ts
+git commit -m "feat(core,cli): widen memory writes union with \"ask\" mode (types only)"
+```
+
+---
+
+### Task 2: `@dawn-ai/permissions` — `MemoryDetail`, `suggestedMemoryPattern`, terminator semantics
+
+**Files:**
+- Modify: `packages/permissions/src/types.ts`
+- Modify: `packages/permissions/src/suggested-pattern.ts`
+- Modify: `packages/permissions/src/index.ts`
+- Test: `packages/permissions/test/suggested-pattern.test.ts`, `packages/permissions/test/pattern-matching.test.ts`
+
+- [ ] **Step 1: Write failing tests for `suggestedMemoryPattern`**
+
+Append to `packages/permissions/test/suggested-pattern.test.ts` (match the file's existing describe/it style and imports — add `suggestedMemoryPattern` to the import from `../src/suggested-pattern.js`):
+
+```ts
+describe("suggestedMemoryPattern", () => {
+  it("returns the workspace+route prefix with a trailing terminator", () => {
+    expect(suggestedMemoryPattern("workspace=app|route=/support|tenant=acme")).toBe(
+      "workspace=app|route=/support|",
+    )
+  })
+
+  it("handles a namespace with no dims after route", () => {
+    expect(suggestedMemoryPattern("workspace=app|route=/support")).toBe(
+      "workspace=app|route=/support|",
+    )
+  })
+
+  it("falls back to the whole namespace when route is absent", () => {
+    expect(suggestedMemoryPattern("workspace=app")).toBe("workspace=app|")
+  })
+})
+```
+
+- [ ] **Step 2: Write failing tests for terminator collision-safety**
+
+Append to `packages/permissions/test/pattern-matching.test.ts` (uses the existing `matchPermission(tool, candidate, allow, deny)` import):
+
+```ts
+describe("memory key (prefix + terminator convention)", () => {
+  // Callers match memory candidates as `namespace + "|"` so a /a rule can
+  // never prefix-match a /ab namespace. matchPermission itself is unchanged.
+  const allow = { memory: ["workspace=app|route=/a|"] }
+
+  it("allows the exact route (terminated candidate)", () => {
+    expect(matchPermission("memory", "workspace=app|route=/a|", allow, {})).toBe("allow")
+  })
+
+  it("allows deeper namespaces under the route", () => {
+    expect(
+      matchPermission("memory", "workspace=app|route=/a|tenant=acme|", allow, {}),
+    ).toBe("allow")
+  })
+
+  it("does NOT match a sibling route sharing the prefix", () => {
+    expect(matchPermission("memory", "workspace=app|route=/ab|", allow, {})).toBe("unknown")
+  })
+
+  it("deny wins over allow for the memory key", () => {
+    const deny = { memory: ["workspace=app|route=/a|"] }
+    expect(matchPermission("memory", "workspace=app|route=/a|", allow, deny)).toBe("deny")
+  })
+})
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `pnpm --filter @dawn-ai/permissions test`
+Expected: FAIL — `suggestedMemoryPattern` is not exported (the pattern-matching tests may already pass since `matchPermission` is generic; that's fine — they pin the convention).
+
+- [ ] **Step 4: Implement**
+
+Append to `packages/permissions/src/suggested-pattern.ts`:
+
+```ts
+/**
+ * Default suggested pattern for a memory-write approval: the namespace's
+ * workspace+route prefix, with a trailing "|" terminator so prefix matching
+ * cannot collide across sibling routes (route=/a vs route=/ab). Callers match
+ * candidates as `namespace + "|"` for the same reason.
+ */
+export function suggestedMemoryPattern(namespace: string): string {
+  const parts = namespace.split("|")
+  const routeIdx = parts.findIndex((p) => p.startsWith("route="))
+  const prefix = routeIdx >= 0 ? parts.slice(0, routeIdx + 1) : parts
+  return `${prefix.join("|")}|`
+}
+```
+
+In `packages/permissions/src/types.ts`, add after `ToolDetail` (line 40):
+
+```ts
+export interface MemoryDetail {
+  /** Full memory namespace of the write (e.g. "workspace=app|route=/support"). */
+  readonly namespace: string
+  /** Rendered identity key of the contradicted fact, e.g. "acme / payment-terms". */
+  readonly identity: string
+  /** Id of the active record that would be superseded. */
+  readonly oldId: string
+  /** Content of the record being overwritten. */
+  readonly oldContent: string
+  /** Content of the replacement. */
+  readonly newContent: string
+  /** Workspace+route namespace prefix (terminator included) — persisted on "always" under the reserved "memory" key. */
+  readonly suggestedPattern: string
+}
+```
+
+Widen `PermissionRequest` (lines 42-48):
+
+```ts
+export interface PermissionRequest {
+  readonly interruptId: string
+  readonly kind: "command" | "path" | "tool" | "memory"
+  readonly detail: CommandDetail | PathDetail | ToolDetail | MemoryDetail
+  readonly threadId: string
+  readonly callId?: string
+}
+```
+
+In `packages/permissions/src/index.ts`: add `suggestedMemoryPattern` to the `./suggested-pattern.js` export line, and `MemoryDetail` to the type exports from `./types.js`.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `pnpm --filter @dawn-ai/permissions test`
+Expected: PASS (all).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/permissions/src packages/permissions/test
+git commit -m "feat(permissions): MemoryDetail + suggestedMemoryPattern for kind:\"memory\" interrupts"
+```
+
+---
+
+### Task 3: `gateMemorySupersede` in core's permission-gate
+
+**Files:**
+- Modify: `packages/core/src/capabilities/permission-gate.ts`
+- Modify: `packages/core/src/index.ts` (export alongside `gateToolOp` — find where `gateToolOp`/`wrapToolWithApproval` are exported and mirror)
+- Test: `packages/core/test/capabilities/permission-gate.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `packages/core/test/capabilities/permission-gate.test.ts`. It already has a `store(mode, config?)` helper building a real `PermissionsStore` (lines 68-84) — reuse it. Add `gateMemorySupersede` to the import from `../../src/capabilities/permission-gate.js`.
+
+```ts
+describe("gateMemorySupersede", () => {
+  const detail = {
+    namespace: "workspace=app|route=/support",
+    identity: "acme / payment-terms",
+    oldId: "memory_abc123",
+    oldContent: "acme prefers net-30",
+    newContent: "acme prefers net-45",
+  }
+
+  it("allows when no permissions store is present (legacy context ≡ auto)", async () => {
+    expect((await gateMemorySupersede(undefined, detail)).allowed).toBe(true)
+  })
+
+  it("allows in bypass mode", async () => {
+    const permissions = await store("bypass")
+    expect((await gateMemorySupersede(permissions, detail)).allowed).toBe(true)
+  })
+
+  it("allows a config-pre-approved route prefix (terminated)", async () => {
+    const permissions = await store("interactive", {
+      allow: { memory: ["workspace=app|route=/support|"] },
+    })
+    expect((await gateMemorySupersede(permissions, detail)).allowed).toBe(true)
+  })
+
+  it("does not let a sibling-route rule leak (route=/s vs route=/support)", async () => {
+    // /s is a string prefix of /support; the terminator must prevent the match.
+    // "unknown" in non-interactive mode → allow-through, so use the deny list
+    // to make leakage observable.
+    const permissions = await store("non-interactive", {
+      deny: { memory: ["workspace=app|route=/s|"] },
+    })
+    expect((await gateMemorySupersede(permissions, detail)).allowed).toBe(true)
+  })
+
+  it("blocks an explicitly denied route prefix with a reason (honored headless)", async () => {
+    const permissions = await store("non-interactive", {
+      deny: { memory: ["workspace=app|route=/support|"] },
+    })
+    const result = await gateMemorySupersede(permissions, detail)
+    expect(result.allowed).toBe(false)
+    if (!result.allowed) expect(result.reason).toMatch(/denied/i)
+  })
+
+  it("allows through on unknown in non-interactive mode (ask ≡ auto headless)", async () => {
+    const permissions = await store("non-interactive")
+    expect((await gateMemorySupersede(permissions, detail)).allowed).toBe(true)
+  })
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm --filter @dawn-ai/core test -- permission-gate`
+Expected: FAIL with `gateMemorySupersede is not a function` (or import error).
+
+- [ ] **Step 3: Implement the gate**
+
+In `packages/core/src/capabilities/permission-gate.ts`:
+
+Add `suggestedMemoryPattern` to the import from `@dawn-ai/permissions` (line 3).
+
+Insert after `gateToolOp` (after line 126):
+
+```ts
+export interface MemorySupersedeDetail {
+  readonly namespace: string
+  readonly identity: string
+  readonly oldId: string
+  readonly oldContent: string
+  readonly newContent: string
+}
+
+/**
+ * Memory supersede gate (memory.writes: "ask"). Prompts ONLY when the agent
+ * contradicts an existing active memory — ADDs and idempotent UPDATEs never
+ * reach this gate. Persisted decisions live under the reserved "memory" key
+ * as workspace+route namespace prefixes; candidates are matched with a "|"
+ * terminator so sibling routes cannot prefix-collide.
+ *
+ * DELIBERATE DIVERGENCE from gateToolOp: on "unknown" with no interactive
+ * human (non-interactive mode), this gate ALLOWS the supersede — ask is a
+ * supervision affordance, not a security boundary; headless it behaves
+ * exactly as writes:"auto". Explicit deny rules are still honored headless.
+ * Only called from inside the memory capability's remember tool, which only
+ * exists on agent routes (in-graph), so interrupt() is safe here.
+ */
+export async function gateMemorySupersede(
+  permissions: PermissionsStore | undefined,
+  detail: MemorySupersedeDetail,
+): Promise<GateResult> {
+  if (!permissions) return { allowed: true }
+  if (permissions.mode === "bypass") return { allowed: true }
+
+  const decision = permissions.match("memory", `${detail.namespace}|`)
+  if (decision === "allow") return { allowed: true }
+  if (decision === "deny") {
+    return { allowed: false, reason: `approval denied for this route's memory overwrites` }
+  }
+  // unknown + headless → allow through (ask ≡ auto without a human).
+  if (permissions.mode === "non-interactive") return { allowed: true }
+
+  const result = await emitPermissionInterrupt({
+    kind: "memory",
+    ...detail,
+    permissions,
+  })
+  if (result === "deny") {
+    return { allowed: false, reason: `approval denied` }
+  }
+  return { allowed: true }
+}
+```
+
+Extend `InterruptArgs` (line 176-179) with a fourth arm:
+
+```ts
+  | {
+      kind: "memory"
+      namespace: string
+      identity: string
+      oldId: string
+      oldContent: string
+      newContent: string
+      permissions: PermissionsStore
+    }
+```
+
+In `emitPermissionInterrupt` (lines 181-211), extend the two chained ternaries and the persistence switch. Replace the `suggestedPattern` initializer:
+
+```ts
+  const suggestedPattern =
+    args.kind === "command"
+      ? suggestedCommandPattern(args.command)
+      : args.kind === "tool"
+        ? args.toolName
+        : args.kind === "memory"
+          ? suggestedMemoryPattern(args.namespace)
+          : suggestedPathPattern(args.path)
+```
+
+Replace the `detail` initializer:
+
+```ts
+    detail:
+      args.kind === "command"
+        ? { command: args.command, suggestedPattern }
+        : args.kind === "tool"
+          ? { toolName: args.toolName, argsPreview: args.argsPreview, suggestedPattern }
+          : args.kind === "memory"
+            ? {
+                namespace: args.namespace,
+                identity: args.identity,
+                oldId: args.oldId,
+                oldContent: args.oldContent,
+                newContent: args.newContent,
+                suggestedPattern,
+              }
+            : { operation: args.operation, path: args.path, suggestedPattern },
+```
+
+Replace the persistence key line (207):
+
+```ts
+    const tool =
+      args.kind === "command"
+        ? "bash"
+        : args.kind === "tool"
+          ? "tool"
+          : args.kind === "memory"
+            ? "memory"
+            : args.operation
+```
+
+- [ ] **Step 4: Export from the core barrel**
+
+In `packages/core/src/index.ts`, find the existing export of `gateToolOp`/`wrapToolWithApproval` from `./capabilities/permission-gate.js` and add `gateMemorySupersede` and the `MemorySupersedeDetail` type to it.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `pnpm --filter @dawn-ai/core test -- permission-gate`
+Expected: PASS (all, including pre-existing).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/core/src/capabilities/permission-gate.ts packages/core/src/index.ts packages/core/test/capabilities/permission-gate.test.ts
+git commit -m "feat(core): gateMemorySupersede — kind:\"memory\" interrupt with old-vs-new detail"
+```
+
+---
+
+### Task 4: `ask` mode in the memory capability
+
+**Files:**
+- Modify: `packages/core/src/capabilities/built-in/memory.ts`
+- Test: `packages/core/test/capabilities/memory.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `packages/core/test/capabilities/memory.test.ts`. The file has `fakeStore()` and `ctxWith(store, writes)` helpers (lines 5-52); `ctxWith`'s second param is typed `"auto" | "candidate" | "off"` — widen it to `"auto" | "candidate" | "off" | "ask"`. Tests inject a minimal fake `PermissionsStore` via `context.permissions`:
+
+```ts
+function fakePermissions(
+  mode: "interactive" | "non-interactive" | "bypass",
+  matchResult: "allow" | "deny" | "unknown" = "unknown",
+) {
+  const added: Array<{ tool: string; pattern: string }> = []
+  return {
+    added,
+    async load() {},
+    match: () => matchResult,
+    async addAllow(tool: string, pattern: string) {
+      added.push({ tool, pattern })
+    },
+    mode,
+  }
+}
+
+function askCtx(store: any, permissions?: any) {
+  const ctx = ctxWith(store, "ask" as any) as any
+  if (permissions) ctx.permissions = permissions
+  return ctx
+}
+
+describe("ask mode", () => {
+  const first = { subject: "billing", predicate: "escalate", value: "500" }
+  const second = { subject: "billing", predicate: "escalate", value: "750" }
+  const run = (tool: any, data: any, content: string) =>
+    tool.run({ data, content }, { signal: new AbortController().signal })
+
+  it("ADD lands active with no gate consulted", async () => {
+    const store = fakeStore()
+    const permissions = fakePermissions("non-interactive", "deny") // would block if consulted
+    const c = await createMemoryMarker().load("/r", askCtx(store, permissions))
+    const remember = c.tools!.find((t) => t.name === "remember")!
+    const result = await run(remember, first, "v1")
+    expect(String(result)).toContain("Stored memory")
+    expect(store.rows.filter((r: any) => r.status === "active")).toHaveLength(1)
+  })
+
+  it("idempotent UPDATE refreshes with no gate consulted", async () => {
+    const store = fakeStore()
+    const permissions = fakePermissions("non-interactive", "deny")
+    const c = await createMemoryMarker().load("/r", askCtx(store, permissions))
+    const remember = c.tools!.find((t) => t.name === "remember")!
+    await run(remember, first, "v1")
+    const result = await run(remember, first, "v1 refreshed")
+    expect(String(result)).toContain("Updated memory")
+  })
+
+  it("SUPERSEDE with explicit deny keeps the old value active and reports it", async () => {
+    const store = fakeStore()
+    const permissions = fakePermissions("non-interactive", "deny")
+    const c = await createMemoryMarker().load("/r", askCtx(store, permissions))
+    const remember = c.tools!.find((t) => t.name === "remember")!
+    await run(remember, first, "v1")
+    const result = await run(remember, second, "v2")
+    expect(String(result)).toContain("Kept existing memory")
+    const active = store.rows.filter((r: any) => r.status === "active")
+    expect(active).toHaveLength(1)
+    expect(active[0].data.value).toBe("500")
+    expect(store.rows.filter((r: any) => r.status === "superseded")).toHaveLength(0)
+  })
+
+  it("SUPERSEDE proceeds headless on unknown (ask ≡ auto non-interactive)", async () => {
+    const store = fakeStore()
+    const permissions = fakePermissions("non-interactive", "unknown")
+    const c = await createMemoryMarker().load("/r", askCtx(store, permissions))
+    const remember = c.tools!.find((t) => t.name === "remember")!
+    await run(remember, first, "v1")
+    const result = await run(remember, second, "v2")
+    expect(String(result)).toContain("Superseded")
+    const active = store.rows.filter((r: any) => r.status === "active")
+    expect(active).toHaveLength(1)
+    expect(active[0].data.value).toBe("750")
+  })
+
+  it("SUPERSEDE proceeds when no permissions store is in context (ask ≡ auto)", async () => {
+    const store = fakeStore()
+    const c = await createMemoryMarker().load("/r", askCtx(store))
+    const remember = c.tools!.find((t) => t.name === "remember")!
+    await run(remember, first, "v1")
+    const result = await run(remember, second, "v2")
+    expect(String(result)).toContain("Superseded")
+  })
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm --filter @dawn-ai/core test -- capabilities/memory`
+Expected: FAIL — in `ask` mode writes currently fall into the candidate branch (`Stored memory candidate …`), so the first test's `"Stored memory"`/active assertions fail.
+
+- [ ] **Step 3: Implement `ask` in the capability**
+
+In `packages/core/src/capabilities/built-in/memory.ts`:
+
+Add the import (after line 3):
+
+```ts
+import { gateMemorySupersede } from "../permission-gate.js"
+```
+
+In `load` (line 27-29), capture permissions alongside memory:
+
+```ts
+    load: async (_routeDir, context) => {
+      const mem = context.memory
+      if (!mem) return {}
+      const permissions = context.permissions
+```
+
+Replace line 105 (`const status = mem.writes === "auto" ? "active" : "candidate"`):
+
+```ts
+          // "ask" shares auto's write semantics; only its SUPERSEDE branch gates.
+          const autoLike = mem.writes === "auto" || mem.writes === "ask"
+          const status = autoLike ? "active" : "candidate"
+```
+
+Replace line 127 (`if (mem.writes === "auto") {`):
+
+```ts
+          if (autoLike) {
+```
+
+Replace the supersede branch (lines 150-153) with the gated version:
+
+```ts
+              // Same identity but different value — supersede. In "ask" mode this
+              // is the one write that gates: the agent is contradicting a prior
+              // belief. ADDs/idempotent UPDATEs above never reach the gate.
+              if (mem.writes === "ask") {
+                const gate = await gateMemorySupersede(permissions, {
+                  namespace: mem.namespace,
+                  identity: identityKeys.map((k) => String(data[k] ?? "")).join(" / "),
+                  oldId: target.id,
+                  oldContent: target.content,
+                  newContent: content,
+                })
+                if (!gate.allowed) {
+                  return (
+                    `Kept existing memory ${target.id} ("${target.content}"); ` +
+                    `your contradicting value was not stored (${gate.reason}).`
+                  )
+                }
+              }
+              await mem.store.put(record)
+              await mem.store.supersede(target.id, id)
+              return `Superseded ${target.id} with ${id}.`
+```
+
+Note: `target.content` exists on `MemoryRecordLike` (the index fragment already reads `r.content`).
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pnpm --filter @dawn-ai/core test -- capabilities/memory`
+Expected: PASS (all, including pre-existing auto/candidate tests).
+
+- [ ] **Step 5: Run the full core suite + typecheck**
+
+Run: `pnpm --filter @dawn-ai/core test && pnpm --filter @dawn-ai/core build`
+Expected: PASS / clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/core/src/capabilities/built-in/memory.ts packages/core/test/capabilities/memory.test.ts
+git commit -m "feat(core): memory writes:\"ask\" — supersede-gated writes in the remember tool"
+```
+
+---
+
+### Task 5: Validation warning — `ask` + `approve: ["remember"]` overlap
+
+**Files:**
+- Modify: `packages/cli/src/lib/runtime/collect-tool-scope-errors.ts`
+- Modify: `packages/cli/src/commands/check.ts` (~line 46)
+- Test: the existing test file for `collectToolScopeIssues` (find it: `grep -rl collectToolScopeIssues packages/cli/test`)
+
+- [ ] **Step 1: Write the failing test**
+
+In the existing `collectToolScopeIssues` test file, mirror an existing warning test (e.g. the deny-overlap one) with a route whose descriptor has `tools: { approve: ["remember"] }`, passing the new options param:
+
+```ts
+it("warns when approve lists remember while memory writes mode is ask", async () => {
+  // Build manifest + deps exactly as the sibling warning tests do, with a
+  // route descriptor of tools: { approve: ["remember"] }.
+  const issues = await collectToolScopeIssues(manifest, deps, { memoryWrites: "ask" })
+  expect(issues.warnings.some((w) => w.includes('approve lists "remember"'))).toBe(true)
+})
+
+it("does not warn about remember when writes mode is not ask", async () => {
+  const issues = await collectToolScopeIssues(manifest, deps, { memoryWrites: "auto" })
+  expect(issues.warnings.some((w) => w.includes('approve lists "remember"'))).toBe(false)
+})
+```
+
+(Adapt `manifest`/`deps` construction verbatim from the sibling tests in that file — do not invent a new harness.)
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `pnpm --filter @dawn-ai/cli test -- collect-tool-scope`
+Expected: FAIL — third parameter doesn't exist.
+
+- [ ] **Step 3: Implement**
+
+In `collect-tool-scope-errors.ts`, extend the signature (lines 58-61) with a backward-compatible third param:
+
+```ts
+export async function collectToolScopeIssues(
+  manifest: RouteManifest,
+  deps: Deps = defaultDeps,
+  opts?: { readonly memoryWrites?: "off" | "candidate" | "auto" | "ask" },
+): Promise<ToolScopeIssues> {
+```
+
+In the `approve` validation loop, alongside the `INTERNALLY_GATED` warning (lines 87-91), add:
+
+```ts
+        if (opts?.memoryWrites === "ask" && name === "remember") {
+          warnings.push(
+            `⚠ ${route.pathname}: approve lists "remember" but memory writes mode is "ask" — ` +
+              `the supersede-level memory gate already prompts; combining both double-prompts.`,
+          )
+        }
+```
+
+In `packages/cli/src/commands/check.ts` (line 46), resolve the mode and pass it (import `resolveMemoryWrites` from `../lib/runtime/resolve-memory.js`; the appRoot variable used elsewhere in the command is in scope):
+
+```ts
+  const memoryWrites = await resolveMemoryWrites(appRoot)
+  const scopeIssues = await collectToolScopeIssues(manifest, undefined, { memoryWrites })
+```
+
+(Passing `undefined` for `deps` engages the default — matches TS default-param semantics.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pnpm --filter @dawn-ai/cli test -- collect-tool-scope`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/cli/src/lib/runtime/collect-tool-scope-errors.ts packages/cli/src/commands/check.ts packages/cli/test
+git commit -m "feat(cli): warn on writes:\"ask\" + approve:[\"remember\"] double-gate overlap"
+```
+
+---
+
+### Task 6: Chat example — render `kind: "memory"` interrupts
+
+**Files:**
+- Modify: `examples/chat/web/app/page.tsx` (type at lines 11-23; JSX at lines 191-240)
+
+- [ ] **Step 1: Widen `PendingInterrupt`**
+
+```ts
+type PendingInterrupt = {
+  interruptId: string
+  type: string
+  kind: "command" | "path" | "tool" | "memory"
+  detail: {
+    command?: string
+    operation?: string
+    path?: string
+    toolName?: string
+    argsPreview?: string
+    identity?: string
+    oldContent?: string
+    newContent?: string
+    suggestedPattern: string
+  }
+}
+```
+
+- [ ] **Step 2: Add the render branch**
+
+In the `<p>` message ternary chain (lines 203-208), insert a memory arm before the path fallback:
+
+```tsx
+      {pendingInterrupt.kind === "command"
+        ? "The agent wants to run command:"
+        : pendingInterrupt.kind === "tool"
+          ? `The agent wants to call tool ${pendingInterrupt.detail.toolName ?? "(unknown)"}:`
+          : pendingInterrupt.kind === "memory"
+            ? `The agent wants to overwrite a memory (${pendingInterrupt.detail.identity ?? "(unknown)"}):`
+            : `The agent wants to ${pendingInterrupt.detail.operation}:`}
+```
+
+In the `<code>` block ternary (lines 220-224), insert the old-vs-new display:
+
+```tsx
+      {pendingInterrupt.kind === "command"
+        ? pendingInterrupt.detail.command
+        : pendingInterrupt.kind === "tool"
+          ? (pendingInterrupt.detail.argsPreview ?? "")
+          : pendingInterrupt.kind === "memory"
+            ? `was: ${pendingInterrupt.detail.oldContent ?? ""}\nnow: ${pendingInterrupt.detail.newContent ?? ""}`
+            : pendingInterrupt.detail.path}
+```
+
+Add `whiteSpace: "pre-wrap"` to the `<code>` style object so the two-line was/now renders on separate lines. The Once/Always/Deny buttons need no changes (`suggestedPattern` is already rendered generically).
+
+- [ ] **Step 3: Typecheck the example**
+
+Run: `pnpm --filter chat-web typecheck 2>/dev/null || pnpm typecheck`
+Expected: clean. (Use whichever target exists for the example; fall back to the workspace-wide typecheck.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add examples/chat/web/app/page.tsx
+git commit -m "feat(examples/chat): render kind:\"memory\" permission interrupts (old vs new)"
+```
+
+---
+
+### Task 7: aimock e2e — fixture + four scenarios
+
+**Files:**
+- Create: `packages/testing/test/fixtures/probe-app-memory-ask/dawn.config.ts`
+- Create: `packages/testing/test/fixtures/probe-app-memory-ask/package.json` (copy `probe-app-memory-candidate`'s verbatim, changing only the `name` field to `probe-app-memory-ask`)
+- Create: `packages/testing/test/fixtures/probe-app-memory-ask/src/app/notes/index.ts`
+- Create: `packages/testing/test/fixtures/probe-app-memory-ask/src/app/notes/memory.ts`
+- Create: `packages/testing/test/memory-ask.e2e.test.ts`
+
+- [ ] **Step 1: Create the fixture app**
+
+`dawn.config.ts`:
+
+```ts
+export default { memory: { writes: "ask" } }
+```
+
+`src/app/notes/index.ts`:
+
+```ts
+import { agent } from "@dawn-ai/sdk"
+export default agent({
+  model: "gpt-5-mini",
+  systemPrompt: "You are a note-taking test agent. Use remember to store facts.",
+})
+```
+
+`src/app/notes/memory.ts`:
+
+```ts
+import { defineMemory } from "@dawn-ai/sdk"
+import { z } from "zod"
+export default defineMemory({
+  kind: "semantic",
+  scope: ["workspace", "route"],
+  schema: z.object({ subject: z.string(), predicate: z.string(), value: z.string() }),
+})
+```
+
+Check `probe-app-memory-candidate` for any other files (e.g. tsconfig) and mirror them.
+
+- [ ] **Step 2: Write the e2e tests**
+
+Create `packages/testing/test/memory-ask.e2e.test.ts` (modeled verbatim on `tool-approval.e2e.test.ts` — imports, harness, matchers, 60s timeouts). The route's namespace is `workspace=probe-app-memory-ask|route=/notes` (workspace = fixture dir basename), so the persisted "always" pattern is `workspace=probe-app-memory-ask|route=/notes|`.
+
+```ts
+import { readFileSync, rmSync } from "node:fs"
+import { join } from "node:path"
+import { fileURLToPath } from "node:url"
+import { beforeEach, expect, it } from "vitest"
+import { script } from "../src/fixture-builder.js"
+import { createAgentHarness } from "../src/harness.js"
+import { expectInterrupt, expectNoInterrupt, expectToolCalled } from "../src/matchers.js"
+
+const askRoot = fileURLToPath(new URL("./fixtures/probe-app-memory-ask", import.meta.url))
+const permissionsPath = join(askRoot, ".dawn", "permissions.json")
+
+const NET30 = { subject: "acme", predicate: "payment-terms", value: "net-30" }
+const NET45 = { subject: "acme", predicate: "payment-terms", value: "net-45" }
+const NET60 = { subject: "acme", predicate: "payment-terms", value: "net-60" }
+
+// Fresh store + permissions per test: memory.sqlite and permissions.json both
+// live under the fixture's .dawn/.
+beforeEach(() => {
+  rmSync(join(askRoot, ".dawn"), { recursive: true, force: true })
+})
+
+const rememberScript = (data: Record<string, string>, content: string, reply: string) =>
+  script().user(`remember: ${content}`).callsTool("remember", { data, content }).replies(reply)
+
+it("ADD never interrupts; a contradicting write interrupts with old-vs-new; resume(once) supersedes", async () => {
+  const h = await createAgentHarness({ appRoot: askRoot, route: "/notes#agent" })
+  try {
+    const run1 = await h.run({
+      input: "remember: acme prefers net-30",
+      fixtures: rememberScript(NET30, "acme prefers net-30", "Noted."),
+    })
+    expectNoInterrupt(run1)
+    expectToolCalled(run1, "remember")
+
+    h.reset()
+    const run2 = await h.run({
+      input: "remember: acme prefers net-45",
+      fixtures: rememberScript(NET45, "acme prefers net-45", "Updated."),
+    })
+    expectInterrupt(run2).ofKind("memory").withDetail({
+      identity: "acme / payment-terms",
+      oldContent: "acme prefers net-30",
+      newContent: "acme prefers net-45",
+    })
+
+    const resumed = await h.resume({ decision: "once" })
+    expect(JSON.stringify(resumed)).toContain("Superseded")
+  } finally {
+    await h.close()
+  }
+}, 60_000)
+
+it("resume(deny) keeps the old value and reports it to the agent", async () => {
+  const h = await createAgentHarness({ appRoot: askRoot, route: "/notes#agent" })
+  try {
+    await h.run({
+      input: "remember: acme prefers net-30",
+      fixtures: rememberScript(NET30, "acme prefers net-30", "Noted."),
+    })
+    h.reset()
+    const run = await h.run({
+      input: "remember: acme prefers net-45",
+      fixtures: rememberScript(NET45, "acme prefers net-45", "Updated."),
+    })
+    expectInterrupt(run).ofKind("memory")
+
+    const resumed = await h.resume({ decision: "deny" })
+    expect(JSON.stringify(resumed)).toContain("Kept existing memory")
+  } finally {
+    await h.close()
+  }
+}, 60_000)
+
+it("resume(always) persists the route prefix; a fresh contradiction does not prompt", async () => {
+  const h = await createAgentHarness({ appRoot: askRoot, route: "/notes#agent" })
+  try {
+    await h.run({
+      input: "remember: acme prefers net-30",
+      fixtures: rememberScript(NET30, "acme prefers net-30", "Noted."),
+    })
+    h.reset()
+    const run = await h.run({
+      input: "remember: acme prefers net-45",
+      fixtures: rememberScript(NET45, "acme prefers net-45", "Updated."),
+    })
+    expectInterrupt(run).ofKind("memory")
+    await h.resume({ decision: "always" })
+
+    const persisted = JSON.parse(readFileSync(permissionsPath, "utf8")) as {
+      allow?: Record<string, string[]>
+    }
+    expect(persisted.allow?.memory).toContain("workspace=probe-app-memory-ask|route=/notes|")
+
+    h.reset()
+    const run3 = await h.run({
+      input: "remember: acme prefers net-60",
+      fixtures: rememberScript(NET60, "acme prefers net-60", "Updated again."),
+    })
+    expectNoInterrupt(run3)
+    expect(JSON.stringify(run3)).toContain("Superseded")
+  } finally {
+    await h.close()
+  }
+}, 60_000)
+```
+
+Note for the implementer: if `expectInterrupt(...).withDetail(...)` only supports flat equality on given keys (see `packages/testing/src/matchers.ts`), the detail assertions above work as-is; if it requires the full detail object, assert the three keys individually via `run2.interrupts[0].detail`.
+
+- [ ] **Step 3: Run the e2e**
+
+Run: `pnpm --filter @dawn-ai/testing test -- memory-ask`
+Expected: PASS (3 tests). Debug notes: an interrupt that never fires usually means the fixture's writes mode didn't resolve (check `dawn.config.ts` loads) or the first write superseded instead of ADDing (check `beforeEach` cleared `.dawn`).
+
+- [ ] **Step 4: Run the full testing suite (no regressions)**
+
+Run: `pnpm --filter @dawn-ai/testing test`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/testing/test/fixtures/probe-app-memory-ask packages/testing/test/memory-ask.e2e.test.ts
+git commit -m "test(testing): aimock e2e for memory writes:\"ask\" — interrupt/once/deny/always"
+```
+
+---
+
+### Task 8: Docs + changeset + spec annotation
+
+**Files:**
+- Modify: `apps/web/content/docs/memory.mdx`
+- Modify: `apps/web/content/docs/permissions.mdx`
+- Modify: `apps/web/content/docs/configuration.mdx`
+- Modify: `docs/superpowers/specs/2026-06-18-long-term-memory-design.md`
+- Create: `.changeset/memory-ask-mode.md`
+
+- [ ] **Step 1: memory.mdx — replace the stale callout, add the `ask` row and section**
+
+Replace the entire `<Callout type="warn" title="auto writes are not gated by permissions">…</Callout>` block (~line 139) with:
+
+```mdx
+<Callout type="info" title="Gating writes: ask mode vs tools.approve">
+  Two gates exist, at different granularities. `writes: "ask"` (below) prompts **only when the agent contradicts an existing memory** — a supersede-level gate inside `remember`. `tools: { approve: ["remember"] }` (see [per-tool approval](/docs/permissions)) prompts on **every** `remember` call. Prefer `ask` for memory; combining both draws a `dawn check` warning (double prompt). `auto` remains fully trusting.
+</Callout>
+```
+
+Update the write-governance table (~line 123) to four rows:
+
+```mdx
+| Mode | `remember` tool | Where writes land | Reconciliation |
+|---|---|---|---|
+| `off` | Not generated (recall-only) | — | — |
+| `candidate` *(default)* | Generated | `candidate` — hidden from `recall` until approved | None |
+| `auto` | Generated | `active` immediately | Inline (see below) |
+| `ask` | Generated | `active` immediately | Inline — supersedes prompt first |
+```
+
+After the existing `auto` reconciliation bullets (~line 133), add:
+
+```mdx
+### `ask` mode
+
+`ask` shares `auto`'s write semantics exactly — same reconciliation, same statuses — with one difference: a **SUPERSEDE** (same identity, different value) asks a human first. The prompt shows the old and new values with Once / Always / Deny; **Always** persists a rule for the whole route, so future overwrites in that route proceed silently. ADDs and idempotent updates never prompt.
+
+- **Deny** keeps the old record active; nothing is written; the agent is told which memory was kept.
+- **Headless** (non-interactive mode, CI, evals, deployed servers): `ask` behaves exactly as `auto` — the supersede proceeds. `ask` is a *supervision affordance for interactive development*, not a security boundary. Explicit `deny` rules in the permissions config are still honored headless.
+- Decisions persist under the `memory` key in `.dawn/permissions.json` as namespace prefixes, e.g. `{ "allow": { "memory": ["workspace=app|route=/support|"] } }` (keep the trailing `|` — it prevents sibling-route prefix collisions).
+```
+
+In the "What's deferred" list (~line 232), delete the line `- Permissions HITL gating for `auto` writes (see the warning above).`
+
+- [ ] **Step 2: permissions.mdx — add a "Memory write approval" section**
+
+After the per-tool approval section (added by #291), insert:
+
+```mdx
+## Memory write approval (`writes: "ask"`)
+
+Routes with [long-term memory](/docs/memory) can gate belief *changes*: with `memory: { writes: "ask" }` in `dawn.config.ts`, a `remember` call that would **supersede** an existing active memory interrupts with the old and new values. New facts and idempotent refreshes never prompt.
+
+- **Once** — this supersede proceeds.
+- **Always** — persists the route's namespace prefix under the `memory` key; all future overwrites in the route proceed silently.
+- **Deny** — the old memory stays active; the agent is told which memory was kept.
+
+Unlike bash/path/tool gates, `ask` **allows through** when no human can answer (non-interactive mode): headless, `ask` ≡ `auto`. It is a supervision affordance, not a security boundary. Explicit `deny` entries are honored in every mode except `bypass`.
+
+Hand-authored patterns should keep the trailing `|` terminator: `"workspace=app|route=/a|"` cannot collide with `route=/ab`.
+```
+
+- [ ] **Step 3: configuration.mdx — update the writes line**
+
+Find the `memory` block documentation and update the `writes` union and comment to include `"ask"` (mirror the Task 1 doc comment).
+
+- [ ] **Step 4: Annotate the 2026-06-18 spec**
+
+In `docs/superpowers/specs/2026-06-18-long-term-memory-design.md`, in the Write governance section's `auto` bullet (~line 118), append: `(2026-07-06: the HITL gate shipped as the separate "ask" mode — see docs/superpowers/specs/2026-07-06-memory-ask-mode-design.md.)`
+
+- [ ] **Step 5: Changeset**
+
+Create `.changeset/memory-ask-mode.md` (**patch** — fixed 0.x group; a minor would force 1.0.0):
+
+```md
+---
+"@dawn-ai/core": patch
+"@dawn-ai/permissions": patch
+"@dawn-ai/cli": patch
+---
+
+New memory write-governance mode `writes: "ask"`: memory supersedes (belief contradictions) prompt a HITL Once/Always/Deny interrupt with old-vs-new detail; ADDs and idempotent updates flow silently; headless behaves as `auto`. New `kind: "memory"` permission interrupt, `gateMemorySupersede`, `suggestedMemoryPattern`, and a `dawn check` warning for the `ask` + `approve: ["remember"]` double-gate overlap.
+```
+
+- [ ] **Step 6: Docs build check + commit**
+
+Run: `pnpm --filter web build 2>/dev/null || pnpm build`
+Expected: clean (mdx compiles).
+
+```bash
+git add apps/web/content/docs docs/superpowers/specs/2026-06-18-long-term-memory-design.md .changeset/memory-ask-mode.md
+git commit -m "docs: memory writes:\"ask\" — supersede gating, permissions section, changeset"
+```
+
+---
+
+### Task 9: Final verification + issue update
+
+- [ ] **Step 1: Full verification**
+
+Run: `pnpm build && pnpm typecheck && pnpm lint && pnpm test`
+Expected: all green. Fix anything that isn't before proceeding (report failures honestly).
+
+- [ ] **Step 2: Update issue #260**
+
+```bash
+gh issue comment 260 --body "Implemented as \`memory.writes: \"ask\"\` (supersede-gated writes) per docs/superpowers/specs/2026-07-06-memory-ask-mode-design.md — re-scoped after #291 shipped generic per-tool approval: the memory gate prompts only on belief contradictions (outcome-sensitive, not expressible via tools.approve). Closing when the implementation PR merges."
+gh issue edit 260 --title "Memory: supersede-gated writes (writes: \"ask\") — HITL for belief contradictions"
+```
+
+- [ ] **Step 3: Commit any stragglers**
+
+```bash
+git status --short   # should be clean; commit anything intentional that remains
+```

--- a/docs/superpowers/specs/2026-06-18-long-term-memory-design.md
+++ b/docs/superpowers/specs/2026-06-18-long-term-memory-design.md
@@ -115,7 +115,7 @@ export default defineMemory({
 
 - Generated **`remember({ ...typed })`** tool. Config `memory: { writes: "off" | "candidate" | "auto" }` (default **`candidate`**).
   - **candidate**: writes `status:"candidate"`; promoted via `dawn memory approve <id>` / `reject <id>`.
-  - **auto**: writes `status:"active"`, gated through `@dawn-ai/permissions` HITL (first write of a pattern interrupts with Once/Always/Deny, like `runBash`).
+  - **auto**: writes `status:"active"`, gated through `@dawn-ai/permissions` HITL (first write of a pattern interrupts with Once/Always/Deny, like `runBash`). (2026-07-06: the HITL gate shipped as the separate "ask" mode — see docs/superpowers/specs/2026-07-06-memory-ask-mode-design.md.)
   - **off**: the `remember` tool is not contributed.
 - **Reconciliation on write** (deterministic, no extra LLM call so it stays testable): against the top-N namespace+keyword matches, classify ADD (no equivalent), UPDATE (same identity key, same value → patch + bump `updatedAt`), or SUPERSEDE (same identity key, different value → write new + flip old to `superseded`). The **identity key is per-kind**; for the v1 `semantic` kind it is `(subject, predicate)`. Identity and equivalence are computed from the typed `data`, never embeddings. (A future `defineMemory({ identity })` hook can declare the key for other kinds.)
 - **`dawn memory` CLI** (v1 surface): `list`, `search <query>`, `inspect <id>`, `approve <id>`, `reject <id>`, `forget <id>` (hard delete). The dev-server **Memory Inspector UI is deferred**.

--- a/docs/superpowers/specs/2026-07-06-memory-ask-mode-design.md
+++ b/docs/superpowers/specs/2026-07-06-memory-ask-mode-design.md
@@ -1,0 +1,166 @@
+# Memory `ask` mode — supersede-gated writes (Design)
+
+**Status:** Approved (design phase) — 2026-07-06
+**Roadmap:** Phase 4 (Richer Authoring Systems) — closes the long-term-memory design's deferred "permissions-gated auto writes" item (2026-06-18 spec §Write governance), re-scoped after per-tool approval gating (#291) shipped.
+**Supersedes:** the 2026-06-18 spec's `auto`-mode HITL line and issue #260's original framing.
+
+## Problem
+
+The long-term-memory design specced HITL gating for agent memory writes, deferred in the v1 implementation (#250). Since then, #291 shipped generic per-tool approval: `tools: { approve: ["remember"] }` gates every `remember` call. That satisfies "a human can gate memory writes" — but at the wrong granularity for memory:
+
+- The generic gate fires **per call**, before `run`, seeing only args. It cannot distinguish a benign ADD (new fact) from a SUPERSEDE (the agent overwriting a prior belief) — that classification is a function of **args × store state**, computed inside `remember`'s reconciliation.
+- The resulting UX has two stable states: **noisy** (every ADD prompts — memory-active agents produce a stream of them) or, after fatigue drives the user to "Always", **blind** (supersedes never prompt again). Oversight erodes exactly where it matters most.
+- This is **not** subsumable by #291's slice 3 (argument-level constraints): no pattern over args can express "prompt only if this contradicts an existing active record", because the answer depends on the store.
+
+The sensitive event for memory is not "the agent called `remember`" — it is **"the agent is contradicting what it previously knew."** Gating that event requires a gate inside `remember`'s run, at the supersede branch.
+
+## Decisions (from brainstorming)
+
+1. **New `writes: "ask"` mode** — `memory.writes` widens to `"off" | "candidate" | "auto" | "ask"`. Default stays `"candidate"`; `auto` is unchanged (trust-all, no migration). `ask` = `auto`'s exact write semantics with one difference: the SUPERSEDE branch gates first.
+2. **SUPERSEDE-only prompting.** ADDs land active silently; idempotent UPDATEs refresh silently; only contradictions prompt. Sustainable oversight — prompts are rare enough that nobody is driven to mute them.
+3. **"Always" = per-route.** The persisted rule is the namespace's `workspace|route` prefix: "stop asking about overwrites in this route."
+4. **Headless: allow through.** With no interactive human (non-interactive mode, CI, evals, deployed prod), `ask` behaves exactly as `auto` — the supersede proceeds. `ask` is a **supervision affordance, not a security boundary** (the #261 "honest scope" framing). This deliberately diverges from `gateToolOp`'s fail-closed ladder and is documented as such. Explicit persisted/config `deny` rules are still honored headless — the allow-through applies only to the `unknown` case. (`bypass` mode skips all gating including deny, consistent with every existing gate.)
+5. **Deny = block only.** Old record stays `active`; nothing is written (no candidate queue — avoids the undrained-queue graveyard and the pre-existing `approve`-doesn't-supersede gap); the tool returns a model-legible result so the agent can adapt.
+6. **Coexists with #291; warn on overlap.** `writes: "ask"` + `tools: { approve: ["remember"] }` on the same route draws a build-time warning (double prompt). Third instance of the established "capability-internal gate coexists with the generic gate" pattern (bash/path gates are the first two).
+
+## Verified constraints (2026-07-06, via code inspection)
+
+- **Namespace prefix is stable.** Serialization order is hardcoded `["workspace", "route", "tenant", "user", "agent"]` (`packages/memory/src/namespace.ts:8`), so `workspace=X|route=Y` always leads the string.
+- **Prefix collision requires a terminator.** Values are not escaped, so `route=/a` would prefix-match `route=/ab`. Fix: the gate matches the candidate as `namespace + "|"` and suggests patterns ending in `"|"` — plain `startsWith` becomes collision-safe with **zero changes to `matchPermission`**.
+- **Permissions store already reaches the memory marker.** `CapabilityMarkerContext.permissions` is populated for all routes (`execute-route.ts:518-546` — loaded outside the agent-only branch); the memory marker currently ignores it (`built-in/memory.ts:27-29`). No new wiring.
+- **`remember` only exists on interrupt-capable routes.** The memory context is built inside the agent-only branch (`execute-route.ts:571+`), and `interruptCapable === (kind === "agent")` (`execute-route.ts:545`). The gate still checks `permissions.mode` before interrupting.
+- **The testing harness needs no changes.** Interrupt collection is kind-agnostic (`packages/testing/src/run-result.ts:215-227`); `harness.resume({ decision })` flows `Command({resume})` through `streamResolvedRoute` (`harness.ts:182-186`).
+
+## Design
+
+### 1. Authoring surface
+
+```ts
+// dawn.config.ts
+export default {
+  memory: {
+    writes: "ask", // "off" | "candidate" | "auto" | "ask"   (default "candidate")
+  },
+}
+```
+
+Touches: `DawnConfig.memory` type, `resolve-memory.ts` (`resolveMemoryWrites`), `MemoryContext.writes` union (`packages/core/src/capabilities/types.ts:39`), and typegen's writes-mode handling (`ask` generates `remember`, same as `auto`/`candidate`).
+
+### 2. Write semantics in `ask` mode
+
+Identical to `auto` — same reconciliation, same statuses — except the supersede branch:
+
+| Outcome | `auto` | `ask` (interactive) | `ask` (headless) |
+|---|---|---|---|
+| ADD (no matching identity) | active, silent | active, silent | active, silent |
+| UPDATE (same identity + data) | refresh, silent | refresh, silent | refresh, silent |
+| SUPERSEDE (same identity, different value) | supersede, silent | **gate → prompt** | supersede, silent (≡ auto) |
+
+In `packages/core/src/capabilities/built-in/memory.ts`: the `status` derivation treats `ask` like `auto` (active path), and the supersede branch calls the gate before `store.put` + `store.supersede`.
+
+### 3. The gate (`packages/core/src/capabilities/permission-gate.ts`)
+
+New `gateMemorySupersede(permissions, detail, opts?)` — sibling of `gateBashOp`/`gateToolOp`. Decision ladder:
+
+1. No store, or `mode === "bypass"` → allow.
+2. `match("memory", namespace + "|")` → explicit `allow` → proceed silently; explicit `deny` → block. Deny rules apply in every mode.
+3. `unknown` + (`mode === "non-interactive"` or not interrupt-capable) → **allow** (ask ≡ auto headless — the documented divergence from `gateToolOp`; see Decision 4).
+4. `unknown` + interactive → `interrupt()` with the `kind: "memory"` payload. **Once** → proceed; **Always** → `addAllow("memory", "<workspace=X|route=Y|>")` then proceed; **Deny** → block.
+
+A blocked supersede keeps the old record `active`, writes nothing, and returns as the tool result:
+`Kept existing memory <oldId> ("<oldContent>"); your contradicting value was not stored (approval denied).`
+
+### 4. Interrupt payload — `kind: "memory"` (`packages/permissions/src/types.ts`)
+
+`PermissionRequest.kind` widens to `"command" | "path" | "tool" | "memory"`:
+
+```ts
+export interface MemoryDetail {
+  readonly namespace: string
+  readonly identity: string        // rendered identity key, e.g. "acme / payment-terms"
+  readonly oldId: string
+  readonly oldContent: string      // what would be overwritten
+  readonly newContent: string      // the replacement
+  readonly suggestedPattern: string // "workspace=X|route=Y|" (terminator included)
+}
+```
+
+This is the decision-quality prompt the generic `argsPreview` cannot provide — the human adjudicates a belief change (old vs new), not an opaque tool call.
+
+### 5. Persistence (`.dawn/permissions.json`)
+
+Reserved `"memory"` key in the existing `PermissionsFile` maps; native prefix matching (no `pattern-matching.ts` changes — the terminator lives in the gate's candidate construction). Config-seeded pre-approval falls out free:
+
+```jsonc
+// .dawn/permissions.json (written by "Always")
+{ "version": 1, "allow": { "memory": ["workspace=app|route=/support|"] }, "deny": {} }
+```
+
+```ts
+// dawn.config.ts (pre-seeded)
+export default { permissions: { allow: { memory: ["workspace=app|route=/support|"] } } }
+```
+
+Docs recommend the trailing `"|"` on hand-authored patterns (collision safety); patterns without it still work as plain prefixes.
+
+### 6. Validation (`packages/cli/src/lib/runtime/collect-tool-scope-errors.ts`)
+
+Extend `collectToolScopeIssues`: when the app's memory `writes` mode is `"ask"` and a route's descriptor lists `"remember"` in `tools.approve` → **warning** (double prompt: per-call generic gate + supersede-level memory gate), analogous to the internally-gated workspace-tool warning (~line 103).
+
+### 7. Client rendering (`examples/chat/web/app/page.tsx`)
+
+`PendingInterrupt.kind` union gains `"memory"`; a render branch shows the belief change:
+
+```text
+Overwrite memory (route /support)?
+  acme / payment-terms
+  was:  net-30
+  now:  net-45
+[Once] [Always for this route] [Deny]
+```
+
+### 8. Exports
+
+`MemoryDetail` from `packages/permissions/src/index.ts`; `gateMemorySupersede` from `@dawn-ai/core`'s barrel.
+
+## Error handling / edge cases
+
+- **Denied supersede** → old stays active, nothing written, denial returned as tool result (return-not-throw, matching #291's convention so the model sees and adapts).
+- **Multiple supersedes in one turn** → each interrupts independently (existing LangGraph behavior, unchanged).
+- **`ask` with no permissions store in context** → allow (ladder step 1; legacy/degraded context behaves as `auto`).
+- **Determinism:** headless (evals, aimock replay, CI) `ask` never interrupts and behaves exactly as `auto`, so recorded fixtures and eval runs stay deterministic with no special-casing. Interactive interrupts use the existing `interruptId` scheme (`Date.now()`-based, same as bash/path/tool kinds — replay-safe under the harness because headless runs never reach it).
+- **Renamed/moved routes:** an "Always" rule keys on the namespace prefix; renaming a route invalidates the rule naturally (re-prompts once).
+
+## Testing
+
+- **Unit (`@dawn-ai/core`, permission-gate):** ladder — bypass / explicit-allow / explicit-deny (honored headless) / unknown×non-interactive → **allow** / unknown×interactive → interrupt; Once/Always/Deny handling; Always persists the terminated route prefix.
+- **Unit (`@dawn-ai/core`, memory capability):** in `ask` mode — ADD never gates; idempotent UPDATE never gates; SUPERSEDE gates; deny keeps old record active and returns the kept-memory message; `ask` ≡ `auto` when store absent.
+- **Unit (`@dawn-ai/permissions`):** `"memory"` key prefix semantics incl. the `route=/a` vs `route=/ab` collision case (terminated candidate does not match).
+- **aimock e2e (`@dawn-ai/testing`, mirroring `tool-approval.e2e.test.ts`):** probe route with seeded memory + `writes: "ask"`:
+  1. contradicting `remember` → `kind: "memory"` interrupt with `oldContent`/`newContent` → `resume("once")` → supersede lands.
+  2. `resume("deny")` → old value still active; tool result carries the kept-memory message.
+  3. `resume("always")` → `.dawn/permissions.json` gains `allow.memory: ["…|route=…|"]`; a fresh contradicting run does not prompt.
+  4. ADD-only run → zero interrupts.
+- **Validation unit (`@dawn-ai/cli`):** ask+approve("remember") overlap warns.
+
+## Documentation & website
+
+- **`apps/web/content/docs/memory.mdx`** — replace the stale "auto writes are not gated by permissions" callout (now false: `approve: ["remember"]` exists); write-governance table gains the `ask` row; document supersede-only semantics, headless ≡ auto, and when to pick `ask` vs `candidate` vs `approve: ["remember"]` (per-call, blunter).
+- **`apps/web/content/docs/permissions.mdx`** — "Memory write approval" section: prompt flow, the `memory` key, trailing-`|` pattern guidance, honest-scope note (supervision, not security).
+- **`apps/web/content/docs/configuration.mdx`** — `writes: "ask"` in the memory block.
+- **2026-06-18 long-term-memory spec** — annotate the `auto`-HITL line: superseded by this design.
+- **Issue #260** — retitle/re-scope to track this implementation.
+- **Changeset** — patch (fixed group, pre-1.0; keep patch, not minor).
+
+## Out of scope (deferred, explicit)
+
+- Finer "Always" granularity (per-subject, per-identity-key) — revisit if per-route proves too coarse.
+- Queue-denied-supersedes-as-candidates — rejected for v1 (graveyard risk; depends on fixing `dawn memory approve` to honor supersession, itself a separate pre-existing gap worth its own issue).
+- Gating `candidate`-mode writes (already human-reviewed by definition) or recalls (reads).
+- Generalizing outcome-sensitive gating beyond memory (no second consumer yet).
+
+## Risks
+
+- **Double-prompt** if authors combine `ask` with `approve: ["remember"]` — mitigated by the build-time warning.
+- **Headless allow-through surprises a user expecting fail-closed** — mitigated by docs (honest-scope framing) and by explicit `deny` rules being honored everywhere.
+- **Interrupt-payload consumers** must render `kind: "memory"` — chat example updated in-repo; external clients degrade to their unknown-kind fallback.

--- a/examples/chat/web/app/page.tsx
+++ b/examples/chat/web/app/page.tsx
@@ -11,13 +11,16 @@ type RouteId = "chat" | "coordinator"
 type PendingInterrupt = {
   interruptId: string
   type: string
-  kind: "command" | "path" | "tool"
+  kind: "command" | "path" | "tool" | "memory"
   detail: {
     command?: string
     operation?: string
     path?: string
     toolName?: string
     argsPreview?: string
+    identity?: string
+    oldContent?: string
+    newContent?: string
     suggestedPattern: string
   }
 }
@@ -204,7 +207,9 @@ export default function Page() {
               ? "The agent wants to run command:"
               : pendingInterrupt.kind === "tool"
                 ? `The agent wants to call tool ${pendingInterrupt.detail.toolName ?? "(unknown)"}:`
-                : `The agent wants to ${pendingInterrupt.detail.operation}:`}
+                : pendingInterrupt.kind === "memory"
+                  ? `The agent wants to overwrite a memory (${pendingInterrupt.detail.identity ?? "(unknown)"}):`
+                  : `The agent wants to ${pendingInterrupt.detail.operation}:`}
           </p>
           <code
             style={{
@@ -214,13 +219,16 @@ export default function Page() {
               border: "1px solid #ddd",
               fontFamily: "monospace",
               fontSize: 13,
+              whiteSpace: "pre-wrap",
             }}
           >
             {pendingInterrupt.kind === "command"
               ? pendingInterrupt.detail.command
               : pendingInterrupt.kind === "tool"
                 ? (pendingInterrupt.detail.argsPreview ?? "")
-                : pendingInterrupt.detail.path}
+                : pendingInterrupt.kind === "memory"
+                  ? `was: ${pendingInterrupt.detail.oldContent ?? ""}\nnow: ${pendingInterrupt.detail.newContent ?? ""}`
+                  : pendingInterrupt.detail.path}
           </code>
           <div style={{ display: "flex", gap: "0.5rem", marginTop: "0.75rem" }}>
             <button onClick={() => resolveInterrupt("once")} style={{ padding: "0.5rem 1rem" }}>

--- a/packages/cli/src/commands/check.ts
+++ b/packages/cli/src/commands/check.ts
@@ -4,6 +4,7 @@ import type { Command } from "commander"
 import { CliError, type CommandIo, formatErrorMessage, writeLine } from "../lib/output.js"
 import { collectSandboxErrors } from "../lib/runtime/collect-sandbox-errors.js"
 import { collectToolScopeIssues } from "../lib/runtime/collect-tool-scope-errors.js"
+import { resolveMemoryWrites } from "../lib/runtime/resolve-memory.js"
 import { discoverToolDefinitions } from "../lib/runtime/tool-discovery.js"
 import { collectUnknownModelIdWarnings } from "../lib/runtime/warn-unknown-model-ids.js"
 
@@ -43,7 +44,8 @@ export async function runCheckCommand(options: CheckOptions, io: CommandIo): Pro
       writeLine(io.stdout, `\n${warning}`)
     }
 
-    const scopeIssues = await collectToolScopeIssues(manifest)
+    const memoryWrites = await resolveMemoryWrites(manifest.appRoot)
+    const scopeIssues = await collectToolScopeIssues(manifest, undefined, { memoryWrites })
     for (const warning of scopeIssues.warnings) {
       writeLine(io.stdout, `\n${warning}`)
     }

--- a/packages/cli/src/lib/runtime/collect-tool-scope-errors.ts
+++ b/packages/cli/src/lib/runtime/collect-tool-scope-errors.ts
@@ -1,4 +1,4 @@
-import type { RouteManifest } from "@dawn-ai/core"
+import type { MemoryWritesMode, RouteManifest } from "@dawn-ai/core"
 import { BUILT_IN_TOOL_NAMES } from "@dawn-ai/core"
 import { isDawnAgent } from "@dawn-ai/sdk"
 
@@ -58,7 +58,7 @@ const defaultDeps: Deps = {
 export async function collectToolScopeIssues(
   manifest: RouteManifest,
   deps: Deps = defaultDeps,
-  opts?: { readonly memoryWrites?: "off" | "candidate" | "auto" | "ask" },
+  opts?: { readonly memoryWrites?: MemoryWritesMode },
 ): Promise<ToolScopeIssues> {
   const errors: string[] = []
   const warnings: string[] = []

--- a/packages/cli/src/lib/runtime/collect-tool-scope-errors.ts
+++ b/packages/cli/src/lib/runtime/collect-tool-scope-errors.ts
@@ -58,6 +58,7 @@ const defaultDeps: Deps = {
 export async function collectToolScopeIssues(
   manifest: RouteManifest,
   deps: Deps = defaultDeps,
+  opts?: { readonly memoryWrites?: "off" | "candidate" | "auto" | "ask" },
 ): Promise<ToolScopeIssues> {
   const errors: string[] = []
   const warnings: string[] = []
@@ -100,6 +101,12 @@ export async function collectToolScopeIssues(
       if (deny.has(name)) {
         warnings.push(
           `⚠ ${route.pathname}: approve lists "${name}" but deny revokes it — deny wins; the approve entry is dead.`,
+        )
+      }
+      if (opts?.memoryWrites === "ask" && name === "remember") {
+        warnings.push(
+          `⚠ ${route.pathname}: approve lists "remember" but memory writes mode is "ask" — ` +
+            `the supersede-level memory gate already prompts; combining both double-prompts.`,
         )
       }
       // Skip names another warning already fully covers — advising "add it to

--- a/packages/cli/src/lib/runtime/resolve-memory.ts
+++ b/packages/cli/src/lib/runtime/resolve-memory.ts
@@ -1,5 +1,5 @@
 import { basename, join } from "node:path"
-import type { MemoryContext, MemoryStoreLike } from "@dawn-ai/core"
+import type { MemoryContext, MemoryStoreLike, MemoryWritesMode } from "@dawn-ai/core"
 import { loadDawnConfig } from "@dawn-ai/core"
 import { serializeNamespace, sqliteMemoryStore } from "@dawn-ai/memory"
 import type { LoadedRouteMemory } from "./load-memory.js"
@@ -55,7 +55,7 @@ export async function resolveMemoryStore(appRoot: string): Promise<MemoryStoreLi
  *
  * Defaults to `"candidate"` when no config is present.
  */
-export async function resolveMemoryWrites(appRoot: string): Promise<"off" | "candidate" | "auto"> {
+export async function resolveMemoryWrites(appRoot: string): Promise<MemoryWritesMode> {
   try {
     const loaded = await loadDawnConfig({ appRoot })
     return loaded.config.memory?.writes ?? "candidate"
@@ -68,7 +68,7 @@ export async function resolveMemoryWrites(appRoot: string): Promise<"off" | "can
 export function buildMemoryContext(args: {
   defined: LoadedRouteMemory
   store: MemoryContext["store"]
-  writes: "off" | "candidate" | "auto"
+  writes: MemoryWritesMode
   appRoot: string
   routePath: string
   now: string

--- a/packages/cli/test/check-tool-scope.test.ts
+++ b/packages/cli/test/check-tool-scope.test.ts
@@ -138,3 +138,36 @@ test("subagent approving an internally-gated tool draws ONLY the already-gated w
   expect(result.warnings).toHaveLength(1)
   expect(result.warnings[0]).toMatch(/already gated/)
 })
+
+test("warns when approve lists remember while memory writes mode is ask", async () => {
+  const result = await collectToolScopeIssues(
+    manifest,
+    {
+      loadScope: async () => ({ approve: ["remember"] }),
+      routeLocalToolNames: async () => ["remember"],
+    },
+    { memoryWrites: "ask" },
+  )
+  expect(result.errors).toEqual([])
+  expect(result.warnings.some((w) => w.includes('approve lists "remember"'))).toBe(true)
+})
+
+test("does not warn about remember when writes mode is not ask", async () => {
+  const result = await collectToolScopeIssues(
+    manifest,
+    {
+      loadScope: async () => ({ approve: ["remember"] }),
+      routeLocalToolNames: async () => ["remember"],
+    },
+    { memoryWrites: "auto" },
+  )
+  expect(result.warnings.some((w) => w.includes('approve lists "remember"'))).toBe(false)
+})
+
+test("does not warn about remember when no memoryWrites opts are passed", async () => {
+  const result = await collectToolScopeIssues(manifest, {
+    loadScope: async () => ({ approve: ["remember"] }),
+    routeLocalToolNames: async () => ["remember"],
+  })
+  expect(result.warnings.some((w) => w.includes('approve lists "remember"'))).toBe(false)
+})

--- a/packages/core/src/capabilities/built-in/memory.ts
+++ b/packages/core/src/capabilities/built-in/memory.ts
@@ -157,6 +157,9 @@ export function createMemoryMarker(): CapabilityMarker {
               if (mem.writes === "ask") {
                 const gate = await gateMemorySupersede(permissions, {
                   namespace: mem.namespace,
+                  // Human-readable display form for the prompt — deliberately NOT
+                  // the `identityKey` match key above (which JSON.stringifies to
+                  // stay unambiguous); do not merge the two.
                   identity: identityKeys.map((k) => String(data[k] ?? "")).join(" / "),
                   oldId: target.id,
                   oldContent: target.content,

--- a/packages/core/src/capabilities/built-in/memory.ts
+++ b/packages/core/src/capabilities/built-in/memory.ts
@@ -1,5 +1,6 @@
 import { createHash } from "node:crypto"
 import { z } from "zod"
+import { gateMemorySupersede } from "../permission-gate.js"
 import type { CapabilityMarker, PromptFragment } from "../types.js"
 
 const DEFAULT_SEMANTIC_IDENTITY = ["subject", "predicate"] as const
@@ -27,6 +28,7 @@ export function createMemoryMarker(): CapabilityMarker {
     load: async (_routeDir, context) => {
       const mem = context.memory
       if (!mem) return {}
+      const permissions = context.permissions
       const indexEntries = await mem.store.search({
         namespace: mem.namespace,
         status: "active",
@@ -102,7 +104,9 @@ export function createMemoryMarker(): CapabilityMarker {
             .digest("hex")
             .slice(0, 16)}`
 
-          const status = mem.writes === "auto" ? "active" : "candidate"
+          // "ask" shares auto's write semantics; only its SUPERSEDE branch gates.
+          const autoLike = mem.writes === "auto" || mem.writes === "ask"
+          const status = autoLike ? "active" : "candidate"
           const content =
             typeof inp.content === "string" && inp.content.length > 0
               ? inp.content
@@ -124,7 +128,7 @@ export function createMemoryMarker(): CapabilityMarker {
             updatedAt: mem.now,
           }
 
-          if (mem.writes === "auto") {
+          if (autoLike) {
             // Inline identity key helper — avoids importing from @dawn-ai/memory
             const identityKey = (d: Record<string, unknown>) =>
               identityKeys.map((k) => JSON.stringify(d[k] ?? null)).join(" ")
@@ -147,7 +151,24 @@ export function createMemoryMarker(): CapabilityMarker {
                 })
                 return `Updated memory ${target.id}.`
               }
-              // Same identity but different value — write new active row then supersede old
+              // Same identity but different value — supersede. In "ask" mode this
+              // is the one write that gates: the agent is contradicting a prior
+              // belief. ADDs/idempotent UPDATEs above never reach the gate.
+              if (mem.writes === "ask") {
+                const gate = await gateMemorySupersede(permissions, {
+                  namespace: mem.namespace,
+                  identity: identityKeys.map((k) => String(data[k] ?? "")).join(" / "),
+                  oldId: target.id,
+                  oldContent: target.content,
+                  newContent: content,
+                })
+                if (!gate.allowed) {
+                  return (
+                    `Kept existing memory ${target.id} ("${target.content}"); ` +
+                    `your contradicting value was not stored (${gate.reason}).`
+                  )
+                }
+              }
               await mem.store.put(record)
               await mem.store.supersede(target.id, id)
               return `Superseded ${target.id} with ${id}.`

--- a/packages/core/src/capabilities/permission-gate.ts
+++ b/packages/core/src/capabilities/permission-gate.ts
@@ -1,6 +1,10 @@
 import { sep } from "node:path"
 import type { PermissionsStore } from "@dawn-ai/permissions"
-import { suggestedCommandPattern, suggestedPathPattern } from "@dawn-ai/permissions"
+import {
+  suggestedCommandPattern,
+  suggestedMemoryPattern,
+  suggestedPathPattern,
+} from "@dawn-ai/permissions"
 import { interrupt } from "@langchain/langgraph"
 
 export type PathOperation = "readFile" | "writeFile" | "listDir"
@@ -125,6 +129,54 @@ export async function gateToolOp(
   return { allowed: true }
 }
 
+export interface MemorySupersedeDetail {
+  readonly namespace: string
+  readonly identity: string
+  readonly oldId: string
+  readonly oldContent: string
+  readonly newContent: string
+}
+
+/**
+ * Memory supersede gate (memory.writes: "ask"). Prompts ONLY when the agent
+ * contradicts an existing active memory — ADDs and idempotent UPDATEs never
+ * reach this gate. Persisted decisions live under the reserved "memory" key
+ * as workspace+route namespace prefixes; candidates are matched with a "|"
+ * terminator so sibling routes cannot prefix-collide.
+ *
+ * DELIBERATE DIVERGENCE from gateToolOp: on "unknown" with no interactive
+ * human (non-interactive mode), this gate ALLOWS the supersede — ask is a
+ * supervision affordance, not a security boundary; headless it behaves
+ * exactly as writes:"auto". Explicit deny rules are still honored headless.
+ * Only called from inside the memory capability's remember tool, which only
+ * exists on agent routes (in-graph), so interrupt() is safe here.
+ */
+export async function gateMemorySupersede(
+  permissions: PermissionsStore | undefined,
+  detail: MemorySupersedeDetail,
+): Promise<GateResult> {
+  if (!permissions) return { allowed: true }
+  if (permissions.mode === "bypass") return { allowed: true }
+
+  const decision = permissions.match("memory", `${detail.namespace}|`)
+  if (decision === "allow") return { allowed: true }
+  if (decision === "deny") {
+    return { allowed: false, reason: `approval denied for this route's memory overwrites` }
+  }
+  // unknown + headless → allow through (ask ≡ auto without a human).
+  if (permissions.mode === "non-interactive") return { allowed: true }
+
+  const result = await emitPermissionInterrupt({
+    kind: "memory",
+    ...detail,
+    permissions,
+  })
+  if (result === "deny") {
+    return { allowed: false, reason: `approval denied` }
+  }
+  return { allowed: true }
+}
+
 /** Best-effort display preview of a tool call's args. Never matched or persisted. */
 function buildArgsPreview(input: unknown): string {
   try {
@@ -177,6 +229,15 @@ type InterruptArgs =
   | { kind: "command"; command: string; permissions: PermissionsStore }
   | { kind: "path"; operation: PathOperation; path: string; permissions: PermissionsStore }
   | { kind: "tool"; toolName: string; argsPreview: string; permissions: PermissionsStore }
+  | {
+      kind: "memory"
+      namespace: string
+      identity: string
+      oldId: string
+      oldContent: string
+      newContent: string
+      permissions: PermissionsStore
+    }
 
 async function emitPermissionInterrupt(args: InterruptArgs): Promise<"allow" | "deny"> {
   const interruptId = `perm-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
@@ -185,7 +246,9 @@ async function emitPermissionInterrupt(args: InterruptArgs): Promise<"allow" | "
       ? suggestedCommandPattern(args.command)
       : args.kind === "tool"
         ? args.toolName
-        : suggestedPathPattern(args.path)
+        : args.kind === "memory"
+          ? suggestedMemoryPattern(args.namespace)
+          : suggestedPathPattern(args.path)
   const payload = {
     interruptId,
     type: "permission-request" as const,
@@ -195,16 +258,28 @@ async function emitPermissionInterrupt(args: InterruptArgs): Promise<"allow" | "
         ? { command: args.command, suggestedPattern }
         : args.kind === "tool"
           ? { toolName: args.toolName, argsPreview: args.argsPreview, suggestedPattern }
-          : {
-              operation: args.operation,
-              path: args.path,
-              suggestedPattern,
-            },
+          : args.kind === "memory"
+            ? {
+                namespace: args.namespace,
+                identity: args.identity,
+                oldId: args.oldId,
+                oldContent: args.oldContent,
+                newContent: args.newContent,
+                suggestedPattern,
+              }
+            : { operation: args.operation, path: args.path, suggestedPattern },
   }
   const decision = interrupt(payload) as "once" | "always" | "deny"
   if (decision === "deny") return "deny"
   if (decision === "always") {
-    const tool = args.kind === "command" ? "bash" : args.kind === "tool" ? "tool" : args.operation
+    const tool =
+      args.kind === "command"
+        ? "bash"
+        : args.kind === "tool"
+          ? "tool"
+          : args.kind === "memory"
+            ? "memory"
+            : args.operation
     await args.permissions.addAllow(tool, suggestedPattern)
   }
   return "allow"

--- a/packages/core/src/capabilities/types.ts
+++ b/packages/core/src/capabilities/types.ts
@@ -33,10 +33,17 @@ export interface MemoryStoreLike {
   supersede(id: string, bySupersedingId: string): Promise<void>
 }
 
+/**
+ * Memory write-governance mode. "ask" = auto's exact write semantics, except
+ * SUPERSEDEs (same identity, different value) pass a HITL gate first — a
+ * supervision affordance, not a security boundary (headless ≡ auto).
+ */
+export type MemoryWritesMode = "off" | "candidate" | "auto" | "ask"
+
 export interface MemoryContext {
   readonly store: MemoryStoreLike
   readonly namespace: string
-  readonly writes: "off" | "candidate" | "auto"
+  readonly writes: MemoryWritesMode
   readonly defined: {
     readonly kind: string
     readonly scope: readonly string[]

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -8,7 +8,12 @@ export { createSkillsMarker } from "./capabilities/built-in/skills.js"
 export { createSubagentsMarker } from "./capabilities/built-in/subagents.js"
 export { createWorkspaceMarker } from "./capabilities/built-in/workspace.js"
 export { BUILT_IN_TOOL_NAMES } from "./capabilities/built-in-tool-names.js"
-export { gateToolOp, wrapToolWithApproval } from "./capabilities/permission-gate.js"
+export type { MemorySupersedeDetail } from "./capabilities/permission-gate.js"
+export {
+  gateMemorySupersede,
+  gateToolOp,
+  wrapToolWithApproval,
+} from "./capabilities/permission-gate.js"
 export type {
   AppliedContribution,
   ApplyResult,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -27,6 +27,7 @@ export type {
   MemoryContext,
   MemoryRecordLike,
   MemoryStoreLike,
+  MemoryWritesMode,
   PromptFragment,
   StreamTransformer,
   StreamTransformerInput,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -68,8 +68,8 @@ export interface DawnConfig {
     readonly enabled?: boolean
     /** Custom memory store. Defaults to an SQLite-backed store at <appRoot>/.dawn/memory.sqlite. */
     readonly store?: import("./capabilities/types.js").MemoryStoreLike
-    /** Write-governance mode. "off" — never write; "candidate" — write as candidate (default); "auto" — write and auto-promote. */
-    readonly writes?: "off" | "candidate" | "auto"
+    /** Write-governance mode. "off" — never write; "candidate" — write as candidate (default); "auto" — write and auto-promote; "ask" — auto, but supersedes require HITL approval when interactive. */
+    readonly writes?: "off" | "candidate" | "auto" | "ask"
     /** Maximum number of entries returned by the index. */
     readonly indexMaxEntries?: number
     /** Derive the memory namespace scope for a given route. */

--- a/packages/core/test/capabilities/memory.test.ts
+++ b/packages/core/test/capabilities/memory.test.ts
@@ -45,9 +45,31 @@ const baseCtx = (store: any) => ({
   },
 })
 
-function ctxWith(store: any, writes: "auto" | "candidate" | "off") {
+function ctxWith(store: any, writes: "auto" | "candidate" | "off" | "ask") {
   const ctx = baseCtx(store)
   ctx.memory = { ...ctx.memory, writes: writes as any }
+  return ctx
+}
+
+function fakePermissions(
+  mode: "interactive" | "non-interactive" | "bypass",
+  matchResult: "allow" | "deny" | "unknown" = "unknown",
+) {
+  const added: Array<{ tool: string; pattern: string }> = []
+  return {
+    added,
+    async load() {},
+    match: () => matchResult,
+    async addAllow(tool: string, pattern: string) {
+      added.push({ tool, pattern })
+    },
+    mode,
+  }
+}
+
+function askCtx(store: any, permissions?: any) {
+  const ctx = ctxWith(store, "ask" as any) as any
+  if (permissions) ctx.permissions = permissions
   return ctx
 }
 
@@ -166,5 +188,68 @@ describe("memory capability", () => {
     expect(active[0].data.value).toBe("750")
     expect(superseded).toHaveLength(1)
     expect(superseded[0].data.value).toBe("500")
+  })
+})
+
+describe("ask mode", () => {
+  const first = { subject: "billing", predicate: "escalate", value: "500" }
+  const second = { subject: "billing", predicate: "escalate", value: "750" }
+  const run = (tool: any, data: any, content: string) =>
+    tool.run({ data, content }, { signal: new AbortController().signal })
+
+  it("ADD lands active with no gate consulted", async () => {
+    const store = fakeStore()
+    const permissions = fakePermissions("non-interactive", "deny") // would block if consulted
+    const c = await createMemoryMarker().load("/r", askCtx(store, permissions))
+    const remember = c.tools!.find((t) => t.name === "remember")!
+    const result = await run(remember, first, "v1")
+    expect(String(result)).toContain("Stored memory")
+    expect(store.rows.filter((r: any) => r.status === "active")).toHaveLength(1)
+  })
+
+  it("idempotent UPDATE refreshes with no gate consulted", async () => {
+    const store = fakeStore()
+    const permissions = fakePermissions("non-interactive", "deny")
+    const c = await createMemoryMarker().load("/r", askCtx(store, permissions))
+    const remember = c.tools!.find((t) => t.name === "remember")!
+    await run(remember, first, "v1")
+    const result = await run(remember, first, "v1 refreshed")
+    expect(String(result)).toContain("Updated memory")
+  })
+
+  it("SUPERSEDE with explicit deny keeps the old value active and reports it", async () => {
+    const store = fakeStore()
+    const permissions = fakePermissions("non-interactive", "deny")
+    const c = await createMemoryMarker().load("/r", askCtx(store, permissions))
+    const remember = c.tools!.find((t) => t.name === "remember")!
+    await run(remember, first, "v1")
+    const result = await run(remember, second, "v2")
+    expect(String(result)).toContain("Kept existing memory")
+    const active = store.rows.filter((r: any) => r.status === "active")
+    expect(active).toHaveLength(1)
+    expect(active[0].data.value).toBe("500")
+    expect(store.rows.filter((r: any) => r.status === "superseded")).toHaveLength(0)
+  })
+
+  it("SUPERSEDE proceeds headless on unknown (ask ≡ auto non-interactive)", async () => {
+    const store = fakeStore()
+    const permissions = fakePermissions("non-interactive", "unknown")
+    const c = await createMemoryMarker().load("/r", askCtx(store, permissions))
+    const remember = c.tools!.find((t) => t.name === "remember")!
+    await run(remember, first, "v1")
+    const result = await run(remember, second, "v2")
+    expect(String(result)).toContain("Superseded")
+    const active = store.rows.filter((r: any) => r.status === "active")
+    expect(active).toHaveLength(1)
+    expect(active[0].data.value).toBe("750")
+  })
+
+  it("SUPERSEDE proceeds when no permissions store is in context (ask ≡ auto)", async () => {
+    const store = fakeStore()
+    const c = await createMemoryMarker().load("/r", askCtx(store))
+    const remember = c.tools!.find((t) => t.name === "remember")!
+    await run(remember, first, "v1")
+    const result = await run(remember, second, "v2")
+    expect(String(result)).toContain("Superseded")
   })
 })

--- a/packages/core/test/capabilities/permission-gate.test.ts
+++ b/packages/core/test/capabilities/permission-gate.test.ts
@@ -5,6 +5,7 @@ import { createPermissionsStore } from "@dawn-ai/permissions"
 import { afterEach, beforeEach, describe, expect, it } from "vitest"
 
 import {
+  gateMemorySupersede,
   gatePathOp,
   gateToolOp,
   wrapToolWithApproval,
@@ -185,5 +186,81 @@ describe("wrapToolWithApproval", () => {
     await permissions.load()
     const wrapped = wrapToolWithApproval({ name: "x", run: async () => "ran" }, permissions)
     expect(String(await wrapped.run({}, { signal }))).toMatch(/fail-closed/)
+  })
+})
+
+describe("gateMemorySupersede", () => {
+  let appRoot: string
+  beforeEach(() => {
+    appRoot = mkdtempSync(join(tmpdir(), "dawn-gate-memory-test-"))
+  })
+  afterEach(() => {
+    rmSync(appRoot, { recursive: true, force: true })
+  })
+
+  async function store(
+    mode: "interactive" | "non-interactive" | "bypass",
+    config?: {
+      allow?: Record<string, readonly string[]>
+      deny?: Record<string, readonly string[]>
+    },
+  ) {
+    const permissions = createPermissionsStore({
+      appRoot,
+      config: config
+        ? { version: 1, allow: config.allow ?? {}, deny: config.deny ?? {} }
+        : undefined,
+      mode,
+    })
+    await permissions.load()
+    return permissions
+  }
+
+  const detail = {
+    namespace: "workspace=app|route=/support",
+    identity: "acme / payment-terms",
+    oldId: "memory_abc123",
+    oldContent: "acme prefers net-30",
+    newContent: "acme prefers net-45",
+  }
+
+  it("allows when no permissions store is present (legacy context ≡ auto)", async () => {
+    expect((await gateMemorySupersede(undefined, detail)).allowed).toBe(true)
+  })
+
+  it("allows in bypass mode", async () => {
+    const permissions = await store("bypass")
+    expect((await gateMemorySupersede(permissions, detail)).allowed).toBe(true)
+  })
+
+  it("allows a config-pre-approved route prefix (terminated)", async () => {
+    const permissions = await store("interactive", {
+      allow: { memory: ["workspace=app|route=/support|"] },
+    })
+    expect((await gateMemorySupersede(permissions, detail)).allowed).toBe(true)
+  })
+
+  it("does not let a sibling-route rule leak (route=/s vs route=/support)", async () => {
+    // /s is a string prefix of /support; the terminator must prevent the match.
+    // "unknown" in non-interactive mode → allow-through, so use the deny list
+    // to make leakage observable.
+    const permissions = await store("non-interactive", {
+      deny: { memory: ["workspace=app|route=/s|"] },
+    })
+    expect((await gateMemorySupersede(permissions, detail)).allowed).toBe(true)
+  })
+
+  it("blocks an explicitly denied route prefix with a reason (honored headless)", async () => {
+    const permissions = await store("non-interactive", {
+      deny: { memory: ["workspace=app|route=/support|"] },
+    })
+    const result = await gateMemorySupersede(permissions, detail)
+    expect(result.allowed).toBe(false)
+    if (!result.allowed) expect(result.reason).toMatch(/denied/i)
+  })
+
+  it("allows through on unknown in non-interactive mode (ask ≡ auto headless)", async () => {
+    const permissions = await store("non-interactive")
+    expect((await gateMemorySupersede(permissions, detail)).allowed).toBe(true)
   })
 })

--- a/packages/permissions/src/index.ts
+++ b/packages/permissions/src/index.ts
@@ -1,8 +1,13 @@
 export { matchPermission } from "./pattern-matching.js"
 export { createPermissionsStore } from "./permissions-store.js"
-export { suggestedCommandPattern, suggestedPathPattern } from "./suggested-pattern.js"
+export {
+  suggestedCommandPattern,
+  suggestedMemoryPattern,
+  suggestedPathPattern,
+} from "./suggested-pattern.js"
 export type {
   CommandDetail,
+  MemoryDetail,
   PathDetail,
   PermissionDecision,
   PermissionMode,

--- a/packages/permissions/src/suggested-pattern.ts
+++ b/packages/permissions/src/suggested-pattern.ts
@@ -20,3 +20,16 @@ export function suggestedPathPattern(path: string): string {
   const parent = dirname(path)
   return parent === "/" ? "/" : `${parent}/`
 }
+
+/**
+ * Default suggested pattern for a memory-write approval: the namespace's
+ * workspace+route prefix, with a trailing "|" terminator so prefix matching
+ * cannot collide across sibling routes (route=/a vs route=/ab). Callers match
+ * candidates as `namespace + "|"` for the same reason.
+ */
+export function suggestedMemoryPattern(namespace: string): string {
+  const parts = namespace.split("|")
+  const routeIdx = parts.findIndex((p) => p.startsWith("route="))
+  const prefix = routeIdx >= 0 ? parts.slice(0, routeIdx + 1) : parts
+  return `${prefix.join("|")}|`
+}

--- a/packages/permissions/src/types.ts
+++ b/packages/permissions/src/types.ts
@@ -39,10 +39,25 @@ export interface ToolDetail {
   readonly suggestedPattern: string
 }
 
+export interface MemoryDetail {
+  /** Full memory namespace of the write (e.g. "workspace=app|route=/support"). */
+  readonly namespace: string
+  /** Rendered identity key of the contradicted fact, e.g. "acme / payment-terms". */
+  readonly identity: string
+  /** Id of the active record that would be superseded. */
+  readonly oldId: string
+  /** Content of the record being overwritten. */
+  readonly oldContent: string
+  /** Content of the replacement. */
+  readonly newContent: string
+  /** Workspace+route namespace prefix (terminator included) — persisted on "always" under the reserved "memory" key. */
+  readonly suggestedPattern: string
+}
+
 export interface PermissionRequest {
   readonly interruptId: string
-  readonly kind: "command" | "path" | "tool"
-  readonly detail: CommandDetail | PathDetail | ToolDetail
+  readonly kind: "command" | "path" | "tool" | "memory"
+  readonly detail: CommandDetail | PathDetail | ToolDetail | MemoryDetail
   readonly threadId: string
   readonly callId?: string
 }

--- a/packages/permissions/test/pattern-matching.test.ts
+++ b/packages/permissions/test/pattern-matching.test.ts
@@ -61,3 +61,28 @@ describe('reserved "tool" key uses exact matching', () => {
     expect(matchPermission("bash", "anything", { bash: [""] }, {})).toBe("allow")
   })
 })
+
+describe("memory key (prefix + terminator convention)", () => {
+  // Callers match memory candidates as `namespace + "|"` so a /a rule can
+  // never prefix-match a /ab namespace. matchPermission itself is unchanged.
+  const allow = { memory: ["workspace=app|route=/a|"] }
+
+  it("allows the exact route (terminated candidate)", () => {
+    expect(matchPermission("memory", "workspace=app|route=/a|", allow, {})).toBe("allow")
+  })
+
+  it("allows deeper namespaces under the route", () => {
+    expect(
+      matchPermission("memory", "workspace=app|route=/a|tenant=acme|", allow, {}),
+    ).toBe("allow")
+  })
+
+  it("does NOT match a sibling route sharing the prefix", () => {
+    expect(matchPermission("memory", "workspace=app|route=/ab|", allow, {})).toBe("unknown")
+  })
+
+  it("deny wins over allow for the memory key", () => {
+    const deny = { memory: ["workspace=app|route=/a|"] }
+    expect(matchPermission("memory", "workspace=app|route=/a|", allow, deny)).toBe("deny")
+  })
+})

--- a/packages/permissions/test/suggested-pattern.test.ts
+++ b/packages/permissions/test/suggested-pattern.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest"
 import {
   suggestedCommandPattern,
+  suggestedMemoryPattern,
   suggestedPathPattern,
 } from "../src/suggested-pattern.js"
 
@@ -37,5 +38,23 @@ describe("suggestedPathPattern", () => {
   })
   it("handles relative paths", () => {
     expect(suggestedPathPattern("notes/agenda.md")).toBe("notes/")
+  })
+})
+
+describe("suggestedMemoryPattern", () => {
+  it("returns the workspace+route prefix with a trailing terminator", () => {
+    expect(suggestedMemoryPattern("workspace=app|route=/support|tenant=acme")).toBe(
+      "workspace=app|route=/support|",
+    )
+  })
+
+  it("handles a namespace with no dims after route", () => {
+    expect(suggestedMemoryPattern("workspace=app|route=/support")).toBe(
+      "workspace=app|route=/support|",
+    )
+  })
+
+  it("falls back to the whole namespace when route is absent", () => {
+    expect(suggestedMemoryPattern("workspace=app")).toBe("workspace=app|")
   })
 })

--- a/packages/testing/test/fixtures/probe-app-memory-ask/dawn.config.ts
+++ b/packages/testing/test/fixtures/probe-app-memory-ask/dawn.config.ts
@@ -1,0 +1,1 @@
+export default { memory: { writes: "ask" } }

--- a/packages/testing/test/fixtures/probe-app-memory-ask/package.json
+++ b/packages/testing/test/fixtures/probe-app-memory-ask/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "probe-app-memory-ask",
+  "private": true,
+  "type": "module"
+}

--- a/packages/testing/test/fixtures/probe-app-memory-ask/src/app/notes/index.ts
+++ b/packages/testing/test/fixtures/probe-app-memory-ask/src/app/notes/index.ts
@@ -1,0 +1,5 @@
+import { agent } from "@dawn-ai/sdk"
+export default agent({
+  model: "gpt-5-mini",
+  systemPrompt: "You are a note-taking test agent. Use remember to store facts.",
+})

--- a/packages/testing/test/fixtures/probe-app-memory-ask/src/app/notes/memory.ts
+++ b/packages/testing/test/fixtures/probe-app-memory-ask/src/app/notes/memory.ts
@@ -1,0 +1,7 @@
+import { defineMemory } from "@dawn-ai/sdk"
+import { z } from "zod"
+export default defineMemory({
+  kind: "semantic",
+  scope: ["workspace", "route"],
+  schema: z.object({ subject: z.string(), predicate: z.string(), value: z.string() }),
+})

--- a/packages/testing/test/memory-ask.e2e.test.ts
+++ b/packages/testing/test/memory-ask.e2e.test.ts
@@ -1,0 +1,115 @@
+// Deterministic (aimock) e2e for memory.writes: "ask" — SUPERSEDE writes (belief
+// contradictions) prompt a HITL Once/Always/Deny interrupt (kind "memory"); ADDs
+// and idempotent updates flow silently. Mirrors tool-approval.e2e.test.ts's
+// structure/conventions. Runs in CI (no API key — aimock).
+import { readFileSync, rmSync } from "node:fs"
+import { join } from "node:path"
+import { fileURLToPath } from "node:url"
+import { afterEach, beforeEach, expect, it } from "vitest"
+import { script } from "../src/fixture-builder.js"
+import { createAgentHarness } from "../src/harness.js"
+import { expectInterrupt, expectNoInterrupt, expectToolCalled } from "../src/matchers.js"
+
+const askRoot = fileURLToPath(new URL("./fixtures/probe-app-memory-ask", import.meta.url))
+const permissionsPath = join(askRoot, ".dawn", "permissions.json")
+
+const NET30 = { subject: "acme", predicate: "payment-terms", value: "net-30" }
+const NET45 = { subject: "acme", predicate: "payment-terms", value: "net-45" }
+const NET60 = { subject: "acme", predicate: "payment-terms", value: "net-60" }
+
+function cleanPersistedState(): void {
+  // Each scenario starts from a clean memory store AND clean permissions —
+  // otherwise a prior scenario's "always" persistence or stored fact would
+  // leak in (the first write of a scenario must ADD silently, never supersede).
+  // "always" also appends a .gitignore inside the fixture (ensureGitignoreEntry)
+  // — the fixture has none committed, so removing it keeps the repo clean.
+  rmSync(join(askRoot, ".dawn"), { recursive: true, force: true })
+  rmSync(join(askRoot, ".gitignore"), { force: true })
+}
+
+beforeEach(cleanPersistedState)
+afterEach(cleanPersistedState)
+
+const rememberScript = (data: Record<string, string>, content: string, reply: string) =>
+  script().user(`remember: ${content}`).callsTool("remember", { data, content }).replies(reply)
+
+it("ADD never interrupts; a contradicting write interrupts with old-vs-new; resume(once) supersedes", async () => {
+  const h = await createAgentHarness({ appRoot: askRoot, route: "/notes#agent" })
+  try {
+    const run1 = await h.run({
+      input: "remember: acme prefers net-30",
+      fixtures: rememberScript(NET30, "acme prefers net-30", "Noted."),
+    })
+    expectNoInterrupt(run1)
+    expectToolCalled(run1, "remember")
+
+    h.reset()
+    const run2 = await h.run({
+      input: "remember: acme prefers net-45",
+      fixtures: rememberScript(NET45, "acme prefers net-45", "Updated."),
+    })
+    expectInterrupt(run2).ofKind("memory").withDetail({
+      identity: "acme / payment-terms",
+      oldContent: "acme prefers net-30",
+      newContent: "acme prefers net-45",
+    })
+
+    const resumed = await h.resume({ decision: "once" })
+    expect(JSON.stringify(resumed)).toContain("Superseded")
+  } finally {
+    await h.close()
+  }
+}, 60_000)
+
+it("resume(deny) keeps the old value and reports it to the agent", async () => {
+  const h = await createAgentHarness({ appRoot: askRoot, route: "/notes#agent" })
+  try {
+    await h.run({
+      input: "remember: acme prefers net-30",
+      fixtures: rememberScript(NET30, "acme prefers net-30", "Noted."),
+    })
+    h.reset()
+    const run = await h.run({
+      input: "remember: acme prefers net-45",
+      fixtures: rememberScript(NET45, "acme prefers net-45", "Updated."),
+    })
+    expectInterrupt(run).ofKind("memory")
+
+    const resumed = await h.resume({ decision: "deny" })
+    expect(JSON.stringify(resumed)).toContain("Kept existing memory")
+  } finally {
+    await h.close()
+  }
+}, 60_000)
+
+it("resume(always) persists the route prefix; a fresh contradiction does not prompt", async () => {
+  const h = await createAgentHarness({ appRoot: askRoot, route: "/notes#agent" })
+  try {
+    await h.run({
+      input: "remember: acme prefers net-30",
+      fixtures: rememberScript(NET30, "acme prefers net-30", "Noted."),
+    })
+    h.reset()
+    const run = await h.run({
+      input: "remember: acme prefers net-45",
+      fixtures: rememberScript(NET45, "acme prefers net-45", "Updated."),
+    })
+    expectInterrupt(run).ofKind("memory")
+    await h.resume({ decision: "always" })
+
+    const persisted = JSON.parse(readFileSync(permissionsPath, "utf8")) as {
+      allow?: Record<string, string[]>
+    }
+    expect(persisted.allow?.memory).toContain("workspace=probe-app-memory-ask|route=/notes|")
+
+    h.reset()
+    const run3 = await h.run({
+      input: "remember: acme prefers net-60",
+      fixtures: rememberScript(NET60, "acme prefers net-60", "Updated again."),
+    })
+    expectNoInterrupt(run3)
+    expect(JSON.stringify(run3)).toContain("Superseded")
+  } finally {
+    await h.close()
+  }
+}, 60_000)


### PR DESCRIPTION
## Summary

Adds `memory.writes: "ask"` — a supervision mode where the agent **contradicting a prior belief** (a SUPERSEDE: same identity, different value) prompts a HITL **Once / Always / Deny** interrupt showing the old vs. new value. New facts (ADD) and idempotent updates flow silently. **Headless behaves exactly as `auto`** — `ask` is a supervision affordance for interactive development, not a security boundary.

This implements the HITL gate the original long-term-memory design (#250) specced but deferred (tracked in #260), re-scoped after #291 shipped generic per-tool approval: rather than gating *every* `remember` call (which `tools: { approve: ["remember"] }` already does), `ask` gates **only belief contradictions** — an outcome-sensitive gate that per-tool approval can't express.

## How it works

- New interrupt `kind: "memory"` with an old-vs-new `MemoryDetail` payload; `gateMemorySupersede` in core's permission-gate (sibling of `gateToolOp`), called from inside `remember` at the supersede branch — the only place the old record is in hand.
- **Always** persists a per-route rule under a reserved `memory` key in `.dawn/permissions.json` as a namespace prefix with a trailing `|` terminator (so `route=/a` can't prefix-collide with `route=/ab`).
- **Deny** keeps the old record active, writes nothing, and tells the agent which memory was kept.
- **Headless** (non-interactive / CI / deployed): the supersede proceeds (≡ `auto`). Explicit `deny` config rules are still honored in every mode except `bypass`.
- `dawn check` warns when a route combines `writes: "ask"` with `tools: { approve: ["remember"] }` (double-prompt).

## Design decisions

Worked through in brainstorming (`docs/superpowers/specs/2026-07-06-memory-ask-mode-design.md`):
- A **distinct `ask` mode**, not overloading `auto` (migration-free; `auto` stays trust-all).
- **Per-route** "Always" granularity (the route is the trust boundary).
- **SUPERSEDE-only** gating (accumulate freely; ask before overwriting).
- **Headless ≡ auto**, not a candidate-queue fallback — sync *and* async review both presuppose a developer who isn't present in production, so a "degrade to candidate" default would just strand knowledge in an unreviewed graveyard.

## Testing

- Unit: permissions primitives (terminator collision-safety), the gate ladder (incl. the deliberate headless allow-through), and the capability (ADD/UPDATE never gate; denied supersede leaves exactly the old row active).
- aimock **e2e** (`memory-ask.e2e.test.ts`): drives the real interrupt→resume cycle through once/deny/always, asserting the old-vs-new detail, the "Superseded"/"Kept existing memory" results, and that `always` persists the route prefix and silences the next contradiction.
- Full suite green: build 18/18, typecheck 19/19, lint 18/18, **1009 tests passed / 14 skipped / 0 failed**.

Changeset: patch bump for `@dawn-ai/core`, `@dawn-ai/permissions`, `@dawn-ai/cli`.

Closes #260.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
