### PR TITLE
feat(examples): flagship research demo — server (slice 1)

### DIFF
--- a/docs/superpowers/plans/2026-07-06-research-demo-slice1-server.md
+++ b/docs/superpowers/plans/2026-07-06-research-demo-slice1-server.md
@@ -1,0 +1,493 @@
+# Research Demo — Slice 1 (Server App + Deterministic Tests) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stand up a polished, standalone `examples/research` Dawn server app that dogfoods the research workflow, subagents, tools, memory candidates/approval, planning, offloading, HITL permissions, and an (optional) Docker sandbox — deterministic and green in CI with no API key.
+
+**Architecture:** A new in-repo pnpm workspace package `@dawn-example/research-server` under `examples/research/server`, mirroring the shape of `examples/chat/server`. It **promotes** the existing `packages/devkit/templates/app-research` template (which is the default scaffold) into a concrete, non-`.template` example: workspace deps (`workspace:*`), no mustache, no standalone-scaffold packaging files. Determinism comes from the same `@dawn-ai/testing` `aimock`/`script()` fixture suite the template ships. CI picks it up automatically: turbo runs `build`/`typecheck` for every workspace package, and the root vitest workspace runs the package's test project (exactly as `examples/chat/server` already does).
+
+**Tech Stack:** TypeScript, `@dawn-ai/{sdk,cli,core,langchain,sandbox}`, `@dawn-ai/{evals,testing,config-typescript}`, Vitest, Zod 4, pnpm workspaces, Turbo.
+
+**Scope note:** This is Slice 1 of 4 (see `docs/superpowers/specs/2026-07-06-research-demo-design.md`). Slices 2–4 (web UI + demo mode, scaffold slimming, docs-recipe extraction) are separate plans. Do **not** touch `packages/devkit/templates/app-research` in this slice.
+
+**Working directory:** This plan executes in the existing worktree `.claude/worktrees/zealous-goldberg-ab9dfc` on branch `blove/zealous-goldberg-ab9dfc`. All paths below are relative to the repo root of that worktree.
+
+---
+
+## File Structure
+
+New files under `examples/research/`:
+
+```
+examples/research/
+  README.md                         # brief pointer (root convenience)
+  package.json                      # non-member convenience scripts (server-only for now)
+  server/
+    README.md                       # the tour (adapted from template README)
+    package.json                    # @dawn-example/research-server, workspace:* deps
+    tsconfig.json                   # from template tsconfig.json.template (verbatim)
+    vitest.config.ts                # from examples/chat/server/vitest.config.ts (verbatim)
+    dawn.config.ts                  # from template (verbatim)
+    .gitignore                      # from template gitignore.template (verbatim)
+    .env.example                    # new
+    AGENTS.md                       # from template (verbatim)
+    src/
+      app/research/
+        index.ts                    # from template (verbatim)
+        state.ts                    # from template (verbatim)
+        memory.ts                   # from template (verbatim)
+        memory.md                   # from template (verbatim)
+        plan.md                     # from template (verbatim)
+        subagents/researcher/index.ts   # from template (verbatim)
+        skills/cite-sources/SKILL.md         # from template (verbatim)
+        skills/synthesize-findings/SKILL.md  # from template (verbatim)
+        evals/research-quality.eval.ts       # from template .eval.ts.template (verbatim)
+      tools/searchCorpus.ts         # from template (verbatim)
+      tools/readDoc.ts              # from template (verbatim)
+    test/
+      research.test.ts              # from template research.test.ts.template (verbatim)
+      sandbox-docker.test.ts        # from template sandbox-docker.test.ts.template (verbatim)
+    workspace/
+      AGENTS.md                     # from template (verbatim)
+      corpus/*.md                   # 5 docs from template (verbatim)
+      scripts/fetch-source.mjs      # from template (verbatim)
+```
+
+Modified files:
+
+```
+vitest.workspace.ts                 # add the research server test project
+```
+
+**Not** created (these are standalone-scaffold-only, unnecessary inside the monorepo): `package.json.template` (replaced with concrete), `npmrc.template`, `pnpm-workspace.yaml.template`, and the generated `.dawn/` directory (gitignored, produced at runtime).
+
+---
+
+## Task 1: Server package skeleton — configs + promoted source, install/typecheck/build green
+
+**Files:**
+- Create: `examples/research/package.json`, `examples/research/README.md`
+- Create: `examples/research/server/package.json`, `.env.example`, `README.md`
+- Create (copied verbatim): everything under `examples/research/server/{src,workspace,test-configs}` per the mapping below
+- Modify: root `pnpm-lock.yaml` (implicitly, via `pnpm install`)
+
+- [ ] **Step 1: Create the copied tree from the template**
+
+Run this exact block from the repo root. It copies every verbatim file and renames the `.template` files. It intentionally does NOT copy `package.json.template`, `npmrc.template`, or `pnpm-workspace.yaml.template`.
+
+```bash
+SRC=packages/devkit/templates/app-research
+DST=examples/research/server
+mkdir -p "$DST/src/app/research/subagents/researcher" \
+         "$DST/src/app/research/skills/cite-sources" \
+         "$DST/src/app/research/skills/synthesize-findings" \
+         "$DST/src/app/research/evals" \
+         "$DST/src/tools" \
+         "$DST/test" \
+         "$DST/workspace/corpus" \
+         "$DST/workspace/scripts"
+
+# Root-level app files (verbatim)
+cp "$SRC/dawn.config.ts"        "$DST/dawn.config.ts"
+cp "$SRC/AGENTS.md"             "$DST/AGENTS.md"
+cp "$SRC/tsconfig.json.template" "$DST/tsconfig.json"
+cp "$SRC/gitignore.template"    "$DST/.gitignore"
+
+# Route + tools (verbatim)
+cp "$SRC/src/app/research/index.ts"  "$DST/src/app/research/index.ts"
+cp "$SRC/src/app/research/state.ts"  "$DST/src/app/research/state.ts"
+cp "$SRC/src/app/research/memory.ts" "$DST/src/app/research/memory.ts"
+cp "$SRC/src/app/research/memory.md" "$DST/src/app/research/memory.md"
+cp "$SRC/src/app/research/plan.md"   "$DST/src/app/research/plan.md"
+cp "$SRC/src/app/research/subagents/researcher/index.ts" "$DST/src/app/research/subagents/researcher/index.ts"
+cp "$SRC/src/app/research/skills/cite-sources/SKILL.md"        "$DST/src/app/research/skills/cite-sources/SKILL.md"
+cp "$SRC/src/app/research/skills/synthesize-findings/SKILL.md" "$DST/src/app/research/skills/synthesize-findings/SKILL.md"
+cp "$SRC/src/tools/searchCorpus.ts" "$DST/src/tools/searchCorpus.ts"
+cp "$SRC/src/tools/readDoc.ts"      "$DST/src/tools/readDoc.ts"
+
+# Eval + tests (strip .template)
+cp "$SRC/src/app/research/evals/research-quality.eval.ts.template" "$DST/src/app/research/evals/research-quality.eval.ts"
+cp "$SRC/test/research.test.ts.template"        "$DST/test/research.test.ts"
+cp "$SRC/test/sandbox-docker.test.ts.template"  "$DST/test/sandbox-docker.test.ts"
+
+# Workspace (verbatim)
+cp "$SRC/workspace/AGENTS.md" "$DST/workspace/AGENTS.md"
+cp "$SRC/workspace/corpus/"*.md "$DST/workspace/corpus/"
+cp "$SRC/workspace/scripts/fetch-source.mjs" "$DST/workspace/scripts/fetch-source.mjs"
+```
+
+- [ ] **Step 2: Write the server `package.json`**
+
+Create `examples/research/server/package.json`:
+
+```json
+{
+  "name": "@dawn-example/research-server",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "node node_modules/@dawn-ai/cli/dist/index.js dev --port 3002",
+    "build": "node node_modules/@dawn-ai/cli/dist/index.js build",
+    "typecheck": "tsc -p . --noEmit",
+    "check": "node node_modules/@dawn-ai/cli/dist/index.js check",
+    "test": "vitest run",
+    "test:sandbox:docker": "DAWN_DEMO_DOCKER_SANDBOX=1 vitest run test/sandbox-docker.test.ts",
+    "eval": "node node_modules/@dawn-ai/cli/dist/index.js eval",
+    "memory:list": "node node_modules/@dawn-ai/cli/dist/index.js memory list",
+    "memory:approve": "node node_modules/@dawn-ai/cli/dist/index.js memory approve"
+  },
+  "dependencies": {
+    "@dawn-ai/cli": "workspace:*",
+    "@dawn-ai/core": "workspace:*",
+    "@dawn-ai/langchain": "workspace:*",
+    "@dawn-ai/sandbox": "workspace:*",
+    "@dawn-ai/sdk": "workspace:*",
+    "zod": "^4.4.3"
+  },
+  "devDependencies": {
+    "@dawn-ai/config-typescript": "workspace:*",
+    "@dawn-ai/evals": "workspace:*",
+    "@dawn-ai/testing": "workspace:*",
+    "@types/node": "26.1.0",
+    "typescript": "6.0.2",
+    "vitest": "^4.1.9"
+  }
+}
+```
+
+- [ ] **Step 3: Write the server `vitest.config.ts`**
+
+Create `examples/research/server/vitest.config.ts` (identical to `examples/chat/server/vitest.config.ts` — the suite boots in-process agents + a `dawn dev` subprocess and mutates process-global `OPENAI_BASE_URL`, so files must run sequentially):
+
+```ts
+import { defineConfig } from "vitest/config"
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["test/**/*.test.ts", "src/**/*.test.ts"],
+    passWithNoTests: true,
+    // The capability suites boot in-process agents + a real dawn dev subprocess
+    // and mutate process-global OPENAI_BASE_URL — run files sequentially to
+    // avoid cross-file env/port races.
+    fileParallelism: false,
+    testTimeout: 120_000,
+    hookTimeout: 120_000,
+  },
+})
+```
+
+- [ ] **Step 4: Write the server `.env.example`**
+
+Create `examples/research/server/.env.example`:
+
+```bash
+# Only needed for live/model runs (e.g. `pnpm eval -- --live`, or `dawn run`
+# without fixtures). Offline tests and evals replay recorded fixtures and need
+# no API key.
+OPENAI_API_KEY=
+```
+
+- [ ] **Step 5: Write the server `README.md` (the tour)**
+
+Create `examples/research/server/README.md`:
+
+```markdown
+# Research demo — server
+
+The flagship [Dawn](https://github.com/cacheplane/dawn) example: a deep-research
+assistant that plans sub-questions, researches a bundled local corpus with a
+specialist subagent, and writes a cited report. It runs **offline and
+deterministically** out of the box, and against a real model when you opt in.
+
+> This is Slice 1 (the server). A polished web UI with a no-key demo mode lands
+> in a later slice; today you exercise the app through its tests, `dawn run`, and
+> `dawn dev`.
+
+## Run it
+
+```bash
+pnpm install                 # from the repo root
+pnpm --filter @dawn-example/research-server check   # generate route + tool types
+pnpm --filter @dawn-example/research-server test    # harness tests, offline (replay fixtures)
+pnpm --filter @dawn-example/research-server eval     # quality evals, offline (replay fixtures)
+pnpm --filter @dawn-example/research-server memory:list
+```
+
+To run against a real model, set `OPENAI_API_KEY` and add `--live`
+(e.g. `pnpm --filter @dawn-example/research-server eval -- --live`). The offline
+path uses recorded fixtures, so tests and evals are deterministic and need no
+API key.
+
+To dogfood the Docker sandbox, start Docker and run:
+
+```bash
+pnpm --filter @dawn-example/research-server test:sandbox:docker
+```
+
+The normal test path uses the local `workspace/` so the bundled corpus works
+immediately. The Docker sandbox path creates an isolated per-thread workspace;
+the sandbox test seeds a corpus document there before running the same tools.
+
+## The tour — where each capability lives
+
+| Capability | File | What it shows |
+|---|---|---|
+| Agent route | `src/app/research/index.ts` | the research coordinator |
+| Tools + typegen | `src/tools/` | shared `searchCorpus`, `readDoc`; `dawn check` types them |
+| Subagents | `src/app/research/subagents/researcher/` | dispatched via `task({ subagent, input })` |
+| Planning | `src/app/research/plan.md` | seeded checklist becomes the thread's todos |
+| Offloading | `dawn.config.ts` + a large `readDoc` | big results spill to the workspace, stubbed in-context |
+| Memory | `workspace/AGENTS.md`, `memory.md`, `memory.ts` | prompt memory plus typed `recall`/`remember` |
+| Skills | `src/app/research/skills/` | `cite-sources`, `synthesize-findings` |
+| HITL permissions | `dawn.config.ts` + `workspace/scripts/fetch-source.mjs` | the external fetch pauses for approval |
+| Workspace | `workspace/` | corpus + report output behind a path-jail |
+| Docker sandbox | `dawn.config.ts`, `test/sandbox-docker.test.ts` | opt-in isolated workspace via `@dawn-ai/sandbox` |
+| Persistence | (default) | threads survive a restart (SQLite) |
+| Tests | `test/research.test.ts` | `createAgentHarness` + `script()` |
+| Evals | `src/app/research/evals/` | `defineEval` + scorers + a gate |
+
+## Memory review
+
+This app uses candidate memory writes. When the agent calls `remember`, the
+memory is saved for review instead of becoming active immediately.
+
+```bash
+pnpm --filter @dawn-example/research-server memory:list
+pnpm --filter @dawn-example/research-server memory:approve -- <memory-id>
+```
+
+The tests show both paths: seeding an active memory with `seedMemory`, and
+writing a reviewable candidate through the real `remember` tool.
+```
+
+- [ ] **Step 6: Write the example root `package.json` and `README.md`**
+
+Create `examples/research/package.json` (a non-member convenience holder — the `examples/*/*` workspace glob makes `server` the package, not this file; web scripts arrive in Slice 2):
+
+```json
+{
+  "name": "@dawn-example/research",
+  "private": true,
+  "version": "0.0.0",
+  "scripts": {
+    "dev": "pnpm --filter ./server dev",
+    "build": "pnpm --filter ./server build",
+    "typecheck": "pnpm --filter ./server typecheck",
+    "test": "pnpm --filter ./server test"
+  }
+}
+```
+
+Create `examples/research/README.md`:
+
+```markdown
+# Research demo
+
+The flagship Dawn example — a deep-research assistant. See
+[`server/README.md`](./server/README.md) for the full tour and how to run it.
+
+- `server/` — the Dawn app (this slice): routes, tools, subagents, memory,
+  planning, offloading, HITL permissions, optional Docker sandbox, tests, evals.
+- `web/` — a Next.js UI with a no-API-key demo mode (added in a later slice).
+```
+
+- [ ] **Step 7: Install so pnpm links the new workspace package**
+
+Run: `pnpm install`
+Expected: completes without error; `examples/research/server` is now a linked workspace package (its `node_modules` contains symlinks to `@dawn-ai/*`).
+
+- [ ] **Step 8: Typecheck the new package**
+
+Run: `pnpm --filter @dawn-example/research-server typecheck`
+Expected: `tsc -p . --noEmit` exits 0 with no errors. (The generated `.dawn/dawn.generated.d.ts` is absent; TypeScript treats the missing `include` entry as an empty glob, and no source references generated ambient types — the same reason `examples/chat/server` typechecks without it.)
+
+- [ ] **Step 9: Build the new package**
+
+Run: `pnpm --filter @dawn-example/research-server build`
+Expected: `dawn build` compiles the routes and exits 0 (same build command `examples/chat/server` uses).
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add examples/research vitest.workspace.ts 2>/dev/null; git add examples/research pnpm-lock.yaml
+git commit -m "feat(examples): scaffold research demo server (promote app-research template)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Deterministic capability suite runs green offline
+
+The suite was copied in Task 1 (`test/research.test.ts`). It is the acceptance test for the promoted app — it exercises corpus search + citation, the `researcher` subagent, memory candidate → CLI-approve → fresh-thread recall, planning, tool-output offloading, and the HITL permission interrupt/resume. Because the app code is a promotion of a known-good template, this task **runs** the suite to confirm the behavior survives promotion, rather than writing new tests first.
+
+**Files:**
+- Test: `examples/research/server/test/research.test.ts` (already present)
+
+- [ ] **Step 1: Run the offline suite (no API key)**
+
+Run: `pnpm --filter @dawn-example/research-server test`
+Expected: `research.test.ts` reports **7 passed**; `sandbox-docker.test.ts` reports **1 skipped** (Docker gate off). Overall: `Test Files 2 passed`, `Tests 7 passed | 1 skipped`. No network/API key required (all model calls resolve against `aimock` fixtures).
+
+- [ ] **Step 2: Confirm determinism (re-run)**
+
+Run: `pnpm --filter @dawn-example/research-server test`
+Expected: identical result — 7 passed, 1 skipped. If any test flakes, stop and debug (do not proceed): most likely a stale `.dawn/memory.sqlite`; the suite's `cleanMemoryDb()` in `beforeAll`/`afterAll` should handle it, but a crashed prior run can leave `-wal`/`-shm` files — remove `examples/research/server/.dawn/memory.sqlite*` and re-run.
+
+- [ ] **Step 3: Commit (no code change; record the green gate)**
+
+No file changes are expected in this task. If the run required removing a stale `.dawn` artifact, nothing to commit (it is gitignored). Skip the commit if `git status` is clean.
+
+---
+
+## Task 3: Gated Docker sandbox test + eval — present, typechecked, skip-clean
+
+**Files:**
+- Test: `examples/research/server/test/sandbox-docker.test.ts` (already present)
+- Eval: `examples/research/server/src/app/research/evals/research-quality.eval.ts` (already present)
+
+- [ ] **Step 1: Confirm the sandbox test skips cleanly without Docker**
+
+Run: `pnpm --filter @dawn-example/research-server test`
+Expected: `sandbox-docker.test.ts` shows its single case **skipped** (guarded by `it.skipIf(!enabled)` where `enabled = process.env.DAWN_DEMO_DOCKER_SANDBOX === "1"`). No Docker daemon is contacted.
+
+- [ ] **Step 2 (optional, only if Docker is available): Run the sandbox path**
+
+Run: `pnpm --filter @dawn-example/research-server test:sandbox:docker`
+Expected (Docker running): the sandbox case passes — shared corpus tools run against an isolated `node:22-slim` per-thread workspace, the sandbox-only report is NOT written to the host (`workspace/reports/sandbox-only.md` absent), and a fresh thread cannot read the prior thread's sandbox file. If Docker is not installed, skip this step — it is explicitly optional and not part of the CI gate.
+
+- [ ] **Step 3: Confirm the eval typechecks (it is compiled but not executed in CI)**
+
+Run: `pnpm --filter @dawn-example/research-server typecheck`
+Expected: exits 0. The eval file lives under `src/**/*.ts` and is type-checked; it is executed only via `pnpm ... eval` (Task 5), not during `pnpm test`.
+
+- [ ] **Step 4: Commit (only if anything changed)**
+
+No file changes are expected here (both files were added in Task 1). If `git status` is clean, skip. Otherwise:
+
+```bash
+git add examples/research/server
+git commit -m "test(examples): verify research demo sandbox gate + eval typecheck
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Wire the demo into the monorepo CI gate
+
+Register the package's test project in the root vitest workspace (turbo already covers `build`/`typecheck`/`lint` for every workspace package, so no turbo config change is needed — the same way `examples/chat/server` is handled).
+
+**Files:**
+- Modify: `vitest.workspace.ts`
+
+- [ ] **Step 1: Add the research server test project**
+
+In `vitest.workspace.ts`, add the research project immediately after the chat entry. The `projects` array currently ends with:
+
+```ts
+    "./examples/chat/server/vitest.config.ts",
+  ],
+```
+
+Change it to:
+
+```ts
+    "./examples/chat/server/vitest.config.ts",
+    "./examples/research/server/vitest.config.ts",
+  ],
+```
+
+- [ ] **Step 2: Confirm the root vitest workspace picks up the new project**
+
+Run: `pnpm exec vitest --run --config vitest.workspace.ts examples/research/server/test/research.test.ts`
+Expected: vitest resolves the `@dawn-example/research-server` project and runs `research.test.ts` → **7 passed**. This proves the project is registered under the workspace config that `pnpm test` uses.
+
+- [ ] **Step 3: Confirm turbo builds and typechecks the package in the graph**
+
+Run: `pnpm exec turbo run typecheck build --filter=@dawn-example/research-server`
+Expected: both tasks succeed for `@dawn-example/research-server` (turbo discovers it as a workspace package with `typecheck` and `build` scripts).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add vitest.workspace.ts
+git commit -m "test(examples): run research demo server in the root vitest workspace
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Local runtime verification + final green gate
+
+Prove the app is genuinely runnable (typegen + a live/optional run), then confirm the broader CI-relevant gates pass locally.
+
+**Files:** none created; verification + optional docs touch-ups only.
+
+- [ ] **Step 1: Generate route + tool types**
+
+Run: `pnpm --filter @dawn-example/research-server check`
+Expected: `dawn check` writes `examples/research/server/.dawn/dawn.generated.d.ts` and exits 0. Confirm the file exists and is gitignored:
+
+Run: `git status --porcelain examples/research/server/.dawn`
+Expected: empty output (the `.dawn/` directory is ignored by the copied `.gitignore`).
+
+- [ ] **Step 2: Offline eval replay**
+
+Run: `pnpm --filter @dawn-example/research-server eval`
+Expected: `dawn eval` runs the `research quality` dataset against recorded fixtures and the gate passes (`gate.all(gate.passRate(1), gate.perScorer())`) with no API key. If the runner requires an explicit offline flag in this repo's CLI version, consult `pnpm --filter @dawn-example/research-server exec dawn eval --help` and use the offline/replay form; do not add `--live`.
+
+- [ ] **Step 3 (optional, needs `OPENAI_API_KEY`): a live smoke run**
+
+Run:
+```bash
+cp examples/research/server/.env.example examples/research/server/.env   # then set OPENAI_API_KEY
+echo '{"input":"What are common agent architectures?"}' | \
+  pnpm --filter @dawn-example/research-server exec dawn run /research#agent
+```
+Expected (with a key): the coordinator plans, searches the corpus, and returns a cited answer containing `[corpus/…]`. This step is optional and never part of the CI gate.
+
+- [ ] **Step 4: Final local gate mirroring CI**
+
+Run each and confirm success:
+```bash
+pnpm --filter @dawn-example/research-server typecheck
+pnpm --filter @dawn-example/research-server build
+pnpm exec vitest --run --config vitest.workspace.ts examples/research/server/test/research.test.ts
+```
+Expected: all exit 0; the vitest run reports 7 passed. (A full `pnpm typecheck`/`pnpm build`/`pnpm test` at the repo root is the ultimate gate but is heavy; run it once before opening the PR.)
+
+- [ ] **Step 5: Commit any docs touch-ups**
+
+If Steps 1–4 surfaced a README correction (e.g. an eval flag name), fix it inline and:
+
+```bash
+git add examples/research
+git commit -m "docs(examples): correct research demo run instructions
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+Otherwise skip — `git status` should be clean.
+
+---
+
+## Self-Review
+
+**Spec coverage (against `2026-07-06-research-demo-design.md`):**
+- Standalone `examples/research` server mirroring `examples/chat` → Tasks 1–4. ✓
+- Concepts dogfooded (coordinator+subagent, tools+offloading, memory candidate/approve/recall, planning, skills, HITL, sandbox, workspace, evals, tests) → all present via the promoted template; exercised by Task 2 and the eval. ✓
+- Deterministic by default, live gated → offline `aimock` fixtures (Task 2), `.env.example` + `--live` opt-in, `dawn run` optional (Task 5). ✓
+- Docker sandbox explicit but optional → env-gated test, skips without Docker (Task 3). ✓
+- Local runtime verification + harness/test strategy → Tasks 4–5; wired into root vitest workspace + turbo. ✓
+- Blueprint/docs extraction end state → deferred to Slice 4 by design; the server README tour table already maps capability→file, which is the raw material for extraction. ✓ (no Slice-1 task needed)
+- Do NOT bloat/modify the default scaffold → this slice creates only `examples/research/*` and one line in `vitest.workspace.ts`; the template is untouched. ✓
+
+**Placeholder scan:** No TBD/TODO/"handle edge cases"; every created file has concrete content or an exact `cp` source; every command has an expected result. ✓
+
+**Type/name consistency:** package name `@dawn-example/research-server` used consistently in all `--filter` commands and the root `package.json`; test project path `./examples/research/server/vitest.config.ts` matches the created config; scripts (`check`/`build`/`typecheck`/`test`/`eval`/`memory:list`/`memory:approve`/`test:sandbox:docker`) match those referenced in the README and verification steps. ✓
+
+**Known assumption to verify during execution (Task 5, Step 2):** the exact offline invocation for `dawn eval` in this CLI version. The fixtures are inline in the eval, so replay should be the default with no key; the step tells the executor to confirm via `--help` rather than guessing a flag.

