### PR TITLE
feat(memory): pgvector backend (@dawn-ai/memory-pgvector)

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -2,7 +2,7 @@
   "$schema": "https://unpkg.com/@changesets/config@3.1.1/schema.json",
   "changelog": "@changesets/cli/changelog",
   "commit": false,
-  "fixed": [["@dawn-ai/cli", "@dawn-ai/config-biome", "@dawn-ai/config-typescript", "@dawn-ai/core", "@dawn-ai/devkit", "@dawn-ai/evals", "@dawn-ai/langchain", "@dawn-ai/langgraph", "@dawn-ai/memory", "@dawn-ai/permissions", "@dawn-ai/sdk", "@dawn-ai/sqlite-storage", "@dawn-ai/testing", "@dawn-ai/vite-plugin", "@dawn-ai/workspace", "create-dawn-ai-app"]],
+  "fixed": [["@dawn-ai/cli", "@dawn-ai/config-biome", "@dawn-ai/config-typescript", "@dawn-ai/core", "@dawn-ai/devkit", "@dawn-ai/evals", "@dawn-ai/langchain", "@dawn-ai/langgraph", "@dawn-ai/memory", "@dawn-ai/memory-pgvector", "@dawn-ai/permissions", "@dawn-ai/sdk", "@dawn-ai/sqlite-storage", "@dawn-ai/testing", "@dawn-ai/vite-plugin", "@dawn-ai/workspace", "create-dawn-ai-app"]],
   "linked": [],
   "access": "public",
   "baseBranch": "main",

--- a/.changeset/pgvector-backend.md
+++ b/.changeset/pgvector-backend.md
@@ -1,0 +1,18 @@
+---
+"@dawn-ai/memory": patch
+"@dawn-ai/testing": patch
+"@dawn-ai/langchain": patch
+"@dawn-ai/memory-pgvector": patch
+---
+
+Add `@dawn-ai/memory-pgvector` — a Postgres + pgvector MemoryStore backend for
+production/multi-instance vector memory. Enable with
+`memory: { store: pgvectorMemoryStore({ connectionString, dimensions }) }`. HNSW
+(cosine) vector retrieval; reuses the exact same pure hybrid ranking (RRF +
+recency/confidence) as the default sqlite backend, so recall ordering is
+identical across backends. Adds a shared `runMemoryStoreConformance` kit
+(@dawn-ai/testing) run against both backends. Dimensions ≤2000 use `vector`,
+≤4000 use `halfvec` (text-embedding-3-large); pgvectorscale/DiskANN and in-SQL
+RRF are deferred. Also pins `openaiEmbedder` to float embedding encoding
+(`encodingFormat: "float"`) — avoids a base64 decode interop quirk that could
+yield wrong embedding dimensionality against some proxies/mocks.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,3 +127,34 @@ jobs:
 
       - name: Real-Docker sandbox conformance + e2e
         run: DAWN_TEST_DOCKER=1 pnpm --filter @dawn-ai/sandbox test docker-sandbox.integration
+
+  pgvector-docker:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+        with:
+          version: 10.33.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          # 22.14.0 — node:sqlite (used by @dawn-ai/sqlite-storage) is only
+          # available without the --experimental-sqlite flag from 22.13+.
+          # Matches release.yml and the engines floor.
+          node-version: 22.14.0
+          cache: pnpm
+
+      - name: Install
+        run: pnpm install --frozen-lockfile
+
+      - name: Build pgvector packages
+        run: pnpm --filter @dawn-ai/memory --filter @dawn-ai/testing --filter @dawn-ai/memory-pgvector build
+
+      - name: Real-Postgres pgvector tests
+        run: DAWN_TEST_PGVECTOR=1 pnpm --filter @dawn-ai/memory-pgvector test

