### PR TITLE
test(cli): fix dev-command CI dist race (drop --force from build helpers)

### DIFF
--- a/packages/cli/test/check-command.test.ts
+++ b/packages/cli/test/check-command.test.ts
@@ -58,7 +58,12 @@ async function buildCliExecutable() {
   const distEntry = join(packageRoot, "dist", "index.js")
 
   await new Promise<void>((resolvePromise, rejectPromise) => {
-    const child = spawn("pnpm", ["exec", "tsc", "-b", "tsconfig.build.json", "--force"], {
+    // No `--force`: it rebuilds every referenced project (incl. @dawn-ai/core)
+    // unconditionally, rewriting the SHARED packages/core/dist mid-suite. Under
+    // vitest's parallel files that races other tests spawning processes which
+    // import @dawn-ai/core from that dist (a half-written dist → "does not
+    // provide an export" crash). Plain `tsc -b` is a no-op when already built.
+    const child = spawn("pnpm", ["exec", "tsc", "-b", "tsconfig.build.json"], {
       cwd: packageRoot,
       stdio: "inherit",
     })

--- a/packages/cli/test/import-diagnostics-integration.test.ts
+++ b/packages/cli/test/import-diagnostics-integration.test.ts
@@ -59,7 +59,12 @@ async function buildCliExecutable() {
   const distEntry = join(packageRoot, "dist", "index.js")
 
   await new Promise<void>((resolvePromise, rejectPromise) => {
-    const child = spawn("pnpm", ["exec", "tsc", "-b", "tsconfig.build.json", "--force"], {
+    // No `--force`: it rebuilds every referenced project (incl. @dawn-ai/core)
+    // unconditionally, rewriting the SHARED packages/core/dist mid-suite. Under
+    // vitest's parallel files that races other tests spawning processes which
+    // import @dawn-ai/core from that dist (a half-written dist → "does not
+    // provide an export" crash). Plain `tsc -b` is a no-op when already built.
+    const child = spawn("pnpm", ["exec", "tsc", "-b", "tsconfig.build.json"], {
       cwd: packageRoot,
       stdio: "inherit",
     })


### PR DESCRIPTION
## Summary

Fixes the intermittent `validate` CI failure where a spawned `dawn dev` (or built-CLI) subprocess crashes on startup with:

```
SyntaxError: The requested module './capabilities/built-in/workspace.js'
does not provide an export named 'createWorkspaceMarker'
```

## Root cause

Not a CI-ordering issue — `pnpm build` fully completes before `pnpm test`. The race is *inside* the single `pnpm test` step. `packages/cli/test/*` run in parallel (vitest default), and two of them (`check-command`, `import-diagnostics-integration`) call `tsc -b tsconfig.build.json --force` in a build helper. `--force` rebuilds **every referenced project unconditionally** — including `@dawn-ai/core` — rewriting the **shared** `packages/core/dist` (`index.js` and `capabilities/built-in/workspace.js` are separate, non-atomic writes). When that rewrite coincides with another test spawning a subprocess that imports `@dawn-ai/core` from that dist, the child can read a half-written dist → the export error. Passes on rerun because the timing rarely collides.

## Fix

Drop `--force`. Plain `tsc -b` respects up-to-dateness, so when the dist is already built (always true in CI, since `pnpm build` runs first) it's a **no-op** — no mid-suite rewrite of the shared dist, no race. The tests still get a correctly-built CLI (incremental build produces exactly what `--force` would, minus the needless rewrite). `--force` was added by a generic "harden entrypoints" commit, not to fix any build correctness issue, so removing it is safe (and post-#273 the incremental `.tsbuildinfo` state is reliable).

Test-only change — no changeset. Verified the full `@dawn-ai/cli` suite (305 tests) passes after a clean build.

Follow-up from PR #303 (the flake that tripped its first `validate` run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