--- a/docs/superpowers/specs/2026-07-06-research-demo-design.md
+++ b/docs/superpowers/specs/2026-07-06-research-demo-design.md
@@ -1,0 +1,230 @@
+# Polished Flagship Research Demo — Design
+
+**Date:** 2026-07-06
+**Status:** Approved (design), pending implementation plan
+**Author:** Brian Love (with Claude)
+
+## Summary
+
+Build a polished, standalone `examples/research` demo app that is the flagship
+expression of Dawn's strongest concepts. It mirrors the structure of the existing
+`examples/chat` demo (a two-package pnpm monorepo: a Dawn `server/` plus a Next.js
+`web/` UI) and dogfoods, in one coherent product, the research workflow, memory
+candidates/approval, Docker sandbox isolation, workspace files, custom tools,
+subagents, permissions/HITL, evals, and deterministic tests.
+
+The default `app-research` scaffold template stays lighter and is aligned to the
+flagship in a later slice. The demo is authored so its real files can be extracted
+into a docs recipe (and, later, a blueprint) rather than remaining a hidden example.
+
+## Motivation & Context
+
+Findings from inspecting the current repo:
+
+- **`examples/chat`** is the canonical demo *shape*: a pnpm monorepo with
+  `server/` (`@dawn-example/chat-server`, a Dawn app with `appDir: src/app`) and
+  `web/` (`@dawn-example/chat-web`, Next.js). The web app streams Server-Sent
+  Events, renders an event log, offers a route picker, and implements a working
+  HITL permission-resume flow (`web/app/api/permission-resume/route.ts`). It has
+  its own vitest suite but is **not** wired into the `test/` harness.
+- **`packages/devkit/templates/app-research`** is the **default scaffold**
+  (`create-dawn-app` defaults to `research`, most recently improved in PR #302).
+  It is already heavy: coordinator + `researcher` subagent, semantic memory with
+  a candidate/approve flow, HITL allow/deny lists, a Docker sandbox gated behind
+  `DAWN_DEMO_DOCKER_SANDBOX=1`, tool-output offloading, skills, evals with an LLM
+  judge, a bundled 5-document corpus, and deterministic replay tests. It is
+  **server-only — no UI.**
+- **Blueprints** (`apps/web/content/blueprints/`) are markdown + frontmatter, but
+  categories are **enforced** to `observability | retrieval | deploy`
+  (`apps/web/lib/blueprints.ts:6`). There is **no research blueprint** and **no
+  extraction tooling** — blueprints are hand-authored and served to `dawn add`.
+- **Docs** (`apps/web/content/docs/`) are rich `.mdx` with `<CodeGroup>` blocks;
+  `getting-started.mdx` already teaches research-as-default-scaffold.
+- **Harness** (`test/generated`, `test/runtime`, `test/smoke`) achieves
+  determinism through `aimock` fixtures (`packages/testing`). A new example gets
+  coverage either as its own vitest suite (chat's approach) or a `test/runtime`
+  fixture.
+
+The core tension: the "scaffold" we want to keep light **is** the heavy default
+template. So this work splits altitude — a polished flagship that goes deep, and
+a slimmer default starter aligned to it.
+
+## Decisions
+
+Captured during brainstorming:
+
+1. **Demo shape:** Server + web UI monorepo (like `examples/chat`).
+2. **Scaffold treatment:** Slim/align the default `app-research` template in a
+   **later slice**, not in the flagship's first PR.
+3. **First implementation slice:** the `server/` app + deterministic tests.
+4. **Extraction:** author a **docs recipe now**; design for a future
+   `research-assistant` blueprint but do **not** add a new blueprint category yet.
+
+## Goals
+
+- A standalone `examples/research` app that is visibly the best demonstration of
+  Dawn, runnable and green at every slice boundary.
+- Deterministic by default; live/model paths explicitly gated.
+- Docker sandbox dogfooding that is explicit but optional (works without Docker).
+- Real local runtime verification plus a deterministic harness/test strategy.
+- An end state that supports docs (and later blueprint) extraction from real files.
+
+## Non-Goals
+
+- Changing the default `app-research` scaffold in the first slice.
+- Adding a new blueprint category or authoring a research blueprint now.
+- Building any new framework abstraction. Prefer existing repo patterns.
+- A production server (Dawn has none; `dawn dev` is localhost-only).
+
+## Architecture
+
+`examples/research/` is a two-package pnpm monorepo mirroring `examples/chat`:
+
+- **`server/`** — `@dawn-example/research-server`, a Dawn app (`appDir: src/app`).
+- **`web/`** — `@dawn-example/research-web`, a Next.js UI.
+
+### Server package (Slice 1)
+
+The `server/` package is the fullest expression of the research pattern, built by
+**promoting** the current `app-research` template patterns into a polished,
+non-`.template` form (concrete files, no mustache variables):
+
+```
+server/
+  dawn.config.ts        # permissions allow/deny; sandbox gated by
+                        #   DAWN_DEMO_DOCKER_SANDBOX=1; toolOutput offloading
+  .env.example          # OPENAI_API_KEY
+  vitest.config.ts      # fileParallelism: false (agents mutate OPENAI_BASE_URL)
+  tsconfig.json         # extends @dawn-ai/config-typescript/node
+  package.json          # @dawn-ai/{core,cli,langchain,sandbox,sdk}, zod
+  workspace/
+    AGENTS.md           # durable house rules injected into system prompt
+    corpus/*.md         # bundled research corpus (seeded from template's 5 docs)
+    scripts/fetch-source.mjs   # external-fetch seam (stub; not allowlisted)
+  src/app/research/
+    index.ts            # coordinator (gpt-5-mini): recall → plan → dispatch →
+                        #   synthesize → remember
+    state.ts            # z.object({ context: z.string().default("") })
+    memory.ts           # defineMemory({ kind: "semantic", scope, schema })
+    memory.md, plan.md
+    skills/cite-sources/SKILL.md
+    skills/synthesize-findings/SKILL.md
+    subagents/researcher/index.ts   # gpt-5-mini; corpus search + cite
+    evals/research-quality.eval.ts
+  src/tools/searchCorpus.ts
+  src/tools/readDoc.ts
+  test/research.test.ts             # deterministic capability suite (fixtures)
+  test/sandbox-docker.test.ts       # gated by DAWN_DEMO_DOCKER_SANDBOX=1
+```
+
+Model defaults follow the `gpt-5` family policy (canonical default `gpt-5-mini`).
+
+### Web package (Slice 2)
+
+Mirrors `examples/chat/web`:
+
+```
+web/
+  app/layout.tsx
+  app/page.tsx                       # topic input; live plan/todos; streaming
+                                     #   report; HITL permission prompts; memory
+                                     #   candidates panel
+  app/api/research/route.ts          # SSE proxy to server /threads/{tid}/runs/stream
+  app/api/permission-resume/route.ts # HITL resume
+  next.config.mjs, package.json, tsconfig.json, .env.example
+```
+
+## Concepts Dogfooded
+
+Coordinator + subagent dispatch (`task({ subagent, input })`); custom tools
+(`searchCorpus`, `readDoc`) with tool-output offloading; semantic memory with
+candidate → CLI-approve → recall; planning/todos (`plan.md`); skills; HITL
+permissions (interrupt + resume); Docker sandbox (explicit but env-gated);
+workspace path-jail; evals with an LLM judge; deterministic replay tests.
+
+## Determinism & Live Gating
+
+- **Slice 1:** deterministic means the vitest suite runs entirely on `aimock`
+  fixtures with **no API key**, exactly like the template's tests. The app is
+  also runnable live via `dawn run` / `dawn dev` with a key.
+- **Slice 2:** a `pnpm dev` **demo mode** boots an `aimock`-backed fixture server
+  (reusing `@dawn-ai/testing`'s `createAimock`, which returns a `baseUrl` set as
+  `OPENAI_BASE_URL`) so the UI runs with **no API key** — a canned but believable
+  research run. `pnpm dev:live` uses a real key. This makes the recorded-fixtures
+  story a visible product feature. (Demo mode is designed here but implemented in
+  Slice 2; Slice 1 does not depend on it.)
+
+## Data Flow
+
+1. User submits a topic (UI → `/api/research` → Dawn server `runs/stream`).
+2. Coordinator recalls durable context, writes a plan (todos), and dispatches a
+   `researcher` subagent per sub-question via `task()`.
+3. Subagents call `searchCorpus` → `readDoc` (path-jailed to `corpus/`); large
+   docs offload to `workspace/tool-outputs/`.
+4. A non-allowlisted bash command (e.g. `node scripts/fetch-source.mjs`) raises a
+   permission interrupt; the UI resumes it via `/api/permission-resume`.
+5. Coordinator synthesizes a cited report to `workspace/reports/<slug>.md` and
+   proposes a durable memory write (`remember()`), which lands as a **candidate**.
+6. SSE events (`plan_update`, tool calls, `interrupt`, final message) stream to
+   the UI throughout.
+
+## Error Handling
+
+- **No Docker:** the sandbox path is gated by `DAWN_DEMO_DOCKER_SANDBOX=1`; the
+  default run and all non-sandbox tests work without Docker.
+- **No API key:** deterministic tests (and Slice 2 demo mode) require no key.
+- **Permission denials:** a denied interrupt returns control to the agent, which
+  follows the `recover-from-failure`-style guidance rather than blindly retrying.
+- **Path-jail violations:** `readDoc` asserts `corpus/` prefix and rejects `..`.
+
+## Testing & Harness Strategy
+
+- The `server/` package owns a deterministic vitest suite (chat's pattern) using
+  `createAgentHarness` + `script()` fixtures, covering: corpus search + citation;
+  subagent dispatch; memory candidate + CLI-approve → fresh-thread recall;
+  planning todos; HITL interrupt + resume; tool-output offloading.
+- A gated `test/sandbox-docker.test.ts` runs only under `DAWN_DEMO_DOCKER_SANDBOX=1`
+  and verifies per-thread isolation (writes do not escape to host).
+- **CI integration:** wire the research server's deterministic tests into the repo
+  test run so the flagship stays green (note: `examples/chat` is currently *not*
+  harnessed; this closes that gap for the flagship). The app must also pass
+  `typecheck` and `build`.
+- **Local verification:** `pnpm --filter research-server test`, `dawn run` on a
+  canonical input, and the eval replay (`dawn eval`).
+
+## Docs / Blueprint Extraction (Slice 4)
+
+- Author a docs recipe under `apps/web/content/docs/recipes/` (e.g.
+  `research-assistant.mdx`) whose `<CodeGroup>` blocks are drawn from the real
+  flagship files, so docs stay honest to runnable code.
+- Design the app so a future `research-assistant` blueprint is a small step:
+  keep files self-contained and note the intended blueprint boundary. Do **not**
+  add a new blueprint category (`agents`/`patterns`) in this work — that is a
+  separate decision because categories are enforced in `apps/web/lib/blueprints.ts`.
+
+## Implementation Slices
+
+1. **Server app + deterministic tests** — the full research `server/` package,
+   fixtures, evals, gated Docker test; green typecheck/build/test; runnable via
+   `dawn run` / `dawn dev`. *(Begin here.)*
+2. **Web UI + demo mode** — Next.js shell, SSE streaming, HITL resume, memory
+   candidates panel; `aimock`-backed no-key demo mode.
+3. **Scaffold slimming + alignment** — trim the default `app-research` template to
+   a lighter starter aligned with the flagship's conventions.
+4. **Docs recipe extraction** — author the recipe from real files; add a design
+   note for a future research blueprint.
+
+## Risks & Mitigations
+
+- **Scope creep into the default scaffold.** Mitigated by deferring scaffold
+  changes to Slice 3, after the flagship exists to align against.
+- **UI hard to keep green.** Mitigated by building the server + tests first
+  (Slice 1) so the UI has a stable, deterministic backend.
+- **Fixture drift.** Deterministic tests replay recorded fixtures; use the
+  harness `record` mode to refresh them when prompts change.
+
+## Open Questions (deferred, not blocking)
+
+- Whether Slice 3 slims the template by *removing* advanced features or by
+  *cross-linking* to the flagship — decide when Slice 3 is planned.
+- Exact blueprint category story — decide when/if a research blueprint is authored.

--- a/examples/research/README.md
+++ b/examples/research/README.md
@@ -1,0 +1,8 @@
+# Research demo
+
+The flagship Dawn example — a deep-research assistant. See
+[`server/README.md`](./server/README.md) for the full tour and how to run it.
+
+- `server/` — the Dawn app (this slice): routes, tools, subagents, memory,
+  planning, offloading, HITL permissions, optional Docker sandbox, tests, evals.
+- `web/` — a Next.js UI with a no-API-key demo mode (added in a later slice).

--- a/examples/research/package.json
+++ b/examples/research/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@dawn-example/research",
+  "private": true,
+  "version": "0.0.0",
+  "scripts": {
+    "dev": "pnpm --filter ./server dev",
+    "build": "pnpm --filter ./server build",
+    "typecheck": "pnpm --filter ./server typecheck",
+    "test": "pnpm --filter ./server test"
+  }
+}

--- a/examples/research/server/.env.example
+++ b/examples/research/server/.env.example
@@ -1,0 +1,4 @@
+# Only needed for live/model runs (e.g. `pnpm eval -- --live`, or `dawn run`
+# without fixtures). Offline tests and evals replay recorded fixtures and need
+# no API key.
+OPENAI_API_KEY=

--- a/examples/research/server/.gitignore
+++ b/examples/research/server/.gitignore
@@ -1,0 +1,7 @@
+node_modules/
+dist/
+.dawn/
+
+# Runtime workspace outputs (the agent writes these at run time).
+workspace/reports/
+workspace/tool-outputs/

--- a/examples/research/server/AGENTS.md
+++ b/examples/research/server/AGENTS.md
@@ -1,0 +1,22 @@
+# Dawn App — Coding Agent Instructions
+
+This project uses **Dawn**, the TypeScript meta-framework for LangGraph. Agents
+and workflows are file-system routes under `src/app/`.
+
+## Key rules
+
+- A route is a directory with an `index.ts` that exports exactly ONE of:
+  `agent` (LLM-driven; default export), `workflow` (deterministic async
+  function), `graph` (LangGraph graph), or `chain` (LangChain LCEL Runnable).
+- Tools are co-located in a route's `tools/` directory — one default-exported
+  async function per file. Their argument types are inferred at build time.
+- Optional route state goes in `state.ts` next to the route.
+- Never edit `.dawn/dawn.generated.d.ts` — it is generated. Run `dawn typegen`
+  if `dawn:routes` types do not resolve.
+
+## Full reference (read this before writing routes)
+
+The complete, version-matched Dawn documentation is bundled with the installed
+CLI. Run `dawn docs` to list topics or `dawn docs <topic>` to read one (for
+example, `dawn docs tools`). The same files are at
+`node_modules/@dawn-ai/cli/docs/` — start with `docs/README.md`.

--- a/examples/research/server/README.md
+++ b/examples/research/server/README.md
@@ -1,0 +1,66 @@
+# Research demo — server
+
+The flagship [Dawn](https://github.com/cacheplane/dawn) example: a deep-research
+assistant that plans sub-questions, researches a bundled local corpus with a
+specialist subagent, and writes a cited report. It runs **offline and
+deterministically** out of the box, and against a real model when you opt in.
+
+> This is Slice 1 (the server). A polished web UI with a no-key demo mode lands
+> in a later slice; today you exercise the app through its tests, `dawn run`, and
+> `dawn dev`.
+
+## Run it
+
+```bash
+pnpm install                 # from the repo root
+pnpm --filter @dawn-example/research-server check   # generate route + tool types
+pnpm --filter @dawn-example/research-server test    # harness tests, offline (replay fixtures)
+pnpm --filter @dawn-example/research-server eval     # quality evals, offline (replay fixtures)
+pnpm --filter @dawn-example/research-server memory:list
+```
+
+To run against a real model, set `OPENAI_API_KEY` and add `--live`
+(e.g. `pnpm --filter @dawn-example/research-server eval -- --live`). The offline
+path uses recorded fixtures, so tests and evals are deterministic and need no
+API key.
+
+To dogfood the Docker sandbox, start Docker and run:
+
+```bash
+pnpm --filter @dawn-example/research-server test:sandbox:docker
+```
+
+The normal test path uses the local `workspace/` so the bundled corpus works
+immediately. The Docker sandbox path creates an isolated per-thread workspace;
+the sandbox test seeds a corpus document there before running the same tools.
+
+## The tour — where each capability lives
+
+| Capability | File | What it shows |
+|---|---|---|
+| Agent route | `src/app/research/index.ts` | the research coordinator |
+| Tools + typegen | `src/tools/` | shared `searchCorpus`, `readDoc`; `dawn check` types them |
+| Subagents | `src/app/research/subagents/researcher/` | dispatched via `task({ subagent, input })` |
+| Planning | `src/app/research/plan.md` | seeded checklist becomes the thread's todos |
+| Offloading | `dawn.config.ts` + a large `readDoc` | big results spill to the workspace, stubbed in-context |
+| Memory | `workspace/AGENTS.md`, `memory.md`, `memory.ts` | prompt memory plus typed `recall`/`remember` |
+| Skills | `src/app/research/skills/` | `cite-sources`, `synthesize-findings` |
+| HITL permissions | `dawn.config.ts` + `workspace/scripts/fetch-source.mjs` | the external fetch pauses for approval |
+| Workspace | `workspace/` | corpus + report output behind a path-jail |
+| Docker sandbox | `dawn.config.ts`, `test/sandbox-docker.test.ts` | opt-in isolated workspace via `@dawn-ai/sandbox` |
+| Persistence | (default) | threads survive a restart (SQLite) |
+| Tests | `test/research.test.ts` | `createAgentHarness` + `script()` |
+| Evals | `src/app/research/evals/` | `defineEval` + scorers + a gate |
+
+## Memory review
+
+This app uses candidate memory writes. When the agent calls `remember`, the
+memory is saved for review instead of becoming active immediately.
+
+```bash
+pnpm --filter @dawn-example/research-server memory:list
+pnpm --filter @dawn-example/research-server memory:approve -- <memory-id>
+```
+
+The tests show both paths: seeding an active memory with `seedMemory`, and
+writing a reviewable candidate through the real `remember` tool.

--- a/examples/research/server/dawn.config.ts
+++ b/examples/research/server/dawn.config.ts
@@ -1,0 +1,60 @@
+import { config } from "@dawn-ai/cli"
+import { dockerSandbox } from "@dawn-ai/sandbox"
+
+export default config({
+  appDir: "src/app",
+
+  // HITL permissions. Default mode (omitted) is "interactive": a runBash
+  // command that is NOT on the allow-list pauses the run for human approval.
+  // The external-fetch step (node scripts/fetch-source.mjs ...) is intentionally
+  // left off the allow-list so the approval flow is visible on first run.
+  permissions: {
+    allow: {
+      bash: ["ls", "cat", "head", "wc"],
+    },
+    deny: {
+      bash: ["rm -rf", "sudo", "chmod 777", "curl", "wget"],
+    },
+  },
+
+  // Tool-output offloading. Large tool results are spilled to
+  // workspace/tool-outputs/ and replaced in-context with a short stub the
+  // agent can read back on demand. The threshold is lowered so a single full
+  // corpus document trips it (the default is 40000 chars).
+  toolOutput: {
+    offloadThresholdChars: 1500,
+    previewLines: 10,
+  },
+
+  memory: {
+    // Keep durable writes reviewable: remember() creates candidates until a
+    // developer runs `npm run memory:approve -- <id>`.
+    writes: "candidate",
+  },
+
+  // Persistence (SQLite checkpointer + Agent Protocol) is on by default — no
+  // config needed. Threads survive a restart.
+
+  // --- Capability seam: Docker execution sandbox ---
+  // Default runs use the local workspace so the bundled corpus works without
+  // Docker. Run `npm run test:sandbox:docker` to dogfood the same scaffold with
+  // per-thread isolated Docker workspaces.
+  ...(process.env.DAWN_DEMO_DOCKER_SANDBOX === "1"
+    ? {
+        sandbox: {
+          provider: dockerSandbox({ image: "node:22-slim" }),
+          network: { mode: "deny" },
+          resources: { memoryMb: 512, cpus: 1, timeoutMs: 120_000 },
+          idleTimeoutMs: 600_000,
+        },
+      }
+    : {}),
+
+  // --- Capability seam (documented, inactive): conversation summarization ---
+  // Uncomment to compress older history once a thread exceeds maxTokens.
+  // summarization: {
+  //   enabled: true,
+  //   maxTokens: 12000,
+  //   keepRecentTurns: 6,
+  // },
+})

--- a/examples/research/server/package.json
+++ b/examples/research/server/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@dawn-example/research-server",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "node node_modules/@dawn-ai/cli/dist/index.js dev --port 3002",
+    "build": "node node_modules/@dawn-ai/cli/dist/index.js build",
+    "typecheck": "tsc -p . --noEmit",
+    "check": "node node_modules/@dawn-ai/cli/dist/index.js check",
+    "test": "vitest run",
+    "test:sandbox:docker": "DAWN_DEMO_DOCKER_SANDBOX=1 vitest run test/sandbox-docker.test.ts",
+    "eval": "node node_modules/@dawn-ai/cli/dist/index.js eval",
+    "memory:list": "node node_modules/@dawn-ai/cli/dist/index.js memory list",
+    "memory:approve": "node node_modules/@dawn-ai/cli/dist/index.js memory approve"
+  },
+  "dependencies": {
+    "@dawn-ai/cli": "workspace:*",
+    "@dawn-ai/core": "workspace:*",
+    "@dawn-ai/langchain": "workspace:*",
+    "@dawn-ai/sandbox": "workspace:*",
+    "@dawn-ai/sdk": "workspace:*",
+    "zod": "^4.4.3"
+  },
+  "devDependencies": {
+    "@dawn-ai/config-typescript": "workspace:*",
+    "@dawn-ai/evals": "workspace:*",
+    "@dawn-ai/testing": "workspace:*",
+    "@types/node": "26.1.0",
+    "typescript": "6.0.2",
+    "vitest": "^4.1.9"
+  }
+}

--- a/examples/research/server/src/app/research/evals/research-quality.eval.ts
+++ b/examples/research/server/src/app/research/evals/research-quality.eval.ts
@@ -1,0 +1,45 @@
+import { contains, custom, defineEval, gate, llmJudge, toolCalled } from "@dawn-ai/evals"
+import { script } from "@dawn-ai/testing"
+
+const JUDGE_CRITERIA =
+  "The report answers the question and cites at least one source document."
+
+export default defineEval({
+  name: "research quality",
+  dataset: [
+    {
+      name: "agent architectures",
+      input: "What are common agent architectures?",
+      fixtures: script()
+        .user("What are common agent architectures?")
+        .callsTool("searchCorpus", { query: "agent architectures" })
+        .replies(
+          "Common architectures include ReAct and plan-and-execute. [corpus/agent-architectures.md]",
+        )
+        .user("cites at least one source")
+        .replies('{"score":1,"reason":"answers and cites a source"}'),
+    },
+    {
+      name: "evaluating llm apps",
+      input: "How should I evaluate an LLM app?",
+      fixtures: script()
+        .user("How should I evaluate an LLM app?")
+        .callsTool("searchCorpus", { query: "evaluate llm app" })
+        .replies(
+          "Use scorers and a gate over a dataset of cases. [corpus/evaluating-llm-apps.md]",
+        )
+        .user("cites at least one source")
+        .replies('{"score":1,"reason":"answers and cites a source"}'),
+    },
+  ],
+  scorers: [
+    toolCalled("searchCorpus", { threshold: 1 }),
+    contains("[corpus/", { threshold: 1 }),
+    custom((run) => (run.finalMessage.includes("corpus/") ? 1 : 0), {
+      name: "cites-source",
+      threshold: 1,
+    }),
+    llmJudge({ criteria: JUDGE_CRITERIA, model: "gpt-5-mini", threshold: 0.7 }),
+  ],
+  gate: gate.all(gate.passRate(1), gate.perScorer()),
+})

--- a/examples/research/server/src/app/research/index.ts
+++ b/examples/research/server/src/app/research/index.ts
@@ -1,0 +1,18 @@
+import { agent } from "@dawn-ai/sdk"
+
+export default agent({
+  model: "gpt-5-mini",
+  description:
+    "A deep-research assistant: plans sub-questions, dispatches researchers, and writes a cited report.",
+  systemPrompt: `You are a deep-research coordinator. Given a question:
+
+1. Start by checking durable context with \`recall({ query: "<the user's topic and preferences>" })\`.
+2. Plan the sub-questions to investigate and record them in your todos.
+3. For each sub-question, dispatch a specialist with \`task({ subagent: "researcher", input: "<sub-question>" })\`.
+4. You may also \`searchCorpus({ query })\` and \`readDoc({ path })\` directly for quick lookups.
+5. When the corpus lacks coverage, you may run \`runBash({ command: "node scripts/fetch-source.mjs <topic>" })\` — the human must approve it.
+6. Synthesize the findings into a cited report and save it with \`writeFile({ path: "reports/<slug>.md", content: "<report>" })\`.
+7. When the user gives a durable preference or you verify a reusable finding, call \`remember({ data, content })\` so it can be reviewed and recalled later.
+
+Cite every claim with its source path in square brackets, e.g. [corpus/agent-architectures.md]. Keep the final answer concise.`,
+})

--- a/examples/research/server/src/app/research/memory.md
+++ b/examples/research/server/src/app/research/memory.md
@@ -1,0 +1,6 @@
+# Research Route Memory
+
+- Every claim in a report must carry an inline citation to a source you actually read.
+- Prefer primary sources; flag anything you could not verify.
+- When you vet a source, settle a user preference, or reach a durable finding,
+  save it with the `remember` tool so future sessions can `recall` it.

--- a/examples/research/server/src/app/research/memory.ts
+++ b/examples/research/server/src/app/research/memory.ts
@@ -1,0 +1,15 @@
+import { defineMemory } from "@dawn-ai/sdk"
+import { z } from "zod"
+
+// Long-term, cross-session memory for the research assistant. The agent stores
+// durable facts (sources vetted, user preferences, domain findings) via the
+// generated `remember` tool and pulls them back with `recall`.
+export default defineMemory({
+  kind: "semantic",
+  scope: ["workspace", "route"],
+  schema: z.object({
+    subject: z.string().describe("What the fact is about, e.g. a source, topic, or preference"),
+    predicate: z.string().describe("The relation, e.g. 'is_credible', 'prefers', 'concluded'"),
+    value: z.string().describe("The value of the fact"),
+  }),
+})

--- a/examples/research/server/src/app/research/plan.md
+++ b/examples/research/server/src/app/research/plan.md
@@ -1,0 +1,10 @@
+<!--
+The presence of this file opts this route into Dawn's planning capability.
+The seeded checklist items below become the thread's initial `todos`. Edit them,
+add your own, or empty the list — the agent will adapt the plan to each question.
+-->
+
+- [ ] Restate the question and list the sub-questions to research
+- [ ] Search the corpus for each sub-question
+- [ ] Read the most relevant documents in full
+- [ ] Synthesize a cited report and write it to the workspace

--- a/examples/research/server/src/app/research/skills/cite-sources/SKILL.md
+++ b/examples/research/server/src/app/research/skills/cite-sources/SKILL.md
@@ -1,0 +1,13 @@
+---
+description: How to attribute every factual claim to a corpus document.
+---
+
+# Cite sources
+
+Every factual sentence in a report must end with a citation to the document it
+came from, written as a workspace path in square brackets: `[corpus/<file>.md]`.
+
+- Cite the most specific document, not a general one.
+- If two documents support a claim, cite both.
+- Never assert a fact you did not read in a cited document. If the corpus does
+  not cover it, say so and consider requesting an external fetch.

--- a/examples/research/server/src/app/research/skills/synthesize-findings/SKILL.md
+++ b/examples/research/server/src/app/research/skills/synthesize-findings/SKILL.md
@@ -1,0 +1,15 @@
+---
+description: How to merge researcher sub-answers into one cited report.
+---
+
+# Synthesize findings
+
+After the researcher subagents return, combine their answers into a single
+report:
+
+1. Open with a two-sentence direct answer to the user's question.
+2. Group supporting points by sub-question, each ending with its citation.
+3. Drop duplicate points; when sources disagree, note the disagreement.
+4. End with a short "Sources" list of every cited document path.
+
+Write the report to `reports/<slug>.md` with `writeFile`.

--- a/examples/research/server/src/app/research/state.ts
+++ b/examples/research/server/src/app/research/state.ts
@@ -1,0 +1,6 @@
+import { z } from "zod"
+
+export default z.object({
+  /** Accumulated research context from tool and subagent results. */
+  context: z.string().default(""),
+})

--- a/examples/research/server/src/app/research/subagents/researcher/index.ts
+++ b/examples/research/server/src/app/research/subagents/researcher/index.ts
@@ -1,0 +1,12 @@
+import { agent } from "@dawn-ai/sdk"
+
+export default agent({
+  model: "gpt-5-mini",
+  description:
+    "Researches one sub-question against the bundled corpus and returns a focused, cited answer.",
+  systemPrompt: `You are a research specialist. Answer the single sub-question you are given using the corpus.
+
+- Use \`searchCorpus({ query })\` to find candidate documents, then \`readDoc({ path })\` to read the most relevant ones in full.
+- Return a focused, factual answer. Cite each claim with its source path in square brackets, e.g. [corpus/agent-architectures.md].
+- If the corpus does not cover the question, say so plainly.`,
+})

--- a/examples/research/server/src/tools/readDoc.ts
+++ b/examples/research/server/src/tools/readDoc.ts
@@ -1,0 +1,18 @@
+import type { DawnToolContext } from "@dawn-ai/sdk"
+
+function assertCorpusPath(path: string): void {
+  if (!path.startsWith("corpus/") || path.includes("..") || path.startsWith("/")) {
+    throw new Error(`readDoc only accepts workspace corpus paths, got "${path}"`)
+  }
+}
+
+/**
+ * Read the full text of a corpus document by its workspace-relative path
+ * (e.g. "corpus/agent-architectures.md"). Large documents are offloaded by
+ * Dawn and retrieved on demand, so reading one does not flood the context.
+ */
+export default async (input: { readonly path: string }, ctx: DawnToolContext) => {
+  assertCorpusPath(input.path)
+  const content = await ctx.fs.readFile(input.path)
+  return { content }
+}

--- a/examples/research/server/src/tools/searchCorpus.ts
+++ b/examples/research/server/src/tools/searchCorpus.ts
@@ -1,0 +1,29 @@
+import type { DawnToolContext } from "@dawn-ai/sdk"
+
+/**
+ * Search the bundled research corpus for documents matching a query.
+ * Returns up to five matches ranked by how many query terms each document
+ * contains, with a short snippet around the first matched term.
+ */
+export default async (input: { readonly query: string }, ctx: DawnToolContext) => {
+  const terms = input.query.toLowerCase().split(/\s+/).filter(Boolean)
+  const files = (await ctx.fs.listDir("corpus")).filter((file) => file.endsWith(".md"))
+
+  const results: { readonly path: string; readonly score: number; readonly snippet: string }[] = []
+  for (const file of files) {
+    const path = `corpus/${file}`
+    const text = await ctx.fs.readFile(path)
+    const haystack = text.toLowerCase()
+    const score = terms.reduce((total, term) => total + (haystack.includes(term) ? 1 : 0), 0)
+    if (score === 0) continue
+    const firstTerm = terms.find((term) => haystack.includes(term))
+    const at = firstTerm ? haystack.indexOf(firstTerm) : 0
+    const snippet = text
+      .slice(Math.max(0, at - 40), at + 120)
+      .replace(/\s+/g, " ")
+      .trim()
+    results.push({ path, score, snippet })
+  }
+
+  return results.sort((a, b) => b.score - a.score).slice(0, 5)
+}

--- a/examples/research/server/test/research.test.ts
+++ b/examples/research/server/test/research.test.ts
@@ -1,0 +1,200 @@
+import { rmSync } from "node:fs"
+import { basename, join } from "node:path"
+import { fileURLToPath } from "node:url"
+import { run as runDawnCli } from "@dawn-ai/cli"
+import { afterAll, beforeAll, expect, it } from "vitest"
+import type { FixtureSet } from "@dawn-ai/testing"
+import {
+  createAgentHarness,
+  expectFinalMessage,
+  expectInterrupt,
+  expectOffloaded,
+  expectSubagent,
+  expectToolCalled,
+  seedMemory,
+  script,
+} from "@dawn-ai/testing"
+
+const appRoot = fileURLToPath(new URL("..", import.meta.url))
+const memoryDb = join(appRoot, ".dawn", "memory.sqlite")
+const memoryNamespace = `workspace=${basename(appRoot)}|route=/research`
+function cleanMemoryDb() {
+  for (const suffix of ["", "-wal", "-shm"]) rmSync(`${memoryDb}${suffix}`, { force: true })
+}
+
+async function runCli(args: readonly string[]) {
+  const stdout: string[] = []
+  const stderr: string[] = []
+  const code = await runDawnCli(args, {
+    stderr: (message) => stderr.push(message),
+    stdout: (message) => stdout.push(message),
+  })
+  expect(stderr.join("")).toBe("")
+  expect(code).toBe(0)
+  return stdout.join("")
+}
+
+beforeAll(cleanMemoryDb)
+const h = await createAgentHarness({ appRoot, route: "/research#agent" })
+afterAll(async () => {
+  await h.close()
+  cleanMemoryDb()
+})
+
+it("searches the corpus and writes a cited answer", async () => {
+  h.reset()
+  const run = await h.run({
+    input: "What are common agent architectures?",
+    fixtures: script()
+      .user("What are common agent architectures?")
+      .callsTool("searchCorpus", { query: "agent architectures" })
+      .callsTool("readDoc", { path: "corpus/agent-architectures.md" })
+      .replies("ReAct and plan-and-execute are common. [corpus/agent-architectures.md]"),
+  })
+  expectToolCalled(run, "searchCorpus")
+  expectToolCalled(run, "readDoc")
+  expectFinalMessage(run).toContain("[corpus/")
+}, 60_000)
+
+it("recalls seeded durable research preferences", async () => {
+  h.reset()
+  await seedMemory({ path: memoryDb }, [
+    {
+      id: "memory_report_style",
+      namespace: memoryNamespace,
+      content: "The user prefers concise executive summaries before detailed research findings.",
+      data: { subject: "user", predicate: "prefers-report-style", value: "concise-summary-first" },
+      tags: ["preference"],
+    },
+  ])
+  const run = await h.run({
+    input: "Research agent architectures with my preferences in mind.",
+    fixtures: script()
+      .user("Research agent architectures with my preferences in mind.")
+      .callsTool("recall", { query: "concise executive summaries" })
+      .replies("I will lead with a concise executive summary."),
+  })
+  expectToolCalled(run, "recall")
+  expect(String(run.toolResults.find((t) => t.name === "recall")?.content ?? "")).toContain(
+    "concise executive summaries",
+  )
+  expectFinalMessage(run).toContain("concise")
+}, 60_000)
+
+it("stores durable findings as reviewable memory candidates", async () => {
+  h.reset()
+  const run = await h.run({
+    input: "Remember that I want every research report to include primary sources.",
+    fixtures: script()
+      .user("Remember that I want every research report to include primary sources.")
+      .callsTool("remember", {
+        data: {
+          subject: "user",
+          predicate: "prefers-source-quality",
+          value: "primary-sources",
+        },
+        content: "The user wants every research report to include primary sources.",
+      })
+      .replies("Saved as a memory candidate for review."),
+  })
+  expectToolCalled(run, "remember")
+  expectFinalMessage(run).toContain("candidate")
+}, 60_000)
+
+it("approves a memory candidate through the CLI and recalls it in a fresh thread", async () => {
+  h.reset()
+  const stored = await h.run({
+    input: "Remember that I prefer source appendices in research reports.",
+    fixtures: script()
+      .user("Remember that I prefer source appendices in research reports.")
+      .callsTool("remember", {
+        data: {
+          subject: "user",
+          predicate: "prefers-report-appendix",
+          value: "source-appendix",
+        },
+        content: "The user prefers source appendices in research reports.",
+      })
+      .replies("Saved as a memory candidate for review."),
+  })
+  expectToolCalled(stored, "remember")
+
+  const list = await runCli(["memory", "--cwd", appRoot, "list"])
+  expect(list).toContain("source appendices")
+  const id = list.match(/^(memory_[a-f0-9]+) \[candidate\].*source appendices/m)?.[1]
+  expect(id).toBeDefined()
+
+  const approved = await runCli(["memory", "--cwd", appRoot, "approve", id ?? ""])
+  expect(approved).toContain(`Approved: ${id}`)
+
+  h.reset()
+  const recalled = await h.run({
+    input: "What report appendix preference should you remember?",
+    fixtures: script()
+      .user("What report appendix preference should you remember?")
+      .callsTool("recall", { query: "source appendices" })
+      .replies("You prefer source appendices in research reports."),
+  })
+  expectToolCalled(recalled, "recall")
+  expect(String(recalled.toolResults.find((t) => t.name === "recall")?.content ?? "")).toContain(
+    "source appendices",
+  )
+}, 60_000)
+
+it("dispatches the researcher subagent with access to shared corpus tools", async () => {
+  h.reset()
+  const subQuestion = "What are common agent architectures?"
+  const run = await h.run({
+    input: "Research agent architectures",
+    fixtures: script()
+      .user("Research agent architectures")
+      .callsTool("task", { subagent: "researcher", input: subQuestion })
+      .replies("Done — see the cited summary.")
+      .user(subQuestion)
+      .callsTool("searchCorpus", { query: "agent architectures" })
+      .callsTool("readDoc", { path: "corpus/agent-architectures.md" })
+      .replies("ReAct and plan-and-execute are common. [corpus/agent-architectures.md]"),
+  })
+  expectSubagent(run, "researcher").called().calledTool("searchCorpus").calledTool("readDoc")
+}, 60_000)
+
+it("offloads a large readDoc result", async () => {
+  h.reset()
+  const fixtures: FixtureSet = [
+    {
+      match: { turnIndex: 0, hasToolResult: false },
+      response: {
+        toolCalls: [
+          {
+            id: "call_read_big_1",
+            name: "readDoc",
+            arguments: { path: "corpus/context-windows-and-offloading.md" },
+          },
+        ],
+      },
+    },
+    { match: { hasToolResult: true }, response: { content: "Summarized the offloaded document." } },
+  ]
+  const run = await h.run({
+    input: "Summarize the context-windows document.",
+    fixtures,
+  })
+  expectOffloaded(run, "readDoc")
+  expectFinalMessage(run).toContain("Summarized")
+}, 60_000)
+
+it("gates the external fetch behind a permission prompt, then resumes", async () => {
+  h.reset()
+  const run = await h.run({
+    input: "Fetch external context on context windows",
+    fixtures: script()
+      .user("Fetch external context on context windows")
+      .callsTool("runBash", { command: "node scripts/fetch-source.mjs context windows" })
+      .replies("Fetched external context."),
+  })
+  expectInterrupt(run).ofKind("command").withDetail({
+    command: "node scripts/fetch-source.mjs context windows",
+  })
+  const resumed = await h.resume({ decision: "once" })
+  expectToolCalled(resumed, "runBash")
+}, 60_000)

--- a/examples/research/server/test/sandbox-docker.test.ts
+++ b/examples/research/server/test/sandbox-docker.test.ts
@@ -1,0 +1,70 @@
+import { constants } from "node:fs"
+import { access, rm } from "node:fs/promises"
+import { join } from "node:path"
+import { fileURLToPath } from "node:url"
+import { expect, it } from "vitest"
+import {
+  createAgentHarness,
+  expectFinalMessage,
+  expectToolCalled,
+  script,
+} from "@dawn-ai/testing"
+import { dockerSandbox } from "@dawn-ai/sandbox"
+
+const appRoot = fileURLToPath(new URL("..", import.meta.url))
+const enabled = process.env.DAWN_DEMO_DOCKER_SANDBOX === "1"
+const sandboxOnlyPath = "reports/sandbox-only.md"
+const hostSandboxOnlyPath = join(appRoot, "workspace", sandboxOnlyPath)
+
+it.skipIf(!enabled)(
+  "runs shared corpus tools against an isolated Docker sandbox workspace without touching host files",
+  async () => {
+    // This import is intentionally used by the test file so `npm run
+    // test:sandbox:docker` proves the generated app can resolve the sandbox
+    // package before dawn.config.ts creates the provider.
+    void dockerSandbox
+    await rm(hostSandboxOnlyPath, { force: true })
+
+    const h = await createAgentHarness({ appRoot, route: "/research#agent" })
+    try {
+      const run = await h.run({
+        input: "Seed and search the sandbox corpus for agent architectures.",
+        fixtures: script()
+          .user("Seed and search the sandbox corpus for agent architectures.")
+          .callsTool("writeFile", {
+            path: "corpus/agent-architectures.md",
+            content:
+              "# Agent Architectures\n\nPlan-and-execute agents split planning from execution and use specialist workers for focused research.",
+          })
+          .callsTool("writeFile", {
+            path: sandboxOnlyPath,
+            content: "This file should exist only in the thread sandbox.",
+          })
+          .callsTool("searchCorpus", { query: "plan execute specialist workers" })
+          .callsTool("readDoc", { path: "corpus/agent-architectures.md" })
+          .replies(
+            "Plan-and-execute agents split planning from execution. [corpus/agent-architectures.md]",
+          ),
+      })
+      expectToolCalled(run, "writeFile")
+      expectToolCalled(run, "searchCorpus")
+      expectToolCalled(run, "readDoc")
+      expectFinalMessage(run).toContain("[corpus/agent-architectures.md]")
+      await expect(access(hostSandboxOnlyPath, constants.F_OK)).rejects.toThrow()
+
+      h.reset()
+      const isolated = await h.run({
+        input: "Read the sandbox-only report from a fresh thread.",
+        fixtures: script()
+          .user("Read the sandbox-only report from a fresh thread.")
+          .callsTool("readFile", { path: sandboxOnlyPath })
+          .replies("The fresh thread could not read the sandbox-only report."),
+      })
+      expectToolCalled(isolated, "readFile")
+      expect(isolated.toolResults.find((t) => t.name === "readFile")?.isError).toBe(true)
+    } finally {
+      await h.close()
+    }
+  },
+  120_000,
+)

--- a/examples/research/server/tsconfig.json
+++ b/examples/research/server/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "@dawn-ai/config-typescript/node",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": [
+    "dawn.config.ts",
+    "src/**/*.ts",
+    ".dawn/dawn.generated.d.ts"
+  ]
+}