--- a/apps/web/content/docs/memory.mdx
+++ b/apps/web/content/docs/memory.mdx
@@ -183,8 +183,41 @@ memory: {
 ```
 
 <Callout type="info" title="Zero native dependencies">
-  Embeddings are stored as Float32 BLOBs in the same `node:sqlite` store, with brute-force cosine in JavaScript — no native modules, no FTS5, no extra service. A `pgvector` store backend is a planned follow-up for larger corpora.
+  Embeddings are stored as Float32 BLOBs in the same `node:sqlite` store, with brute-force cosine in JavaScript — no native modules, no FTS5, no extra service. For larger corpora and multi-instance deployments, swap in the [Postgres backend](#postgres-backend-pgvector).
 </Callout>
+
+### Postgres backend (pgvector)
+
+The default SQLite store is local-first: one file, no service, brute-force cosine in JS. For a **production or multi-instance** deployment — many app instances sharing one memory store, or a corpus too large for linear cosine — Dawn ships a Postgres + [pgvector](https://github.com/pgvector/pgvector) backend as `@dawn-ai/memory-pgvector`. Point `memory.store` at it in `dawn.config.ts`:
+
+```ts title="dawn.config.ts"
+import { openaiEmbedder } from "@dawn-ai/langchain"
+import { pgvectorMemoryStore } from "@dawn-ai/memory-pgvector"
+
+export default {
+  memory: {
+    store: pgvectorMemoryStore({
+      connectionString: process.env.DATABASE_URL,
+      dimensions: 1536, // must match your embedder's output dims
+    }),
+    vector: { embedder: openaiEmbedder() },
+  },
+} satisfies import("@dawn-ai/core").DawnConfig
+```
+
+It requires a running Postgres with the [`vector` extension](https://github.com/pgvector/pgvector) available (the store runs `CREATE EXTENSION IF NOT EXISTS vector` on first use). For local development, the official image ships the extension pre-installed:
+
+```bash
+docker run --rm -e POSTGRES_PASSWORD=postgres -p 5432:5432 pgvector/pgvector:pg16
+```
+
+Retrieval runs **in Postgres**: an [HNSW](https://github.com/pgvector/pgvector#hnsw) index over the embedding column with **cosine** distance (`vector_cosine_ops`) for the vector list, plus a token index for the keyword list. The `dimensions` you pass selects the column type — dimensions ≤ 2000 use pgvector's `vector` type, and larger dimensions (e.g. `text-embedding-3-large`'s 3072) use `halfvec`, up to a 4000 ceiling.
+
+<Callout type="info" title="Recall ranking is identical to SQLite">
+  Both backends retrieve their own candidates (SQL here, in-process there) and then rank through the **same pure hybrid core** — the RRF fusion plus the recency/confidence second stage from [semantic recall](#semantic-recall-opt-in). Recall ordering is the same across backends; switching stores changes where the data lives and how it is retrieved, not how results are ranked. A [shared conformance kit](/docs/testing-agents) runs the same contract against both.
+</Callout>
+
+SQLite stays the local-first default — reach for pgvector when you outgrow a single-file store, not before. See the runnable `examples/memory` app, which switches to pgvector automatically when `DATABASE_URL` is set and falls back to SQLite otherwise.
 
 ### The injected index
 
@@ -321,8 +354,9 @@ Long-term memory ships with the `semantic` kind, deterministic ranked keyword re
 - The `episodic`, `procedural`, and `reflection` kinds.
 - Full BM25 (term-frequency / length-normalized) ranking via FTS5, and a memory graph.
 - A dev-server Memory Inspector UI.
-- Postgres / pgvector store adapters (vector recall today runs brute-force over the `node:sqlite` store).
 - Schema-typed `remember.data` (typed loosely as `Record<string, unknown>` today).
+
+The SQLite (local-first, default) and [Postgres/pgvector](#postgres-backend-pgvector) (production/multi-instance) store backends both ship today.
 
 For anything beyond the semantic collection, use `memory.md` for stable profile text and `memory.ts` for facts the agent should accumulate over time.
 

--- a/docs/dev/memory-system.md
+++ b/docs/dev/memory-system.md
@@ -27,10 +27,16 @@ unless stated. "Smarter recall" touches exactly one function inside L3.
 - `sqlite-store.ts` — `sqliteMemoryStore()`: schema/migrations (v1 tokens, v2 embedding cols), tokenized index, hybrid `search()`.
 - `score.ts` — pure recall scoring: `idf()`, `scoreMemory()`, exported `recencyDecay()` (reused by the hybrid second stage), `RecallRankingOptions` + defaults.
 - `vector.ts` — pure vector primitives: `cosineSimilarity()`, `fuseRRF()` (Reciprocal Rank Fusion), `RankedList`, `DEFAULT_RRF_K` / `DEFAULT_VECTOR_K`. No I/O, no clock — deterministic for aimock/replay.
+- `hybrid.ts` — the **shared, backend-agnostic ranking core**: `rankKeywordCandidates()` (IDF relevance over a store-supplied candidate pool + df/N stats) and `fuseHybrid()` (co-equal RRF over a keyword list and a vector list + the bounded recency/confidence second stage). Pure — no I/O, no clock. Both stores call it after doing their own retrieval, so recall ordering is the same across backends.
 - `tokenize.ts` — lowercase / split / drop-1-char / **dedupe** → tokens.
 - `namespace.ts` — `serializeNamespace()` + `MemoryScopeTuple`.
 - `reconcile.ts` — `classifyWrite()` (deterministic add/update/supersede).
-- `index.ts` — barrel.
+- `index.ts` — barrel (also re-exports `rankKeywordCandidates` / `fuseHybrid`).
+
+**`@dawn-ai/memory-pgvector`** — the Tier-2 Postgres + pgvector `MemoryStore` backend (production / multi-instance):
+- `schema.ts` — `vectorColumnDef()` (the pure `vector` ≤2000 / `halfvec` ≤4000 dimension branch + cosine ops) and idempotent `initSchema()` (extension, tables, token indexes, HNSW index).
+- `pgvector-store.ts` — `pgvectorMemoryStore()`: a full `MemoryStore` over a `pg` pool. Retrieves in SQL (HNSW `<=>` cosine top-K vector list + a token-matched keyword pool with live df/N), then ranks through the shared `rankKeywordCandidates` / `fuseHybrid` core — same ordering as sqlite. Lazy idempotent schema init; `close()` ends the pool.
+- `queries.ts` — SQL strings + `rowToRecord` / `pageAndTagFilter` (mirrors the sqlite bodies).
 
 **`@dawn-ai/sdk`**
 - `memory.ts` — `defineMemory({ kind, scope, schema, identity? })` (author API).
@@ -50,7 +56,7 @@ unless stated. "Smarter recall" touches exactly one function inside L3.
 **`@dawn-ai/langchain`**
 - `agent-adapter.ts` — materializes the agent; folds the fragment `cacheKey` into the materialize cache.
 
-**`@dawn-ai/testing`** — `seedMemory()`. **`@dawn-ai/evals`** — `memoryRecalled`/`memoryFresh`/`memoryIsolated` scorers.
+**`@dawn-ai/testing`** — `seedMemory()` + `runMemoryStoreConformance()` (the shared `MemoryStore` contract kit; see §4). **`@dawn-ai/evals`** — `memoryRecalled`/`memoryFresh`/`memoryIsolated` scorers.
 
 ## 3. The data model
 
@@ -150,6 +156,19 @@ embedding, with the same stable `updated_at, id` tiebreak. The store never embed
 capability supplies `queryEmbedding`; the store persists `{embedding, embeddingModel}` passed
 to `put`. Store-side default tuning comes from `sqliteMemoryStore({ vector })`, overridable
 per-query via `q.vector`.
+
+**The ranking core is shared, not per-store (`hybrid.ts`).** The two reusable pure pieces of
+the ranked path above — IDF relevance over a candidate pool, and RRF fusion + the recency/
+confidence second stage — live in `hybrid.ts` as `rankKeywordCandidates()` and `fuseHybrid()`.
+`sqlite-store.ts` does its retrieval (SQL over `node:sqlite`) and then calls them; the
+`@dawn-ai/memory-pgvector` store does *its* retrieval (HNSW `<=>` cosine top-K + a token-matched
+keyword pool over `pg`) and calls the **same** functions. So a backend can only change *where
+data lives and how it is retrieved*, never *how results are ranked* — recall ordering is the
+same across sqlite and pgvector. This parity is enforced, not just asserted: the shared
+`runMemoryStoreConformance()` kit (`@dawn-ai/testing`) runs one `MemoryStore` contract (put/get,
+namespace isolation, query-less recency, supersede, candidate listing, the hybrid/vector-recall
+cases) against **sqlite** in-process on every run, and against **real pgvector** in a gated
+Testcontainers lane (`DAWN_TEST_PGVECTOR=1`, `pgvector/pgvector:pg16`; skipped otherwise).
 
 **`classifyWrite()` (`reconcile.ts`)** decides add/update/supersede deterministically by
 comparing the incoming record's identity key (default `["subject","predicate"]`) against
@@ -273,15 +292,18 @@ Shipped: the `semantic` kind with ranked keyword recall — IDF-weighted relevan
 recency decay and stored confidence — **plus opt-in hybrid vector recall** (keyword ∪ vector,
 RRF-fused, bounded recency/confidence second stage; see §4). Vector recall is enabled by
 supplying `DawnConfig.memory.vector.embedder`; absent, recall is the unchanged keyword path.
-Explicitly deferred (spec §"Out of scope"):
+The **Tier-2 Postgres / pgvector store backend** (`@dawn-ai/memory-pgvector`) also ships now:
+HNSW + cosine retrieval in SQL, the same shared ranking core, dimension branch (`vector` ≤2000 /
+`halfvec` ≤4000), enabled via `config.memory.store` (see §4). Explicitly still deferred (spec
+§"Out of scope"):
 
 - `episodic` / `procedural` / `reflection` kinds; episodic-from-traces; background consolidation.
 - BM25/FTS5 (term frequency is not stored).
-- Faster ANN over the local store — a `sqlite-vec` middle tier — before reaching for Postgres.
-  Vector recall today is brute-force cosine in JS over Float32 BLOBs (fine for typical
-  per-namespace corpora; linear in matching rows).
-- Postgres / **pgvector** store adapter (Tier-2 backend for large corpora; the `MemoryStore` +
-  pluggable `Embedder` interfaces leave room).
+- Faster ANN over the *local* store — a `sqlite-vec` middle tier. Vector recall on the sqlite
+  backend is brute-force cosine in JS over Float32 BLOBs (fine for typical per-namespace corpora;
+  linear in matching rows); the pgvector backend already uses an HNSW index for larger corpora.
+- pgvector follow-ups: `pgvectorscale` / DiskANN indexing, and pushing the RRF fusion down into
+  SQL (today pgvector retrieves both lists and fuses in the shared JS core).
 - Memory graph (edges/relations).
 - Dev-server Memory Inspector UI (no dev UI host exists today).
 - Schema-typed `remember.data` in typegen.

--- a/docs/superpowers/plans/2026-07-07-pgvector-backend.md
+++ b/docs/superpowers/plans/2026-07-07-pgvector-backend.md
@@ -1,0 +1,686 @@
+# pgvector Memory Backend Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship `@dawn-ai/memory-pgvector` — a Postgres + pgvector `MemoryStore` backend with recall ranking byte-identical to the sqlite backend, per `docs/superpowers/specs/2026-07-07-pgvector-backend-design.md`.
+
+**Architecture:** Extract the hybrid ranking into pure, backend-agnostic functions in `@dawn-ai/memory` (`hybrid.ts`); both stores do their own retrieval (SQL) then call the shared core. pgvector does two indexed retrievals (HNSW `<=>` vector top-K + keyword pool) and reuses the pure fusion. A shared `MemoryStore` conformance kit runs against sqlite (always) and real pgvector (gated, Testcontainers). A dedicated `examples/memory` app is the continuous dogfood.
+
+**Tech Stack:** TypeScript, `pg` + `pgvector` (pure-JS), `@testcontainers/postgresql` (`pgvector/pgvector:pg16`), vitest, biome. Branch: `feat/memory-pgvector` (created off origin/main; spec committed).
+
+**Working dir:** `/Users/blove/repos/dawn` (primary checkout, on branch). Every Bash cmd starts `cd /Users/blove/repos/dawn`.
+
+**Guardrails (every subagent, every task):**
+- BRANCH PIN: before ANY commit, `git rev-parse --abbrev-ref HEAD` MUST print `feat/memory-pgvector`; else STOP + report BLOCKED. Never switch branches / commit detached.
+- LINT: only `pnpm exec biome check --config-path packages/config-biome/biome.json <files>` (scoped `--write` OK). NEVER bare `biome check --write`. Style: no semicolons, 2-space, double quotes.
+- Determinism: no `Date.now()`/argless `new Date()` in `packages/*/src` (tests may). Pure fns stay pure.
+- `pnpm test` in a CLEAN shell (do NOT source `.env`).
+- Testcontainers needs a running Docker daemon; pgvector tests are gated on `DAWN_TEST_PGVECTOR=1` and SKIP otherwise.
+- `.env` (`OPENAI_API_KEY`) is LOCAL-only for the doubly-gated dogfood smoke; never print, never CI.
+- Monorepo build ordering: rebuild changed dep dists (`pnpm --filter @dawn-ai/memory --filter @dawn-ai/core build`) before typechecking downstream packages.
+
+---
+
+## File structure
+
+| File | Responsibility |
+|---|---|
+| `packages/memory/src/hybrid.ts` (create) | Pure `rankKeywordCandidates` + `fuseHybrid` (extracted ranking core) |
+| `packages/memory/src/sqlite-store.ts` (modify) | Refactor `rankKeyword`/hybrid gate to call `hybrid.ts` (retrieval stays) |
+| `packages/memory/src/index.ts` (modify) | Export `rankKeywordCandidates`, `fuseHybrid` |
+| `packages/memory/test/hybrid.test.ts` (create) | Pure ranking-core units |
+| `packages/testing/src/memory-conformance.ts` (create) | `runMemoryStoreConformance` kit |
+| `packages/testing/src/index.ts` (modify) | Export the kit |
+| `packages/testing/test/sqlite-conformance.test.ts` (create) | Kit against sqlite (always) |
+| `packages/memory-pgvector/**` (create) | New package: `pgvectorMemoryStore`, schema, queries |
+| `.github/workflows/ci.yml` (modify) | `pgvector-docker` gated lane |
+| `examples/memory/**` (create) | Dedicated memory example (backend-switch) |
+| `apps/web/content/docs/memory.mdx` + `docs/dev/memory-system.md` (modify) | Postgres backend docs |
+| `.changeset/pgvector-backend.md` (create) | patch: memory, testing, memory-pgvector |
+
+---
+
+### Task 1: Extract the shared ranking core into `@dawn-ai/memory/hybrid.ts`
+
+**Files:** create `packages/memory/src/hybrid.ts`, `packages/memory/test/hybrid.test.ts`; modify `packages/memory/src/sqlite-store.ts`, `packages/memory/src/index.ts`.
+
+The sqlite hybrid path (read `packages/memory/src/sqlite-store.ts` lines ~215–445) has two reusable pure pieces. Extract them so pgvector reuses identical ranking. The 60 shipped memory tests are the refactor guard.
+
+- [ ] **Step 1: Write failing tests** — `packages/memory/test/hybrid.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest"
+import { fuseHybrid, rankKeywordCandidates } from "../src/hybrid.js"
+import type { MemoryRecord } from "../src/types.js"
+
+function rec(over: Partial<MemoryRecord> & Pick<MemoryRecord, "id" | "content">): MemoryRecord {
+  return {
+    kind: "semantic", namespace: "ns", data: {}, source: { type: "run", id: "r" },
+    confidence: 1, tags: [], status: "active",
+    createdAt: "2026-01-01T00:00:00.000Z", updatedAt: "2026-01-01T00:00:00.000Z",
+    ...over,
+  }
+}
+
+describe("rankKeywordCandidates", () => {
+  it("ranks by IDF relevance; rare-token match beats common-token match", () => {
+    const cands = [
+      rec({ id: "rare", content: "acme threshold" }),
+      rec({ id: "common", content: "acme owner jordan" }),
+    ]
+    const df = new Map([["acme", 2], ["threshold", 1]])
+    const out = rankKeywordCandidates(cands, df, 2, ["acme", "threshold"], "2026-07-05T00:00:00.000Z")
+    expect(out[0]?.id).toBe("rare")
+  })
+  it("relevance-only weights ignore recency (for the hybrid keyword list)", () => {
+    const cands = [
+      rec({ id: "old", content: "billing threshold", updatedAt: "2026-05-01T00:00:00.000Z" }),
+      rec({ id: "new", content: "billing note", updatedAt: "2026-07-01T00:00:00.000Z" }),
+    ]
+    const df = new Map([["billing", 2], ["threshold", 1]])
+    const out = rankKeywordCandidates(cands, df, 2, ["billing", "threshold"],
+      "2026-07-05T00:00:00.000Z", { weights: { relevance: 1, recency: 0, confidence: 0 } })
+    expect(out[0]?.id).toBe("old") // 2/2 tokens beats 1/2 despite being older
+  })
+})
+
+describe("fuseHybrid", () => {
+  it("a semantic-only match (only in the vector list) is fused in and can win", () => {
+    const kw = [rec({ id: "kwonly", content: "acme billing" })]
+    const vec = [rec({ id: "semonly", content: "faster shipping" }), rec({ id: "kwonly", content: "acme billing" })]
+    const out = fuseHybrid({ keywordRanked: kw, vectorRanked: vec, now: "2026-07-05T00:00:00.000Z" })
+    expect(out.map((r) => r.id)).toContain("semonly")
+    expect(out[0]?.id).toBe("semonly") // rank1 in vector, absent from keyword; kwonly is rank2 vector + rank1 keyword
+  })
+  it("co-equal RRF: an exact keyword hit is not buried by a strong vector list", () => {
+    const kw = [rec({ id: "exact", content: "order ALPHA-111" })]
+    const vec = [rec({ id: "near", content: "delivery" }), rec({ id: "exact", content: "order ALPHA-111" })]
+    const out = fuseHybrid({ keywordRanked: kw, vectorRanked: vec, now: "2026-07-05T00:00:00.000Z" })
+    expect(out.map((r) => r.id)).toContain("exact")
+  })
+  it("NaN tuning weights degrade to defaults (finite, deterministic order)", () => {
+    const kw = [rec({ id: "a", content: "x" })]
+    const vec = [rec({ id: "a", content: "x" })]
+    const out = fuseHybrid({ keywordRanked: kw, vectorRanked: vec, now: "2026-07-05T00:00:00.000Z",
+      options: { recencyWeight: Number.NaN } })
+    expect(out.map((r) => r.id)).toEqual(["a"])
+  })
+})
+```
+
+- [ ] **Step 2: Run — expect fail** (`Cannot find module '../src/hybrid.js'`):
+  `pnpm --filter @dawn-ai/memory exec vitest run test/hybrid.test.ts`
+
+- [ ] **Step 3: Implement `hybrid.ts`.** Move the pure logic out of `sqlite-store.ts`. Create `packages/memory/src/hybrid.ts`:
+
+```ts
+// Pure, backend-agnostic hybrid ranking core. Both sqliteMemoryStore and
+// @dawn-ai/memory-pgvector call these after doing their own retrieval, so recall
+// ranking is byte-identical across backends. No I/O, no clock, no randomness.
+import { recencyDecay, type RecallRankingOptions, type RecallWeights, scoreMemory } from "./score.js"
+import type { MemoryRecord, VectorRankingOptions } from "./types.js"
+import { fuseRRF } from "./vector.js"
+
+function cmp(a: string, b: string): number {
+  return a < b ? -1 : a > b ? 1 : 0
+}
+function newestUpdatedAt(records: readonly MemoryRecord[]): string {
+  return records.reduce((m, r) => (r.updatedAt > m ? r.updatedAt : m), "")
+}
+function tokensFor(rec: MemoryRecord, tokenize: (s: string) => string[]): string[] {
+  const values = Object.values(rec.data).filter((v) => typeof v === "string") as string[]
+  return tokenize([rec.content, rec.tags.join(" "), values.join(" ")].join(" "))
+}
+
+/**
+ * Rank keyword candidates by IDF relevance (+ recency/confidence per weights).
+ * `candidates` are the rows the store retrieved as matching ≥1 query token;
+ * `dfByToken`/`corpusSize` are the store's live stats. Returns the full sorted
+ * list (caller pages + tag-filters). `now` absent → newest candidate's updatedAt.
+ */
+export function rankKeywordCandidates(
+  candidates: readonly MemoryRecord[],
+  dfByToken: ReadonlyMap<string, number>,
+  corpusSize: number,
+  queryTokens: readonly string[],
+  now: string | undefined,
+  options?: RecallRankingOptions,
+  tokenize?: (s: string) => string[],
+): MemoryRecord[] {
+  if (candidates.length === 0) return []
+  const tk = tokenize ?? ((s: string) => s.toLowerCase().split(/[^a-z0-9]+/).filter((x) => x.length > 1))
+  const referenceNow = now ?? newestUpdatedAt(candidates)
+  const scored = candidates.map((record) => ({
+    record,
+    score: scoreMemory({
+      memoryTokens: new Set(tokensFor(record, tk)),
+      queryTokens: [...queryTokens],
+      dfByToken,
+      corpusSize,
+      updatedAt: record.updatedAt,
+      confidence: record.confidence,
+      referenceNow,
+      ...(options ? { options } : {}),
+    }),
+  }))
+  scored.sort(
+    (a, b) => b.score - a.score || cmp(b.record.updatedAt, a.record.updatedAt) || cmp(a.record.id, b.record.id),
+  )
+  return scored.map((s) => s.record)
+}
+
+function finite(n: unknown, d: number): number {
+  return typeof n === "number" && Number.isFinite(n) ? n : d
+}
+
+/**
+ * Fuse a keyword-ranked list and a vector-ranked list (already cosine-sorted and
+ * sliced to vectorK by the store) via co-equal RRF, then a bounded recency/
+ * confidence second stage. Returns the fused sorted records (caller pages +
+ * tag-filters). `options.recencyHalfLifeMs` should be pre-resolved by the caller
+ * (the pure fn cannot see recall config).
+ */
+export function fuseHybrid(args: {
+  readonly keywordRanked: readonly MemoryRecord[]
+  readonly vectorRanked: readonly MemoryRecord[]
+  readonly now?: string
+  readonly options?: VectorRankingOptions
+}): MemoryRecord[] {
+  const v = args.options ?? {}
+  const wKeyword = finite(v.weights?.keyword, 1)
+  const wVector = finite(v.weights?.vector, 1)
+  const wRec = finite(v.recencyWeight, 0.3)
+  const wConf = finite(v.confidenceWeight, 0.1)
+
+  const byId = new Map<string, MemoryRecord>()
+  for (const r of args.keywordRanked) byId.set(r.id, r)
+  for (const r of args.vectorRanked) if (!byId.has(r.id)) byId.set(r.id, r)
+  if (byId.size === 0) return []
+
+  const rrf = fuseRRF(
+    [
+      { ids: args.keywordRanked.map((r) => r.id), weight: wKeyword },
+      { ids: args.vectorRanked.map((r) => r.id), weight: wVector },
+    ],
+    typeof v.rrfK === "number" ? { k: v.rrfK } : undefined,
+  )
+  const referenceNow = args.now ?? newestUpdatedAt([...byId.values()])
+  const fused = [...byId.values()].map((record) => {
+    const base = rrf.get(record.id) ?? 0
+    const rec = recencyDecay(record.updatedAt, referenceNow, v.recencyHalfLifeMs)
+    const conf = record.confidence < 0 ? 0 : record.confidence > 1 ? 1 : record.confidence
+    return { record, score: base * (1 + wRec * rec + wConf * conf) }
+  })
+  fused.sort(
+    (a, b) => b.score - a.score || cmp(b.record.updatedAt, a.record.updatedAt) || cmp(a.record.id, b.record.id),
+  )
+  return fused.map((s) => s.record)
+}
+
+export type { RecallWeights }
+```
+
+Note: the keyword-token recomputation must match `sqlite-store.ts`'s `tokensFor` — pass the real `tokenize` from the caller (sqlite passes its imported `tokenize`; the default arg mirrors it for the pure tests). Confirm the default matches `tokenize.ts` behavior (lowercase, split non-alnum, drop <2). If they can differ, ALWAYS pass the real `tokenize` from callers and drop the default (safer — do that if unsure).
+
+- [ ] **Step 4: Refactor `sqlite-store.ts` to call the core.** Replace the JS body of `rankKeyword` so it does only SQL (fetch candidate pool + df/N) then `return rankKeywordCandidates(candidates, dfByToken, corpusSize, terms, q.now, options, tokenize)`. Replace the hybrid gate's fusion tail (from `const byId = ...` through the final `fused.sort`) with: build `kwRecords` (relevance-only via `rankKeyword` as today), do the vector cosine+sort+slice(vectorK) as today to get `vectorRanked: MemoryRecord[]` (look up records by id), then `return pageAndTagFilter(fuseHybrid({ keywordRanked: kwRecords, vectorRanked, now: q.now, options: { ...v, recencyHalfLifeMs: v.recencyHalfLifeMs ?? opts.recall?.recencyHalfLifeMs } }), limit, q)`. Import `{ fuseHybrid, rankKeywordCandidates }` from `./hybrid.js`. Delete the now-inlined scoring/fusion code. Keep all SQL + `pageAndTagFilter` + query-less path unchanged.
+
+- [ ] **Step 5: Export** — add to `packages/memory/src/index.ts`: `export { fuseHybrid, rankKeywordCandidates } from "./hybrid.js"`.
+
+- [ ] **Step 6: Run — ALL green, unchanged behavior.** `pnpm --filter @dawn-ai/memory test` (expect the shipped 60 + new hybrid units). The shipped smarter-recall + vector-recall ordering tests are the guard — if any reorders, the extraction diverged; fix `hybrid.ts`, NOT the test. `pnpm --filter @dawn-ai/memory typecheck` clean.
+
+- [ ] **Step 7: Lint + commit**:
+```bash
+cd /Users/blove/repos/dawn
+pnpm exec biome check --config-path packages/config-biome/biome.json packages/memory/src packages/memory/test
+git add packages/memory/src packages/memory/test
+git commit -m "refactor(memory): extract pure hybrid ranking core (rankKeywordCandidates + fuseHybrid)"
+```
+
+---
+
+### Task 2: `runMemoryStoreConformance` kit + run it against sqlite
+
+**Files:** create `packages/testing/src/memory-conformance.ts`, `packages/testing/test/sqlite-conformance.test.ts`; modify `packages/testing/src/index.ts`.
+
+Mirror `packages/sandbox/src/testing/conformance.ts` (`runProviderConformance` — inject `describe`, import `test`/`expect` from vitest).
+
+- [ ] **Step 1: Implement the kit** — `packages/testing/src/memory-conformance.ts`:
+
+```ts
+import type { MemoryRecord, MemoryStore } from "@dawn-ai/memory"
+import { expect, test } from "vitest"
+
+function rec(over: Partial<MemoryRecord> & Pick<MemoryRecord, "id" | "namespace" | "content">): MemoryRecord {
+  return {
+    kind: "semantic", data: {}, source: { type: "eval", id: "seed" }, confidence: 1, tags: [],
+    status: "active", createdAt: "2026-01-01T00:00:00.000Z", updatedAt: "2026-01-01T00:00:00.000Z", ...over,
+  }
+}
+const vec = (...xs: number[]) => new Float32Array(xs)
+
+/**
+ * The contract every MemoryStore must satisfy. Run against sqlite (in-process,
+ * always) and pgvector (real Postgres, gated) so backends cannot drift. Pass
+ * vitest's `describe`; `makeStore` returns a FRESH empty store per call.
+ */
+export function runMemoryStoreConformance(opts: {
+  readonly name: string
+  readonly makeStore: () => Promise<MemoryStore> | MemoryStore
+  readonly describe: (name: string, fn: () => void) => void
+  readonly close?: (store: MemoryStore) => Promise<void> | void
+}): void {
+  const { name, makeStore, describe, close } = opts
+  describe(`MemoryStore conformance: ${name}`, () => {
+    test("put + get round-trips", async () => {
+      const s = await makeStore()
+      try {
+        await s.put(rec({ id: "a", namespace: "ns", content: "hello billing" }))
+        expect((await s.get("a"))?.content).toBe("hello billing")
+      } finally { await close?.(s) }
+    })
+    test("search is namespace-isolated", async () => {
+      const s = await makeStore()
+      try {
+        await s.put(rec({ id: "a", namespace: "ns1", content: "billing escalation" }))
+        await s.put(rec({ id: "b", namespace: "ns2", content: "billing escalation" }))
+        expect((await s.search({ namespace: "ns1", query: "billing" })).map((r) => r.id)).toEqual(["a"])
+      } finally { await close?.(s) }
+    })
+    test("query-less search is pure recency order", async () => {
+      const s = await makeStore()
+      try {
+        await s.put(rec({ id: "old", namespace: "ns", content: "x", updatedAt: "2026-07-01T00:00:00.000Z" }))
+        await s.put(rec({ id: "new", namespace: "ns", content: "y", updatedAt: "2026-07-04T00:00:00.000Z" }))
+        expect((await s.search({ namespace: "ns" })).map((r) => r.id)).toEqual(["new", "old"])
+      } finally { await close?.(s) }
+    })
+    test("supersede: old→superseded, new active, link recorded", async () => {
+      const s = await makeStore()
+      try {
+        await s.put(rec({ id: "old", namespace: "ns", content: "v1" }))
+        await s.put(rec({ id: "new", namespace: "ns", content: "v2" }))
+        await s.supersede("old", "new")
+        expect((await s.get("old"))?.status).toBe("superseded")
+        expect((await s.get("new"))?.supersedes).toContain("old")
+      } finally { await close?.(s) }
+    })
+    test("candidate listing + delete", async () => {
+      const s = await makeStore()
+      try {
+        await s.put(rec({ id: "c", namespace: "ns", content: "cand", status: "candidate" }))
+        expect((await s.listCandidates("")).map((r) => r.id)).toContain("c")
+        await s.delete("c")
+        expect(await s.get("c")).toBeNull()
+      } finally { await close?.(s) }
+    })
+    test("update preserves the stored embedding (vector recall still finds it)", async () => {
+      const s = await makeStore()
+      try {
+        await s.put(rec({ id: "e", namespace: "ns", content: "faster shipping" }),
+          { embedding: vec(1, 0, 0), embeddingModel: "fake:test" })
+        await s.update("e", { confidence: 0.5 })
+        const out = await s.search({ namespace: "ns", query: "expedite delivery",
+          queryEmbedding: vec(1, 0, 0), embedderId: "fake:test", now: "2026-07-05T00:00:00.000Z" })
+        expect(out.map((r) => r.id)).toContain("e")
+      } finally { await close?.(s) }
+    })
+    test("hybrid: a 0-shared-token semantic match is recalled via the vector list", async () => {
+      const s = await makeStore()
+      try {
+        await s.put(rec({ id: "sem", namespace: "ns", content: "faster shipping preferred" }),
+          { embedding: vec(1, 0, 0), embeddingModel: "fake:test" })
+        await s.put(rec({ id: "kw", namespace: "ns", content: "acme billing" }),
+          { embedding: vec(0, 1, 0), embeddingModel: "fake:test" })
+        const out = await s.search({ namespace: "ns", query: "expedite delivery",
+          queryEmbedding: vec(0.95, 0.05, 0), embedderId: "fake:test", now: "2026-07-05T00:00:00.000Z" })
+        expect(out.map((r) => r.id)).toContain("sem")
+        expect(out[0]?.id).toBe("sem")
+      } finally { await close?.(s) }
+    })
+    test("hybrid: mismatched embedder tag is excluded from the vector list", async () => {
+      const s = await makeStore()
+      try {
+        await s.put(rec({ id: "stale", namespace: "ns", content: "faster shipping" }),
+          { embedding: vec(1, 0, 0), embeddingModel: "old:model" })
+        const out = await s.search({ namespace: "ns", query: "expedite delivery",
+          queryEmbedding: vec(1, 0, 0), embedderId: "fake:test", now: "2026-07-05T00:00:00.000Z" })
+        expect(out.map((r) => r.id)).not.toContain("stale")
+      } finally { await close?.(s) }
+    })
+  })
+}
+```
+
+- [ ] **Step 2: Export** — `packages/testing/src/index.ts`: `export { runMemoryStoreConformance } from "./memory-conformance.js"`.
+
+- [ ] **Step 3: Run the kit against sqlite** — `packages/testing/test/sqlite-conformance.test.ts`:
+```ts
+import { sqliteMemoryStore } from "@dawn-ai/memory"
+import { describe } from "vitest"
+import { runMemoryStoreConformance } from "../src/memory-conformance.js"
+
+runMemoryStoreConformance({
+  name: "sqliteMemoryStore",
+  makeStore: () => sqliteMemoryStore({ path: ":memory:" }),
+  describe,
+})
+```
+
+- [ ] **Step 4: Run — green** (`pnpm build` first for dists): `pnpm --filter @dawn-ai/testing exec vitest run test/sqlite-conformance.test.ts` (8 conformance tests pass — this both proves the kit and backfills formal sqlite conformance). Typecheck clean.
+
+- [ ] **Step 5: Lint + commit** `feat(testing): shared MemoryStore conformance kit (run against sqlite)`.
+
+---
+
+### Task 3: Scaffold `@dawn-ai/memory-pgvector`
+
+**Files:** create `packages/memory-pgvector/{package.json,tsconfig.json,vitest.config.ts,src/index.ts,src/pgvector-store.ts}`; modify root `pnpm-workspace.yaml` if needed (workspaces are globbed — likely no change), `tsconfig.json` references if the repo uses project refs.
+
+- [ ] **Step 1: package.json** (mirror `packages/sqlite-storage/package.json`, adapt):
+```json
+{
+  "name": "@dawn-ai/memory-pgvector",
+  "version": "0.8.8",
+  "private": false,
+  "type": "module",
+  "license": "MIT",
+  "homepage": "https://github.com/cacheplane/dawnai/tree/main/packages/memory-pgvector#readme",
+  "repository": { "type": "git", "url": "git+https://github.com/cacheplane/dawnai.git", "directory": "packages/memory-pgvector" },
+  "bugs": { "url": "https://github.com/cacheplane/dawnai/issues" },
+  "engines": { "node": ">=22.13.0" },
+  "files": ["dist"],
+  "types": "./dist/index.d.ts",
+  "exports": { ".": { "types": "./dist/index.d.ts", "default": "./dist/index.js" } },
+  "publishConfig": { "access": "public" },
+  "scripts": {
+    "build": "tsc -b tsconfig.json",
+    "lint": "biome check --config-path ../config-biome/biome.json package.json src test tsconfig.json vitest.config.ts",
+    "test": "vitest --run --config vitest.config.ts --passWithNoTests",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@dawn-ai/memory": "workspace:*",
+    "pg": "^8.13.1",
+    "pgvector": "^0.2.0"
+  },
+  "devDependencies": {
+    "@dawn-ai/config-typescript": "workspace:*",
+    "@testcontainers/postgresql": "^10.13.2",
+    "@types/node": "26.1.0",
+    "@types/pg": "^8.11.10"
+  }
+}
+```
+(Confirm latest resolvable versions during `pnpm install`; pin to what resolves.)
+
+- [ ] **Step 2:** `tsconfig.json` + `vitest.config.ts` — copy from `packages/sqlite-storage/` verbatim (same compiler + vitest setup). `src/index.ts` barrel `export { pgvectorMemoryStore } from "./pgvector-store.js"` (stub the store for now: a factory that throws `new Error("not implemented")` so the package builds).
+
+- [ ] **Step 3: Install + build + typecheck**:
+```bash
+cd /Users/blove/repos/dawn
+pnpm install
+pnpm --filter @dawn-ai/memory-pgvector build
+pnpm --filter @dawn-ai/memory-pgvector typecheck
+```
+Expected: package builds (stub). Report the resolved `pg`/`pgvector`/`@testcontainers/postgresql` versions.
+
+- [ ] **Step 4: Lint + commit** `feat(memory-pgvector): scaffold package`.
+
+---
+
+### Task 4: pgvector schema (dimension branch + idempotent DDL)
+
+**Files:** create `packages/memory-pgvector/src/schema.ts`, `packages/memory-pgvector/test/schema.test.ts`.
+
+- [ ] **Step 1: Write failing PURE tests** (dimension branch is pure — no PG needed) — `test/schema.test.ts`:
+```ts
+import { describe, expect, it } from "vitest"
+import { vectorColumnDef } from "../src/schema.js"
+
+describe("vectorColumnDef", () => {
+  it("dims ≤ 2000 → plain vector + vector_cosine_ops", () => {
+    expect(vectorColumnDef(1536)).toEqual({ type: "vector(1536)", ops: "vector_cosine_ops" })
+  })
+  it("2000 < dims ≤ 4000 → halfvec + halfvec_cosine_ops (text-embedding-3-large)", () => {
+    expect(vectorColumnDef(3072)).toEqual({ type: "halfvec(3072)", ops: "halfvec_cosine_ops" })
+  })
+  it("dims > 4000 → throws a clear error naming the ceiling", () => {
+    expect(() => vectorColumnDef(5000)).toThrow(/4000/)
+  })
+  it("non-positive/non-integer dims throw", () => {
+    expect(() => vectorColumnDef(0)).toThrow()
+    expect(() => vectorColumnDef(1.5)).toThrow()
+  })
+})
+```
+
+- [ ] **Step 2: Run — expect fail.** `DAWN_TEST_PGVECTOR= pnpm --filter @dawn-ai/memory-pgvector exec vitest run test/schema.test.ts`
+
+- [ ] **Step 3: Implement `schema.ts`** — the pure dimension branch + the DDL builder:
+```ts
+import type { PoolClient } from "pg"
+
+/** pgvector index dimension ceilings: plain vector ≤2000, halfvec ≤4000. */
+export function vectorColumnDef(dimensions: number): { type: string; ops: string } {
+  if (!Number.isInteger(dimensions) || dimensions <= 0)
+    throw new Error(`pgvector: dimensions must be a positive integer, got ${dimensions}`)
+  if (dimensions <= 2000) return { type: `vector(${dimensions})`, ops: "vector_cosine_ops" }
+  if (dimensions <= 4000) return { type: `halfvec(${dimensions})`, ops: "halfvec_cosine_ops" }
+  throw new Error(
+    `pgvector: ${dimensions} dims exceeds the 4000 halfvec index ceiling; reduce embedding dimensions or use a smaller model`,
+  )
+}
+
+/** Idempotent schema init. Safe to call repeatedly (IF NOT EXISTS everywhere). */
+export async function initSchema(
+  client: PoolClient,
+  opts: { prefix: string; schema: string; dimensions: number; m: number; efConstruction: number },
+): Promise<void> {
+  const { prefix, schema, dimensions, m, efConstruction } = opts
+  const t = `${schema}.${prefix}_memories`
+  const tk = `${schema}.${prefix}_tokens`
+  const { type, ops } = vectorColumnDef(dimensions)
+  await client.query("CREATE EXTENSION IF NOT EXISTS vector")
+  await client.query(`CREATE SCHEMA IF NOT EXISTS ${schema}`)
+  await client.query(`CREATE TABLE IF NOT EXISTS ${t} (
+    id text PRIMARY KEY, kind text NOT NULL, namespace text NOT NULL, content text NOT NULL,
+    data jsonb NOT NULL, source jsonb NOT NULL, confidence real NOT NULL, tags jsonb NOT NULL,
+    status text NOT NULL, supersedes jsonb, created_at text NOT NULL, updated_at text NOT NULL,
+    effective_at text, expires_at text, embedding ${type}, embedding_model text)`)
+  await client.query(`CREATE TABLE IF NOT EXISTS ${tk} (
+    memory_id text NOT NULL REFERENCES ${t}(id) ON DELETE CASCADE, token text NOT NULL)`)
+  await client.query(`CREATE INDEX IF NOT EXISTS ${prefix}_ns_status_updated ON ${t} (namespace, status, updated_at DESC)`)
+  await client.query(`CREATE INDEX IF NOT EXISTS ${prefix}_tok ON ${tk} (token)`)
+  await client.query(`CREATE INDEX IF NOT EXISTS ${prefix}_tok_mem ON ${tk} (memory_id)`)
+  await client.query(
+    `CREATE INDEX IF NOT EXISTS ${prefix}_hnsw ON ${t} USING hnsw (embedding ${ops}) WITH (m = ${m}, ef_construction = ${efConstruction})`,
+  )
+}
+```
+
+- [ ] **Step 4: Run — pure tests pass.** (DDL is exercised in Task 6 against real PG.)
+
+- [ ] **Step 5: Lint + commit** `feat(memory-pgvector): schema + dimension branch (vector/halfvec ceilings)`.
+
+---
+
+### Task 5: `pgvectorMemoryStore` implementation
+
+**Files:** create `packages/memory-pgvector/src/queries.ts` (SQL) + implement `packages/memory-pgvector/src/pgvector-store.ts`.
+
+Implement the full `MemoryStore` (from `@dawn-ai/memory`). The store owns retrieval; ranking reuses `rankKeywordCandidates` + `fuseHybrid`. Use the `pgvector` package's `toSql`/registration for the vector param. Key points (no test in this task — Task 6's conformance kit is the test, gated on real PG):
+
+- Constructor: `pgvectorMemoryStore({ connectionString?, pool?, dimensions, index?, schema="public", tablePrefix="dawn_memory" })`. Build a `pg.Pool` from `connectionString` (or use injected `pool`). Lazy idempotent `initSchema` guarded by a memoized `initP: Promise<void>` (await it at the top of every method). Register `pgvector` types on the pool.
+- `put(rec, opts?)`: `INSERT ... ON CONFLICT (id) DO UPDATE SET ...` all columns incl `embedding` (serialize the Float32Array via `pgvector.toSql([...embedding])` — or the package's helper) + `embedding_model`; then delete+reinsert `memory_tokens` via the same `tokenize` from `@dawn-ai/memory`. On UPDATE with no embedding opts, preserve the existing embedding (read-then-write, parity with sqlite `getEmbeddingRow`).
+- `get`/`delete`/`listCandidates`/`update`/`supersede`: direct SQL translations of the sqlite behaviors (row↔record JSON parse/stringify).
+- `search(q)`:
+  - Query-less (no `query`): `WHERE namespace/status[/kind] ORDER BY updated_at DESC, id ASC LIMIT`.
+  - Keyword-only (no `queryEmbedding`): fetch candidate pool (rows matching ≥1 token, `LIMIT candidatePool`) + `df`/`N` stats → `rankKeywordCandidates(...)` → `pageAndTagFilter`.
+  - Hybrid: (a) `SET LOCAL hnsw.ef_search = $efSearch` then vector top-K — `SELECT id FROM <t> WHERE ... AND embedding_model = $model AND embedding IS NOT NULL ORDER BY embedding <=> $vec LIMIT $vectorK`; look up those records; (b) keyword candidate pool + stats → `rankKeywordCandidates` with relevance-only weights; then `fuseHybrid({ keywordRanked, vectorRanked, now: q.now, options: { ...q.vector, recencyHalfLifeMs: q.vector?.recencyHalfLifeMs } })` → `pageAndTagFilter`.
+  - Reuse a shared `pageAndTagFilter` + `rowToRecord` (copy the sqlite versions into `queries.ts`).
+- `close()`: `await pool.end()`.
+
+- [ ] **Step 1:** Write `queries.ts` (rowToRecord, tokenize import, the SQL strings, pageAndTagFilter) + `pgvector-store.ts` (the factory + methods above). Full code is mechanical translation of `sqlite-store.ts` to `pg` async SQL — follow the sqlite method bodies exactly, swapping `db.prepare().all/get/run` for `await client.query(text, params)` and `?`→`$1..$n`.
+- [ ] **Step 2:** `pnpm --filter @dawn-ai/memory-pgvector build && typecheck` — clean (no runtime test yet).
+- [ ] **Step 3: Lint + commit** `feat(memory-pgvector): pgvectorMemoryStore (full MemoryStore over pg + pgvector)`.
+
+---
+
+### Task 6: Gated conformance + pgvector integration against real Postgres
+
+**Files:** create `packages/memory-pgvector/test/pgvector-conformance.test.ts`, `packages/memory-pgvector/test/pgvector-integration.test.ts`.
+
+- [ ] **Step 1: Gated conformance** — `pgvector-conformance.test.ts`:
+```ts
+import { runMemoryStoreConformance } from "@dawn-ai/testing"
+import { afterAll, beforeAll, describe } from "vitest"
+import { PostgreSqlContainer, type StartedPostgreSqlContainer } from "@testcontainers/postgresql"
+import { pgvectorMemoryStore } from "../src/index.js"
+
+const enabled = process.env.DAWN_TEST_PGVECTOR === "1"
+let container: StartedPostgreSqlContainer
+let url: string
+
+describe.skipIf(!enabled)("pgvector real-Postgres conformance", () => {
+  beforeAll(async () => {
+    container = await new PostgreSqlContainer("pgvector/pgvector:pg16").start()
+    url = container.getConnectionUri()
+  }, 120_000)
+  afterAll(async () => { await container?.stop() })
+
+  runMemoryStoreConformance({
+    name: "pgvectorMemoryStore",
+    // Fresh isolated store per test via a unique table prefix (no cross-test bleed).
+    makeStore: () => pgvectorMemoryStore({ connectionString: url, dimensions: 3, tablePrefix: `t_${Math.random().toString(36).slice(2)}` }),
+    describe,
+    close: (s) => (s as { close(): Promise<void> }).close(),
+  })
+})
+```
+Note: `dimensions: 3` matches the conformance kit's `vec(1,0,0)` fixtures. (Deviation from Math.random determinism rule is TEST-ONLY and acceptable — it just isolates tables; if biome/policy flags it, use a beforeAll counter instead.)
+
+- [ ] **Step 2: pgvector-specific integration** — `pgvector-integration.test.ts` (gated, same container): schema idempotency (`initSchema` twice → no error), the dimension branch on real PG (create a 1536 `vector` store and a 3072 `halfvec` store, both init cleanly), HNSW index exists (`SELECT indexname ... WHERE indexdef LIKE '%hnsw%'`), and a concurrency check (10 parallel `put`s + a `search`, all resolve). Each with `describe.skipIf(!enabled)`.
+
+- [ ] **Step 3: Run gated locally (needs Docker):**
+```bash
+cd /Users/blove/repos/dawn
+pnpm build
+DAWN_TEST_PGVECTOR=1 pnpm --filter @dawn-ai/memory-pgvector test
+```
+Expected: the 8 conformance tests + integration tests pass against real pgvector. Also confirm they SKIP without the flag: `pnpm --filter @dawn-ai/memory-pgvector test` → skipped.
+Report both. If the vector-ordering conformance tests are flaky under HNSW at tiny N, note it — at N≤2 HNSW recall is effectively exact, so they should be stable; if not, the retrieval SQL is wrong, not the test.
+
+- [ ] **Step 4: Lint + commit** `test(memory-pgvector): gated real-Postgres conformance + integration`.
+
+---
+
+### Task 7: CI gated lane
+
+**Files:** modify `.github/workflows/ci.yml`.
+
+- [ ] **Step 1:** Add a `pgvector-docker` job mirroring `sandbox-docker` (read it at ci.yml ~line 97). Same checkout/pnpm/node(22.14.0)/install; then:
+```yaml
+  pgvector-docker:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      # ... same checkout / setup-pnpm / setup-node(22.14.0, cache pnpm) / install as sandbox-docker ...
+      - name: Build memory-pgvector + deps
+        run: pnpm --filter @dawn-ai/memory --filter @dawn-ai/testing --filter @dawn-ai/memory-pgvector build
+      - name: Real-Postgres pgvector conformance + integration
+        run: DAWN_TEST_PGVECTOR=1 pnpm --filter @dawn-ai/memory-pgvector test
+```
+(Testcontainers pulls `pgvector/pgvector:pg16` itself; the ubuntu runner has Docker. No `services:` block needed.)
+
+- [ ] **Step 2:** Validate the workflow YAML parses (`node -e "require('js-yaml')"` if available, or `gh workflow view` after push). Commit `ci: gated pgvector real-Postgres lane`.
+
+---
+
+### Task 8: `examples/memory` app + continuous dogfood
+
+**Files:** create `examples/memory/**` (package.json, dawn.config.ts, src/app/notes/{index.ts,memory.ts}, tsconfig); create `packages/testing/test/memory-example-dogfood.test.ts` OR co-locate under the example. Read `examples/chat/server` for the example-app shape.
+
+- [ ] **Step 1: The example app.** Minimal: one route `src/app/notes/` with `index.ts` (`agent({ model: "gpt-5-mini", systemPrompt: "You are a note-taking assistant with long-term memory. Use remember/recall." })`) + `memory.ts` (`defineMemory({ kind: "semantic", scope: ["route"], schema: z.object({ subject, predicate, value }) })`). `dawn.config.ts` backend-switch:
+```ts
+import { openaiEmbedder } from "@dawn-ai/langchain"
+const url = process.env.DATABASE_URL
+export default {
+  appDir: "src/app",
+  memory: {
+    writes: "auto",
+    ...(process.env.OPENAI_API_KEY || url ? { vector: { embedder: openaiEmbedder() } } : {}),
+    ...(url
+      ? { store: (await import("@dawn-ai/memory-pgvector")).pgvectorMemoryStore({ connectionString: url, dimensions: 1536 }) }
+      : {}),
+  },
+}
+```
+(If top-level await in the config is a problem for the loader, use a synchronous import + a factory that connects lazily — verify against how `loadDawnConfig` evaluates the config; adjust to a non-async default export if needed.)
+
+- [ ] **Step 2: Continuous dogfood test** (CI-safe path always; pgvector path gated). Using `createAgentHarness` against the example appRoot with a scripted `fakeEmbedder`-backed run: remember a fact → assert it persisted (store search finds it) → recall returns it. Run the sqlite path always; add a `describe.skipIf(!DAWN_TEST_PGVECTOR)` block that points the example at a Testcontainers Postgres (set `DATABASE_URL`) and re-runs the same flow, asserting recall works through pgvector. Model this on `packages/testing/test/memory-vector-e2e.test.ts`.
+
+- [ ] **Step 3:** Add root scripts: `"dogfood:pgvector"` in root package.json that starts a pgvector container (or documents `docker run -e POSTGRES_PASSWORD=x -p 5432:5432 pgvector/pgvector:pg16`) + runs the example's dogfood flow with a real `OPENAI_API_KEY` (documented as local-only). Write `examples/memory/README.md` with the sqlite default + the `DATABASE_URL` pgvector toggle + the docker one-liner.
+
+- [ ] **Step 4:** Run the CI-safe dogfood (`pnpm --filter ... exec vitest run memory-example-dogfood`) green; run the gated pgvector dogfood locally (Docker) green. `pnpm build` first. Commit `feat(examples): memory example app + continuous pgvector dogfood`.
+
+---
+
+### Task 9: Local doubly-gated real-embedder smoke
+
+**Files:** add to `packages/memory-pgvector/test/pgvector-live.smoke.test.ts` (or extend the example dogfood).
+
+- [ ] **Step 1:** `describe.skipIf(!(process.env.DAWN_TEST_PGVECTOR === "1" && process.env.OPENAI_API_KEY))`: boot the `examples/memory` app against a Testcontainers Postgres + real `openaiEmbedder`, remember "the customer wants faster shipping", recall with "expedite delivery options" (zero shared tokens), assert the recalled content contains "shipping". Proves real embeddings + real pgvector end-to-end.
+- [ ] **Step 2:** Confirm it SKIPS without both flags. Run locally with `.env` loaded ONLY in the smoke shell (`set -a; . ./.env; set +a`) + `DAWN_TEST_PGVECTOR=1`; never print the key. Report pass + recalled content (no secret).
+- [ ] **Step 3: Lint + commit** `test(memory-pgvector): doubly-gated real-embedder paraphrase smoke`.
+
+---
+
+### Task 10: Docs, changeset, validate, PR
+
+**Files:** modify `apps/web/content/docs/memory.mdx`, `docs/dev/memory-system.md`; create `.changeset/pgvector-backend.md`.
+
+- [ ] **Step 1: `memory.mdx`** — a "### Postgres backend (pgvector)" subsection under long-term memory: enable via `config.memory.store = pgvectorMemoryStore({ connectionString, dimensions })`; HNSW + cosine; the dimension note (1536 fits `vector`; 3072 uses `halfvec`); that **ranking is identical to the sqlite backend** (shared pure core); needs a running Postgres with the `vector` extension; local `docker run` one-liner. Note it's a production/multi-instance option; sqlite stays the local-first default.
+
+- [ ] **Step 2: `docs/dev/memory-system.md`** — §2 file map add `hybrid.ts` + `@dawn-ai/memory-pgvector`; a new section on the shared ranking core (both backends retrieve then call `fuseHybrid`); note the conformance kit + gated lane; pgvector now shipped (Tier-2), DiskANN/pgvectorscale + in-SQL RRF still deferred.
+
+- [ ] **Step 3:** `node scripts/check-docs.mjs` — pass (reword banned phrases if flagged).
+
+- [ ] **Step 4: Changeset** `.changeset/pgvector-backend.md` (PATCH — fixed 0.x group; minor bumps the whole group to 1.0.0):
+```markdown
+---
+"@dawn-ai/memory": patch
+"@dawn-ai/testing": patch
+"@dawn-ai/memory-pgvector": patch
+---
+
+Add `@dawn-ai/memory-pgvector` — a Postgres + pgvector MemoryStore backend for
+production/multi-instance vector memory. Enable with
+`memory: { store: pgvectorMemoryStore({ connectionString, dimensions }) }`. Uses
+an HNSW index (cosine) for vector retrieval and reuses the exact same pure hybrid
+ranking (RRF + recency/confidence) as the default sqlite backend, so recall
+ordering is identical across backends. Ships a shared `runMemoryStoreConformance`
+kit (@dawn-ai/testing) run against both backends. Dimensions ≤2000 use `vector`,
+≤4000 use `halfvec` (text-embedding-3-large); pgvectorscale/DiskANN and in-SQL RRF
+are deferred.
+```
+
+- [ ] **Step 5: Full validate** (clean shell, no `.env`, no `DAWN_TEST_PGVECTOR`):
+  `pnpm lint && pnpm build && pnpm typecheck && pnpm test` — all green; pgvector conformance/integration/live SKIP (no flag). Report the final summary line.
+
+- [ ] **Step 6: Commit, push, open PR (do NOT auto-merge — coordinator runs the final whole-branch review + a gated-lane check first):**
+```bash
+cd /Users/blove/repos/dawn
+git add apps/web/content/docs/memory.mdx docs/dev/memory-system.md .changeset/pgvector-backend.md
+git commit -m "docs+changeset: pgvector memory backend"
+git push -u origin feat/memory-pgvector
+gh pr create --base main --head feat/memory-pgvector --title "feat(memory): pgvector backend (@dawn-ai/memory-pgvector)" --body "<summary: production Postgres+pgvector MemoryStore, HNSW+cosine, retrieve-in-PG + shared pure fusion (identical ranking to sqlite), dimension branch vector/halfvec, shared conformance kit run against both backends, gated real-Postgres CI lane, examples/memory continuous dogfood; new-package OIDC bootstrap needed at release; research: docs/superpowers/specs/2026-07-07-pgvector-backend-design.md>. End with Generated-with-Claude-Code."
+```
+
+---
+
+## Self-review
+
+- **Spec coverage:** shared core extract + sqlite refactor (T1); conformance kit + sqlite run (T2); package scaffold (T3); schema + dimension branch (T4); full store (T5); gated conformance + integration (T6); gated CI lane (T7); examples/memory + continuous dogfood (T8); doubly-gated real smoke (T9); docs + changeset + validate + PR (T10). App-side fusion via shared core ✓. New-package OIDC bootstrap noted (T10 PR body + release memory). ✓
+- **Type consistency:** `MemoryStore` (from @dawn-ai/memory) implemented in full by pgvector incl `delete`/`listCandidates`; `fuseHybrid`/`rankKeywordCandidates` signatures identical across T1 (def), sqlite refactor (T1), and pgvector store (T5); `pgvectorMemoryStore(opts)` shape identical across T3/T5/T6/T8; `VectorRankingOptions` reused. ✓
+- **Traps flagged inline:** branch pin; scoped biome; patch-not-minor; `.env` + `DAWN_TEST_PGVECTOR` gating; Testcontainers needs Docker; monorepo dist rebuild ordering; the sqlite refactor guarded by shipped tests (fix extraction not test); top-level-await-in-config caveat (T8); HNSW-at-tiny-N stability note (T6); new-package OIDC bootstrap at release.
+- **Biggest risk:** T1 extraction (parity) and T5 SQL translation (correctness, only caught by T6's gated lane — so T6 must actually run against Docker locally before the PR, not just be written).

--- a/docs/superpowers/specs/2026-07-07-pgvector-backend-design.md
+++ b/docs/superpowers/specs/2026-07-07-pgvector-backend-design.md
@@ -177,11 +177,28 @@ Three tiers:
    idempotency (run init twice, no error), the dimension branch (1536→vector,
    3072→halfvec, >4000→throw), HNSW index existence + `ef_search` application,
    concurrency (parallel puts/searches over a pool), and the exact retrieval SQL.
-3. **Dogfood smoke** (doubly-gated, local): a full Dawn agent + `pgvectorMemoryStore`
-   (real Postgres via Testcontainers or a local container) + real `openaiEmbedder`
-   (real key) — the "expedite delivery → faster shipping" zero-shared-token
-   paraphrase recall, end to end. Ships a `docker run` / compose one-liner + a
-   `pnpm dogfood:pgvector` script so it's runnable by hand.
+3. **Continuous dogfood via a visible, dedicated example app.** A new small
+   memory-centric example `examples/memory` is the dogfood vehicle and a copyable
+   reference (there is no standing memory example on main today — chat has no
+   memory route, and `app-research` is a scaffold *template*, not a running app;
+   the `examples/research` promotion is a separate in-flight effort we don't
+   depend on). The example is one agent route with a `memory.ts`, and a
+   `dawn.config.ts` that is **backend-switchable**: `pgvectorMemoryStore` when
+   `DATABASE_URL` is set, else the default sqlite store. So:
+   - **Default / offline:** sqlite, zero-config — the example runs with no
+     Postgres and no key. This is what a reader copies first.
+   - **Continuous CI dogfood** (gated pgvector lane): boot the *actual example
+     app* against a Testcontainers Postgres (`DATABASE_URL` set) + the
+     deterministic `fakeEmbedder` (no key) and drive a real agent run through the
+     harness — remember a fact → it lands in pgvector → recall returns it via the
+     hybrid path. Any regression in the real Postgres integration surfaces on the
+     example itself, every gated run. This IS the dogfood.
+   - **Local hands-on** (doubly-gated): the same example + a local/Testcontainers
+     Postgres + real `openaiEmbedder` (real key) → the "expedite delivery →
+     faster shipping" zero-shared-token paraphrase recall. A `pnpm dogfood:pgvector`
+     script + a `docker run`/compose one-liner make it a one-command hand-run.
+   - Follow-up (noted, not in scope): when `examples/research` (#311) lands, the
+     same `DATABASE_URL` toggle can be added there too.
 
 Local ergonomics: `DAWN_TEST_PGVECTOR=1 pnpm --filter @dawn-ai/memory-pgvector test`
 spins the container programmatically (Testcontainers needs a Docker daemon).
@@ -210,8 +227,9 @@ concrete type call it).
 ## Scope / non-goals
 
 In: the backend package, the shared ranking-core extraction (+ sqlite refactor
-under its test guard), the conformance kit, the Testcontainers gated lane + the
-dogfood smoke, docs, changeset. **Out (deferred, noted):** DiskANN via
+under its test guard), the conformance kit, the Testcontainers gated lane, the
+new `examples/memory` app (env-toggled sqlite/pgvector) + its continuous-dogfood
+lane, docs, changeset. **Out (deferred, noted):** DiskANN via
 `pgvectorscale` (very-large-scale path mem0 offers); in-SQL RRF as a future
 single-round-trip perf option; IVFFlat; binary quantization / subvector indexing
 for >4000 dims; connection-secret management; multi-tenant pool strategies;

--- a/docs/superpowers/specs/2026-07-07-pgvector-backend-design.md
+++ b/docs/superpowers/specs/2026-07-07-pgvector-backend-design.md
@@ -1,0 +1,243 @@
+# pgvector Memory Backend Design (Phase 4 — memory follow-up)
+
+Date: 2026-07-07
+Status: approved design, pending implementation plan
+Branch: `feat/memory-pgvector`
+Prior art: vector recall (`docs/superpowers/specs/2026-07-06-vector-recall-design.md`, PR #313)
+
+## Goal
+
+Ship `@dawn-ai/memory-pgvector` — a production, Postgres + pgvector backend that
+implements the `MemoryStore` interface, selected via `config.memory.store`. It
+gives Dawn apps a multi-instance, large-scale vector memory option while keeping
+recall ranking **byte-identical** to the default sqlite backend. Emphasis on
+thorough, real-Postgres testing and hands-on dogfooding.
+
+## Background
+
+- The `MemoryStore` seam is already vector-ready (PR #313): a custom store is a
+  live value on `config.memory.store`; `resolveMemoryStore` returns it directly
+  and skips all sqlite tuning (custom stores own their ranking); the capability
+  embeds queries/content and passes `queryEmbedding` + `embedderId` to *any*
+  store — so pgvector needs zero embedder awareness.
+- `pg` (node-postgres) and the `pgvector` npm helper are **pure JavaScript** — no
+  native build. The only friction is a *running Postgres* for tests.
+- `@dawn-ai/memory` already exports the pure ranking primitives this backend
+  reuses: `fuseRRF`, `recencyDecay`, `scoreMemory`, `tokenize`, `cosineSimilarity`,
+  `serializeNamespace`, `classifyWrite`, and the record/query types.
+- Note: the structural `MemoryStoreLike` (the config type) omits `delete` /
+  `listCandidates`, but the `dawn memory` CLI needs them — pgvector implements
+  the **full** `MemoryStore`.
+
+## Research-grounded decisions (2026-07-07, 3-vote verified)
+
+- **App-side fusion for parity (chosen), knowingly.** In-SQL RRF *is* the
+  canonical pgvector pattern (Supabase `hybrid_search`, Katz `rrf_score()`,
+  pgvector-python `rrf.py`) and its edge is one round-trip. We deliberately fuse
+  **app-side in shared pure JS** to guarantee identical ranking to the sqlite
+  backend (DRY, one implementation). The research explicitly supports this
+  ("pgvector does not force app-side fusion; app-side keeps parity"). Documented
+  as a conscious tradeoff, not an oversight.
+- **HNSW + `vector_cosine_ops` + `<=>`.** HNSW is the consensus best practice
+  (~30× IVFFlat QPS at 99% recall on 1536-dim OpenAI data; **no training step, so
+  it builds on an empty table** — essential for a store that starts empty). mem0
+  uses HNSW (or DiskANN), never IVFFlat. Defaults `m=16`, `ef_construction=64`
+  (allow 256 for quality), `ef_search=40`, all config-exposed.
+- **The 2,000-dim index ceiling is real.** pgvector `vector` *stores* to 16k dims
+  but HNSW/IVFFlat on plain `vector` caps at **2,000**. `text-embedding-3-small`
+  (1536) fits; `text-embedding-3-large` (3072) does **not** — it needs `halfvec`
+  (indexable to 4,000 via `halfvec_cosine_ops`). The store branches on dimension.
+- **Testcontainers, not GitHub-services-only.** `@testcontainers/postgresql` +
+  `pgvector/pgvector:pg16` spins the container programmatically, so the *same*
+  gated tests run locally and in CI with one mechanism. (PGlite-pgvector exists
+  but its index fidelity is undocumented — reinforces the Docker-only decision.)
+- **Hybrid keyword+vector is rare in the field.** mem0 and Mastra pgvector are
+  vector-*only*; only Zep/Graphiti fuses (app-side RRF). Dawn's hybrid is already
+  ahead — not catching up.
+
+## Architecture — a thin backend over a shared ranking core
+
+Today the hybrid ranking (keyword scoring, RRF, recency/confidence second stage)
+lives *inside* `sqlite-store.ts`. To guarantee cross-backend parity, extract the
+**pure** ranking pieces into a backend-agnostic module in `@dawn-ai/memory`
+(`hybrid.ts`):
+
+- `rankKeywordCandidates(records, dfByToken, corpusSize, queryTokens, opts)` →
+  keyword-ranked records (the JS scoring, minus SQL).
+- `fuseHybrid({ keywordRanked, vectorRanked, records, referenceNow, opts })` →
+  final ranked records: `fuseRRF` over the two id-lists + the bounded
+  `recencyDecay`/confidence second stage + stable sort. (Reuses shipped `fuseRRF`
+  + `recencyDecay`.)
+
+Both stores become: *do your own retrieval (backend SQL), then call the shared
+core*. `sqliteMemoryStore` is refactored to call it (its existing hybrid tests are
+the guard — any reorder means the extraction diverged, fix the extraction not the
+test). `pgvectorMemoryStore` calls it fresh. So `@dawn-ai/memory-pgvector`
+contains **only** Postgres retrieval + schema and depends on `@dawn-ai/memory`
+(pure-JS) for ranking. Parity is structural.
+
+## Package layout (`@dawn-ai/memory-pgvector`)
+
+Mirrors `@dawn-ai/sqlite-storage` / `@dawn-ai/sandbox`:
+
+- `src/pgvector-store.ts` — `pgvectorMemoryStore(opts)` factory implementing `MemoryStore`.
+- `src/schema.ts` — idempotent DDL (extension, tables, indexes) + tiny migration runner.
+- `src/queries.ts` — the retrieval SQL (vector top-K, keyword pool + df/N stats, get/put/update/supersede/delete/listCandidates).
+- `src/index.ts` — barrel.
+- Dependencies: `pg`, `pgvector`, `@dawn-ai/memory` (workspace). Dev: `@testcontainers/postgresql`.
+
+## Schema, dimensions, config
+
+Config:
+```ts
+pgvectorMemoryStore({
+  connectionString?: string        // or pass a pg.Pool
+  pool?: import("pg").Pool         // caller-owned pool (mutually exclusive with connectionString)
+  dimensions: number               // REQUIRED — must match the embedder's dims
+  index?: { type?: "hnsw"; m?: number; efConstruction?: number; efSearch?: number }  // HNSW defaults 16/64/40
+  schema?: string                  // Postgres schema name, default "public"
+  tablePrefix?: string             // default "dawn_memory"
+})
+```
+
+DDL (idempotent, run once on first connect, transactional):
+```sql
+CREATE EXTENSION IF NOT EXISTS vector;
+CREATE TABLE IF NOT EXISTS <prefix>_memories (
+  id text PRIMARY KEY, kind text NOT NULL, namespace text NOT NULL,
+  content text NOT NULL, data jsonb NOT NULL, source jsonb NOT NULL,
+  confidence real NOT NULL, tags jsonb NOT NULL, status text NOT NULL,
+  supersedes jsonb, created_at text NOT NULL, updated_at text NOT NULL,
+  effective_at text, expires_at text,
+  embedding <VECTOR_TYPE>(<dimensions>), embedding_model text
+);
+CREATE TABLE IF NOT EXISTS <prefix>_tokens (
+  memory_id text NOT NULL REFERENCES <prefix>_memories(id) ON DELETE CASCADE, token text NOT NULL
+);
+CREATE INDEX ... ON <prefix>_memories (namespace, status, updated_at DESC);
+CREATE INDEX ... ON <prefix>_tokens (token);
+CREATE INDEX ... ON <prefix>_memories USING hnsw (embedding <OPS>) WITH (m=?, ef_construction=?);
+```
+
+**Dimension branch:** `dimensions ≤ 2000` → `VECTOR_TYPE = vector`, `OPS =
+vector_cosine_ops`. `dimensions ≤ 4000` (i.e. > 2000) → `VECTOR_TYPE = halfvec`,
+`OPS = halfvec_cosine_ops` (enables `text-embedding-3-large` at 3072).
+`dimensions > 4000` → throw a clear config error at construction. Document 1536
+(`-small`) as the smooth default.
+
+## Retrieval flow
+
+`put(rec, { embedding, embeddingModel })` — upsert the row (`INSERT ... ON
+CONFLICT (id) DO UPDATE`), re-tokenize into the tokens table (same `tokenize()`),
+write the `embedding` (via the `pgvector` serializer) + `embedding_model`. `update`
+re-reads and preserves the embedding when the patch omits it (parity with sqlite).
+
+`search(q)`:
+- **Query-less** (no `query`): `... WHERE namespace/status[/kind] ORDER BY updated_at DESC, id ASC LIMIT` — recency, unchanged semantics.
+- **No `queryEmbedding`** (keyword-only): keyword pool + df/N stats → `rankKeywordCandidates` → page → tag filter.
+- **Hybrid** (`queryEmbedding` present): in Postgres, run (a) vector top-K —
+  `ORDER BY embedding <=> $vec LIMIT vectorK` filtered to namespace/status[/kind]
+  + `embedding_model = $embedderId`, `ef_search` set per query via `SET LOCAL
+  hnsw.ef_search`; and (b) the keyword pool + df/N stats. Hand both to the shared
+  `fuseHybrid` → identical ranking → return records.
+
+Determinism/parity: the fusion is the shared pure code; only retrieval differs.
+HNSW is approximate, so vector *retrieval* can vary run-to-run at scale — accept
+this (it is the nature of ANN and matches every production backend); the
+conformance kit's vector-ordering assertions use small corpora where HNSW recall
+is effectively exact, and looser "is recalled" assertions at scale.
+
+## The shared `MemoryStore` conformance kit
+
+New export in `@dawn-ai/testing` (mirrors sandbox `runProviderConformance`):
+```ts
+runMemoryStoreConformance({
+  name: string,
+  makeStore: () => Promise<MemoryStore> | MemoryStore,
+  describe, test,   // injected vitest fns
+})
+```
+Asserts the full contract: put/get round-trip, namespace + status isolation,
+supersession (old→superseded, new active, supersedes link), candidate
+list/approve semantics, delete, embedding round-trip, keyword ranking order,
+and hybrid ordering with **injected** vectors (deterministic — the
+"semantic-only match recalled" + "exact-token match not buried" cases from #313).
+Run it against **sqliteMemoryStore (in-process, always)** — backfilling formal
+conformance coverage sqlite never had — and **pgvectorMemoryStore (real PG,
+gated)**. The kit is the parity guarantee: the fake cannot drift from reality.
+
+## Testing strategy (the emphasis)
+
+Three tiers:
+1. **Conformance kit** — sqlite always (default validate lane); pgvector behind
+   `DAWN_TEST_PGVECTOR=1` via Testcontainers (`pgvector/pgvector:pg16`), in a
+   dedicated CI lane modeled on `sandbox-docker`. Default validate never sets the
+   flag → CI stays green with no Postgres.
+2. **pgvector-specific integration** (same gated lane): schema/migration
+   idempotency (run init twice, no error), the dimension branch (1536→vector,
+   3072→halfvec, >4000→throw), HNSW index existence + `ef_search` application,
+   concurrency (parallel puts/searches over a pool), and the exact retrieval SQL.
+3. **Dogfood smoke** (doubly-gated, local): a full Dawn agent + `pgvectorMemoryStore`
+   (real Postgres via Testcontainers or a local container) + real `openaiEmbedder`
+   (real key) — the "expedite delivery → faster shipping" zero-shared-token
+   paraphrase recall, end to end. Ships a `docker run` / compose one-liner + a
+   `pnpm dogfood:pgvector` script so it's runnable by hand.
+
+Local ergonomics: `DAWN_TEST_PGVECTOR=1 pnpm --filter @dawn-ai/memory-pgvector test`
+spins the container programmatically (Testcontainers needs a Docker daemon).
+
+## Connection & lifecycle
+
+A `pg.Pool` (built from `connectionString`, or the caller's injected `pool`). The
+store exposes `close(): Promise<void>` (ends the pool) — used by tests and
+graceful shutdown. Schema init runs once, guarded by an in-memory `initialized`
+promise (idempotent + concurrency-safe). `MemoryStore` itself gains no `close` —
+`close` is a pgvector-store extra (structural typing lets callers who hold the
+concrete type call it).
+
+## Error handling
+
+- Missing `pgvector` extension / insufficient privileges to `CREATE EXTENSION` →
+  a clear actionable error at init ("enable the vector extension or grant …").
+- `dimensions > 4000` → construction error naming the halfvec ceiling.
+- A stored `embedding_model` ≠ the query `embedderId` → excluded from the vector
+  retrieval (SQL `WHERE embedding_model = $1`), graceful keyword-only fallback —
+  parity with sqlite.
+- Connection errors surface as thrown errors (the capability's recall/remember
+  already degrade gracefully around store failures where designed; a hard DB
+  outage is a real error, not silently swallowed).
+
+## Scope / non-goals
+
+In: the backend package, the shared ranking-core extraction (+ sqlite refactor
+under its test guard), the conformance kit, the Testcontainers gated lane + the
+dogfood smoke, docs, changeset. **Out (deferred, noted):** DiskANN via
+`pgvectorscale` (very-large-scale path mem0 offers); in-SQL RRF as a future
+single-round-trip perf option; IVFFlat; binary quantization / subvector indexing
+for >4000 dims; connection-secret management; multi-tenant pool strategies;
+pg-native `tsvector`/BM25 ranking (we replicate the token+IDF table for parity).
+
+## Packaging & release
+
+- New package `@dawn-ai/memory-pgvector` (public). Its first publish needs the
+  OIDC new-package bootstrap (see the npm-release memory: bootstrap BEFORE merging
+  the Version PR, pack the tarball from `changeset-release/main`).
+- Changed existing packages: `@dawn-ai/memory` (extract `hybrid.ts`, refactor
+  sqlite-store to use it), `@dawn-ai/testing` (`runMemoryStoreConformance`).
+- Changeset: **patch** for `@dawn-ai/memory`, `@dawn-ai/testing`, AND the new
+  `@dawn-ai/memory-pgvector` (new packages join the fixed group and take a
+  changeset entry so they version with the group). Fixed 0.x group — GOTCHA 6:
+  never `minor` (it inflates the whole group to 1.0.0). The conformance kit takes
+  a `makeStore` factory, so `@dawn-ai/testing` does NOT depend on the pgvector
+  package (no cycle) — the pgvector package's own test imports the kit.
+- Docs: `apps/web/content/docs/memory.mdx` (a "Postgres backend" subsection —
+  enable via `config.memory.store = pgvectorMemoryStore({ … })`, HNSW, the
+  dimension note, that ranking matches sqlite); `docs/dev/memory-system.md`
+  (pgvector now shipped; the shared ranking core).
+
+## Open tuning questions (validate during build, not blockers)
+
+- HNSW `ef_construction` default 64 vs 256 (quality vs build time) — pick 64,
+  expose, revisit with the dogfood corpus.
+- `vectorK` / `candidatePool` defaults for pgvector — reuse the #313 defaults (64
+  / 256) for parity; confirm they behave on a real ANN index.

--- a/examples/memory/README.md
+++ b/examples/memory/README.md
@@ -1,0 +1,78 @@
+# `@dawn-example/memory` — long-term memory, backend-switchable
+
+A one-route Dawn app (`notes`) with a note-taking agent that has durable,
+cross-session memory. It ships with a **zero-setup SQLite backend** and switches
+to **Postgres + [pgvector]** with a single environment variable — the same app
+code, a different store.
+
+## The route
+
+- `src/app/notes/index.ts` — the agent (`gpt-5-mini`) with a `remember`/`recall`
+  system prompt.
+- `src/app/notes/memory.ts` — a `semantic` memory schema (`subject` /
+  `predicate` / `value`), route-scoped.
+
+The `remember` and `recall` tools are generated from `memory.ts`.
+
+## Backends
+
+The backend is chosen at load time from the environment (see `dawn.config.ts`):
+
+| Env                                | Store            | Recall                       |
+| ---------------------------------- | ---------------- | ---------------------------- |
+| _(none)_                           | SQLite (default) | keyword-only                 |
+| `OPENAI_API_KEY`                   | SQLite           | hybrid keyword **+ vector**  |
+| `DATABASE_URL`                     | Postgres/pgvector | keyword-only                |
+| `DATABASE_URL` + `OPENAI_API_KEY`  | Postgres/pgvector | hybrid keyword **+ vector**  |
+
+The two toggles are independent. `DATABASE_URL` swaps the store; `OPENAI_API_KEY`
+lights up vector/semantic recall (`text-embedding-3-small`, 1536 dims). Both the
+store and the embedder connect lazily, so nothing touches the network until the
+first `remember`/`recall`.
+
+## Run it (SQLite, zero setup)
+
+```sh
+pnpm --filter @dawn-example/memory dev
+```
+
+Memory persists to `.dawn/memory.sqlite`. That's it — no key, no database.
+
+## Run it against Postgres + pgvector
+
+Start a pgvector-enabled Postgres:
+
+```sh
+docker run --rm -e POSTGRES_PASSWORD=postgres -p 5432:5432 pgvector/pgvector:pg16
+```
+
+Point the app at it (and, optionally, add a key for vector recall):
+
+```sh
+export DATABASE_URL="postgres://postgres:postgres@localhost:5432/postgres"
+export OPENAI_API_KEY="sk-..."   # optional — enables hybrid keyword+vector recall
+pnpm --filter @dawn-example/memory dev
+```
+
+The app creates its tables + HNSW index on first write.
+
+## Continuous dogfood
+
+`packages/testing/test/memory-example-dogfood.test.ts` drives this **real
+example app** through a scripted remember → recall flow:
+
+- **Always (CI-safe, no key, no Docker):** the default SQLite backend, proving
+  the memory route works end-to-end.
+- **Gated (`DAWN_TEST_PGVECTOR=1`, Docker):** the same flow against a
+  [Testcontainers] Postgres, proving recall works through pgvector.
+
+```sh
+# CI-safe (SQLite) — gated block auto-skips:
+pnpm --filter @dawn-ai/testing exec vitest run test/memory-example-dogfood.test.ts
+
+# Local hands-on pgvector dogfood (needs Docker):
+DAWN_TEST_PGVECTOR=1 pnpm --filter @dawn-ai/testing exec vitest run test/memory-example-dogfood.test.ts
+```
+
+[pgvector]: https://github.com/pgvector/pgvector
+[Testcontainers]: https://testcontainers.com/

--- a/examples/memory/server/.gitignore
+++ b/examples/memory/server/.gitignore
@@ -1,0 +1,5 @@
+.dawn/
+node_modules/
+dist/
+.env
+.env.local

--- a/examples/memory/server/dawn.config.ts
+++ b/examples/memory/server/dawn.config.ts
@@ -1,0 +1,72 @@
+import type { Embedder } from "@dawn-ai/core"
+import { openaiEmbedder } from "@dawn-ai/langchain"
+import { pgvectorMemoryStore } from "@dawn-ai/memory-pgvector"
+
+// Backend-switchable memory example.
+//
+//   default (no env)          → SQLite store, keyword-only recall. Zero setup.
+//   OPENAI_API_KEY set        → adds vector/semantic recall via OpenAI embeddings
+//                               (text-embedding-3-small, 1536 dims).
+//   DATABASE_URL set          → swaps the SQLite store for Postgres + pgvector.
+//
+// The two toggles are independent: DATABASE_URL alone gives you keyword recall
+// through Postgres; add OPENAI_API_KEY to light up the hybrid keyword+vector
+// path. See README.md for the `docker run` one-liner.
+//
+// The loader (`loadDawnConfig`) evaluates this module with `await import(...)`,
+// so a top-level `await import("@dawn-ai/memory-pgvector")` would also work —
+// but a plain static import is simpler and the example depends on the package
+// directly. Both the store and the embedder connect/authenticate lazily, so
+// constructing them here does no I/O until the first remember/recall.
+const url = process.env.DATABASE_URL
+
+// Network-free test seam for the continuous dogfood: a deterministic
+// bag-of-token-hash embedder (mirrors @dawn-ai/testing's fakeEmbedder) so the
+// hybrid vector path can be exercised without a real OpenAI key or network. Off
+// by default — real usage goes through `openaiEmbedder` above.
+function fakeEmbedder(dims = 1536): Embedder {
+  const hash = (s: string): number => {
+    let h = 2166136261
+    for (let i = 0; i < s.length; i++) {
+      h ^= s.charCodeAt(i)
+      h = Math.imul(h, 16777619)
+    }
+    return h >>> 0
+  }
+  return {
+    id: `fake:${dims}`,
+    dims,
+    async embed(texts) {
+      return texts.map((t) => {
+        const v = new Float32Array(dims)
+        for (const tok of t
+          .toLowerCase()
+          .split(/[^a-z0-9]+/)
+          .filter((x) => x.length > 1)) {
+          const idx = hash(tok) % dims
+          v[idx] = (v[idx] as number) + 1
+        }
+        let n = 0
+        for (const x of v) n += x * x
+        n = Math.sqrt(n) || 1
+        for (let i = 0; i < dims; i++) v[i] = (v[i] as number) / n
+        return v
+      })
+    },
+  }
+}
+
+const embedder: Embedder | undefined = process.env.DAWN_MEMORY_FAKE_EMBEDDER
+  ? fakeEmbedder(1536)
+  : process.env.OPENAI_API_KEY
+    ? openaiEmbedder()
+    : undefined
+
+export default {
+  appDir: "src/app",
+  memory: {
+    writes: "auto",
+    ...(embedder ? { vector: { embedder } } : {}),
+    ...(url ? { store: pgvectorMemoryStore({ connectionString: url, dimensions: 1536 }) } : {}),
+  },
+}

--- a/examples/memory/server/dawn.config.ts
+++ b/examples/memory/server/dawn.config.ts
@@ -1,4 +1,3 @@
-import type { Embedder } from "@dawn-ai/core"
 import { openaiEmbedder } from "@dawn-ai/langchain"
 import { pgvectorMemoryStore } from "@dawn-ai/memory-pgvector"
 
@@ -13,54 +12,10 @@ import { pgvectorMemoryStore } from "@dawn-ai/memory-pgvector"
 // through Postgres; add OPENAI_API_KEY to light up the hybrid keyword+vector
 // path. See README.md for the `docker run` one-liner.
 //
-// The loader (`loadDawnConfig`) evaluates this module with `await import(...)`,
-// so a top-level `await import("@dawn-ai/memory-pgvector")` would also work —
-// but a plain static import is simpler and the example depends on the package
-// directly. Both the store and the embedder connect/authenticate lazily, so
-// constructing them here does no I/O until the first remember/recall.
+// Both the store and the embedder connect/authenticate lazily, so constructing
+// them here does no I/O until the first remember/recall.
 const url = process.env.DATABASE_URL
-
-// Network-free test seam for the continuous dogfood: a deterministic
-// bag-of-token-hash embedder (mirrors @dawn-ai/testing's fakeEmbedder) so the
-// hybrid vector path can be exercised without a real OpenAI key or network. Off
-// by default — real usage goes through `openaiEmbedder` above.
-function fakeEmbedder(dims = 1536): Embedder {
-  const hash = (s: string): number => {
-    let h = 2166136261
-    for (let i = 0; i < s.length; i++) {
-      h ^= s.charCodeAt(i)
-      h = Math.imul(h, 16777619)
-    }
-    return h >>> 0
-  }
-  return {
-    id: `fake:${dims}`,
-    dims,
-    async embed(texts) {
-      return texts.map((t) => {
-        const v = new Float32Array(dims)
-        for (const tok of t
-          .toLowerCase()
-          .split(/[^a-z0-9]+/)
-          .filter((x) => x.length > 1)) {
-          const idx = hash(tok) % dims
-          v[idx] = (v[idx] as number) + 1
-        }
-        let n = 0
-        for (const x of v) n += x * x
-        n = Math.sqrt(n) || 1
-        for (let i = 0; i < dims; i++) v[i] = (v[i] as number) / n
-        return v
-      })
-    },
-  }
-}
-
-const embedder: Embedder | undefined = process.env.DAWN_MEMORY_FAKE_EMBEDDER
-  ? fakeEmbedder(1536)
-  : process.env.OPENAI_API_KEY
-    ? openaiEmbedder()
-    : undefined
+const embedder = process.env.OPENAI_API_KEY ? openaiEmbedder() : undefined
 
 export default {
   appDir: "src/app",

--- a/examples/memory/server/package.json
+++ b/examples/memory/server/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@dawn-example/memory",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "node node_modules/@dawn-ai/cli/dist/index.js dev --port 3002",
+    "build": "node node_modules/@dawn-ai/cli/dist/index.js build",
+    "typecheck": "tsc -p . --noEmit",
+    "check": "node node_modules/@dawn-ai/cli/dist/index.js check",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@dawn-ai/cli": "workspace:*",
+    "@dawn-ai/core": "workspace:*",
+    "@dawn-ai/langchain": "workspace:*",
+    "@dawn-ai/memory-pgvector": "workspace:*",
+    "@dawn-ai/sdk": "workspace:*",
+    "zod": "^4.4.3"
+  },
+  "devDependencies": {
+    "@dawn-ai/config-typescript": "workspace:*",
+    "@dawn-ai/testing": "workspace:*",
+    "@types/node": "26.1.0",
+    "typescript": "6.0.2",
+    "vitest": "^4.1.9"
+  }
+}

--- a/examples/memory/server/src/app/notes/index.ts
+++ b/examples/memory/server/src/app/notes/index.ts
@@ -1,0 +1,7 @@
+import { agent } from "@dawn-ai/sdk"
+
+export default agent({
+  model: "gpt-5-mini",
+  systemPrompt:
+    "You are a note-taking assistant with long-term memory. Use the remember and recall tools.",
+})

--- a/examples/memory/server/src/app/notes/memory.ts
+++ b/examples/memory/server/src/app/notes/memory.ts
@@ -1,0 +1,14 @@
+import { defineMemory } from "@dawn-ai/sdk"
+import { z } from "zod"
+
+// Long-term, cross-session memory for the note-taking assistant. Durable facts
+// are stored via the generated `remember` tool and pulled back with `recall`.
+export default defineMemory({
+  kind: "semantic",
+  scope: ["route"],
+  schema: z.object({
+    subject: z.string().describe("What the fact is about, e.g. a person, project, or preference"),
+    predicate: z.string().describe("The relation, e.g. 'prefers', 'lives_in', 'deadline'"),
+    value: z.string().describe("The value of the fact"),
+  }),
+})

--- a/examples/memory/server/tsconfig.json
+++ b/examples/memory/server/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "@dawn-ai/config-typescript/node",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": ["dawn.config.ts", "src/**/*.ts", ".dawn/dawn.generated.d.ts"]
+}

