### PR TITLE
feat: argument-level tool constraints — tools.constrain predicates (Phase 4, tool policies slice 3)

### DIFF
--- a/.changeset/arg-constraints.md
+++ b/.changeset/arg-constraints.md
@@ -1,0 +1,8 @@
+---
+"@dawn-ai/sdk": patch
+"@dawn-ai/core": patch
+"@dawn-ai/langchain": patch
+"@dawn-ai/cli": patch
+---
+
+Argument-level tool constraints: `agent({ tools: { constrain: { deployProd: (args, ctx) => … } } })` runs a per-tool predicate against the model's arguments at call time, returning allow / deny-with-reason / `{ approve: true }` (escalate to the HITL prompt). Predicates may be async and receive a read-only policy context; a throwing or off-contract predicate fails closed. The tool run context now also carries the live `threadId` + route params. `dawn check` validates `constrain` tool names and warns on `approve`/`constrain` overlap.

--- a/apps/web/content/docs/permissions.mdx
+++ b/apps/web/content/docs/permissions.mdx
@@ -65,6 +65,8 @@ export default agent({
 
 Every call to `deployProd` pauses the run and emits a `kind: "tool"` interrupt, unless the tool is pre-approved (see below) or a prior "Always" decision already covers it.
 
+An argument [constraint](/docs/tools#constraining-arguments) can escalate a specific call to this same prompt by returning `{ approve: true }` — e.g. allow staging deploys silently but require approval for prod. The "Always" decision is still **name-level** (it persists the tool name), so it auto-approves future escalations of that tool; use an outright `deny` in the predicate if a case should never run.
+
 ### The tool interrupt payload
 
 ```

--- a/apps/web/content/docs/tools.mdx
+++ b/apps/web/content/docs/tools.mdx
@@ -88,6 +88,28 @@ See [Permissions](/docs/permissions#per-tool-approval) for the full interrupt pa
   `runBash`, `readFile`, `writeFile`, and `listDir` already have their own pattern-aware allow/deny gates (see [Permissions](/docs/permissions)). Adding them to `approve` is redundant and would double-prompt — `dawn check` warns if you do.
 </Callout>
 
+### Constraining arguments
+
+`constrain` is the fourth scoping knob: a predicate per tool, run at call time against the model's arguments. It returns `true` (allow), a string (deny — returned to the model as the tool result), or `{ approve: true }` (escalate to the [approval prompt](/docs/permissions#per-tool-approval)).
+
+```ts title="src/app/ops/index.ts"
+export default agent({
+  model: "gpt-5",
+  systemPrompt: "…",
+  tools: {
+    constrain: {
+      deployProd: (args, ctx) => {
+        if (args.env === "prod") return { approve: true }   // human-in-the-loop
+        if (args.env === "staging") return true             // allow
+        return `Unknown environment "${args.env}".`         // deny, model sees this
+      },
+    },
+  },
+})
+```
+
+The predicate receives the parsed `args` and a read-only `ctx` (`{ toolName, routeId, threadId?, signal, params? }`); it may be async. A predicate that throws — or returns anything other than the three shapes above — **fails closed** (the call is denied). Predicate bodies are not statically validated; `dawn check` validates only the tool names. Don't list a tool in both `approve` and `constrain`: `constrain` wins (it can escalate via `{ approve }`) and `dawn check` warns.
+
 ## The runtime signature
 
 The full runtime signature accepted by tool discovery is `(input, ctx) => ...`, where `ctx` is `DawnToolContext` from `@dawn-ai/sdk` — carrying `signal`, `middleware?`, and `fs`:

--- a/apps/web/content/docs/tools.mdx
+++ b/apps/web/content/docs/tools.mdx
@@ -99,9 +99,10 @@ export default agent({
   tools: {
     constrain: {
       deployProd: (args, ctx) => {
-        if (args.env === "prod") return { approve: true }   // human-in-the-loop
-        if (args.env === "staging") return true             // allow
-        return `Unknown environment "${args.env}".`         // deny, model sees this
+        const { env } = args as { env?: string }             // args is typed `unknown`
+        if (env === "prod") return { approve: true }         // human-in-the-loop
+        if (env === "staging") return true                   // allow
+        return `Unknown environment "${env}".`               // deny, model sees this
       },
     },
   },

--- a/docs/superpowers/plans/2026-07-06-arg-constraints.md
+++ b/docs/superpowers/plans/2026-07-06-arg-constraints.md
@@ -1,0 +1,804 @@
+# Argument-level Tool Constraints Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `agent({ tools: { constrain: { deployProd: (args, ctx) => args.env === "prod" ? { approve: true } : args.env === "staging" ? true : "staging/prod only" } } })` — a per-tool predicate evaluated against the model's arguments at call time, returning allow / deny-with-reason / escalate-to-HITL.
+
+**Architecture:** A runtime wrapper (`wrapToolWithConstraint`) on the tool's `run`, applied at the same `execute-route.ts` compose seam as slice 2's `approve` wrap. The predicate's `{approve}` verdict reuses the shipped `gateToolOp` interrupt/resume path. Because the wrapper is baked into a per-descriptor-cached agent (the `materializedAgents` WeakMap), all per-call data (args, signal, threadId, params) is read from the **live run context**, never closed over at compose time — so nothing goes stale across invokes. This requires the langchain tool-converter to forward `thread_id` + route params from `config.configurable` into the tool run context (a small, additive widening that also benefits any tool wanting its thread id).
+
+**Tech Stack:** TypeScript monorepo (pnpm + turbo), vitest, biome (repo lint script only — NEVER bare `biome check --write` on dirs), `@dawn-ai/{sdk,core,langchain,cli,testing}`, aimock deterministic e2e.
+
+**Spec:** `docs/superpowers/specs/2026-07-06-arg-constraints-design.md`
+
+**Conventions for every task:**
+- Cross-package tests resolve against built `dist`: after changing a package's `src/`, `npx turbo run build --filter=@dawn-ai/<pkg>` before running a *dependent* package's tests. Same-package tests import from `src/` and don't need it.
+- Verify `git branch --show-current` before each commit (should be the feature branch). Commit after each green task; do NOT push until the final task.
+- Lint per file: `pnpm exec biome check --config-path packages/config-biome/biome.json <files>`.
+
+---
+
+### Task 1: `ConstraintPredicate` types + `ToolScope.constrain` (`@dawn-ai/sdk`)
+
+**Files:**
+- Modify: `packages/sdk/src/agent.ts` (the `ToolScope` interface + new exported types)
+- Modify: `packages/sdk/src/index.ts` (export the new types if the file re-exports agent types — grep first)
+- Test: `packages/sdk/test/agent.test.ts`
+
+- [ ] **Step 1: Write the failing test.** Append to `packages/sdk/test/agent.test.ts`:
+
+```ts
+it("passes tools.constrain predicates through to the descriptor", () => {
+  const predicate = (args: unknown) =>
+    (args as { env?: string }).env === "prod" ? ({ approve: true } as const) : true
+  const a = agent({
+    model: "gpt-5-mini",
+    systemPrompt: "x",
+    tools: { constrain: { deployProd: predicate } },
+  })
+  expect(a.tools?.constrain?.deployProd).toBe(predicate)
+})
+```
+
+- [ ] **Step 2: Run to verify it fails.** `cd packages/sdk && npx vitest run test/agent.test.ts` — FAIL: `constrain` not on `ToolScope`.
+
+- [ ] **Step 3: Add the types.** In `packages/sdk/src/agent.ts`, immediately above `export interface ToolScope`:
+
+```ts
+export interface ConstraintContext {
+  readonly toolName: string
+  readonly routeId: string
+  readonly threadId?: string
+  readonly signal: AbortSignal
+  /** Route params in scope (e.g. tenant) when the route is parameterized. */
+  readonly params?: Readonly<Record<string, string>>
+}
+
+export type ConstraintVerdict = true | string | { readonly approve: true; readonly reason?: string }
+
+export type ConstraintPredicate = (
+  args: unknown,
+  ctx: ConstraintContext,
+) => ConstraintVerdict | Promise<ConstraintVerdict>
+```
+
+Then add to `ToolScope` (after `approve`):
+
+```ts
+  /**
+   * Per-call argument constraints: a predicate per tool name, run at call time
+   * against the model's arguments. Return `true` to allow, a string to deny
+   * (returned as the tool result), or `{ approve: true }` to escalate to a HITL
+   * approval prompt. Predicate bodies are not statically validated — only the
+   * tool names are. See docs/permissions.
+   */
+  readonly constrain?: Readonly<Record<string, ConstraintPredicate>>
+```
+
+- [ ] **Step 4: Export the types.** In `packages/sdk/src/index.ts`, grep for how `ToolScope` is exported (`grep -n "ToolScope" packages/sdk/src/index.ts`). If types are re-exported there, add `ConstraintContext`, `ConstraintVerdict`, `ConstraintPredicate` to that export block. If `agent.ts`'s types are exported via `export * from "./agent.js"`, nothing to do.
+
+- [ ] **Step 5: Run to verify pass.** `cd packages/sdk && npx vitest run` — all pass.
+
+- [ ] **Step 6: Lint + commit.**
+```bash
+pnpm exec biome check --config-path packages/config-biome/biome.json packages/sdk/src/agent.ts packages/sdk/test/agent.test.ts
+git add packages/sdk/src/agent.ts packages/sdk/src/index.ts packages/sdk/test/agent.test.ts
+git commit -m "feat(sdk): ToolScope.constrain — per-tool argument-constraint predicates"
+```
+
+---
+
+### Task 2: widen the tool run context with `threadId` + `params` (`@dawn-ai/core`)
+
+**Files:**
+- Modify: `packages/core/src/capabilities/types.ts` (the `DawnToolDefinition.run` context object type, ~lines 72-87)
+- Test: none (a type-only widening; exercised by Task 3's converter test and Task 4's wrapper).
+
+- [ ] **Step 1: Add the optional fields.** In `packages/core/src/capabilities/types.ts`, the `DawnToolDefinition.run`'s `context` object currently is:
+
+```ts
+    context: {
+      readonly middleware?: Readonly<Record<string, unknown>>
+      readonly signal: AbortSignal
+      readonly fs?: WorkspaceFs
+    },
+```
+
+Change it to:
+
+```ts
+    context: {
+      readonly middleware?: Readonly<Record<string, unknown>>
+      readonly signal: AbortSignal
+      readonly fs?: WorkspaceFs
+      // Live per-call runtime identity, forwarded by the langchain tool-converter
+      // from config.configurable. Optional because pre-wrap/legacy invokers omit
+      // it. Read by the argument-constraint wrapper to build ConstraintContext.
+      readonly threadId?: string
+      readonly params?: Readonly<Record<string, string>>
+    },
+```
+
+- [ ] **Step 2: Build to verify it typechecks.** `npx turbo run build --filter=@dawn-ai/core` — success.
+
+- [ ] **Step 3: Commit.**
+```bash
+git add packages/core/src/capabilities/types.ts
+git commit -m "feat(core): tool run context carries optional live threadId + route params"
+```
+
+---
+
+### Task 3: forward `thread_id` + route params in the tool-converter (`@dawn-ai/langchain`)
+
+**Files:**
+- Modify: `packages/langchain/src/tool-converter.ts` (the `func` that calls `tool.run`, ~lines 34-39)
+- Test: `packages/langchain/test/tool-converter.test.ts`
+
+The langchain `config` (3rd arg of the tool `func`) is a `RunnableConfig`; `config.configurable` holds `thread_id` and the route params (set by the agent-adapter's `prepareAgentCall`). Forward them into the run context so the constraint wrapper reads live values.
+
+- [ ] **Step 1: Write the failing test.** Read `packages/langchain/test/tool-converter.test.ts` first to match its style. Append a test that a converted tool's `run` receives `threadId`/`params` from `config.configurable`:
+
+```ts
+it("forwards thread_id and route params from config.configurable into the tool run context", async () => {
+  let seen: { threadId?: string; params?: Record<string, string> } | undefined
+  const tool = {
+    name: "probe",
+    run: (_input: unknown, ctx: { threadId?: string; params?: Record<string, string> }) => {
+      seen = { threadId: ctx.threadId, params: ctx.params }
+      return "ok"
+    },
+  }
+  const lc = convertToolToLangChain(tool)
+  await lc.invoke(
+    {},
+    { configurable: { thread_id: "t-123", tenant: "acme" } },
+  )
+  expect(seen?.threadId).toBe("t-123")
+  expect(seen?.params).toEqual({ tenant: "acme" })
+})
+```
+
+(If `convertToolToLangChain`'s signature/invoke differs, mirror the existing tests in the file — they already invoke converted tools.)
+
+- [ ] **Step 2: Run to verify fail.** `cd packages/langchain && npx vitest run test/tool-converter.test.ts` — FAIL: `seen.threadId`/`seen.params` undefined.
+
+- [ ] **Step 3: Implement.** In `packages/langchain/src/tool-converter.ts`, the `func` (~line 34) currently:
+
+```ts
+    func: async (input, _runManager, config) => {
+      const signal = config?.signal ?? new AbortController().signal
+      const rawResult = await tool.run(input, {
+        ...(middlewareContext ? { middleware: middlewareContext } : {}),
+        signal,
+      })
+```
+
+Change the `tool.run` context to extract thread_id + params from `config.configurable`:
+
+```ts
+    func: async (input, _runManager, config) => {
+      const signal = config?.signal ?? new AbortController().signal
+      // config.configurable carries thread_id + the route params (set by the
+      // agent-adapter's prepareAgentCall). Forward them so tools — and the
+      // argument-constraint wrapper — can read live per-call identity.
+      const configurable = (config?.configurable ?? {}) as Record<string, unknown>
+      const threadId =
+        typeof configurable.thread_id === "string" ? configurable.thread_id : undefined
+      const params: Record<string, string> = {}
+      for (const [key, value] of Object.entries(configurable)) {
+        if (key !== "thread_id" && typeof value === "string") params[key] = value
+      }
+      const rawResult = await tool.run(input, {
+        ...(middlewareContext ? { middleware: middlewareContext } : {}),
+        signal,
+        ...(threadId ? { threadId } : {}),
+        ...(Object.keys(params).length > 0 ? { params } : {}),
+      })
+```
+
+- [ ] **Step 4: Run to verify pass + full package.** `cd packages/langchain && npx vitest run test/tool-converter.test.ts && npx vitest run` — all pass (existing tools unaffected — the new context fields are additive/optional).
+
+- [ ] **Step 5: Lint + commit.**
+```bash
+pnpm exec biome check --config-path packages/config-biome/biome.json packages/langchain/src/tool-converter.ts packages/langchain/test/tool-converter.test.ts
+git add packages/langchain/src/tool-converter.ts packages/langchain/test/tool-converter.test.ts
+git commit -m "feat(langchain): forward thread_id + route params into the tool run context"
+```
+
+---
+
+### Task 4: `wrapToolWithConstraint` (`@dawn-ai/core`)
+
+**Files:**
+- Modify: `packages/core/src/capabilities/permission-gate.ts` (new wrapper + a small fail-closed constant)
+- Modify: `packages/core/src/index.ts` (export `wrapToolWithConstraint`)
+- Test: `packages/core/test/capabilities/permission-gate.test.ts`
+
+The wrapper closes over `routeId` + `predicate` (both stable per descriptor); it reads `signal`/`threadId`/`params` from the **live** run context. `ConstraintPredicate`/`ConstraintContext`/`ConstraintVerdict` are imported from `@dawn-ai/sdk` (build sdk first).
+
+- [ ] **Step 1: Write the failing tests.** Append to `packages/core/test/capabilities/permission-gate.test.ts` (reuse its `mkdtempSync` appRoot + `createPermissionsStore` helpers; add `wrapToolWithConstraint` to the import from `../../src/capabilities/permission-gate.js`):
+
+```ts
+describe("wrapToolWithConstraint", () => {
+  let appRoot: string
+  beforeEach(() => {
+    appRoot = mkdtempSync(join(tmpdir(), "dawn-constrain-test-"))
+  })
+  afterEach(() => {
+    rmSync(appRoot, { recursive: true, force: true })
+  })
+  const signal = new AbortController().signal
+  const runCtx = { signal }
+
+  it("allows (runs the real tool) when the predicate returns true", async () => {
+    const tool = { name: "deployProd", run: async (i: unknown) => `ran:${JSON.stringify(i)}` }
+    const wrapped = wrapToolWithConstraint(tool, () => true, undefined, "/ops#agent")
+    expect(await wrapped.run({ env: "staging" }, runCtx)).toBe('ran:{"env":"staging"}')
+  })
+
+  it("denies with the reason string as the tool result", async () => {
+    let ran = false
+    const tool = {
+      name: "deployProd",
+      run: async () => {
+        ran = true
+        return "ran"
+      },
+    }
+    const wrapped = wrapToolWithConstraint(tool, () => "prod not allowed here", undefined, "/ops#agent")
+    const result = await wrapped.run({ env: "prod" }, runCtx)
+    expect(ran).toBe(false)
+    expect(String(result)).toBe("prod not allowed here")
+  })
+
+  it("passes toolName/routeId and live threadId/params to the predicate", async () => {
+    let seen: { toolName?: string; routeId?: string; threadId?: string; params?: unknown } = {}
+    const tool = { name: "deployProd", run: async () => "ran" }
+    const wrapped = wrapToolWithConstraint(
+      tool,
+      (_args, ctx) => {
+        seen = { toolName: ctx.toolName, routeId: ctx.routeId, threadId: ctx.threadId, params: ctx.params }
+        return true
+      },
+      undefined,
+      "/ops#agent",
+    )
+    await wrapped.run({}, { signal, threadId: "t-9", params: { tenant: "acme" } })
+    expect(seen).toEqual({ toolName: "deployProd", routeId: "/ops#agent", threadId: "t-9", params: { tenant: "acme" } })
+  })
+
+  it("fails closed (deny result) when the predicate throws", async () => {
+    let ran = false
+    const tool = {
+      name: "deployProd",
+      run: async () => {
+        ran = true
+        return "ran"
+      },
+    }
+    const wrapped = wrapToolWithConstraint(
+      tool,
+      () => {
+        throw new Error("boom")
+      },
+      undefined,
+      "/ops#agent",
+    )
+    const result = await wrapped.run({}, runCtx)
+    expect(ran).toBe(false)
+    expect(String(result)).toMatch(/constraint check failed/i)
+  })
+
+  it("awaits an async predicate", async () => {
+    const tool = { name: "deployProd", run: async () => "ran" }
+    const wrapped = wrapToolWithConstraint(
+      tool,
+      async () => await Promise.resolve("async denied"),
+      undefined,
+      "/ops#agent",
+    )
+    expect(String(await wrapped.run({}, runCtx))).toBe("async denied")
+  })
+
+  it("{approve} escalates through gateToolOp — pre-approved tool runs", async () => {
+    const permissions = createPermissionsStore({
+      appRoot,
+      config: { version: 1, allow: { tool: ["deployProd"] }, deny: {} },
+      mode: "interactive",
+    })
+    await permissions.load()
+    const tool = { name: "deployProd", run: async () => "deployed" }
+    const wrapped = wrapToolWithConstraint(tool, () => ({ approve: true }), permissions, "/ops#agent")
+    expect(await wrapped.run({ env: "prod" }, runCtx)).toBe("deployed")
+  })
+
+  it("{approve} escalates through gateToolOp — denied tool returns the gate reason", async () => {
+    const permissions = createPermissionsStore({
+      appRoot,
+      config: { version: 1, allow: {}, deny: { tool: ["deployProd"] } },
+      mode: "interactive",
+    })
+    await permissions.load()
+    let ran = false
+    const tool = {
+      name: "deployProd",
+      run: async () => {
+        ran = true
+        return "deployed"
+      },
+    }
+    const wrapped = wrapToolWithConstraint(tool, () => ({ approve: true }), permissions, "/ops#agent")
+    const result = await wrapped.run({ env: "prod" }, runCtx)
+    expect(ran).toBe(false)
+    expect(String(result)).toMatch(/denied.*deployProd/i)
+  })
+})
+```
+
+- [ ] **Step 2: Run to verify fail.** `npx turbo run build --filter=@dawn-ai/sdk && cd packages/core && npx vitest run test/capabilities/permission-gate.test.ts` — FAIL: `wrapToolWithConstraint` not exported.
+
+- [ ] **Step 3: Implement.** In `packages/core/src/capabilities/permission-gate.ts`, add the import at the top (with the other `@dawn-ai/sdk`/type imports — check what's already imported):
+
+```ts
+import type { ConstraintContext, ConstraintPredicate } from "@dawn-ai/sdk"
+```
+
+Then add after `wrapToolWithApproval`:
+
+```ts
+const CONSTRAINT_FAILED_REASON =
+  "Blocked: the tool's argument constraint check failed (the policy predicate threw). Not run."
+
+/**
+ * Wrap a tool so each call is first evaluated by an argument-constraint predicate
+ * (tools.constrain). The predicate returns `true` (allow), a string (deny — the
+ * string is returned as the tool result, matching wrapToolWithApproval's
+ * return-not-throw contract), or `{ approve: true }` (escalate to the HITL gate
+ * via gateToolOp). A predicate that THROWS fails closed (deny) — a broken policy
+ * never silently allows. Per-call identity (signal/threadId/params) is read from
+ * the LIVE run context, never closed over, so the wrapper is safe inside the
+ * per-descriptor-cached agent. `routeId` and `predicate` are stable per descriptor
+ * and closed over.
+ */
+export function wrapToolWithConstraint<
+  C extends { readonly signal: AbortSignal; readonly threadId?: string; readonly params?: Readonly<Record<string, string>> },
+  T extends { readonly name: string; readonly run: (input: unknown, context: C) => Promise<unknown> | unknown },
+>(tool: T, predicate: ConstraintPredicate, permissions: PermissionsStore | undefined, routeId: string): T {
+  return {
+    ...tool,
+    run: async (input: unknown, context: C) => {
+      const ctx: ConstraintContext = {
+        toolName: tool.name,
+        routeId,
+        signal: context.signal,
+        ...(context.threadId ? { threadId: context.threadId } : {}),
+        ...(context.params ? { params: context.params } : {}),
+      }
+      let verdict: Awaited<ReturnType<ConstraintPredicate>>
+      try {
+        verdict = await predicate(input, ctx)
+      } catch {
+        return CONSTRAINT_FAILED_REASON
+      }
+      if (verdict === true) return tool.run(input, context)
+      if (typeof verdict === "string") return verdict
+      // verdict is { approve: true, reason? } — escalate to the HITL gate.
+      const gate = await gateToolOp(permissions, tool.name, buildArgsPreview(input))
+      if (!gate.allowed) return gate.reason
+      return tool.run(input, context)
+    },
+  }
+}
+```
+
+In `packages/core/src/index.ts`, extend the existing `permission-gate.js` export line to include `wrapToolWithConstraint`.
+
+- [ ] **Step 4: Run to verify pass + full core suite + build.** `cd packages/core && npx vitest run test/capabilities/permission-gate.test.ts && npx vitest run` then `npx turbo run build --filter=@dawn-ai/core` — all green.
+
+- [ ] **Step 5: Lint + commit.**
+```bash
+pnpm exec biome check --config-path packages/config-biome/biome.json packages/core/src/capabilities/permission-gate.ts packages/core/src/index.ts packages/core/test/capabilities/permission-gate.test.ts
+git add packages/core/src/capabilities/permission-gate.ts packages/core/src/index.ts packages/core/test/capabilities/permission-gate.test.ts
+git commit -m "feat(core): wrapToolWithConstraint — per-call argument-constraint gate"
+```
+
+---
+
+### Task 5: wire constraint wrapping at the compose seam (`@dawn-ai/cli`)
+
+**Files:**
+- Modify: `packages/cli/src/lib/runtime/execute-route.ts` (import + the block right after the `approve` wrap, ~line 707)
+
+- [ ] **Step 1: Add the import.** Add `wrapToolWithConstraint` to the existing `@dawn-ai/core` import block (alphabetical, next to `wrapToolWithApproval`).
+
+- [ ] **Step 2: Exclude constrain keys from the approve set + add the constrain wrap.** Replace the existing `approveSet` block (currently `const approveSet = new Set(descriptor?.tools?.approve ?? [])` … through its `.map`) with:
+
+```ts
+    // Per-tool approval gating (tools.approve). A tool that ALSO has a
+    // constraint predicate is excluded here — `constrain` is authoritative and
+    // can itself escalate via `{ approve }`, so wrapping both would double-gate.
+    const constrain = descriptor?.tools?.constrain
+    const approveSet = new Set(
+      (descriptor?.tools?.approve ?? []).filter((n) => !constrain?.[n]),
+    )
+    if (approveSet.size > 0) {
+      tools = tools.map((t) =>
+        approveSet.has(t.name)
+          ? wrapToolWithApproval<
+              Parameters<DiscoveredToolDefinition["run"]>[1],
+              DiscoveredToolDefinition
+            >(t, permissionsStore)
+          : t,
+      )
+    }
+
+    // Per-tool argument constraints (tools.constrain): wrap surviving tools so
+    // each call is evaluated by the author's predicate against the model's args
+    // before the tool runs. Runs at call time; reads live identity (signal/
+    // threadId/params) from the run context. `{ approve }` verdicts reuse the
+    // same HITL gate as tools.approve.
+    if (constrain) {
+      tools = tools.map((t) => {
+        // Local const: TS does not narrow a repeated indexed access across the
+        // ternary, so bind once.
+        const predicate = constrain[t.name]
+        return predicate
+          ? wrapToolWithConstraint<
+              Parameters<DiscoveredToolDefinition["run"]>[1],
+              DiscoveredToolDefinition
+            >(t, predicate, permissionsStore, options.routeId)
+          : t
+      })
+    }
+```
+
+(`options.routeId` is the stable per-descriptor route id already used for `keptToolNames`/scope validation; confirm it's in scope at this point — it is, it's used a few lines above.)
+
+- [ ] **Step 3: Build + full cli suite.** `npx turbo run build --filter=@dawn-ai/cli` then `cd packages/cli && npx vitest run` — all pass (behavior unchanged for routes without `constrain`; `approve`-only routes unaffected since `constrain?.[n]` is undefined).
+
+- [ ] **Step 4: Commit.**
+```bash
+git add packages/cli/src/lib/runtime/execute-route.ts
+git commit -m "feat(cli): apply argument-constraint wrapping at the tool-scoping seam"
+```
+
+---
+
+### Task 6: `dawn check` validates `constrain` + warns on `approve`∩`constrain` (`@dawn-ai/cli`)
+
+**Files:**
+- Modify: `packages/cli/src/lib/runtime/collect-tool-scope-errors.ts`
+- Test: `packages/cli/test/check-tool-scope.test.ts`
+
+- [ ] **Step 1: Write the failing tests.** Append to `packages/cli/test/check-tool-scope.test.ts`:
+
+```ts
+test("flags an unknown tool name in constrain", async () => {
+  const result = await collectToolScopeIssues(manifest, {
+    loadScope: async () => ({ constrain: { deployPord: () => true } }),
+    routeLocalToolNames: async () => ["deployProd"],
+  })
+  expect(result.errors.join("\n")).toMatch(/\/research.*unknown tool.*deployPord/s)
+})
+
+test("warns when a tool is in both approve and constrain (constrain wins)", async () => {
+  const result = await collectToolScopeIssues(manifest, {
+    loadScope: async () => ({ approve: ["deployProd"], constrain: { deployProd: () => true } }),
+    routeLocalToolNames: async () => ["deployProd"],
+  })
+  expect(result.errors).toEqual([])
+  expect(result.warnings.join("\n")).toMatch(/\/research.*deployProd.*constrain/s)
+})
+
+test("clean constrain produces no issues", async () => {
+  const result = await collectToolScopeIssues(manifest, {
+    loadScope: async () => ({ constrain: { deployProd: () => true } }),
+    routeLocalToolNames: async () => ["deployProd"],
+  })
+  expect(result.errors).toEqual([])
+  expect(result.warnings).toEqual([])
+})
+```
+
+- [ ] **Step 2: Run to verify fail.** `cd packages/cli && npx vitest run test/check-tool-scope.test.ts` — FAIL (constrain not handled).
+
+- [ ] **Step 3: Implement.** In `packages/cli/src/lib/runtime/collect-tool-scope-errors.ts`:
+
+(a) Widen `ToolScopeShape`:
+```ts
+interface ToolScopeShape {
+  readonly allow?: readonly string[]
+  readonly deny?: readonly string[]
+  readonly approve?: readonly string[]
+  readonly constrain?: Readonly<Record<string, unknown>>
+}
+```
+
+(b) Update the skip guard to include constrain:
+```ts
+    if (!scope || (!scope.allow && !scope.deny && !scope.approve && !scope.constrain)) continue
+```
+
+(c) Include constrain keys in the unknown-name check:
+```ts
+    const constrainNames = Object.keys(scope.constrain ?? {})
+    const unknown = [
+      ...(scope.allow ?? []),
+      ...(scope.deny ?? []),
+      ...(scope.approve ?? []),
+      ...constrainNames,
+    ].filter((n) => !available.has(n))
+```
+
+(d) After the existing `for (const name of scope.approve ?? [])` loop, add the overlap warning:
+```ts
+    const approveSet = new Set(scope.approve ?? [])
+    for (const name of constrainNames) {
+      if (approveSet.has(name)) {
+        warnings.push(
+          `⚠ ${route.pathname}: "${name}" is in both approve and constrain — constrain wins (it can escalate via { approve }); the approve entry is redundant.`,
+        )
+      }
+    }
+```
+
+- [ ] **Step 4: Run to verify pass + full cli suite.** `cd packages/cli && npx vitest run test/check-tool-scope.test.ts && npx vitest run` — all pass.
+
+- [ ] **Step 5: Lint + commit.**
+```bash
+pnpm exec biome check --config-path packages/config-biome/biome.json packages/cli/src/lib/runtime/collect-tool-scope-errors.ts packages/cli/test/check-tool-scope.test.ts
+git add packages/cli/src/lib/runtime/collect-tool-scope-errors.ts packages/cli/test/check-tool-scope.test.ts
+git commit -m "feat(cli): dawn check validates tools.constrain names and warns on approve overlap"
+```
+
+---
+
+### Task 7: deterministic aimock e2e (`@dawn-ai/testing`)
+
+**Files:**
+- Create: `packages/testing/test/fixtures/probe-app/src/app/constrain-chat/index.ts`
+- Create: `packages/testing/test/fixtures/probe-app/src/app/constrain-chat/tools/deployProd.ts`
+- Create: `packages/testing/test/tool-constrain.e2e.test.ts`
+
+- [ ] **Step 1: Create the fixture route.**
+
+`packages/testing/test/fixtures/probe-app/src/app/constrain-chat/index.ts`:
+```ts
+import { agent } from "@dawn-ai/sdk"
+export default agent({
+  model: "gpt-4o-mini",
+  systemPrompt: "You are a test agent. Use deployProd when asked to deploy.",
+  tools: {
+    constrain: {
+      deployProd: (args) => {
+        const env = (args as { env?: string }).env
+        if (env === "staging") return true
+        if (env === "prod") return { approve: true }
+        return "Only staging or prod are valid environments."
+      },
+    },
+  },
+})
+```
+
+`packages/testing/test/fixtures/probe-app/src/app/constrain-chat/tools/deployProd.ts`:
+```ts
+export default async function deployProd(input: { env: string }): Promise<string> {
+  return `deployed to ${input.env}`
+}
+```
+
+- [ ] **Step 2: Write the e2e.** `packages/testing/test/tool-constrain.e2e.test.ts` (mirror `tool-approval.e2e.test.ts` — read it first for the harness/permissions-cleanup idiom):
+
+```ts
+// Deterministic (aimock) e2e for argument-level tool constraints (tools.constrain).
+// CI-safe (no real key). Cleans permissions.json between scenarios (the {approve}
+// path persists there on "always").
+import { rmSync } from "node:fs"
+import { join } from "node:path"
+import { fileURLToPath } from "node:url"
+import { afterEach, beforeEach, expect, it } from "vitest"
+import { script } from "../src/fixture-builder.js"
+import { createAgentHarness } from "../src/harness.js"
+import { expectInterrupt, expectNoInterrupt, expectToolCalled } from "../src/matchers.js"
+
+const probeRoot = fileURLToPath(new URL("./fixtures/probe-app", import.meta.url))
+const permissionsPath = join(probeRoot, ".dawn", "permissions.json")
+beforeEach(() => rmSync(permissionsPath, { force: true }))
+afterEach(() => rmSync(permissionsPath, { force: true }))
+
+function toolResultText(run: { toolResults: ReadonlyArray<{ name: string; content: unknown }> }, name: string): string {
+  const r = run.toolResults.find((t) => t.name === name)
+  return typeof r?.content === "string" ? r.content : JSON.stringify(r?.content ?? "")
+}
+
+it("allowed arg (staging) runs the tool without an interrupt", async () => {
+  const h = await createAgentHarness({ appRoot: probeRoot, route: "/constrain-chat#agent" })
+  try {
+    const run = await h.run({
+      input: "deploy to staging",
+      fixtures: script().user("deploy to staging").callsTool("deployProd", { env: "staging" }).replies("Done."),
+    })
+    expectNoInterrupt(run)
+    expectToolCalled(run, "deployProd")
+    expect(toolResultText(run, "deployProd")).toContain("deployed to staging")
+  } finally {
+    await h.close()
+  }
+}, 60_000)
+
+it("escalating arg (prod) raises the kind:'tool' interrupt, then resume(once) runs it", async () => {
+  const h = await createAgentHarness({ appRoot: probeRoot, route: "/constrain-chat#agent" })
+  try {
+    const run = await h.run({
+      input: "deploy to prod",
+      fixtures: script().user("deploy to prod").callsTool("deployProd", { env: "prod" }).replies("Done."),
+    })
+    expectInterrupt(run).ofKind("tool").withDetail({ toolName: "deployProd" })
+    const resumed = await h.resume({ decision: "once" })
+    expectToolCalled(resumed, "deployProd")
+    expect(toolResultText(resumed, "deployProd")).toContain("deployed to prod")
+  } finally {
+    await h.close()
+  }
+}, 60_000)
+
+it("disallowed arg returns the deny reason as the tool result", async () => {
+  const h = await createAgentHarness({ appRoot: probeRoot, route: "/constrain-chat#agent" })
+  try {
+    const run = await h.run({
+      input: "deploy to qa",
+      fixtures: script().user("deploy to qa").callsTool("deployProd", { env: "qa" }).replies("Understood."),
+    })
+    expectNoInterrupt(run)
+    expect(toolResultText(run, "deployProd")).toMatch(/staging or prod/i)
+  } finally {
+    await h.close()
+  }
+}, 60_000)
+```
+
+- [ ] **Step 3: Build + run the e2e.** `npx turbo run build --filter=@dawn-ai/cli --filter=@dawn-ai/testing` then `cd packages/testing && npx vitest run test/tool-constrain.e2e.test.ts` — iterate until all 3 pass. (If typegen for the new route is stale, the harness runs it at boot; a real failure to look for is the constraint not firing.)
+
+- [ ] **Step 4: Full testing suite.** `cd packages/testing && npx vitest run` — all green (live smokes skip; your cleanup hooks must not clobber other tests' state).
+
+- [ ] **Step 5: Lint + commit.**
+```bash
+pnpm exec biome check --config-path packages/config-biome/biome.json packages/testing/test/tool-constrain.e2e.test.ts packages/testing/test/fixtures/probe-app/src/app/constrain-chat/index.ts packages/testing/test/fixtures/probe-app/src/app/constrain-chat/tools/deployProd.ts
+git add packages/testing/test/fixtures/probe-app/src/app/constrain-chat packages/testing/test/tool-constrain.e2e.test.ts
+git commit -m "test(testing): deterministic e2e for argument-level tool constraints (allow/deny/escalate)"
+```
+
+---
+
+### Task 8: docs + changeset
+
+**Files:**
+- Modify: `apps/web/content/docs/tools.mdx` (after the `approve` "Requiring approval per call" subsection)
+- Modify: `apps/web/content/docs/permissions.mdx` (short note under "Per-tool approval")
+- Create: `.changeset/arg-constraints.md`
+
+- [ ] **Step 1: tools.mdx — `constrain` as the fourth knob.** After the approval subsection's closing content, add:
+
+```mdx
+### Constraining arguments
+
+`constrain` is the fourth scoping knob: a predicate per tool, run at call time against the model's arguments. It returns `true` (allow), a string (deny — returned to the model as the tool result), or `{ approve: true }` (escalate to the [approval prompt](/docs/permissions#per-tool-approval)).
+
+```ts title="src/app/ops/index.ts"
+export default agent({
+  model: "gpt-5",
+  systemPrompt: "…",
+  tools: {
+    constrain: {
+      deployProd: (args, ctx) => {
+        if (args.env === "prod") return { approve: true }   // human-in-the-loop
+        if (args.env === "staging") return true             // allow
+        return `Unknown environment "${args.env}".`         // deny, model sees this
+      },
+    },
+  },
+})
+```
+
+The predicate receives the parsed `args` and a read-only `ctx` (`{ toolName, routeId, threadId?, signal, params? }`); it may be async. A predicate that throws **fails closed** (the call is denied). Predicate bodies are not statically validated — `dawn check` validates only the tool names. Don't list a tool in both `approve` and `constrain`: `constrain` wins (it can escalate via `{ approve }`) and `dawn check` warns.
+```
+
+- [ ] **Step 2: permissions.mdx — the `{approve}` cross-reference.** Under the "Per-tool approval" section, add one paragraph:
+
+```mdx
+An argument [constraint](/docs/tools#constraining-arguments) can escalate a specific call to this same prompt by returning `{ approve: true }` — e.g. allow staging deploys silently but require approval for prod. The "Always" decision is still **name-level** (it persists the tool name), so it auto-approves future escalations of that tool; use an outright `deny` in the predicate if a case should never run.
+```
+
+- [ ] **Step 3: Changeset.** Create `.changeset/arg-constraints.md`:
+```md
+---
+"@dawn-ai/sdk": patch
+"@dawn-ai/core": patch
+"@dawn-ai/langchain": patch
+"@dawn-ai/cli": patch
+---
+
+Argument-level tool constraints: `agent({ tools: { constrain: { deployProd: (args, ctx) => … } } })` runs a per-tool predicate against the model's arguments at call time, returning allow / deny-with-reason / `{ approve: true }` (escalate to the HITL prompt). Predicates may be async and receive a read-only policy context; a throwing predicate fails closed. The tool run context now also carries the live `threadId` + route params. `dawn check` validates `constrain` tool names and warns on `approve`/`constrain` overlap.
+```
+(All `patch` — fixed group keeps it pre-1.0.)
+
+- [ ] **Step 4: Docs check + commit.** `node scripts/check-docs.mjs` (avoid banned phrases). Then:
+```bash
+git add apps/web/content/docs/tools.mdx apps/web/content/docs/permissions.mdx .changeset/arg-constraints.md
+git commit -m "docs: argument-level tool constraints — tools/permissions + changeset"
+```
+
+---
+
+### Task 9: gated live smoke (`@dawn-ai/testing`)
+
+**Files:**
+- Create: `packages/testing/test/tool-constrain-live.smoke.test.ts`
+
+- [ ] **Step 1: Write the gated live smoke.** Mirror `tool-approval-live.smoke.test.ts`:
+
+```ts
+// LIVE SMOKE — argument-level constraints (tools.constrain) against a real model.
+// Gated on OPENAI_API_KEY: SKIPS in CI, runs only locally.
+import { rmSync } from "node:fs"
+import { join } from "node:path"
+import { fileURLToPath } from "node:url"
+import { afterEach, beforeEach, expect, it } from "vitest"
+import { createAgentHarness } from "../src/harness.js"
+import { expectInterrupt, expectNoInterrupt, expectToolCalled } from "../src/matchers.js"
+
+const live = Boolean(process.env.OPENAI_API_KEY)
+const probeRoot = fileURLToPath(new URL("./fixtures/probe-app", import.meta.url))
+const permissionsPath = join(probeRoot, ".dawn", "permissions.json")
+beforeEach(() => rmSync(permissionsPath, { force: true }))
+afterEach(() => rmSync(permissionsPath, { force: true }))
+
+it.skipIf(!live)(
+  "a real model deploying to staging is allowed; deploying to prod escalates to the HITL gate",
+  async () => {
+    const staging = await createAgentHarness({ appRoot: probeRoot, route: "/constrain-chat#agent", live: true })
+    try {
+      const run = await staging.run({ input: "Deploy the app to the staging environment." })
+      expectNoInterrupt(run)
+      expectToolCalled(run, "deployProd")
+    } finally {
+      await staging.close()
+    }
+    const prod = await createAgentHarness({ appRoot: probeRoot, route: "/constrain-chat#agent", live: true })
+    try {
+      const run = await prod.run({ input: "Deploy the app to the production (prod) environment." })
+      expectInterrupt(run).ofKind("tool").withDetail({ toolName: "deployProd" })
+    } finally {
+      await prod.close()
+    }
+  },
+  180_000,
+)
+```
+
+- [ ] **Step 2: Verify locally with a key** (the runner has `OPENAI_API_KEY` in the repo `.env`): build, then run with the key exported. If no key is available in the execution environment, confirm it SKIPS cleanly (`it.skipIf`) and note that in the report — do not block on it.
+
+- [ ] **Step 3: Lint + commit.**
+```bash
+pnpm exec biome check --config-path packages/config-biome/biome.json packages/testing/test/tool-constrain-live.smoke.test.ts
+git add packages/testing/test/tool-constrain-live.smoke.test.ts
+git commit -m "test(testing): gated live smoke for argument-level tool constraints"
+```
+
+---
+
+### Task 10: full verification + final whole-implementation review
+
+- [ ] **Step 1: Full build + test + lint.** From repo root:
+```bash
+npx turbo run build && npx turbo run test && pnpm lint
+```
+Expected: all green (gated live smokes skip without a key). If `create-dawn-ai-app`/generated-app lanes fail on registry versions, check whether it's the known publish-lifecycle artifact before assuming this change caused it.
+
+- [ ] **Step 2: Spec conformance re-read.** Re-read `docs/superpowers/specs/2026-07-06-arg-constraints-design.md` section by section; confirm each requirement maps to landed code/tests/docs. In particular verify: throwing predicate fails closed; a tool in both approve+constrain is wrapped ONLY by constrain (not double-gated); `{approve}` reuses gateToolOp; threadId/params are read live (not stale across invokes).
+
+- [ ] **Step 3: Cross-cutting check — no staleness.** Confirm `wrapToolWithConstraint` reads `signal`/`threadId`/`params` from the `context` argument (live), and only `routeId`/`predicate`/`tool.name` are closed over (stable per descriptor). A grep for `options.threadId`/`options.signal` inside the constraint wiring should find NONE closed into the wrapper.
+
+- [ ] **Step 4: Commit any stragglers; do not push.** The session driver handles PR creation and merge.
+```

--- a/docs/superpowers/specs/2026-07-06-arg-constraints-design.md
+++ b/docs/superpowers/specs/2026-07-06-arg-constraints-design.md
@@ -1,0 +1,165 @@
+# Argument-level tool constraints (Design)
+
+**Status:** Approved for planning
+**Date:** 2026-07-06
+**Roadmap:** Phase 4 (Richer Authoring Systems) — *richer tool policies*, slice 3: **argument-level constraints**. Follows slice 1 (tool scoping, PR #261) and slice 2 (per-tool approval gating, PR #291). Rate/usage limits and MCP/connection filtering remain later slices.
+
+## Problem
+
+Slices 1–2 police tools by **name**: `tools.allow`/`deny` control *which* tools the model may call, and `tools.approve` gates a call for HITL approval — but unconditionally, regardless of *how* the tool is called. Neither can express "this tool is fine with these arguments but not those":
+
+- `runBash` is allowed, but `rm -rf /` should be blocked while `ls` runs freely.
+- `deployProd` is available, but `env: "staging"` should run, `env: "prod"` should require a human.
+- `writeFile` inside the workspace is fine, but a path outside a per-tenant prefix should be denied.
+
+The Phase-3 bash/path gates already do a hardcoded, pattern-matched version of this for `runBash`/`readFile`/`writeFile`/`listDir` (`gateBashOp`/`gatePathOp` in `permission-gate.ts`). Slice 3 generalizes it to **any** tool, author-defined.
+
+## Decisions (from brainstorming)
+
+1. **Constraint form: predicate functions** (not declarative field patterns). Dawn is code-first (tsx-evaluated `dawn.config.ts`, callable backends, tools-as-functions), so a JS predicate fits the grain and is maximally expressive. The tradeoff — predicate bodies are opaque to static validation — is accepted.
+2. **Declared on the descriptor**, extending slices 1–2's `ToolScope`: `agent({ tools: { constrain: { <toolName>: predicate } } })`. Uniform across top routes and subagents.
+3. **Outcome vocabulary** (composes all three slices): a predicate returns
+   - `true` → **allow** (proceed to the tool),
+   - `string` → **deny**; the string is the reason returned *as the tool result* (model-visible; deliberately return-not-throw, matching `wrapToolWithApproval`),
+   - `{ approve: true; reason?: string }` → **escalate to HITL**, reusing the shipped `gateToolOp` interrupt/resume path.
+4. **Predicate signature**: `predicate(args, ctx)`, sync or async. `ctx` is a curated, read-only *policy* view — `{ toolName, routeId, threadId?, signal, params? }` — not the full runtime `DawnToolContext` (keeps the contract stable, testable, side-effect-discouraged).
+5. **Enforcement at the compose seam** (approach A): a runtime wrapper on the tool's `run`, applied where slice 2 already wraps `approve` tools in `execute-route.ts`. Constraints must run at call time (args are only known then).
+6. **Additive, not breaking.** `constrain` is optional; omitting it changes nothing. No migration.
+
+## Approaches considered
+
+- **A. Compose-seam runtime wrapper (chosen).** New `wrapToolWithConstraint(tool, predicate, permissions)` in `permission-gate.ts`, applied at the `execute-route.ts` seam right after the `approve` wrap. Reuses the exact, proven slice-2 pattern; one enforcement point; authored + capability tools uniform; the `{approve}` outcome delegates to the already-shipped `gateToolOp` so the interrupt/resume/persistence plumbing is reused verbatim.
+- **B. A new "policies" capability marker.** Rejected: capabilities contribute tools, they don't transform peers' tools — same reason slice 2 rejected its option C.
+- **C. Gate inside the langchain tool-converter.** Rejected: drags policy into `@dawn-ai/langchain` (policy lives in core) and needs duplicating for the legacy runnable path.
+
+## Design
+
+### 1. Authoring surface (`@dawn-ai/sdk`, `packages/sdk/src/agent.ts`)
+
+```ts
+export interface ConstraintContext {
+  readonly toolName: string
+  readonly routeId: string
+  readonly threadId?: string
+  readonly signal: AbortSignal
+  /** Route params in scope (e.g. tenant) when the route is parameterized. */
+  readonly params?: Readonly<Record<string, string>>
+}
+
+export type ConstraintVerdict = true | string | { readonly approve: true; readonly reason?: string }
+
+export type ConstraintPredicate = (
+  args: unknown,
+  ctx: ConstraintContext,
+) => ConstraintVerdict | Promise<ConstraintVerdict>
+
+export interface ToolScope {
+  readonly allow?: readonly string[]
+  readonly deny?: readonly string[]
+  readonly approve?: readonly string[]
+  /**
+   * Per-call argument constraints: a predicate per tool name. Runs at call time
+   * against the model's arguments. Return `true` to allow, a string to deny
+   * (the string is returned as the tool result), or `{ approve: true }` to
+   * escalate to a HITL approval prompt. Predicate bodies are not statically
+   * validated (only the tool names are). See docs/permissions.
+   */
+  readonly constrain?: Readonly<Record<string, ConstraintPredicate>>
+}
+```
+
+`agent()` passes `tools` through unchanged (already does). Applies to subagent descriptors identically.
+
+### 2. Enforcement (`@dawn-ai/core`, `packages/core/src/capabilities/permission-gate.ts`)
+
+New sibling of `wrapToolWithApproval`, generic over the tool shape (so `DiscoveredToolDefinition` survives with its extra fields, matching the slice-2 wrapper):
+
+```ts
+export function wrapToolWithConstraint<C, T extends { readonly name: string; readonly run: (input: unknown, context: C) => Promise<unknown> | unknown }>(
+  tool: T,
+  predicate: ConstraintPredicate,
+  permissions: PermissionsStore | undefined,
+  makeCtx: (input: unknown) => ConstraintContext,
+): T
+```
+
+The wrapped `run(input, context)`:
+1. `ctx = makeCtx(input)` (the wiring layer supplies `toolName`/`routeId`/`threadId`/`signal`/`params`).
+2. `let verdict; try { verdict = await predicate(input, ctx) } catch (e) { return DENY_REASON }` — **a throwing predicate fails closed** (returns a generic "constraint check failed" reason as the tool result; debug-gated warn). A broken policy never silently allows.
+3. Dispatch:
+   - `verdict === true` → `return tool.run(input, context)`.
+   - `typeof verdict === "string"` → `return verdict` (deny; model-visible result).
+   - `verdict && verdict.approve === true` → `const gate = await gateToolOp(permissions, tool.name, buildArgsPreview(input)); if (!gate.allowed) return gate.reason; return tool.run(input, context)`. (The predicate's optional `reason` is surfaced in the approval prompt.)
+
+Reuses `buildArgsPreview` and `gateToolOp` unchanged. The `{approve}` branch inherits every mode behavior (bypass/non-interactive/interruptCapable) and the Once/Always/Deny persistence from slice 2.
+
+### 3. Wiring (`@dawn-ai/cli`, `packages/cli/src/lib/runtime/execute-route.ts`)
+
+At the existing compose seam, **after** the `approve` wrap (so precedence is well-defined):
+
+```ts
+const constrain = descriptor?.tools?.constrain
+if (constrain) {
+  tools = tools.map((t) =>
+    constrain[t.name]
+      ? wrapToolWithConstraint(t, constrain[t.name], permissionsStore, (input) => ({
+          toolName: t.name,
+          routeId: options.routeId,
+          ...(threadId ? { threadId } : {}),
+          signal,
+          ...(routeParams ? { params: routeParams } : {}),
+        }))
+      : t,
+  )
+}
+```
+
+(The exact in-scope names for `threadId`/`signal`/`routeParams` are verified during planning; `permissionsStore`/`descriptor`/`options.routeId` are the same ones slice 2 uses.)
+
+**Precedence when a tool is in both `approve` and `constrain`:** `constrain` is authoritative and a constrained tool is wrapped **only** by `constrain` (the wiring excludes `constrain` keys from the `approve` set: `approveSet = approve.filter(n => !constrain[n])`). This avoids a double-gate — wrapping both would make the predicate's `true` verdict still hit the inner name-level prompt. `constrain` can itself escalate via `{approve}`, so nothing is lost; `dawn check` warns the `approve` entry is redundant (see §4).
+
+**"Always" is name-level (documented limitation).** When a constraint's `{approve}` escalation is answered "Always", `gateToolOp` persists the **tool name** under the reserved `tool` key (slice 2's mechanism) — so *future* `{approve}` escalations of that same tool auto-pass, regardless of args. The predicate still runs first on every call (it can `deny` outright), but the escalation's persistence is coarser than the args that triggered it. Args-level persistence is explicitly out of scope; authors who need per-args durability should `deny` the disallowed case outright rather than escalate it.
+
+### 4. Validation (`dawn check`, `packages/cli/src/lib/runtime/collect-tool-scope-errors.ts`)
+
+- Each `constrain` key must be a real **post-scope** tool name → **error** (same shape/report as unknown `allow`/`deny`/`approve` names). Predicate *bodies* are opaque and not checked — stated plainly in docs.
+- A tool in **both** `approve` and `constrain` → **warning**: the `approve` entry is redundant (constrain can escalate); constrain wins.
+- (No `task` special-case needed beyond the existing one — a `constrain` on `task` has the same bridge caveat as `approve` on `task`; warn identically if the effort is cheap, else document.)
+
+`ToolScopeShape` in the check module gains `constrain?: Record<string, unknown>` (only the keys matter for validation; values are opaque).
+
+### 5. Error handling / edge cases
+
+- **Throwing predicate** → fail closed (deny result), never allow. Debug-gated warn (`DAWN_DEBUG_CONSTRAINTS=1`).
+- **Async predicate** → awaited; honors the call's `AbortSignal` via `ctx.signal` (author's responsibility to respect it for long checks).
+- **`constrain` names a tool not present** → build-time error + runtime no-op (the wrap map only wraps tools that exist post-scope, exactly like slice 2).
+- **`{approve}` in a non-interactive / non-interrupt-capable context** → inherits `gateToolOp`'s fail-closed-with-guidance behavior (no new path).
+- **Determinism** — the wrapper adds no `Date.now()`/rand; `gateToolOp` already owns the only non-deterministic bits (interruptId), unchanged.
+
+### 6. Testing
+
+- **Unit (`@dawn-ai/core`):** `wrapToolWithConstraint` verdict ladder — allow proceeds to real run; string denies with that result; `{approve}` reaches `gateToolOp` (allow→proceed, deny→reason); throwing predicate fails closed; async predicate awaited; tool metadata preserved.
+- **Unit (`@dawn-ai/cli`):** `dawn check` — unknown `constrain` key errors; `approve`∩`constrain` warns.
+- **aimock e2e (`@dawn-ai/testing`) — headline:** a probe route whose `deployProd` has a `constrain` predicate (`env==="staging"`→allow, `env==="prod"`→`{approve}`, else deny). Assert: staging call runs; prod call raises the `kind:"tool"` interrupt → resume(once) runs; a bad value returns the deny reason. Reuse the `approval-chat` fixture shape.
+- **Gated live smoke:** a real model driven to call the constrained tool with an allowed vs escalating arg, mirroring `tool-approval-live.smoke.test.ts`.
+
+### 7. Documentation & website
+
+- **tools.mdx** — `constrain` as the **fourth** scoping knob; predicate example (staging vs prod); the "predicate bodies aren't statically validated" note; cross-link to permissions for the `{approve}` flow.
+- **permissions.mdx** — a short subsection: how a constraint's `{approve}` verdict reuses the per-tool approval prompt/persistence.
+- **api.mdx** — `ConstraintPredicate`/`ConstraintVerdict`/`ConstraintContext` types if the file lists `ToolScope` (it currently doesn't — skip if still absent).
+- **Changeset** — patch across `@dawn-ai/sdk`, `@dawn-ai/core`, `@dawn-ai/cli` (fixed group → stays pre-1.0).
+
+## Out of scope (later slices / other features)
+
+- Declarative (data) constraint DSL — predicates cover it; a serializable form is a possible future addition, not now.
+- Transforming/sanitizing args (return-modified-args) — explicitly rejected in brainstorming (surprising, blurs policy vs implementation).
+- Rate / usage limits, per-tool concurrency.
+- Static analysis of predicate bodies.
+- Refactoring the built-in bash/path gates onto this mechanism (they stay pattern-aware and independent).
+
+## Risks
+
+- **Opaque predicates** — no static safety on the logic; a buggy predicate that throws fails closed (safe default) but blocks the tool. Mitigated by the fail-closed + debug warn + docs.
+- **Precedence confusion** with `approve` — mitigated by the `dawn check` warning and clear docs (constrain wins; it can escalate).
+- **Predicate side effects / latency** — a slow or effectful predicate delays every gated call; docs steer authors toward pure, fast checks and honoring `ctx.signal`.

--- a/packages/cli/src/lib/runtime/collect-tool-scope-errors.ts
+++ b/packages/cli/src/lib/runtime/collect-tool-scope-errors.ts
@@ -9,6 +9,7 @@ interface ToolScopeShape {
   readonly allow?: readonly string[]
   readonly deny?: readonly string[]
   readonly approve?: readonly string[]
+  readonly constrain?: Readonly<Record<string, unknown>>
 }
 
 export interface ToolScopeIssues {
@@ -65,15 +66,17 @@ export async function collectToolScopeIssues(
   for (const route of manifest.routes) {
     if (route.kind !== "agent") continue
     const scope = await deps.loadScope(route.entryFile, manifest.appRoot)
-    if (!scope || (!scope.allow && !scope.deny && !scope.approve)) continue
+    if (!scope || (!scope.allow && !scope.deny && !scope.approve && !scope.constrain)) continue
     const available = new Set([
       ...(await deps.routeLocalToolNames(manifest.appRoot, route.routeDir)),
       ...BUILT_IN_TOOL_NAMES,
     ])
+    const constrainNames = Object.keys(scope.constrain ?? {})
     const unknown = [
       ...(scope.allow ?? []),
       ...(scope.deny ?? []),
       ...(scope.approve ?? []),
+      ...constrainNames,
     ].filter((n) => !available.has(n))
     if (unknown.length > 0) {
       errors.push(
@@ -123,6 +126,14 @@ export async function collectToolScopeIssues(
         warnings.push(
           `⚠ ${route.pathname}: approve lists "${name}", but subagents withhold capability tools ` +
             `by default — add it to allow or the approve entry has no effect.`,
+        )
+      }
+    }
+    const approveSetForConstrain = new Set(scope.approve ?? [])
+    for (const name of constrainNames) {
+      if (approveSetForConstrain.has(name)) {
+        warnings.push(
+          `⚠ ${route.pathname}: "${name}" is in both approve and constrain — constrain wins (it can escalate via { approve }); the approve entry is redundant.`,
         )
       }
     }

--- a/packages/cli/src/lib/runtime/execute-route.ts
+++ b/packages/cli/src/lib/runtime/execute-route.ts
@@ -25,6 +25,7 @@ import {
   resolveToolScope,
   toolOrigin,
   wrapToolWithApproval,
+  wrapToolWithConstraint,
 } from "@dawn-ai/core"
 import {
   Command,
@@ -721,7 +722,11 @@ async function prepareRouteExecution(options: {
     // the wrapper interrupts for a human decision (kind: "tool"). Bash/path
     // gates inside the workspace tools are separate (pattern-aware) and
     // unaffected; `dawn check` warns on redundant overlap.
-    const approveSet = new Set(descriptor?.tools?.approve ?? [])
+    // Per-tool approval gating (tools.approve). A tool that ALSO has a
+    // constraint predicate is excluded here — `constrain` is authoritative and
+    // can itself escalate via `{ approve }`, so wrapping both would double-gate.
+    const constrain = descriptor?.tools?.constrain
+    const approveSet = new Set((descriptor?.tools?.approve ?? []).filter((n) => !constrain?.[n]))
     if (approveSet.size > 0) {
       tools = tools.map((t) =>
         approveSet.has(t.name)
@@ -731,6 +736,25 @@ async function prepareRouteExecution(options: {
             >(t, permissionsStore)
           : t,
       )
+    }
+
+    // Per-tool argument constraints (tools.constrain): wrap surviving tools so
+    // each call is evaluated by the author's predicate against the model's args
+    // before the tool runs. Runs at call time; reads live identity (signal/
+    // threadId/params) from the run context. `{ approve }` verdicts reuse the
+    // same HITL gate as tools.approve.
+    if (constrain) {
+      tools = tools.map((t) => {
+        // Local const: TS does not narrow a repeated indexed access across the
+        // ternary, so bind once.
+        const predicate = constrain[t.name]
+        return predicate
+          ? wrapToolWithConstraint<
+              Parameters<DiscoveredToolDefinition["run"]>[1],
+              DiscoveredToolDefinition
+            >(t, predicate, permissionsStore, options.routeId)
+          : t
+      })
     }
     stateFields = stateFields ? [...stateFields, ...capStateFields] : capStateFields
     promptFragments = capPromptFragments

--- a/packages/cli/src/lib/runtime/execute-route.ts
+++ b/packages/cli/src/lib/runtime/execute-route.ts
@@ -721,9 +721,8 @@ async function prepareRouteExecution(options: {
     // call consults the permissions store; on "unknown" in interactive mode
     // the wrapper interrupts for a human decision (kind: "tool"). Bash/path
     // gates inside the workspace tools are separate (pattern-aware) and
-    // unaffected; `dawn check` warns on redundant overlap.
-    // Per-tool approval gating (tools.approve). A tool that ALSO has a
-    // constraint predicate is excluded here — `constrain` is authoritative and
+    // unaffected; `dawn check` warns on redundant overlap. A tool that ALSO has
+    // a constraint predicate is excluded here — `constrain` is authoritative and
     // can itself escalate via `{ approve }`, so wrapping both would double-gate.
     const constrain = descriptor?.tools?.constrain
     const approveSet = new Set((descriptor?.tools?.approve ?? []).filter((n) => !constrain?.[n]))

--- a/packages/cli/test/check-tool-scope.test.ts
+++ b/packages/cli/test/check-tool-scope.test.ts
@@ -171,3 +171,29 @@ test("does not warn about remember when no memoryWrites opts are passed", async 
   })
   expect(result.warnings.some((w) => w.includes('approve lists "remember"'))).toBe(false)
 })
+
+test("flags an unknown tool name in constrain", async () => {
+  const result = await collectToolScopeIssues(manifest, {
+    loadScope: async () => ({ constrain: { deployPord: () => true } }),
+    routeLocalToolNames: async () => ["deployProd"],
+  })
+  expect(result.errors.join("\n")).toMatch(/\/research.*unknown tool.*deployPord/s)
+})
+
+test("warns when a tool is in both approve and constrain (constrain wins)", async () => {
+  const result = await collectToolScopeIssues(manifest, {
+    loadScope: async () => ({ approve: ["deployProd"], constrain: { deployProd: () => true } }),
+    routeLocalToolNames: async () => ["deployProd"],
+  })
+  expect(result.errors).toEqual([])
+  expect(result.warnings.join("\n")).toMatch(/\/research.*deployProd.*constrain/s)
+})
+
+test("clean constrain produces no issues", async () => {
+  const result = await collectToolScopeIssues(manifest, {
+    loadScope: async () => ({ constrain: { deployProd: () => true } }),
+    routeLocalToolNames: async () => ["deployProd"],
+  })
+  expect(result.errors).toEqual([])
+  expect(result.warnings).toEqual([])
+})

--- a/packages/core/src/capabilities/permission-gate.ts
+++ b/packages/core/src/capabilities/permission-gate.ts
@@ -5,6 +5,7 @@ import {
   suggestedMemoryPattern,
   suggestedPathPattern,
 } from "@dawn-ai/permissions"
+import type { ConstraintContext, ConstraintPredicate } from "@dawn-ai/sdk"
 import { interrupt } from "@langchain/langgraph"
 
 export type PathOperation = "readFile" | "writeFile" | "listDir"
@@ -216,6 +217,62 @@ export function wrapToolWithApproval<
     ...tool,
     run: async (input: unknown, context: C) => {
       const gate = await gateToolOp(permissions, tool.name, buildArgsPreview(input), opts)
+      if (!gate.allowed) return gate.reason
+      return tool.run(input, context)
+    },
+  }
+}
+
+const CONSTRAINT_FAILED_REASON =
+  "Blocked: the tool's argument constraint check failed (the policy predicate threw). Not run."
+
+/**
+ * Wrap a tool so each call is first evaluated by an argument-constraint predicate
+ * (tools.constrain). The predicate returns `true` (allow), a string (deny — the
+ * string is returned as the tool result, matching wrapToolWithApproval's
+ * return-not-throw contract), or `{ approve: true }` (escalate to the HITL gate
+ * via gateToolOp). A predicate that THROWS fails closed (deny) — a broken policy
+ * never silently allows. Per-call identity (signal/threadId/params) is read from
+ * the LIVE run context, never closed over, so the wrapper is safe inside the
+ * per-descriptor-cached agent. `routeId` and `predicate` are stable per descriptor
+ * and closed over.
+ */
+export function wrapToolWithConstraint<
+  C extends {
+    readonly signal: AbortSignal
+    readonly threadId?: string
+    readonly params?: Readonly<Record<string, string>>
+  },
+  T extends {
+    readonly name: string
+    readonly run: (input: unknown, context: C) => Promise<unknown> | unknown
+  },
+>(
+  tool: T,
+  predicate: ConstraintPredicate,
+  permissions: PermissionsStore | undefined,
+  routeId: string,
+): T {
+  return {
+    ...tool,
+    run: async (input: unknown, context: C) => {
+      const ctx: ConstraintContext = {
+        toolName: tool.name,
+        routeId,
+        signal: context.signal,
+        ...(context.threadId ? { threadId: context.threadId } : {}),
+        ...(context.params ? { params: context.params } : {}),
+      }
+      let verdict: Awaited<ReturnType<ConstraintPredicate>>
+      try {
+        verdict = await predicate(input, ctx)
+      } catch {
+        return CONSTRAINT_FAILED_REASON
+      }
+      if (verdict === true) return tool.run(input, context)
+      if (typeof verdict === "string") return verdict
+      // verdict is { approve: true, reason? } — escalate to the HITL gate.
+      const gate = await gateToolOp(permissions, tool.name, buildArgsPreview(input))
       if (!gate.allowed) return gate.reason
       return tool.run(input, context)
     },

--- a/packages/core/src/capabilities/permission-gate.ts
+++ b/packages/core/src/capabilities/permission-gate.ts
@@ -224,7 +224,7 @@ export function wrapToolWithApproval<
 }
 
 const CONSTRAINT_FAILED_REASON =
-  "Blocked: the tool's argument constraint check failed (the policy predicate threw). Not run."
+  "Blocked: the tool's argument constraint check failed (the policy predicate threw or returned an invalid verdict). Not run."
 
 /**
  * Wrap a tool so each call is first evaluated by an argument-constraint predicate
@@ -271,10 +271,19 @@ export function wrapToolWithConstraint<
       }
       if (verdict === true) return tool.run(input, context)
       if (typeof verdict === "string") return verdict
-      // verdict is { approve: true, reason? } — escalate to the HITL gate.
-      const gate = await gateToolOp(permissions, tool.name, buildArgsPreview(input))
-      if (!gate.allowed) return gate.reason
-      return tool.run(input, context)
+      // Escalate to HITL ONLY on a genuine { approve: true } verdict.
+      if (
+        typeof verdict === "object" &&
+        verdict !== null &&
+        (verdict as { approve?: unknown }).approve === true
+      ) {
+        const gate = await gateToolOp(permissions, tool.name, buildArgsPreview(input))
+        if (!gate.allowed) return gate.reason
+        return tool.run(input, context)
+      }
+      // Any other value (false, undefined, { approve: false }, a number, …) is
+      // off-contract — fail closed rather than silently escalate or allow.
+      return CONSTRAINT_FAILED_REASON
     },
   }
 }

--- a/packages/core/src/capabilities/permission-gate.ts
+++ b/packages/core/src/capabilities/permission-gate.ts
@@ -231,8 +231,9 @@ const CONSTRAINT_FAILED_REASON =
  * (tools.constrain). The predicate returns `true` (allow), a string (deny — the
  * string is returned as the tool result, matching wrapToolWithApproval's
  * return-not-throw contract), or `{ approve: true }` (escalate to the HITL gate
- * via gateToolOp). A predicate that THROWS fails closed (deny) — a broken policy
- * never silently allows. Per-call identity (signal/threadId/params) is read from
+ * via gateToolOp). A predicate that throws OR returns any off-contract value
+ * (false, undefined, `{ approve: false }`, …) fails closed (deny) — a broken
+ * policy never silently allows. Per-call identity (signal/threadId/params) is read from
  * the LIVE run context, never closed over, so the wrapper is safe inside the
  * per-descriptor-cached agent. `routeId` and `predicate` are stable per descriptor
  * and closed over.

--- a/packages/core/src/capabilities/types.ts
+++ b/packages/core/src/capabilities/types.ts
@@ -125,6 +125,11 @@ export interface DawnToolDefinition {
       // omit it; the cli's prepareRouteExecution wrapper guarantees it at
       // runtime, which is why the author-facing DawnToolContext requires it.
       readonly fs?: WorkspaceFs
+      // Live per-call runtime identity, forwarded by the langchain tool-converter
+      // from config.configurable. Optional because pre-wrap/legacy invokers omit
+      // it. Read by the argument-constraint wrapper to build ConstraintContext.
+      readonly threadId?: string
+      readonly params?: Readonly<Record<string, string>>
     },
   ) => Promise<unknown> | unknown
   readonly schema?: unknown

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -13,6 +13,7 @@ export {
   gateMemorySupersede,
   gateToolOp,
   wrapToolWithApproval,
+  wrapToolWithConstraint,
 } from "./capabilities/permission-gate.js"
 export type {
   AppliedContribution,

--- a/packages/core/test/capabilities/permission-gate.test.ts
+++ b/packages/core/test/capabilities/permission-gate.test.ts
@@ -328,6 +328,25 @@ describe("wrapToolWithConstraint", () => {
     expect(ran).toBe(false)
     expect(String(result)).toMatch(/denied.*deployProd/i)
   })
+
+  it("fails closed on an off-contract verdict (false / undefined / {approve:false})", async () => {
+    for (const bad of [() => false, () => undefined, () => ({ approve: false })]) {
+      let ran = false
+      const tool = {
+        name: "deployProd",
+        run: async () => {
+          ran = true
+          return "ran"
+        },
+      }
+      // permissions omitted (undefined) — if this WRONGLY escalated it would still
+      // not throw, but the result would not be the constraint-failed string.
+      const wrapped = wrapToolWithConstraint(tool, bad as never, undefined, "/ops#agent")
+      const result = await wrapped.run({}, { signal: new AbortController().signal })
+      expect(ran).toBe(false)
+      expect(String(result)).toMatch(/constraint check failed/i)
+    }
+  })
 })
 
 describe("gateMemorySupersede", () => {

--- a/packages/core/test/capabilities/permission-gate.test.ts
+++ b/packages/core/test/capabilities/permission-gate.test.ts
@@ -9,6 +9,7 @@ import {
   gatePathOp,
   gateToolOp,
   wrapToolWithApproval,
+  wrapToolWithConstraint,
 } from "../../src/capabilities/permission-gate.js"
 
 describe("gatePathOp interrupt suppression", () => {
@@ -186,6 +187,146 @@ describe("wrapToolWithApproval", () => {
     await permissions.load()
     const wrapped = wrapToolWithApproval({ name: "x", run: async () => "ran" }, permissions)
     expect(String(await wrapped.run({}, { signal }))).toMatch(/fail-closed/)
+  })
+})
+
+describe("wrapToolWithConstraint", () => {
+  let appRoot: string
+  beforeEach(() => {
+    appRoot = mkdtempSync(join(tmpdir(), "dawn-constrain-test-"))
+  })
+  afterEach(() => {
+    rmSync(appRoot, { recursive: true, force: true })
+  })
+  const signal = new AbortController().signal
+  const runCtx = { signal }
+
+  it("allows (runs the real tool) when the predicate returns true", async () => {
+    const tool = { name: "deployProd", run: async (i: unknown) => `ran:${JSON.stringify(i)}` }
+    const wrapped = wrapToolWithConstraint(tool, () => true, undefined, "/ops#agent")
+    expect(await wrapped.run({ env: "staging" }, runCtx)).toBe('ran:{"env":"staging"}')
+  })
+
+  it("denies with the reason string as the tool result", async () => {
+    let ran = false
+    const tool = {
+      name: "deployProd",
+      run: async () => {
+        ran = true
+        return "ran"
+      },
+    }
+    const wrapped = wrapToolWithConstraint(
+      tool,
+      () => "prod not allowed here",
+      undefined,
+      "/ops#agent",
+    )
+    const result = await wrapped.run({ env: "prod" }, runCtx)
+    expect(ran).toBe(false)
+    expect(String(result)).toBe("prod not allowed here")
+  })
+
+  it("passes toolName/routeId and live threadId/params to the predicate", async () => {
+    let seen: { toolName?: string; routeId?: string; threadId?: string; params?: unknown } = {}
+    const tool = { name: "deployProd", run: async () => "ran" }
+    const wrapped = wrapToolWithConstraint(
+      tool,
+      (_args, ctx) => {
+        seen = {
+          toolName: ctx.toolName,
+          routeId: ctx.routeId,
+          threadId: ctx.threadId,
+          params: ctx.params,
+        }
+        return true
+      },
+      undefined,
+      "/ops#agent",
+    )
+    await wrapped.run({}, { signal, threadId: "t-9", params: { tenant: "acme" } })
+    expect(seen).toEqual({
+      toolName: "deployProd",
+      routeId: "/ops#agent",
+      threadId: "t-9",
+      params: { tenant: "acme" },
+    })
+  })
+
+  it("fails closed (deny result) when the predicate throws", async () => {
+    let ran = false
+    const tool = {
+      name: "deployProd",
+      run: async () => {
+        ran = true
+        return "ran"
+      },
+    }
+    const wrapped = wrapToolWithConstraint(
+      tool,
+      () => {
+        throw new Error("boom")
+      },
+      undefined,
+      "/ops#agent",
+    )
+    const result = await wrapped.run({}, runCtx)
+    expect(ran).toBe(false)
+    expect(String(result)).toMatch(/constraint check failed/i)
+  })
+
+  it("awaits an async predicate", async () => {
+    const tool = { name: "deployProd", run: async () => "ran" }
+    const wrapped = wrapToolWithConstraint(
+      tool,
+      async () => await Promise.resolve("async denied"),
+      undefined,
+      "/ops#agent",
+    )
+    expect(String(await wrapped.run({}, runCtx))).toBe("async denied")
+  })
+
+  it("{approve} escalates through gateToolOp — pre-approved tool runs", async () => {
+    const permissions = createPermissionsStore({
+      appRoot,
+      config: { version: 1, allow: { tool: ["deployProd"] }, deny: {} },
+      mode: "interactive",
+    })
+    await permissions.load()
+    const tool = { name: "deployProd", run: async () => "deployed" }
+    const wrapped = wrapToolWithConstraint(
+      tool,
+      () => ({ approve: true }),
+      permissions,
+      "/ops#agent",
+    )
+    expect(await wrapped.run({ env: "prod" }, runCtx)).toBe("deployed")
+  })
+
+  it("{approve} escalates through gateToolOp — denied tool returns the gate reason", async () => {
+    const permissions = createPermissionsStore({
+      appRoot,
+      config: { version: 1, allow: {}, deny: { tool: ["deployProd"] } },
+      mode: "interactive",
+    })
+    await permissions.load()
+    let ran = false
+    const tool = {
+      name: "deployProd",
+      run: async () => {
+        ran = true
+        return "deployed"
+      },
+    }
+    const wrapped = wrapToolWithConstraint(
+      tool,
+      () => ({ approve: true }),
+      permissions,
+      "/ops#agent",
+    )
+    const result = await wrapped.run({ env: "prod" }, runCtx)
+    expect(ran).toBe(false)
+    expect(String(result)).toMatch(/denied.*deployProd/i)
   })
 })
 

--- a/packages/langchain/src/agent-adapter.ts
+++ b/packages/langchain/src/agent-adapter.ts
@@ -100,6 +100,7 @@ async function materializeAgent(
     readonly bypassCache?: boolean
     readonly offload?: OffloadFn
     readonly summarization?: ResolvedSummarizationConfig
+    readonly routeParamNames?: readonly string[]
   } = {},
 ): Promise<AgentLike> {
   const fingerprint = fragmentFingerprint(opts.promptFragments ?? [])
@@ -114,7 +115,7 @@ async function materializeAgent(
   const { createReactAgent } = await import("@langchain/langgraph/prebuilt")
 
   const langchainTools = tools.map((tool) =>
-    convertToolToLangChain(tool, opts.middlewareContext, opts.offload),
+    convertToolToLangChain(tool, opts.middlewareContext, opts.offload, opts.routeParamNames ?? []),
   )
 
   const provider = resolveProvider({
@@ -442,6 +443,7 @@ export async function* streamAgent(options: AgentOptions): AsyncGenerator<AgentS
         ...((resolver && hasTaskTool) || options.sandboxed ? { bypassCache: true } : {}),
         ...(options.offload ? { offload: options.offload } : {}),
         ...(options.summarization ? { summarization: options.summarization } : {}),
+        routeParamNames: options.routeParamNames,
       },
     )
     const retryConfig = options.entry.retry
@@ -462,7 +464,12 @@ export async function* streamAgent(options: AgentOptions): AsyncGenerator<AgentS
   assertAgentLike(options.entry)
 
   const langchainTools = effectiveTools.map((tool) =>
-    convertToolToLangChain(tool, options.middlewareContext, options.offload),
+    convertToolToLangChain(
+      tool,
+      options.middlewareContext,
+      options.offload,
+      options.routeParamNames,
+    ),
   )
   if (langchainTools.length > 0) {
     config.tools = langchainTools

--- a/packages/langchain/src/tool-converter.ts
+++ b/packages/langchain/src/tool-converter.ts
@@ -13,6 +13,8 @@ interface DawnToolDefinition {
     context: {
       readonly middleware?: Readonly<Record<string, unknown>>
       readonly signal: AbortSignal
+      readonly threadId?: string
+      readonly params?: Readonly<Record<string, string>>
     },
   ) => Promise<unknown> | unknown
   readonly schema?: unknown
@@ -33,9 +35,21 @@ export function convertToolToLangChain(
     schema,
     func: async (input, _runManager, config) => {
       const signal = config?.signal ?? new AbortController().signal
+      // config.configurable carries thread_id + the route params (set by the
+      // agent-adapter's prepareAgentCall). Forward them so tools — and the
+      // argument-constraint wrapper — can read live per-call identity.
+      const configurable = (config?.configurable ?? {}) as Record<string, unknown>
+      const threadId =
+        typeof configurable.thread_id === "string" ? configurable.thread_id : undefined
+      const params: Record<string, string> = {}
+      for (const [key, value] of Object.entries(configurable)) {
+        if (key !== "thread_id" && typeof value === "string") params[key] = value
+      }
       const rawResult = await tool.run(input, {
         ...(middlewareContext ? { middleware: middlewareContext } : {}),
         signal,
+        ...(threadId ? { threadId } : {}),
+        ...(Object.keys(params).length > 0 ? { params } : {}),
       })
       const { content, stateUpdates } = unwrapToolResult(rawResult)
       const toolCallId = extractToolCallId(config)

--- a/packages/langchain/src/tool-converter.ts
+++ b/packages/langchain/src/tool-converter.ts
@@ -26,8 +26,10 @@ export function convertToolToLangChain(
   tool: DawnToolDefinition,
   middlewareContext?: Readonly<Record<string, unknown>>,
   offload?: OffloadFn,
+  routeParamNames: readonly string[] = [],
 ): DynamicStructuredTool {
   const schema = toZodSchema(tool.schema)
+  const paramNameSet = new Set(routeParamNames)
 
   return new DynamicStructuredTool({
     name: tool.name,
@@ -41,9 +43,12 @@ export function convertToolToLangChain(
       const configurable = (config?.configurable ?? {}) as Record<string, unknown>
       const threadId =
         typeof configurable.thread_id === "string" ? configurable.thread_id : undefined
+      // Allowlist against the route's declared param names. A denylist would
+      // also capture LangGraph internals injected into configurable (e.g.
+      // checkpoint_ns, __pregel_task_id), which must never surface as route params.
       const params: Record<string, string> = {}
       for (const [key, value] of Object.entries(configurable)) {
-        if (key !== "thread_id" && typeof value === "string") params[key] = value
+        if (paramNameSet.has(key) && typeof value === "string") params[key] = value
       }
       const rawResult = await tool.run(input, {
         ...(middlewareContext ? { middleware: middlewareContext } : {}),

--- a/packages/langchain/test/tool-converter.test.ts
+++ b/packages/langchain/test/tool-converter.test.ts
@@ -151,6 +151,23 @@ describe("convertToolToLangChain — {result, state} wrapped returns", () => {
   })
 })
 
+describe("convertToolToLangChain — config.configurable forwarding", () => {
+  it("forwards thread_id and route params from config.configurable into the tool run context", async () => {
+    let seen: { threadId?: string; params?: Record<string, string> } | undefined
+    const tool = {
+      name: "probe",
+      run: (_input: unknown, ctx: { threadId?: string; params?: Record<string, string> }) => {
+        seen = { threadId: ctx.threadId, params: ctx.params }
+        return "ok"
+      },
+    }
+    const lc = convertToolToLangChain(tool)
+    await lc.invoke({}, { configurable: { thread_id: "t-123", tenant: "acme" } })
+    expect(seen?.threadId).toBe("t-123")
+    expect(seen?.params).toEqual({ tenant: "acme" })
+  })
+})
+
 describe("jsonSchemaToZod nesting", () => {
   it("builds a nested object schema that validates", () => {
     const zodSchema = jsonSchemaToZod({

--- a/packages/langchain/test/tool-converter.test.ts
+++ b/packages/langchain/test/tool-converter.test.ts
@@ -161,9 +161,21 @@ describe("convertToolToLangChain — config.configurable forwarding", () => {
         return "ok"
       },
     }
-    const lc = convertToolToLangChain(tool)
-    await lc.invoke({}, { configurable: { thread_id: "t-123", tenant: "acme" } })
+    const lc = convertToolToLangChain(tool, undefined, undefined, ["tenant"])
+    await lc.invoke(
+      {},
+      {
+        configurable: {
+          thread_id: "t-123",
+          tenant: "acme",
+          checkpoint_ns: "tools:xyz",
+          __pregel_task_id: "abc",
+        },
+      },
+    )
     expect(seen?.threadId).toBe("t-123")
+    // ONLY the allowlisted route param — LangGraph internals like checkpoint_ns
+    // and __pregel_task_id must NOT leak into ctx.params.
     expect(seen?.params).toEqual({ tenant: "acme" })
   })
 })

--- a/packages/sdk/src/agent.ts
+++ b/packages/sdk/src/agent.ts
@@ -10,6 +10,22 @@ export interface RetryConfig {
   readonly baseDelay?: number
 }
 
+export interface ConstraintContext {
+  readonly toolName: string
+  readonly routeId: string
+  readonly threadId?: string
+  readonly signal: AbortSignal
+  /** Route params in scope (e.g. tenant) when the route is parameterized. */
+  readonly params?: Readonly<Record<string, string>>
+}
+
+export type ConstraintVerdict = true | string | { readonly approve: true; readonly reason?: string }
+
+export type ConstraintPredicate = (
+  args: unknown,
+  ctx: ConstraintContext,
+) => ConstraintVerdict | Promise<ConstraintVerdict>
+
 export interface ToolScope {
   readonly allow?: readonly string[]
   readonly deny?: readonly string[]
@@ -20,6 +36,14 @@ export interface ToolScope {
    * tool name. See docs/permissions.
    */
   readonly approve?: readonly string[]
+  /**
+   * Per-call argument constraints: a predicate per tool name, run at call time
+   * against the model's arguments. Return `true` to allow, a string to deny
+   * (returned as the tool result), or `{ approve: true }` to escalate to a HITL
+   * approval prompt. Predicate bodies are not statically validated — only the
+   * tool names are. See docs/permissions.
+   */
+  readonly constrain?: Readonly<Record<string, ConstraintPredicate>>
 }
 
 /**

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -1,5 +1,8 @@
 export type {
   AgentConfig,
+  ConstraintContext,
+  ConstraintPredicate,
+  ConstraintVerdict,
   DawnAgent,
   ReasoningConfig,
   RetryConfig,

--- a/packages/sdk/test/agent.test.ts
+++ b/packages/sdk/test/agent.test.ts
@@ -107,4 +107,15 @@ describe("agent() tool scope", () => {
     expect(a.tools?.approve).toEqual(["deployProd"])
     expect(a.tools?.deny).toEqual(["runBash"])
   })
+
+  test("passes tools.constrain predicates through to the descriptor", () => {
+    const predicate = (args: unknown) =>
+      (args as { env?: string }).env === "prod" ? ({ approve: true } as const) : true
+    const a = agent({
+      model: "gpt-5-mini",
+      systemPrompt: "x",
+      tools: { constrain: { deployProd: predicate } },
+    })
+    expect(a.tools?.constrain?.deployProd).toBe(predicate)
+  })
 })

--- a/packages/testing/test/fixtures/probe-app/src/app/constrain-chat/index.ts
+++ b/packages/testing/test/fixtures/probe-app/src/app/constrain-chat/index.ts
@@ -1,0 +1,15 @@
+import { agent } from "@dawn-ai/sdk"
+export default agent({
+  model: "gpt-4o-mini",
+  systemPrompt: "You are a test agent. Use deployProd when asked to deploy.",
+  tools: {
+    constrain: {
+      deployProd: (args) => {
+        const env = (args as { env?: string }).env
+        if (env === "staging") return true
+        if (env === "prod") return { approve: true }
+        return "Only staging or prod are valid environments."
+      },
+    },
+  },
+})

--- a/packages/testing/test/fixtures/probe-app/src/app/constrain-chat/tools/deployProd.ts
+++ b/packages/testing/test/fixtures/probe-app/src/app/constrain-chat/tools/deployProd.ts
@@ -1,0 +1,3 @@
+export default async function deployProd(input: { env: string }): Promise<string> {
+  return `deployed to ${input.env}`
+}

--- a/packages/testing/test/tool-constrain-live.smoke.test.ts
+++ b/packages/testing/test/tool-constrain-live.smoke.test.ts
@@ -1,0 +1,53 @@
+// LIVE SMOKE — argument-level constraints (tools.constrain) against a real
+// model. Gated on OPENAI_API_KEY: SKIPS in CI, runs only locally. The aimock
+// e2e scripts the tool call; this proves a REAL model, told to deploy, produces
+// arguments the constraint evaluates: env==="staging" is allowed and runs,
+// while env==="prod" escalates to the HITL gate.
+import { rmSync } from "node:fs"
+import { join } from "node:path"
+import { fileURLToPath } from "node:url"
+import { afterEach, beforeEach, it } from "vitest"
+import { createAgentHarness } from "../src/harness.js"
+import { expectInterrupt, expectNoInterrupt, expectToolCalled } from "../src/matchers.js"
+
+const live = Boolean(process.env.OPENAI_API_KEY)
+const probeRoot = fileURLToPath(new URL("./fixtures/probe-app", import.meta.url))
+const permissionsPath = join(probeRoot, ".dawn", "permissions.json")
+
+beforeEach(() => rmSync(permissionsPath, { force: true }))
+afterEach(() => rmSync(permissionsPath, { force: true }))
+
+it.skipIf(!live)(
+  "a real model deploying to staging is allowed; deploying to prod escalates to the HITL gate",
+  async () => {
+    const staging = await createAgentHarness({
+      appRoot: probeRoot,
+      route: "/constrain-chat#agent",
+      live: true,
+    })
+    try {
+      staging.reset()
+      const run = await staging.run({ input: "Deploy the app to the staging environment." })
+      // env==="staging" satisfies the constraint → the tool runs, no interrupt.
+      expectNoInterrupt(run)
+      expectToolCalled(run, "deployProd")
+    } finally {
+      await staging.close()
+    }
+
+    const prod = await createAgentHarness({
+      appRoot: probeRoot,
+      route: "/constrain-chat#agent",
+      live: true,
+    })
+    try {
+      prod.reset()
+      const run = await prod.run({ input: "Deploy the app to the production (prod) environment." })
+      // env==="prod" escalates → parked as a kind:"tool" permission interrupt.
+      expectInterrupt(run).ofKind("tool").withDetail({ toolName: "deployProd" })
+    } finally {
+      await prod.close()
+    }
+  },
+  180_000,
+)

--- a/packages/testing/test/tool-constrain-live.smoke.test.ts
+++ b/packages/testing/test/tool-constrain-live.smoke.test.ts
@@ -27,7 +27,9 @@ it.skipIf(!live)(
     })
     try {
       staging.reset()
-      const run = await staging.run({ input: "Deploy the app to the staging environment." })
+      const run = await staging.run({
+        input: 'Call the deployProd tool now with env set to "staging".',
+      })
       // env==="staging" satisfies the constraint → the tool runs, no interrupt.
       expectNoInterrupt(run)
       expectToolCalled(run, "deployProd")
@@ -42,7 +44,9 @@ it.skipIf(!live)(
     })
     try {
       prod.reset()
-      const run = await prod.run({ input: "Deploy the app to the production (prod) environment." })
+      const run = await prod.run({
+        input: 'Call the deployProd tool now with env set to "prod".',
+      })
       // env==="prod" escalates → parked as a kind:"tool" permission interrupt.
       expectInterrupt(run).ofKind("tool").withDetail({ toolName: "deployProd" })
     } finally {

--- a/packages/testing/test/tool-constrain.e2e.test.ts
+++ b/packages/testing/test/tool-constrain.e2e.test.ts
@@ -1,0 +1,99 @@
+// Deterministic (aimock) e2e for argument-level tool constraints (tools.constrain).
+// The probe-app constrain-chat route runs a per-call predicate against the tool
+// args: env "staging" → true (allow), env "prod" → { approve: true } (fires a
+// LangGraph interrupt of kind "tool"), anything else → a deny string returned as
+// the tool RESULT. The escalation path's resume("always") would persist
+// allow.tool into <appRoot>/.dawn/permissions.json, so clean it between
+// scenarios. Runs in CI (no API key — aimock).
+import { rmSync } from "node:fs"
+import { join } from "node:path"
+import { fileURLToPath } from "node:url"
+import { afterEach, beforeEach, expect, it } from "vitest"
+import { script } from "../src/fixture-builder.js"
+import { createAgentHarness } from "../src/harness.js"
+import { expectInterrupt, expectNoInterrupt, expectToolCalled } from "../src/matchers.js"
+import type { AgentRunResult } from "../src/run-result.js"
+
+const probeRoot = fileURLToPath(new URL("./fixtures/probe-app", import.meta.url))
+const permissionsPath = join(probeRoot, ".dawn", "permissions.json")
+
+function cleanPersistedState(): void {
+  // The { approve: true } escalation, if resumed "always", persists allow.tool
+  // into permissions.json and would leak across scenarios. It also appends a
+  // .gitignore inside the probe app (ensureGitignoreEntry) — the fixture has
+  // none committed, so removing it keeps the repo clean.
+  rmSync(permissionsPath, { force: true })
+  rmSync(join(probeRoot, ".gitignore"), { force: true })
+}
+
+beforeEach(cleanPersistedState)
+afterEach(cleanPersistedState)
+
+/** Concatenated string content of all tool results for the named tool. */
+function toolResultText(run: AgentRunResult, name: string): string {
+  return run.toolResults
+    .filter((r) => r.name === name)
+    .map((r) => (typeof r.content === "string" ? r.content : JSON.stringify(r.content)))
+    .join("\n")
+}
+
+it("allowed arg (staging) runs the tool without an interrupt", async () => {
+  const h = await createAgentHarness({ appRoot: probeRoot, route: "/constrain-chat#agent" })
+  try {
+    const run = await h.run({
+      input: "deploy to staging",
+      fixtures: script()
+        .user("deploy to staging")
+        .callsTool("deployProd", { env: "staging" })
+        .replies("Done."),
+    })
+    expectNoInterrupt(run)
+    expectToolCalled(run, "deployProd")
+    // The result comes from the REAL deployProd fn, not the fixture reply.
+    expect(toolResultText(run, "deployProd")).toContain("deployed to staging")
+  } finally {
+    await h.close()
+  }
+}, 60_000)
+
+it("escalating arg (prod) raises the kind:'tool' interrupt, then resume(once) runs it", async () => {
+  const h = await createAgentHarness({ appRoot: probeRoot, route: "/constrain-chat#agent" })
+  try {
+    const run = await h.run({
+      input: "deploy to prod",
+      fixtures: script()
+        .user("deploy to prod")
+        .callsTool("deployProd", { env: "prod" })
+        .replies("Done."),
+    })
+    expectInterrupt(run).ofKind("tool").withDetail({ toolName: "deployProd" })
+
+    const resumed = await h.resume({ decision: "once" })
+    expectToolCalled(resumed, "deployProd")
+    // The result comes from the REAL deployProd fn, not the fixture reply.
+    expect(toolResultText(resumed, "deployProd")).toContain("deployed to prod")
+  } finally {
+    await h.close()
+  }
+}, 60_000)
+
+it("disallowed arg returns the deny reason as the tool result", async () => {
+  const h = await createAgentHarness({ appRoot: probeRoot, route: "/constrain-chat#agent" })
+  try {
+    const run = await h.run({
+      input: "deploy to qa",
+      fixtures: script()
+        .user("deploy to qa")
+        .callsTool("deployProd", { env: "qa" })
+        .replies("Understood."),
+    })
+    expectNoInterrupt(run)
+    // The deny string renders JSON-quoted through the tool-result path — match
+    // with regex, never exact equality.
+    expect(toolResultText(run, "deployProd")).toMatch(/staging or prod/i)
+    // The tool body itself must NOT have run.
+    expect(toolResultText(run, "deployProd")).not.toContain("deployed to qa")
+  } finally {
+    await h.close()
+  }
+}, 60_000)


### PR DESCRIPTION
## What

`agent({ tools: { constrain: { deployProd: (args, ctx) => … } } })` — the **fourth** `ToolScope` knob (after allow/deny #261 and approve #291). A per-tool **predicate**, run at call time against the model's arguments:

- returns **`true`** → allow,
- returns a **string** → deny (returned to the model as the tool result — return-not-throw, like the approval gate),
- returns **`{ approve: true }`** → escalate to the shipped per-tool HITL prompt (`kind:"tool"`).

Predicates may be **async** and receive a read-only `ctx = { toolName, routeId, threadId?, signal, params? }`. A predicate that **throws or returns an off-contract value fails closed** (deny) — a broken policy never silently allows.

```ts
tools: {
  constrain: {
    deployProd: (args) => {
      const { env } = args as { env?: string }
      if (env === "prod") return { approve: true }   // human-in-the-loop
      if (env === "staging") return true             // allow
      return `Unknown environment "${env}".`         // deny; model sees this
    },
  },
}
```

## Architecture

- `wrapToolWithConstraint` (core `permission-gate.ts`) applied at the same compose seam as slice-2's `approve` wrap; the `{approve}` verdict reuses `gateToolOp` verbatim (same interrupt/resume/persistence).
- **No staleness:** the wrapper reads `signal`/`threadId`/`params` from the **live** run context each call (never closed over), so it's correct inside the per-descriptor-cached agent. This required the langchain tool-converter to forward `thread_id` + route params from `config.configurable` — **allowlisted to the route's declared param names** so LangGraph internals (`checkpoint_ns`, `__pregel_task_id`) never leak into `ctx.params`.
- A tool in both `approve` and `constrain` is wrapped **only** by `constrain` (excluded from the approve set) — no double-gate. `dawn check` validates `constrain` tool names and warns on the overlap.
- Additive; omitting `constrain` changes nothing. No migration.

## Tests

- Unit (core): verdict ladder — allow/deny-string/`{approve}`→gateToolOp/throw-fail-closed/off-contract-fail-closed/async/live-context.
- Unit (langchain): converter forwards threadId + allowlisted params, **excludes** `checkpoint_ns`/`__pregel_task_id` (watched-red).
- Unit (cli): `dawn check` unknown-name error + approve∩constrain warning.
- **aimock e2e** (adversarially reviewed, mutation-traced — a no-op wrapper fails S2/S3): staging→runs, prod→interrupt→resume(once)→runs, qa→deny-as-result.
- **Live smoke** (gated, verified locally against gpt-4o-mini): staging allowed+ran, prod escalated to the HITL gate.
- Full: build 18/18, `turbo run test` 16/16 (core 228, cli 312, langchain 164, testing 116).

## Known limitations (documented)

- **"Always" on a constraint-escalated approval is name-level** (persists the tool name → auto-approves future escalations of that tool). Use an outright `deny` in the predicate for per-args durability. Args-level persistence is out of scope.
- **`ctx.params` is allowlisted to route-declared params** — paths that don't populate `config.configurable` route params (e.g. `dawn build` static graphs) give predicates `params: undefined`. Deliberate (the allowlist is what keeps LangGraph internals out).
- Predicate bodies are **not** statically validated (the code-first choice) — `dawn check` validates only names. Live smoke is model-dependent (gated, skips in CI).

Spec: `docs/superpowers/specs/2026-07-06-arg-constraints-design.md` · Plan: `docs/superpowers/plans/2026-07-06-arg-constraints.md`

Built via subagent-driven development (per-task spec+quality reviews, adversarial e2e review, final whole-branch review — verdict: ready to merge). The review loops caught two real correctness bugs pre-merge: the `ctx.params` LangGraph-internals leak, and off-contract verdicts silently escalating instead of denying.

🤖 Generated with [Claude Code](https://claude.com/claude-code)