--- a/examples/research/server/vitest.config.ts
+++ b/examples/research/server/vitest.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from "vitest/config"
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["test/**/*.test.ts", "src/**/*.test.ts"],
+    passWithNoTests: true,
+    // The capability suites boot in-process agents + a real dawn dev subprocess
+    // and mutate process-global OPENAI_BASE_URL — run files sequentially to
+    // avoid cross-file env/port races.
+    fileParallelism: false,
+    testTimeout: 120_000,
+    hookTimeout: 120_000,
+  },
+})

--- a/examples/research/server/workspace/AGENTS.md
+++ b/examples/research/server/workspace/AGENTS.md
@@ -1,0 +1,16 @@
+# Research workspace memory
+
+Dawn injects this file into the agent's system prompt every turn. Use it for
+durable research conventions; the agent updates it with
+`writeFile({ path: "AGENTS.md", content: "..." })` when it learns something
+worth keeping across sessions.
+
+## House style
+
+- Cite every factual claim with its source path in square brackets, e.g.
+  `[corpus/agent-architectures.md]`.
+- Prefer the bundled corpus. Only request an external fetch when the corpus
+  lacks coverage — and expect the human to approve it.
+- Write the final report to `reports/<slug>.md` in the workspace.
+- Keep reports skimmable: a two-sentence answer first, then cited supporting
+  points, then a short Sources list.

