### PR TITLE
test(testing): gated live smoke for per-tool approval gating

### DIFF
--- a/packages/testing/test/tool-approval-live.smoke.test.ts
+++ b/packages/testing/test/tool-approval-live.smoke.test.ts
@@ -1,0 +1,43 @@
+// LIVE SMOKE — per-tool approval gating (tools.approve, PR #291) against a real
+// model. Gated on OPENAI_API_KEY: SKIPS in CI, runs only locally. The aimock
+// e2e (tool-approval.e2e.test.ts) scripts the tool call; this proves a REAL
+// model, told to deploy, actually calls the gated tool and hits the HITL gate.
+import { rmSync } from "node:fs"
+import { join } from "node:path"
+import { fileURLToPath } from "node:url"
+import { afterEach, beforeEach, expect, it } from "vitest"
+import { createAgentHarness } from "../src/harness.js"
+import { expectInterrupt, expectToolCalled } from "../src/matchers.js"
+
+const live = Boolean(process.env.OPENAI_API_KEY)
+const probeRoot = fileURLToPath(new URL("./fixtures/probe-app", import.meta.url))
+const permissionsPath = join(probeRoot, ".dawn", "permissions.json")
+
+beforeEach(() => rmSync(permissionsPath, { force: true }))
+afterEach(() => rmSync(permissionsPath, { force: true }))
+
+it.skipIf(!live)(
+  "a real model calling a gated tool triggers the kind:'tool' interrupt, then resume(once) runs it",
+  async () => {
+    const h = await createAgentHarness({
+      appRoot: probeRoot,
+      route: "/approval-chat#agent",
+      live: true,
+    })
+    try {
+      h.reset()
+      const run = await h.run({ input: "Deploy the app to the staging environment now." })
+      // The real model must have chosen to call deployProd, and the approval
+      // wrapper must have parked it as a kind:"tool" permission interrupt.
+      expectInterrupt(run).ofKind("tool").withDetail({ toolName: "deployProd" })
+
+      const resumed = await h.resume({ decision: "once" })
+      expectToolCalled(resumed, "deployProd")
+      const result = resumed.toolResults.find((t) => t.name === "deployProd")
+      expect(String(result?.content ?? "")).toContain("deployed to")
+    } finally {
+      await h.close()
+    }
+  },
+  120_000,
+)


### PR DESCRIPTION
Fills the gap the #291 final review explicitly flagged: the aimock e2e (`tool-approval.e2e.test.ts`) *scripts* the gated tool call, but nothing proved a **real model**, told to deploy, actually chooses to call the gated tool and hits the HITL gate.

Adds `packages/testing/test/tool-approval-live.smoke.test.ts` — gated on `OPENAI_API_KEY` (skips in CI, runs locally), mirroring `memory-live.smoke.test.ts`. Against the `approval-chat` probe fixture: real model → calls `deployProd` → asserts the `kind:"tool"` interrupt with `toolName: "deployProd"` → `resume(once)` → the real tool runs.

Verified passing locally against a real model (gpt-4o-mini) as part of a post-release production smoke of recently-shipped features (per-tool approvals #291, execution sandbox #289, smarter recall #294 — all green live).

Test-only; `@dawn-ai/testing`'s source is unchanged, so no changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)