--- a/packages/langchain/src/openai-embedder.ts
+++ b/packages/langchain/src/openai-embedder.ts
@@ -24,6 +24,11 @@ export function openaiEmbedder(opts?: {
         const baseURL = process.env.OPENAI_BASE_URL
         return new Ctor({
           model,
+          // Request float arrays explicitly. The OpenAI SDK defaults to base64
+          // encoding for embeddings; pinning "float" avoids base64 decode
+          // interop quirks (some mocks/proxies return a byte length that decodes
+          // to the wrong dimension) and yields the model's true dimensionality.
+          encodingFormat: "float",
           ...(baseURL ? { configuration: { baseURL } } : {}),
         })
       })

--- a/packages/memory-pgvector/package.json
+++ b/packages/memory-pgvector/package.json
@@ -1,0 +1,49 @@
+{
+  "name": "@dawn-ai/memory-pgvector",
+  "version": "0.8.8",
+  "private": false,
+  "type": "module",
+  "license": "MIT",
+  "homepage": "https://github.com/cacheplane/dawnai/tree/main/packages/memory-pgvector#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/cacheplane/dawnai.git",
+    "directory": "packages/memory-pgvector"
+  },
+  "bugs": {
+    "url": "https://github.com/cacheplane/dawnai/issues"
+  },
+  "engines": {
+    "node": ">=22.13.0"
+  },
+  "files": [
+    "dist"
+  ],
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "tsc -b tsconfig.json",
+    "lint": "biome check --config-path ../config-biome/biome.json package.json src tsconfig.json vitest.config.ts",
+    "test": "vitest --run --config vitest.config.ts --passWithNoTests",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@dawn-ai/memory": "workspace:*",
+    "pg": "^8.22.0",
+    "pgvector": "^0.3.0"
+  },
+  "devDependencies": {
+    "@dawn-ai/config-typescript": "workspace:*",
+    "@testcontainers/postgresql": "^12.0.4",
+    "@types/node": "26.1.0",
+    "@types/pg": "^8.20.0"
+  }
+}