--- a/examples/research/server/workspace/corpus/agent-architectures.md
+++ b/examples/research/server/workspace/corpus/agent-architectures.md
@@ -1,0 +1,15 @@
+# Agent architectures
+
+Most LLM agent systems fall into a few recurring shapes.
+
+- **ReAct**: the model interleaves reasoning traces with tool calls, observing
+  each result before deciding the next action. Simple and robust for tool use.
+- **Plan-and-execute**: a planner drafts a multi-step plan up front, then an
+  executor carries out each step. Better for long tasks where re-planning is
+  expensive.
+- **Coordinator / subagent**: a coordinator decomposes a task and dispatches
+  sub-questions to specialist subagents, then synthesizes their answers. Scales
+  to broad research where each branch needs focused context.
+
+Pick the simplest architecture that fits: ReAct for short tool-using tasks,
+coordinator/subagent for wide research, plan-and-execute for long procedures.

--- a/examples/research/server/workspace/corpus/context-windows-and-offloading.md
+++ b/examples/research/server/workspace/corpus/context-windows-and-offloading.md
@@ -1,0 +1,35 @@
+# Context windows and tool-output offloading
+
+A model's context window is the finite budget of tokens it can attend to in a
+single turn: the system prompt, the conversation history, retrieved documents,
+and tool results all compete for the same space. When that budget is exceeded,
+something must give — older turns get summarized, retrieved context gets
+truncated, or tool outputs get displaced. Managing the window deliberately is
+one of the highest-leverage things an agent framework can do.
+
+Tool outputs are a common cause of context blowups. A single tool call that
+returns a large file, a long search result, or a multi-thousand-row report can
+consume a large fraction of the window in one shot, pushing out the very
+history the model needs to stay coherent. Naively, you either cap tool outputs
+(losing information) or let them flood the window (losing coherence).
+
+Offloading is a middle path. When a tool result exceeds a size threshold, the
+framework writes the full output to durable storage and replaces it in-context
+with a short stub: a preview of the first few lines plus a handle the model can
+use to read the full content back on demand. The model sees that the data
+exists and where to find it, but only pays the token cost of the slice it
+actually needs. Retrieval tools that read the offloaded content back are
+exempted from offloading, so reading a stub does not immediately re-offload it.
+
+Offloading composes well with summarization. Summarization compresses the
+*conversation* — older turns are folded into a running summary once the thread
+grows long — while offloading compresses individual *tool results* at the
+moment they are produced. Together they keep the window focused on what the
+model needs now while preserving the ability to recover detail later. A good
+default: offload large tool outputs aggressively, summarize conversations only
+once they cross a token threshold, and always keep the most recent turns
+verbatim so the model never loses its immediate working context.
+
+The practical guidance: measure where your tokens go, offload the outputs that
+are large-but-rarely-needed-in-full, summarize long histories, and keep
+retrieval cheap so the model can pull detail back when a stub is not enough.

