### PR TITLE
docs(contributing): build dist/ before running dev drivers against it

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,6 +29,23 @@ Before opening a larger PR, run the full validation lane:
 pnpm ci:validate
 ```
 
+### Build before running anything against `dist/`
+
+Packages compile `src/*.ts` into a **gitignored** `dist/`, and consumers (the CLI runtime, the test harness, one-off scripts) import the built `dist/` — not `src/`. Two facts make `dist/` easy to leave inconsistent with `src/`:
+
+- `git checkout <branch>` swaps `src/` but leaves `dist/` exactly as the last build left it.
+- Building one package at a time (`pnpm --filter <pkg> build`) updates only that package's `dist/`, leaving siblings from an earlier build.
+
+So it's possible to have correct, consistent `src/` on a branch while `dist/` on disk is **stale or skewed** — one package built from this branch, another from a different one. A dev driver or smoke script that imports `dist/` then runs against mismatched output (this produced a false negative during memory verification).
+
+Before running any dev driver, smoke script, or one-off that imports built packages, do a full build so `dist/` matches `src/`:
+
+```bash
+pnpm build   # Turbo, whole dependency graph — a fast cache-restore when already built
+```
+
+Prefer `pnpm build` over a per-package `--filter` build whenever you're about to *run* against the output. (`pnpm test` and `pnpm ci:validate` already build first, so tests are unaffected — this applies to ad-hoc scripts.)
+
 ## Issues
 
 Use GitHub Issues for reproducible bugs and concrete feature requests. Include:


### PR DESCRIPTION
## Summary

Adds a CONTRIBUTING note: **run `pnpm build` before any dev driver, smoke script, or one-off that imports built `dist/`.**

`dist/` is gitignored, so `git checkout` swaps `src/` but leaves `dist/` from the last build; and `pnpm --filter <pkg> build` updates only one package. That combination can leave `dist/` on disk **skewed vs `src/`** (one package built from this branch, another from a different one) while `src/` itself is correct — and a script importing `dist/` then runs against mismatched output.

This isn't hypothetical: it produced a **false negative during memory verification this cycle** (core `dist` had the `{result}` fix, memory `dist` lacked the namespace-escaping fix; a clean `pnpm build` resolved it). It's the same family as the #273 tsBuildInfo cache-integrity flake and the #307 parallel-test dist race — three mechanisms, one root: dev-runs depend on a mutable, gitignored artifact that can diverge from source.

## Scope

Docs-only (CONTRIBUTING.md). The chosen "cheap + effective" follow-up — codify the build-first habit. A structural fix (an affected-graph build orchestrator like Nx, or resolving `@dawn-ai/*` from `src` via tsx in the dev/harness path so dev-runs never touch `dist/`) is noted as a future option if the class keeps recurring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
