### PR TITLE
fix(memory): escape reserved delimiters in namespace scope values

### DIFF
--- a/.changeset/memory-namespace-escaping.md
+++ b/.changeset/memory-namespace-escaping.md
@@ -1,0 +1,5 @@
+---
+"@dawn-ai/memory": patch
+---
+
+`serializeNamespace` now percent-encodes the reserved delimiters (`%`, `|`, `=`) in scope dimension values, so a `tenant`/`user`/`agent` value (from `resolveScope`) or an oddly-named workspace/route containing a delimiter can no longer corrupt the namespace or collide across scopes. Ordinary values (no reserved chars) are unchanged, so existing stored memories and persisted permission patterns keep matching byte-for-byte.

--- a/packages/memory/src/namespace.ts
+++ b/packages/memory/src/namespace.ts
@@ -6,12 +6,24 @@ export interface MemoryScopeTuple {
   readonly agent?: string
 }
 const ORDER = ["workspace", "route", "tenant", "user", "agent"] as const
+
+// "|" separates dimensions and "=" separates key from value, so a dimension
+// VALUE containing either would corrupt the namespace (prefix-match collisions,
+// mis-split in suggestedMemoryPattern). Percent-encode both — and "%" itself,
+// first, so the encoding is reversible. Keys are fixed names from ORDER and
+// never need encoding. Values with none of these chars (the common case) are
+// returned unchanged, so existing stored namespaces and persisted permission
+// patterns keep matching byte-for-byte.
+function encodeValue(value: string): string {
+  return value.replaceAll("%", "%25").replaceAll("|", "%7C").replaceAll("=", "%3D")
+}
+
 /** Serialize a scope tuple to a stable namespace string. Fail-closed on empty. */
 export function serializeNamespace(tuple: MemoryScopeTuple): string {
   const parts: string[] = []
   for (const key of ORDER) {
     const value = tuple[key]
-    if (value !== undefined && value !== "") parts.push(`${key}=${value}`)
+    if (value !== undefined && value !== "") parts.push(`${key}=${encodeValue(value)}`)
   }
   if (parts.length === 0)
     throw new Error("serializeNamespace: scope tuple must have at least one dimension")

--- a/packages/memory/test/namespace.test.ts
+++ b/packages/memory/test/namespace.test.ts
@@ -15,4 +15,40 @@ describe("serializeNamespace", () => {
   it("throws on an empty tuple (fail-closed)", () => {
     expect(() => serializeNamespace({})).toThrow(/at least one/i)
   })
+
+  describe("delimiter escaping in values", () => {
+    it("leaves ordinary values byte-identical (backward compatibility)", () => {
+      // The common case — no reserved chars — must not change, or existing
+      // stored rows and persisted permission patterns would stop matching.
+      expect(serializeNamespace({ workspace: "acme", route: "/support", user: "u-1" })).toBe(
+        "workspace=acme|route=/support|user=u-1",
+      )
+    })
+
+    it("percent-encodes a pipe in a value so it can't act as a delimiter", () => {
+      expect(serializeNamespace({ workspace: "app", tenant: "a|b" })).toBe(
+        "workspace=app|tenant=a%7Cb",
+      )
+    })
+
+    it("percent-encodes an equals in a value so it can't act as a separator", () => {
+      expect(serializeNamespace({ workspace: "app", user: "k=v" })).toBe("workspace=app|user=k%3Dv")
+    })
+
+    it("percent-encodes a literal percent first (reversibly)", () => {
+      expect(serializeNamespace({ workspace: "app", tenant: "50%off" })).toBe(
+        "workspace=app|tenant=50%25off",
+      )
+    })
+
+    it("distinguishes values that would otherwise collide across the delimiter", () => {
+      // Without escaping, a tenant value carrying delimiters could masquerade as
+      // extra dimensions; escaping keeps distinct scopes distinct.
+      const injected = serializeNamespace({ workspace: "app", tenant: "a|route=/x" })
+      const genuine = serializeNamespace({ workspace: "app", route: "/x", tenant: "a" })
+      expect(injected).not.toBe(genuine)
+      expect(injected).toBe("workspace=app|tenant=a%7Croute%3D/x")
+      expect(genuine).toBe("workspace=app|route=/x|tenant=a")
+    })
+  })
 })

--- a/packages/memory/test/namespace.test.ts
+++ b/packages/memory/test/namespace.test.ts
@@ -17,7 +17,7 @@ describe("serializeNamespace", () => {
   })
 
   describe("delimiter escaping in values", () => {
-    it("leaves ordinary values byte-identical (backward compatibility)", () => {
+    it("leaves ordinary values unchanged (backward compatibility)", () => {
       // The common case — no reserved chars — must not change, or existing
       // stored rows and persisted permission patterns would stop matching.
       expect(serializeNamespace({ workspace: "acme", route: "/support", user: "u-1" })).toBe(


### PR DESCRIPTION
## Summary

`serializeNamespace` (`@dawn-ai/memory`) joins scope dimensions as `key=value` with `|` separators but did **not** escape the values. A value containing `|` or `=` — most realistically a `tenant`/`user`/`agent` dimension from an app's `resolveScope()` (e.g. a free-text tenant slug), or an oddly-named workspace/route directory — could corrupt the namespace: cause prefix-match collisions across scopes, or mis-split in `suggestedMemoryPattern` (breaking the `ask`-mode "Always" pattern).

## Fix

Percent-encode the reserved set (`%`, `|`, `=`, with `%` first so it's reversible) in each **value**. Keys are fixed names and never need it.

- **Backward-compatible:** values with no reserved chars (the overwhelmingly common case — `/research`, `acme`, `anon`) serialize **byte-identically**, so existing `.dawn/memory.sqlite` rows and persisted `.dawn/permissions.json` memory patterns keep matching. Only values that already contained a delimiter change — and those were already in a broken/ambiguous state.
- Closes the collision for all five scope dimensions at once.
- `suggestedMemoryPattern` keeps working: `|` now only appears as a true delimiter and each `key=value` has exactly one unencoded `=`.

## Tests

Added to `packages/memory/test/namespace.test.ts`: encode cases for `|`/`=`/`%`, a **backward-compat** assertion that ordinary values are unchanged, and a collision-safety case (an injected `tenant: "a|route=/x"` no longer masquerades as extra dimensions). Verified no regressions across `@dawn-ai/permissions`, `@dawn-ai/core` memory, and the `@dawn-ai/testing` memory e2es (which assert exact persisted namespace patterns).

Follow-up from PR #303 review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