--- a/examples/research/server/workspace/corpus/evaluating-llm-apps.md
+++ b/examples/research/server/workspace/corpus/evaluating-llm-apps.md
@@ -1,0 +1,12 @@
+# Evaluating LLM apps
+
+Treat evaluation as code: a dataset of cases, one or more scorers, and a gate
+that turns scores into a pass/fail decision.
+
+- **Deterministic scorers** (exact match, contains, regex, tool-called) are
+  cheap and stable; prefer them where the expected behavior is well-defined.
+- **LLM-as-judge** scorers grade open-ended quality against written criteria;
+  use them when there is no single correct string.
+- **Gates** (mean, pass-rate, per-scorer) decide whether a run ships. Run evals
+  in replay by default so they are deterministic and offline; run them live to
+  measure against the real model.

--- a/examples/research/server/workspace/corpus/retrieval-augmented-generation.md
+++ b/examples/research/server/workspace/corpus/retrieval-augmented-generation.md
@@ -1,0 +1,11 @@
+# Retrieval-augmented generation (RAG)
+
+RAG grounds a model's answer in retrieved source documents instead of relying
+only on parametric memory. A typical pipeline: chunk the corpus, embed the
+chunks, retrieve the top matches for a query, and pass them to the model as
+context with an instruction to cite them.
+
+- Retrieval quality dominates answer quality — bad retrieval cannot be fixed by
+  a better prompt.
+- Keep chunks small enough to be specific but large enough to be self-contained.
+- Always ask the model to cite the chunk it used so claims are auditable.

