### PR TITLE
fix(core): wrap memory tool returns in {result} (avoid JSON-escaped agent content)

### DIFF
--- a/.changeset/memory-result-envelope.md
+++ b/.changeset/memory-result-envelope.md
@@ -1,0 +1,5 @@
+---
+"@dawn-ai/core": patch
+---
+
+Memory `remember`/`recall` tools now return the `{ result }` wrapper shape (like other capability tools) instead of a bare string. Previously the langchain bridge JSON-stringified their returns, so the agent saw quoted, backslash-escaped content — most visibly `recall`'s multi-line list arriving as one quoted string with literal `\n`. The wrapper makes the string the ToolMessage content verbatim.

--- a/packages/core/src/capabilities/built-in/memory.ts
+++ b/packages/core/src/capabilities/built-in/memory.ts
@@ -79,8 +79,11 @@ export function createMemoryMarker(): CapabilityMarker {
             // NOT Date.now() (determinism rule; see module docblock).
             now: mem.now,
           })
-          if (rows.length === 0) return "(no memories found)"
-          return rows.map((r) => `${r.id}: ${r.content}`).join("\n")
+          // Wrap in {result} so the langchain bridge uses the string verbatim as
+          // the ToolMessage content; a bare string hits unwrapToolResult's
+          // JSON.stringify path, quoting it and escaping the newlines below.
+          if (rows.length === 0) return { result: "(no memories found)" }
+          return { result: rows.map((r) => `${r.id}: ${r.content}`).join("\n") }
         },
       }
 
@@ -96,7 +99,8 @@ export function createMemoryMarker(): CapabilityMarker {
             confidence?: number
           }
           const validated = mem.validate(inp.data)
-          if (!validated.ok) return `Rejected: ${validated.errors}`
+          // All returns below wrap in {result} — see the recall tool's note.
+          if (!validated.ok) return { result: `Rejected: ${validated.errors}` }
           const data = validated.value
           const identityKeys = mem.defined.identity ?? DEFAULT_SEMANTIC_IDENTITY
 
@@ -152,7 +156,7 @@ export function createMemoryMarker(): CapabilityMarker {
                   confidence,
                   tags,
                 })
-                return `Updated memory ${target.id}.`
+                return { result: `Updated memory ${target.id}.` }
               }
               // Same identity but different value — supersede. In "ask" mode this
               // is the one write that gates: the agent is contradicting a prior
@@ -169,26 +173,27 @@ export function createMemoryMarker(): CapabilityMarker {
                   newContent: content,
                 })
                 if (!gate.allowed) {
-                  return (
-                    `Kept existing memory ${target.id} ("${target.content}"); ` +
-                    `your contradicting value was not stored (${gate.reason}).`
-                  )
+                  return {
+                    result:
+                      `Kept existing memory ${target.id} ("${target.content}"); ` +
+                      `your contradicting value was not stored (${gate.reason}).`,
+                  }
                 }
               }
               await mem.store.put(record)
               await mem.store.supersede(target.id, id)
-              return `Superseded ${target.id} with ${id}.`
+              return { result: `Superseded ${target.id} with ${id}.` }
             }
 
             // No existing record with same identity — add new active row
             await mem.store.put(record)
-            return `Stored memory ${id}.`
+            return { result: `Stored memory ${id}.` }
           }
 
           // Candidate mode (and "off" never reaches here — remember tool absent):
           // write a candidate; reconciliation happens later at CLI approval.
           await mem.store.put(record)
-          return `Stored memory candidate ${id} (pending approval).`
+          return { result: `Stored memory candidate ${id} (pending approval).` }
         },
       }
 

--- a/packages/core/test/capabilities/memory.test.ts
+++ b/packages/core/test/capabilities/memory.test.ts
@@ -113,11 +113,42 @@ describe("memory capability", () => {
     })
     const c = await createMemoryMarker().load("/r", baseCtx(store))
     const recall = c.tools!.find((t) => t.name === "recall")!
