### PR TITLE
feat(sandbox): hardened-by-default container isolation (tier 1)

### DIFF
--- a/.changeset/sandbox-hardening-tier1.md
+++ b/.changeset/sandbox-hardening-tier1.md
@@ -1,0 +1,14 @@
+---
+"@dawn-ai/workspace": patch
+"@dawn-ai/sandbox": patch
+"@dawn-ai/cli": patch
+---
+
+Harden the Docker sandbox by default: drop all Linux capabilities, no-new-privileges,
+a PID limit (512), a read-only root filesystem (workspace + /tmp stay writable), and
+run-as-non-root (uid/gid 1000:1000 via a create-time root chown-init) — expressed as a
+provider-agnostic `SandboxPolicy.security` intent. `resources.timeoutMs` is now enforced
+per command (in-container `timeout`, exit 124). All hardening is on by default with
+per-flag opt-outs (`readOnlyRootFilesystem`, `runAsNonRoot`, etc.). Behavior changes only
+for apps already using `sandbox`; runtime system-directory writes / global installs now
+fail under the defaults — bake system deps into your image or opt out.

--- a/apps/web/content/docs/sandbox.mdx
+++ b/apps/web/content/docs/sandbox.mdx
@@ -96,7 +96,7 @@ sandbox: {
 },
 ```
 
-It's enforced only when set — omitting `resources.timeoutMs` leaves exec calls unbounded in duration (still subject to `memoryMb`/`cpus` caps, if configured).
+It's enforced only when set — omitting `resources.timeoutMs` leaves exec calls unbounded in duration (still subject to `memoryMb`/`cpus` caps, if configured). Enforcement shells out to the `timeout` binary (GNU coreutils) inside the container, so when you set `resources.timeoutMs` make sure your image ships it — most full base images (`node:22-slim`, `debian`, `ubuntu`) do, but minimal ones (`alpine` without the `coreutils` package, distroless) may not. The ceiling is rounded up to whole seconds (`timeoutMs: 500` enforces a 1-second limit).
 
 ## Network policy
 

--- a/apps/web/content/docs/sandbox.mdx
+++ b/apps/web/content/docs/sandbox.mdx
@@ -45,6 +45,59 @@ One sandbox is created per conversation thread, on that thread's first turn. It 
 
 Turn trace: turn 1 on a new thread → no live sandbox → `acquire()` creates the container and volume. Turns 2..N on the same thread → the same live sandbox is reused. Thread idle past `idleTimeoutMs` → container released, volume kept. Next turn after that → `acquire()` reattaches the existing volume into a fresh container. Thread deleted → `destroy()` removes the container and the volume.
 
+## Security hardening
+
+The Docker provider is hardened by default — a fresh `dockerSandbox()` config with no `security` key applies all of the following:
+
+| Control | Default | Effect |
+| --- | --- | --- |
+| Linux capabilities | `--cap-drop ALL` | The container gets none of the default Docker capability set (no `CAP_NET_RAW`, `CAP_SYS_ADMIN`, etc.) |
+| Privilege escalation | `--security-opt no-new-privileges` | setuid/setgid binaries can't escalate to root inside the container |
+| Process count | `--pids-limit 512` | Caps forked processes as a fork-bomb defense |
+| Root filesystem | `--read-only` + `--tmpfs /tmp` + `--tmpfs /run` | The image's root filesystem is immutable; only the workspace volume and the two tmpfs mounts are writable |
+| User | `--user 1000:1000` with `HOME=/workspace` | The process runs as a non-root uid/gid instead of the image's default (often root) |
+
+This is expressed as a provider-agnostic `SandboxPolicy.security` intent, not a Docker-only flag set — a future microVM- or gVisor-backed provider implements the same fields against its own mechanism.
+
+Every control has a per-flag opt-out for images that need it:
+
+```ts title="dawn.config.ts"
+import { config } from "@dawn-ai/cli"
+import { dockerSandbox } from "@dawn-ai/sandbox"
+
+export default config({
+  sandbox: {
+    provider: dockerSandbox({ image: "node:22-slim" }),
+    security: { runAsNonRoot: false, readOnlyRootFilesystem: false }, // opt out if your image needs it
+  },
+})
+```
+
+`security` accepts:
+
+- `dropAllCapabilities?: boolean` — default `true`
+- `noNewPrivileges?: boolean` — default `true`
+- `readOnlyRootFilesystem?: boolean` — default `true`
+- `runAsNonRoot?: boolean | { uid: number; gid: number }` — default `true` (uid/gid `1000:1000`); pass an object for a different fixed uid/gid, or `false` to run as the image's default user
+- `pidsLimit?: number` — default `512`
+
+<Callout type="warn" title="Bake system deps into your image">
+  The read-only root filesystem and non-root user mean runtime `apt`/`apk` installs, `npm install -g`, and writes outside the workspace all fail by default — there's nowhere writable for them to land. Install system packages and global tooling at image-build time, and let the agent mutate only its workspace at runtime. If a workload genuinely needs to write elsewhere or run as root, opt out with `readOnlyRootFilesystem: false` / `runAsNonRoot: false`.
+</Callout>
+
+### Per-command timeout
+
+`resources.timeoutMs` bounds how long a single `runBash` call may run, enforced inside the container (the command is wrapped in `timeout`; an overrun exits with code `124`):
+
+```ts
+sandbox: {
+  provider: dockerSandbox({ image: "node:22-slim" }),
+  resources: { timeoutMs: 120_000 },
+},
+```
+
+It's enforced only when set — omitting `resources.timeoutMs` leaves exec calls unbounded in duration (still subject to `memoryMb`/`cpus` caps, if configured).
+
 ## Network policy
 
 `sandbox.network` takes one of two shapes:
@@ -117,9 +170,9 @@ Use it in harness-driven tests the same way you'd test any other agent route —
 
 ## What it is — and isn't
 
-**Is:** per-thread kernel-level filesystem and process isolation; the host filesystem is never touched; the host environment is never leaked into the sandbox; CPU and memory caps via `resources`; multi-tenant separation by thread; `network: { mode: "deny" }` is zero egress; the workspace survives turns, server restarts, and container crashes.
+**Is:** per-thread kernel-level filesystem and process isolation; the host filesystem is never touched; the host environment is never leaked into the sandbox; CPU and memory caps via `resources`; multi-tenant separation by thread; `network: { mode: "deny" }` is zero egress; the workspace survives turns, server restarts, and container crashes; hardened by default — all Linux capabilities dropped, no privilege escalation, a read-only root filesystem, a non-root user, and a process-count limit, each with an explicit opt-out.
 
-**Is not:** a guarantee against container-escape zero-days. This is Docker's isolation boundary, not a microVM — which is why the contract is provider-agnostic: a gVisor-, Kata-, or cloud-microVM-backed provider is a stronger drop-in replacement with no change to your app code. The `allow`-mode denylist is best-effort in the Docker reference; it does not stop an agent exfiltrating its own sandbox's data under `allow` mode. And the sandbox does not govern tool *surface* — that's [tool scoping](/docs/tools)'s job (`agent({ tools })`); the sandbox and tool scoping are complementary layers, not substitutes for each other.
+**Is not:** a guarantee against container-escape zero-days. Dropped capabilities, a non-root user, a read-only root filesystem, and deny-mode networking materially raise the bar an attacker has to clear, but this remains Docker's isolation boundary, not a microVM. That's why the hardening is expressed as a provider-agnostic `SandboxPolicy.security` intent rather than a Docker-specific flag set: a gVisor-, Kata-, or cloud-microVM-backed provider satisfies the same seam with a stronger underlying substrate, as a drop-in replacement with no change to your app code. The `allow`-mode denylist is best-effort in the Docker reference; it does not stop an agent exfiltrating its own sandbox's data under `allow` mode. And the sandbox does not govern tool *surface* — that's [tool scoping](/docs/tools)'s job (`agent({ tools })`); the sandbox and tool scoping are complementary layers, not substitutes for each other.
 
 Dawn ships the isolation seam plus a Docker reference. For hostile-grade multi-tenant isolation, plug in a microVM-backed provider.
 

--- a/docs/superpowers/plans/2026-07-06-sandbox-hardening-tier1.md
+++ b/docs/superpowers/plans/2026-07-06-sandbox-hardening-tier1.md
@@ -1,0 +1,650 @@
+# Sandbox Hardening Tier 1 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Harden `dockerSandbox` by default — drop all capabilities, no-new-privileges, PID limit, read-only root filesystem, run-as-non-root (via a create-time root chown-init), and per-command timeout enforcement — expressed as a provider-agnostic `SandboxPolicy.security` intent.
+
+**Architecture:** Add a `SandboxSecurityPolicy` intent object to the `@dawn-ai/workspace` contract. The Docker provider treats each unset field as its secure default and translates intent → `docker run`/`docker exec` flags. Non-root uses Architecture B: an ephemeral, create-only, agent-input-free root `docker run --rm … chown` initializes volume ownership, then a non-root keeper runs; nothing in the live container graph is root.
+
+**Tech Stack:** TypeScript (ESM, `node:` builtins), Vitest, Biome, pnpm fixed-group workspace, the `docker` CLI (coreutils `timeout`/`chown` in-container).
+
+**Spec:** `docs/superpowers/specs/2026-07-06-sandbox-hardening-tier1-design.md` — read it first.
+
+**Grounding (verify before editing — main evolves):**
+- Contract: `packages/workspace/src/sandbox-types.ts` — `SandboxPolicy { network, env?, resources?{memoryMb?,cpus?,timeoutMs?} }`, `SandboxConfig { provider, network?, env?, resources?, idleTimeoutMs? }`.
+- Provider: `packages/sandbox/src/docker/docker-sandbox.ts` — `ensureContainer` builds the `docker run -d` args (`--name`, `--label`, `-v vol:/workspace`, `-w /workspace`, `net`, `envArgs`, `limits`, image, `sleep infinity`); `acquire` constructs `dockerExec(docker, container)` + `dockerFilesystem(docker, container)`. `ROOT = "/workspace"`, `sanitize`, `containerName`, `volumeName`.
+- Exec: `packages/sandbox/src/docker/docker-exec.ts` — `dockerExec(docker, container)`; `runCommand` builds `sh -c "<envPrefix><cdPrefix><command>"`, already **validates env keys** (`/^[A-Za-z_][A-Za-z0-9_]*$/`) and `shellQuote`s values. **Preserve that** — READ the file and add to it; don't paste-replace.
+- CLI: `packages/cli/src/lib/runtime/resolve-sandbox.ts` (builds `SandboxPolicy` from `SandboxConfig`), `packages/cli/src/lib/runtime/collect-sandbox-errors.ts` (`dawn check` pass), both in `test/`.
+- Sandbox tests live in `packages/sandbox/test/` with `../src/...ts` (`.ts`-extension) imports. `docker-sandbox.unit.test.ts` uses a recording fake `Docker`; `docker-sandbox.integration.test.ts` is gated `describe.skipIf(process.env.DAWN_TEST_DOCKER !== "1")` and runs the conformance kit + adversarial e2e.
+- Conventions: per-package lint (`pnpm --filter <pkg> lint`) — never a repo-wide bare `biome check --write`. Build upstream deps before cross-package typecheck. Confirm `git branch --show-current` before every commit (multi-worktree repo).
+
+---
+
+### Task 1: `SandboxSecurityPolicy` contract intent (`@dawn-ai/workspace`)
+
+**Files:**
+- Modify: `packages/workspace/src/sandbox-types.ts`
+- Test: `packages/workspace/test/sandbox-types.test.ts` (append to the existing file)
+
+- [ ] **Step 1: Write the failing test** (append inside the existing `describe` or add a new one in `packages/workspace/test/sandbox-types.test.ts`)
+
+```ts
+import type { SandboxConfig, SandboxPolicy, SandboxSecurityPolicy } from "../src/sandbox-types.ts"
+
+describe("sandbox security intent", () => {
+  test("security is optional on the policy and config, with all-optional fields", () => {
+    const sec: SandboxSecurityPolicy = {
+      dropAllCapabilities: true,
+      noNewPrivileges: true,
+      readOnlyRootFilesystem: false,
+      runAsNonRoot: { uid: 1000, gid: 1000 },
+      pidsLimit: 256,
+    }
+    const policy: SandboxPolicy = { network: { mode: "deny" }, security: sec }
+    expect(policy.security?.pidsLimit).toBe(256)
+    const off: SandboxPolicy = { network: { mode: "deny" }, security: { runAsNonRoot: false } }
+    expect(off.security?.runAsNonRoot).toBe(false)
+    const cfg: SandboxConfig = { provider: {} as never, security: sec }
+    expect(cfg.security).toBe(sec)
+  })
+})
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `pnpm --filter @dawn-ai/workspace test sandbox-types`
+Expected: FAIL — `SandboxSecurityPolicy` not exported, `security` not on `SandboxPolicy`/`SandboxConfig`.
+
+- [ ] **Step 3: Add the intent type + fields** in `packages/workspace/src/sandbox-types.ts`
+
+```ts
+/**
+ * Provider-agnostic hardening intent. Each provider translates these to its own
+ * mechanism; a field left unset means the provider applies its SECURE default
+ * (all of these default ON/hardened at the Docker provider). Authors relax
+ * explicitly. See the sandbox-hardening spec.
+ */
+export interface SandboxSecurityPolicy {
+  /** Drop all Linux capabilities. Secure default: true. */
+  readonly dropAllCapabilities?: boolean
+  /** Block setuid/setgid privilege escalation. Secure default: true. */
+  readonly noNewPrivileges?: boolean
+  /** Immutable root filesystem (workspace + scratch stay writable). Secure default: true. */
+  readonly readOnlyRootFilesystem?: boolean
+  /** Run as non-root. Secure default: true → uid/gid 1000:1000. `false` = image default (often root). */
+  readonly runAsNonRoot?: boolean | { readonly uid: number; readonly gid: number }
+  /** Max process count (fork-bomb defense). Secure default: 512. */
+  readonly pidsLimit?: number
+}
+```
+
+Add `readonly security?: SandboxSecurityPolicy` to the `SandboxPolicy` interface (after `resources`) and to `SandboxConfig` (after `resources`). Export `SandboxSecurityPolicy` alongside the other type exports in `packages/workspace/src/index.ts`.
+
+- [ ] **Step 4: Run test + typecheck + lint + build**
+
+Run: `pnpm --filter @dawn-ai/workspace test sandbox-types && pnpm --filter @dawn-ai/workspace typecheck && pnpm --filter @dawn-ai/workspace lint && pnpm --filter @dawn-ai/workspace build`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/workspace/src/sandbox-types.ts packages/workspace/src/index.ts packages/workspace/test/sandbox-types.test.ts
+git commit -m "feat(workspace): SandboxSecurityPolicy hardening intent on the contract"
+```
+
+---
+
+### Task 2: Per-command timeout in `dockerExec`
+
+**Files:**
+- Modify: `packages/sandbox/src/docker/docker-exec.ts`
+- Modify: `packages/sandbox/src/docker/docker-sandbox.ts` (wire the timeout at `acquire`)
+- Test: `packages/sandbox/test/docker-backends.test.ts` (append)
+
+- [ ] **Step 1: Write the failing test** (append to `packages/sandbox/test/docker-backends.test.ts`; reuse its existing `fakeDocker`/`ctx` helpers)
+
+```ts
+describe("dockerExec timeout", () => {
+  test("wraps the command in `timeout Ns` when timeoutMs is set", async () => {
+    let seen: readonly string[] = []
+    const exec = dockerExec(
+      fakeDocker({ exec: async (_c, cmd) => { seen = cmd; return { stdout: "", stderr: "", exitCode: 0 } } }),
+      "c1",
+      { timeoutMs: 1500 },
+    )
+    await exec.runCommand({ command: "echo hi" }, ctx)
+    expect(seen[0]).toBe("timeout")
+    expect(seen[1]).toBe("2s") // ceil(1500/1000)
+    expect(seen[2]).toBe("sh")
+    expect(seen.join(" ")).toContain("echo hi")
+  })
+
+  test("no timeout wrapping when timeoutMs is unset", async () => {
+    let seen: readonly string[] = []
+    const exec = dockerExec(
+      fakeDocker({ exec: async (_c, cmd) => { seen = cmd; return { stdout: "", stderr: "", exitCode: 0 } } }),
+      "c1",
+    )
+    await exec.runCommand({ command: "echo hi" }, ctx)
+    expect(seen[0]).toBe("sh")
+  })
+
+  test("exit 124 → annotated stderr pointing at the config", async () => {
+    const exec = dockerExec(
+      fakeDocker({ exec: async () => ({ stdout: "", stderr: "", exitCode: 124 }) }),
+      "c1",
+      { timeoutMs: 500 },
+    )
+    const r = await exec.runCommand({ command: "sleep 999" }, ctx)
+    expect(r.exitCode).toBe(124)
+    expect(r.stderr).toMatch(/timed out after 500ms/i)
+    expect(r.stderr).toMatch(/resources\.timeoutMs/)
+  })
+
+  test("still validates env keys (regression: keep existing behavior)", async () => {
+    const exec = dockerExec(fakeDocker({}), "c1", { timeoutMs: 500 })
+    await expect(
+      exec.runCommand({ command: "echo", env: { "BAD KEY;x": "1" } }, ctx),
+    ).rejects.toThrow(/Invalid environment variable name/i)
+  })
+})
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `pnpm --filter @dawn-ai/sandbox test docker-backends`
+Expected: FAIL — `dockerExec` takes 2 args; timeout not implemented.
+
+- [ ] **Step 3: Implement** — READ the current `packages/sandbox/src/docker/docker-exec.ts` and modify it (do NOT drop the existing env-key validation or `shellQuote`):
+1. Change the signature to `export function dockerExec(docker: Docker, container: string, opts: { readonly timeoutMs?: number } = {}): ExecBackend`.
+2. In `runCommand`, after building the full `sh -c` string as today (`const full = \`${envPrefix}${cdPrefix}${args.command}\``), build the exec argv:
+
+```ts
+const shArgs = ["sh", "-c", full]
+const argv =
+  opts.timeoutMs !== undefined
+    ? ["timeout", `${Math.ceil(opts.timeoutMs / 1000)}s`, ...shArgs]
+    : shArgs
+const r = await docker.exec(container, argv, { signal: ctx.signal })
+if (opts.timeoutMs !== undefined && r.exitCode === 124) {
+  return {
+    stdout: r.stdout,
+    stderr: `${r.stderr}${r.stderr ? "\n" : ""}Command timed out after ${opts.timeoutMs}ms (resources.timeoutMs).`,
+    exitCode: 124,
+  }
+}
+return { stdout: r.stdout, stderr: r.stderr, exitCode: r.exitCode }
+```
+
+3. Keep the env-key validation loop exactly as-is (it must run before building `envPrefix`).
+
+- [ ] **Step 4: Wire the provider** — in `packages/sandbox/src/docker/docker-sandbox.ts` `acquire`, change `exec: dockerExec(docker, container)` to:
+
+```ts
+exec: dockerExec(docker, container, { timeoutMs: policy.resources?.timeoutMs }),
+```
+
+(`policy` is in scope in `acquire`.)
+
+- [ ] **Step 5: Run tests + typecheck + lint + build**
+
+Run: `pnpm --filter @dawn-ai/sandbox test docker-backends && pnpm --filter @dawn-ai/sandbox typecheck && pnpm --filter @dawn-ai/sandbox lint && pnpm --filter @dawn-ai/sandbox build`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/sandbox/src/docker/docker-exec.ts packages/sandbox/src/docker/docker-sandbox.ts packages/sandbox/test/docker-backends.test.ts
+git commit -m "feat(sandbox): enforce per-command timeout via in-container coreutils timeout"
+```
+
+---
+
+### Task 3: Hardening flags in `dockerSandbox` (secure-by-default translation)
+
+**Files:**
+- Modify: `packages/sandbox/src/docker/docker-sandbox.ts` (`ensureContainer`)
+- Test: `packages/sandbox/test/docker-sandbox.unit.test.ts` (append)
+
+- [ ] **Step 1: Write the failing test** (append; reuse the file's `recordingDocker()` + `signal()` helpers)
+
+```ts
+describe("dockerSandbox hardening flags", () => {
+  const acquireArgs = (runs: string[][]) => (runs.find((r) => r[0] === "run") ?? []).join(" ")
+
+  test("hardened by default: cap-drop ALL, no-new-privileges, pids-limit 512, read-only + tmpfs, non-root user + HOME", async () => {
+    const { docker, runs } = recordingDocker()
+    const p = dockerSandbox({ image: "node:22-slim", docker })
+    await p.acquire({ threadId: "abc", policy: { network: { mode: "deny" } }, signal: signal() })
+    const j = acquireArgs(runs)
+    expect(j).toContain("--cap-drop ALL")
+    expect(j).toContain("--security-opt no-new-privileges")
+    expect(j).toContain("--pids-limit 512")
+    expect(j).toContain("--read-only")
+    expect(j).toContain("--tmpfs /tmp")
+    expect(j).toContain("--tmpfs /run")
+    expect(j).toContain("--user 1000:1000")
+    expect(j).toContain("HOME=/workspace")
+  })
+
+  test("per-flag opt-outs remove exactly their flags", async () => {
+    const { docker, runs } = recordingDocker()
+    const p = dockerSandbox({ image: "node:22-slim", docker })
+    await p.acquire({
+      threadId: "abc",
+      policy: {
+        network: { mode: "deny" },
+        security: {
+          dropAllCapabilities: false,
+          noNewPrivileges: false,
+          readOnlyRootFilesystem: false,
+          runAsNonRoot: false,
+          pidsLimit: 128,
+        },
+      },
+      signal: signal(),
+    })
+    const j = acquireArgs(runs)
+    expect(j).not.toContain("--cap-drop")
+    expect(j).not.toContain("no-new-privileges")
+    expect(j).not.toContain("--read-only")
+    expect(j).not.toContain("--tmpfs")
+    expect(j).not.toContain("--user")
+    expect(j).not.toContain("HOME=/workspace")
+    expect(j).toContain("--pids-limit 128")
+  })
+
+  test("custom runAsNonRoot uid/gid", async () => {
+    const { docker, runs } = recordingDocker()
+    const p = dockerSandbox({ image: "node:22-slim", docker })
+    await p.acquire({
+      threadId: "abc",
+      policy: { network: { mode: "deny" }, security: { runAsNonRoot: { uid: 2000, gid: 3000 } } },
+      signal: signal(),
+    })
+    expect(acquireArgs(runs)).toContain("--user 2000:3000")
+  })
+})
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `pnpm --filter @dawn-ai/sandbox test docker-sandbox.unit`
+Expected: FAIL — no hardening flags emitted.
+
+- [ ] **Step 3: Implement** in `ensureContainer` (`packages/sandbox/src/docker/docker-sandbox.ts`). Before building the `docker run` argv, resolve the effective posture:
+
+```ts
+const sec = policy.security ?? {}
+const dropCaps = sec.dropAllCapabilities ?? true
+const noNewPriv = sec.noNewPrivileges ?? true
+const readOnly = sec.readOnlyRootFilesystem ?? true
+const pids = sec.pidsLimit ?? 512
+const user: { uid: number; gid: number } | undefined =
+  sec.runAsNonRoot === false
+    ? undefined
+    : typeof sec.runAsNonRoot === "object"
+      ? sec.runAsNonRoot
+      : { uid: 1000, gid: 1000 }
+
+const hardening: string[] = [
+  ...(dropCaps ? ["--cap-drop", "ALL"] : []),
+  ...(noNewPriv ? ["--security-opt", "no-new-privileges"] : []),
+  "--pids-limit",
+  String(pids),
+  ...(readOnly ? ["--read-only", "--tmpfs", "/tmp", "--tmpfs", "/run"] : []),
+  ...(user ? ["--user", `${user.uid}:${user.gid}`, "-e", "HOME=/workspace"] : []),
+]
+```
+
+Insert `...hardening` into the existing `docker run` argv array, right after `...limits` (before `opts.image`). Do NOT change the existing `net`/`envArgs`/`limits`/`-v`/`-w`/`--label` args.
+
+- [ ] **Step 4: Run tests + typecheck + lint + build**
+
+Run: `pnpm --filter @dawn-ai/sandbox test docker-sandbox.unit && pnpm --filter @dawn-ai/sandbox typecheck && pnpm --filter @dawn-ai/sandbox lint && pnpm --filter @dawn-ai/sandbox build`
+Expected: PASS (existing unit tests + new ones).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/sandbox/src/docker/docker-sandbox.ts packages/sandbox/test/docker-sandbox.unit.test.ts
+git commit -m "feat(sandbox): hardened-by-default docker flags (caps, no-new-priv, pids, read-only, non-root)"
+```
+
+---
+
+### Task 4: Architecture B — non-root volume chown-init (create-only)
+
+**Files:**
+- Modify: `packages/sandbox/src/docker/docker-sandbox.ts` (`ensureContainer` create branch)
+- Test: `packages/sandbox/test/docker-sandbox.unit.test.ts` (append)
+
+- [ ] **Step 1: Write the failing test** (append)
+
+```ts
+describe("dockerSandbox chown-init (Architecture B)", () => {
+  // volume-absent recorder: `volume inspect` fails (exit 1); everything else ok.
+  function chownRecorder(volumeExists: boolean) {
+    const runs: string[][] = []
+    const docker: Docker = {
+      run: async (args) => {
+        runs.push([...args])
+        if (args[0] === "volume" && args[1] === "inspect") {
+          return { stdout: "", stderr: "", exitCode: volumeExists ? 0 : 1 }
+        }
+        if (args[0] === "ps") return { stdout: "", stderr: "", exitCode: 0 } // container absent
+        return { stdout: "ok", stderr: "", exitCode: 0 }
+      },
+      exec: async () => ({ stdout: "", stderr: "", exitCode: 0 }),
+    }
+    return { docker, runs }
+  }
+  const chownRun = (runs: string[][]) =>
+    runs.find((r) => r[0] === "run" && r.includes("--rm") && r.join(" ").includes("chown"))
+
+  test("volume absent + non-root → chown-init runs as root BEFORE the keeper", async () => {
+    const { docker, runs } = chownRecorder(false)
+    const p = dockerSandbox({ image: "node:22-slim", docker })
+    await p.acquire({ threadId: "abc", policy: { network: { mode: "deny" } }, signal: signal() })
+    const init = chownRun(runs)
+    expect(init).toBeDefined()
+    const j = (init ?? []).join(" ")
+    expect(j).toContain("--user 0:0")
+    expect(j).toContain("dawn-sbx-vol-abc:/workspace")
+    expect(j).toContain("chown 1000:1000 /workspace")
+    // ordering: chown-init before the keeper (-d)
+    const idxInit = runs.findIndex((r) => r === init)
+    const idxKeeper = runs.findIndex((r) => r[0] === "run" && r.includes("-d"))
+    expect(idxInit).toBeLessThan(idxKeeper)
+  })
+
+  test("volume present → NO chown-init (reattach)", async () => {
+    const { docker, runs } = chownRecorder(true)
+    const p = dockerSandbox({ image: "node:22-slim", docker })
+    await p.acquire({ threadId: "abc", policy: { network: { mode: "deny" } }, signal: signal() })
+    expect(chownRun(runs)).toBeUndefined()
+  })
+
+  test("runAsNonRoot:false → NO chown-init", async () => {
+    const { docker, runs } = chownRecorder(false)
+    const p = dockerSandbox({ image: "node:22-slim", docker })
+    await p.acquire({
+      threadId: "abc",
+      policy: { network: { mode: "deny" }, security: { runAsNonRoot: false } },
+      signal: signal(),
+    })
+    expect(chownRun(runs)).toBeUndefined()
+  })
+})
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `pnpm --filter @dawn-ai/sandbox test docker-sandbox.unit`
+Expected: FAIL — no `volume inspect` / chown-init issued.
+
+- [ ] **Step 3: Implement** in `ensureContainer`, in the CREATE branch (after the `ps -aq` reattach check falls through to "container absent → create"), and only when `user` is defined (from Task 3's resolved posture):
+
+```ts
+if (user) {
+  const volExists = await docker.run(["volume", "inspect", volumeName(threadId)], { signal })
+  if (volExists.exitCode !== 0) {
+    const init = await docker.run(
+      [
+        "run", "--rm", "--user", "0:0",
+        "-v", `${volumeName(threadId)}:${ROOT}`,
+        opts.image, "sh", "-c",
+        `mkdir -p ${ROOT} && chown ${user.uid}:${user.gid} ${ROOT}`,
+      ],
+      { signal },
+    )
+    if (init.exitCode !== 0) {
+      throw new Error(
+        `Sandbox unavailable: could not initialize workspace ownership for thread "${threadId}": ${init.stderr.trim() || "unknown error"}. Run \`dawn check\`.`,
+      )
+    }
+  }
+}
+```
+
+This block goes immediately before the keeper `docker run -d …` call. (The keeper's `--user`/`--read-only`/etc. come from Task 3.)
+
+- [ ] **Step 4: Run tests + typecheck + lint + build**
+
+Run: `pnpm --filter @dawn-ai/sandbox test docker-sandbox.unit && pnpm --filter @dawn-ai/sandbox typecheck && pnpm --filter @dawn-ai/sandbox lint && pnpm --filter @dawn-ai/sandbox build`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/sandbox/src/docker/docker-sandbox.ts packages/sandbox/test/docker-sandbox.unit.test.ts
+git commit -m "feat(sandbox): non-root volume chown-init (create-only, no steady-state root)"
+```
+
+---
+
+### Task 5: CLI passthrough + `dawn check` validation
+
+**Files:**
+- Modify: `packages/cli/src/lib/runtime/resolve-sandbox.ts`
+- Modify: `packages/cli/src/lib/runtime/collect-sandbox-errors.ts`
+- Test: `packages/cli/test/collect-sandbox-errors.test.ts` (append)
+
+- [ ] **Step 1: Write the failing test** (append to `packages/cli/test/collect-sandbox-errors.test.ts`)
+
+```ts
+describe("collectSandboxErrors: security shape", () => {
+  const ok = { name: "p", acquire: async () => ({}) as never, release: async () => {}, destroy: async () => {}, preflight: async () => ({ ok: true }) }
+
+  test("pidsLimit must be a positive integer", async () => {
+    const errors = await collectSandboxErrors({ sandbox: { provider: ok, security: { pidsLimit: 0 } } })
+    expect(errors.join("\n")).toMatch(/pidsLimit/)
+  })
+
+  test("runAsNonRoot object needs numeric uid/gid", async () => {
+    const errors = await collectSandboxErrors({ sandbox: { provider: ok, security: { runAsNonRoot: { uid: -1, gid: 0 } as never } } })
+    expect(errors.join("\n")).toMatch(/uid|gid/)
+  })
+
+  test("valid security → no errors", async () => {
+    expect(
+      await collectSandboxErrors({ sandbox: { provider: ok, security: { pidsLimit: 256, runAsNonRoot: { uid: 1000, gid: 1000 } } } }),
+    ).toEqual([])
+  })
+})
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `pnpm --filter @dawn-ai/cli test collect-sandbox-errors`
+Expected: FAIL — no `security` validation.
+
+- [ ] **Step 3: `resolve-sandbox.ts` passthrough** — READ the file; where it builds the `SandboxPolicy` from `sandbox` config (currently spreads `network`/`env`/`resources`), add the security passthrough:
+
+```ts
+...(sandbox.security ? { security: sandbox.security } : {}),
+```
+
+(Mirror the existing `...(sandbox.env ? { env: sandbox.env } : {})` conditional-spread style.)
+
+- [ ] **Step 4: `collect-sandbox-errors.ts` validation** — after the existing provider-shape + preflight checks, add security-shape validation:
+
+```ts
+const sec = sandbox.security
+if (sec) {
+  if (sec.pidsLimit !== undefined && (!Number.isInteger(sec.pidsLimit) || sec.pidsLimit <= 0)) {
+    errors.push(`dawn.config sandbox.security.pidsLimit must be a positive integer (got: ${String(sec.pidsLimit)}).`)
+  }
+  if (typeof sec.runAsNonRoot === "object" && sec.runAsNonRoot !== null) {
+    const { uid, gid } = sec.runAsNonRoot
+    if (!Number.isInteger(uid) || uid < 0 || !Number.isInteger(gid) || gid < 0) {
+      errors.push(`dawn.config sandbox.security.runAsNonRoot uid/gid must be non-negative integers.`)
+    }
+  }
+}
+```
+
+(`sandbox` is the `config.sandbox` object already in scope; `errors` is the accumulator array. Preserve the early-return-on-bad-provider behavior — put this block after that, before the `return errors`.)
+
+- [ ] **Step 5: Run tests + typecheck + lint**
+
+Run: `pnpm --filter @dawn-ai/workspace build && pnpm --filter @dawn-ai/core build && pnpm --filter @dawn-ai/cli test collect-sandbox-errors && pnpm --filter @dawn-ai/cli typecheck && pnpm --filter @dawn-ai/cli lint`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/cli/src/lib/runtime/resolve-sandbox.ts packages/cli/src/lib/runtime/collect-sandbox-errors.ts packages/cli/test/collect-sandbox-errors.test.ts
+git commit -m "feat(cli): pass sandbox.security through + validate it in dawn check"
+```
+
+---
+
+### Task 6: Adversarial real-Docker hardening conformance (gated lane)
+
+**Files:**
+- Modify: `packages/sandbox/test/docker-sandbox.integration.test.ts` (append; it's already `describe.skipIf(!enabled)` gated on `DAWN_TEST_DOCKER=1`)
+
+- [ ] **Step 1: Add the adversarial suite** — append inside the gated `describe` (or a sibling gated `describe`). READ the file first for its `enabled`/`IMAGE`/`ctx`/policy helpers and reuse them; each test acquires a unique threadId and `destroy`s it in `finally`.
+
+```ts
+test("hardened defaults contain a fork bomb (pids-limit)", { timeout: 180_000 }, async () => {
+  const p = dockerSandbox({ image: IMAGE })
+  const threadId = `fork-${randomUUID()}`
+  try {
+    const h = await p.acquire({ threadId, policy: { network: { mode: "deny" } }, signal: ctx("/").signal })
+    // bounded spawn attempt; pids-limit (512) makes fork fail rather than take the host down
+    const r = await h.exec.runCommand(
+      { command: "for i in $(seq 1 2000); do sleep 30 & done; echo done" },
+      ctx(h.workspaceRoot),
+    )
+    // either the shell reports fork failures, or the command is non-zero — host stays up (test completes)
+    expect(typeof r.exitCode).toBe("number")
+    // sanity: the container still responds afterward
+    const alive = await h.exec.runCommand({ command: "echo alive" }, ctx(h.workspaceRoot))
+    expect(alive.stdout).toContain("alive")
+  } finally {
+    await p.destroy(threadId)
+  }
+})
+
+test("read-only root blocks /etc writes; workspace + /tmp writable", { timeout: 120_000 }, async () => {
+  const p = dockerSandbox({ image: IMAGE })
+  const threadId = `ro-${randomUUID()}`
+  try {
+    const h = await p.acquire({ threadId, policy: { network: { mode: "deny" } }, signal: ctx("/").signal })
+    const etc = await h.exec.runCommand({ command: "echo x > /etc/dawn-probe" }, ctx(h.workspaceRoot))
+    expect(etc.exitCode).not.toBe(0)
+    const ws = await h.exec.runCommand({ command: "echo x > /workspace/probe && echo ok" }, ctx(h.workspaceRoot))
+    expect(ws.stdout).toContain("ok")
+    const tmp = await h.exec.runCommand({ command: "echo x > /tmp/probe && echo ok" }, ctx(h.workspaceRoot))
+    expect(tmp.stdout).toContain("ok")
+  } finally {
+    await p.destroy(threadId)
+  }
+})
+
+test("runs as non-root by default", { timeout: 120_000 }, async () => {
+  const p = dockerSandbox({ image: IMAGE })
+  const threadId = `nr-${randomUUID()}`
+  try {
+    const h = await p.acquire({ threadId, policy: { network: { mode: "deny" } }, signal: ctx("/").signal })
+    const r = await h.exec.runCommand({ command: "id -u" }, ctx(h.workspaceRoot))
+    expect(r.stdout.trim()).not.toBe("0")
+    expect(r.stdout.trim()).toBe("1000")
+  } finally {
+    await p.destroy(threadId)
+  }
+})
+
+test("per-command timeout kills the in-container process (exit 124)", { timeout: 120_000 }, async () => {
+  const p = dockerSandbox({ image: IMAGE })
+  const threadId = `to-${randomUUID()}`
+  try {
+    const h = await p.acquire(
+      { threadId, policy: { network: { mode: "deny" }, resources: { timeoutMs: 500 } }, signal: ctx("/").signal },
+    )
+    const r = await h.exec.runCommand({ command: "sleep 999" }, ctx(h.workspaceRoot))
+    expect(r.exitCode).toBe(124)
+    // process actually gone: no lingering sleep 999
+    const ps = await h.exec.runCommand({ command: "ps -e -o args= 2>/dev/null | grep -c 'sleep 999' || true" }, ctx(h.workspaceRoot))
+    expect(ps.stdout.trim()).toBe("0")
+  } finally {
+    await p.destroy(threadId)
+  }
+})
+```
+
+- [ ] **Step 2: Verify the gate is closed without Docker**
+
+Run: `pnpm --filter @dawn-ai/sandbox test docker-sandbox.integration`
+Expected: the suite SKIPS (env unset), exit 0. Confirm skipped count includes the new tests. (The existing conformance kit against real Docker still runs the hardened path in CI — no change needed there; it proves normal workloads survive the defaults.)
+
+- [ ] **Step 3: If a Docker daemon is available locally**, run `DAWN_TEST_DOCKER=1 pnpm --filter @dawn-ai/sandbox test docker-sandbox.integration` and report results. If not (this machine's daemon can't pull), state that the CI `sandbox-docker` lane is the authoritative gate.
+
+- [ ] **Step 4: Typecheck + lint + commit**
+
+Run: `pnpm --filter @dawn-ai/sandbox typecheck && pnpm --filter @dawn-ai/sandbox lint`
+```bash
+git add packages/sandbox/test/docker-sandbox.integration.test.ts
+git commit -m "test(sandbox): adversarial real-Docker hardening conformance (gated)"
+```
+
+---
+
+### Task 7: Docs + changeset + full verification + PR
+
+**Files:**
+- Modify: `apps/web/content/docs/sandbox.mdx`
+- Create: `.changeset/sandbox-hardening-tier1.md`
+
+- [ ] **Step 1: Update the docs page** `apps/web/content/docs/sandbox.mdx` — add a "Security hardening" section: the hardened-by-default table (cap-drop ALL, no-new-privileges, pids-limit 512, read-only root + writable `/workspace` + tmpfs `/tmp`/`/run`, run-as-non-root 1000:1000 with `HOME=/workspace`), the `security` config shape + per-flag opt-outs, the per-command `resources.timeoutMs`, and the guidance callout: *bake system deps into your image; mutate only your workspace at runtime — runtime `apt`/`npm -g` will fail under the read-only + non-root defaults (opt out with `readOnlyRootFilesystem:false` / `runAsNonRoot:false` if you must).* Update the honest-scope section to note the hardened posture materially raises the bar while still being Docker's boundary (not a microVM), and that `security` is the provider-agnostic seam a stronger substrate satisfies. No banned marketing phrases (`check-docs.mjs`). Any example `model:` id stays gpt-5 family.
+
+- [ ] **Step 2: Check docs**
+
+Run: `node scripts/check-docs.mjs`
+Expected: PASS.
+
+- [ ] **Step 3: Write the changeset (patch)** `.changeset/sandbox-hardening-tier1.md`:
+
+```md
+---
+"@dawn-ai/workspace": patch
+"@dawn-ai/sandbox": patch
+"@dawn-ai/cli": patch
+---
+
+Harden the Docker sandbox by default: drop all Linux capabilities, no-new-privileges,
+a PID limit (512), a read-only root filesystem (workspace + /tmp stay writable), and
+run-as-non-root (uid/gid 1000:1000 via a create-time root chown-init) — expressed as a
+provider-agnostic `SandboxPolicy.security` intent. `resources.timeoutMs` is now enforced
+per command (in-container `timeout`, exit 124). All hardening is on by default with
+per-flag opt-outs (`readOnlyRootFilesystem`, `runAsNonRoot`, etc.). Behavior changes only
+for apps already using `sandbox`; runtime system-directory writes / global installs now
+fail under the defaults — bake system deps into your image or opt out.
+```
+
+- [ ] **Step 4: Full local verification**
+
+Run: `pnpm lint && pnpm build && pnpm typecheck && pnpm test && node scripts/check-docs.mjs && pnpm --filter @dawn-ai/sandbox test && pnpm verify:harness:framework`
+Expected: all PASS. (Gated Docker integration tests SKIP without `DAWN_TEST_DOCKER` — correct. If a pre-existing unrelated flake appears in `pnpm test`, confirm it also fails on unmodified `origin/main` before attributing.)
+
+- [ ] **Step 5: Rebase, align version, push, open PR**
+
+```bash
+git fetch origin main
+git rebase origin/main
+# align the new package's version if main advanced (the fixed group is uniform): set packages/sandbox/package.json version to match packages/workspace/package.json, if they differ, then pnpm install and commit
+git push -u origin feat/sandbox-hardening-tier1
+gh pr create --title "feat: sandbox hardening tier 1 — hardened-by-default docker + per-command timeout" --body "Implements docs/superpowers/specs/2026-07-06-sandbox-hardening-tier1-design.md. Watch the sandbox-docker CI lane for the real-Docker adversarial proofs."
+```
+
+- [ ] **Step 6: After merge**, verify the post-merge Release run / Version PR reads the next patch (NOT 1.0.0) per GOTCHA 6. No new package this time, so no OIDC bootstrap needed.
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** contract intent (T1), timeout (T2), flags (T3), non-root chown-init/Architecture B (T4), cli passthrough + dawn check (T5), adversarial real-Docker conformance (T6), docs + changeset + honest-scope (T7). Secure-by-default at the provider (T3/T4 default-unset→hardened). Existing conformance-still-green-under-defaults noted in T6.
+- **Type/name consistency:** `SandboxSecurityPolicy` fields (`dropAllCapabilities`/`noNewPrivileges`/`readOnlyRootFilesystem`/`runAsNonRoot`/`pidsLimit`) used identically in T1/T3/T4/T5; `dockerExec(docker, container, { timeoutMs })` consistent T2↔provider; `resources.timeoutMs` is the timeout home (not a new `security` field).
+- **Watch-outs:** (1) T2 must PRESERVE the existing env-key validation + `shellQuote` in `docker-exec.ts` (read, don't paste-replace). (2) T3+T4 both edit `ensureContainer` — the chown-init (T4) uses the `user` variable resolved in T3, so T4 depends on T3's block existing. (3) T4 chown-init must be gated on volume-ABSENCE (`volume inspect` exit≠0) AND `user` defined — never on reattach. (4) `--tmpfs /run` included because some tools write `/run`; if an image breaks, it's covered by `readOnlyRootFilesystem:false`. (5) coreutils `timeout`/`chown` assumed present (all standard base images) — the honest-scope note already says images need a POSIX shell + coreutils.

--- a/docs/superpowers/specs/2026-07-06-sandbox-hardening-tier1-design.md
+++ b/docs/superpowers/specs/2026-07-06-sandbox-hardening-tier1-design.md
@@ -1,0 +1,166 @@
+# Sandbox Hardening — Tier 1 (Design)
+
+**Status:** Approved for planning
+**Date:** 2026-07-06
+**Roadmap:** Phase 4 follow-up to the execution sandbox (PR #289, shipped in 0.8.6). Tier 1 = the container-runtime hardening the initial `dockerSandbox` deliberately left off: capability drop, no-new-privileges, PID limit, read-only root filesystem, **run-as-non-root**, and per-command timeout enforcement.
+
+## Problem
+
+The shipped `dockerSandbox` isolates per thread (fs + exec + network) but runs each container with a weak runtime posture: **full Linux capabilities, root user, writable root filesystem, unbounded PIDs, and no per-command timeout** (`resources.timeoutMs` exists on the type but is never applied). `--cap-drop`, `--security-opt no-new-privileges`, `--pids-limit`, `--read-only`, and `--user` are all absent from the `docker run` in `ensureContainer` (`packages/sandbox/src/docker/docker-sandbox.ts`). For a feature positioned as a "hard boundary for untrusted/multi-tenant," these are table stakes: a hostile agent can currently fork-bomb the host, run privileged-capability operations, mutate the container root fs, and run unbounded-time commands.
+
+This is Tier 1 of a hardening effort: the high-value, in-place runtime hardening that needs no new isolation substrate. (Stronger substrates — gVisor/Kata/microVM providers — remain the provider-agnostic escape hatch, out of scope here.)
+
+## Decisions (from brainstorming)
+
+1. **Hardened by default.** The structural flags are on by default (near-zero breakage). The sandbox shipped one day prior (0.8.6) → effectively no users to break, and pre-1.0 favors the correct default.
+2. **Run-as-non-root by default, done properly now** (not deferred/opt-in) via **Architecture B**: no root in the container's steady state.
+3. **Per-command timeout: enforce only when set** (`resources.timeoutMs`). A default would break legitimate long installs/builds; explicit opt-in with a clear timeout error is the chosen tradeoff.
+4. **Hardening is provider-agnostic policy *intent*, in the contract** (`SandboxPolicy.security`) — NOT Docker-coupled options. Each provider translates intent → mechanism; the posture stays consistent for future providers and is verifiable via conformance.
+5. **Prove it adversarially against real Docker** — property/attack-based conformance in the gated `sandbox-docker` lane, not just arg-string unit assertions.
+
+## Design
+
+### 1. Contract: `SandboxPolicy.security` intent (`@dawn-ai/workspace`)
+
+Extend the contract with a provider-agnostic security intent object. `pidsLimit` lives here (it is hardened-by-default, unlike the opt-in `resources` caps). `timeoutMs` stays in `resources` (a quantitative cap, alongside memory/cpu) and simply gets wired.
+
+```ts
+// packages/workspace/src/sandbox-types.ts
+export interface SandboxSecurityPolicy {
+  /** Drop all Linux capabilities. Default true. */
+  readonly dropAllCapabilities?: boolean
+  /** Block privilege escalation via setuid/setgid. Default true. */
+  readonly noNewPrivileges?: boolean
+  /** Immutable root filesystem; the workspace + scratch stay writable. Default true. */
+  readonly readOnlyRootFilesystem?: boolean
+  /** Run the workload as a non-root user. Default true → uid/gid 1000:1000.
+   *  `false` runs as the image default (typically root). */
+  readonly runAsNonRoot?: boolean | { readonly uid: number; readonly gid: number }
+  /** Max process count (fork-bomb defense). Default 512. */
+  readonly pidsLimit?: number
+}
+
+export interface SandboxPolicy {
+  readonly network: /* unchanged */
+  readonly env?: Readonly<Record<string, string>>
+  readonly resources?: {
+    readonly memoryMb?: number
+    readonly cpus?: number
+    readonly timeoutMs?: number   // per-command wall clock; now ENFORCED when set
+  }
+  readonly security?: SandboxSecurityPolicy   // NEW
+}
+```
+
+`SandboxConfig` (author-facing, same file) gains `readonly security?: SandboxSecurityPolicy`. `resolveSandboxManager` (cli) passes `config.security` straight into the built `SandboxPolicy` (like `env`/`resources` today) — no defaulting in the cli.
+
+**Secure-by-default is enforced at the provider**, treating each unset field as its secure default. Rationale: `dockerSandbox` used directly (tests, conformance, non-manager callers) is then hardened without a manager in the loop; the *absence* of `security` means *fully hardened*, and authors relax explicitly.
+
+### 2. Docker translation (`dockerSandbox`)
+
+Resolve the effective posture once per `acquire`, defaulting unset fields:
+
+```ts
+const sec = policy.security ?? {}
+const dropCaps  = sec.dropAllCapabilities   ?? true
+const noNewPriv = sec.noNewPrivileges       ?? true
+const readOnly  = sec.readOnlyRootFilesystem ?? true
+const pids      = sec.pidsLimit             ?? 512
+const user =                                     // undefined → root (image default)
+  sec.runAsNonRoot === false ? undefined
+  : typeof sec.runAsNonRoot === "object" ? sec.runAsNonRoot
+  : { uid: 1000, gid: 1000 }                     // true or unset → default non-root
+```
+
+`ensureContainer` (create path) gains, appended to the existing `docker run -d` args:
+
+```
+...(dropCaps  ? ["--cap-drop", "ALL"] : [])
+...(noNewPriv ? ["--security-opt", "no-new-privileges"] : [])
+["--pids-limit", String(pids)]
+...(readOnly  ? ["--read-only", "--tmpfs", "/tmp", "--tmpfs", "/run"] : [])
+...(user      ? ["--user", `${user.uid}:${user.gid}`, "-e", "HOME=/workspace"] : [])
+```
+
+- `/workspace` is a mounted volume → writable regardless of `--read-only`; `/tmp` + `/run` are tmpfs scratch. tmpfs size is bounded by `--memory` when set (tmpfs pages count against the container memory cgroup); an explicit tmpfs size cap is a later refinement.
+- `HOME=/workspace` (only when non-root) gives tools a writable, persistent home under the read-only root (npm/git config, caches). Chosen over a tmpfs home for persistence + simplicity.
+
+### 3. Architecture B — non-root with volume ownership (no steady-state root)
+
+A fresh named volume mounts `root:root`; a non-root workload cannot write `/workspace`. Fix with a **create-only, ephemeral, root chown-init** — the *only* root that ever runs, and it takes no agent input:
+
+In `ensureContainer`, on the **create** branch (container absent), when `user` is set:
+1. Probe volume existence: `docker volume inspect <volumeName>` (exit 0 = exists).
+2. **If the volume is absent** (truly fresh): run the chown-init
+   `docker run --rm --user 0:0 -v <vol>:/workspace <image> sh -c 'mkdir -p /workspace && chown <uid>:<gid> /workspace'`.
+   Non-zero exit → throw an actionable "Sandbox unavailable: could not initialize workspace ownership … run `dawn check`" error.
+3. **If the volume exists** (reattach after container reap/restart): **skip** the chown-init — ownership already correct; a `chown -R` on a populated volume would be wrong and slow.
+4. Start the keeper with `--user <uid>:<gid>` (+ the flags from §2).
+
+Every fs op (`dockerFilesystem`) and command (`dockerExec`) then runs as the keeper's non-root user automatically (`docker exec` inherits the run `--user`) — **no per-exec `--user`, and nothing in the live container graph is root.** `release`/`destroy` unchanged. Auditable claim: *nothing in a Dawn sandbox runs as root except a create-time, no-input chown.*
+
+`runAsNonRoot: false` → no `--user`, no chown-init, no `HOME` override (image default, typically root).
+
+### 4. Per-command timeout (`dockerExec`)
+
+Thread the timeout into the exec backend; the provider passes it from policy:
+
+```ts
+// docker-sandbox.ts acquire:
+exec: dockerExec(docker, container, { timeoutMs: policy.resources?.timeoutMs })
+```
+
+When `timeoutMs` is set, wrap the command with coreutils `timeout` **inside the container** so the actual process is killed (client-side `docker exec` abort alone leaves the in-container process running):
+
+```
+docker exec <c> timeout <ceil(ms/1000)>s sh -c '<envPrefix><cdPrefix><command>'
+```
+
+`timeout` exits `124` on kill → `runCommand` returns that result with `stderr` annotated `Command timed out after <ms>ms (resources.timeoutMs).` (Surfaced as a normal non-zero exit the agent sees — not thrown; consistent with how `runBash` reports failures.) When `timeoutMs` is unset, the command runs exactly as today. `ctx.signal` remains wired for cancel. Filesystem ops are **not** timeout-wrapped (fast + internal; `maxBytes` guards large reads).
+
+### 5. `dawn check`
+
+No new pass required — `collectSandboxErrors` already runs `provider.preflight()`. Add a lightweight config-shape validation for the new `security` fields inside `collectSandboxErrors` (e.g. `pidsLimit` must be a positive integer; `runAsNonRoot` object needs numeric `uid`/`gid`) so misconfig fails at check-time.
+
+## Testing
+
+Two layers, matching the sandbox's existing split.
+
+**Unit (fake `Docker`, no daemon) — `docker-sandbox.unit.test.ts` / `docker-exec` tests:**
+- Default `acquire` run args include `--cap-drop ALL`, `--security-opt no-new-privileges`, `--pids-limit 512`, `--read-only --tmpfs /tmp --tmpfs /run`, `--user 1000:1000`, `-e HOME=/workspace`.
+- Each opt-out removes exactly its flag(s): `dropAllCapabilities:false`, `readOnlyRootFilesystem:false`, `runAsNonRoot:false` (also drops `--user`/HOME/chown-init), custom `{uid,gid}`, custom `pidsLimit`.
+- **Chown-init gating:** volume-absent (inspect fails) + non-root → a `docker run --rm --user 0:0 … chown` is issued before the keeper `run`; volume-present → NO chown-init; `runAsNonRoot:false` → NO chown-init.
+- `dockerExec` wraps in `timeout Ns sh -c` iff `timeoutMs` set; exit 124 → annotated stderr; unset → unwrapped.
+
+**Adversarial hardening conformance (REAL Docker, gated `sandbox-docker` lane only):** a new suite (fakeSandbox can't enforce kernel controls, so these are Docker-lane-only, distinct from the cross-provider behavioral conformance which stays as-is and must still pass under hardened defaults):
+- Fork bomb (`:(){ :|:& };:` / a bounded process-spawn loop) → hits `--pids-limit`, host unaffected, command fails.
+- Write `/etc/passwd` → fails (read-only root); write `/workspace/f` and `/tmp/f` → succeed.
+- `id -u` → non-zero (non-root); an attempt to use a dropped capability (e.g. `chown` a root-owned path outside workspace, or `mount`) → denied.
+- `sleep 999` with `resources.timeoutMs: 500` → returns exit 124 within a few seconds; a follow-up `ps` shows the process gone (killed in-container, not just client-detached).
+- Restart durability + isolation (existing conformance) still green under hardened defaults — proof normal workloads survive.
+
+Local run of the adversarial lane needs a working Docker daemon (`DAWN_TEST_DOCKER=1`); CI ubuntu runners are the authoritative gate (this dev machine's daemon can't pull images).
+
+## Packaging & rollout
+
+- **Changeset: patch** (`@dawn-ai/workspace` types, `@dawn-ai/sandbox` provider, `@dawn-ai/cli` resolve-passthrough). Fixed-group 0.x → patch keeps it off 1.0.0.
+- **Docs (`/docs/sandbox`):** document the hardened defaults table, the opt-outs, non-root + `HOME=/workspace`, the timeout, and the guidance: *bake system deps into your image; mutate only your workspace at runtime.* Update the honest-scope section — `deny` network + `cap-drop ALL` + read-only + non-root materially raise the bar, still Docker's boundary (not a microVM); the provider-agnostic `security` intent is what a stronger substrate would satisfy.
+- **Rollout:** behavior change ONLY for apps already using `sandbox` (they get hardened automatically). No sandbox config → still zero change.
+
+## Honest scope / breakage (documented)
+
+Hardened defaults **will** break: runtime `apt`/`npm -g`/system-directory writes (read-only + non-root), and images that require root or a specific user. This is correct behavior for a hard boundary. Project-local installs (into `/workspace`) and normal tool use continue to work. Escape hatches: `readOnlyRootFilesystem:false`, `runAsNonRoot:false`, or a custom `{uid,gid}`. The guidance is standard container hygiene.
+
+## Out of scope (later tiers / follow-ups)
+
+- Disk quota (`--storage-opt size=`) — requires xfs+pquota backing storage most Docker installs lack; belongs behind a provider capability probe.
+- tmpfs explicit size caps, seccomp/AppArmor profile customization, user-namespace remapping.
+- Non-Docker hardened providers (gVisor/Kata/cloud microVM) — the `security` intent is the seam they'd implement.
+- The three prior sandbox follow-up chips (idle-reaper turn tracking, offloading-inside-sandbox, name-collision hardening) — independent.
+
+## Risks
+
+- **Non-root breakage surprise** — mitigated by the opt-outs, `HOME=/workspace`, docs, and near-zero current userbase.
+- **Chown-init correctness** — must run on true-create only (volume-absence gate), never on reattach; covered by the gating unit tests + the real-Docker restart-durability conformance.
+- **`timeout`/`chown` binary availability** — coreutils `timeout` + `chown` are in essentially all base images; the honest-scope note tells authors their image needs a POSIX shell + coreutils (already implied by `sh -c`).
+- **Provider-default drift** — defaults live in the provider; a future provider must re-apply the same secure defaults. The adversarial conformance suite is the guardrail (any provider running it must pass hardened).

--- a/packages/cli/src/lib/runtime/collect-sandbox-errors.ts
+++ b/packages/cli/src/lib/runtime/collect-sandbox-errors.ts
@@ -41,7 +41,11 @@ export async function collectSandboxErrors(
         `dawn.config sandbox.security.pidsLimit must be a positive integer (got: ${String(sec.pidsLimit)}).`,
       )
     }
-    if (typeof sec.runAsNonRoot === "object" && sec.runAsNonRoot !== null) {
+    if (sec.runAsNonRoot === null) {
+      errors.push(
+        "dawn.config sandbox.security.runAsNonRoot must be a boolean or a { uid, gid } object, not null.",
+      )
+    } else if (typeof sec.runAsNonRoot === "object") {
       const { uid, gid } = sec.runAsNonRoot
       if (!Number.isInteger(uid) || uid < 0 || !Number.isInteger(gid) || gid < 0) {
         errors.push(

--- a/packages/cli/src/lib/runtime/collect-sandbox-errors.ts
+++ b/packages/cli/src/lib/runtime/collect-sandbox-errors.ts
@@ -34,5 +34,21 @@ export async function collectSandboxErrors(
       )
     }
   }
+  const sec = sandbox.security
+  if (sec) {
+    if (sec.pidsLimit !== undefined && (!Number.isInteger(sec.pidsLimit) || sec.pidsLimit <= 0)) {
+      errors.push(
+        `dawn.config sandbox.security.pidsLimit must be a positive integer (got: ${String(sec.pidsLimit)}).`,
+      )
+    }
+    if (typeof sec.runAsNonRoot === "object" && sec.runAsNonRoot !== null) {
+      const { uid, gid } = sec.runAsNonRoot
+      if (!Number.isInteger(uid) || uid < 0 || !Number.isInteger(gid) || gid < 0) {
+        errors.push(
+          "dawn.config sandbox.security.runAsNonRoot uid/gid must be non-negative integers.",
+        )
+      }
+    }
+  }
   return errors
 }

--- a/packages/cli/src/lib/runtime/resolve-sandbox.ts
+++ b/packages/cli/src/lib/runtime/resolve-sandbox.ts
@@ -19,6 +19,7 @@ export async function resolveSandboxManager(appRoot: string): Promise<SandboxMan
     network: sandbox.network ?? DEFAULT_NETWORK,
     ...(sandbox.env ? { env: sandbox.env } : {}),
     ...(sandbox.resources ? { resources: sandbox.resources } : {}),
+    ...(sandbox.security ? { security: sandbox.security } : {}),
   }
   return new SandboxManager({
     provider: sandbox.provider,

--- a/packages/cli/test/collect-sandbox-errors.test.ts
+++ b/packages/cli/test/collect-sandbox-errors.test.ts
@@ -72,6 +72,13 @@ describe("collectSandboxErrors: security shape", () => {
     expect(errors.join("\n")).toMatch(/uid|gid/)
   })
 
+  test("runAsNonRoot: null → error (must be boolean or object, not null)", async () => {
+    const errors = await collectSandboxErrors({
+      sandbox: { provider: ok, security: { runAsNonRoot: null as never } },
+    })
+    expect(errors.join("\n")).toMatch(/not null/)
+  })
+
   test("valid security → no errors", async () => {
     expect(
       await collectSandboxErrors({

--- a/packages/cli/test/collect-sandbox-errors.test.ts
+++ b/packages/cli/test/collect-sandbox-errors.test.ts
@@ -48,3 +48,38 @@ describe("collectSandboxErrors", () => {
     expect(await collectSandboxErrors({ sandbox: { provider } })).toEqual([])
   })
 })
+
+describe("collectSandboxErrors: security shape", () => {
+  const ok = {
+    name: "p",
+    acquire: async () => ({}) as never,
+    release: async () => {},
+    destroy: async () => {},
+    preflight: async () => ({ ok: true }),
+  }
+
+  test("pidsLimit must be a positive integer", async () => {
+    const errors = await collectSandboxErrors({
+      sandbox: { provider: ok, security: { pidsLimit: 0 } },
+    })
+    expect(errors.join("\n")).toMatch(/pidsLimit/)
+  })
+
+  test("runAsNonRoot object needs numeric uid/gid", async () => {
+    const errors = await collectSandboxErrors({
+      sandbox: { provider: ok, security: { runAsNonRoot: { uid: -1, gid: 0 } as never } },
+    })
+    expect(errors.join("\n")).toMatch(/uid|gid/)
+  })
+
+  test("valid security → no errors", async () => {
+    expect(
+      await collectSandboxErrors({
+        sandbox: {
+          provider: ok,
+          security: { pidsLimit: 256, runAsNonRoot: { uid: 1000, gid: 1000 } },
+        },
+      }),
+    ).toEqual([])
+  })
+})

--- a/packages/sandbox/src/docker/docker-exec.ts
+++ b/packages/sandbox/src/docker/docker-exec.ts
@@ -6,7 +6,11 @@ function shellQuote(s: string): string {
 }
 
 /** ExecBackend that runs commands inside a docker container via `docker exec sh -c`. */
-export function dockerExec(docker: Docker, container: string): ExecBackend {
+export function dockerExec(
+  docker: Docker,
+  container: string,
+  opts: { readonly timeoutMs?: number } = {},
+): ExecBackend {
   return {
     async runCommand(args, ctx: BackendContext) {
       const envPrefix = args.env
@@ -22,13 +26,20 @@ export function dockerExec(docker: Docker, container: string): ExecBackend {
             .join("")
         : ""
       const cdPrefix = args.cwd ? `cd ${shellQuote(args.cwd)} && ` : ""
-      const r = await docker.exec(
-        container,
-        ["sh", "-c", `${envPrefix}${cdPrefix}${args.command}`],
-        {
-          signal: ctx.signal,
-        },
-      )
+      const full = `${envPrefix}${cdPrefix}${args.command}`
+      const shArgs = ["sh", "-c", full]
+      const argv =
+        opts.timeoutMs !== undefined
+          ? ["timeout", `${Math.ceil(opts.timeoutMs / 1000)}s`, ...shArgs]
+          : shArgs
+      const r = await docker.exec(container, argv, { signal: ctx.signal })
+      if (opts.timeoutMs !== undefined && r.exitCode === 124) {
+        return {
+          stdout: r.stdout,
+          stderr: `${r.stderr}${r.stderr ? "\n" : ""}Command timed out after ${opts.timeoutMs}ms (resources.timeoutMs).`,
+          exitCode: 124,
+        }
+      }
       return { stdout: r.stdout, stderr: r.stderr, exitCode: r.exitCode }
     },
   }

--- a/packages/sandbox/src/docker/docker-exec.ts
+++ b/packages/sandbox/src/docker/docker-exec.ts
@@ -29,15 +29,17 @@ export function dockerExec(
       const cdPrefix = cwd ? `cd ${shellQuote(cwd)} && ` : ""
       const full = `${envPrefix}${cdPrefix}${args.command}`
       const shArgs = ["sh", "-c", full]
-      const argv =
-        opts.timeoutMs !== undefined
-          ? ["timeout", `${Math.ceil(opts.timeoutMs / 1000)}s`, ...shArgs]
-          : shArgs
+      // `timeout` has second granularity, so round up to the enforced ceiling and
+      // report THAT (not the raw ms) — otherwise `timeoutMs: 500` reports "500ms"
+      // while the process actually gets a full 1s.
+      const timeoutSecs =
+        opts.timeoutMs !== undefined ? Math.ceil(opts.timeoutMs / 1000) : undefined
+      const argv = timeoutSecs !== undefined ? ["timeout", `${timeoutSecs}s`, ...shArgs] : shArgs
       const r = await docker.exec(container, argv, { signal: ctx.signal })
-      if (opts.timeoutMs !== undefined && r.exitCode === 124) {
+      if (timeoutSecs !== undefined && r.exitCode === 124) {
         return {
           stdout: r.stdout,
-          stderr: `${r.stderr}${r.stderr ? "\n" : ""}Command timed out after ${opts.timeoutMs}ms (resources.timeoutMs).`,
+          stderr: `${r.stderr}${r.stderr ? "\n" : ""}Command timed out after ${timeoutSecs}s (resources.timeoutMs: ${opts.timeoutMs}ms).`,
           exitCode: 124,
         }
       }

--- a/packages/sandbox/src/docker/docker-exec.ts
+++ b/packages/sandbox/src/docker/docker-exec.ts
@@ -25,7 +25,8 @@ export function dockerExec(
             })
             .join("")
         : ""
-      const cdPrefix = args.cwd ? `cd ${shellQuote(args.cwd)} && ` : ""
+      const cwd = args.cwd ?? ctx.workspaceRoot
+      const cdPrefix = cwd ? `cd ${shellQuote(cwd)} && ` : ""
       const full = `${envPrefix}${cdPrefix}${args.command}`
       const shArgs = ["sh", "-c", full]
       const argv =

--- a/packages/sandbox/src/docker/docker-sandbox.ts
+++ b/packages/sandbox/src/docker/docker-sandbox.ts
@@ -60,7 +60,10 @@ export function dockerSandbox(opts: DockerSandboxOptions): SandboxProvider {
     const user: { uid: number; gid: number } | undefined =
       sec.runAsNonRoot === false
         ? undefined
-        : typeof sec.runAsNonRoot === "object"
+        : // `typeof null === "object"`, so guard against it explicitly — a raw-parsed
+          // config could carry null (the TS type excludes it); fail SAFE to the
+          // hardened non-root default rather than silently running as the image's root.
+          typeof sec.runAsNonRoot === "object" && sec.runAsNonRoot !== null
           ? sec.runAsNonRoot
           : { uid: 1000, gid: 1000 }
 
@@ -75,10 +78,12 @@ export function dockerSandbox(opts: DockerSandboxOptions): SandboxProvider {
 
     // Architecture B (no steady-state root): a fresh named volume mounts
     // root:root, so a non-root keeper cannot write /workspace. Fix it with a
-    // CREATE-ONLY, VOLUME-ABSENCE-GATED, ephemeral (`--rm`) root chown — the
+    // CREATE-ONLY, VOLUME-ABSENCE-CHECKED, ephemeral (`--rm`) root chown — the
     // only root that ever runs, and it takes no agent input. On reattach (the
     // volume already exists) this is skipped so a populated volume is never
     // re-chowned. Skipped entirely when runAsNonRoot:false (`user` undefined).
+    // The inspect→chown is not atomic, but chown is idempotent, so two racing
+    // acquires for the same fresh thread both converge on the same ownership.
     if (user) {
       const volExists = await docker.run(["volume", "inspect", volumeName(threadId)], { signal })
       if (volExists.exitCode !== 0) {

--- a/packages/sandbox/src/docker/docker-sandbox.ts
+++ b/packages/sandbox/src/docker/docker-sandbox.ts
@@ -115,8 +115,6 @@ export function dockerSandbox(opts: DockerSandboxOptions): SandboxProvider {
         `dawn.sandbox=${sanitize(threadId)}`,
         "-v",
         `${volumeName(threadId)}:${ROOT}`,
-        "-w",
-        ROOT,
         ...net,
         ...envArgs,
         ...limits,

--- a/packages/sandbox/src/docker/docker-sandbox.ts
+++ b/packages/sandbox/src/docker/docker-sandbox.ts
@@ -47,6 +47,32 @@ export function dockerSandbox(opts: DockerSandboxOptions): SandboxProvider {
       ...(res?.memoryMb ? ["--memory", `${res.memoryMb}m`] : []),
       ...(res?.cpus ? ["--cpus", String(res.cpus)] : []),
     ]
+
+    // Hardened-by-default posture: an unset field means SECURE default, not
+    // "off". Authors relax explicitly via policy.security. `user` is resolved
+    // here (rather than inline in the argv) so a later create-path addition
+    // (volume chown-init) can reuse the same resolved uid/gid.
+    const sec = policy.security ?? {}
+    const dropCaps = sec.dropAllCapabilities ?? true
+    const noNewPriv = sec.noNewPrivileges ?? true
+    const readOnly = sec.readOnlyRootFilesystem ?? true
+    const pids = sec.pidsLimit ?? 512
+    const user: { uid: number; gid: number } | undefined =
+      sec.runAsNonRoot === false
+        ? undefined
+        : typeof sec.runAsNonRoot === "object"
+          ? sec.runAsNonRoot
+          : { uid: 1000, gid: 1000 }
+
+    const hardening: string[] = [
+      ...(dropCaps ? ["--cap-drop", "ALL"] : []),
+      ...(noNewPriv ? ["--security-opt", "no-new-privileges"] : []),
+      "--pids-limit",
+      String(pids),
+      ...(readOnly ? ["--read-only", "--tmpfs", "/tmp", "--tmpfs", "/run"] : []),
+      ...(user ? ["--user", `${user.uid}:${user.gid}`, "-e", "HOME=/workspace"] : []),
+    ]
+
     const created = await docker.run(
       [
         "run",
@@ -62,6 +88,7 @@ export function dockerSandbox(opts: DockerSandboxOptions): SandboxProvider {
         ...net,
         ...envArgs,
         ...limits,
+        ...hardening,
         opts.image,
         "sleep",
         "infinity",

--- a/packages/sandbox/src/docker/docker-sandbox.ts
+++ b/packages/sandbox/src/docker/docker-sandbox.ts
@@ -73,6 +73,38 @@ export function dockerSandbox(opts: DockerSandboxOptions): SandboxProvider {
       ...(user ? ["--user", `${user.uid}:${user.gid}`, "-e", "HOME=/workspace"] : []),
     ]
 
+    // Architecture B (no steady-state root): a fresh named volume mounts
+    // root:root, so a non-root keeper cannot write /workspace. Fix it with a
+    // CREATE-ONLY, VOLUME-ABSENCE-GATED, ephemeral (`--rm`) root chown — the
+    // only root that ever runs, and it takes no agent input. On reattach (the
+    // volume already exists) this is skipped so a populated volume is never
+    // re-chowned. Skipped entirely when runAsNonRoot:false (`user` undefined).
+    if (user) {
+      const volExists = await docker.run(["volume", "inspect", volumeName(threadId)], { signal })
+      if (volExists.exitCode !== 0) {
+        const init = await docker.run(
+          [
+            "run",
+            "--rm",
+            "--user",
+            "0:0",
+            "-v",
+            `${volumeName(threadId)}:${ROOT}`,
+            opts.image,
+            "sh",
+            "-c",
+            `mkdir -p ${ROOT} && chown ${user.uid}:${user.gid} ${ROOT}`,
+          ],
+          { signal },
+        )
+        if (init.exitCode !== 0) {
+          throw new Error(
+            `Sandbox unavailable: could not initialize workspace ownership for thread "${threadId}": ${init.stderr.trim() || "unknown error"}. Run \`dawn check\`.`,
+          )
+        }
+      }
+    }
+
     const created = await docker.run(
       [
         "run",

--- a/packages/sandbox/src/docker/docker-sandbox.ts
+++ b/packages/sandbox/src/docker/docker-sandbox.ts
@@ -83,7 +83,13 @@ export function dockerSandbox(opts: DockerSandboxOptions): SandboxProvider {
       return {
         threadId,
         filesystem: dockerFilesystem(docker, container),
-        exec: dockerExec(docker, container),
+        exec: dockerExec(
+          docker,
+          container,
+          policy.resources?.timeoutMs !== undefined
+            ? { timeoutMs: policy.resources.timeoutMs }
+            : {},
+        ),
         workspaceRoot: ROOT,
       }
     },

--- a/packages/sandbox/test/docker-backends.test.ts
+++ b/packages/sandbox/test/docker-backends.test.ts
@@ -176,8 +176,19 @@ describe("dockerExec timeout", () => {
     )
     const r = await exec.runCommand({ command: "sleep 999" }, ctx)
     expect(r.exitCode).toBe(124)
-    expect(r.stderr).toMatch(/timed out after 500ms/i)
-    expect(r.stderr).toMatch(/resources\.timeoutMs/)
+    expect(r.stderr).toMatch(/timed out after 1s/i) // ceil(500/1000)
+    expect(r.stderr).toMatch(/resources\.timeoutMs: 500ms/)
+  })
+
+  test("exit 124 stderr reports the rounded-up ceiling AND the raw configured ms", async () => {
+    const exec = dockerExec(
+      fakeDocker({ exec: async () => ({ stdout: "", stderr: "", exitCode: 124 }) }),
+      "c1",
+      { timeoutMs: 500 },
+    )
+    const r = await exec.runCommand({ command: "sleep 999" }, ctx)
+    expect(r.stderr).toContain("after 1s")
+    expect(r.stderr).toContain("resources.timeoutMs: 500ms")
   })
 
   test("still validates env keys (regression: keep existing behavior)", async () => {

--- a/packages/sandbox/test/docker-backends.test.ts
+++ b/packages/sandbox/test/docker-backends.test.ts
@@ -111,3 +111,48 @@ describe("dockerExec", () => {
     ).rejects.toThrow(/Invalid environment variable name "BAD KEY;x"/)
   })
 })
+
+describe("dockerExec timeout", () => {
+  test("wraps the command in `timeout Ns` when timeoutMs is set", async () => {
+    let seen: readonly string[] = []
+    const exec = dockerExec(
+      fakeDocker({ exec: async (_c, cmd) => { seen = cmd; return { stdout: "", stderr: "", exitCode: 0 } } }),
+      "c1",
+      { timeoutMs: 1500 },
+    )
+    await exec.runCommand({ command: "echo hi" }, ctx)
+    expect(seen[0]).toBe("timeout")
+    expect(seen[1]).toBe("2s") // ceil(1500/1000)
+    expect(seen[2]).toBe("sh")
+    expect(seen.join(" ")).toContain("echo hi")
+  })
+
+  test("no timeout wrapping when timeoutMs is unset", async () => {
+    let seen: readonly string[] = []
+    const exec = dockerExec(
+      fakeDocker({ exec: async (_c, cmd) => { seen = cmd; return { stdout: "", stderr: "", exitCode: 0 } } }),
+      "c1",
+    )
+    await exec.runCommand({ command: "echo hi" }, ctx)
+    expect(seen[0]).toBe("sh")
+  })
+
+  test("exit 124 → annotated stderr pointing at the config", async () => {
+    const exec = dockerExec(
+      fakeDocker({ exec: async () => ({ stdout: "", stderr: "", exitCode: 124 }) }),
+      "c1",
+      { timeoutMs: 500 },
+    )
+    const r = await exec.runCommand({ command: "sleep 999" }, ctx)
+    expect(r.exitCode).toBe(124)
+    expect(r.stderr).toMatch(/timed out after 500ms/i)
+    expect(r.stderr).toMatch(/resources\.timeoutMs/)
+  })
+
+  test("still validates env keys (regression: keep existing behavior)", async () => {
+    const exec = dockerExec(fakeDocker({}), "c1", { timeoutMs: 500 })
+    await expect(
+      exec.runCommand({ command: "echo", env: { "BAD KEY;x": "1" } }, ctx),
+    ).rejects.toThrow(/Invalid environment variable name/i)
+  })
+})

--- a/packages/sandbox/test/docker-backends.test.ts
+++ b/packages/sandbox/test/docker-backends.test.ts
@@ -104,6 +104,37 @@ describe("dockerExec", () => {
     expect(r).toEqual({ stdout: "out", stderr: "", exitCode: 0 })
   })
 
+  test("runCommand defaults cwd to ctx.workspaceRoot when args.cwd is absent", async () => {
+    let seen: readonly string[] = []
+    const exec = dockerExec(
+      fakeDocker({
+        exec: async (_c, cmd) => {
+          seen = cmd
+          return { stdout: "", stderr: "", exitCode: 0 }
+        },
+      }),
+      "c1",
+    )
+    await exec.runCommand({ command: "echo hi" }, ctx)
+    expect(seen[2]).toContain("cd '/workspace' &&")
+  })
+
+  test("runCommand uses args.cwd over ctx.workspaceRoot when provided", async () => {
+    let seen: readonly string[] = []
+    const exec = dockerExec(
+      fakeDocker({
+        exec: async (_c, cmd) => {
+          seen = cmd
+          return { stdout: "", stderr: "", exitCode: 0 }
+        },
+      }),
+      "c1",
+    )
+    await exec.runCommand({ command: "echo hi", cwd: "/workspace/sub" }, ctx)
+    expect(seen[2]).toContain("cd '/workspace/sub' &&")
+    expect(seen[2]).not.toContain("cd '/workspace' &&")
+  })
+
   test("runCommand rejects invalid env keys with a clear error", async () => {
     const exec = dockerExec(fakeDocker({}), "c1")
     await expect(

--- a/packages/sandbox/test/docker-sandbox.integration.test.ts
+++ b/packages/sandbox/test/docker-sandbox.integration.test.ts
@@ -27,8 +27,7 @@ describe.skipIf(!enabled)("dockerSandbox (real Docker)", { timeout: 120_000 }, (
       // node:22-slim has node; use node's fetch with a short timeout — no curl dependency.
       const r = await h.exec.runCommand(
         {
-          command:
-            `node -e "fetch('https://registry.npmjs.org/', {signal: AbortSignal.timeout(5000)}).then(()=>{console.log('REACHED');process.exit(0)}).catch(()=>{console.log('BLOCKED');process.exit(7)})"`,
+          command: `node -e "fetch('https://registry.npmjs.org/', {signal: AbortSignal.timeout(5000)}).then(()=>{console.log('REACHED');process.exit(0)}).catch(()=>{console.log('BLOCKED');process.exit(7)})"`,
         },
         ctx(h.workspaceRoot),
       )
@@ -44,10 +43,14 @@ describe.skipIf(!enabled)("dockerSandbox (real Docker)", { timeout: 120_000 }, (
     const threadId = `host-${randomUUID()}`
     try {
       const h = await p.acquire({ threadId, policy: policyDeny, signal: ctx("/").signal })
-      await h.filesystem.writeFile(`${h.workspaceRoot}/host-check.txt`, "sandboxed", ctx(h.workspaceRoot))
-      expect(await h.filesystem.readFile(`${h.workspaceRoot}/host-check.txt`, ctx(h.workspaceRoot))).toBe(
+      await h.filesystem.writeFile(
+        `${h.workspaceRoot}/host-check.txt`,
         "sandboxed",
+        ctx(h.workspaceRoot),
       )
+      expect(
+        await h.filesystem.readFile(`${h.workspaceRoot}/host-check.txt`, ctx(h.workspaceRoot)),
+      ).toBe("sandboxed")
       expect(existsSync("/workspace/host-check.txt")).toBe(false)
       expect(existsSync(`${process.cwd()}/workspace/host-check.txt`)).toBe(false)
     } finally {
@@ -55,7 +58,9 @@ describe.skipIf(!enabled)("dockerSandbox (real Docker)", { timeout: 120_000 }, (
     }
   })
 
-  test("restart durability: release then reacquire reattaches the volume", { timeout: 180_000 }, async () => {
+  test("restart durability: release then reacquire reattaches the volume", {
+    timeout: 180_000,
+  }, async () => {
     const p = dockerSandbox({ image: IMAGE })
     const threadId = `dur-${randomUUID()}`
     try {
@@ -63,7 +68,94 @@ describe.skipIf(!enabled)("dockerSandbox (real Docker)", { timeout: 120_000 }, (
       await h1.filesystem.writeFile(`${h1.workspaceRoot}/persist.txt`, "v1", ctx(h1.workspaceRoot))
       await p.release(threadId) // container gone, volume kept
       const h2 = await p.acquire({ threadId, policy: policyDeny, signal: ctx("/").signal })
-      expect(await h2.filesystem.readFile(`${h2.workspaceRoot}/persist.txt`, ctx(h2.workspaceRoot))).toBe("v1")
+      expect(
+        await h2.filesystem.readFile(`${h2.workspaceRoot}/persist.txt`, ctx(h2.workspaceRoot)),
+      ).toBe("v1")
+    } finally {
+      await p.destroy(threadId)
+    }
+  })
+
+  // Adversarial hardening conformance: these tests actually attempt the abuse
+  // (fork bomb, /etc write, non-root escalation, timeout overrun) and assert
+  // containment. fakeSandbox can't enforce kernel controls (caps/pids/
+  // read-only/non-root), so these properties are Docker-lane-only.
+
+  test("hardened defaults contain a fork bomb (pids-limit)", { timeout: 180_000 }, async () => {
+    const p = dockerSandbox({ image: IMAGE })
+    const threadId = `fork-${randomUUID()}`
+    try {
+      const h = await p.acquire({ threadId, policy: policyDeny, signal: ctx("/").signal })
+      const r = await h.exec.runCommand(
+        { command: "for i in $(seq 1 2000); do sleep 30 & done; echo done" },
+        ctx(h.workspaceRoot),
+      )
+      expect(typeof r.exitCode).toBe("number")
+      // container still responsive → the host/container survived the spawn storm
+      const alive = await h.exec.runCommand({ command: "echo alive" }, ctx(h.workspaceRoot))
+      expect(alive.stdout).toContain("alive")
+    } finally {
+      await p.destroy(threadId)
+    }
+  })
+
+  test("read-only root blocks /etc writes; workspace + /tmp writable", {
+    timeout: 120_000,
+  }, async () => {
+    const p = dockerSandbox({ image: IMAGE })
+    const threadId = `ro-${randomUUID()}`
+    try {
+      const h = await p.acquire({ threadId, policy: policyDeny, signal: ctx("/").signal })
+      const etc = await h.exec.runCommand(
+        { command: "echo x > /etc/dawn-probe" },
+        ctx(h.workspaceRoot),
+      )
+      expect(etc.exitCode).not.toBe(0)
+      const ws = await h.exec.runCommand(
+        { command: "echo x > /workspace/probe && echo ok" },
+        ctx(h.workspaceRoot),
+      )
+      expect(ws.stdout).toContain("ok")
+      const tmp = await h.exec.runCommand(
+        { command: "echo x > /tmp/probe && echo ok" },
+        ctx(h.workspaceRoot),
+      )
+      expect(tmp.stdout).toContain("ok")
+    } finally {
+      await p.destroy(threadId)
+    }
+  })
+
+  test("runs as non-root by default", { timeout: 120_000 }, async () => {
+    const p = dockerSandbox({ image: IMAGE })
+    const threadId = `nr-${randomUUID()}`
+    try {
+      const h = await p.acquire({ threadId, policy: policyDeny, signal: ctx("/").signal })
+      const r = await h.exec.runCommand({ command: "id -u" }, ctx(h.workspaceRoot))
+      expect(r.stdout.trim()).toBe("1000")
+    } finally {
+      await p.destroy(threadId)
+    }
+  })
+
+  test("per-command timeout kills the in-container process (exit 124)", {
+    timeout: 120_000,
+  }, async () => {
+    const p = dockerSandbox({ image: IMAGE })
+    const threadId = `to-${randomUUID()}`
+    try {
+      const h = await p.acquire({
+        threadId,
+        policy: { network: { mode: "deny" }, resources: { timeoutMs: 500 } },
+        signal: ctx("/").signal,
+      })
+      const r = await h.exec.runCommand({ command: "sleep 999" }, ctx(h.workspaceRoot))
+      expect(r.exitCode).toBe(124)
+      const ps = await h.exec.runCommand(
+        { command: "ps -e -o args= 2>/dev/null | grep -c 'sleep 999' || true" },
+        ctx(h.workspaceRoot),
+      )
+      expect(ps.stdout.trim()).toBe("0")
     } finally {
       await p.destroy(threadId)
     }

--- a/packages/sandbox/test/docker-sandbox.unit.test.ts
+++ b/packages/sandbox/test/docker-sandbox.unit.test.ts
@@ -156,6 +156,15 @@ describe("dockerSandbox hardening flags", () => {
     expect(j).toContain("--pids-limit 128")
   })
 
+  test("keeper `run -d` does NOT set -w (so Docker can't stomp the chown'd /workspace ownership)", async () => {
+    const { docker, runs } = recordingDocker()
+    const p = dockerSandbox({ image: "node:22-slim", docker })
+    await p.acquire({ threadId: "abc", policy: { network: { mode: "deny" } }, signal: signal() })
+    const keeper = runs.find((r) => r[0] === "run" && r.includes("-d")) ?? []
+    expect(keeper).not.toContain("-w")
+    expect(acquireArgs(runs)).not.toContain(" -w ")
+  })
+
   test("custom runAsNonRoot uid/gid", async () => {
     const { docker, runs } = recordingDocker()
     const p = dockerSandbox({ image: "node:22-slim", docker })

--- a/packages/sandbox/test/docker-sandbox.unit.test.ts
+++ b/packages/sandbox/test/docker-sandbox.unit.test.ts
@@ -167,3 +167,58 @@ describe("dockerSandbox hardening flags", () => {
     expect(acquireArgs(runs)).toContain("--user 2000:3000")
   })
 })
+
+describe("dockerSandbox chown-init (Architecture B)", () => {
+  // container absent; `volume inspect` exit encodes existence.
+  function chownRecorder(volumeExists: boolean) {
+    const runs: string[][] = []
+    const docker: Docker = {
+      run: async (args) => {
+        runs.push([...args])
+        if (args[0] === "volume" && args[1] === "inspect") {
+          return { stdout: "", stderr: "", exitCode: volumeExists ? 0 : 1 }
+        }
+        if (args[0] === "ps") return { stdout: "", stderr: "", exitCode: 0 } // container absent
+        return { stdout: "ok", stderr: "", exitCode: 0 }
+      },
+      exec: async () => ({ stdout: "", stderr: "", exitCode: 0 }),
+    }
+    return { docker, runs }
+  }
+  const chownRun = (runs: string[][]) =>
+    runs.find((r) => r[0] === "run" && r.includes("--rm") && r.join(" ").includes("chown"))
+
+  test("volume absent + non-root → chown-init runs as root BEFORE the keeper", async () => {
+    const { docker, runs } = chownRecorder(false)
+    const p = dockerSandbox({ image: "node:22-slim", docker })
+    await p.acquire({ threadId: "abc", policy: { network: { mode: "deny" } }, signal: signal() })
+    const init = chownRun(runs)
+    expect(init).toBeDefined()
+    const j = (init ?? []).join(" ")
+    expect(j).toContain("--user 0:0")
+    expect(j).toContain("dawn-sbx-vol-abc:/workspace")
+    expect(j).toContain("chown 1000:1000 /workspace")
+    const idxInit = runs.findIndex((r) => r === init)
+    const idxKeeper = runs.findIndex((r) => r[0] === "run" && r.includes("-d"))
+    expect(idxInit).toBeGreaterThanOrEqual(0)
+    expect(idxInit).toBeLessThan(idxKeeper)
+  })
+
+  test("volume present → NO chown-init (reattach)", async () => {
+    const { docker, runs } = chownRecorder(true)
+    const p = dockerSandbox({ image: "node:22-slim", docker })
+    await p.acquire({ threadId: "abc", policy: { network: { mode: "deny" } }, signal: signal() })
+    expect(chownRun(runs)).toBeUndefined()
+  })
+
+  test("runAsNonRoot:false → NO chown-init", async () => {
+    const { docker, runs } = chownRecorder(false)
+    const p = dockerSandbox({ image: "node:22-slim", docker })
+    await p.acquire({
+      threadId: "abc",
+      policy: { network: { mode: "deny" }, security: { runAsNonRoot: false } },
+      signal: signal(),
+    })
+    expect(chownRun(runs)).toBeUndefined()
+  })
+})

--- a/packages/sandbox/test/docker-sandbox.unit.test.ts
+++ b/packages/sandbox/test/docker-sandbox.unit.test.ts
@@ -110,3 +110,60 @@ describe("dockerSandbox (unit, no daemon)", () => {
     expect(joined).not.toContain("t/1:x")
   })
 })
+
+describe("dockerSandbox hardening flags", () => {
+  const acquireArgs = (runs: string[][]) => (runs.find((r) => r[0] === "run") ?? []).join(" ")
+
+  test("hardened by default: cap-drop ALL, no-new-privileges, pids-limit 512, read-only + tmpfs, non-root user + HOME", async () => {
+    const { docker, runs } = recordingDocker()
+    const p = dockerSandbox({ image: "node:22-slim", docker })
+    await p.acquire({ threadId: "abc", policy: { network: { mode: "deny" } }, signal: signal() })
+    const j = acquireArgs(runs)
+    expect(j).toContain("--cap-drop ALL")
+    expect(j).toContain("--security-opt no-new-privileges")
+    expect(j).toContain("--pids-limit 512")
+    expect(j).toContain("--read-only")
+    expect(j).toContain("--tmpfs /tmp")
+    expect(j).toContain("--tmpfs /run")
+    expect(j).toContain("--user 1000:1000")
+    expect(j).toContain("HOME=/workspace")
+  })
+
+  test("per-flag opt-outs remove exactly their flags", async () => {
+    const { docker, runs } = recordingDocker()
+    const p = dockerSandbox({ image: "node:22-slim", docker })
+    await p.acquire({
+      threadId: "abc",
+      policy: {
+        network: { mode: "deny" },
+        security: {
+          dropAllCapabilities: false,
+          noNewPrivileges: false,
+          readOnlyRootFilesystem: false,
+          runAsNonRoot: false,
+          pidsLimit: 128,
+        },
+      },
+      signal: signal(),
+    })
+    const j = acquireArgs(runs)
+    expect(j).not.toContain("--cap-drop")
+    expect(j).not.toContain("no-new-privileges")
+    expect(j).not.toContain("--read-only")
+    expect(j).not.toContain("--tmpfs")
+    expect(j).not.toContain("--user")
+    expect(j).not.toContain("HOME=/workspace")
+    expect(j).toContain("--pids-limit 128")
+  })
+
+  test("custom runAsNonRoot uid/gid", async () => {
+    const { docker, runs } = recordingDocker()
+    const p = dockerSandbox({ image: "node:22-slim", docker })
+    await p.acquire({
+      threadId: "abc",
+      policy: { network: { mode: "deny" }, security: { runAsNonRoot: { uid: 2000, gid: 3000 } } },
+      signal: signal(),
+    })
+    expect(acquireArgs(runs)).toContain("--user 2000:3000")
+  })
+})

--- a/packages/sandbox/test/docker-sandbox.unit.test.ts
+++ b/packages/sandbox/test/docker-sandbox.unit.test.ts
@@ -175,6 +175,17 @@ describe("dockerSandbox hardening flags", () => {
     })
     expect(acquireArgs(runs)).toContain("--user 2000:3000")
   })
+
+  test("runAsNonRoot: null (raw-parsed config) still runs non-root — fails safe, not root", async () => {
+    const { docker, runs } = recordingDocker()
+    const p = dockerSandbox({ image: "node:22-slim", docker })
+    await p.acquire({
+      threadId: "abc",
+      policy: { network: { mode: "deny" }, security: { runAsNonRoot: null as never } },
+      signal: signal(),
+    })
+    expect(acquireArgs(runs)).toContain("--user 1000:1000")
+  })
 })
 
 describe("dockerSandbox chown-init (Architecture B)", () => {

--- a/packages/workspace/src/index.ts
+++ b/packages/workspace/src/index.ts
@@ -6,6 +6,7 @@ export type {
   SandboxHandle,
   SandboxPolicy,
   SandboxProvider,
+  SandboxSecurityPolicy,
 } from "./sandbox-types.js"
 export type {
   BackendContext,

--- a/packages/workspace/src/sandbox-types.ts
+++ b/packages/workspace/src/sandbox-types.ts
@@ -18,6 +18,26 @@ export interface SandboxPolicy {
     readonly cpus?: number
     readonly timeoutMs?: number
   }
+  readonly security?: SandboxSecurityPolicy
+}
+
+/**
+ * Provider-agnostic hardening intent. Each provider translates these to its own
+ * mechanism; a field left unset means the provider applies its SECURE default
+ * (all of these default ON/hardened at the Docker provider). Authors relax
+ * explicitly. See the sandbox-hardening spec.
+ */
+export interface SandboxSecurityPolicy {
+  /** Drop all Linux capabilities. Secure default: true. */
+  readonly dropAllCapabilities?: boolean
+  /** Block setuid/setgid privilege escalation. Secure default: true. */
+  readonly noNewPrivileges?: boolean
+  /** Immutable root filesystem (workspace + scratch stay writable). Secure default: true. */
+  readonly readOnlyRootFilesystem?: boolean
+  /** Run as non-root. Secure default: true → uid/gid 1000:1000. `false` = image default (often root). */
+  readonly runAsNonRoot?: boolean | { readonly uid: number; readonly gid: number }
+  /** Max process count (fork-bomb defense). Secure default: 512. */
+  readonly pidsLimit?: number
 }
 
 export interface SandboxHandle {
@@ -54,6 +74,7 @@ export interface SandboxConfig {
   readonly network?: SandboxPolicy["network"]
   readonly env?: SandboxPolicy["env"]
   readonly resources?: SandboxPolicy["resources"]
+  readonly security?: SandboxSecurityPolicy
   /** Manager-level idle reap window. Default 600_000 (10 min). */
   readonly idleTimeoutMs?: number
 }

--- a/packages/workspace/test/sandbox-types.test.ts
+++ b/packages/workspace/test/sandbox-types.test.ts
@@ -4,6 +4,7 @@ import type {
   SandboxHandle,
   SandboxPolicy,
   SandboxProvider,
+  SandboxSecurityPolicy,
 } from "../src/sandbox-types.ts"
 import type { ExecBackend, FilesystemBackend } from "../src/types.ts"
 
@@ -38,5 +39,23 @@ describe("sandbox contract types", () => {
     expect(h.threadId).toBe("t1")
     const cfg: SandboxConfig = { provider }
     expect(cfg.provider.name).toBe("noop")
+  })
+})
+
+describe("sandbox security intent", () => {
+  test("security is optional on the policy and config, with all-optional fields", () => {
+    const sec: SandboxSecurityPolicy = {
+      dropAllCapabilities: true,
+      noNewPrivileges: true,
+      readOnlyRootFilesystem: false,
+      runAsNonRoot: { uid: 1000, gid: 1000 },
+      pidsLimit: 256,
+    }
+    const policy: SandboxPolicy = { network: { mode: "deny" }, security: sec }
+    expect(policy.security?.pidsLimit).toBe(256)
+    const off: SandboxPolicy = { network: { mode: "deny" }, security: { runAsNonRoot: false } }
+    expect(off.security?.runAsNonRoot).toBe(false)
+    const cfg: SandboxConfig = { provider: {} as never, security: sec }
+    expect(cfg.security).toBe(sec)
   })
 })


### PR DESCRIPTION
## Sandbox hardening, tier 1

The per-thread execution sandbox (shipped in 0.8.6) deliberately ran the keeper container with Docker's default posture: full capability set, root user, writable root filesystem, no PID cap, and `resources.timeoutMs` accepted but never enforced. This PR closes that gap — **the Docker provider is now hardened by default**, expressed through a new provider-agnostic `SandboxPolicy.security` intent so a future microVM/gVisor provider satisfies the same contract.

### Hardened by default (each with a per-flag opt-out)

| Control | Flag | Default |
| --- | --- | --- |
| Drop all Linux capabilities | `--cap-drop ALL` | on |
| No privilege escalation | `--security-opt no-new-privileges` | on |
| Process-count cap | `--pids-limit` | 512 |
| Read-only root fs (+ tmpfs `/tmp`,`/run`; workspace stays writable) | `--read-only` | on |
| Run as non-root | `--user 1000:1000` + `HOME=/workspace` | on |
| Per-command timeout | in-container `timeout` (exit 124) | enforced only when `resources.timeoutMs` set |

### Architecture: non-root without steady-state root

A fresh named volume mounts `root:root`, so a non-root process can't write its own `/workspace`. Rather than run anything privileged in the live container graph, the provider does a **create-time, volume-absence-gated, ephemeral** `docker run --rm --user 0:0 … chown 1000:1000 /workspace` to seed ownership once. Nothing in the steady-state runs as root.

The intent object is provider-agnostic — unset fields resolve to the hardened default *at the provider*, so a policy can't accidentally under-harden. `dawn check` validates the `security` shape (positive-integer `pidsLimit`; non-negative-integer `uid`/`gid`).

### Verification

- Full local suite green: `lint`, `build`, `typecheck`, `test` (1031 passed), `check-docs`, and the `verify:harness:framework` ephemeral-Verdaccio lane.
- **Adversarial real-Docker conformance** (gated `sandbox-docker` lane; verified locally on Docker Desktop, 11/11): runs as uid 1000, `/etc` write blocked while workspace + `/tmp` writable, fork-bomb contained by the PID cap, and a per-command timeout kills the in-container process with exit 124.

Found and fixed a latent bug in the process: `docker run -d -w /workspace` recreates the WORKDIR as **root** at container start, stomping the chown — harmless when the keeper was root (0.8.6), fatal once the keeper is non-root. The keeper no longer sets `-w`; exec defaults its cwd to the workspace root via an in-container `cd`, which doesn't trigger the stomp.

Docs: new "Security hardening" section in `sandbox.mdx` with the defaults table, opt-out shape, the bake-deps-into-your-image guidance, and an updated honest-scope section (raised bar, still Docker's boundary, `security` is the seam a stronger substrate satisfies).

Changeset: **patch** for `@dawn-ai/workspace`, `@dawn-ai/sandbox`, `@dawn-ai/cli`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