--- a/examples/research/server/workspace/corpus/tool-use-and-function-calling.md
+++ b/examples/research/server/workspace/corpus/tool-use-and-function-calling.md
@@ -1,0 +1,11 @@
+# Tool use and function calling
+
+Tools let a model take actions and read external state. Each tool has a name, a
+typed input schema, and a return value the model reads back.
+
+- Give tools narrow, well-described inputs — the schema is the contract the
+  model plans against.
+- Return structured, concise results; large outputs should be summarized or
+  offloaded so they do not crowd the context window.
+- Validate tool inputs and fail with a clear message; a good error lets the
+  model recover instead of looping.

--- a/examples/research/server/workspace/scripts/fetch-source.mjs
+++ b/examples/research/server/workspace/scripts/fetch-source.mjs
@@ -1,0 +1,11 @@
+#!/usr/bin/env node
+// Offline seam for "fetch an external source". The default scaffold has no
+// network access, so this prints a deterministic stub. It is intentionally NOT
+// on the dawn.config.ts allow-list, so invoking it pauses the run for human
+// approval (the HITL permissions demo). Replace the body with a real fetch —
+// and add it to permissions.allow.bash — when you wire up an external source.
+const topic = process.argv.slice(2).join(" ").trim() || "(no topic)"
+process.stdout.write(
+  `No external source configured for "${topic}". ` +
+    `Edit workspace/scripts/fetch-source.mjs to fetch real content.\n`,
+)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -234,6 +234,46 @@ importers:
         specifier: ^4.1.10
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(@vitest/ui@4.1.10)(vite@6.4.3(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.0)(yaml@2.9.0))
 