-    const out = (await recall.run(
-      { query: "x" },
+    const out = (await recall.run({ query: "x" }, { signal: new AbortController().signal })) as {
+      result: string
+    }
+    expect(out.result).toContain("m1")
+  })
+  it("wraps tool returns in {result} so the bridge doesn't JSON-quote/escape them", async () => {
+    // Bare-string returns hit unwrapToolResult's JSON.stringify path — the model
+    // then sees a quoted string with literal \n. The {result} wrapper makes the
+    // string the ToolMessage content verbatim.
+    const store = fakeStore()
+    for (const id of ["m1", "m2"]) {
+      store.rows.push({
+        id,
+        namespace: "ws=a|route=/r",
+        status: "active",
+        content: `note ${id}`,
+        data: {},
+        kind: "semantic",
+        tags: [],
+      })
+    }
+    const c = await createMemoryMarker().load("/r", baseCtx(store))
+    const recall = c.tools!.find((t) => t.name === "recall")!
+    const out = (await recall.run({ query: "note" }, { signal: new AbortController().signal })) as {
+      result: string
+    }
+    expect(typeof out.result).toBe("string")
+    expect(out.result).toContain("\n") // real newline between rows, not "\\n"
+    expect(out.result.startsWith('"')).toBe(false) // not a JSON-quoted string
+
+    const remember = c.tools!.find((t) => t.name === "remember")!
+    const stored = (await remember.run(
+      { data: { subject: "s", predicate: "p", value: "v" }, content: "c" },
       { signal: new AbortController().signal },
-    )) as string
-    expect(out).toContain("m1")
+    )) as { result: string }
+    expect(stored.result).toMatch(/Stored memory candidate/)
   })
 
   it("falls back to a permissive data schema when context.memory.schema is not a Zod type", async () => {
@@ -194,8 +225,8 @@ describe("memory capability", () => {
 describe("ask mode", () => {
   const first = { subject: "billing", predicate: "escalate", value: "500" }
   const second = { subject: "billing", predicate: "escalate", value: "750" }
-  const run = (tool: any, data: any, content: string) =>
-    tool.run({ data, content }, { signal: new AbortController().signal })
+  const run = async (tool: any, data: any, content: string) =>
+    (await tool.run({ data, content }, { signal: new AbortController().signal })).result
 
   it("ADD lands active with no gate consulted", async () => {
     const store = fakeStore()


### PR DESCRIPTION
## Summary

Memory's `remember`/`recall` tools returned **bare strings**. The langchain bridge's `unwrapToolResult` sends a bare (non-`{result}`) value to the model as `JSON.stringify(value)` — so the agent saw the strings **quoted and backslash-escaped**. Most visible on `recall`: its multi-line `id: content` list reached the model as a *single quoted string* with literal `\n` between rows, instead of clean lines.

## Fix

Wrap every `remember`/`recall` return in the `{ result: … }` shape — the same convention other capability tools already use (`writeTodos`, `readSkill`, `runBash`, …). `unwrapToolResult` then uses the string as the ToolMessage content **verbatim**.

- Scope is `packages/core/src/capabilities/built-in/memory.ts` + its unit tests. This makes memory *conform* to the established `{result, state?}` capability-tool contract it was the outlier from.
- **No typegen change:** `outputType` describes the *unwrapped* result (e.g. `writeTodos` → `{todos}`, not the wrapper), and memory's unwrapped result is still `string`, so `outputType: "string"` stays correct.
- Considered fixing it broadly in `unwrapToolResult` (pass bare strings through verbatim) but that changes the documented bridge contract for every tool — out of scope; the memory-side fix matches the filed chip.

## Tests

Updated the memory capability tests to the `{result}` contract and added a focused test asserting `recall` returns a wrapped, multi-line string that is **not** JSON-quoted (real `\n`, no leading `"`). Verified no regressions: full `@dawn-ai/core` suite (216) and the `@dawn-ai/testing` memory e2es (110) — the aimock replays match on user turns, not tool-result content, so the cleaner content doesn't disturb fixtures.

Follow-up chip from the long-term-memory work (#250 / #294).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