--- a/packages/memory-pgvector/package.json
+++ b/packages/memory-pgvector/package.json
@@ -42,6 +42,7 @@
   },
   "devDependencies": {
     "@dawn-ai/config-typescript": "workspace:*",
+    "@dawn-ai/testing": "workspace:*",
     "@testcontainers/postgresql": "^12.0.4",
     "@types/node": "26.1.0",
     "@types/pg": "^8.20.0"

--- a/packages/memory-pgvector/package.json
+++ b/packages/memory-pgvector/package.json
@@ -42,6 +42,7 @@
   },
   "devDependencies": {
     "@dawn-ai/config-typescript": "workspace:*",
+    "@dawn-ai/langchain": "workspace:*",
     "@dawn-ai/testing": "workspace:*",
     "@testcontainers/postgresql": "^12.0.4",
     "@types/node": "26.1.0",

--- a/packages/memory-pgvector/src/index.ts
+++ b/packages/memory-pgvector/src/index.ts
@@ -1,0 +1,1 @@
+export { pgvectorMemoryStore } from "./pgvector-store.js"

--- a/packages/memory-pgvector/src/index.ts
+++ b/packages/memory-pgvector/src/index.ts
@@ -1,1 +1,2 @@
-export { pgvectorMemoryStore } from "./pgvector-store.js"
+export { type PgvectorMemoryStore, pgvectorMemoryStore } from "./pgvector-store.js"
+export { assertIdentifier, initSchema, vectorColumnDef } from "./schema.js"

--- a/packages/memory-pgvector/src/pgvector-store.ts
+++ b/packages/memory-pgvector/src/pgvector-store.ts
@@ -1,0 +1,8 @@
+import type { MemoryStore } from "@dawn-ai/memory"
+
+export function pgvectorMemoryStore(_opts: {
+  connectionString?: string
+  dimensions: number
+}): MemoryStore {
+  throw new Error("pgvectorMemoryStore: not implemented (scaffold)")
+}

--- a/packages/memory-pgvector/src/pgvector-store.ts
+++ b/packages/memory-pgvector/src/pgvector-store.ts
@@ -1,8 +1,384 @@
-import type { MemoryStore } from "@dawn-ai/memory"
+import {
+  DEFAULT_CANDIDATE_POOL,
+  DEFAULT_VECTOR_K,
+  fuseHybrid,
+  type MemoryQuery,
+  type MemoryRecord,
+  type MemoryStore,
+  type RecallRankingOptions,
+  rankKeywordCandidates,
+  tokenize,
+  type VectorRankingOptions,
+} from "@dawn-ai/memory"
+import { Pool, type PoolClient } from "pg"
+import pgvector from "pgvector/pg"
+import { pageAndTagFilter, rowToRecord, tokensFor } from "./queries.js"
+import { assertIdentifier, initSchema } from "./schema.js"
 
-export function pgvectorMemoryStore(_opts: {
+// Default HNSW build/search parameters (pgvector defaults; overridable per store).
+const DEFAULT_M = 16
+const DEFAULT_EF_CONSTRUCTION = 64
+const DEFAULT_EF_SEARCH = 40
+
+export interface PgvectorMemoryStore extends MemoryStore {
+  /** Close the underlying pool. No-op if an external pool was injected. */
+  close(): Promise<void>
+}
+
+export function pgvectorMemoryStore(opts: {
+  /** Postgres connection string; used to build an owned pool. */
   connectionString?: string
+  /** An existing pool to use instead of building one from `connectionString`. */
+  pool?: Pool
+  /** Embedding dimensions (≤2000 → `vector`, ≤4000 → `halfvec`). */
   dimensions: number
-}): MemoryStore {
-  throw new Error("pgvectorMemoryStore: not implemented (scaffold)")
+  /** HNSW index/search tuning; all fields defaulted. */
+  index?: { m?: number; efConstruction?: number; efSearch?: number }
+  /** Postgres schema to place tables in. */
+  schema?: string
+  /** Table name prefix (isolates multiple stores in one database). */
+  tablePrefix?: string
+  /** Recall ranking tuning; all fields defaulted. See @dawn-ai/memory score.ts. */
+  recall?: RecallRankingOptions
+  /** Store-level hybrid tuning; used when a query omits `vector`. All fields defaulted. */
+  vector?: VectorRankingOptions
+}): PgvectorMemoryStore {
+  const schema = opts.schema ?? "public"
+  const prefix = opts.tablePrefix ?? "dawn_memory"
+  assertIdentifier("schema", schema)
+  assertIdentifier("tablePrefix", prefix)
+  const m = opts.index?.m ?? DEFAULT_M
+  const efConstruction = opts.index?.efConstruction ?? DEFAULT_EF_CONSTRUCTION
+  const efSearch = opts.index?.efSearch ?? DEFAULT_EF_SEARCH
+
+  // Fully-qualified table identifiers (both parts validated above).
+  const T = `${schema}.${prefix}_memories`
+  const TK = `${schema}.${prefix}_tokens`
+
+  const ownsPool = !opts.pool
+  const pool =
+    opts.pool ?? new Pool(opts.connectionString ? { connectionString: opts.connectionString } : {})
+
+  // Memoized idempotent schema init. Every method awaits ready() first so the
+  // first call to touch the store creates the extension/tables/indexes exactly
+  // once; concurrent callers share the single in-flight promise.
+  let initP: Promise<void> | undefined
+  function ready(): Promise<void> {
+    initP ??= (async () => {
+      const c = await pool.connect()
+      try {
+        await initSchema(c, { prefix, schema, dimensions: opts.dimensions, m, efConstruction })
+        // Register pgvector type parsers on this connection (needs the extension
+        // to exist, which initSchema just guaranteed). New pool connections get
+        // registration via the "connect" handler below.
+        await pgvector.registerTypes(c)
+      } finally {
+        c.release()
+      }
+    })()
+    return initP
+  }
+
+  // Register vector type parsers on every future pooled connection. Safe once the
+  // extension exists; the very first connection is registered inside ready().
+  pool.on("connect", (c) => {
+    pgvector.registerTypes(c).catch(() => {
+      // Extension not yet present on a brand-new database — ready() registers the
+      // first connection explicitly, so ignore the race here.
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // Row-level helpers
+  // -------------------------------------------------------------------------
+
+  async function getById(id: string): Promise<MemoryRecord | null> {
+    const res = await pool.query(`SELECT * FROM ${T} WHERE id = $1`, [id])
+    const row = res.rows[0] as Record<string, unknown> | undefined
+    return row ? rowToRecord(row) : null
+  }
+
+  async function reindex(client: PoolClient, rec: MemoryRecord): Promise<void> {
+    await client.query(`DELETE FROM ${TK} WHERE memory_id = $1`, [rec.id])
+    for (const t of tokensFor(rec)) {
+      await client.query(`INSERT INTO ${TK} (memory_id, token) VALUES ($1, $2)`, [rec.id, t])
+    }
+  }
+
+  async function putRecord(
+    rec: MemoryRecord,
+    embed?: { embedding?: Float32Array; embeddingModel?: string },
+  ): Promise<void> {
+    const hasEmbedding = Boolean(embed?.embedding && embed.embeddingModel)
+    const vec = hasEmbedding ? pgvector.toSql(Array.from(embed?.embedding ?? [])) : null
+    const model = hasEmbedding ? (embed?.embeddingModel ?? null) : null
+    const client = await pool.connect()
+    try {
+      await client.query("BEGIN")
+      await client.query(
+        `INSERT INTO ${T}
+          (id,kind,namespace,content,data,source,confidence,tags,status,supersedes,created_at,updated_at,effective_at,expires_at,embedding,embedding_model)
+         VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16)
+         ON CONFLICT (id) DO UPDATE SET
+           kind = EXCLUDED.kind, namespace = EXCLUDED.namespace, content = EXCLUDED.content,
+           data = EXCLUDED.data, source = EXCLUDED.source, confidence = EXCLUDED.confidence,
+           tags = EXCLUDED.tags, status = EXCLUDED.status, supersedes = EXCLUDED.supersedes,
+           created_at = EXCLUDED.created_at, updated_at = EXCLUDED.updated_at,
+           effective_at = EXCLUDED.effective_at, expires_at = EXCLUDED.expires_at,
+           embedding = EXCLUDED.embedding, embedding_model = EXCLUDED.embedding_model`,
+        [
+          rec.id,
+          rec.kind,
+          rec.namespace,
+          rec.content,
+          JSON.stringify(rec.data),
+          JSON.stringify(rec.source),
+          rec.confidence,
+          JSON.stringify(rec.tags),
+          rec.status,
+          rec.supersedes ? JSON.stringify(rec.supersedes) : null,
+          rec.createdAt,
+          rec.updatedAt,
+          rec.effectiveAt ?? null,
+          rec.expiresAt ?? null,
+          vec,
+          model,
+        ],
+      )
+      await reindex(client, rec)
+      await client.query("COMMIT")
+    } catch (err) {
+      await client.query("ROLLBACK")
+      throw err
+    } finally {
+      client.release()
+    }
+  }
+
+  // Re-read a row's persisted embedding so update() does not drop it (putRecord
+  // rewrites the full row; without this the embedding columns would go null).
+  // Returns the raw pgvector-serialized string for the embedding column so we can
+  // re-INSERT it verbatim without a Float32Array round-trip.
+  async function getEmbeddingRow(
+    id: string,
+  ): Promise<{ embedding?: Float32Array; embeddingModel?: string }> {
+    const res = await pool.query(
+      `SELECT embedding::text AS embedding, embedding_model FROM ${T} WHERE id = $1`,
+      [id],
+    )
+    const row = res.rows[0] as { embedding?: string; embedding_model?: string } | undefined
+    if (row?.embedding && row.embedding_model) {
+      // `embedding::text` is a pgvector literal like "[1,0,0]"; parse to floats.
+      const floats = row.embedding
+        .slice(1, -1)
+        .split(",")
+        .filter((s) => s.length > 0)
+        .map(Number)
+      return { embedding: Float32Array.from(floats), embeddingModel: row.embedding_model }
+    }
+    return {}
+  }
+
+  // -------------------------------------------------------------------------
+  // Keyword ranking — candidate pool + live corpus stats → shared pure core.
+  // -------------------------------------------------------------------------
+
+  async function rankKeyword(
+    q: MemoryQuery,
+    baseSql: string,
+    baseParams: unknown[],
+    terms: string[],
+    weightsOverride?: RecallRankingOptions["weights"],
+  ): Promise<MemoryRecord[]> {
+    const rawPool = opts.recall?.candidatePool
+    const pool_ =
+      typeof rawPool === "number" && Number.isFinite(rawPool) && rawPool > 0
+        ? Math.floor(rawPool)
+        : DEFAULT_CANDIDATE_POOL
+
+    const n = baseParams.length
+    const termPlaceholders = terms.map((_, i) => `$${n + 1 + i}`).join(",")
+
+    // 1) Candidate pool: rows matching ≥1 query token, newest first.
+    const candidateRes = await pool.query(
+      `SELECT m.* FROM ${T} m WHERE ${baseSql}
+         AND m.id IN (SELECT memory_id FROM ${TK} WHERE token IN (${termPlaceholders}))
+         ORDER BY m.updated_at DESC, m.id ASC LIMIT $${n + 1 + terms.length}`,
+      [...baseParams, ...terms, pool_],
+    )
+    const candidates = (candidateRes.rows as Record<string, unknown>[]).map(rowToRecord)
+    if (candidates.length === 0) return []
+
+    // 2) Corpus stats, computed live (nothing cached → nothing to go stale).
+    const corpusRes = await pool.query(
+      `SELECT COUNT(*)::int AS n FROM ${T} m WHERE ${baseSql}`,
+      baseParams,
+    )
+    const corpusSize = (corpusRes.rows[0] as { n: number }).n
+
+    const dfRes = await pool.query(
+      `SELECT t.token AS token, COUNT(DISTINCT t.memory_id)::int AS df
+         FROM ${TK} t JOIN ${T} m ON m.id = t.memory_id
+         WHERE ${baseSql} AND t.token IN (${termPlaceholders}) GROUP BY t.token`,
+      [...baseParams, ...terms],
+    )
+    const dfByToken = new Map(
+      (dfRes.rows as { token: string; df: number }[]).map((r) => [r.token, r.df]),
+    )
+
+    // 3) Score + sort via the shared pure ranking core.
+    const options: RecallRankingOptions | undefined =
+      weightsOverride || opts.recall
+        ? { ...opts.recall, ...(weightsOverride ? { weights: weightsOverride } : {}) }
+        : undefined
+    return rankKeywordCandidates(candidates, dfByToken, corpusSize, terms, q.now, options, tokenize)
+  }
+
+  // -------------------------------------------------------------------------
+  // Store interface
+  // -------------------------------------------------------------------------
+
+  return {
+    async put(rec, putOpts) {
+      await ready()
+      await putRecord(rec, putOpts)
+    },
+
+    async get(id) {
+      await ready()
+      return getById(id)
+    },
+
+    async search(q: MemoryQuery) {
+      await ready()
+      const status = q.status ?? "active"
+      const limit = q.limit ?? 8
+      const terms = q.query ? tokenize(q.query) : []
+
+      // Shared base filter (namespace + status [+ kind]) — the "corpus".
+      let baseSql = "m.namespace = $1 AND m.status = $2"
+      const baseParams: unknown[] = [q.namespace, status]
+      if (q.kind) {
+        baseParams.push(q.kind)
+        baseSql += ` AND m.kind = $${baseParams.length}`
+      }
+
+      if (terms.length === 0) {
+        // Query-less path: pure recency order (index-fragment behavior).
+        const res = await pool.query(
+          `SELECT m.* FROM ${T} m WHERE ${baseSql} ORDER BY m.updated_at DESC, m.id ASC LIMIT $${baseParams.length + 1}`,
+          [...baseParams, limit],
+        )
+        let records = (res.rows as Record<string, unknown>[]).map(rowToRecord)
+        if (q.tags && q.tags.length > 0) {
+          const want = new Set(q.tags)
+          records = records.filter((r) => r.tags.some((t) => want.has(t)))
+        }
+        return records
+      }
+
+      // Hybrid path — active only when the caller supplies a query embedding.
+      if (q.queryEmbedding && q.embedderId) {
+        const v = q.vector ?? opts.vector ?? {}
+        const vectorK =
+          typeof v.vectorK === "number" && Number.isFinite(v.vectorK) && v.vectorK > 0
+            ? Math.floor(v.vectorK)
+            : DEFAULT_VECTOR_K
+
+        // Keyword-ranked records: reuse the ranked pool, ordered by relevance ONLY.
+        const kwRecords = await rankKeyword(q, baseSql, baseParams, terms, {
+          relevance: 1,
+          recency: 0,
+          confidence: 0,
+        })
+
+        // Vector-ranked records: pgvector HNSW top-K by cosine distance (<=>),
+        // filtered to the matching embedder tag with a non-null embedding. Run in
+        // a transaction so SET LOCAL hnsw.ef_search applies to just this query.
+        const queryVec = pgvector.toSql(Array.from(q.queryEmbedding))
+        const client = await pool.connect()
+        let vectorRanked: MemoryRecord[]
+        try {
+          await client.query("BEGIN")
+          await client.query(`SET LOCAL hnsw.ef_search = ${efSearch}`)
+          const modelIdx = baseParams.length + 1
+          const vecIdx = baseParams.length + 2
+          const kIdx = baseParams.length + 3
+          const vecRes = await client.query(
+            `SELECT m.* FROM ${T} m
+               WHERE ${baseSql} AND m.embedding_model = $${modelIdx} AND m.embedding IS NOT NULL
+               ORDER BY m.embedding <=> $${vecIdx} LIMIT $${kIdx}`,
+            [...baseParams, q.embedderId, queryVec, vectorK],
+          )
+          await client.query("COMMIT")
+          vectorRanked = (vecRes.rows as Record<string, unknown>[]).map(rowToRecord)
+        } catch (err) {
+          await client.query("ROLLBACK")
+          throw err
+        } finally {
+          client.release()
+        }
+
+        // One half-life knob: fall back to the shared recall tuning so a
+        // configured recall.recencyHalfLifeMs governs hybrid recency too.
+        const recencyHalfLifeMs = v.recencyHalfLifeMs ?? opts.recall?.recencyHalfLifeMs
+        return pageAndTagFilter(
+          fuseHybrid({
+            keywordRanked: kwRecords,
+            vectorRanked,
+            now: q.now,
+            options: {
+              ...v,
+              ...(recencyHalfLifeMs !== undefined ? { recencyHalfLifeMs } : {}),
+            },
+          }),
+          limit,
+          q.tags,
+        )
+      }
+
+      // Ranked path — keyword-only recall.
+      return pageAndTagFilter(await rankKeyword(q, baseSql, baseParams, terms), limit, q.tags)
+    },
+
+    async update(id, patch) {
+      await ready()
+      const current = await getById(id)
+      if (!current) throw new Error(`memory not found: ${id}`)
+      const embed = await getEmbeddingRow(id)
+      await putRecord({ ...current, ...patch, id }, embed)
+    },
+
+    async supersede(id, bySupersedingId) {
+      await ready()
+      if (!(await getById(id))) throw new Error(`memory not found: ${id}`)
+      await pool.query(`UPDATE ${T} SET status = 'superseded' WHERE id = $1`, [id])
+      const superseding = await getById(bySupersedingId)
+      if (superseding) {
+        const links = new Set([...(superseding.supersedes ?? []), id])
+        await pool.query(`UPDATE ${T} SET supersedes = $1 WHERE id = $2`, [
+          JSON.stringify([...links]),
+          bySupersedingId,
+        ])
+      }
+    },
+
+    async delete(id) {
+      await ready()
+      await pool.query(`DELETE FROM ${T} WHERE id = $1`, [id])
+    },
+
+    async listCandidates(namespacePrefix) {
+      await ready()
+      const res = await pool.query(
+        `SELECT * FROM ${T} WHERE status = 'candidate' AND namespace LIKE $1 ORDER BY created_at DESC`,
+        [`${namespacePrefix}%`],
+      )
+      return (res.rows as Record<string, unknown>[]).map(rowToRecord)
+    },
+
+    async close() {
+      if (ownsPool) await pool.end()
+    },
+  }
 }

--- a/packages/memory-pgvector/src/pgvector-store.ts
+++ b/packages/memory-pgvector/src/pgvector-store.ts
@@ -12,7 +12,13 @@ import {
 } from "@dawn-ai/memory"
 import { Pool, type PoolClient } from "pg"
 import pgvector from "pgvector/pg"
-import { pageAndTagFilter, rowToRecord, tokensFor } from "./queries.js"
+import {
+  pageAndTagFilter,
+  RECORD_COLUMNS,
+  recordColumns,
+  rowToRecord,
+  tokensFor,
+} from "./queries.js"
 import { assertIdentifier, initSchema } from "./schema.js"
 
 // Default HNSW build/search parameters (pgvector defaults; overridable per store).
@@ -81,21 +87,34 @@ export function pgvectorMemoryStore(opts: {
 
   // Register vector type parsers on every future pooled connection. Safe once the
   // extension exists; the very first connection is registered inside ready().
-  pool.on("connect", (c) => {
-    pgvector.registerTypes(c).catch(() => {
-      // Extension not yet present on a brand-new database — ready() registers the
-      // first connection explicitly, so ignore the race here.
+  // Only attach to a pool WE built — an injected pool is the caller's to manage;
+  // we must not mutate its listeners.
+  if (ownsPool) {
+    pool.on("connect", (c) => {
+      pgvector.registerTypes(c).catch(() => {
+        // Extension not yet present on a brand-new database — ready() registers the
+        // first connection explicitly, so ignore the race here.
+      })
     })
-  })
+  }
 
   // -------------------------------------------------------------------------
   // Row-level helpers
   // -------------------------------------------------------------------------
 
   async function getById(id: string): Promise<MemoryRecord | null> {
-    const res = await pool.query(`SELECT * FROM ${T} WHERE id = $1`, [id])
+    const res = await pool.query(`SELECT ${RECORD_COLUMNS} FROM ${T} WHERE id = $1`, [id])
     const row = res.rows[0] as Record<string, unknown> | undefined
     return row ? rowToRecord(row) : null
+  }
+
+  // Roll back best-effort — a failing ROLLBACK must not mask the original error.
+  async function rollbackQuietly(client: PoolClient): Promise<void> {
+    try {
+      await client.query("ROLLBACK")
+    } catch {
+      // Swallow: propagate the root-cause error from the caller's catch instead.
+    }
   }
 
   async function reindex(client: PoolClient, rec: MemoryRecord): Promise<void> {
@@ -148,7 +167,7 @@ export function pgvectorMemoryStore(opts: {
       await reindex(client, rec)
       await client.query("COMMIT")
     } catch (err) {
-      await client.query("ROLLBACK")
+      await rollbackQuietly(client)
       throw err
     } finally {
       client.release()
@@ -201,7 +220,7 @@ export function pgvectorMemoryStore(opts: {
 
     // 1) Candidate pool: rows matching ≥1 query token, newest first.
     const candidateRes = await pool.query(
-      `SELECT m.* FROM ${T} m WHERE ${baseSql}
+      `SELECT ${recordColumns("m")} FROM ${T} m WHERE ${baseSql}
          AND m.id IN (SELECT memory_id FROM ${TK} WHERE token IN (${termPlaceholders}))
          ORDER BY m.updated_at DESC, m.id ASC LIMIT $${n + 1 + terms.length}`,
       [...baseParams, ...terms, pool_],
@@ -266,7 +285,7 @@ export function pgvectorMemoryStore(opts: {
       if (terms.length === 0) {
         // Query-less path: pure recency order (index-fragment behavior).
         const res = await pool.query(
-          `SELECT m.* FROM ${T} m WHERE ${baseSql} ORDER BY m.updated_at DESC, m.id ASC LIMIT $${baseParams.length + 1}`,
+          `SELECT ${recordColumns("m")} FROM ${T} m WHERE ${baseSql} ORDER BY m.updated_at DESC, m.id ASC LIMIT $${baseParams.length + 1}`,
           [...baseParams, limit],
         )
         let records = (res.rows as Record<string, unknown>[]).map(rowToRecord)
@@ -305,7 +324,7 @@ export function pgvectorMemoryStore(opts: {
           const vecIdx = baseParams.length + 2
           const kIdx = baseParams.length + 3
           const vecRes = await client.query(
-            `SELECT m.* FROM ${T} m
+            `SELECT ${recordColumns("m")} FROM ${T} m
                WHERE ${baseSql} AND m.embedding_model = $${modelIdx} AND m.embedding IS NOT NULL
                ORDER BY m.embedding <=> $${vecIdx} LIMIT $${kIdx}`,
             [...baseParams, q.embedderId, queryVec, vectorK],
@@ -313,7 +332,7 @@ export function pgvectorMemoryStore(opts: {
           await client.query("COMMIT")
           vectorRanked = (vecRes.rows as Record<string, unknown>[]).map(rowToRecord)
         } catch (err) {
-          await client.query("ROLLBACK")
+          await rollbackQuietly(client)
           throw err
         } finally {
           client.release()
@@ -371,7 +390,7 @@ export function pgvectorMemoryStore(opts: {
     async listCandidates(namespacePrefix) {
       await ready()
       const res = await pool.query(
-        `SELECT * FROM ${T} WHERE status = 'candidate' AND namespace LIKE $1 ORDER BY created_at DESC`,
+        `SELECT ${RECORD_COLUMNS} FROM ${T} WHERE status = 'candidate' AND namespace LIKE $1 ORDER BY created_at DESC`,
         [`${namespacePrefix}%`],
       )
       return (res.rows as Record<string, unknown>[]).map(rowToRecord)

--- a/packages/memory-pgvector/src/queries.ts
+++ b/packages/memory-pgvector/src/queries.ts
@@ -64,7 +64,7 @@ export function rowToRecord(row: Record<string, unknown>): MemoryRecord {
 
 // Codepoint compare — matches the sqlite backend's BINARY-collation ordering,
 // independent of Postgres's locale-sensitive collation (id ASC tiebreaks are
-// applied in JS, so ordering is byte-identical across backends).
+// applied in JS, so ordering is the same across backends).
 export function cmp(a: string, b: string): number {
   return a < b ? -1 : a > b ? 1 : 0
 }

--- a/packages/memory-pgvector/src/queries.ts
+++ b/packages/memory-pgvector/src/queries.ts
@@ -2,6 +2,41 @@ import type { MemoryRecord } from "@dawn-ai/memory"
 import { tokenize } from "@dawn-ai/memory"
 
 // ---------------------------------------------------------------------------
+// Column selection
+// ---------------------------------------------------------------------------
+
+// The exact 14 columns rowToRecord reads — deliberately EXCLUDES `embedding`
+// (1536/3072-dim) and `embedding_model`. rowToRecord never touches those, so a
+// bare `SELECT *`/`SELECT m.*` would transfer + deserialize the full vector on
+// every record read (candidate pools of 256, query-less lists, hybrid lookups)
+// for nothing. Callers that need the embedding read it separately via
+// getEmbeddingRow's `SELECT embedding::text`.
+const RECORD_COLUMN_NAMES = [
+  "id",
+  "kind",
+  "namespace",
+  "content",
+  "data",
+  "source",
+  "confidence",
+  "tags",
+  "status",
+  "supersedes",
+  "created_at",
+  "updated_at",
+  "effective_at",
+  "expires_at",
+] as const
+
+/** Comma-separated record columns (unqualified), e.g. `SELECT ${RECORD_COLUMNS} FROM ...`. */
+export const RECORD_COLUMNS = RECORD_COLUMN_NAMES.join(", ")
+
+/** Record columns qualified with a table alias, e.g. `SELECT ${recordColumns("m")} FROM ... m`. */
+export function recordColumns(alias: string): string {
+  return RECORD_COLUMN_NAMES.map((c) => `${alias}.${c}`).join(", ")
+}
+
+// ---------------------------------------------------------------------------
 // Row ↔ record conversion
 // ---------------------------------------------------------------------------
 

--- a/packages/memory-pgvector/src/queries.ts
+++ b/packages/memory-pgvector/src/queries.ts
@@ -1,0 +1,55 @@
+import type { MemoryRecord } from "@dawn-ai/memory"
+import { tokenize } from "@dawn-ai/memory"
+
+// ---------------------------------------------------------------------------
+// Row ↔ record conversion
+// ---------------------------------------------------------------------------
+
+// pg auto-parses `jsonb` columns to JS values, so `data`/`source`/`tags`/
+// `supersedes` arrive already-deserialized — do NOT JSON.parse them again (the
+// sqlite backend stores them as TEXT and must parse; here that would throw).
+export function rowToRecord(row: Record<string, unknown>): MemoryRecord {
+  return {
+    id: row.id as string,
+    kind: row.kind as MemoryRecord["kind"],
+    namespace: row.namespace as string,
+    content: row.content as string,
+    data: row.data as Record<string, unknown>,
+    source: row.source as MemoryRecord["source"],
+    confidence: row.confidence as number,
+    tags: row.tags as string[],
+    status: row.status as MemoryRecord["status"],
+    ...(row.supersedes ? { supersedes: row.supersedes as string[] } : {}),
+    createdAt: row.created_at as string,
+    updatedAt: row.updated_at as string,
+    ...(row.effective_at ? { effectiveAt: row.effective_at as string } : {}),
+    ...(row.expires_at ? { expiresAt: row.expires_at as string } : {}),
+  }
+}
+
+// Codepoint compare — matches the sqlite backend's BINARY-collation ordering,
+// independent of Postgres's locale-sensitive collation (id ASC tiebreaks are
+// applied in JS, so ordering is byte-identical across backends).
+export function cmp(a: string, b: string): number {
+  return a < b ? -1 : a > b ? 1 : 0
+}
+
+export function tokensFor(rec: MemoryRecord): string[] {
+  const values = Object.values(rec.data).filter((v) => typeof v === "string") as string[]
+  return tokenize([rec.content, rec.tags.join(" "), values.join(" ")].join(" "))
+}
+
+// Page (limit) then tag post-filter — mirrors the sqlite backend's ranked-path
+// semantics exactly.
+export function pageAndTagFilter(
+  records: readonly MemoryRecord[],
+  limit: number,
+  tags: readonly string[] | undefined,
+): MemoryRecord[] {
+  let out = records.slice(0, limit)
+  if (tags && tags.length > 0) {
+    const want = new Set(tags)
+    out = out.filter((r) => r.tags.some((t) => want.has(t)))
+  }
+  return out
+}

--- a/packages/memory-pgvector/src/schema.ts
+++ b/packages/memory-pgvector/src/schema.ts
@@ -1,0 +1,55 @@
+import type { PoolClient } from "pg"
+
+/** pgvector index dimension ceilings: plain vector ≤2000, halfvec ≤4000. */
+export function vectorColumnDef(dimensions: number): { type: string; ops: string } {
+  if (!Number.isInteger(dimensions) || dimensions <= 0)
+    throw new Error(`pgvector: dimensions must be a positive integer, got ${dimensions}`)
+  if (dimensions <= 2000) return { type: `vector(${dimensions})`, ops: "vector_cosine_ops" }
+  if (dimensions <= 4000) return { type: `halfvec(${dimensions})`, ops: "halfvec_cosine_ops" }
+  throw new Error(
+    `pgvector: ${dimensions} dims exceeds the 4000 halfvec index ceiling; reduce embedding dimensions or use a smaller model`,
+  )
+}
+
+/**
+ * Guard SQL identifiers that are interpolated into DDL (they can't be bound as
+ * $1 placeholders in Postgres). `prefix`/`schema` come from the store's own
+ * config, not untrusted query input, but a malformed config must not produce
+ * broken/injected DDL — so reject anything that isn't a plain identifier.
+ */
+export function assertIdentifier(name: string, value: string): void {
+  if (!/^[a-z_][a-z0-9_]*$/i.test(value))
+    throw new Error(
+      `pgvector: ${name} must be a valid SQL identifier (/^[a-z_][a-z0-9_]*$/i), got ${JSON.stringify(value)}`,
+    )
+}
+
+/** Idempotent schema init. Safe to call repeatedly (IF NOT EXISTS everywhere). */
+export async function initSchema(
+  client: PoolClient,
+  opts: { prefix: string; schema: string; dimensions: number; m: number; efConstruction: number },
+): Promise<void> {
+  const { prefix, schema, dimensions, m, efConstruction } = opts
+  assertIdentifier("prefix", prefix)
+  assertIdentifier("schema", schema)
+  const t = `${schema}.${prefix}_memories`
+  const tk = `${schema}.${prefix}_tokens`
+  const { type, ops } = vectorColumnDef(dimensions)
+  await client.query("CREATE EXTENSION IF NOT EXISTS vector")
+  await client.query(`CREATE SCHEMA IF NOT EXISTS ${schema}`)
+  await client.query(`CREATE TABLE IF NOT EXISTS ${t} (
+    id text PRIMARY KEY, kind text NOT NULL, namespace text NOT NULL, content text NOT NULL,
+    data jsonb NOT NULL, source jsonb NOT NULL, confidence real NOT NULL, tags jsonb NOT NULL,
+    status text NOT NULL, supersedes jsonb, created_at text NOT NULL, updated_at text NOT NULL,
+    effective_at text, expires_at text, embedding ${type}, embedding_model text)`)
+  await client.query(`CREATE TABLE IF NOT EXISTS ${tk} (
+    memory_id text NOT NULL REFERENCES ${t}(id) ON DELETE CASCADE, token text NOT NULL)`)
+  await client.query(
+    `CREATE INDEX IF NOT EXISTS ${prefix}_ns_status_updated ON ${t} (namespace, status, updated_at DESC)`,
+  )
+  await client.query(`CREATE INDEX IF NOT EXISTS ${prefix}_tok ON ${tk} (token)`)
+  await client.query(`CREATE INDEX IF NOT EXISTS ${prefix}_tok_mem ON ${tk} (memory_id)`)
+  await client.query(
+    `CREATE INDEX IF NOT EXISTS ${prefix}_hnsw ON ${t} USING hnsw (embedding ${ops}) WITH (m = ${m}, ef_construction = ${efConstruction})`,
+  )
+}

--- a/packages/memory-pgvector/test/pgvector-conformance.test.ts
+++ b/packages/memory-pgvector/test/pgvector-conformance.test.ts
@@ -1,0 +1,32 @@
+import { runMemoryStoreConformance } from "@dawn-ai/testing"
+import { PostgreSqlContainer, type StartedPostgreSqlContainer } from "@testcontainers/postgresql"
+import { afterAll, beforeAll, describe } from "vitest"
+import { type PgvectorMemoryStore, pgvectorMemoryStore } from "../src/index.js"
+
+const enabled = process.env.DAWN_TEST_PGVECTOR === "1"
+let container: StartedPostgreSqlContainer
+let url: string
+
+describe.skipIf(!enabled)("pgvector real-Postgres conformance", () => {
+  beforeAll(async () => {
+    container = await new PostgreSqlContainer("pgvector/pgvector:pg16").start()
+    url = container.getConnectionUri()
+  }, 120_000)
+
+  afterAll(async () => {
+    await container?.stop()
+  })
+
+  runMemoryStoreConformance({
+    name: "pgvectorMemoryStore",
+    // Fresh isolated store per test via a unique table prefix (no cross-test bleed).
+    makeStore: () =>
+      pgvectorMemoryStore({
+        connectionString: url,
+        dimensions: 3,
+        tablePrefix: `t_${Math.random().toString(36).slice(2)}`,
+      }),
+    describe,
+    close: (s) => (s as PgvectorMemoryStore).close(),
+  })
+})

--- a/packages/memory-pgvector/test/pgvector-integration.test.ts
+++ b/packages/memory-pgvector/test/pgvector-integration.test.ts
@@ -1,0 +1,117 @@
+import { PostgreSqlContainer, type StartedPostgreSqlContainer } from "@testcontainers/postgresql"
+import { Pool } from "pg"
+import { afterAll, beforeAll, describe, expect, test } from "vitest"
+import { initSchema, pgvectorMemoryStore } from "../src/index.js"
+
+const enabled = process.env.DAWN_TEST_PGVECTOR === "1"
+let container: StartedPostgreSqlContainer
+let url: string
+
+function rec(id: string, namespace: string, content: string) {
+  return {
+    id,
+    kind: "semantic" as const,
+    namespace,
+    content,
+    data: {},
+    source: { type: "eval" as const, id: "seed" },
+    confidence: 1,
+    tags: [] as string[],
+    status: "active" as const,
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+  }
+}
+
+describe.skipIf(!enabled)("pgvector integration", () => {
+  beforeAll(async () => {
+    container = await new PostgreSqlContainer("pgvector/pgvector:pg16").start()
+    url = container.getConnectionUri()
+  }, 120_000)
+
+  afterAll(async () => {
+    await container?.stop()
+  })
+
+  test("initSchema is idempotent (running twice does not error)", async () => {
+    const pool = new Pool({ connectionString: url })
+    try {
+      const c = await pool.connect()
+      try {
+        const args = {
+          prefix: "idem_a",
+          schema: "public",
+          dimensions: 3,
+          m: 16,
+          efConstruction: 64,
+        }
+        await initSchema(c, args)
+        await initSchema(c, args)
+      } finally {
+        c.release()
+      }
+    } finally {
+      await pool.end()
+    }
+  })
+
+  test("dimension branch on real PG: 1536 vector + 3072 halfvec both init cleanly", async () => {
+    const small = pgvectorMemoryStore({
+      connectionString: url,
+      dimensions: 1536,
+      tablePrefix: "dim_small",
+    })
+    const large = pgvectorMemoryStore({
+      connectionString: url,
+      dimensions: 3072,
+      tablePrefix: "dim_large",
+    })
+    try {
+      await small.put(rec("s", "ns", "small vector row"))
+      await large.put(rec("l", "ns", "halfvec row"))
+      expect((await small.get("s"))?.id).toBe("s")
+      expect((await large.get("l"))?.id).toBe("l")
+    } finally {
+      await small.close()
+      await large.close()
+    }
+  })
+
+  test("an HNSW index exists on the memories table", async () => {
+    const store = pgvectorMemoryStore({
+      connectionString: url,
+      dimensions: 3,
+      tablePrefix: "hnsw_check",
+    })
+    // Force schema init.
+    await store.put(rec("x", "ns", "row"))
+    const pool = new Pool({ connectionString: url })
+    try {
+      const res = await pool.query(
+        "SELECT indexname FROM pg_indexes WHERE tablename = $1 AND indexdef LIKE '%hnsw%'",
+        ["hnsw_check_memories"],
+      )
+      expect(res.rows.length).toBeGreaterThan(0)
+    } finally {
+      await pool.end()
+      await store.close()
+    }
+  })
+
+  test("concurrency: 10 parallel puts + a search all resolve", async () => {
+    const store = pgvectorMemoryStore({
+      connectionString: url,
+      dimensions: 3,
+      tablePrefix: "concurrency",
+    })
+    try {
+      await Promise.all(
+        Array.from({ length: 10 }, (_, i) => store.put(rec(`p${i}`, "ns", `parallel row ${i}`))),
+      )
+      const out = await store.search({ namespace: "ns", query: "parallel" })
+      expect(out.length).toBeGreaterThan(0)
+    } finally {
+      await store.close()
+    }
+  })
+})

--- a/packages/memory-pgvector/test/pgvector-integration.test.ts
+++ b/packages/memory-pgvector/test/pgvector-integration.test.ts
@@ -98,6 +98,37 @@ describe.skipIf(!enabled)("pgvector integration", () => {
     }
   })
 
+  test("halfvec update round-trip: an embedding survives update() on a 3072-dim store", async () => {
+    const store = pgvectorMemoryStore({
+      connectionString: url,
+      dimensions: 3072,
+      tablePrefix: "halfvec_update",
+    })
+    try {
+      // A 3072-dim halfvec embedding; only the first axis is 1 so a matching
+      // query vector recalls it via the vector path.
+      const embedding = Float32Array.from({ length: 3072 }, (_, i) => (i === 0 ? 1 : 0))
+      await store.put(rec("h", "ns", "faster shipping"), {
+        embedding,
+        embeddingModel: "fake:halfvec",
+      })
+      // Update an unrelated field — putRecord rewrites the full row, so this
+      // exercises getEmbeddingRow's `embedding::text` parse for halfvec.
+      await store.update("h", { confidence: 0.5 })
+      const out = await store.search({
+        namespace: "ns",
+        query: "expedite delivery",
+        queryEmbedding: embedding,
+        embedderId: "fake:halfvec",
+        now: "2026-07-05T00:00:00.000Z",
+      })
+      expect(out.map((r) => r.id)).toContain("h")
+      expect((await store.get("h"))?.confidence).toBe(0.5)
+    } finally {
+      await store.close()
+    }
+  })
+
   test("concurrency: 10 parallel puts + a search all resolve", async () => {
     const store = pgvectorMemoryStore({
       connectionString: url,

--- a/packages/memory-pgvector/test/pgvector-live.smoke.test.ts
+++ b/packages/memory-pgvector/test/pgvector-live.smoke.test.ts
@@ -1,0 +1,84 @@
+import { openaiEmbedder } from "@dawn-ai/langchain"
+import type { MemoryRecord } from "@dawn-ai/memory"
+import { PostgreSqlContainer, type StartedPostgreSqlContainer } from "@testcontainers/postgresql"
+import { afterAll, beforeAll, describe, expect, test } from "vitest"
+import { type PgvectorMemoryStore, pgvectorMemoryStore } from "../src/index.js"
+
+// Doubly gated: needs BOTH a running Docker (DAWN_TEST_PGVECTOR=1) AND a real
+// OPENAI_API_KEY. This is the top-tier dogfood proof — real OpenAI embeddings +
+// real Postgres + pgvector recall across a zero-shared-token paraphrase.
+const enabled = process.env.DAWN_TEST_PGVECTOR === "1" && Boolean(process.env.OPENAI_API_KEY)
+
+let container: StartedPostgreSqlContainer
+let store: PgvectorMemoryStore
+
+function rec(
+  over: Partial<MemoryRecord> & Pick<MemoryRecord, "id" | "namespace" | "content">,
+): MemoryRecord {
+  return {
+    kind: "semantic",
+    data: {},
+    source: { type: "eval", id: "seed" },
+    confidence: 1,
+    tags: [],
+    status: "active",
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+    ...over,
+  }
+}
+
+describe.skipIf(!enabled)("pgvector live real-embedder paraphrase smoke", () => {
+  beforeAll(async () => {
+    container = await new PostgreSqlContainer("pgvector/pgvector:pg16").start()
+    store = pgvectorMemoryStore({
+      connectionString: container.getConnectionUri(),
+      dimensions: 1536,
+    })
+  }, 120_000)
+
+  afterAll(async () => {
+    // close() ends the pool BEFORE the container stops, avoiding the 57P01
+    // "terminating connection due to administrator command" idle-connection error.
+    await store?.close()
+    await container?.stop()
+  })
+
+  test("real OpenAI embeddings recall 'faster shipping' from a 0-shared-token paraphrase through pgvector", async () => {
+    const embedder = openaiEmbedder()
+    const namespace = "smoke"
+    const content = "the customer wants faster shipping on their orders"
+
+    // Embed + store the memory with a REAL 1536-dim OpenAI vector.
+    const [embedding] = await embedder.embed([content])
+    expect(embedding).toBeDefined()
+    // Validates the encodingFormat:"float" fix against real OpenAI. A base64
+    // interop regression would surface as the wrong dimensionality (e.g. 384),
+    // which would fail here or throw on put against the vector(1536) column.
+    expect(embedding?.length).toBe(1536)
+
+    await store.put(rec({ id: "ship", namespace, content }), {
+      embedding,
+      embeddingModel: embedder.id,
+    })
+
+    // Embed the paraphrase query — ZERO lexical overlap with the stored content.
+    const query = "expedite delivery options"
+    const [queryEmbedding] = await embedder.embed([query])
+    expect(queryEmbedding?.length).toBe(1536)
+
+    const out = await store.search({
+      namespace,
+      query,
+      queryEmbedding,
+      embedderId: embedder.id,
+      now: "2026-07-05T00:00:00.000Z",
+    })
+
+    const hit = out.find((r) => r.id === "ship")
+    // The vector list surfaced the memory across zero lexical overlap, through
+    // real pgvector + real embeddings.
+    expect(hit).toBeDefined()
+    expect(hit?.content).toBe(content)
+  }, 60_000)
+})

--- a/packages/memory-pgvector/test/schema.test.ts
+++ b/packages/memory-pgvector/test/schema.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest"
+import { assertIdentifier, vectorColumnDef } from "../src/schema.js"
+
+describe("vectorColumnDef", () => {
+  it("dims ≤ 2000 → plain vector + vector_cosine_ops", () => {
+    expect(vectorColumnDef(1536)).toEqual({ type: "vector(1536)", ops: "vector_cosine_ops" })
+  })
+  it("2000 < dims ≤ 4000 → halfvec + halfvec_cosine_ops (text-embedding-3-large)", () => {
+    expect(vectorColumnDef(3072)).toEqual({ type: "halfvec(3072)", ops: "halfvec_cosine_ops" })
+  })
+  it("dims > 4000 → throws a clear error naming the ceiling", () => {
+    expect(() => vectorColumnDef(5000)).toThrow(/4000/)
+  })
+  it("non-positive/non-integer dims throw", () => {
+    expect(() => vectorColumnDef(0)).toThrow()
+    expect(() => vectorColumnDef(1.5)).toThrow()
+  })
+})
+
+describe("assertIdentifier", () => {
+  it("accepts valid SQL identifiers", () => {
+    expect(() => assertIdentifier("prefix", "dawn")).not.toThrow()
+    expect(() => assertIdentifier("schema", "public")).not.toThrow()
+    expect(() => assertIdentifier("prefix", "_mem_v2")).not.toThrow()
+    expect(() => assertIdentifier("schema", "MySchema")).not.toThrow()
+  })
+  it("rejects identifiers with unsafe characters", () => {
+    expect(() => assertIdentifier("prefix", "bad-name")).toThrow(/prefix/)
+    expect(() => assertIdentifier("schema", "public; DROP TABLE x")).toThrow(/schema/)
+    expect(() => assertIdentifier("prefix", "1leading")).toThrow(/prefix/)
+    expect(() => assertIdentifier("schema", "")).toThrow(/schema/)
+  })
+})

--- a/packages/memory-pgvector/tsconfig.json
+++ b/packages/memory-pgvector/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "../config-typescript/node.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo"
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/packages/memory-pgvector/vitest.config.ts
+++ b/packages/memory-pgvector/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config"
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["test/**/*.test.ts"],
+    passWithNoTests: true,
+  },
+})

--- a/packages/memory/src/hybrid.ts
+++ b/packages/memory/src/hybrid.ts
@@ -1,0 +1,117 @@
+// Pure, backend-agnostic hybrid ranking core. Both sqliteMemoryStore and
+// @dawn-ai/memory-pgvector call these after doing their own retrieval, so recall
+// ranking is byte-identical across backends. No I/O, no clock, no randomness.
+import {
+  type RecallRankingOptions,
+  type RecallWeights,
+  recencyDecay,
+  scoreMemory,
+} from "./score.js"
+import { tokenize } from "./tokenize.js"
+import type { MemoryRecord, VectorRankingOptions } from "./types.js"
+import { fuseRRF } from "./vector.js"
+
+function cmp(a: string, b: string): number {
+  return a < b ? -1 : a > b ? 1 : 0
+}
+function newestUpdatedAt(records: readonly MemoryRecord[]): string {
+  return records.reduce((m, r) => (r.updatedAt > m ? r.updatedAt : m), "")
+}
+function tokensFor(rec: MemoryRecord, tk: (s: string) => string[]): string[] {
+  const values = Object.values(rec.data).filter((v) => typeof v === "string") as string[]
+  return tk([rec.content, rec.tags.join(" "), values.join(" ")].join(" "))
+}
+
+/**
+ * Rank keyword candidates by IDF relevance (+ recency/confidence per weights).
+ * `candidates` are the rows the store retrieved as matching ≥1 query token;
+ * `dfByToken`/`corpusSize` are the store's live stats. Returns the full sorted
+ * list (caller pages + tag-filters). `now` absent → newest candidate's updatedAt.
+ * `tokenize` defaults to the shared `tokenize()` — callers pass their own only if
+ * they index tokens differently (both stores pass the imported `tokenize`).
+ */
+export function rankKeywordCandidates(
+  candidates: readonly MemoryRecord[],
+  dfByToken: ReadonlyMap<string, number>,
+  corpusSize: number,
+  queryTokens: readonly string[],
+  now: string | undefined,
+  options?: RecallRankingOptions,
+  tk: (s: string) => string[] = tokenize,
+): MemoryRecord[] {
+  if (candidates.length === 0) return []
+  const referenceNow = now ?? newestUpdatedAt(candidates)
+  const scored = candidates.map((record) => ({
+    record,
+    score: scoreMemory({
+      memoryTokens: new Set(tokensFor(record, tk)),
+      queryTokens: [...queryTokens],
+      dfByToken,
+      corpusSize,
+      updatedAt: record.updatedAt,
+      confidence: record.confidence,
+      referenceNow,
+      ...(options ? { options } : {}),
+    }),
+  }))
+  scored.sort(
+    (a, b) =>
+      b.score - a.score ||
+      cmp(b.record.updatedAt, a.record.updatedAt) ||
+      cmp(a.record.id, b.record.id),
+  )
+  return scored.map((s) => s.record)
+}
+
+function finite(n: unknown, d: number): number {
+  return typeof n === "number" && Number.isFinite(n) ? n : d
+}
+
+/**
+ * Fuse a keyword-ranked list and a vector-ranked list (already cosine-sorted and
+ * sliced to vectorK by the store) via co-equal RRF, then a bounded recency/
+ * confidence second stage. Returns the fused sorted records (caller pages +
+ * tag-filters). `options.recencyHalfLifeMs` should be pre-resolved by the caller
+ * (the pure fn cannot see recall config).
+ */
+export function fuseHybrid(args: {
+  readonly keywordRanked: readonly MemoryRecord[]
+  readonly vectorRanked: readonly MemoryRecord[]
+  readonly now?: string | undefined
+  readonly options?: VectorRankingOptions | undefined
+}): MemoryRecord[] {
+  const v = args.options ?? {}
+  const wKeyword = finite(v.weights?.keyword, 1)
+  const wVector = finite(v.weights?.vector, 1)
+  const wRec = finite(v.recencyWeight, 0.3)
+  const wConf = finite(v.confidenceWeight, 0.1)
+
+  const byId = new Map<string, MemoryRecord>()
+  for (const r of args.keywordRanked) byId.set(r.id, r)
+  for (const r of args.vectorRanked) if (!byId.has(r.id)) byId.set(r.id, r)
+  if (byId.size === 0) return []
+
+  const rrf = fuseRRF(
+    [
+      { ids: args.keywordRanked.map((r) => r.id), weight: wKeyword },
+      { ids: args.vectorRanked.map((r) => r.id), weight: wVector },
+    ],
+    typeof v.rrfK === "number" ? { k: v.rrfK } : undefined,
+  )
+  const referenceNow = args.now ?? newestUpdatedAt([...byId.values()])
+  const fused = [...byId.values()].map((record) => {
+    const base = rrf.get(record.id) ?? 0
+    const rec = recencyDecay(record.updatedAt, referenceNow, v.recencyHalfLifeMs)
+    const conf = record.confidence < 0 ? 0 : record.confidence > 1 ? 1 : record.confidence
+    return { record, score: base * (1 + wRec * rec + wConf * conf) }
+  })
+  fused.sort(
+    (a, b) =>
+      b.score - a.score ||
+      cmp(b.record.updatedAt, a.record.updatedAt) ||
+      cmp(a.record.id, b.record.id),
+  )
+  return fused.map((s) => s.record)
+}
+
+export type { RecallWeights }

--- a/packages/memory/src/hybrid.ts
+++ b/packages/memory/src/hybrid.ts
@@ -1,6 +1,6 @@
 // Pure, backend-agnostic hybrid ranking core. Both sqliteMemoryStore and
 // @dawn-ai/memory-pgvector call these after doing their own retrieval, so recall
-// ranking is byte-identical across backends. No I/O, no clock, no randomness.
+// ranking is identical across backends. No I/O, no clock, no randomness.
 import {
   type RecallRankingOptions,
   type RecallWeights,

--- a/packages/memory/src/index.ts
+++ b/packages/memory/src/index.ts
@@ -1,3 +1,4 @@
+export { fuseHybrid, rankKeywordCandidates } from "./hybrid.js"
 export { type MemoryScopeTuple, serializeNamespace } from "./namespace.js"
 export { classifyWrite, type WriteOp } from "./reconcile.js"
 export {

--- a/packages/memory/src/sqlite-store.ts
+++ b/packages/memory/src/sqlite-store.ts
@@ -2,16 +2,11 @@ import { mkdirSync } from "node:fs"
 import { dirname } from "node:path"
 import type { SQLInputValue } from "node:sqlite"
 import { DatabaseSync } from "node:sqlite"
-import {
-  DEFAULT_CANDIDATE_POOL,
-  type RecallRankingOptions,
-  type RecallWeights,
-  recencyDecay,
-  scoreMemory,
-} from "./score.js"
+import { fuseHybrid, rankKeywordCandidates } from "./hybrid.js"
+import { DEFAULT_CANDIDATE_POOL, type RecallRankingOptions, type RecallWeights } from "./score.js"
 import { tokenize } from "./tokenize.js"
 import type { MemoryQuery, MemoryRecord, MemoryStore, VectorRankingOptions } from "./types.js"
-import { cosineSimilarity, DEFAULT_VECTOR_K, fuseRRF } from "./vector.js"
+import { cosineSimilarity, DEFAULT_VECTOR_K } from "./vector.js"
 
 // ---------------------------------------------------------------------------
 // Inline DB helpers (mirrors packages/sqlite-storage/src/internal — not
@@ -255,37 +250,14 @@ export function sqliteMemoryStore(opts: {
       .all(...baseParams, ...terms) as { token: string; df: number }[]
     const dfByToken = new Map(dfRows.map((r) => [r.token, r.df]))
 
-    // 3) Score. Candidate token sets are recomputed via the same helper
-    //    reindex() uses, so they are guaranteed consistent with the table.
-    //    Pool is updated_at-DESC ordered, so candidates[0] is the newest —
-    //    the data-derived reference when the caller supplies no clock.
-    const referenceNow = q.now ?? candidates[0]?.updatedAt ?? ""
+    // 3) Score + sort via the shared pure ranking core. Candidate token sets are
+    //    recomputed via the same `tokenize` reindex() uses, so they are
+    //    guaranteed consistent with the table.
     const options: RecallRankingOptions | undefined =
       weightsOverride || opts.recall
         ? { ...opts.recall, ...(weightsOverride ? { weights: weightsOverride } : {}) }
         : undefined
-    const scored = candidates.map((record) => ({
-      record,
-      score: scoreMemory({
-        memoryTokens: new Set(tokensFor(record)),
-        queryTokens: terms,
-        dfByToken,
-        corpusSize,
-        updatedAt: record.updatedAt,
-        confidence: record.confidence,
-        referenceNow,
-        ...(options ? { options } : {}),
-      }),
-    }))
-
-    // 4) Sort (score DESC, updated_at DESC, id ASC — stable).
-    scored.sort(
-      (a, b) =>
-        b.score - a.score ||
-        cmp(b.record.updatedAt, a.record.updatedAt) ||
-        cmp(a.record.id, b.record.id),
-    )
-    return scored.map((s) => s.record)
+    return rankKeywordCandidates(candidates, dfByToken, corpusSize, terms, q.now, options, tokenize)
   }
 
   // Page (limit) then tag post-filter — today's ranked-path semantics, unchanged.
@@ -347,25 +319,16 @@ export function sqliteMemoryStore(opts: {
           typeof v.vectorK === "number" && Number.isFinite(v.vectorK) && v.vectorK > 0
             ? Math.floor(v.vectorK)
             : DEFAULT_VECTOR_K
-        const wKeyword =
-          typeof v.weights?.keyword === "number" && Number.isFinite(v.weights.keyword)
-            ? v.weights.keyword
-            : 1
-        const wVector =
-          typeof v.weights?.vector === "number" && Number.isFinite(v.weights.vector)
-            ? v.weights.vector
-            : 1
 
-        // Keyword-ranked ids: reuse the ranked pool, ordered by relevance ONLY.
+        // Keyword-ranked records: reuse the ranked pool, ordered by relevance ONLY.
         const kwRecords = rankKeyword(q, baseSql, baseParams, terms, {
           relevance: 1,
           recency: 0,
           confidence: 0,
         })
-        const keywordIds = kwRecords.map((r) => r.id)
 
-        // Vector-ranked ids: brute-force cosine over rows with a matching
-        // embedder tag and a non-null embedding.
+        // Vector-ranked records: brute-force cosine over rows with a matching
+        // embedder tag and a non-null embedding, cosine-sorted then sliced to K.
         const vecRows = db
           .prepare(
             `SELECT m.id AS id, m.embedding AS embedding FROM memories m
@@ -373,7 +336,7 @@ export function sqliteMemoryStore(opts: {
           )
           .all(...baseParams, q.embedderId) as { id: string; embedding: Uint8Array }[]
         const queryEmbedding = q.queryEmbedding
-        const scoredVec = vecRows
+        const vectorRanked = vecRows
           .map((r) => {
             const emb = new Float32Array(
               r.embedding.buffer.slice(
@@ -385,59 +348,22 @@ export function sqliteMemoryStore(opts: {
           })
           .sort((a, b) => b.sim - a.sim || cmp(a.id, b.id))
           .slice(0, vectorK)
-        const vectorIds = scoredVec.map((r) => r.id)
+          .map((r) => getById(r.id))
+          .filter((r): r is MemoryRecord => r !== null)
 
-        // Union pool of records (dedup by id) for the second stage.
-        const byId = new Map<string, MemoryRecord>()
-        for (const r of kwRecords) byId.set(r.id, r)
-        for (const id of vectorIds) {
-          if (!byId.has(id)) {
-            const rec2 = getById(id)
-            if (rec2) byId.set(id, rec2)
-          }
-        }
-        if (byId.size === 0) return []
-
-        const rrf = fuseRRF(
-          [
-            { ids: keywordIds, weight: wKeyword },
-            { ids: vectorIds, weight: wVector },
-          ],
-          typeof v.rrfK === "number" ? { k: v.rrfK } : undefined,
-        )
-
-        const wRec =
-          typeof v.recencyWeight === "number" && Number.isFinite(v.recencyWeight)
-            ? v.recencyWeight
-            : 0.3
-        const wConf =
-          typeof v.confidenceWeight === "number" && Number.isFinite(v.confidenceWeight)
-            ? v.confidenceWeight
-            : 0.1
-        // Match the non-hybrid path: the data-derived recency reference is the
-        // NEWEST record's updatedAt (ISO strings compare chronologically).
-        const referenceNow =
-          q.now ?? [...byId.values()].reduce((m, r) => (r.updatedAt > m ? r.updatedAt : m), "")
-        const fused = [...byId.values()].map((record) => {
-          const base = rrf.get(record.id) ?? 0
-          // One half-life knob: fall back to the shared recall tuning so a
-          // configured recall.recencyHalfLifeMs governs hybrid recency too.
-          const rec2 = recencyDecay(
-            record.updatedAt,
-            referenceNow,
-            v.recencyHalfLifeMs ?? opts.recall?.recencyHalfLifeMs,
-          )
-          const conf = record.confidence < 0 ? 0 : record.confidence > 1 ? 1 : record.confidence
-          return { record, score: base * (1 + wRec * rec2 + wConf * conf) }
-        })
-        fused.sort(
-          (a, b) =>
-            b.score - a.score ||
-            cmp(b.record.updatedAt, a.record.updatedAt) ||
-            cmp(a.record.id, b.record.id),
-        )
+        // One half-life knob: fall back to the shared recall tuning so a
+        // configured recall.recencyHalfLifeMs governs hybrid recency too.
+        const recencyHalfLifeMs = v.recencyHalfLifeMs ?? opts.recall?.recencyHalfLifeMs
         return pageAndTagFilter(
-          fused.map((s) => s.record),
+          fuseHybrid({
+            keywordRanked: kwRecords,
+            vectorRanked,
+            now: q.now,
+            options: {
+              ...v,
+              ...(recencyHalfLifeMs !== undefined ? { recencyHalfLifeMs } : {}),
+            },
+          }),
           limit,
           q,
         )

--- a/packages/memory/test/hybrid.test.ts
+++ b/packages/memory/test/hybrid.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vitest"
+import { fuseHybrid, rankKeywordCandidates } from "../src/hybrid.js"
+import type { MemoryRecord } from "../src/types.js"
+
+function rec(over: Partial<MemoryRecord> & Pick<MemoryRecord, "id" | "content">): MemoryRecord {
+  return {
+    kind: "semantic",
+    namespace: "ns",
+    data: {},
+    source: { type: "run", id: "r" },
+    confidence: 1,
+    tags: [],
+    status: "active",
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+    ...over,
+  }
+}
+
+describe("rankKeywordCandidates", () => {
+  it("ranks by IDF relevance; rare-token match beats common-token match", () => {
+    const cands = [
+      rec({ id: "rare", content: "acme threshold" }),
+      rec({ id: "common", content: "acme owner jordan" }),
+    ]
+    const df = new Map([
+      ["acme", 2],
+      ["threshold", 1],
+    ])
+    const out = rankKeywordCandidates(
+      cands,
+      df,
+      2,
+      ["acme", "threshold"],
+      "2026-07-05T00:00:00.000Z",
+    )
+    expect(out[0]?.id).toBe("rare")
+  })
+  it("relevance-only weights ignore recency (for the hybrid keyword list)", () => {
+    const cands = [
+      rec({ id: "old", content: "billing threshold", updatedAt: "2026-05-01T00:00:00.000Z" }),
+      rec({ id: "new", content: "billing note", updatedAt: "2026-07-01T00:00:00.000Z" }),
+    ]
+    const df = new Map([
+      ["billing", 2],
+      ["threshold", 1],
+    ])
+    const out = rankKeywordCandidates(
+      cands,
+      df,
+      2,
+      ["billing", "threshold"],
+      "2026-07-05T00:00:00.000Z",
+      { weights: { relevance: 1, recency: 0, confidence: 0 } },
+    )
+    expect(out[0]?.id).toBe("old") // 2/2 tokens beats 1/2 despite being older
+  })
+})
+
+describe("fuseHybrid", () => {
+  it("a semantic-only match (only in the vector list) is fused into the results", () => {
+    const kw = [rec({ id: "kwonly", content: "acme billing" })]
+    const vec = [
+      rec({ id: "semonly", content: "faster shipping" }),
+      rec({ id: "kwonly", content: "acme billing" }),
+    ]
+    const out = fuseHybrid({
+      keywordRanked: kw,
+      vectorRanked: vec,
+      now: "2026-07-05T00:00:00.000Z",
+    })
+    // A vector-only match (absent from the keyword list) is unioned in via RRF.
+    // Under co-equal RRF, kwonly (rank1 keyword + rank2 vector) outscores semonly
+    // (rank1 vector only), matching the pre-extraction sqlite fusion exactly.
+    expect(out.map((r) => r.id)).toContain("semonly")
+    expect(out[0]?.id).toBe("kwonly")
+  })
+  it("co-equal RRF: an exact keyword hit is not buried by a strong vector list", () => {
+    const kw = [rec({ id: "exact", content: "order ALPHA-111" })]
+    const vec = [
+      rec({ id: "near", content: "delivery" }),
+      rec({ id: "exact", content: "order ALPHA-111" }),
+    ]
+    const out = fuseHybrid({
+      keywordRanked: kw,
+      vectorRanked: vec,
+      now: "2026-07-05T00:00:00.000Z",
+    })
+    expect(out.map((r) => r.id)).toContain("exact")
+  })
+  it("NaN tuning weights degrade to defaults (finite, deterministic order)", () => {
+    const kw = [rec({ id: "a", content: "x" })]
+    const vec = [rec({ id: "a", content: "x" })]
+    const out = fuseHybrid({
+      keywordRanked: kw,
+      vectorRanked: vec,
+      now: "2026-07-05T00:00:00.000Z",
+      options: { recencyWeight: Number.NaN },
+    })
+    expect(out.map((r) => r.id)).toEqual(["a"])
+  })
+})

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -55,6 +55,7 @@
     "@dawn-ai/sdk": "workspace:*",
     "@dawn-ai/workspace": "workspace:*",
     "@langchain/langgraph-checkpoint": "^1.1.3",
+    "@testcontainers/postgresql": "^12.0.4",
     "@types/node": "26.1.0",
     "zod": "^4.4.3"
   }

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -34,6 +34,7 @@ export {
   type Todo,
 } from "./matchers.js"
 export { seedMemory } from "./memory.js"
+export { runMemoryStoreConformance } from "./memory-conformance.js"
 export {
   createMiddlewareHarness,
   type MiddlewareHarness,

--- a/packages/testing/src/memory-conformance.ts
+++ b/packages/testing/src/memory-conformance.ts
@@ -1,0 +1,156 @@
+import type { MemoryRecord, MemoryStore } from "@dawn-ai/memory"
+import { expect, test } from "vitest"
+
+function rec(
+  over: Partial<MemoryRecord> & Pick<MemoryRecord, "id" | "namespace" | "content">,
+): MemoryRecord {
+  return {
+    kind: "semantic",
+    data: {},
+    source: { type: "eval", id: "seed" },
+    confidence: 1,
+    tags: [],
+    status: "active",
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+    ...over,
+  }
+}
+const vec = (...xs: number[]) => new Float32Array(xs)
+
+/**
+ * The contract every MemoryStore must satisfy. Run against sqlite (in-process,
+ * always) and pgvector (real Postgres, gated) so backends cannot drift. Pass
+ * vitest's `describe`; `makeStore` returns a FRESH empty store per call.
+ */
+export function runMemoryStoreConformance(opts: {
+  readonly name: string
+  readonly makeStore: () => Promise<MemoryStore> | MemoryStore
+  readonly describe: (name: string, fn: () => void) => void
+  readonly close?: (store: MemoryStore) => Promise<void> | void
+}): void {
+  const { name, makeStore, describe, close } = opts
+  describe(`MemoryStore conformance: ${name}`, () => {
+    test("put + get round-trips", async () => {
+      const s = await makeStore()
+      try {
+        await s.put(rec({ id: "a", namespace: "ns", content: "hello billing" }))
+        expect((await s.get("a"))?.content).toBe("hello billing")
+      } finally {
+        await close?.(s)
+      }
+    })
+    test("search is namespace-isolated", async () => {
+      const s = await makeStore()
+      try {
+        await s.put(rec({ id: "a", namespace: "ns1", content: "billing escalation" }))
+        await s.put(rec({ id: "b", namespace: "ns2", content: "billing escalation" }))
+        expect((await s.search({ namespace: "ns1", query: "billing" })).map((r) => r.id)).toEqual([
+          "a",
+        ])
+      } finally {
+        await close?.(s)
+      }
+    })
+    test("query-less search is pure recency order", async () => {
+      const s = await makeStore()
+      try {
+        await s.put(
+          rec({ id: "old", namespace: "ns", content: "x", updatedAt: "2026-07-01T00:00:00.000Z" }),
+        )
+        await s.put(
+          rec({ id: "new", namespace: "ns", content: "y", updatedAt: "2026-07-04T00:00:00.000Z" }),
+        )
+        expect((await s.search({ namespace: "ns" })).map((r) => r.id)).toEqual(["new", "old"])
+      } finally {
+        await close?.(s)
+      }
+    })
+    test("supersede: old→superseded, new active, link recorded", async () => {
+      const s = await makeStore()
+      try {
+        await s.put(rec({ id: "old", namespace: "ns", content: "v1" }))
+        await s.put(rec({ id: "new", namespace: "ns", content: "v2" }))
+        await s.supersede("old", "new")
+        expect((await s.get("old"))?.status).toBe("superseded")
+        expect((await s.get("new"))?.supersedes).toContain("old")
+      } finally {
+        await close?.(s)
+      }
+    })
+    test("candidate listing + delete", async () => {
+      const s = await makeStore()
+      try {
+        await s.put(rec({ id: "c", namespace: "ns", content: "cand", status: "candidate" }))
+        expect((await s.listCandidates("")).map((r) => r.id)).toContain("c")
+        await s.delete("c")
+        expect(await s.get("c")).toBeNull()
+      } finally {
+        await close?.(s)
+      }
+    })
+    test("update preserves the stored embedding (vector recall still finds it)", async () => {
+      const s = await makeStore()
+      try {
+        await s.put(rec({ id: "e", namespace: "ns", content: "faster shipping" }), {
+          embedding: vec(1, 0, 0),
+          embeddingModel: "fake:test",
+        })
+        await s.update("e", { confidence: 0.5 })
+        const out = await s.search({
+          namespace: "ns",
+          query: "expedite delivery",
+          queryEmbedding: vec(1, 0, 0),
+          embedderId: "fake:test",
+          now: "2026-07-05T00:00:00.000Z",
+        })
+        expect(out.map((r) => r.id)).toContain("e")
+      } finally {
+        await close?.(s)
+      }
+    })
+    test("hybrid: a 0-shared-token semantic match is recalled via the vector list", async () => {
+      const s = await makeStore()
+      try {
+        await s.put(rec({ id: "sem", namespace: "ns", content: "faster shipping preferred" }), {
+          embedding: vec(1, 0, 0),
+          embeddingModel: "fake:test",
+        })
+        await s.put(rec({ id: "kw", namespace: "ns", content: "acme billing" }), {
+          embedding: vec(0, 1, 0),
+          embeddingModel: "fake:test",
+        })
+        const out = await s.search({
+          namespace: "ns",
+          query: "expedite delivery",
+          queryEmbedding: vec(0.95, 0.05, 0),
+          embedderId: "fake:test",
+          now: "2026-07-05T00:00:00.000Z",
+        })
+        expect(out.map((r) => r.id)).toContain("sem")
+        expect(out[0]?.id).toBe("sem")
+      } finally {
+        await close?.(s)
+      }
+    })
+    test("hybrid: mismatched embedder tag is excluded from the vector list", async () => {
+      const s = await makeStore()
+      try {
+        await s.put(rec({ id: "stale", namespace: "ns", content: "faster shipping" }), {
+          embedding: vec(1, 0, 0),
+          embeddingModel: "old:model",
+        })
+        const out = await s.search({
+          namespace: "ns",
+          query: "expedite delivery",
+          queryEmbedding: vec(1, 0, 0),
+          embedderId: "fake:test",
+          now: "2026-07-05T00:00:00.000Z",
+        })
+        expect(out.map((r) => r.id)).not.toContain("stale")
+      } finally {
+        await close?.(s)
+      }
+    })
+  })
+}

--- a/packages/testing/test/memory-example-dogfood.test.ts
+++ b/packages/testing/test/memory-example-dogfood.test.ts
@@ -1,0 +1,155 @@
+// Continuous dogfood of the REAL `examples/memory` app — the same app a user
+// runs — driven through a scripted remember → recall flow. Two paths:
+//
+//   ALWAYS (CI-safe): the default SQLite backend, no key, no Docker. Proves the
+//     example's memory route works end to end.
+//
+//   GATED (DAWN_TEST_PGVECTOR=1, needs Docker): a Testcontainers Postgres set as
+//     DATABASE_URL, so the example switches to its pgvector store. Drives the
+//     SAME flow and asserts recall works through pgvector.
+//
+// Each block copies the example app into its OWN throwaway dir under
+// `examples/memory/` (so `@dawn-ai/*` still resolves up to the example's
+// node_modules) BEFORE creating the harness. This matters because
+// `dawn.config.ts` reads the backend env at module-eval time and ESM caches
+// modules by URL — a distinct copy URL per block guarantees each config
+// evaluates against the right env (SQLite vs pgvector) instead of a cached one.
+import { cpSync, mkdtempSync, rmSync } from "node:fs"
+import { join } from "node:path"
+import { DatabaseSync } from "node:sqlite"
+import { fileURLToPath } from "node:url"
+import { loadDawnConfig } from "@dawn-ai/core"
+import { PostgreSqlContainer, type StartedPostgreSqlContainer } from "@testcontainers/postgresql"
+import { afterAll, beforeAll, describe, expect, it } from "vitest"
+import { script } from "../src/fixture-builder.js"
+import { createAgentHarness } from "../src/harness.js"
+
+// The real example app, resolved from this test file up to the repo.
+const exampleRoot = fileURLToPath(new URL("../../../examples/memory/server", import.meta.url))
+
+/** Copy the example app (config + src) into a fresh throwaway dir under the
+ *  example so `@dawn-ai/*` resolves up to `examples/memory/node_modules`. */
+function copyExampleApp(): string {
+  const dir = mkdtempSync(join(exampleRoot, ".tmp-dogfood-"))
+  for (const entry of ["dawn.config.ts", "src", "tsconfig.json", "package.json"]) {
+    cpSync(join(exampleRoot, entry), join(dir, entry), { recursive: true })
+  }
+  return dir
+}
+
+/** Scripted remember → recall flow against the notes route. Returns the decoded
+ *  recall tool output. */
+async function driveRememberRecall(appRoot: string): Promise<string> {
+  const h = await createAgentHarness({ appRoot, route: "/notes#agent" })
+  try {
+    h.reset()
+    await h.run({
+      input: "Remember that Ada prefers dark roast coffee.",
+      fixtures: script()
+        .user("Remember that Ada prefers dark roast coffee.")
+        .callsTool("remember", {
+          data: { subject: "Ada", predicate: "prefers", value: "dark roast coffee" },
+          content: "Ada prefers dark roast coffee",
+        })
+        .replies("Noted."),
+    })
+
+    h.reset()
+    const r = await h.run({
+      input: "What coffee does Ada prefer?",
+      fixtures: script()
+        .user("What coffee does Ada prefer?")
+        .callsTool("recall", { query: "Ada coffee preference" })
+        .replies("Ada prefers dark roast coffee."),
+    })
+    const recall = r.toolResults.find((t) => t.name === "recall")
+    expect(recall, "recall tool must have been executed").toBeDefined()
+    // Plain (non-{result}) tool returns arrive JSON-encoded into ToolMessage
+    // content — decode the quoted string before asserting.
+    const raw = String(recall?.content ?? "")
+    return raw.startsWith('"') ? (JSON.parse(raw) as string) : raw
+  } finally {
+    await h.close()
+  }
+}
+
+// ---- ALWAYS: default SQLite backend (no key, no Docker) --------------------
+describe("examples/memory dogfood — SQLite (default backend)", () => {
+  let appRoot: string
+  beforeAll(() => {
+    appRoot = copyExampleApp()
+  })
+  afterAll(() => {
+    if (appRoot) rmSync(appRoot, { recursive: true, force: true })
+  })
+
+  it("remembers a fact to .dawn/memory.sqlite and recalls it", async () => {
+    const text = await driveRememberRecall(appRoot)
+
+    // Load-bearing persistence proof: the example's own SQLite file holds the row.
+    const db = new DatabaseSync(join(appRoot, ".dawn", "memory.sqlite"))
+    try {
+      const rows = db.prepare("SELECT content FROM memories WHERE status = 'active'").all() as {
+        content: string
+      }[]
+      expect(rows.some((row) => row.content.includes("Ada prefers dark roast coffee"))).toBe(true)
+    } finally {
+      db.close()
+    }
+
+    expect(text, "recall must return the remembered fact").toContain(
+      "Ada prefers dark roast coffee",
+    )
+  }, 60_000)
+})
+
+// ---- GATED: real Postgres + pgvector (Docker) -----------------------------
+const pgvectorEnabled = process.env.DAWN_TEST_PGVECTOR === "1"
+
+describe.skipIf(!pgvectorEnabled)("examples/memory dogfood — pgvector backend", () => {
+  let container: StartedPostgreSqlContainer
+  let appRoot: string
+  let prevUrl: string | undefined
+  let prevFake: string | undefined
+
+  beforeAll(async () => {
+    container = await new PostgreSqlContainer("pgvector/pgvector:pg16").start()
+    // Set the backend env BEFORE copying/loading the example config so it picks
+    // the pgvector store + the network-free fake embedder (exercises the hybrid
+    // vector path without a real OpenAI key or network).
+    prevUrl = process.env.DATABASE_URL
+    prevFake = process.env.DAWN_MEMORY_FAKE_EMBEDDER
+    process.env.DATABASE_URL = container.getConnectionUri()
+    process.env.DAWN_MEMORY_FAKE_EMBEDDER = "1"
+    appRoot = copyExampleApp()
+  }, 120_000)
+
+  afterAll(async () => {
+    // Close the example's pgvector pool BEFORE stopping the container, or its
+    // idle connections raise an unhandled "terminating connection" (57P01) when
+    // Postgres goes away. The config module is ESM-cached by URL, so this
+    // returns the exact store instance the harness used.
+    if (appRoot) {
+      try {
+        const loaded = await loadDawnConfig({ appRoot })
+        const store = loaded.config.memory?.store as { close?: () => Promise<void> } | undefined
+        await store?.close?.()
+      } catch {
+        // best-effort — fall through to container teardown
+      }
+      rmSync(appRoot, { recursive: true, force: true })
+    }
+    if (prevUrl === undefined) delete process.env.DATABASE_URL
+    else process.env.DATABASE_URL = prevUrl
+    if (prevFake === undefined) delete process.env.DAWN_MEMORY_FAKE_EMBEDDER
+    else process.env.DAWN_MEMORY_FAKE_EMBEDDER = prevFake
+    await container?.stop()
+  })
+
+  it("remembers + recalls through the real pgvector store", async () => {
+    const text = await driveRememberRecall(appRoot)
+    expect(text, "pgvector recall must return the remembered fact").toContain(
+      "Ada prefers dark roast coffee",
+    )
+  }, 120_000)
+})

--- a/packages/testing/test/memory-example-dogfood.test.ts
+++ b/packages/testing/test/memory-example-dogfood.test.ts
@@ -6,7 +6,10 @@
 //
 //   GATED (DAWN_TEST_PGVECTOR=1, needs Docker): a Testcontainers Postgres set as
 //     DATABASE_URL, so the example switches to its pgvector store. Drives the
-//     SAME flow and asserts recall works through pgvector.
+//     SAME flow and asserts recall works through pgvector. This proves the real
+//     example app boots on the pgvector store, writes to Postgres, and recalls
+//     end-to-end; the hybrid/vector RANKING quality is proven separately by the
+//     pgvector conformance kit + the live smoke.
 //
 // Each block copies the example app into its OWN throwaway dir under
 // `examples/memory/` (so `@dawn-ai/*` still resolves up to the example's
@@ -36,6 +39,14 @@ function copyExampleApp(): string {
   }
   return dir
 }
+
+// Note: under the aimock harness the example's config wires openaiEmbedder (the
+// harness injects a dummy OPENAI_API_KEY, and the config gates its embedder on
+// that var — exactly as a real keyed user runs it). openaiEmbedder returns
+// 1536-dim vectors through aimock, matching the pgvector `vector(1536)` column,
+// so the write embeds + persists. This dogfood asserts only that the fact is
+// remembered and recalled end to end; hybrid/vector RANKING quality is proven
+// separately by the pgvector conformance kit + the live smoke, not here.
 
 /** Scripted remember → recall flow against the notes route. Returns the decoded
  *  recall tool output. */
@@ -110,17 +121,15 @@ describe.skipIf(!pgvectorEnabled)("examples/memory dogfood — pgvector backend"
   let container: StartedPostgreSqlContainer
   let appRoot: string
   let prevUrl: string | undefined
-  let prevFake: string | undefined
 
   beforeAll(async () => {
     container = await new PostgreSqlContainer("pgvector/pgvector:pg16").start()
-    // Set the backend env BEFORE copying/loading the example config so it picks
-    // the pgvector store + the network-free fake embedder (exercises the hybrid
-    // vector path without a real OpenAI key or network).
+    // Set DATABASE_URL BEFORE copying/loading the example config so it picks the
+    // pgvector store. (The config also wires openaiEmbedder because the harness
+    // injects a dummy key — see driveRememberRecall for how the embedding
+    // fixture keeps that write dimension-compatible with vector(1536).)
     prevUrl = process.env.DATABASE_URL
-    prevFake = process.env.DAWN_MEMORY_FAKE_EMBEDDER
     process.env.DATABASE_URL = container.getConnectionUri()
-    process.env.DAWN_MEMORY_FAKE_EMBEDDER = "1"
     appRoot = copyExampleApp()
   }, 120_000)
 
@@ -141,8 +150,6 @@ describe.skipIf(!pgvectorEnabled)("examples/memory dogfood — pgvector backend"
     }
     if (prevUrl === undefined) delete process.env.DATABASE_URL
     else process.env.DATABASE_URL = prevUrl
-    if (prevFake === undefined) delete process.env.DAWN_MEMORY_FAKE_EMBEDDER
-    else process.env.DAWN_MEMORY_FAKE_EMBEDDER = prevFake
     await container?.stop()
   })
 

--- a/packages/testing/test/sqlite-conformance.test.ts
+++ b/packages/testing/test/sqlite-conformance.test.ts
@@ -1,0 +1,9 @@
+import { sqliteMemoryStore } from "@dawn-ai/memory"
+import { describe } from "vitest"
+import { runMemoryStoreConformance } from "../src/memory-conformance.js"
+
+runMemoryStoreConformance({
+  name: "sqliteMemoryStore",
+  makeStore: () => sqliteMemoryStore({ path: ":memory:" }),
+  describe,
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -458,6 +458,9 @@ importers:
       '@dawn-ai/config-typescript':
         specifier: workspace:*
         version: link:../config-typescript
+      '@dawn-ai/langchain':
+        specifier: workspace:*
+        version: link:../langchain
       '@dawn-ai/testing':
         specifier: workspace:*
         version: link:../testing

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -421,6 +421,9 @@ importers:
       '@dawn-ai/config-typescript':
         specifier: workspace:*
         version: link:../config-typescript
+      '@dawn-ai/testing':
+        specifier: workspace:*
+        version: link:../testing
       '@testcontainers/postgresql':
         specifier: ^12.0.4
         version: 12.0.4

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -188,6 +188,43 @@ importers:
         specifier: 6.0.2
         version: 6.0.2
 
+  examples/memory/server:
+    dependencies:
+      '@dawn-ai/cli':
+        specifier: workspace:*
+        version: link:../../../packages/cli
+      '@dawn-ai/core':
+        specifier: workspace:*
+        version: link:../../../packages/core
+      '@dawn-ai/langchain':
+        specifier: workspace:*
+        version: link:../../../packages/langchain
+      '@dawn-ai/memory-pgvector':
+        specifier: workspace:*
+        version: link:../../../packages/memory-pgvector
+      '@dawn-ai/sdk':
+        specifier: workspace:*
+        version: link:../../../packages/sdk
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
+    devDependencies:
+      '@dawn-ai/config-typescript':
+        specifier: workspace:*
+        version: link:../../../packages/config-typescript
+      '@dawn-ai/testing':
+        specifier: workspace:*
+        version: link:../../../packages/testing
+      '@types/node':
+        specifier: 26.1.0
+        version: 26.1.0
+      typescript:
+        specifier: 6.0.2
+        version: 6.0.2
+      vitest:
+        specifier: ^4.1.9
+        version: 4.1.9(@types/node@26.1.0)(@vitest/ui@4.1.9)(vite@6.4.3(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0))
+
   packages/cli:
     dependencies:
       '@dawn-ai/core':
@@ -519,6 +556,9 @@ importers:
       '@langchain/langgraph-checkpoint':
         specifier: ^1.1.3
         version: 1.1.3(@langchain/core@1.2.1(openai@6.45.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0))
+      '@testcontainers/postgresql':
+        specifier: ^12.0.4
+        version: 12.0.4
       '@types/node':
         specifier: 26.1.0
         version: 26.1.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -406,6 +406,31 @@ importers:
         specifier: 26.1.0
         version: 26.1.0
 
+  packages/memory-pgvector:
+    dependencies:
+      '@dawn-ai/memory':
+        specifier: workspace:*
+        version: link:../memory
+      pg:
+        specifier: ^8.22.0
+        version: 8.22.0
+      pgvector:
+        specifier: ^0.3.0
+        version: 0.3.0
+    devDependencies:
+      '@dawn-ai/config-typescript':
+        specifier: workspace:*
+        version: link:../config-typescript
+      '@testcontainers/postgresql':
+        specifier: ^12.0.4
+        version: 12.0.4
+      '@types/node':
+        specifier: 26.1.0
+        version: 26.1.0
+      '@types/pg':
+        specifier: ^8.20.0
+        version: 8.20.0
+
   packages/permissions:
     devDependencies:
       '@dawn-ai/config-typescript':
@@ -544,6 +569,9 @@ packages:
   '@babel/runtime@7.29.7':
     resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
     engines: {node: '>=6.9.0'}
+
+  '@balena/dockerignore@1.0.2':
+    resolution: {integrity: sha512-wMue2Sy4GAVTk6Ic4tJVcnfdau+gx2EnG7S+uAEe+TWJFqE4YoWN4/H8MSLj4eYJKxGg26lZwboEniNiNwZQ6Q==}
 
   '@biomejs/biome@2.5.1':
     resolution: {integrity: sha512-IXWLCxKmae+rI7LOHS1B3EbVisQ6GRAWbhN9msa6KjNCyFWrvKZWR4oUdinaNssrV852OrSHuSPa95h1GPJc7Q==}
@@ -996,6 +1024,20 @@ packages:
     resolution: {integrity: sha512-MqO+MLfM6kjxcKoy0p1wRzG3b4ZZXtPI+z2IE26UogS2Cm/XHO+7gGRBh6gcJsOiIVoH93UwKvW4HdgiOZCy9Q==}
     engines: {node: '>=18.0.0'}
 
+  '@grpc/grpc-js@1.14.4':
+    resolution: {integrity: sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ==}
+    engines: {node: '>=12.10.0'}
+
+  '@grpc/proto-loader@0.7.15':
+    resolution: {integrity: sha512-tMXdRCfYVixjuFK+Hk0Q1s38gV9zDiDJfWL3h1rv4Qc39oILCu1TRTDt7+fGUI8K4G1Fj125Hx/ru3azECWTyQ==}
+    engines: {node: '>=6'}
+    hasBin: true
+
+  '@grpc/proto-loader@0.8.1':
+    resolution: {integrity: sha512-wtF6h+DY6M3YaDBPAmvuuA6jV8Sif9MjtOI5euKFWRgCDl5PeDpPsHR9u2l6St5ceY8AZgoNDww5+HvEsXFsGg==}
+    engines: {node: '>=6'}
+    hasBin: true
+
   '@img/colour@1.1.0':
     resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
     engines: {node: '>=18'}
@@ -1158,6 +1200,10 @@ packages:
       '@types/node':
         optional: true
 
+  '@isaacs/cliui@8.0.2':
+    resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
+    engines: {node: '>=12'}
+
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
 
@@ -1173,6 +1219,12 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@js-sdsl/ordered-map@4.4.2':
+    resolution: {integrity: sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==}
+
+  '@kwsites/file-exists@1.1.1':
+    resolution: {integrity: sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==}
 
   '@langchain/anthropic@1.5.1':
     resolution: {integrity: sha512-j92zCCd5BFH3rHMRzc2wBmSKDoVpinof1oh8aFiAz9TWbSOc4tGU4n6bqwy/wP0GH1uO96zZHLGCHBMPgrxTNw==}
@@ -1367,8 +1419,39 @@ packages:
   '@pinojs/redact@0.4.0':
     resolution: {integrity: sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==}
 
+  '@pkgjs/parseargs@0.11.0':
+    resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
+    engines: {node: '>=14'}
+
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
+
+  '@protobufjs/aspromise@1.1.2':
+    resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
+
+  '@protobufjs/base64@1.1.2':
+    resolution: {integrity: sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==}
+
+  '@protobufjs/codegen@2.0.5':
+    resolution: {integrity: sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==}
+
+  '@protobufjs/eventemitter@1.1.1':
+    resolution: {integrity: sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==}
+
+  '@protobufjs/fetch@1.1.1':
+    resolution: {integrity: sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==}
+
+  '@protobufjs/float@1.0.2':
+    resolution: {integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==}
+
+  '@protobufjs/path@1.1.2':
+    resolution: {integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==}
+
+  '@protobufjs/pool@1.1.0':
+    resolution: {integrity: sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==}
+
+  '@protobufjs/utf8@1.1.2':
+    resolution: {integrity: sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==}
 
   '@publint/pack@0.1.5':
     resolution: {integrity: sha512-edgyN2pP07uXiP4tJs0s8KVmU8M8i60YPbbI0/WDeok1mIJHRXz+CgD8I0nelwDkoCh3EWL/G5kGfbuHjsdbvw==}
@@ -1652,6 +1735,9 @@ packages:
   '@tailwindcss/postcss@4.3.2':
     resolution: {integrity: sha512-rjVWYCa7Ngbi5AarT6k8TkxUG3Wl1QKzHdIZVsjZSzf36Jmo2IKZt/NHRAwly8oDkbBOH0YTu+CHuf9jPxMc+g==}
 
+  '@testcontainers/postgresql@12.0.4':
+    resolution: {integrity: sha512-a/pLU6j5lpKKAlUTPwqweqMGhOSjgTSb6HBX69TOrXn32ifU37nnQDmNFTj8ddOAw+BQL9oTRkeOxVbZkqhgZA==}
+
   '@turbo/darwin-64@2.10.0':
     resolution: {integrity: sha512-EwvHThXzpY0KGd1/NAmuewI5D+aVa3Rl/OlxE36yfjUKb/+ySrfJrSlEFt8aD1OXwnnaHnQnPKHFndor0Zxlsg==}
     cpu: [x64]
@@ -1691,6 +1777,12 @@ packages:
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
+  '@types/docker-modem@3.0.6':
+    resolution: {integrity: sha512-yKpAGEuKRSS8wwx0joknWxsmLha78wNMe9R2S3UNsVOkZded8UqOrV8KoeDXoXsjndxwyF3eIhyClGbO1SEhEg==}
+
+  '@types/dockerode@4.0.1':
+    resolution: {integrity: sha512-cmUpB+dPN955PxBEuXE3f6lKO1hHiIGYJA46IVF3BJpNsZGvtBDcRnlrHYHtOH/B6vtDOyl2kZ2ShAu3mgc27Q==}
+
   '@types/estree-jsx@1.0.5':
     resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
 
@@ -1718,11 +1810,17 @@ packages:
   '@types/node@12.20.55':
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
 
+  '@types/node@18.19.130':
+    resolution: {integrity: sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==}
+
   '@types/node@25.6.0':
     resolution: {integrity: sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==}
 
   '@types/node@26.1.0':
     resolution: {integrity: sha512-O0A1G3xPGy4w7AgQdAQYUlQ+BKk2Oovw8eRpofyp5KdBZULnbe+WqaOVNrm705SHphCiG4XHsACrSmPu1f+Kgw==}
+
+  '@types/pg@8.20.0':
+    resolution: {integrity: sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==}
 
   '@types/react-dom@19.2.3':
     resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
@@ -1734,6 +1832,15 @@ packages:
 
   '@types/responselike@1.0.0':
     resolution: {integrity: sha512-85Y2BjiufFzaMIlvJDvTTB8Fxl2xfLo4HgmHzVBz08w4wDePCTjYw66PdrolO0kzli3yam/YCgRufyo1DdQVTA==}
+
+  '@types/ssh2-streams@0.1.13':
+    resolution: {integrity: sha512-faHyY3brO9oLEA0QlcO8N2wT7R0+1sHWZvQ+y3rMLwdY1ZyS1z0W3t65j9PqT4HmQ6ALzNe7RZlNuCNE0wBSWA==}
+
+  '@types/ssh2@0.5.52':
+    resolution: {integrity: sha512-lbLLlXxdCZOSJMCInKH2+9V/77ET2J6NPQHpFI0kda61Dd1KglJs+fPQBchizmzYSOJBgdTajhPqBO1xxLywvg==}
+
+  '@types/ssh2@1.15.5':
+    resolution: {integrity: sha512-N1ASjp/nXH3ovBHddRJpli4ozpk6UdDYIX4RJWFa9L1YKnzdhTlVmiGHm4DZnj/jLbqZpes4aeR30EFGQtvhQQ==}
 
   '@types/unist@2.0.11':
     resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
@@ -1891,9 +1998,29 @@ packages:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
 
+  ansi-regex@6.2.2:
+    resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
+    engines: {node: '>=12'}
+
+  ansi-styles@4.3.0:
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
+    engines: {node: '>=8'}
+
+  ansi-styles@6.2.3:
+    resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
+    engines: {node: '>=12'}
+
   apache-md5@1.1.8:
     resolution: {integrity: sha512-FCAJojipPn0bXjuEpjOOOMN8FZDkxfWWp4JGN9mifU2IhxvKyXZYqpzPHdnTSUpmPDy+tsslB6Z1g+Vg6nVbYA==}
     engines: {node: '>=8'}
+
+  archiver-utils@5.0.2:
+    resolution: {integrity: sha512-wuLJMmIBQYCsGZgYLTy5FIB2pF6Lfb6cXMSF8Qywwk3t20zWnAi7zLcQFdKQmIB8wyZpY5ER38x08GbwtR2cLA==}
+    engines: {node: '>= 14'}
+
+  archiver@7.0.1:
+    resolution: {integrity: sha512-ZcbTaIqJOfCc03QwD468Unz/5Ir8ATtvAHsK+FdXbDIbGfihqh9mrvdcYunQzqn4HrvWWaFyaxJhGZagaJJpPQ==}
+    engines: {node: '>= 14'}
 
   argparse@1.0.10:
     resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
@@ -1922,6 +2049,9 @@ packages:
   astring@1.9.0:
     resolution: {integrity: sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==}
     hasBin: true
+
+  async-lock@1.4.1:
+    resolution: {integrity: sha512-Az2ZTpuytrtqENulXwO3GGv1Bztugx6TT37NIo7imr/Qo0gsYiGtSdBa2B6fsXhTpVZDNfu1Qn3pk531e3q+nQ==}
 
   async@3.2.6:
     resolution: {integrity: sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==}
@@ -1961,6 +2091,35 @@ packages:
       bare-abort-controller:
         optional: true
 
+  bare-fs@4.7.4:
+    resolution: {integrity: sha512-y1kC+ffIx/tPLdTE693uNjHfzTfr+ravR5tvWlMXe25nELbkqV400S71qHDwbkAQ1FVEZobB1NFRzFbCCcyBCQ==}
+    engines: {bare: '>=1.16.0'}
+    peerDependencies:
+      bare-buffer: '*'
+    peerDependenciesMeta:
+      bare-buffer:
+        optional: true
+
+  bare-path@3.1.0:
+    resolution: {integrity: sha512-322oSBHOhMhOm2CVwn7b3+gWQqwzSgIY4gNpKKb+Ha5jx2dEl9ClOgz/SK57DwuDql8YQg8JRpb9U0o8K3pW9g==}
+
+  bare-stream@2.13.3:
+    resolution: {integrity: sha512-Kc+brLqvEqGkjyfiwJmImAOqLZL7OsoLKuavx+hJjgVV3nLTOjloJyPMFxjUPerGGHrNH0fLU06jjykMLWrERQ==}
+    peerDependencies:
+      bare-abort-controller: '*'
+      bare-buffer: '*'
+      bare-events: '*'
+    peerDependenciesMeta:
+      bare-abort-controller:
+        optional: true
+      bare-buffer:
+        optional: true
+      bare-events:
+        optional: true
+
+  bare-url@2.4.5:
+    resolution: {integrity: sha512-K+y9xF1tN+CdPu4qWwr0QiK1Al07eFPGYK5M2pDXcmHdMdgC/tT/bpmMe1hrmRHaidKLkXrC+cRNYf3XVDUhSQ==}
+
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
@@ -1979,6 +2138,9 @@ packages:
     resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
     engines: {node: '>=4'}
 
+  bl@4.1.0:
+    resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
+
   body-parser@1.20.5:
     resolution: {integrity: sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
@@ -1993,14 +2155,29 @@ packages:
   browserify-zlib@0.1.4:
     resolution: {integrity: sha512-19OEpq7vWgsH6WkvkBJQDFvJS1uPcbFOQ4v9CU839dO+ZZXUZO6XpE6hNCqvlIIj+4fZvRiJ6DsAQ382GwiyTQ==}
 
+  buffer-crc32@1.0.0:
+    resolution: {integrity: sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==}
+    engines: {node: '>=8.0.0'}
+
   buffer-equal-constant-time@1.0.1:
     resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
 
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
 
+  buffer@5.7.1:
+    resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
+
   buffer@6.0.3:
     resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
+
+  buildcheck@0.0.7:
+    resolution: {integrity: sha512-lHblz4ahamxpTmnsk+MNTRWsjYKv965MwOrSJyeD588rR3Jcu7swE+0wN5F+PbL5cjgu/9ObkhfzEPuofEMwLA==}
+    engines: {node: '>=10.0.0'}
+
+  byline@5.0.0:
+    resolution: {integrity: sha512-s6webAy+R4SR8XVuJWt2V2rGvhnrhxN+9S15GNuTK3wKPOXFF6RNc+8ug2XhH+2s4f+uudG4kUVYmYOQWL2g0Q==}
+    engines: {node: '>=0.10.0'}
 
   bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
@@ -2050,6 +2227,9 @@ packages:
   chardet@2.2.0:
     resolution: {integrity: sha512-rddelWYNPRrXq6PtNEN2S3f6t9ILzvqaN5pVgi4kqt9jHQaXIial9PznB5iSPVlQSLNaaH22ItWz3EJtQ10+OA==}
 
+  chownr@1.1.4:
+    resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
+
   client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
 
@@ -2058,11 +2238,22 @@ packages:
     peerDependencies:
       typanion: '*'
 
+  cliui@8.0.1:
+    resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
+    engines: {node: '>=12'}
+
   clone-response@1.0.3:
     resolution: {integrity: sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==}
 
   collapse-white-space@2.1.0:
     resolution: {integrity: sha512-loKTxY1zCOuG4j9f6EPnuyyYkf58RnhhWTvRoZEokgB+WbdXehfjFviyOVYkqzEWz1Q5kRiZdBYS5SwxbQYwzw==}
+
+  color-convert@2.0.1:
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    engines: {node: '>=7.0.0'}
+
+  color-name@1.1.4:
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
   colorette@2.0.20:
     resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
@@ -2077,6 +2268,10 @@ packages:
   commander@15.0.0:
     resolution: {integrity: sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==}
     engines: {node: '>=22.12.0'}
+
+  compress-commons@6.0.2:
+    resolution: {integrity: sha512-6FqVXeETqWPoGcfzrXb37E50NP0LXT8kAMu5ooZayhWWdgEY4lBEEcbQNXtkuKQsGduxiIcI4gOTsxTmuq/bSg==}
+    engines: {node: '>= 14'}
 
   compressible@2.0.18:
     resolution: {integrity: sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==}
@@ -2117,6 +2312,19 @@ packages:
   cors@2.8.6:
     resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
     engines: {node: '>= 0.10'}
+
+  cpu-features@0.0.10:
+    resolution: {integrity: sha512-9IkYqtX3YHPCzoVg1Py+o9057a3i0fp7S530UWokCSaFVTc7CwXPRiOjRjBQQ18ZCNafx78YfnG+HALxtVmOGA==}
+    engines: {node: '>=10.0.0'}
+
+  crc-32@1.2.2:
+    resolution: {integrity: sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==}
+    engines: {node: '>=0.8'}
+    hasBin: true
+
+  crc32-stream@6.0.0:
+    resolution: {integrity: sha512-piICUB6ei4IlTv1+653yq5+KoqfBYmj9bw6LqXoOneTMDXk5nM1qt12mFW1caG3LlJXEKW1Bp0WggEmIfQB34g==}
+    engines: {node: '>= 14'}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -2191,12 +2399,27 @@ packages:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
     engines: {node: '>=8'}
 
+  docker-compose@1.4.2:
+    resolution: {integrity: sha512-rPHigTKGaEHpkUmfd69QgaOp+Os5vGJwG/Ry8lcr8W/382AmI+z/D7qoa9BybKIkqNppaIbs8RYeHSevdQjWww==}
+    engines: {node: '>= 6.0.0'}
+
+  docker-modem@5.0.7:
+    resolution: {integrity: sha512-XJgGhoR/CLpqshm4d3L7rzH6t8NgDFUIIpztYlLHIApeJjMZKYJMz2zxPsYxnejq5h3ELYSw/RBsi3t5h7gNTA==}
+    engines: {node: '>= 8.0'}
+
+  dockerode@5.0.1:
+    resolution: {integrity: sha512-avsq/xk4YPIrn0CgleX5bjT9Y8IT1p9PxrNQ++RBQ2WEyFfHCTDsT9kmyxz+H/axnjAwg8wJWEIuPGOUuNupiA==}
+    engines: {node: '>= 14.17'}
+
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
 
   duplexify@3.7.1:
     resolution: {integrity: sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==}
+
+  eastasianwidth@0.2.0:
+    resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
 
   ecc-jsbn@0.1.2:
     resolution: {integrity: sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==}
@@ -2206,6 +2429,12 @@ packages:
 
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
+
+  emoji-regex@8.0.0:
+    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
+  emoji-regex@9.2.2:
+    resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
 
   encodeurl@2.0.0:
     resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
@@ -2265,6 +2494,10 @@ packages:
     resolution: {integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==}
     engines: {node: '>=18'}
     hasBin: true
+
+  escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
+    engines: {node: '>=6'}
 
   escape-html@1.0.3:
     resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
@@ -2405,6 +2638,10 @@ packages:
   flatted@3.4.2:
     resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
+  foreground-child@3.3.1:
+    resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
+    engines: {node: '>=14'}
+
   forever-agent@0.6.1:
     resolution: {integrity: sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==}
 
@@ -2427,6 +2664,9 @@ packages:
     resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
     engines: {node: '>= 0.6'}
 
+  fs-constants@1.0.0:
+    resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
+
   fs-extra@7.0.1:
     resolution: {integrity: sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==}
     engines: {node: '>=6 <7 || >=8'}
@@ -2447,9 +2687,17 @@ packages:
     resolution: {integrity: sha512-plz8RVjfcDedTGfVngWH1jmJvBvAwi1v2jecfDerbEnMcmOYUEEwKFTHbNoCiYyzaK2Ws8lABkTCcRSqCY1q4w==}
     engines: {node: '>=10'}
 
+  get-caller-file@2.0.5:
+    resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
+    engines: {node: 6.* || 8.* || >= 10.*}
+
   get-intrinsic@1.3.0:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
     engines: {node: '>= 0.4'}
+
+  get-port@5.1.1:
+    resolution: {integrity: sha512-g/Q1aTSDOxFpchXC4i8ZWvxA1lnPqx/JHqcpIw0/LX9T8x/GBbi6YnlN5nhaKIFkT8oFsscUKgDJYxfwfS6QsQ==}
+    engines: {node: '>=8'}
 
   get-proto@1.0.1:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
@@ -2469,6 +2717,11 @@ packages:
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
     engines: {node: '>= 6'}
+
+  glob@10.5.0:
+    resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+    hasBin: true
 
   globby@11.1.0:
     resolution: {integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==}
@@ -2618,6 +2871,10 @@ packages:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
 
+  is-fullwidth-code-point@3.0.0:
+    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
+    engines: {node: '>=8'}
+
   is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
@@ -2644,6 +2901,10 @@ packages:
   is-promise@2.2.2:
     resolution: {integrity: sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==}
 
+  is-stream@2.0.1:
+    resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
+    engines: {node: '>=8'}
+
   is-subdir@1.2.0:
     resolution: {integrity: sha512-2AT6j+gXe/1ueqbW6fLZJiIw3F8iXGJtt0yDrZaBhAZEG1raiTxKWU+IPqMCzQAXOUCKdA4UDMgacKH25XG2Cw==}
     engines: {node: '>=4'}
@@ -2663,6 +2924,9 @@ packages:
 
   isstream@0.1.2:
     resolution: {integrity: sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==}
+
+  jackspeak@3.4.3:
+    resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
 
   jiti@2.7.0:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
@@ -2750,6 +3014,10 @@ packages:
       ws:
         optional: true
 
+  lazystream@1.0.1:
+    resolution: {integrity: sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==}
+    engines: {node: '>= 0.6.3'}
+
   light-my-request@6.6.0:
     resolution: {integrity: sha512-CHYbu8RtboSIoVsHZ6Ye4cj4Aw/yg2oAFimlF7mNvfDV192LR7nDiKtSIfCuLT7KokPSTn/9kfVLm5OGN0A28A==}
 
@@ -2834,6 +3102,9 @@ packages:
   lockfile@1.0.4:
     resolution: {integrity: sha512-cvbTwETRfsFh4nHsL1eGWapU1XFi5Ot9E85sWAwia7Y7EgB7vfqcZhTKZ+l7hCGxSPoushMv5GKhT5PdLv03WA==}
 
+  lodash.camelcase@4.3.0:
+    resolution: {integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==}
+
   lodash.includes@4.3.0:
     resolution: {integrity: sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==}
 
@@ -2861,6 +3132,9 @@ packages:
   lodash@4.18.1:
     resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
 
+  long@5.3.2:
+    resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
+
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
 
@@ -2871,6 +3145,9 @@ packages:
   lowercase-keys@2.0.0:
     resolution: {integrity: sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==}
     engines: {node: '>=8'}
+
+  lru-cache@10.4.3:
+    resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
   lru-cache@7.18.3:
     resolution: {integrity: sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==}
@@ -3098,15 +3375,35 @@ packages:
     resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
     engines: {node: '>=10'}
 
+  minimatch@5.1.9:
+    resolution: {integrity: sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==}
+    engines: {node: '>=10'}
+
   minimatch@7.4.9:
     resolution: {integrity: sha512-Brg/fp/iAVDOQoHxkuN5bEYhyQlZhxddI78yWsCbeEwTHXQjlNLtiJDUsp1GIptVqMI7/gkJMz4vVAc01mpoBw==}
     engines: {node: '>=10'}
 
+  minimatch@9.0.9:
+    resolution: {integrity: sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
 
+  minipass@7.1.3:
+    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
+  mkdirp-classic@0.5.3:
+    resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
+
   mkdirp@1.0.4:
     resolution: {integrity: sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  mkdirp@3.0.1:
+    resolution: {integrity: sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -3127,6 +3424,9 @@ packages:
   mustache@4.2.0:
     resolution: {integrity: sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==}
     hasBin: true
+
+  nan@2.28.0:
+    resolution: {integrity: sha512-fTsDz99OTq2sVePhGdp4qQhggZFtKr64ZNVyVajRKtMOkJxYekplBh577PiJB12v/D3s2E5cGtOI45LWp6rnLQ==}
 
   nanoid@3.3.15:
     resolution: {integrity: sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==}
@@ -3173,6 +3473,10 @@ packages:
     peerDependenciesMeta:
       encoding:
         optional: true
+
+  normalize-path@3.0.0:
+    resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
+    engines: {node: '>=0.10.0'}
 
   normalize-url@6.1.0:
     resolution: {integrity: sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==}
@@ -3285,6 +3589,9 @@ packages:
     resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
     engines: {node: '>=6'}
 
+  package-json-from-dist@1.0.1:
+    resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
+
   package-manager-detector@0.2.11:
     resolution: {integrity: sha512-BEnLolu+yuz22S56CU1SUKq3XC3PkwD5wv4ikR4MfGvnRVcmzXR9DwSlW2fEamyTPyXHomBJRzgapeuBvRNzJQ==}
 
@@ -3315,6 +3622,10 @@ packages:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
 
+  path-scurry@1.11.1:
+    resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
+    engines: {node: '>=16 || 14 >=14.18'}
+
   path-to-regexp@0.1.13:
     resolution: {integrity: sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==}
 
@@ -3330,6 +3641,44 @@ packages:
 
   performance-now@2.1.0:
     resolution: {integrity: sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==}
+
+  pg-cloudflare@1.4.0:
+    resolution: {integrity: sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==}
+
+  pg-connection-string@2.14.0:
+    resolution: {integrity: sha512-XwWDGcLRGCXAR8F/AM5bG7Q+A3Wm2s6QeEjlOKZLlH3UYcguiqCWKyWXVag5TLTIjR7oOJUY8kcADaZgWPyLeg==}
+
+  pg-int8@1.0.1:
+    resolution: {integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==}
+    engines: {node: '>=4.0.0'}
+
+  pg-pool@3.14.0:
+    resolution: {integrity: sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw==}
+    peerDependencies:
+      pg: '>=8.0'
+
+  pg-protocol@1.15.0:
+    resolution: {integrity: sha512-cq9sECI5s0+uPUXjbz8ioyPJni6RzsRib0US67i5IoTZKw8fNeYlVE7u8F4dG7vEJJtc5wdD1K189lCCUwqWTQ==}
+
+  pg-types@2.2.0:
+    resolution: {integrity: sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==}
+    engines: {node: '>=4'}
+
+  pg@8.22.0:
+    resolution: {integrity: sha512-8wih1vVIBMxoUM2oB4soJsD9tDnDpLv4OXBJ+EJzFsvycD+lfyIreC2gGHq78f8jbLLt+bvlPTFdFZfJkOuzAA==}
+    engines: {node: '>= 16.0.0'}
+    peerDependencies:
+      pg-native: '>=3.0.1'
+    peerDependenciesMeta:
+      pg-native:
+        optional: true
+
+  pgpass@1.0.5:
+    resolution: {integrity: sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==}
+
+  pgvector@0.3.0:
+    resolution: {integrity: sha512-+t7qcQD2us8fO8YIq/3lA0gUrD+bVO70MG1MhcDcxJz/OlRGGIIHzFq/4x57Vn/LpzX5wFdfOTLQp9QMPd4ljQ==}
+    engines: {node: '>=22'}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -3367,6 +3716,22 @@ packages:
     resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
     engines: {node: ^10 || ^12 || >=14}
 
+  postgres-array@2.0.0:
+    resolution: {integrity: sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==}
+    engines: {node: '>=4'}
+
+  postgres-bytea@1.0.1:
+    resolution: {integrity: sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==}
+    engines: {node: '>=0.10.0'}
+
+  postgres-date@1.0.7:
+    resolution: {integrity: sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==}
+    engines: {node: '>=0.10.0'}
+
+  postgres-interval@1.2.0:
+    resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
+    engines: {node: '>=0.10.0'}
+
   prettier@2.8.8:
     resolution: {integrity: sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==}
     engines: {node: '>=10.13.0'}
@@ -3388,11 +3753,22 @@ packages:
     resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
     engines: {node: '>= 0.6.0'}
 
+  proper-lockfile@4.1.2:
+    resolution: {integrity: sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==}
+
+  properties-reader@3.0.1:
+    resolution: {integrity: sha512-WPn+h9RGEExOKdu4bsF4HksG/uzd3cFq3MFtq8PsFeExPse5Ha/VOjQNyHhjboBFwGXGev6muJYTSPAOkROq2g==}
+    engines: {node: '>=18'}
+
   property-information@7.1.0:
     resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
 
   property-information@7.2.0:
     resolution: {integrity: sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==}
+
+  protobufjs@7.6.5:
+    resolution: {integrity: sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==}
+    engines: {node: '>=12.0.0'}
 
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
@@ -3453,9 +3829,16 @@ packages:
   readable-stream@2.3.8:
     resolution: {integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==}
 
+  readable-stream@3.6.2:
+    resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
+    engines: {node: '>= 6'}
+
   readable-stream@4.7.0:
     resolution: {integrity: sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  readdir-glob@1.1.3:
+    resolution: {integrity: sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==}
 
   reading-time@1.5.0:
     resolution: {integrity: sha512-onYyVhBNr4CmAxFsKS7bz+uTLRakypIe4R+5A824vBSkQy/hB3fZepoVEf8OVAxzLvK+H/jm9TzpI3ETSm64Kg==}
@@ -3520,6 +3903,10 @@ packages:
   remark-stringify@11.0.0:
     resolution: {integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==}
 
+  require-directory@2.1.1:
+    resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
+    engines: {node: '>=0.10.0'}
+
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
@@ -3533,6 +3920,10 @@ packages:
 
   responselike@2.0.1:
     resolution: {integrity: sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==}
+
+  retry@0.12.0:
+    resolution: {integrity: sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==}
+    engines: {node: '>= 4'}
 
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
@@ -3676,12 +4067,22 @@ packages:
   spawndamnit@3.0.1:
     resolution: {integrity: sha512-MmnduQUuHCoFckZoWnXsTg7JaiLBJrKFj9UI2MbRPGaJeVpsLcVBu6P/IGZovziM/YBsellCmsprgNA+w0CzVg==}
 
+  split-ca@1.0.1:
+    resolution: {integrity: sha512-Q5thBSxp5t8WPTTJQS59LrGqOZqOsrhDGDVm8azCqIBjSBd7nd9o2PM+mDulQQkh8h//4U6hFZnc/mul8t5pWQ==}
+
   split2@4.2.0:
     resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
     engines: {node: '>= 10.x'}
 
   sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
+
+  ssh-remote-port-forward@1.0.4:
+    resolution: {integrity: sha512-x0LV1eVDwjf1gmG7TTnfqIzf+3VPRz7vrNIjX6oYLbeCrf/PeVY6hkT68Mg+q02qXxQhrLjB0jfgvhevoCRmLQ==}
+
+  ssh2@1.17.0:
+    resolution: {integrity: sha512-wPldCk3asibAjQ/kziWQQt1Wh3PgDFpC0XpwclzKcdT1vql6KeYxf5LIt4nlFkUeR8WuphYMKqUA56X4rjbfgQ==}
+    engines: {node: '>=10.16.0'}
 
   sshpk@1.18.0:
     resolution: {integrity: sha512-2p2KJZTSqQ/I3+HX42EpYOa2l3f8Erv8MWKsy2I9uf4wA7yFIkXRffYdsx86y6z4vHtV8u7g+pPlr8/4ouAxsQ==}
@@ -3710,6 +4111,14 @@ packages:
   streamx@2.28.0:
     resolution: {integrity: sha512-1Yowhzjf0ivGMrTIkY9hav5TxobO9qIVqUE41fiCGMGgc3CLlf4MY+9AHmZqBWgDTue0fY9zWjYFVyf6Diuobw==}
 
+  string-width@4.2.3:
+    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
+    engines: {node: '>=8'}
+
+  string-width@5.1.2:
+    resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
+    engines: {node: '>=12'}
+
   string_decoder@1.1.1:
     resolution: {integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==}
 
@@ -3722,6 +4131,10 @@ packages:
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
+
+  strip-ansi@7.2.0:
+    resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
+    engines: {node: '>=12'}
 
   strip-bom-string@1.0.0:
     resolution: {integrity: sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==}
@@ -3757,12 +4170,28 @@ packages:
     resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
     engines: {node: '>=6'}
 
+  tar-fs@2.1.5:
+    resolution: {integrity: sha512-OboTd8mmMhZDNPV+UjQcK9yKAatXu2aJ+r1w4im1Otd4M4fl2hwvdoXUxIYHFTHWK/3y3FarBP70v3vwmGlOxw==}
+
+  tar-fs@3.1.3:
+    resolution: {integrity: sha512-/hU4AXnIdZu+Gvl1pk0oI5f5HxWsCJRtY2aFaJdk9VvyL48DWU6iU5WAIPG+wIi1YvWA6eTJvIviP/tMAZZNwQ==}
+
+  tar-stream@2.2.0:
+    resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
+    engines: {node: '>=6'}
+
   tar-stream@3.1.7:
     resolution: {integrity: sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==}
+
+  teex@1.0.1:
+    resolution: {integrity: sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==}
 
   term-size@2.2.1:
     resolution: {integrity: sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==}
     engines: {node: '>=8'}
+
+  testcontainers@12.0.4:
+    resolution: {integrity: sha512-QIR/8xF1+F/26cIM+9B4yyxNTbKJxAv3hygZyhPRgZ8Q2AhlPZjDdpXRuk16V37X4bgJRI3hXFhoEICMBA7Adg==}
 
   text-decoder@1.2.7:
     resolution: {integrity: sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==}
@@ -3797,6 +4226,10 @@ packages:
   tldts@6.1.86:
     resolution: {integrity: sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==}
     hasBin: true
+
+  tmp@0.2.7:
+    resolution: {integrity: sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==}
+    engines: {node: '>=14.14'}
 
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
@@ -3872,11 +4305,18 @@ packages:
     engines: {node: '>=0.8.0'}
     hasBin: true
 
+  undici-types@5.26.5:
+    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
+
   undici-types@7.19.2:
     resolution: {integrity: sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==}
 
   undici-types@8.3.0:
     resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
+
+  undici@8.7.0:
+    resolution: {integrity: sha512-N7iQtfyLhIMOFgQubvmLV26svHpO0bqKnAiWotTQCVKCmWrcGbBotPuW1x+xwYZ2VHdSTVUfPQQnlEt1/LouTQ==}
+    engines: {node: '>=22.19.0'}
 
   unified@11.0.5:
     resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
@@ -4067,6 +4507,14 @@ packages:
   wordwrap@1.0.0:
     resolution: {integrity: sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==}
 
+  wrap-ansi@7.0.0:
+    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
+    engines: {node: '>=10'}
+
+  wrap-ansi@8.1.0:
+    resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
+    engines: {node: '>=12'}
+
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
@@ -4086,10 +4534,26 @@ packages:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
     engines: {node: '>=0.4'}
 
+  y18n@5.0.8:
+    resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
+    engines: {node: '>=10'}
+
   yaml@2.9.0:
     resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
     engines: {node: '>= 14.6'}
     hasBin: true
+
+  yargs-parser@21.1.1:
+    resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
+    engines: {node: '>=12'}
+
+  yargs@17.7.3:
+    resolution: {integrity: sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==}
+    engines: {node: '>=12'}
+
+  zip-stream@6.0.1:
+    resolution: {integrity: sha512-zK7YHHz4ZXpW89AHXUPbQVGKI7uvkd3hzusTdotCg1UxyaVtg0zFJSTfW/Dq5f7OBBVnq6cZIaC8Ti4hb6dtCA==}
+    engines: {node: '>= 14'}
 
   zod-to-json-schema@3.25.2:
     resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
@@ -4114,6 +4578,8 @@ snapshots:
       zod: 4.4.3
 
   '@babel/runtime@7.29.7': {}
+
+  '@balena/dockerignore@1.0.2': {}
 
   '@biomejs/biome@2.5.1':
     optionalDependencies:
@@ -4483,6 +4949,25 @@ snapshots:
 
   '@google/generative-ai@0.24.1': {}
 
+  '@grpc/grpc-js@1.14.4':
+    dependencies:
+      '@grpc/proto-loader': 0.8.1
+      '@js-sdsl/ordered-map': 4.4.2
+
+  '@grpc/proto-loader@0.7.15':
+    dependencies:
+      lodash.camelcase: 4.3.0
+      long: 5.3.2
+      protobufjs: 7.6.5
+      yargs: 17.7.3
+
+  '@grpc/proto-loader@0.8.1':
+    dependencies:
+      lodash.camelcase: 4.3.0
+      long: 5.3.2
+      protobufjs: 7.6.5
+      yargs: 17.7.3
+
   '@img/colour@1.1.0':
     optional: true
 
@@ -4587,6 +5072,15 @@ snapshots:
     optionalDependencies:
       '@types/node': 26.1.0
 
+  '@isaacs/cliui@8.0.2':
+    dependencies:
+      string-width: 5.1.2
+      string-width-cjs: string-width@4.2.3
+      strip-ansi: 7.2.0
+      strip-ansi-cjs: strip-ansi@6.0.1
+      wrap-ansi: 8.1.0
+      wrap-ansi-cjs: wrap-ansi@7.0.0
+
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -4605,6 +5099,14 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@js-sdsl/ordered-map@4.4.2': {}
+
+  '@kwsites/file-exists@1.1.1':
+    dependencies:
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
 
   '@langchain/anthropic@1.5.1(@langchain/core@1.2.1(openai@6.45.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0))':
     dependencies:
@@ -4832,7 +5334,30 @@ snapshots:
 
   '@pinojs/redact@0.4.0': {}
 
+  '@pkgjs/parseargs@0.11.0':
+    optional: true
+
   '@polka/url@1.0.0-next.29': {}
+
+  '@protobufjs/aspromise@1.1.2': {}
+
+  '@protobufjs/base64@1.1.2': {}
+
+  '@protobufjs/codegen@2.0.5': {}
+
+  '@protobufjs/eventemitter@1.1.1': {}
+
+  '@protobufjs/fetch@1.1.1':
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+
+  '@protobufjs/float@1.0.2': {}
+
+  '@protobufjs/path@1.1.2': {}
+
+  '@protobufjs/pool@1.1.0': {}
+
+  '@protobufjs/utf8@1.1.2': {}
 
   '@publint/pack@0.1.5':
     dependencies:
@@ -5036,6 +5561,15 @@ snapshots:
       postcss: 8.5.10
       tailwindcss: 4.3.2
 
+  '@testcontainers/postgresql@12.0.4':
+    dependencies:
+      testcontainers: 12.0.4
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - react-native-b4a
+      - supports-color
+
   '@turbo/darwin-64@2.10.0':
     optional: true
 
@@ -5065,6 +5599,17 @@ snapshots:
 
   '@types/deep-eql@4.0.2': {}
 
+  '@types/docker-modem@3.0.6':
+    dependencies:
+      '@types/node': 26.1.0
+      '@types/ssh2': 1.15.5
+
+  '@types/dockerode@4.0.1':
+    dependencies:
+      '@types/docker-modem': 3.0.6
+      '@types/node': 26.1.0
+      '@types/ssh2': 1.15.5
+
   '@types/estree-jsx@1.0.5':
     dependencies:
       '@types/estree': 1.0.8
@@ -5089,6 +5634,10 @@ snapshots:
 
   '@types/node@12.20.55': {}
 
+  '@types/node@18.19.130':
+    dependencies:
+      undici-types: 5.26.5
+
   '@types/node@25.6.0':
     dependencies:
       undici-types: 7.19.2
@@ -5096,6 +5645,12 @@ snapshots:
   '@types/node@26.1.0':
     dependencies:
       undici-types: 8.3.0
+
+  '@types/pg@8.20.0':
+    dependencies:
+      '@types/node': 26.1.0
+      pg-protocol: 1.15.0
+      pg-types: 2.2.0
 
   '@types/react-dom@19.2.3(@types/react@19.2.17)':
     dependencies:
@@ -5108,6 +5663,19 @@ snapshots:
   '@types/responselike@1.0.0':
     dependencies:
       '@types/node': 26.1.0
+
+  '@types/ssh2-streams@0.1.13':
+    dependencies:
+      '@types/node': 26.1.0
+
+  '@types/ssh2@0.5.52':
+    dependencies:
+      '@types/node': 26.1.0
+      '@types/ssh2-streams': 0.1.13
+
+  '@types/ssh2@1.15.5':
+    dependencies:
+      '@types/node': 18.19.130
 
   '@types/unist@2.0.11': {}
 
@@ -5366,7 +5934,38 @@ snapshots:
 
   ansi-regex@5.0.1: {}
 
+  ansi-regex@6.2.2: {}
+
+  ansi-styles@4.3.0:
+    dependencies:
+      color-convert: 2.0.1
+
+  ansi-styles@6.2.3: {}
+
   apache-md5@1.1.8: {}
+
+  archiver-utils@5.0.2:
+    dependencies:
+      glob: 10.5.0
+      graceful-fs: 4.2.11
+      is-stream: 2.0.1
+      lazystream: 1.0.1
+      lodash: 4.18.1
+      normalize-path: 3.0.0
+      readable-stream: 4.7.0
+
+  archiver@7.0.1:
+    dependencies:
+      archiver-utils: 5.0.2
+      async: 3.2.6
+      buffer-crc32: 1.0.0
+      readable-stream: 4.7.0
+      readdir-glob: 1.1.3
+      tar-stream: 3.1.7
+      zip-stream: 6.0.1
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
 
   argparse@1.0.10:
     dependencies:
@@ -5388,6 +5987,8 @@ snapshots:
 
   astring@1.9.0: {}
 
+  async-lock@1.4.1: {}
+
   async@3.2.6: {}
 
   asynckit@0.4.0: {}
@@ -5406,6 +6007,37 @@ snapshots:
 
   bare-events@2.9.1: {}
 
+  bare-fs@4.7.4:
+    dependencies:
+      bare-events: 2.9.1
+      bare-path: 3.1.0
+      bare-stream: 2.13.3(bare-events@2.9.1)
+      bare-url: 2.4.5
+      fast-fifo: 1.3.2
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+    optional: true
+
+  bare-path@3.1.0:
+    optional: true
+
+  bare-stream@2.13.3(bare-events@2.9.1):
+    dependencies:
+      b4a: 1.8.1
+      streamx: 2.28.0
+      teex: 1.0.1
+    optionalDependencies:
+      bare-events: 2.9.1
+    transitivePeerDependencies:
+      - react-native-b4a
+    optional: true
+
+  bare-url@2.4.5:
+    dependencies:
+      bare-path: 3.1.0
+    optional: true
+
   base64-js@1.5.1: {}
 
   baseline-browser-mapping@2.10.17: {}
@@ -5419,6 +6051,12 @@ snapshots:
   better-path-resolve@1.0.0:
     dependencies:
       is-windows: 1.0.2
+
+  bl@4.1.0:
+    dependencies:
+      buffer: 5.7.1
+      inherits: 2.0.4
+      readable-stream: 3.6.2
 
   body-parser@1.20.5:
     dependencies:
@@ -5449,14 +6087,26 @@ snapshots:
     dependencies:
       pako: 0.2.9
 
+  buffer-crc32@1.0.0: {}
+
   buffer-equal-constant-time@1.0.1: {}
 
   buffer-from@1.1.2: {}
+
+  buffer@5.7.1:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
 
   buffer@6.0.3:
     dependencies:
       base64-js: 1.5.1
       ieee754: 1.2.1
+
+  buildcheck@0.0.7:
+    optional: true
+
+  byline@5.0.0: {}
 
   bytes@3.1.2: {}
 
@@ -5500,17 +6150,31 @@ snapshots:
 
   chardet@2.2.0: {}
 
+  chownr@1.1.4: {}
+
   client-only@0.0.1: {}
 
   clipanion@4.0.0-rc.4(typanion@3.14.0):
     dependencies:
       typanion: 3.14.0
 
+  cliui@8.0.1:
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 7.0.0
+
   clone-response@1.0.3:
     dependencies:
       mimic-response: 1.0.1
 
   collapse-white-space@2.1.0: {}
+
+  color-convert@2.0.1:
+    dependencies:
+      color-name: 1.1.4
+
+  color-name@1.1.4: {}
 
   colorette@2.0.20: {}
 
@@ -5521,6 +6185,14 @@ snapshots:
   comma-separated-tokens@2.0.3: {}
 
   commander@15.0.0: {}
+
+  compress-commons@6.0.2:
+    dependencies:
+      crc-32: 1.2.2
+      crc32-stream: 6.0.0
+      is-stream: 2.0.1
+      normalize-path: 3.0.0
+      readable-stream: 4.7.0
 
   compressible@2.0.18:
     dependencies:
@@ -5560,6 +6232,19 @@ snapshots:
     dependencies:
       object-assign: 4.1.1
       vary: 1.1.2
+
+  cpu-features@0.0.10:
+    dependencies:
+      buildcheck: 0.0.7
+      nan: 2.28.0
+    optional: true
+
+  crc-32@1.2.2: {}
+
+  crc32-stream@6.0.0:
+    dependencies:
+      crc-32: 1.2.2
+      readable-stream: 4.7.0
 
   cross-spawn@7.0.6:
     dependencies:
@@ -5613,6 +6298,30 @@ snapshots:
     dependencies:
       path-type: 4.0.0
 
+  docker-compose@1.4.2:
+    dependencies:
+      yaml: 2.9.0
+
+  docker-modem@5.0.7:
+    dependencies:
+      debug: 4.4.3
+      readable-stream: 3.6.2
+      split-ca: 1.0.1
+      ssh2: 1.17.0
+    transitivePeerDependencies:
+      - supports-color
+
+  dockerode@5.0.1:
+    dependencies:
+      '@balena/dockerignore': 1.0.2
+      '@grpc/grpc-js': 1.14.4
+      '@grpc/proto-loader': 0.7.15
+      docker-modem: 5.0.7
+      protobufjs: 7.6.5
+      tar-fs: 2.1.5
+    transitivePeerDependencies:
+      - supports-color
+
   dunder-proto@1.0.1:
     dependencies:
       call-bind-apply-helpers: 1.0.2
@@ -5626,6 +6335,8 @@ snapshots:
       readable-stream: 2.3.8
       stream-shift: 1.0.3
 
+  eastasianwidth@0.2.0: {}
+
   ecc-jsbn@0.1.2:
     dependencies:
       jsbn: 0.1.1
@@ -5636,6 +6347,10 @@ snapshots:
       safe-buffer: 5.2.1
 
   ee-first@1.1.1: {}
+
+  emoji-regex@8.0.0: {}
+
+  emoji-regex@9.2.2: {}
 
   encodeurl@2.0.0: {}
 
@@ -5745,6 +6460,8 @@ snapshots:
       '@esbuild/win32-arm64': 0.28.1
       '@esbuild/win32-ia32': 0.28.1
       '@esbuild/win32-x64': 0.28.1
+
+  escalade@3.2.0: {}
 
   escape-html@1.0.3: {}
 
@@ -5946,6 +6663,11 @@ snapshots:
 
   flatted@3.4.2: {}
 
+  foreground-child@3.3.1:
+    dependencies:
+      cross-spawn: 7.0.6
+      signal-exit: 4.1.0
+
   forever-agent@0.6.1: {}
 
   form-data-encoder@1.7.2: {}
@@ -5963,6 +6685,8 @@ snapshots:
   forwarded@0.2.0: {}
 
   fresh@0.5.2: {}
+
+  fs-constants@1.0.0: {}
 
   fs-extra@7.0.1:
     dependencies:
@@ -5983,6 +6707,8 @@ snapshots:
 
   fuse.js@7.3.0: {}
 
+  get-caller-file@2.0.5: {}
+
   get-intrinsic@1.3.0:
     dependencies:
       call-bind-apply-helpers: 1.0.2
@@ -5995,6 +6721,8 @@ snapshots:
       has-symbols: 1.1.0
       hasown: 2.0.4
       math-intrinsics: 1.1.0
+
+  get-port@5.1.1: {}
 
   get-proto@1.0.1:
     dependencies:
@@ -6014,6 +6742,15 @@ snapshots:
   glob-parent@5.1.2:
     dependencies:
       is-glob: 4.0.3
+
+  glob@10.5.0:
+    dependencies:
+      foreground-child: 3.3.1
+      jackspeak: 3.4.3
+      minimatch: 9.0.9
+      minipass: 7.1.3
+      package-json-from-dist: 1.0.1
+      path-scurry: 1.11.1
 
   globby@11.1.0:
     dependencies:
@@ -6244,6 +6981,8 @@ snapshots:
 
   is-extglob@2.1.1: {}
 
+  is-fullwidth-code-point@3.0.0: {}
+
   is-glob@4.0.3:
     dependencies:
       is-extglob: 2.1.1
@@ -6260,6 +6999,8 @@ snapshots:
 
   is-promise@2.2.2: {}
 
+  is-stream@2.0.1: {}
+
   is-subdir@1.2.0:
     dependencies:
       better-path-resolve: 1.0.0
@@ -6273,6 +7014,12 @@ snapshots:
   isexe@2.0.0: {}
 
   isstream@0.1.2: {}
+
+  jackspeak@3.4.3:
+    dependencies:
+      '@isaacs/cliui': 8.0.2
+    optionalDependencies:
+      '@pkgjs/parseargs': 0.11.0
 
   jiti@2.7.0: {}
 
@@ -6359,6 +7106,10 @@ snapshots:
       openai: 6.45.0(ws@8.21.0)(zod@4.4.3)
       ws: 8.21.0
 
+  lazystream@1.0.1:
+    dependencies:
+      readable-stream: 2.3.8
+
   light-my-request@6.6.0:
     dependencies:
       cookie: 1.1.1
@@ -6422,6 +7173,8 @@ snapshots:
     dependencies:
       signal-exit: 3.0.7
 
+  lodash.camelcase@4.3.0: {}
+
   lodash.includes@4.3.0: {}
 
   lodash.isboolean@3.0.3: {}
@@ -6440,6 +7193,8 @@ snapshots:
 
   lodash@4.18.1: {}
 
+  long@5.3.2: {}
+
   longest-streak@3.1.0: {}
 
   lowdb@1.0.0:
@@ -6451,6 +7206,8 @@ snapshots:
       steno: 0.4.4
 
   lowercase-keys@2.0.0: {}
+
+  lru-cache@10.4.3: {}
 
   lru-cache@7.18.3: {}
 
@@ -6938,13 +7695,27 @@ snapshots:
 
   mimic-response@3.1.0: {}
 
+  minimatch@5.1.9:
+    dependencies:
+      brace-expansion: 2.1.1
+
   minimatch@7.4.9:
+    dependencies:
+      brace-expansion: 2.1.1
+
+  minimatch@9.0.9:
     dependencies:
       brace-expansion: 2.1.1
 
   minimist@1.2.8: {}
 
+  minipass@7.1.3: {}
+
+  mkdirp-classic@0.5.3: {}
+
   mkdirp@1.0.4: {}
+
+  mkdirp@3.0.1: {}
 
   mri@1.2.0: {}
 
@@ -6955,6 +7726,9 @@ snapshots:
   ms@2.1.3: {}
 
   mustache@4.2.0: {}
+
+  nan@2.28.0:
+    optional: true
 
   nanoid@3.3.15: {}
 
@@ -6991,6 +7765,8 @@ snapshots:
   node-fetch@2.6.7:
     dependencies:
       whatwg-url: 5.0.0
+
+  normalize-path@3.0.0: {}
 
   normalize-url@6.1.0: {}
 
@@ -7071,6 +7847,8 @@ snapshots:
 
   p-try@2.2.0: {}
 
+  package-json-from-dist@1.0.1: {}
+
   package-manager-detector@0.2.11:
     dependencies:
       quansync: 0.2.11
@@ -7101,6 +7879,11 @@ snapshots:
 
   path-key@3.1.1: {}
 
+  path-scurry@1.11.1:
+    dependencies:
+      lru-cache: 10.4.3
+      minipass: 7.1.3
+
   path-to-regexp@0.1.13: {}
 
   path-type@4.0.0: {}
@@ -7114,6 +7897,43 @@ snapshots:
       through2: 2.0.5
 
   performance-now@2.1.0: {}
+
+  pg-cloudflare@1.4.0:
+    optional: true
+
+  pg-connection-string@2.14.0: {}
+
+  pg-int8@1.0.1: {}
+
+  pg-pool@3.14.0(pg@8.22.0):
+    dependencies:
+      pg: 8.22.0
+
+  pg-protocol@1.15.0: {}
+
+  pg-types@2.2.0:
+    dependencies:
+      pg-int8: 1.0.1
+      postgres-array: 2.0.0
+      postgres-bytea: 1.0.1
+      postgres-date: 1.0.7
+      postgres-interval: 1.2.0
+
+  pg@8.22.0:
+    dependencies:
+      pg-connection-string: 2.14.0
+      pg-pool: 3.14.0(pg@8.22.0)
+      pg-protocol: 1.15.0
+      pg-types: 2.2.0
+      pgpass: 1.0.5
+    optionalDependencies:
+      pg-cloudflare: 1.4.0
+
+  pgpass@1.0.5:
+    dependencies:
+      split2: 4.2.0
+
+  pgvector@0.3.0: {}
 
   picocolors@1.1.1: {}
 
@@ -7156,6 +7976,16 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  postgres-array@2.0.0: {}
+
+  postgres-bytea@1.0.1: {}
+
+  postgres-date@1.0.7: {}
+
+  postgres-interval@1.2.0:
+    dependencies:
+      xtend: 4.0.2
+
   prettier@2.8.8: {}
 
   process-nextick-args@2.0.1: {}
@@ -7168,9 +7998,36 @@ snapshots:
 
   process@0.11.10: {}
 
+  proper-lockfile@4.1.2:
+    dependencies:
+      graceful-fs: 4.2.11
+      retry: 0.12.0
+      signal-exit: 3.0.7
+
+  properties-reader@3.0.1:
+    dependencies:
+      '@kwsites/file-exists': 1.1.1
+      mkdirp: 3.0.1
+    transitivePeerDependencies:
+      - supports-color
+
   property-information@7.1.0: {}
 
   property-information@7.2.0: {}
+
+  protobufjs@7.6.5:
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/base64': 1.1.2
+      '@protobufjs/codegen': 2.0.5
+      '@protobufjs/eventemitter': 1.1.1
+      '@protobufjs/fetch': 1.1.1
+      '@protobufjs/float': 1.0.2
+      '@protobufjs/path': 1.1.2
+      '@protobufjs/pool': 1.1.0
+      '@protobufjs/utf8': 1.1.2
+      '@types/node': 26.1.0
+      long: 5.3.2
 
   proxy-addr@2.0.7:
     dependencies:
@@ -7246,6 +8103,12 @@ snapshots:
       string_decoder: 1.1.1
       util-deprecate: 1.0.2
 
+  readable-stream@3.6.2:
+    dependencies:
+      inherits: 2.0.4
+      string_decoder: 1.3.0
+      util-deprecate: 1.0.2
+
   readable-stream@4.7.0:
     dependencies:
       abort-controller: 3.0.0
@@ -7253,6 +8116,10 @@ snapshots:
       events: 3.3.0
       process: 0.11.10
       string_decoder: 1.3.0
+
+  readdir-glob@1.1.3:
+    dependencies:
+      minimatch: 5.1.9
 
   reading-time@1.5.0: {}
 
@@ -7380,6 +8247,8 @@ snapshots:
       mdast-util-to-markdown: 2.1.2
       unified: 11.0.5
 
+  require-directory@2.1.1: {}
+
   require-from-string@2.0.2: {}
 
   resolve-alpn@1.2.1: {}
@@ -7389,6 +8258,8 @@ snapshots:
   responselike@2.0.1:
     dependencies:
       lowercase-keys: 2.0.0
+
+  retry@0.12.0: {}
 
   reusify@1.1.0: {}
 
@@ -7599,9 +8470,24 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
+  split-ca@1.0.1: {}
+
   split2@4.2.0: {}
 
   sprintf-js@1.0.3: {}
+
+  ssh-remote-port-forward@1.0.4:
+    dependencies:
+      '@types/ssh2': 0.5.52
+      ssh2: 1.17.0
+
+  ssh2@1.17.0:
+    dependencies:
+      asn1: 0.2.6
+      bcrypt-pbkdf: 1.0.2
+    optionalDependencies:
+      cpu-features: 0.0.10
+      nan: 2.28.0
 
   sshpk@1.18.0:
     dependencies:
@@ -7641,6 +8527,18 @@ snapshots:
       - bare-abort-controller
       - react-native-b4a
 
+  string-width@4.2.3:
+    dependencies:
+      emoji-regex: 8.0.0
+      is-fullwidth-code-point: 3.0.0
+      strip-ansi: 6.0.1
+
+  string-width@5.1.2:
+    dependencies:
+      eastasianwidth: 0.2.0
+      emoji-regex: 9.2.2
+      strip-ansi: 7.2.0
+
   string_decoder@1.1.1:
     dependencies:
       safe-buffer: 5.1.2
@@ -7657,6 +8555,10 @@ snapshots:
   strip-ansi@6.0.1:
     dependencies:
       ansi-regex: 5.0.1
+
+  strip-ansi@7.2.0:
+    dependencies:
+      ansi-regex: 6.2.2
 
   strip-bom-string@1.0.0: {}
 
@@ -7679,6 +8581,33 @@ snapshots:
 
   tapable@2.3.3: {}
 
+  tar-fs@2.1.5:
+    dependencies:
+      chownr: 1.1.4
+      mkdirp-classic: 0.5.3
+      pump: 3.0.4
+      tar-stream: 2.2.0
+
+  tar-fs@3.1.3:
+    dependencies:
+      pump: 3.0.4
+      tar-stream: 3.1.7
+    optionalDependencies:
+      bare-fs: 4.7.4
+      bare-path: 3.1.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - react-native-b4a
+
+  tar-stream@2.2.0:
+    dependencies:
+      bl: 4.1.0
+      end-of-stream: 1.4.5
+      fs-constants: 1.0.0
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+
   tar-stream@3.1.7:
     dependencies:
       b4a: 1.8.1
@@ -7688,7 +8617,38 @@ snapshots:
       - bare-abort-controller
       - react-native-b4a
 
+  teex@1.0.1:
+    dependencies:
+      streamx: 2.28.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+    optional: true
+
   term-size@2.2.1: {}
+
+  testcontainers@12.0.4:
+    dependencies:
+      '@balena/dockerignore': 1.0.2
+      '@types/dockerode': 4.0.1
+      archiver: 7.0.1
+      async-lock: 1.4.1
+      byline: 5.0.0
+      debug: 4.4.3
+      docker-compose: 1.4.2
+      dockerode: 5.0.1
+      get-port: 5.1.1
+      proper-lockfile: 4.1.2
+      properties-reader: 3.0.1
+      ssh-remote-port-forward: 1.0.4
+      tar-fs: 3.1.3
+      tmp: 0.2.7
+      undici: 8.7.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - react-native-b4a
+      - supports-color
 
   text-decoder@1.2.7:
     dependencies:
@@ -7723,6 +8683,8 @@ snapshots:
   tldts@6.1.86:
     dependencies:
       tldts-core: 6.1.86
+
+  tmp@0.2.7: {}
 
   to-regex-range@5.0.1:
     dependencies:
@@ -7787,9 +8749,13 @@ snapshots:
   uglify-js@3.19.3:
     optional: true
 
+  undici-types@5.26.5: {}
+
   undici-types@7.19.2: {}
 
   undici-types@8.3.0: {}
+
+  undici@8.7.0: {}
 
   unified@11.0.5:
     dependencies:
@@ -8006,13 +8972,45 @@ snapshots:
 
   wordwrap@1.0.0: {}
 
+  wrap-ansi@7.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
+  wrap-ansi@8.1.0:
+    dependencies:
+      ansi-styles: 6.2.3
+      string-width: 5.1.2
+      strip-ansi: 7.2.0
+
   wrappy@1.0.2: {}
 
   ws@8.21.0: {}
 
   xtend@4.0.2: {}
 
+  y18n@5.0.8: {}
+
   yaml@2.9.0: {}
+
+  yargs-parser@21.1.1: {}
+
+  yargs@17.7.3:
+    dependencies:
+      cliui: 8.0.1
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      string-width: 4.2.3
+      y18n: 5.0.8
+      yargs-parser: 21.1.1
+
+  zip-stream@6.0.1:
+    dependencies:
+      archiver-utils: 5.0.2
+      compress-commons: 6.0.2
+      readable-stream: 4.7.0
 
   zod-to-json-schema@3.25.2(zod@4.4.3):
     dependencies:


### PR DESCRIPTION
## Summary

Adds `@dawn-ai/memory-pgvector` — a production, multi-instance Postgres + pgvector `MemoryStore` backend. The default SQLite store stays the local-first default; reach for pgvector when many app instances share one memory store or a corpus outgrows linear cosine.

- **Retrieve in Postgres, rank in shared pure core.** The store does its own retrieval in SQL — an HNSW `<=>` cosine top-K vector list plus a token-matched keyword pool with live df/N — then ranks through the **same** pure `rankKeywordCandidates` / `fuseHybrid` core (`@dawn-ai/memory/hybrid.ts`) as the sqlite backend. A backend can only change where data lives and how it is retrieved, never how results are ranked, so **recall ordering is identical to sqlite**.
- **HNSW + cosine** index (`vector_cosine_ops`), created idempotently on first use.
- **Dimension branch:** dimensions ≤ 2000 use pgvector's `vector` type; larger (e.g. `text-embedding-3-large`'s 3072) use `halfvec`, up to a 4000 ceiling.
- **Shared conformance kit.** New `runMemoryStoreConformance` (`@dawn-ai/testing`) runs one `MemoryStore` contract against **both** backends — sqlite in-process on every run, and real pgvector in a gated Testcontainers lane (`DAWN_TEST_PGVECTOR=1`, `pgvector/pgvector:pg16`).
- **Gated real-Postgres CI lane** added (`pgvector-docker`), plus an `examples/memory` app as a continuous dogfood (switches to pgvector when `DATABASE_URL` is set, sqlite otherwise).
- **`openaiEmbedder` `encodingFormat: "float"` fix** (`@dawn-ai/langchain`) — avoids a base64 decode interop quirk that could yield wrong embedding dimensionality against some proxies/mocks.

Enable it:

```ts
import { pgvectorMemoryStore } from "@dawn-ai/memory-pgvector"

export default {
  memory: {
    store: pgvectorMemoryStore({ connectionString: process.env.DATABASE_URL, dimensions: 1536 }),
    vector: { embedder: openaiEmbedder() },
  },
}
```

## Proof

- Full validate (clean shell, no `.env`, no `DAWN_TEST_PGVECTOR`): lint 19/19, build 20/20, typecheck 21/21, **tests 1069 passed | 23 skipped (1092)** — the pgvector gated conformance/integration + doubly-gated live smoke all skip correctly.
- 19/19 gated real-Postgres conformance + integration pass locally against real `pgvector/pgvector:pg16` via Testcontainers.
- Doubly-gated (real OpenAI + real Postgres) paraphrase smoke recalled "faster shipping" from a "expedite delivery" query at 1536 dims, run locally against real pgvector.

## Release note

**New package `@dawn-ai/memory-pgvector` needs the OIDC new-package bootstrap at release** — bootstrap it manually **before** merging the Version PR (publish is fail-fast/alphabetical).

## Research

- Design spec: `docs/superpowers/specs/2026-07-07-pgvector-backend-design.md`
- Plan: `docs/superpowers/plans/2026-07-07-pgvector-backend.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)