+  examples/research/server:
+    dependencies:
+      '@dawn-ai/cli':
+        specifier: workspace:*
+        version: link:../../../packages/cli
+      '@dawn-ai/core':
+        specifier: workspace:*
+        version: link:../../../packages/core
+      '@dawn-ai/langchain':
+        specifier: workspace:*
+        version: link:../../../packages/langchain
+      '@dawn-ai/sandbox':
+        specifier: workspace:*
+        version: link:../../../packages/sandbox
+      '@dawn-ai/sdk':
+        specifier: workspace:*
+        version: link:../../../packages/sdk
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
+    devDependencies:
+      '@dawn-ai/config-typescript':
+        specifier: workspace:*
+        version: link:../../../packages/config-typescript
+      '@dawn-ai/evals':
+        specifier: workspace:*
+        version: link:../../../packages/evals
+      '@dawn-ai/testing':
+        specifier: workspace:*
+        version: link:../../../packages/testing
+      '@types/node':
+        specifier: 26.1.0
+        version: 26.1.0
+      typescript:
+        specifier: 6.0.2
+        version: 6.0.2
+      vitest:
+        specifier: ^4.1.9
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.0)(@vitest/ui@4.1.10)(vite@6.4.3(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.0)(yaml@2.9.0))
+
   packages/ag-ui:
     dependencies:
       '@ag-ui/core':
