### PR TITLE
ci(pgvector): fix broken pgvector-docker build ordering

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,8 +153,11 @@ jobs:
       - name: Install
         run: pnpm install --frozen-lockfile
 
-      - name: Build pgvector packages
-        run: pnpm --filter @dawn-ai/memory --filter @dawn-ai/testing --filter @dawn-ai/memory-pgvector build
+      - name: Build packages
+        # Full topological build — @dawn-ai/memory-pgvector (and @dawn-ai/testing)
+        # compile from source against @dawn-ai/cli/@dawn-ai/workspace etc., so a
+        # narrow per-package filter fails to build those deps first (TS2307).
+        run: pnpm build
 
       - name: Real-Postgres pgvector tests
         run: DAWN_TEST_PGVECTOR=1 pnpm --filter @dawn-ai/memory-pgvector test


### PR DESCRIPTION
## Fix the broken `pgvector-docker` CI lane

The `pgvector-docker` job (added by #318) fails on `main` — its build step
`pnpm --filter @dawn-ai/memory --filter @dawn-ai/testing --filter @dawn-ai/memory-pgvector build`
runs each package's own `tsc -b` **without** first building the workspace deps those packages import from source, so it dies with:

```
Cannot find module '@dawn-ai/cli/runtime' or its corresponding type declarations.
Cannot find module '@dawn-ai/workspace' or its corresponding type declarations.
```

(`@dawn-ai/testing` peer-deps `@dawn-ai/cli`, which pulls the rest of the graph.) This has left the default branch's CI red and every open PR showing `UNSTABLE`.

Fix: build the full workspace topologically (`pnpm build`), exactly as the `validate` lane does, so all deps are compiled before the `DAWN_TEST_PGVECTOR` test runs. CI-only change; no package/source/changeset impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