@@ -2746,6 +2786,9 @@ packages:
 
   '@types/node@24.13.3':
     resolution: {integrity: sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==}
+
+  '@types/node@26.1.0':
+    resolution: {integrity: sha512-O0A1G3xPGy4w7AgQdAQYUlQ+BKk2Oovw8eRpofyp5KdBZULnbe+WqaOVNrm705SHphCiG4XHsACrSmPu1f+Kgw==}
 
   '@types/node@26.1.1':
     resolution: {integrity: sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==}
@@ -8723,6 +8766,10 @@ snapshots:
     dependencies:
       undici-types: 7.18.2
 
+  '@types/node@26.1.0':
+    dependencies:
+      undici-types: 8.3.0
+
   '@types/node@26.1.1':
     dependencies:
       undici-types: 8.3.0
@@ -8964,6 +9011,14 @@ snapshots:
       '@vitest/utils': 4.1.10
       chai: 6.2.2
       tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.10(vite@6.4.3(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.0)(yaml@2.9.0))':
+    dependencies:
+      '@vitest/spy': 4.1.10
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 6.4.3(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.0)(yaml@2.9.0)
 
   '@vitest/mocker@4.1.10(vite@6.4.3(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.0)(yaml@2.9.0))':
     dependencies:
@@ -13386,6 +13441,22 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
+  vite@6.4.3(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.0)(yaml@2.9.0):
+    dependencies:
+      esbuild: 0.25.12
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
+      postcss: 8.5.10
+      rollup: 4.62.2
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      '@types/node': 26.1.0
+      fsevents: 2.3.3
+      jiti: 2.7.0
+      lightningcss: 1.32.0
+      tsx: 4.23.0
+      yaml: 2.9.0
+
   vite@6.4.3(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.0)(yaml@2.9.0):
     dependencies:
       esbuild: 0.25.12
@@ -13401,6 +13472,35 @@ snapshots:
       lightningcss: 1.32.0
       tsx: 4.23.0
       yaml: 2.9.0
+
+  vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.0)(@vitest/ui@4.1.10)(vite@6.4.3(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.0)(yaml@2.9.0)):
+    dependencies:
+      '@vitest/expect': 4.1.10
+      '@vitest/mocker': 4.1.10(vite@6.4.3(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.0)(yaml@2.9.0))
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/runner': 4.1.10
+      '@vitest/snapshot': 4.1.10
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      es-module-lexer: 2.3.0
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      obug: 2.1.3
+      pathe: 2.0.3
+      picomatch: 4.0.5
+      std-env: 4.2.0
+      tinybench: 2.9.0
+      tinyexec: 1.2.4
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.0
+      vite: 6.4.3(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.0)(yaml@2.9.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
+      '@types/node': 26.1.0
+      '@vitest/ui': 4.1.10(vitest@4.1.10)
+    transitivePeerDependencies:
+      - msw
 
   vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(@vitest/ui@4.1.10)(vite@6.4.3(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.0)(yaml@2.9.0)):
     dependencies:

--- a/vitest.workspace.ts
+++ b/vitest.workspace.ts
@@ -17,6 +17,7 @@ export default defineConfig({
       "./packages/testing/vitest.config.ts",
       "./packages/vite-plugin/vitest.config.ts",
       "./examples/chat/server/vitest.config.ts",
+      "./examples/research/server/vitest.config.ts",
     ],
   },
 })


### PR DESCRIPTION
## Summary

Slice 1 of the **polished flagship research demo**: a new standalone in-repo example `examples/research/server` (`@dawn-example/research-server`), created by **promoting** the default scaffold template `packages/devkit/templates/app-research` into a concrete example that mirrors `examples/chat/server`. The default scaffold template is untouched.

This is the first of four planned slices (see design + plan docs in this PR). Later slices add the web UI + no-key demo mode, slim/align the default scaffold, and extract a docs recipe.

**What it dogfoods** (the demo's point): a research coordinator + `researcher` subagent, custom corpus tools (`searchCorpus`/`readDoc`) with tool-output offloading, semantic memory with candidate → CLI-approve → recall, planning/todos, skills, HITL permissions (interrupt + resume), an **optional** Docker execution sandbox, workspace path-jail, evals with an LLM judge, and a deterministic test suite.

**Determinism:** the capability suite and evals run entirely on `aimock` fixtures — **no API key** required. Live/model paths are gated behind `OPENAI_API_KEY` + `--live`. The Docker sandbox is explicit but env-gated (`DAWN_DEMO_DOCKER_SANDBOX=1`) and skips cleanly without Docker.

**CI wiring:** the package is discovered automatically by the `examples/*/*` workspace glob (turbo `build`/`typecheck`) plus one line registering its test project in `vitest.workspace.ts` — the same treatment `examples/chat/server` gets.

Design: `docs/superpowers/specs/2026-07-06-research-demo-design.md`
Plan: `docs/superpowers/plans/2026-07-06-research-demo-slice1-server.md`

## Test Plan
- [x] `pnpm --filter @dawn-example/research-server test` → 7 passed | 1 skipped (offline, no key)
- [x] `pnpm --filter @dawn-example/research-server eval` → PASS, mean 1.00 across scorers (offline)
- [x] `pnpm --filter @dawn-example/research-server test:sandbox:docker` → 1 passed (Docker present)
- [x] `pnpm --filter @dawn-example/research-server typecheck` / `build` → green
- [x] `pnpm --filter @dawn-example/research-server check` generates `.dawn/` types (gitignored)
- [x] Runs under the root vitest workspace (`vitest.workspace.ts`) → 7 passed
- [ ] Full `pnpm ci:validate` on CI (standard gate for a new workspace package)

🤖 Generated with [Claude Code](https://claude.com/claude-code)