### PR TITLE
feat(ag-ui): AG-UI protocol capability (@dawn-ai/ag-ui + /agui endpoint)

### DIFF
--- a/.changeset/ag-ui-capability.md
+++ b/.changeset/ag-ui-capability.md
@@ -1,0 +1,8 @@
+---
+"@dawn-ai/ag-ui": patch
+"@dawn-ai/cli": patch
+---
+
+Add `@dawn-ai/ag-ui`: translate Dawn's runtime stream to the AG-UI protocol and
+serve it at `POST /agui/{routeId}`, so CopilotKit and other AG-UI clients can
+drive Dawn agents. Additive — the existing Agent-Protocol endpoints are unchanged.

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -2,7 +2,7 @@
   "$schema": "https://unpkg.com/@changesets/config@3.1.1/schema.json",
   "changelog": "@changesets/cli/changelog",
   "commit": false,
-  "fixed": [["@dawn-ai/cli", "@dawn-ai/config-biome", "@dawn-ai/config-typescript", "@dawn-ai/core", "@dawn-ai/devkit", "@dawn-ai/evals", "@dawn-ai/langchain", "@dawn-ai/langgraph", "@dawn-ai/memory", "@dawn-ai/memory-pgvector", "@dawn-ai/permissions", "@dawn-ai/sdk", "@dawn-ai/sqlite-storage", "@dawn-ai/testing", "@dawn-ai/vite-plugin", "@dawn-ai/workspace", "create-dawn-ai-app"]],
+  "fixed": [["@dawn-ai/ag-ui", "@dawn-ai/cli", "@dawn-ai/config-biome", "@dawn-ai/config-typescript", "@dawn-ai/core", "@dawn-ai/devkit", "@dawn-ai/evals", "@dawn-ai/langchain", "@dawn-ai/langgraph", "@dawn-ai/memory", "@dawn-ai/memory-pgvector", "@dawn-ai/permissions", "@dawn-ai/sdk", "@dawn-ai/sqlite-storage", "@dawn-ai/testing", "@dawn-ai/vite-plugin", "@dawn-ai/workspace", "create-dawn-ai-app"]],
   "linked": [],
   "access": "public",
   "baseBranch": "main",

--- a/docs/superpowers/plans/2026-07-07-ag-ui-capability.md
+++ b/docs/superpowers/plans/2026-07-07-ag-ui-capability.md
@@ -1,0 +1,1209 @@
+# @dawn-ai/ag-ui Capability Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make Dawn a first-class AG-UI agent by adding a new `@dawn-ai/ag-ui` package that translates Dawn's runtime event stream into the AG-UI protocol, plus a new additive `POST /agui/{routeId}` endpoint on the dev server — without touching the existing Agent-Protocol endpoints or Dawn's core streaming.
+
+**Architecture:** A **pure, isolated translator** (`@dawn-ai/ag-ui`, deps only on `@ag-ui/core` + `@ag-ui/encoder`) maps `DawnStreamChunk`s → AG-UI events, ported from the canonical `@ag-ui/langgraph` mapping (snapshot-only state, IDs synthesized in-adapter). A thin **HTTP handler in `@dawn-ai/cli`** wires the translator to the existing `streamResolvedRoute` + thread/checkpoint machinery and mounts `/agui/{routeId}`. Conformance is proven against the real `@ag-ui/client` (`verifyEvents` + `HttpAgent`).
+
+**Tech Stack:** TypeScript (ESM, `tsc -b` composite build), Vitest, `@ag-ui/core`/`@ag-ui/encoder`/`@ag-ui/client` (pinned `0.0.57`), pnpm workspaces, Turbo.
+
+**Scope:** Sub-project 1 of the AG-UI + CopilotKit design (`docs/superpowers/specs/2026-07-07-ag-ui-copilotkit-ui-design.md`). This plan builds the framework capability only — no UI. The chat/research CopilotKit UIs are separate plans.
+
+**Working directory:** worktree `.claude/worktrees/zealous-goldberg-ab9dfc`, branch `blove/zealous-goldberg-ab9dfc`. All paths are repo-root-relative.
+
+---
+
+## Reference — exact signatures (verified against the tree / local checkouts)
+
+**Dawn runtime (from `@dawn-ai/cli`):**
+```ts
+// packages/cli/src/lib/runtime/stream-types.ts
+export type StreamChunk =
+  | { readonly type: "chunk"; readonly data: unknown }
+  | { readonly type: "tool_call"; readonly name: string; readonly input: unknown }
+  | { readonly type: "tool_result"; readonly name: string; readonly output: unknown }
+  | { readonly type: "done"; readonly output: unknown }
+  | { readonly type: string; readonly data: unknown }   // capability events: token, plan_update, interrupt, subagent.*
+
+// packages/cli/src/lib/runtime/execute-route.ts  (exported via "@dawn-ai/cli/runtime")
+export async function* streamResolvedRoute(options: {
+  readonly appRoot: string
+  readonly input: unknown
+  readonly resumeDecision?: "once" | "always" | "deny"
+  readonly middlewareContext?: Readonly<Record<string, unknown>>
+  readonly routeFile: string
+  readonly routeId: string
+  readonly routePath: string
+  readonly sandboxManager?: SandboxManager
+  readonly signal?: AbortSignal
+  readonly threadId?: string
+}): AsyncGenerator<StreamChunk>
+```
+Dawn capability chunk payloads (the `{type, data}` variant): `token` → `data` is the token string; `plan_update` → `data` is `{ todos: {content,status}[] }`; `interrupt` → `data` is `{ interruptId, type:"permission-request", kind, detail }`; `subagent.start|message|tool_call|tool_result|end` → `data` is `{ call_id, ... }`. `done` uses the named `output` field (`{ ...state }` or `{ error }`).
+
+**Runtime server seams (`packages/cli/src/lib/dev/runtime-server.ts`):** route entries are `{ method, pattern: RegExp, handle: (req,res,params)=>Promise<void> }` in `buildRouteTable`; helpers `readRequestBody(req): Promise<string>`, `sendJson(res, code, body)`; registry `registry.lookup(assistantId) => { routeId, routeFile, routePath, mode } | null`; idempotent thread `await threadsStore.getThread(id) ?? await threadsStore.createThread({ thread_id: id })`; in-process test entry `createRuntimeRequestListener({ appRoot }) => { listener, close }`.
+
+**AG-UI SDK (`@ag-ui/core` / `@ag-ui/encoder` / `@ag-ui/client`, all exported at package root):**
+```ts
+enum EventType { RUN_STARTED, RUN_FINISHED, RUN_ERROR, TEXT_MESSAGE_START, TEXT_MESSAGE_CONTENT,
+  TEXT_MESSAGE_END, TOOL_CALL_START, TOOL_CALL_ARGS, TOOL_CALL_END, TOOL_CALL_RESULT,
+  STATE_SNAPSHOT, CUSTOM, ... }  // string enum, values === member names
+type BaseEvent = { type: EventType; timestamp?: number; rawEvent?: any }
+// event fields: RUN_STARTED{threadId,runId}; RUN_FINISHED{threadId,runId,result?}; RUN_ERROR{message,code?}
+// TEXT_MESSAGE_START{messageId,role?}; TEXT_MESSAGE_CONTENT{messageId,delta /* NON-EMPTY */}; TEXT_MESSAGE_END{messageId}
+// TOOL_CALL_START{toolCallId,toolCallName,parentMessageId?}; TOOL_CALL_ARGS{toolCallId,delta}; TOOL_CALL_END{toolCallId}
+// TOOL_CALL_RESULT{messageId,toolCallId,content,role?:"tool"}; STATE_SNAPSHOT{snapshot}; CUSTOM{name,value}
+type RunAgentInput = { threadId:string; runId:string; state:any; messages:Message[]; tools:Tool[]; context:Context[]; forwardedProps:any }
+// @ag-ui/core also exports the zod schemas: RunAgentInputSchema, TextMessageStartEventSchema, ... (use for validation)
+class EventEncoder { constructor(p?:{accept?:string}); getContentType():string; encode(e:BaseEvent):string /* `data: ${JSON}\n\n` */ }
+class HttpAgent { constructor(c:{url:string; headers?:Record<string,string>; initialMessages?:Message[]}); run(input:RunAgentInput):Observable<BaseEvent>; runAgent(...):Promise<{result:any;newMessages:Message[]}> }
+const verifyEvents: (debug:boolean) => (src:Observable<BaseEvent>)=>Observable<BaseEvent>  // throws on ordering violations
+```
+NOTE: the local `~/repos/ag-ui` checkout is `0.0.47`; npm latest is `0.0.57`. Pin `0.0.57`. If any field differs in the installed types, trust the installed `.d.ts` and adjust — the TDD tests will surface mismatches.
+
+---
+
+## File Structure
+
+```
+packages/ag-ui/
+  package.json                # @dawn-ai/ag-ui; deps @ag-ui/core,@ag-ui/encoder; dev @ag-ui/client,rxjs
+  tsconfig.json               # extends ../config-typescript/node.json; composite; no references
+  vitest.config.ts            # node env, test/**/*.test.ts
+  src/
+    index.ts                  # public exports
+    types.ts                  # DawnStreamChunk (structural), AgUiEvent, TranslatorOptions
+    translate.ts              # createAgUiTranslator — the ported mapping (the risk, isolated)
+    run-input.ts              # mapRunInput: RunAgentInput -> { dawnInput, resumeDecision? }
+    encode.ts                 # encodeAgUiSse wrapper over EventEncoder
+  test/
+    translate-text-tools.test.ts   # text + tool-call mapping, schema-validated
+    translate-capabilities.test.ts # plan_update/subagent/interrupt/done mapping
+    run-input.test.ts
+    conformance.test.ts            # real @ag-ui/client HttpAgent + verifyEvents oracle
+
+packages/cli/
+  src/lib/dev/agui-handler.ts # NEW: handleAgUiRequest — wires translator to streamResolvedRoute
+  src/lib/dev/runtime-server.ts  # MODIFY: mount POST /agui/{routeId}
+  package.json                # MODIFY: add "@dawn-ai/ag-ui": "workspace:*"
+  tsconfig.build.json         # MODIFY: add { "path": "../ag-ui" } reference
+  test/agui-endpoint.test.ts  # NEW: in-process listener e2e (aimock, no key)
+
+Root:
+  vitest.workspace.ts         # MODIFY: add ./packages/ag-ui/vitest.config.ts
+  .changeset/config.json      # MODIFY: add @dawn-ai/ag-ui to fixed group
+  .changeset/ag-ui-capability.md  # NEW: changeset
+```
+
+---
+
+## Task 1: Scaffold `@dawn-ai/ag-ui` package + register it
+
+**Files:** Create `packages/ag-ui/{package.json,tsconfig.json,vitest.config.ts,src/index.ts}`; Modify `vitest.workspace.ts`, `.changeset/config.json`.
+
+- [ ] **Step 1: Create `packages/ag-ui/package.json`** (modeled on `packages/sandbox/package.json`; the `0.8.7` version matches the current release cohort):
+
+```json
+{
+  "name": "@dawn-ai/ag-ui",
+  "version": "0.8.7",
+  "private": false,
+  "type": "module",
+  "license": "MIT",
+  "homepage": "https://github.com/cacheplane/dawnai/tree/main/packages/ag-ui#readme",
+  "repository": { "type": "git", "url": "git+https://github.com/cacheplane/dawnai.git", "directory": "packages/ag-ui" },
+  "bugs": { "url": "https://github.com/cacheplane/dawnai/issues" },
+  "engines": { "node": ">=22.13.0" },
+  "files": ["dist"],
+  "types": "./dist/index.d.ts",
+  "exports": { ".": { "types": "./dist/index.d.ts", "default": "./dist/index.js" } },
+  "publishConfig": { "access": "public" },
+  "scripts": {
+    "build": "tsc -b tsconfig.json",
+    "lint": "biome check --config-path ../config-biome/biome.json package.json src tsconfig.json vitest.config.ts",
+    "test": "vitest --run --config vitest.config.ts --passWithNoTests",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@ag-ui/core": "0.0.57",
+    "@ag-ui/encoder": "0.0.57"
+  },
+  "devDependencies": {
+    "@ag-ui/client": "0.0.57",
+    "@dawn-ai/config-typescript": "workspace:*",
+    "@types/node": "26.1.0",
+    "rxjs": "7.8.1"
+  }
+}
+```
+
+- [ ] **Step 2: Create `packages/ag-ui/tsconfig.json`** (no `references` — this package depends on no other `@dawn-ai` package):
+
+```json
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "../config-typescript/node.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo"
+  },
+  "include": ["src/**/*.ts"]
+}
+```
+
+- [ ] **Step 3: Create `packages/ag-ui/vitest.config.ts`:**
+
+```ts
+import { defineConfig } from "vitest/config"
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["test/**/*.test.ts"],
+    passWithNoTests: true,
+  },
+})
+```
+
+- [ ] **Step 4: Create a stub `packages/ag-ui/src/index.ts`** so the package builds:
+
+```ts
+export {}
+```
+
+- [ ] **Step 5: Register in the root vitest workspace.** In `vitest.workspace.ts`, add the line after `"./examples/chat/server/vitest.config.ts",` and before/after research to keep the packages grouped — insert immediately after the `"./apps/web/vitest.config.ts",` group in alphabetical position, i.e. add:
+
+```ts
+      "./packages/ag-ui/vitest.config.ts",
+```
+as the FIRST entry of the `./packages/*` block (before `"./packages/cli/vitest.config.ts",`).
+
+- [ ] **Step 6: Add to the changeset fixed group.** In `.changeset/config.json`, add `"@dawn-ai/ag-ui"` as the FIRST element of the `fixed[0]` array (before `"@dawn-ai/cli"`), keeping the array otherwise unchanged.
+
+- [ ] **Step 7: Install + build + typecheck**
+
+Run: `pnpm install`
+Then: `pnpm --filter @dawn-ai/ag-ui build && pnpm --filter @dawn-ai/ag-ui typecheck`
+Expected: `pnpm install` resolves `@ag-ui/core@0.0.57`, `@ag-ui/encoder@0.0.57`, `@ag-ui/client@0.0.57`, `rxjs@7.8.1`; build + typecheck exit 0.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add packages/ag-ui vitest.workspace.ts .changeset/config.json pnpm-lock.yaml
+git commit -m "feat(ag-ui): scaffold @dawn-ai/ag-ui package
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Structural types (`types.ts`)
+
+**Files:** Create `packages/ag-ui/src/types.ts`; Test: none (types only, exercised by later tasks).
+
+- [ ] **Step 1: Write `packages/ag-ui/src/types.ts`.** This defines the loose structural shape of a Dawn stream chunk (so the package never imports `@dawn-ai/cli`) and re-exports the AG-UI event union alias:
+
+```ts
+import type { BaseEvent } from "@ag-ui/core"
+
+/** An AG-UI protocol event. Alias kept local so consumers import one name. */
+export type AgUiEvent = BaseEvent
+
+/**
+ * Structural mirror of `@dawn-ai/cli`'s `StreamChunk`. Kept loose (all fields
+ * optional beyond `type`) so this package has ZERO dependency on the CLI. The
+ * translator inspects fields at runtime by `type`.
+ */
+export interface DawnStreamChunk {
+  readonly type: string
+  readonly data?: unknown
+  readonly name?: string
+  readonly input?: unknown
+  readonly output?: unknown
+}
+
+export interface TranslatorOptions {
+  readonly threadId: string
+  readonly runId: string
+}
+```
+
+- [ ] **Step 2: Typecheck**
+
+Run: `pnpm --filter @dawn-ai/ag-ui typecheck`
+Expected: exit 0.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/ag-ui/src/types.ts
+git commit -m "feat(ag-ui): structural DawnStreamChunk + AgUiEvent types
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Translator — text + tool calls + lifecycle (`translate.ts`)
+
+Ported from `~/repos/ag-ui/integrations/langgraph/typescript/src/agent.ts` `handleSingleEvent` (non-streaming branch). The translator is a stateful factory: `begin()` emits `RUN_STARTED`; `translate(chunk)` emits events per chunk; it synthesizes message/tool IDs and pairs tool results FIFO-by-name. **Rule: flush any open text message (`TEXT_MESSAGE_END`) before emitting any non-text event** (keeps the stream `verifyEvents`-clean).
+
+**Files:** Create `packages/ag-ui/src/translate.ts`; Test: `packages/ag-ui/test/translate-text-tools.test.ts`.
+
+- [ ] **Step 1: Write the failing test** `packages/ag-ui/test/translate-text-tools.test.ts`:
+
+```ts
+import { EventType } from "@ag-ui/core"
+import {
+  RunStartedEventSchema,
+  TextMessageStartEventSchema,
+  TextMessageContentEventSchema,
+  TextMessageEndEventSchema,
+  ToolCallStartEventSchema,
+  ToolCallArgsEventSchema,
+  ToolCallEndEventSchema,
+  ToolCallResultEventSchema,
+  RunFinishedEventSchema,
+} from "@ag-ui/core"
+import { describe, expect, it } from "vitest"
+import { createAgUiTranslator } from "../src/translate.js"
+import type { AgUiEvent } from "../src/types.js"
+
+const opts = { threadId: "t1", runId: "r1" }
+const types = (evs: AgUiEvent[]) => evs.map((e) => e.type)
+
+describe("translator: lifecycle + text + tools", () => {
+  it("begin() emits a valid RUN_STARTED", () => {
+    const t = createAgUiTranslator(opts)
+    const evs = t.begin()
+    expect(types(evs)).toEqual([EventType.RUN_STARTED])
+    expect(() => RunStartedEventSchema.parse(evs[0])).not.toThrow()
+  })
+
+  it("maps a token run to START/CONTENT+/END and validates each event", () => {
+    const t = createAgUiTranslator(opts)
+    const evs = [
+      ...t.translate({ type: "token", data: "Hello" }),
+      ...t.translate({ type: "token", data: " world" }),
+      ...t.translate({ type: "done", output: { messages: [] } }),
+    ]
+    expect(types(evs)).toEqual([
+      EventType.TEXT_MESSAGE_START,
+      EventType.TEXT_MESSAGE_CONTENT,
+      EventType.TEXT_MESSAGE_CONTENT,
+      EventType.TEXT_MESSAGE_END,
+      EventType.RUN_FINISHED,
+    ])
+    TextMessageStartEventSchema.parse(evs[0])
+    TextMessageContentEventSchema.parse(evs[1])
+    TextMessageContentEventSchema.parse(evs[2])
+    TextMessageEndEventSchema.parse(evs[3])
+    RunFinishedEventSchema.parse(evs[4])
+    // same synthesized messageId across the message
+    const mid = (evs[0] as { messageId: string }).messageId
+    expect((evs[1] as { messageId: string }).messageId).toBe(mid)
+    expect((evs[3] as { messageId: string }).messageId).toBe(mid)
+  })
+
+  it("skips empty token deltas (schema forbids empty content)", () => {
+    const t = createAgUiTranslator(opts)
+    const evs = t.translate({ type: "token", data: "" })
+    expect(evs).toEqual([])
+  })
+
+  it("maps tool_call to START/ARGS/END and pairs tool_result by FIFO", () => {
+    const t = createAgUiTranslator(opts)
+    const evs = [
+      ...t.translate({ type: "tool_call", name: "searchCorpus", input: { query: "x" } }),
+      ...t.translate({ type: "tool_result", name: "searchCorpus", output: [{ path: "corpus/a.md" }] }),
+    ]
+    expect(types(evs)).toEqual([
+      EventType.TOOL_CALL_START,
+      EventType.TOOL_CALL_ARGS,
+      EventType.TOOL_CALL_END,
+      EventType.TOOL_CALL_RESULT,
+    ])
+    ToolCallStartEventSchema.parse(evs[0])
+    ToolCallArgsEventSchema.parse(evs[1])
+    ToolCallEndEventSchema.parse(evs[2])
+    ToolCallResultEventSchema.parse(evs[3])
+    const id = (evs[0] as { toolCallId: string }).toolCallId
+    expect((evs[1] as { toolCallId: string }).toolCallId).toBe(id)
+    expect((evs[3] as { toolCallId: string }).toolCallId).toBe(id)
+    expect((evs[1] as { delta: string }).delta).toBe(JSON.stringify({ query: "x" }))
+  })
+
+  it("flushes an open text message before a tool_call", () => {
+    const t = createAgUiTranslator(opts)
+    const evs = [
+      ...t.translate({ type: "token", data: "thinking" }),
+      ...t.translate({ type: "tool_call", name: "readDoc", input: { path: "corpus/a.md" } }),
+    ]
+    expect(types(evs)).toEqual([
+      EventType.TEXT_MESSAGE_START,
+      EventType.TEXT_MESSAGE_CONTENT,
+      EventType.TEXT_MESSAGE_END,
+      EventType.TOOL_CALL_START,
+      EventType.TOOL_CALL_ARGS,
+      EventType.TOOL_CALL_END,
+    ])
+  })
+
+  it("maps a done error to RUN_ERROR", () => {
+    const t = createAgUiTranslator(opts)
+    const evs = t.translate({ type: "done", output: { error: "boom" } })
+    expect(types(evs)).toEqual([EventType.RUN_ERROR])
+    expect((evs[0] as { message: string }).message).toBe("boom")
+  })
+})
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `pnpm --filter @dawn-ai/ag-ui test`
+Expected: FAIL — `createAgUiTranslator` not found.
+
+- [ ] **Step 3: Write `packages/ag-ui/src/translate.ts`:**
+
+```ts
+import { EventType } from "@ag-ui/core"
+import type { AgUiEvent, DawnStreamChunk, TranslatorOptions } from "./types.js"
+
+let counter = 0
+/** Deterministic-per-process id (no Math.random/Date — safe for tests). */
+function nextId(prefix: string): string {
+  counter += 1
+  return `${prefix}_${counter}`
+}
+
+export interface AgUiTranslator {
+  /** Emit RUN_STARTED. Call once before feeding chunks. */
+  begin(): AgUiEvent[]
+  /** Translate one Dawn chunk into zero or more AG-UI events. */
+  translate(chunk: DawnStreamChunk): AgUiEvent[]
+  /** Emit a terminal RUN_FINISHED if the stream ended without a `done` chunk. */
+  end(): AgUiEvent[]
+}
+
+export function createAgUiTranslator(options: TranslatorOptions): AgUiTranslator {
+  const { threadId, runId } = options
+  let activeTextId: string | null = null
+  // FIFO of synthesized tool-call ids per tool name, to pair results to calls.
+  const pendingToolCalls = new Map<string, string[]>()
+  let finished = false
+
+  function flushText(): AgUiEvent[] {
+    if (activeTextId === null) return []
+    const id = activeTextId
+    activeTextId = null
+    return [{ type: EventType.TEXT_MESSAGE_END, messageId: id }]
+  }
+
+  function toText(chunk: DawnStreamChunk): AgUiEvent[] {
+    const text = typeof chunk.data === "string" ? chunk.data : String(chunk.data ?? "")
+    if (text.length === 0) return []
+    const out: AgUiEvent[] = []
+    if (activeTextId === null) {
+      activeTextId = nextId("msg")
+      out.push({ type: EventType.TEXT_MESSAGE_START, messageId: activeTextId, role: "assistant" })
+    }
+    out.push({ type: EventType.TEXT_MESSAGE_CONTENT, messageId: activeTextId, delta: text })
+    return out
+  }
+
+  function toToolCall(chunk: DawnStreamChunk): AgUiEvent[] {
+    const name = chunk.name ?? "tool"
+    const toolCallId = nextId("call")
+    const queue = pendingToolCalls.get(name) ?? []
+    queue.push(toolCallId)
+    pendingToolCalls.set(name, queue)
+    return [
+      ...flushText(),
+      { type: EventType.TOOL_CALL_START, toolCallId, toolCallName: name },
+      { type: EventType.TOOL_CALL_ARGS, toolCallId, delta: JSON.stringify(chunk.input ?? {}) },
+      { type: EventType.TOOL_CALL_END, toolCallId },
+    ]
+  }
+
+  function toToolResult(chunk: DawnStreamChunk): AgUiEvent[] {
+    const name = chunk.name ?? "tool"
+    const queue = pendingToolCalls.get(name) ?? []
+    const toolCallId = queue.shift() ?? nextId("call")
+    pendingToolCalls.set(name, queue)
+    const content =
+      typeof chunk.output === "string" ? chunk.output : JSON.stringify(chunk.output ?? null)
+    return [
+      ...flushText(),
+      {
+        type: EventType.TOOL_CALL_RESULT,
+        messageId: nextId("msg"),
+        toolCallId,
+        content,
+        role: "tool",
+      },
+    ]
+  }
+
+  function toDone(chunk: DawnStreamChunk): AgUiEvent[] {
+    finished = true
+    const out = flushText()
+    const output = chunk.output
+    if (output && typeof output === "object" && "error" in output) {
+      out.push({
+        type: EventType.RUN_ERROR,
+        message: String((output as { error: unknown }).error),
+      })
+      return out
+    }
+    out.push({ type: EventType.RUN_FINISHED, threadId, runId, result: output })
+    return out
+  }
+
+  return {
+    begin() {
+      return [{ type: EventType.RUN_STARTED, threadId, runId }]
+    },
+    translate(chunk) {
+      switch (chunk.type) {
+        case "token":
+        case "chunk":
+          return toText(chunk)
+        case "tool_call":
+          return toToolCall(chunk)
+        case "tool_result":
+          return toToolResult(chunk)
+        case "done":
+          return toDone(chunk)
+        default:
+          // Capability events (plan_update / subagent.* / interrupt) — Task 4.
+          return flushText()
+      }
+    },
+    end() {
+      if (finished) return []
+      finished = true
+      return [...flushText(), { type: EventType.RUN_FINISHED, threadId, runId }]
+    },
+  }
+}
+```
+
+- [ ] **Step 4: Export it.** In `packages/ag-ui/src/index.ts`:
+
+```ts
+export { createAgUiTranslator, type AgUiTranslator } from "./translate.js"
+export type { AgUiEvent, DawnStreamChunk, TranslatorOptions } from "./types.js"
+```
+
+- [ ] **Step 5: Run to verify it passes**
+
+Run: `pnpm --filter @dawn-ai/ag-ui test`
+Expected: PASS — all cases in `translate-text-tools.test.ts` green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/ag-ui/src/translate.ts packages/ag-ui/src/index.ts packages/ag-ui/test/translate-text-tools.test.ts
+git commit -m "feat(ag-ui): translator for text, tool calls, and run lifecycle
+
+Ported from @ag-ui/langgraph handleSingleEvent (non-streaming branch).
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Translator — capability events (state, subagents, interrupts)
+
+Extends the `default` branch: `plan_update` → accumulated `STATE_SNAPSHOT`; `subagent.*` → `CUSTOM{name:"dawn.<type>"}`; `interrupt` → `CUSTOM{name:"on_interrupt"}` (matches the reference + shipping CopilotKit `useLangGraphInterrupt`/`useInterrupt`).
+
+**Files:** Modify `packages/ag-ui/src/translate.ts`; Test: `packages/ag-ui/test/translate-capabilities.test.ts`.
+
+- [ ] **Step 1: Write the failing test** `packages/ag-ui/test/translate-capabilities.test.ts`:
+
+```ts
+import { EventType, StateSnapshotEventSchema, CustomEventSchema } from "@ag-ui/core"
+import { describe, expect, it } from "vitest"
+import { createAgUiTranslator } from "../src/translate.js"
+import type { AgUiEvent } from "../src/types.js"
+
+const opts = { threadId: "t1", runId: "r1" }
+const type1 = (evs: AgUiEvent[]) => evs[0]?.type
+
+describe("translator: capability events", () => {
+  it("maps plan_update to a STATE_SNAPSHOT carrying todos", () => {
+    const t = createAgUiTranslator(opts)
+    const todos = [{ content: "search", status: "pending" }]
+    const evs = t.translate({ type: "plan_update", data: { todos } })
+    expect(type1(evs)).toBe(EventType.STATE_SNAPSHOT)
+    const parsed = StateSnapshotEventSchema.parse(evs[0])
+    expect((parsed.snapshot as { todos: unknown }).todos).toEqual(todos)
+  })
+
+  it("accumulates state across snapshots", () => {
+    const t = createAgUiTranslator(opts)
+    t.translate({ type: "plan_update", data: { todos: [{ content: "a", status: "pending" }] } })
+    const evs = t.translate({ type: "report_update", data: { report: "hello" } })
+    // unknown capability with a `data` object is merged into state as well
+    const snap = (evs.find((e) => e.type === EventType.STATE_SNAPSHOT) as { snapshot: Record<string, unknown> } | undefined)
+    expect(snap?.snapshot.todos).toBeDefined()
+    expect(snap?.snapshot.report).toBe("hello")
+  })
+
+  it("maps subagent events to CUSTOM dawn.<type>", () => {
+    const t = createAgUiTranslator(opts)
+    const evs = t.translate({ type: "subagent.start", data: { call_id: "c1", subagent: "researcher" } })
+    expect(type1(evs)).toBe(EventType.CUSTOM)
+    const parsed = CustomEventSchema.parse(evs[0])
+    expect(parsed.name).toBe("dawn.subagent.start")
+    expect((parsed.value as { call_id: string }).call_id).toBe("c1")
+  })
+
+  it("maps interrupt to CUSTOM on_interrupt", () => {
+    const t = createAgUiTranslator(opts)
+    const detail = { command: "node scripts/fetch-source.mjs x", suggestedPattern: "node scripts" }
+    const evs = t.translate({
+      type: "interrupt",
+      data: { interruptId: "perm-1", type: "permission-request", kind: "command", detail },
+    })
+    expect(type1(evs)).toBe(EventType.CUSTOM)
+    const parsed = CustomEventSchema.parse(evs[0])
+    expect(parsed.name).toBe("on_interrupt")
+    expect((parsed.value as { interruptId: string }).interruptId).toBe("perm-1")
+    expect((parsed.value as { kind: string }).kind).toBe("command")
+  })
+
+  it("flushes open text before a capability event", () => {
+    const t = createAgUiTranslator(opts)
+    const evs = [
+      ...t.translate({ type: "token", data: "hi" }),
+      ...t.translate({ type: "subagent.start", data: { call_id: "c1" } }),
+    ]
+    expect(evs.map((e) => e.type)).toEqual([
+      EventType.TEXT_MESSAGE_START,
+      EventType.TEXT_MESSAGE_CONTENT,
+      EventType.TEXT_MESSAGE_END,
+      EventType.CUSTOM,
+    ])
+  })
+})
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `pnpm --filter @dawn-ai/ag-ui test test/translate-capabilities.test.ts`
+Expected: FAIL — capability events currently only flush text (no STATE_SNAPSHOT/CUSTOM).
+
+- [ ] **Step 3: Implement.** In `packages/ag-ui/src/translate.ts`, add an accumulated-state field and replace the `default` branch. Add near the other `let` declarations:
+
+```ts
+  let state: Record<string, unknown> = {}
+```
+
+Replace the `default:` case in `translate` with:
+
+```ts
+        case "plan_update": {
+          const flushed = flushText()
+          const data = (chunk.data ?? {}) as Record<string, unknown>
+          state = { ...state, ...data }
+          return [...flushed, { type: EventType.STATE_SNAPSHOT, snapshot: state }]
+        }
+        case "interrupt": {
+          return [
+            ...flushText(),
+            { type: EventType.CUSTOM, name: "on_interrupt", value: chunk.data ?? {} },
+          ]
+        }
+        default: {
+          const flushed = flushText()
+          if (chunk.type.startsWith("subagent.")) {
+            return [
+              ...flushed,
+              { type: EventType.CUSTOM, name: `dawn.${chunk.type}`, value: chunk.data ?? {} },
+            ]
+          }
+          // Other capability events with an object `data` merge into state.
+          if (chunk.data && typeof chunk.data === "object") {
+            state = { ...state, ...(chunk.data as Record<string, unknown>) }
+            return [...flushed, { type: EventType.STATE_SNAPSHOT, snapshot: state }]
+          }
+          return flushed
+        }
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `pnpm --filter @dawn-ai/ag-ui test`
+Expected: PASS — both translate test files green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/ag-ui/src/translate.ts packages/ag-ui/test/translate-capabilities.test.ts
+git commit -m "feat(ag-ui): map plan_update/subagent/interrupt capability events
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: RunAgentInput → Dawn run mapping (`run-input.ts`)
+
+**Files:** Create `packages/ag-ui/src/run-input.ts`; Test: `packages/ag-ui/test/run-input.test.ts`.
+
+- [ ] **Step 1: Write the failing test** `packages/ag-ui/test/run-input.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest"
+import { mapRunInput } from "../src/run-input.js"
+
+const base = { threadId: "t", runId: "r", state: {}, messages: [], tools: [], context: [], forwardedProps: {} }
+
+describe("mapRunInput", () => {
+  it("extracts the last user message as the Dawn input", () => {
+    const result = mapRunInput({
+      ...base,
+      messages: [
+        { id: "1", role: "user", content: "old" },
+        { id: "2", role: "assistant", content: "hi" },
+        { id: "3", role: "user", content: "new question" },
+      ],
+    } as never)
+    expect(result.resumeDecision).toBeUndefined()
+    expect(result.dawnInput).toEqual({ messages: [{ role: "user", content: "new question" }] })
+  })
+
+  it("decodes a resume decision from forwardedProps.command.resume", () => {
+    const result = mapRunInput({
+      ...base,
+      forwardedProps: { command: { resume: { interruptId: "perm-1", decision: "once" } } },
+    } as never)
+    expect(result.resumeDecision).toBe("once")
+    expect(result.interruptId).toBe("perm-1")
+  })
+
+  it("accepts a bare string decision", () => {
+    const result = mapRunInput({
+      ...base,
+      forwardedProps: { command: { resume: "deny" } },
+    } as never)
+    expect(result.resumeDecision).toBe("deny")
+  })
+
+  it("falls back to empty messages when no user message exists", () => {
+    const result = mapRunInput(base as never)
+    expect(result.dawnInput).toEqual({ messages: [] })
+  })
+})
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `pnpm --filter @dawn-ai/ag-ui test test/run-input.test.ts`
+Expected: FAIL — `mapRunInput` not found.
+
+- [ ] **Step 3: Write `packages/ag-ui/src/run-input.ts`:**
+
+```ts
+import type { RunAgentInput } from "@ag-ui/core"
+
+export type ResumeDecision = "once" | "always" | "deny"
+
+export interface MappedRunInput {
+  readonly dawnInput: { readonly messages: ReadonlyArray<{ role: string; content: string }> }
+  readonly resumeDecision?: ResumeDecision
+  readonly interruptId?: string
+}
+
+function coerceDecision(value: unknown): ResumeDecision | undefined {
+  if (value === "once" || value === "always" || value === "deny") return value
+  return undefined
+}
+
+/**
+ * Map an AG-UI RunAgentInput onto a Dawn run. HITL resume rides on
+ * forwardedProps.command.resume (the @ag-ui/langgraph convention); otherwise
+ * the newest user message becomes the turn's input (Dawn keeps history in its
+ * checkpoint keyed by threadId).
+ */
+export function mapRunInput(input: RunAgentInput): MappedRunInput {
+  const resume = (input.forwardedProps as { command?: { resume?: unknown } } | undefined)?.command
+    ?.resume
+  if (resume !== undefined) {
+    if (typeof resume === "string") {
+      const decision = coerceDecision(resume)
+      return decision ? { dawnInput: { messages: [] }, resumeDecision: decision } : { dawnInput: { messages: [] } }
+    }
+    if (resume && typeof resume === "object") {
+      const r = resume as { decision?: unknown; interruptId?: unknown }
+      const decision = coerceDecision(r.decision)
+      const interruptId = typeof r.interruptId === "string" ? r.interruptId : undefined
+      return {
+        dawnInput: { messages: [] },
+        ...(decision ? { resumeDecision: decision } : {}),
+        ...(interruptId ? { interruptId } : {}),
+      }
+    }
+  }
+
+  const lastUser = [...input.messages].reverse().find((m) => m.role === "user")
+  const content =
+    lastUser && typeof lastUser.content === "string" ? lastUser.content : lastUser ? "" : undefined
+  return {
+    dawnInput: { messages: content === undefined ? [] : [{ role: "user", content }] },
+  }
+}
+```
+
+- [ ] **Step 4: Export it.** Append to `packages/ag-ui/src/index.ts`:
+
+```ts
+export { mapRunInput, type MappedRunInput, type ResumeDecision } from "./run-input.js"
+```
+
+- [ ] **Step 5: Run to verify it passes**
+
+Run: `pnpm --filter @dawn-ai/ag-ui test`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/ag-ui/src/run-input.ts packages/ag-ui/src/index.ts packages/ag-ui/test/run-input.test.ts
+git commit -m "feat(ag-ui): map RunAgentInput to a Dawn run (+ resume decoding)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: SSE encode helper + conformance test against `@ag-ui/client`
+
+The big de-risker: stand up a real `node:http` server that serves translated **canned** Dawn chunks, drive it with `@ag-ui/client`'s `HttpAgent`, and run the stream through the exported `verifyEvents` oracle. No model, no CLI — proves translate + encode + client-parse + ordering end to end.
+
+**Files:** Create `packages/ag-ui/src/encode.ts`; Test: `packages/ag-ui/test/conformance.test.ts`.
+
+- [ ] **Step 1: Write `packages/ag-ui/src/encode.ts`:**
+
+```ts
+import { EventEncoder } from "@ag-ui/encoder"
+import type { AgUiEvent } from "./types.js"
+
+/** Encode one AG-UI event as an SSE frame (`data: <json>\n\n`). */
+export function encodeAgUiSse(event: AgUiEvent, accept?: string): string {
+  const encoder = new EventEncoder(accept ? { accept } : {})
+  return encoder.encode(event)
+}
+```
+
+Append to `packages/ag-ui/src/index.ts`:
+
+```ts
+export { encodeAgUiSse } from "./encode.js"
+```
+
+- [ ] **Step 2: Write the failing conformance test** `packages/ag-ui/test/conformance.test.ts`:
+
+```ts
+import { createServer, type Server } from "node:http"
+import { AddressInfo } from "node:net"
+import { EventType } from "@ag-ui/core"
+import { HttpAgent } from "@ag-ui/client"
+import { verifyEvents } from "@ag-ui/client"
+import { lastValueFrom, toArray } from "rxjs"
+import { afterEach, expect, it } from "vitest"
+import { createAgUiTranslator } from "../src/translate.js"
+import { encodeAgUiSse } from "../src/encode.js"
+import type { DawnStreamChunk } from "../src/types.js"
+
+let server: Server | undefined
+afterEach(() => server?.close())
+
+// A canned Dawn run exercising every mapping branch.
+const CANNED: DawnStreamChunk[] = [
+  { type: "token", data: "Researching" },
+  { type: "tool_call", name: "searchCorpus", input: { query: "agents" } },
+  { type: "tool_result", name: "searchCorpus", output: [{ path: "corpus/a.md" }] },
+  { type: "plan_update", data: { todos: [{ content: "search", status: "completed" }] } },
+  { type: "subagent.start", data: { call_id: "c1", subagent: "researcher" } },
+  { type: "token", data: " done. [corpus/a.md]" },
+  { type: "done", output: { messages: [] } },
+]
+
+async function startCannedServer(): Promise<string> {
+  server = createServer((req, res) => {
+    // Consume the RunAgentInput body (required by HttpAgent POST).
+    req.resume()
+    res.writeHead(200, { "content-type": "text/event-stream", "cache-control": "no-cache" })
+    const t = createAgUiTranslator({ threadId: "t1", runId: "r1" })
+    for (const e of t.begin()) res.write(encodeAgUiSse(e))
+    for (const chunk of CANNED) for (const e of t.translate(chunk)) res.write(encodeAgUiSse(e))
+    for (const e of t.end()) res.write(encodeAgUiSse(e))
+    res.end()
+  })
+  await new Promise<void>((resolve) => server!.listen(0, "127.0.0.1", resolve))
+  const { port } = server!.address() as AddressInfo
+  return `http://127.0.0.1:${port}`
+}
+
+it("produces an AG-UI stream that @ag-ui/client parses and verifyEvents accepts", async () => {
+  const url = await startCannedServer()
+  const agent = new HttpAgent({ url })
+  const input = {
+    threadId: "t1",
+    runId: "r1",
+    state: {},
+    messages: [{ id: "1", role: "user", content: "research agents" }],
+    tools: [],
+    context: [],
+    forwardedProps: {},
+  }
+  // verifyEvents throws on any ordering/schema violation — the oracle.
+  const events = await lastValueFrom(agent.run(input as never).pipe(verifyEvents(false), toArray()))
+  const kinds = events.map((e) => e.type)
+  expect(kinds[0]).toBe(EventType.RUN_STARTED)
+  expect(kinds).toContain(EventType.TOOL_CALL_START)
+  expect(kinds).toContain(EventType.TOOL_CALL_RESULT)
+  expect(kinds).toContain(EventType.STATE_SNAPSHOT)
+  expect(kinds).toContain(EventType.CUSTOM)
+  expect(kinds[kinds.length - 1]).toBe(EventType.RUN_FINISHED)
+})
+```
+
+- [ ] **Step 3: Run to verify it fails**
+
+Run: `pnpm --filter @dawn-ai/ag-ui test test/conformance.test.ts`
+Expected: FAIL first because `encode.ts` is new / imports unresolved, then (once compiling) it must PASS. If `agent.run(...)` has a different signature in the installed `@ag-ui/client@0.0.57`, adapt the call to the installed `.d.ts` (e.g. `agent.runAgent()` returning `{ newMessages }`), keeping the intent: consume the stream through `verifyEvents` and assert the event kinds. Document any adaptation in the commit body.
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `pnpm --filter @dawn-ai/ag-ui test`
+Expected: PASS — all four test files green, including the `verifyEvents` conformance oracle.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/ag-ui/src/encode.ts packages/ag-ui/src/index.ts packages/ag-ui/test/conformance.test.ts
+git commit -m "test(ag-ui): conformance via real @ag-ui/client HttpAgent + verifyEvents
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7: CLI — the `/agui/{routeId}` handler
+
+**Files:** Modify `packages/cli/package.json`, `packages/cli/tsconfig.build.json`; Create `packages/cli/src/lib/dev/agui-handler.ts`; Modify `packages/cli/src/lib/dev/runtime-server.ts`.
+
+- [ ] **Step 1: Add the dependency + project reference.**
+
+In `packages/cli/package.json`, add to `dependencies` (alphabetically): `"@dawn-ai/ag-ui": "workspace:*"`.
+In `packages/cli/tsconfig.build.json`, add `{ "path": "../ag-ui" }` to the `references` array.
+Run: `pnpm install`
+Expected: links `@dawn-ai/ag-ui` into the CLI.
+
+- [ ] **Step 2: Create `packages/cli/src/lib/dev/agui-handler.ts`.** This mirrors `handleApStreamRequest`'s thread/stream shape but emits AG-UI. It reuses the closure deps the route table already has.
+
+```ts
+import type { IncomingMessage, ServerResponse } from "node:http"
+import { RunAgentInputSchema } from "@ag-ui/core"
+import { createAgUiTranslator, encodeAgUiSse, mapRunInput } from "@dawn-ai/ag-ui"
+import { streamResolvedRoute } from "../runtime/execute-route.js"
+import type { RuntimeRegistry } from "./runtime-registry.js"
+import type { SandboxManager } from "../sandbox/sandbox-manager.js"
+import type { ThreadsStore } from "@dawn-ai/sqlite-storage"
+
+interface AgUiRequestOptions {
+  readonly appRoot: string
+  readonly registry: RuntimeRegistry
+  readonly threadsStore: ThreadsStore
+  readonly sandboxManager?: SandboxManager
+  readonly signal: AbortSignal
+  readonly request: IncomingMessage
+  readonly response: ServerResponse
+  readonly routeKey: string
+}
+
+async function readBody(request: IncomingMessage): Promise<string> {
+  const chunks: Buffer[] = []
+  for await (const chunk of request) chunks.push(typeof chunk === "string" ? Buffer.from(chunk) : chunk)
+  return Buffer.concat(chunks).toString("utf8")
+}
+
+export async function handleAgUiRequest(options: AgUiRequestOptions): Promise<void> {
+  const { appRoot, registry, threadsStore, sandboxManager, signal, request, response, routeKey } =
+    options
+
+  const raw = await readBody(request)
+  let parsedJson: unknown
+  try {
+    parsedJson = JSON.parse(raw)
+  } catch {
+    response.statusCode = 400
+    response.setHeader("content-type", "application/json")
+    response.end(JSON.stringify({ error: { kind: "request_error", message: "Malformed body" } }))
+    return
+  }
+  const parsed = RunAgentInputSchema.safeParse(parsedJson)
+  if (!parsed.success) {
+    response.statusCode = 400
+    response.setHeader("content-type", "application/json")
+    response.end(JSON.stringify({ error: { kind: "request_error", message: "Invalid RunAgentInput" } }))
+    return
+  }
+  const input = parsed.data
+
+  const route = registry.lookup(routeKey)
+  if (!route) {
+    response.statusCode = 404
+    response.setHeader("content-type", "application/json")
+    response.end(JSON.stringify({ error: { kind: "request_error", message: `Unknown route: ${routeKey}` } }))
+    return
+  }
+
+  const threadId = input.threadId
+  const existing = await threadsStore.getThread(threadId)
+  if (!existing) await threadsStore.createThread({ thread_id: threadId })
+
+  const { dawnInput, resumeDecision } = mapRunInput(input)
+  const translator = createAgUiTranslator({ threadId, runId: input.runId })
+
+  response.writeHead(200, {
+    "cache-control": "no-cache",
+    connection: "keep-alive",
+    "content-type": "text/event-stream",
+  })
+  for (const e of translator.begin()) response.write(encodeAgUiSse(e))
+
+  try {
+    for await (const chunk of streamResolvedRoute({
+      appRoot,
+      input: dawnInput,
+      ...(resumeDecision ? { resumeDecision } : {}),
+      routeFile: route.routeFile,
+      routeId: route.routeId,
+      routePath: route.routePath,
+      ...(sandboxManager ? { sandboxManager } : {}),
+      signal,
+      threadId,
+    })) {
+      for (const e of translator.translate(chunk)) response.write(encodeAgUiSse(e))
+    }
+    for (const e of translator.end()) response.write(encodeAgUiSse(e))
+  } catch (error) {
+    response.write(
+      encodeAgUiSse({
+        type: "RUN_ERROR" as never,
+        message: error instanceof Error ? error.message : String(error),
+      } as never),
+    )
+  }
+  response.end()
+}
+```
+
+Note: verify the exact import paths of `RuntimeRegistry`, `SandboxManager`, `ThreadsStore`, and `streamResolvedRoute` against the tree (the seam report cites `./runtime-registry.js`, `../sandbox/sandbox-manager.js`, `@dawn-ai/sqlite-storage`, `../runtime/execute-route.js`); adjust to the real module paths if they differ. Prefer importing `streamResolvedRoute` from the same relative path `runtime-server.ts` uses.
+
+- [ ] **Step 3: Mount the route.** In `packages/cli/src/lib/dev/runtime-server.ts`, import the handler at the top:
+
+```ts
+import { handleAgUiRequest } from "./agui-handler.js"
+```
+
+Add a route entry inside `buildRouteTable`'s routes array (next to the `runs/stream` entry):
+
+```ts
+{
+  handle: async (req, res, params) => {
+    await handleAgUiRequest({
+      appRoot,
+      registry,
+      threadsStore,
+      ...(sandboxManager ? { sandboxManager } : {}),
+      signal,
+      request: req,
+      response: res,
+      routeKey: params.routeId ?? "",
+    })
+  },
+  method: "POST",
+  pattern: /^\/agui\/(?<routeId>[^/?#]+)(?:\?.*)?$/,
+},
+```
+
+- [ ] **Step 4: Build + typecheck the CLI**
+
+Run: `pnpm exec turbo run build typecheck --filter=@dawn-ai/cli...`
+Expected: `@dawn-ai/ag-ui` and `@dawn-ai/cli` build and typecheck clean. (The `...` includes dependencies.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/cli/package.json packages/cli/tsconfig.build.json packages/cli/src/lib/dev/agui-handler.ts packages/cli/src/lib/dev/runtime-server.ts pnpm-lock.yaml
+git commit -m "feat(cli): mount POST /agui/{routeId} AG-UI endpoint
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 8: CLI — in-process endpoint e2e (deterministic, no key)
+
+Boot the runtime listener in-process against a tiny agent fixture with aimock, POST a `RunAgentInput` to `/agui/<route>`, and assert an AG-UI SSE stream comes back. Mirrors the existing `packages/cli/test/runtime-request-listener.test.ts` pattern.
+
+**Files:** Create `packages/cli/test/agui-endpoint.test.ts`.
+
+- [ ] **Step 1: Write the test.** It calls the listener with a mock `req`/`res` (no port) and parses the SSE text. Use the aimock helper the CLI tests already use for a deterministic model. Model the fixture app + aimock wiring on an existing CLI runtime test that boots an agent route (search `packages/cli/test` for a test that streams an agent with aimock — reuse its `createAimock`/fixture setup verbatim).
+
+```ts
+import { createServer, type Server } from "node:http"
+import type { AddressInfo } from "node:net"
+import { mkdtemp, mkdir, writeFile, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { afterEach, expect, it } from "vitest"
+import { createRuntimeRequestListener } from "../src/lib/dev/runtime-server.js"
+// Reuse the CLI test suite's aimock helper (adjust the import to the real path
+// used by other packages/cli runtime tests, e.g. "./support/aimock" or
+// "@dawn-ai/testing"). It must set process.env.OPENAI_BASE_URL to the mock.
+import { createAimock, script } from "@dawn-ai/testing"
+
+const cleanup: Array<() => Promise<void> | void> = []
+afterEach(async () => {
+  for (const fn of cleanup.splice(0)) await fn()
+})
+
+async function fixtureApp(): Promise<string> {
+  const appRoot = await mkdtemp(join(tmpdir(), "dawn-agui-"))
+  cleanup.push(() => rm(appRoot, { force: true, recursive: true }))
+  const files: Record<string, string> = {
+    "dawn.config.ts": "export default { appDir: 'src/app' }\n",
+    "package.json": '{ "name": "agui-fixture", "type": "module" }\n',
+    "src/app/chat/index.ts":
+      "import { agent } from '@dawn-ai/sdk'\nexport default agent({ model: 'gpt-5-mini', systemPrompt: 'You are helpful.' })\n",
+  }
+  for (const [rel, body] of Object.entries(files)) {
+    const p = join(appRoot, rel)
+    await mkdir(join(p, ".."), { recursive: true })
+    await writeFile(p, body, "utf8")
+  }
+  return appRoot
+}
+
+it("streams AG-UI events from POST /agui/<route>", async () => {
+  const aimock = await createAimock({ fixtures: [] })
+  process.env.OPENAI_BASE_URL = aimock.baseUrl
+  cleanup.push(() => aimock.close())
+  aimock.addFixtures(script().user("hello").replies("Hi there!").build())
+
+  const appRoot = await fixtureApp()
+  const { listener, close } = await createRuntimeRequestListener({ appRoot })
+  cleanup.push(() => close())
+
+  // Bind the pure listener to an ephemeral port so we can POST with fetch.
+  const server: Server = createServer(listener)
+  await new Promise<void>((r) => server.listen(0, "127.0.0.1", r))
+  cleanup.push(() => new Promise<void>((r) => server.close(() => r())))
+  const { port } = server.address() as AddressInfo
+
+  const routeKey = encodeURIComponent("/chat#agent")
+  const res = await fetch(`http://127.0.0.1:${port}/agui/${routeKey}`, {
+    method: "POST",
+    headers: { "content-type": "application/json", accept: "text/event-stream" },
+    body: JSON.stringify({
+      threadId: "th1",
+      runId: "rn1",
+      state: {},
+      messages: [{ id: "1", role: "user", content: "hello" }],
+      tools: [],
+      context: [],
+      forwardedProps: {},
+    }),
+  })
+  const text = await res.text()
+  expect(res.status).toBe(200)
+  expect(text).toContain('"type":"RUN_STARTED"')
+  expect(text).toContain('"type":"TEXT_MESSAGE_CONTENT"')
+  expect(text).toContain("Hi there!")
+  expect(text).toContain('"type":"RUN_FINISHED"')
+}, 60_000)
+```
+
+- [ ] **Step 2: Run it**
+
+Run: `pnpm --filter @dawn-ai/cli test test/agui-endpoint.test.ts`
+Expected: PASS. If `createAimock`/`script` are imported from a different module in the CLI's test suite, fix the import to match a sibling CLI runtime test (they already do exactly this). If the agent input shape needs wrapping (`{ input: { messages } }` vs `{ messages }`), align `mapRunInput`/the fixture so the model receives the user message — the fixture's `.user("hello")` must match. Verify no `OPENAI_API_KEY` is required.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/cli/test/agui-endpoint.test.ts
+git commit -m "test(cli): in-process AG-UI endpoint e2e (aimock, no key)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 9: Changeset + final gate
+
+**Files:** Create `.changeset/ag-ui-capability.md`.
+
+- [ ] **Step 1: Write the changeset.** Because `@dawn-ai/ag-ui` is now in the fixed group, a single `minor` entry versions the whole cohort together. Per the release runbook, a **minor** on a fixed 0.x group triggers a `1.0.0` bump — to keep it a patch cohort, use `patch`.
+
+Create `.changeset/ag-ui-capability.md`:
+
+```markdown
+---
+"@dawn-ai/ag-ui": patch
+"@dawn-ai/cli": patch
+---
+
+Add `@dawn-ai/ag-ui`: translate Dawn's runtime stream to the AG-UI protocol and
+serve it at `POST /agui/{routeId}`, so CopilotKit and other AG-UI clients can
+drive Dawn agents. Additive — existing Agent-Protocol endpoints are unchanged.
+```
+
+- [ ] **Step 2: Run the affected-package gate**
+
+Run:
+```bash
+pnpm --filter @dawn-ai/ag-ui test
+pnpm exec turbo run build typecheck --filter=@dawn-ai/ag-ui --filter=@dawn-ai/cli
+pnpm exec vitest --run --config vitest.workspace.ts packages/ag-ui
+```
+Expected: all green; the ag-ui project runs under the root vitest workspace.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .changeset/ag-ui-capability.md
+git commit -m "chore(ag-ui): changeset for the AG-UI capability
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+- [ ] **Step 4: Release note (no code).** The first publish of `@dawn-ai/ag-ui` needs the one-time manual OIDC bootstrap before the Version PR merges (pack + `npm publish --access public` once, per the npm-release runbook and the `@dawn-ai/sandbox`/`@dawn-ai/memory` precedent). Record this in the PR description; do not attempt to publish from this plan.
+
+---
+
+## Self-Review
+
+**Spec coverage (against `2026-07-07-ag-ui-copilotkit-ui-design.md`):**
+- Additive `@dawn-ai/ag-ui` package → Tasks 1–6. ✓
+- `/agui/{routeId}` endpoint, AP endpoints untouched → Task 7 (new route only). ✓
+- Translator ported from `@ag-ui/langgraph`, tap Dawn's assembled stream, synthesize IDs, FIFO tool pairing → Task 3. ✓
+- Snapshot-only state; `subagent.*`→CUSTOM; `interrupt`→CUSTOM `on_interrupt`; resume via `command.resume`→Dawn `resumeDecision` → Tasks 4, 5, 7. ✓
+- Schema-validate every emitted event → Tasks 3–4 (parse through `@ag-ui/core` schemas). ✓
+- `@ag-ui/client` `verifyEvents` conformance oracle → Task 6. ✓
+- Pin `@ag-ui/*` → Task 1 (exact `0.0.57`). ✓
+- Registration (changeset fixed group, vitest.workspace, OIDC note) → Tasks 1, 9. ✓
+- Deterministic, no key → Tasks 6 (canned), 8 (aimock). ✓
+
+**Placeholder scan:** No TBD/TODO; each code step has complete code; each command has an expected result. The two "verify the installed `.d.ts` / import path and adapt" notes (Tasks 6, 7, 8) are explicit fallbacks for the pre-1.0 SDK surface + CLI internal paths, not missing content.
+
+**Type consistency:** `createAgUiTranslator(TranslatorOptions)` → `{begin,translate,end}` used identically in Tasks 3/4/6/7. `mapRunInput → {dawnInput, resumeDecision?, interruptId?}` consumed in Task 7. `encodeAgUiSse(event)` defined Task 6, used Task 7. `DawnStreamChunk` fields (`type/data/name/input/output`) consistent across translator + tests. `EventType`/schema names match the verified `@ag-ui/core` surface.
+
+**Known adaptation points (pre-1.0 surface, flagged in-task):** exact `@ag-ui/client` run/consume method (Task 6), CLI internal import paths for `streamResolvedRoute`/`RuntimeRegistry`/`ThreadsStore`/`SandboxManager` (Task 7), and the CLI test's aimock helper import + agent input wrapping (Task 8). Each task tells the implementer to trust the installed types / sibling tests and adapt.

--- a/docs/superpowers/specs/2026-07-07-ag-ui-copilotkit-ui-design.md
+++ b/docs/superpowers/specs/2026-07-07-ag-ui-copilotkit-ui-design.md
@@ -1,0 +1,218 @@
+# AG-UI + CopilotKit UI — Design
+
+**Date:** 2026-07-07
+**Status:** Approved (design), pending implementation plan for sub-project 1
+**Author:** Brian Love (with Claude)
+
+## Summary
+
+Make Dawn a first-class **AG-UI** agent so its example UIs (and any Dawn user's UI)
+can be built on **CopilotKit** instead of hand-rolled SSE parsing. Dawn's dev
+server gains a new, additive AG-UI endpoint served by a new `@dawn-ai/ag-ui`
+package that translates Dawn's existing runtime event stream into the AG-UI
+protocol. The current Agent-Protocol endpoints (and the bespoke SSE envelope)
+stay exactly as they are. The chat and research example UIs are then rebuilt on
+CopilotKit consuming the AG-UI endpoint.
+
+The AG-UI layer is a permanent **anti-corruption layer**: it lives only at the
+edge (one package, one endpoint), so AG-UI's pre-1.0 churn never touches Dawn's
+stable core or its test harness.
+
+## Motivation
+
+The existing `examples/chat/web` UI was throwaway smoke-test scaffolding. Rather
+than hand-roll another bespoke SSE UI for the research demo, we adopt AG-UI (the
+open agent↔UI event protocol, created by CopilotKit) so Dawn gets a standard,
+batteries-included React UI layer (streaming, human-in-the-loop, shared state,
+generative UI) and interop with the broader AG-UI ecosystem.
+
+## Decisions (from brainstorming)
+
+1. **Altitude:** framework capability — Dawn natively speaks AG-UI; examples are
+   thin CopilotKit consumers.
+2. **Emission strategy:** **additive only.** A new `@dawn-ai/ag-ui` adapter + a
+   new `/agui` endpoint. The existing AP endpoints and the bespoke `runs/stream`
+   envelope are kept indefinitely; no plan to retire them. (Rationale: AG-UI is
+   pre-1.0 with breaking changes planned; keeping it at the edge insulates Dawn's
+   stable contract and its green test harness.)
+3. **Sequencing:** chat UI first (prove the capability against the simpler
+   example), then the research UI.
+4. **Translator risk:** port the canonical `@ag-ui/langgraph` mapping rather than
+   invent one; snapshot-only state; validate emitted events against `@ag-ui/core`
+   schemas; conformance-test with a real `@ag-ui/client`.
+
+## Research Findings (verified mid-2026, pin these)
+
+- **AG-UI packages:** `@ag-ui/core`/`@ag-ui/encoder`/`@ag-ui/client` at **0.0.57**
+  (2026-06-12), MIT. Pre-1.0; breaking changes explicitly planned before 1.0; no
+  curated changelog. `@ag-ui/core`'s zod schemas are the normative spec.
+- **Transport:** default is SSE, encoded literally as `data: ${JSON}\n\n`
+  (`EventEncoder.encodeSSE`). Protobuf is an alternative via `Accept` negotiation.
+- **Backend contract:** an AG-UI agent endpoint accepts `POST` of a
+  `RunAgentInput` (`{threadId, runId, parentRunId?, state, messages, tools,
+  context, forwardedProps, resume?}`) and streams `BaseEvent`s. There is **no
+  official TS server framework** — you wire `@ag-ui/core` types + `@ag-ui/encoder`
+  into your own handler (Dawn's raw `node:http` server suits this).
+- **CopilotKit:** MIT `1.62.2`. React connects via a CopilotRuntime endpoint that
+  registers agents (`new HttpAgent({ url })`). The **v2 runtime dropped GraphQL**
+  for REST/SSE and is recommended for new projects. A dev-only
+  `agents__unsafe_dev_only` path connects the browser directly (not for prod).
+  CopilotKit is mid v1→v2 hook migration (`useCopilotAction` → `useFrontendTool`/
+  `useHumanInTheLoop`/`useRenderToolCall`); isolate usage behind thin wrappers.
+- **Reference translator:** `@ag-ui/langgraph` (local at
+  `~/repos/ag-ui/integrations/langgraph`, v0.0.24). TS is **server-only** (needs a
+  LangGraph deployment URL) so it can't wrap Dawn's in-process graph — we **port**
+  its mapping. Key: it emits **only `STATE_SNAPSHOT`** (no `STATE_DELTA`), and it
+  models interrupts as a `CUSTOM {name:"on_interrupt"}` event with resume via
+  `forwardedProps.command.resume`.
+- **Dawn's current event catalog** (what we translate from), produced by
+  `streamResolvedRoute`/`agent-adapter.ts`/`execute-route.ts`: `token`,
+  `tool_call {name,input}`, `tool_result {name,output}`, `plan_update {todos}`,
+  `interrupt {interruptId,type,kind,detail}` (kinds command/tool/memory/path),
+  `subagent.{start,message,tool_call,tool_result,end}`, `done {output|error}`.
+
+## Architecture
+
+```
+Dawn route (in-process LangGraph)
+   │  streamResolvedRoute → Dawn events
+   ▼
+@dawn-ai/ag-ui  (NEW pkg; deps: @ag-ui/core + @ag-ui/encoder, pinned)
+   • translate(dawnEvent, ctx) → AGUIEvent[]      (pure, table-driven, ported)
+   • runAgUi(RunAgentInput) → maps to a Dawn run, applies resume, streams
+   • createAgUiHandler() → node:http handler for POST /agui/{routeId}
+   ▼  SSE: data: <AG-UI JSON>\n\n
+CopilotKit v2 runtime route in the example's Next.js app
+   (HttpAgent → /agui/{routeId}; GraphQL-free)
+   ▼
+CopilotKit React UI  (thin Dawn wrappers isolate v1/v2 churn)
+```
+
+The existing AP endpoints (`/threads`, `runs/stream`, `runs/wait`, `state`,
+`resume`) are unchanged; the harness and `dawn run --url` keep working.
+
+### Endpoint
+
+`POST /agui/{routeId}` — one AG-UI agent per Dawn route (so a CopilotKit
+`HttpAgent` maps 1:1 to a Dawn route URL). The handler:
+
+1. Parses & validates the body as `RunAgentInput` (zod, from `@ag-ui/core`).
+2. Resolves `routeId` to a Dawn route; creates-or-reuses the Dawn thread/
+   checkpoint keyed by `RunAgentInput.threadId` (reusing existing thread
+   machinery).
+3. If `forwardedProps.command.resume` (or `resume[]`) is present, routes it to
+   Dawn's existing resume decision path; otherwise starts a run from
+   `messages`/`state`.
+4. Consumes `streamResolvedRoute`, translates each Dawn event to AG-UI event(s),
+   and writes them via `EventEncoder` as SSE.
+
+Mounted one-line on the runtime server (like existing capabilities). Always
+available; no cost when unused. (A `dawn.config.ts` opt-out may be added later;
+not required for v1.)
+
+### Translation (ported from `@ag-ui/langgraph` `handleSingleEvent`)
+
+Tap **Dawn's assembled stream** (not raw LangGraph events) so Dawn's capability
+events survive; synthesize AG-UI IDs in the adapter.
+
+| Dawn event | AG-UI event(s) | Notes |
+|---|---|---|
+| `token` (run of tokens) | `TEXT_MESSAGE_START` (once, minted `messageId`) → `TEXT_MESSAGE_CONTENT{delta}` … → `TEXT_MESSAGE_END` | END on the next `tool_call`/`done`. |
+| `tool_call {name,input}` | `TOOL_CALL_START{toolCallId,toolCallName}` + `TOOL_CALL_ARGS{delta:JSON.stringify(input)}` + `TOOL_CALL_END` | Non-streaming branch (matches reference agent.ts:876–931). `toolCallId` minted + pushed to a per-name FIFO. |
+| `tool_result {name,output}` | `TOOL_CALL_RESULT{toolCallId,content}` | `toolCallId` popped FIFO-by-name. |
+| `plan_update {todos}`, route state (`context`, research `report`/`citations`) | `STATE_SNAPSHOT{snapshot}` | Snapshot-only (reference does the same). Full snapshot of exposed channels per change. |
+| `subagent.*` | `CUSTOM{name:"dawn.subagent", value:{call_id,phase,...}}` | Rendered by the UI as a nested activity. |
+| `interrupt {interruptId,kind,detail}` | `CUSTOM{name:"on_interrupt", value:{interruptId,kind,detail}}` | Matches reference + shipping CopilotKit hooks. Resume via `forwardedProps.command.resume` → Dawn `/resume {decision}`. |
+| `done {output}` / `done {error}` | `RUN_FINISHED` / `RUN_ERROR` | `RUN_STARTED` emitted at stream open. |
+
+**Known v1 limitations (documented, acceptable):** parallel same-name tool calls
+could mis-pair FIFO; STATE deltas not emitted (full snapshots); one active
+assistant message per run.
+
+### HITL / resume
+
+Dawn's permission gate is backend-enforced, so we use the reference's
+CUSTOM-`on_interrupt` path (not the newer opt-in `RUN_FINISHED.outcome=interrupt`).
+The adapter encodes Dawn's `kind` + `detail` (command/tool/memory/path;
+suggestedPattern; memory old-vs-new) into the event `value`; the example UI maps
+it to an approve/deny (Once/Always/Deny) control and returns the decision via
+`forwardedProps.command.resume`, which the adapter forwards to Dawn's existing
+`/resume` decision path. No change to Dawn's hardened resume internals.
+
+### Example wiring (Next.js)
+
+A CopilotKit **v2 runtime** route (`/api/copilotkit`, REST/SSE, no graphql-yoga)
+registers `new HttpAgent({ url: `${DAWN_URL}/agui/<route>` })`; React uses
+`CopilotKitProvider` + `CopilotChat`, `useCoAgent`/`useCoAgentStateRender` for the
+plan/report panels, and the HITL hook for approvals — all behind thin Dawn
+wrapper components so the CopilotKit v1/v2 churn is contained.
+
+## De-risking Strategy
+
+1. **Port, don't invent.** Lift the mapping from `~/repos/ag-ui/integrations/
+   langgraph/typescript/src/agent.ts` (`handleSingleEvent`, non-streaming branch)
+   and `interrupts.ts`, with file citations in the code for future diffs.
+2. **Snapshot-only state** — at parity with the reference; defers all RFC-6902
+   diffing risk.
+3. **Schema oracle the reference lacks:** every emitted event is parsed through
+   the pinned `@ag-ui/core` zod schema in tests (the reference does not validate
+   at emit time — we do better).
+4. **Ordering verifier:** a tiny checker for START→CONTENT→END and
+   RESULT-after-END invariants.
+5. **Consumer conformance:** an e2e points a real `@ag-ui/client` `HttpAgent` at
+   `/agui/{route}` (aimock-backed Dawn run, no key) and asserts a clean typed
+   parse + expected event sequence.
+6. **Pin + guard:** pin `@ag-ui/core`/`@ag-ui/encoder`; the schema test fails
+   loudly on a breaking bump, and the blast radius is one package.
+
+## Testing Strategy
+
+- **Translator unit tests** (pure, no model): Dawn-event fixtures → assert exact
+  AG-UI event arrays; every event validated against `@ag-ui/core` schema.
+- **Endpoint e2e** (aimock, no key): drive a Dawn route through `/agui/{route}`,
+  consume with `@ag-ui/client` `HttpAgent`, assert the typed event sequence
+  (text, tool call+result, todos snapshot, subagent custom, interrupt+resume,
+  run finished). Wired into the harness like existing lanes.
+- **Example UIs:** no-key **demo mode** (aimock-backed `pnpm dev`) serving both
+  chat and research; plus each example's existing offline test story.
+
+## Decomposition
+
+This is multi-subsystem; each sub-project gets its own spec → plan → build → PR.
+
+1. **`@dawn-ai/ag-ui` capability** — translator + `/agui` handler + tests, mounted
+   on the dev server. *(First plan; foundation, no UI.)*
+2. **Chat UI on CopilotKit** — rebuild `examples/chat/web`; prove the capability
+   end-to-end; establish the CopilotKit-v2-runtime + wrapper-component pattern +
+   demo mode.
+3. **Research UI on CopilotKit** — `examples/research/web` (plan/report/HITL/
+   memory panels) = the research demo's Slice 2, on the proven capability.
+
+## Risks & Mitigations
+
+- **AG-UI pre-1.0 churn** → edge-only adapter + pinned deps + schema-guard test.
+- **Translator fidelity** → port a maintained reference + consumer-level
+  conformance test.
+- **CopilotKit v1/v2 migration churn** → thin wrapper components; prefer the v2
+  runtime (GraphQL-free) but keep hook choices swappable.
+- **New published package** → first release of `@dawn-ai/ag-ui` needs the manual
+  OIDC bootstrap before the Version PR merges (see the npm-release runbook).
+- **Two streaming protocols coexist** → accepted by decision; the AP envelope is
+  unchanged and the AG-UI path is independently tested.
+
+## Open Questions (non-blocking)
+
+- Whether to gate `/agui` behind a `dawn.config.ts` flag (default on) for surface
+  control — decide during sub-project 1.
+- Exact CopilotKit hook set (v1 stable vs v2) for HITL and state rendering —
+  decide during sub-project 2 against the installed `1.62.x` types.
+- Whether `dawn.config.ts` should let a route declare the AG-UI state channels it
+  exposes (vs. exposing the whole output schema) — decide in sub-project 1.
+
+## Non-Goals
+
+- Replacing or retiring the AP endpoints / bespoke SSE envelope.
+- `STATE_DELTA` / RFC-6902 diffing (snapshot-only for now).
+- Depending on `@ag-ui/langgraph` at runtime (server-only; we port it).
+- Protobuf transport (SSE only for now).
+- Modifying Dawn's core streaming or resume internals.

--- a/packages/ag-ui/package.json
+++ b/packages/ag-ui/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "@dawn-ai/ag-ui",
+  "version": "0.8.9",
+  "private": false,
+  "type": "module",
+  "license": "MIT",
+  "homepage": "https://github.com/cacheplane/dawnai/tree/main/packages/ag-ui#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/cacheplane/dawnai.git",
+    "directory": "packages/ag-ui"
+  },
+  "bugs": {
+    "url": "https://github.com/cacheplane/dawnai/issues"
+  },
+  "engines": {
+    "node": ">=22.13.0"
+  },
+  "files": [
+    "dist"
+  ],
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "tsc -b tsconfig.json",
+    "lint": "biome check --config-path ../config-biome/biome.json package.json src tsconfig.json vitest.config.ts",
+    "test": "vitest --run --config vitest.config.ts --passWithNoTests",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@ag-ui/core": "0.0.57",
+    "@ag-ui/encoder": "0.0.57"
+  },
+  "devDependencies": {
+    "@ag-ui/client": "0.0.57",
+    "@dawn-ai/config-typescript": "workspace:*",
+    "@types/node": "26.1.0",
+    "rxjs": "7.8.1"
+  }
+}

--- a/packages/ag-ui/src/encode.ts
+++ b/packages/ag-ui/src/encode.ts
@@ -1,0 +1,8 @@
+import { EventEncoder } from "@ag-ui/encoder"
+import type { AgUiEvent } from "./types.js"
+
+/** Encode one AG-UI event as an SSE frame (`data: <json>\n\n`). */
+export function encodeAgUiSse(event: AgUiEvent, accept?: string): string {
+  const encoder = new EventEncoder(accept ? { accept } : {})
+  return encoder.encode(event)
+}

--- a/packages/ag-ui/src/index.ts
+++ b/packages/ag-ui/src/index.ts
@@ -1,0 +1,4 @@
+export { encodeAgUiSse } from "./encode.js"
+export { type MappedRunInput, mapRunInput, type ResumeDecision } from "./run-input.js"
+export { type AgUiTranslator, createAgUiTranslator } from "./translate.js"
+export type { AgUiEvent, DawnStreamChunk, TranslatorOptions } from "./types.js"

--- a/packages/ag-ui/src/run-input.ts
+++ b/packages/ag-ui/src/run-input.ts
@@ -1,0 +1,50 @@
+import type { RunAgentInput } from "@ag-ui/core"
+
+export type ResumeDecision = "once" | "always" | "deny"
+
+export interface MappedRunInput {
+  readonly dawnInput: { readonly messages: ReadonlyArray<{ role: string; content: string }> }
+  readonly resumeDecision?: ResumeDecision
+  readonly interruptId?: string
+}
+
+function coerceDecision(value: unknown): ResumeDecision | undefined {
+  if (value === "once" || value === "always" || value === "deny") return value
+  return undefined
+}
+
+/**
+ * Map an AG-UI RunAgentInput onto a Dawn run. HITL resume rides on
+ * forwardedProps.command.resume (the @ag-ui/langgraph convention); otherwise
+ * the newest user message becomes the turn's input (Dawn keeps history in its
+ * checkpoint keyed by threadId).
+ */
+export function mapRunInput(input: RunAgentInput): MappedRunInput {
+  const resume = (input.forwardedProps as { command?: { resume?: unknown } } | undefined)?.command
+    ?.resume
+  if (resume !== undefined) {
+    if (typeof resume === "string") {
+      const decision = coerceDecision(resume)
+      return decision
+        ? { dawnInput: { messages: [] }, resumeDecision: decision }
+        : { dawnInput: { messages: [] } }
+    }
+    if (resume && typeof resume === "object") {
+      const r = resume as { decision?: unknown; interruptId?: unknown }
+      const decision = coerceDecision(r.decision)
+      const interruptId = typeof r.interruptId === "string" ? r.interruptId : undefined
+      return {
+        dawnInput: { messages: [] },
+        ...(decision ? { resumeDecision: decision } : {}),
+        ...(interruptId ? { interruptId } : {}),
+      }
+    }
+  }
+
+  const lastUser = [...input.messages].reverse().find((m) => m.role === "user")
+  const content =
+    lastUser && typeof lastUser.content === "string" ? lastUser.content : lastUser ? "" : undefined
+  return {
+    dawnInput: { messages: content === undefined ? [] : [{ role: "user", content }] },
+  }
+}

--- a/packages/ag-ui/src/translate.ts
+++ b/packages/ag-ui/src/translate.ts
@@ -1,0 +1,147 @@
+import { EventType } from "@ag-ui/core"
+import type { AgUiEvent, DawnStreamChunk, TranslatorOptions } from "./types.js"
+
+let counter = 0
+/** Deterministic-per-process id (no Math.random/Date — safe for tests). */
+function nextId(prefix: string): string {
+  counter += 1
+  return `${prefix}_${counter}`
+}
+
+export interface AgUiTranslator {
+  /** Emit RUN_STARTED. Call once before feeding chunks. */
+  begin(): AgUiEvent[]
+  /** Translate one Dawn chunk into zero or more AG-UI events. */
+  translate(chunk: DawnStreamChunk): AgUiEvent[]
+  /** Emit a terminal RUN_FINISHED if the stream ended without a `done` chunk. */
+  end(): AgUiEvent[]
+}
+
+export function createAgUiTranslator(options: TranslatorOptions): AgUiTranslator {
+  const { threadId, runId } = options
+  let activeTextId: string | null = null
+  const pendingToolCalls = new Map<string, string[]>()
+  let finished = false
+  let state: Record<string, unknown> = {}
+
+  function flushText(): AgUiEvent[] {
+    if (activeTextId === null) return []
+    const id = activeTextId
+    activeTextId = null
+    return [{ type: EventType.TEXT_MESSAGE_END, messageId: id }]
+  }
+
+  function toText(chunk: DawnStreamChunk): AgUiEvent[] {
+    const text = typeof chunk.data === "string" ? chunk.data : String(chunk.data ?? "")
+    if (text.length === 0) return []
+    const out: AgUiEvent[] = []
+    if (activeTextId === null) {
+      activeTextId = nextId("msg")
+      out.push({
+        type: EventType.TEXT_MESSAGE_START,
+        messageId: activeTextId,
+        role: "assistant",
+      })
+    }
+    out.push({ type: EventType.TEXT_MESSAGE_CONTENT, messageId: activeTextId, delta: text })
+    return out
+  }
+
+  function toToolCall(chunk: DawnStreamChunk): AgUiEvent[] {
+    const name = chunk.name ?? "tool"
+    const toolCallId = nextId("call")
+    const queue = pendingToolCalls.get(name) ?? []
+    queue.push(toolCallId)
+    pendingToolCalls.set(name, queue)
+    return [
+      ...flushText(),
+      { type: EventType.TOOL_CALL_START, toolCallId, toolCallName: name },
+      { type: EventType.TOOL_CALL_ARGS, toolCallId, delta: JSON.stringify(chunk.input ?? {}) },
+      { type: EventType.TOOL_CALL_END, toolCallId },
+    ]
+  }
+
+  function toToolResult(chunk: DawnStreamChunk): AgUiEvent[] {
+    const name = chunk.name ?? "tool"
+    const queue = pendingToolCalls.get(name) ?? []
+    const toolCallId = queue.shift() ?? nextId("call")
+    pendingToolCalls.set(name, queue)
+    const content =
+      typeof chunk.output === "string" ? chunk.output : JSON.stringify(chunk.output ?? null)
+    return [
+      ...flushText(),
+      {
+        type: EventType.TOOL_CALL_RESULT,
+        messageId: nextId("msg"),
+        toolCallId,
+        content,
+        role: "tool",
+      },
+    ]
+  }
+
+  function toDone(chunk: DawnStreamChunk): AgUiEvent[] {
+    finished = true
+    const out = flushText()
+    const output = chunk.output
+    if (output && typeof output === "object" && "error" in output) {
+      out.push({
+        type: EventType.RUN_ERROR,
+        message: String((output as { error: unknown }).error),
+      })
+      return out
+    }
+    out.push({ type: EventType.RUN_FINISHED, threadId, runId, result: output })
+    return out
+  }
+
+  return {
+    begin() {
+      return [{ type: EventType.RUN_STARTED, threadId, runId }]
+    },
+    translate(chunk) {
+      switch (chunk.type) {
+        case "token":
+        case "chunk":
+          return toText(chunk)
+        case "tool_call":
+          return toToolCall(chunk)
+        case "tool_result":
+          return toToolResult(chunk)
+        case "done":
+          return toDone(chunk)
+        case "plan_update": {
+          const flushed = flushText()
+          const data = (chunk.data ?? {}) as Record<string, unknown>
+          state = { ...state, ...data }
+          return [...flushed, { type: EventType.STATE_SNAPSHOT, snapshot: state }]
+        }
+        case "interrupt": {
+          return [
+            ...flushText(),
+            { type: EventType.CUSTOM, name: "on_interrupt", value: chunk.data ?? {} },
+          ]
+        }
+        default: {
+          const flushed = flushText()
+          if (chunk.type.startsWith("subagent.")) {
+            return [
+              ...flushed,
+              { type: EventType.CUSTOM, name: `dawn.${chunk.type}`, value: chunk.data ?? {} },
+            ]
+          }
+          if (chunk.data && typeof chunk.data === "object") {
+            state = { ...state, ...(chunk.data as Record<string, unknown>) }
+            return [...flushed, { type: EventType.STATE_SNAPSHOT, snapshot: state }]
+          }
+          return flushed
+        }
+      }
+    },
+    end() {
+      if (finished) return []
+      finished = true
+      return [...flushText(), { type: EventType.RUN_FINISHED, threadId, runId }]
+    },
+  }
+}

--- a/packages/ag-ui/src/types.ts
+++ b/packages/ag-ui/src/types.ts
@@ -1,0 +1,22 @@
+import type { BaseEvent } from "@ag-ui/core"
+
+/** An AG-UI protocol event. Alias kept local so consumers import one name. */
+export type AgUiEvent = BaseEvent
+
+/**
+ * Structural mirror of `@dawn-ai/cli`'s `StreamChunk`. Kept loose (all fields
+ * optional beyond `type`) so this package has ZERO dependency on the CLI. The
+ * translator inspects fields at runtime by `type`.
+ */
+export interface DawnStreamChunk {
+  readonly type: string
+  readonly data?: unknown
+  readonly name?: string
+  readonly input?: unknown
+  readonly output?: unknown
+}
+
+export interface TranslatorOptions {
+  readonly threadId: string
+  readonly runId: string
+}

--- a/packages/ag-ui/test/conformance.test.ts
+++ b/packages/ag-ui/test/conformance.test.ts
@@ -1,0 +1,63 @@
+import { createServer, type Server } from "node:http"
+import type { AddressInfo } from "node:net"
+import { HttpAgent, verifyEvents } from "@ag-ui/client"
+import { EventType } from "@ag-ui/core"
+import { lastValueFrom, toArray } from "rxjs"
+import { afterEach, expect, it } from "vitest"
+import { encodeAgUiSse } from "../src/encode.js"
+import { createAgUiTranslator } from "../src/translate.js"
+import type { DawnStreamChunk } from "../src/types.js"
+
+let server: Server | undefined
+afterEach(() => server?.close())
+
+const CANNED: DawnStreamChunk[] = [
+  { type: "token", data: "Researching" },
+  { type: "tool_call", name: "searchCorpus", input: { query: "agents" } },
+  { type: "tool_result", name: "searchCorpus", output: [{ path: "corpus/a.md" }] },
+  { type: "plan_update", data: { todos: [{ content: "search", status: "completed" }] } },
+  { type: "subagent.start", data: { call_id: "c1", subagent: "researcher" } },
+  { type: "token", data: " done. [corpus/a.md]" },
+  { type: "done", output: { messages: [] } },
+]
+
+async function startCannedServer(): Promise<string> {
+  server = createServer((req, res) => {
+    req.resume()
+    res.writeHead(200, { "content-type": "text/event-stream", "cache-control": "no-cache" })
+    const t = createAgUiTranslator({ threadId: "t1", runId: "r1" })
+    for (const e of t.begin()) res.write(encodeAgUiSse(e))
+    for (const chunk of CANNED) for (const e of t.translate(chunk)) res.write(encodeAgUiSse(e))
+    for (const e of t.end()) res.write(encodeAgUiSse(e))
+    res.end()
+  })
+  await new Promise<void>((resolve) => {
+    // biome-ignore lint/style/noNonNullAssertion: assigned above, listen callback is sync-scheduled
+    server!.listen(0, "127.0.0.1", resolve)
+  })
+  // biome-ignore lint/style/noNonNullAssertion: assigned above
+  const { port } = server!.address() as AddressInfo
+  return `http://127.0.0.1:${port}`
+}
+
+it("produces an AG-UI stream that @ag-ui/client parses and verifyEvents accepts", async () => {
+  const url = await startCannedServer()
+  const agent = new HttpAgent({ url })
+  const input = {
+    threadId: "t1",
+    runId: "r1",
+    state: {},
+    messages: [{ id: "1", role: "user", content: "research agents" }],
+    tools: [],
+    context: [],
+    forwardedProps: {},
+  }
+  const events = await lastValueFrom(agent.run(input as never).pipe(verifyEvents(false), toArray()))
+  const kinds = events.map((e) => e.type)
+  expect(kinds[0]).toBe(EventType.RUN_STARTED)
+  expect(kinds).toContain(EventType.TOOL_CALL_START)
+  expect(kinds).toContain(EventType.TOOL_CALL_RESULT)
+  expect(kinds).toContain(EventType.STATE_SNAPSHOT)
+  expect(kinds).toContain(EventType.CUSTOM)
+  expect(kinds[kinds.length - 1]).toBe(EventType.RUN_FINISHED)
+})

--- a/packages/ag-ui/test/run-input.test.ts
+++ b/packages/ag-ui/test/run-input.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest"
+import { mapRunInput } from "../src/run-input.js"
+
+const base = { threadId: "t", runId: "r", state: {}, messages: [], tools: [], context: [], forwardedProps: {} }
+
+describe("mapRunInput", () => {
+  it("extracts the last user message as the Dawn input", () => {
+    const result = mapRunInput({
+      ...base,
+      messages: [
+        { id: "1", role: "user", content: "old" },
+        { id: "2", role: "assistant", content: "hi" },
+        { id: "3", role: "user", content: "new question" },
+      ],
+    } as never)
+    expect(result.resumeDecision).toBeUndefined()
+    expect(result.dawnInput).toEqual({ messages: [{ role: "user", content: "new question" }] })
+  })
+
+  it("decodes a resume decision from forwardedProps.command.resume", () => {
+    const result = mapRunInput({
+      ...base,
+      forwardedProps: { command: { resume: { interruptId: "perm-1", decision: "once" } } },
+    } as never)
+    expect(result.resumeDecision).toBe("once")
+    expect(result.interruptId).toBe("perm-1")
+  })
+
+  it("accepts a bare string decision", () => {
+    const result = mapRunInput({
+      ...base,
+      forwardedProps: { command: { resume: "deny" } },
+    } as never)
+    expect(result.resumeDecision).toBe("deny")
+  })
+
+  it("falls back to empty messages when no user message exists", () => {
+    const result = mapRunInput(base as never)
+    expect(result.dawnInput).toEqual({ messages: [] })
+  })
+})

--- a/packages/ag-ui/test/translate-capabilities.test.ts
+++ b/packages/ag-ui/test/translate-capabilities.test.ts
@@ -1,0 +1,69 @@
+import { CustomEventSchema, EventType, StateSnapshotEventSchema } from "@ag-ui/core"
+import { describe, expect, it } from "vitest"
+import { createAgUiTranslator } from "../src/translate.js"
+import type { AgUiEvent } from "../src/types.js"
+
+const opts = { threadId: "t1", runId: "r1" }
+const type1 = (evs: AgUiEvent[]) => evs[0]?.type
+
+describe("translator: capability events", () => {
+  it("maps plan_update to a STATE_SNAPSHOT carrying todos", () => {
+    const t = createAgUiTranslator(opts)
+    const todos = [{ content: "search", status: "pending" }]
+    const evs = t.translate({ type: "plan_update", data: { todos } })
+    expect(type1(evs)).toBe(EventType.STATE_SNAPSHOT)
+    const parsed = StateSnapshotEventSchema.parse(evs[0])
+    expect((parsed.snapshot as { todos: unknown }).todos).toEqual(todos)
+  })
+
+  it("accumulates state across snapshots", () => {
+    const t = createAgUiTranslator(opts)
+    t.translate({ type: "plan_update", data: { todos: [{ content: "a", status: "pending" }] } })
+    const evs = t.translate({ type: "report_update", data: { report: "hello" } })
+    const snap = evs.find((e) => e.type === EventType.STATE_SNAPSHOT) as
+      | { snapshot: Record<string, unknown> }
+      | undefined
+    expect(snap?.snapshot.todos).toBeDefined()
+    expect(snap?.snapshot.report).toBe("hello")
+  })
+
+  it("maps subagent events to CUSTOM dawn.<type>", () => {
+    const t = createAgUiTranslator(opts)
+    const evs = t.translate({
+      type: "subagent.start",
+      data: { call_id: "c1", subagent: "researcher" },
+    })
+    expect(type1(evs)).toBe(EventType.CUSTOM)
+    const parsed = CustomEventSchema.parse(evs[0])
+    expect(parsed.name).toBe("dawn.subagent.start")
+    expect((parsed.value as { call_id: string }).call_id).toBe("c1")
+  })
+
+  it("maps interrupt to CUSTOM on_interrupt", () => {
+    const t = createAgUiTranslator(opts)
+    const detail = { command: "node scripts/fetch-source.mjs x", suggestedPattern: "node scripts" }
+    const evs = t.translate({
+      type: "interrupt",
+      data: { interruptId: "perm-1", type: "permission-request", kind: "command", detail },
+    })
+    expect(type1(evs)).toBe(EventType.CUSTOM)
+    const parsed = CustomEventSchema.parse(evs[0])
+    expect(parsed.name).toBe("on_interrupt")
+    expect((parsed.value as { interruptId: string }).interruptId).toBe("perm-1")
+    expect((parsed.value as { kind: string }).kind).toBe("command")
+  })
+
+  it("flushes open text before a capability event", () => {
+    const t = createAgUiTranslator(opts)
+    const evs = [
+      ...t.translate({ type: "token", data: "hi" }),
+      ...t.translate({ type: "subagent.start", data: { call_id: "c1" } }),
+    ]
+    expect(evs.map((e) => e.type)).toEqual([
+      EventType.TEXT_MESSAGE_START,
+      EventType.TEXT_MESSAGE_CONTENT,
+      EventType.TEXT_MESSAGE_END,
+      EventType.CUSTOM,
+    ])
+  })
+})

--- a/packages/ag-ui/test/translate-text-tools.test.ts
+++ b/packages/ag-ui/test/translate-text-tools.test.ts
@@ -1,0 +1,102 @@
+import { EventType } from "@ag-ui/core"
+import {
+  RunStartedEventSchema,
+  TextMessageStartEventSchema,
+  TextMessageContentEventSchema,
+  TextMessageEndEventSchema,
+  ToolCallStartEventSchema,
+  ToolCallArgsEventSchema,
+  ToolCallEndEventSchema,
+  ToolCallResultEventSchema,
+  RunFinishedEventSchema,
+} from "@ag-ui/core"
+import { describe, expect, it } from "vitest"
+import { createAgUiTranslator } from "../src/translate.js"
+import type { AgUiEvent } from "../src/types.js"
+
+const opts = { threadId: "t1", runId: "r1" }
+const types = (evs: AgUiEvent[]) => evs.map((e) => e.type)
+
+describe("translator: lifecycle + text + tools", () => {
+  it("begin() emits a valid RUN_STARTED", () => {
+    const t = createAgUiTranslator(opts)
+    const evs = t.begin()
+    expect(types(evs)).toEqual([EventType.RUN_STARTED])
+    expect(() => RunStartedEventSchema.parse(evs[0])).not.toThrow()
+  })
+
+  it("maps a token run to START/CONTENT+/END and validates each event", () => {
+    const t = createAgUiTranslator(opts)
+    const evs = [
+      ...t.translate({ type: "token", data: "Hello" }),
+      ...t.translate({ type: "token", data: " world" }),
+      ...t.translate({ type: "done", output: { messages: [] } }),
+    ]
+    expect(types(evs)).toEqual([
+      EventType.TEXT_MESSAGE_START,
+      EventType.TEXT_MESSAGE_CONTENT,
+      EventType.TEXT_MESSAGE_CONTENT,
+      EventType.TEXT_MESSAGE_END,
+      EventType.RUN_FINISHED,
+    ])
+    TextMessageStartEventSchema.parse(evs[0])
+    TextMessageContentEventSchema.parse(evs[1])
+    TextMessageContentEventSchema.parse(evs[2])
+    TextMessageEndEventSchema.parse(evs[3])
+    RunFinishedEventSchema.parse(evs[4])
+    const mid = (evs[0] as { messageId: string }).messageId
+    expect((evs[1] as { messageId: string }).messageId).toBe(mid)
+    expect((evs[3] as { messageId: string }).messageId).toBe(mid)
+  })
+
+  it("skips empty token deltas (translator no-ops rather than emit empty content)", () => {
+    const t = createAgUiTranslator(opts)
+    const evs = t.translate({ type: "token", data: "" })
+    expect(evs).toEqual([])
+  })
+
+  it("maps tool_call to START/ARGS/END and pairs tool_result by FIFO", () => {
+    const t = createAgUiTranslator(opts)
+    const evs = [
+      ...t.translate({ type: "tool_call", name: "searchCorpus", input: { query: "x" } }),
+      ...t.translate({ type: "tool_result", name: "searchCorpus", output: [{ path: "corpus/a.md" }] }),
+    ]
+    expect(types(evs)).toEqual([
+      EventType.TOOL_CALL_START,
+      EventType.TOOL_CALL_ARGS,
+      EventType.TOOL_CALL_END,
+      EventType.TOOL_CALL_RESULT,
+    ])
+    ToolCallStartEventSchema.parse(evs[0])
+    ToolCallArgsEventSchema.parse(evs[1])
+    ToolCallEndEventSchema.parse(evs[2])
+    ToolCallResultEventSchema.parse(evs[3])
+    const id = (evs[0] as { toolCallId: string }).toolCallId
+    expect((evs[1] as { toolCallId: string }).toolCallId).toBe(id)
+    expect((evs[3] as { toolCallId: string }).toolCallId).toBe(id)
+    expect((evs[1] as { delta: string }).delta).toBe(JSON.stringify({ query: "x" }))
+  })
+
+  it("flushes an open text message before a tool_call", () => {
+    const t = createAgUiTranslator(opts)
+    const evs = [
+      ...t.translate({ type: "token", data: "thinking" }),
+      ...t.translate({ type: "tool_call", name: "readDoc", input: { path: "corpus/a.md" } }),
+    ]
+    expect(types(evs)).toEqual([
+      EventType.TEXT_MESSAGE_START,
+      EventType.TEXT_MESSAGE_CONTENT,
+      EventType.TEXT_MESSAGE_END,
+      EventType.TOOL_CALL_START,
+      EventType.TOOL_CALL_ARGS,
+      EventType.TOOL_CALL_END,
+    ])
+  })
+
+  it("maps a done error to RUN_ERROR", () => {
+    const t = createAgUiTranslator(opts)
+    const evs = t.translate({ type: "done", output: { error: "boom" } })
+    expect(types(evs)).toEqual([EventType.RUN_ERROR])
+    expect((evs[0] as { message: string }).message).toBe("boom")
+  })
+})

--- a/packages/ag-ui/tsconfig.json
+++ b/packages/ag-ui/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "../config-typescript/node.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo"
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/packages/ag-ui/vitest.config.ts
+++ b/packages/ag-ui/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config"
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["test/**/*.test.ts"],
+    passWithNoTests: true,
+  },
+})

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -49,6 +49,8 @@
     "typecheck": "tsc -p tsconfig.json"
   },
   "dependencies": {
+    "@ag-ui/core": "0.0.57",
+    "@dawn-ai/ag-ui": "workspace:*",
     "@dawn-ai/core": "workspace:*",
     "@dawn-ai/langchain": "workspace:*",
     "@dawn-ai/langgraph": "workspace:*",

--- a/packages/cli/src/lib/dev/agui-handler.ts
+++ b/packages/cli/src/lib/dev/agui-handler.ts
@@ -1,0 +1,103 @@
+import type { IncomingMessage, ServerResponse } from "node:http"
+import { EventType, RunAgentInputSchema } from "@ag-ui/core"
+import { createAgUiTranslator, encodeAgUiSse, mapRunInput } from "@dawn-ai/ag-ui"
+import type { ThreadsStore } from "@dawn-ai/sqlite-storage"
+import { streamResolvedRoute } from "../runtime/execute-route.js"
+import type { SandboxManager } from "../runtime/sandbox-manager.js"
+import type { RuntimeRegistry } from "./runtime-registry.js"
+
+interface AgUiRequestOptions {
+  readonly appRoot: string
+  readonly registry: RuntimeRegistry
+  readonly threadsStore: ThreadsStore
+  readonly sandboxManager?: SandboxManager
+  readonly signal: AbortSignal
+  readonly request: IncomingMessage
+  readonly response: ServerResponse
+  readonly routeKey: string
+}
+
+async function readBody(request: IncomingMessage): Promise<string> {
+  const chunks: Buffer[] = []
+  for await (const chunk of request)
+    chunks.push(typeof chunk === "string" ? Buffer.from(chunk) : chunk)
+  return Buffer.concat(chunks).toString("utf8")
+}
+
+export async function handleAgUiRequest(options: AgUiRequestOptions): Promise<void> {
+  const { appRoot, registry, threadsStore, sandboxManager, signal, request, response, routeKey } =
+    options
+
+  const raw = await readBody(request)
+  let parsedJson: unknown
+  try {
+    parsedJson = JSON.parse(raw)
+  } catch {
+    response.statusCode = 400
+    response.setHeader("content-type", "application/json")
+    response.end(JSON.stringify({ error: { kind: "request_error", message: "Malformed body" } }))
+    return
+  }
+  const parsed = RunAgentInputSchema.safeParse(parsedJson)
+  if (!parsed.success) {
+    response.statusCode = 400
+    response.setHeader("content-type", "application/json")
+    response.end(
+      JSON.stringify({ error: { kind: "request_error", message: "Invalid RunAgentInput" } }),
+    )
+    return
+  }
+  const input = parsed.data
+
+  const route = registry.lookup(routeKey)
+  if (!route) {
+    response.statusCode = 404
+    response.setHeader("content-type", "application/json")
+    response.end(
+      JSON.stringify({ error: { kind: "request_error", message: `Unknown route: ${routeKey}` } }),
+    )
+    return
+  }
+
+  const threadId = input.threadId
+  const existing = await threadsStore.getThread(threadId)
+  if (!existing) await threadsStore.createThread({ thread_id: threadId })
+  await threadsStore.updateStatus(threadId, "busy")
+
+  const { dawnInput, resumeDecision } = mapRunInput(input)
+  const translator = createAgUiTranslator({ threadId, runId: input.runId })
+
+  response.writeHead(200, {
+    "cache-control": "no-cache",
+    connection: "keep-alive",
+    "content-type": "text/event-stream",
+  })
+  for (const e of translator.begin()) response.write(encodeAgUiSse(e))
+
+  try {
+    for await (const chunk of streamResolvedRoute({
+      appRoot,
+      input: dawnInput,
+      ...(resumeDecision ? { resumeDecision } : {}),
+      routeFile: route.routeFile,
+      routeId: route.routeId,
+      routePath: route.routePath,
+      ...(sandboxManager ? { sandboxManager } : {}),
+      signal,
+      threadId,
+    })) {
+      for (const e of translator.translate(chunk)) response.write(encodeAgUiSse(e))
+    }
+    for (const e of translator.end()) response.write(encodeAgUiSse(e))
+    await threadsStore.updateStatus(threadId, "idle")
+  } catch (error) {
+    response.write(
+      encodeAgUiSse({
+        type: EventType.RUN_ERROR,
+        message: error instanceof Error ? error.message : String(error),
+      }),
+    )
+    await threadsStore.updateStatus(threadId, "idle").catch(() => undefined)
+  }
+  response.end()
+}

--- a/packages/cli/src/lib/dev/runtime-server.ts
+++ b/packages/cli/src/lib/dev/runtime-server.ts
@@ -12,6 +12,7 @@ import {
 import { resolveSandboxManager } from "../runtime/resolve-sandbox.js"
 import type { SandboxManager } from "../runtime/sandbox-manager.js"
 import { type StreamChunk, toSseEvent } from "../runtime/stream-types.js"
+import { handleAgUiRequest } from "./agui-handler.js"
 import { loadMiddleware, runMiddleware } from "./middleware.js"
 import { createRuntimeRegistry, type RuntimeRegistry } from "./runtime-registry.js"
 import { createExecutionErrorBody, createRequestErrorBody } from "./server-errors.js"
@@ -311,6 +312,26 @@ function buildRouteTable(ctx: {
       },
       method: "POST",
       pattern: /^\/threads\/(?<thread_id>[^/?#]+)\/runs\/stream(?:\?.*)?$/,
+    },
+
+    // ------------------------------------------------------------------
+    // POST /agui/:routeId — AG-UI protocol endpoint (SSE)
+    // ------------------------------------------------------------------
+    {
+      handle: async (req, res, params) => {
+        await handleAgUiRequest({
+          appRoot,
+          registry,
+          threadsStore,
+          ...(sandboxManager ? { sandboxManager } : {}),
+          signal,
+          request: req,
+          response: res,
+          routeKey: params.routeId ?? "",
+        })
+      },
+      method: "POST",
+      pattern: /^\/agui\/(?<routeId>[^/?#]+)(?:\?.*)?$/,
     },
 
     // ------------------------------------------------------------------

--- a/packages/cli/test/agui-endpoint.test.ts
+++ b/packages/cli/test/agui-endpoint.test.ts
@@ -1,0 +1,78 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises"
+import { createServer, type Server } from "node:http"
+import type { AddressInfo } from "node:net"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+import { afterEach, expect, it } from "vitest"
+import { createAimock, script } from "../../testing/dist/index.js"
+import { createRuntimeRequestListener } from "../src/lib/dev/runtime-server.js"
+
+const cleanup: Array<() => Promise<void> | void> = []
+
+afterEach(async () => {
+  for (const fn of cleanup.splice(0).reverse()) await fn()
+})
+
+async function fixtureApp(): Promise<string> {
+  const appRoot = await mkdtemp(join(tmpdir(), "dawn-agui-"))
+  cleanup.push(() => rm(appRoot, { force: true, recursive: true }))
+  const files: Record<string, string> = {
+    "dawn.config.ts": "export default {}\n",
+    "package.json": '{ "name": "agui-fixture", "type": "module" }\n',
+    "src/app/chat/index.ts":
+      'import { agent } from "@dawn-ai/sdk"\nexport default agent({ model: "gpt-5-mini", systemPrompt: "You are helpful." })\n',
+  }
+  for (const [rel, body] of Object.entries(files)) {
+    const p = join(appRoot, rel)
+    await mkdir(join(p, ".."), { recursive: true })
+    await writeFile(p, body, "utf8")
+  }
+  return appRoot
+}
+
+it("streams AG-UI events from POST /agui/<route>", async () => {
+  const aimock = await createAimock({ fixtures: [] })
+  cleanup.push(() => aimock.close())
+  const prevBaseUrl = process.env.OPENAI_BASE_URL
+  const prevKey = process.env.OPENAI_API_KEY
+  process.env.OPENAI_BASE_URL = aimock.baseUrl
+  process.env.OPENAI_API_KEY = process.env.OPENAI_API_KEY ?? "test-not-used"
+  cleanup.push(() => {
+    if (prevBaseUrl === undefined) delete process.env.OPENAI_BASE_URL
+    else process.env.OPENAI_BASE_URL = prevBaseUrl
+    if (prevKey === undefined) delete process.env.OPENAI_API_KEY
+    else process.env.OPENAI_API_KEY = prevKey
+  })
+  aimock.addFixtures(script().user("hello").replies("Hi there!").build())
+
+  const appRoot = await fixtureApp()
+  const { listener, close } = await createRuntimeRequestListener({ appRoot })
+  cleanup.push(() => close())
+
+  const server: Server = createServer(listener)
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve))
+  cleanup.push(() => new Promise<void>((resolve) => server.close(() => resolve())))
+  const { port } = server.address() as AddressInfo
+
+  const routeKey = encodeURIComponent("/chat#agent")
+  const res = await fetch(`http://127.0.0.1:${port}/agui/${routeKey}`, {
+    method: "POST",
+    headers: { "content-type": "application/json", accept: "text/event-stream" },
+    body: JSON.stringify({
+      threadId: "th1",
+      runId: "rn1",
+      state: {},
+      messages: [{ id: "1", role: "user", content: "hello" }],
+      tools: [],
+      context: [],
+      forwardedProps: {},
+    }),
+  })
+  const text = await res.text()
+  expect(res.status).toBe(200)
+  expect(text).toContain('"type":"RUN_STARTED"')
+  expect(text).toContain('"type":"TEXT_MESSAGE_CONTENT"')
+  expect(text).toContain("Hi there!")
+  expect(text).toContain('"type":"RUN_FINISHED"')
+}, 60_000)

--- a/packages/cli/test/typegen-command.test.ts
+++ b/packages/cli/test/typegen-command.test.ts
@@ -183,6 +183,7 @@ describe("dawn typegen", () => {
     await mkdir(packsRoot, { recursive: true })
     await mkdir(join(appRoot, "src", "custom-app", "[tenant]"), { recursive: true })
 
+    const agUiTarball = await packPackage("@dawn-ai/ag-ui", packsRoot)
     const cliTarball = await packPackage("@dawn-ai/cli", packsRoot)
     const coreTarball = await packPackage("@dawn-ai/core", packsRoot)
     const langchainTarball = await packPackage("@dawn-ai/langchain", packsRoot)
@@ -225,6 +226,7 @@ describe("dawn typegen", () => {
         "  esbuild: true",
         "",
         "overrides:",
+        `  "@dawn-ai/ag-ui": ${JSON.stringify(`file:${agUiTarball}`)}`,
         `  "@dawn-ai/core": ${JSON.stringify(`file:${coreTarball}`)}`,
         `  "@dawn-ai/langchain": ${JSON.stringify(`file:${langchainTarball}`)}`,
         `  "@dawn-ai/langgraph": ${JSON.stringify(`file:${langgraphTarball}`)}`,

--- a/packages/cli/tsconfig.build.json
+++ b/packages/cli/tsconfig.build.json
@@ -6,6 +6,7 @@
     "outDir": "dist",
     "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo",
     "paths": {
+      "@dawn-ai/ag-ui": ["../ag-ui/src/index.ts"],
       "@dawn-ai/core": ["../core/src/index.ts"],
       "@dawn-ai/langchain": ["../langchain/src/index.ts"],
       "@dawn-ai/langgraph": ["../langgraph/src/index.ts"],
@@ -18,6 +19,9 @@
   },
   "include": ["src/**/*.ts"],
   "references": [
+    {
+      "path": "../ag-ui"
+    },
     {
       "path": "../core"
     },

--- a/packages/create-dawn-app/src/index.ts
+++ b/packages/create-dawn-app/src/index.ts
@@ -174,6 +174,7 @@ function createTemplateReplacements(
   options: CliOptions,
 ): {
   readonly appName: string
+  readonly dawnAgUiSpecifier: string
   readonly dawnCliSpecifier: string
   readonly dawnConfigTypescriptSpecifier: string
   readonly dawnCoreSpecifier: string
@@ -191,6 +192,7 @@ function createTemplateReplacements(
   if (options.mode === "internal") {
     return {
       appName: basename(appRoot),
+      dawnAgUiSpecifier: createAbsoluteFileSpecifier(resolve(repoRoot, "packages/ag-ui")),
       dawnCliSpecifier: createAbsoluteFileSpecifier(resolve(repoRoot, "packages/cli")),
       dawnConfigTypescriptSpecifier: createAbsoluteFileSpecifier(
         resolve(repoRoot, "packages/config-typescript"),
@@ -215,6 +217,7 @@ function createTemplateReplacements(
 
   return {
     appName: basename(appRoot),
+    dawnAgUiSpecifier: options.distTag,
     dawnCliSpecifier: options.distTag,
     dawnConfigTypescriptSpecifier: options.distTag,
     dawnCoreSpecifier: options.distTag,
@@ -236,6 +239,7 @@ async function applyInternalModePackageOverrides(
   replacements: ReturnType<typeof createTemplateReplacements>,
 ): Promise<void> {
   const overrides = {
+    "@dawn-ai/ag-ui": replacements.dawnAgUiSpecifier,
     "@dawn-ai/cli": replacements.dawnCliSpecifier,
     "@dawn-ai/config-typescript": replacements.dawnConfigTypescriptSpecifier,
     "@dawn-ai/core": replacements.dawnCoreSpecifier,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -225,8 +225,36 @@ importers:
         specifier: ^4.1.9
         version: 4.1.9(@types/node@26.1.0)(@vitest/ui@4.1.9)(vite@6.4.3(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4)(yaml@2.9.0))
 
+  packages/ag-ui:
+    dependencies:
+      '@ag-ui/core':
+        specifier: 0.0.57
+        version: 0.0.57
+      '@ag-ui/encoder':
+        specifier: 0.0.57
+        version: 0.0.57
+    devDependencies:
+      '@ag-ui/client':
+        specifier: 0.0.57
+        version: 0.0.57
+      '@dawn-ai/config-typescript':
+        specifier: workspace:*
+        version: link:../config-typescript
+      '@types/node':
+        specifier: 26.1.0
+        version: 26.1.0
+      rxjs:
+        specifier: 7.8.1
+        version: 7.8.1
+
   packages/cli:
     dependencies:
+      '@ag-ui/core':
+        specifier: 0.0.57
+        version: 0.0.57
+      '@dawn-ai/ag-ui':
+        specifier: workspace:*
+        version: link:../ag-ui
       '@dawn-ai/core':
         specifier: workspace:*
         version: link:../core
@@ -602,6 +630,18 @@ importers:
 
 packages:
 
+  '@ag-ui/client@0.0.57':
+    resolution: {integrity: sha512-Xap2alG9Z0/j5kb3x4D7oTpe2sw1dfrC9rgJJr2NZu5vKcm8dzIPNd31mF2B4zS3BKqYIu245yxKPhEtT30MHw==}
+
+  '@ag-ui/core@0.0.57':
+    resolution: {integrity: sha512-gho1OWjNE6E3Rl7ZEZ1wr2CEpUHjLFU0FqzCZZk439TicLu+BfLCMkMokB07bMGlRmbJ60hM6LW60iOVauCx+Q==}
+
+  '@ag-ui/encoder@0.0.57':
+    resolution: {integrity: sha512-ifD9NctR4xyPDR58xF9GK1bj/S8oECFkTeDfuYD8tXdbcOstIJ2TOqU2zhiCKnw7Vw+zR9Qv3TbsM9E7Gi9X3Q==}
+
+  '@ag-ui/proto@0.0.57':
+    resolution: {integrity: sha512-pPENOZt0P6ibH8sCTgq05wLYXi5t3P9B5r/1bWYehXjUxtyOdnukSlWM++SsCIwUXsQdm/b3aBgGjEeTF7RenA==}
+
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
@@ -678,6 +718,9 @@ packages:
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [win32]
+
+  '@bufbuild/protobuf@2.12.1':
+    resolution: {integrity: sha512-BvAMfS6LrgZiryOAZ4pBYucu4wG/Ei/9o9DZ9akbREnMLbPJiom2i8b9C8IsKErQoiKqVhrerzt3kOT/RrzLHg==}
 
   '@cfworker/json-schema@4.1.1':
     resolution: {integrity: sha512-gAmrUZSGtKc3AiBL71iNWxDsyUC5uMaKKGdvzYsBoTW/xi42JQHl7eKV2OYzCUqvc+D2RCcf7EXY2iCyFIk6og==}
@@ -1490,6 +1533,10 @@ packages:
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
 
+  '@protobuf-ts/protoc@2.11.1':
+    resolution: {integrity: sha512-mUZJaV0daGO6HUX90o/atzQ6A7bbN2RSuHtdwo8SSF2Qoe3zHwa4IHyCN1evftTeHfLmdz+45qo47sL+5P8nyg==}
+    hasBin: true
+
   '@protobufjs/aspromise@1.1.2':
     resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
 
@@ -1924,6 +1971,9 @@ packages:
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
 
+  '@types/uuid@10.0.0':
+    resolution: {integrity: sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==}
+
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
     deprecated: Potential CWE-502 - Update to 1.3.1 or higher
@@ -2349,6 +2399,9 @@ packages:
     resolution: {integrity: sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==}
     engines: {node: '>=22.12.0'}
 
+  compare-versions@6.1.1:
+    resolution: {integrity: sha512-4hm4VPpIecmlg59CHXnRDnqGplJFrbLG4aFEl5vl6cK1u76ws3LLvX7ikFnTDl5vo39sjWD6AaDPYodJp/NNHg==}
+
   compress-commons@6.0.2:
     resolution: {integrity: sha512-6FqVXeETqWPoGcfzrXb37E50NP0LXT8kAMu5ooZayhWWdgEY4lBEEcbQNXtkuKQsGduxiIcI4gOTsxTmuq/bSg==}
     engines: {node: '>= 14'}
@@ -2678,6 +2731,9 @@ packages:
   fast-glob@3.3.3:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
     engines: {node: '>=8.6.0'}
+
+  fast-json-patch@3.1.1:
+    resolution: {integrity: sha512-vf6IHUX2SBcA+5/+4883dsIjpBTqmfBjmYiWK1savxQmFk4JfBMLa7ynTYOs1Rolp/T1betJxHiGD3g1Mn8lUQ==}
 
   fast-sha256@1.3.0:
     resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
@@ -4060,6 +4116,9 @@ packages:
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
+  rxjs@7.8.1:
+    resolution: {integrity: sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==}
+
   sade@1.8.1:
     resolution: {integrity: sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==}
     engines: {node: '>=6'}
@@ -4495,6 +4554,9 @@ packages:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
     engines: {node: '>= 0.8'}
 
+  untruncate-json@0.0.1:
+    resolution: {integrity: sha512-4W9enDK4X1y1s2S/Rz7ysw6kDuMS3VmRjMFg7GZrNO+98OSe+x5Lh7PKYoVjy3lW/1wmhs6HW0lusnQRHgMarA==}
+
   utf8-byte-length@1.0.5:
     resolution: {integrity: sha512-Xn0w3MtiQ6zoz2vFyUVruaCL53O/DwUvkEeOvj+uulMm0BkUGYWmBYVyElqZaSLhY6ZD0ulfU3aBra2aVT4xfA==}
 
@@ -4702,6 +4764,9 @@ packages:
     peerDependencies:
       zod: ^3.25.28 || ^4
 
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
   zod@4.4.3:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
@@ -4709,6 +4774,34 @@ packages:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
 snapshots:
+
+  '@ag-ui/client@0.0.57':
+    dependencies:
+      '@ag-ui/core': 0.0.57
+      '@ag-ui/encoder': 0.0.57
+      '@ag-ui/proto': 0.0.57
+      '@types/uuid': 10.0.0
+      compare-versions: 6.1.1
+      fast-json-patch: 3.1.1
+      rxjs: 7.8.1
+      untruncate-json: 0.0.1
+      uuid: 11.1.1
+      zod: 3.25.76
+
+  '@ag-ui/core@0.0.57':
+    dependencies:
+      zod: 3.25.76
+
+  '@ag-ui/encoder@0.0.57':
+    dependencies:
+      '@ag-ui/core': 0.0.57
+      '@ag-ui/proto': 0.0.57
+
+  '@ag-ui/proto@0.0.57':
+    dependencies:
+      '@ag-ui/core': 0.0.57
+      '@bufbuild/protobuf': 2.12.1
+      '@protobuf-ts/protoc': 2.11.1
 
   '@alloc/quick-lru@5.2.0': {}
 
@@ -4757,6 +4850,8 @@ snapshots:
 
   '@biomejs/cli-win32-x64@2.5.1':
     optional: true
+
+  '@bufbuild/protobuf@2.12.1': {}
 
   '@cfworker/json-schema@4.1.1': {}
 
@@ -5516,6 +5611,8 @@ snapshots:
 
   '@polka/url@1.0.0-next.29': {}
 
+  '@protobuf-ts/protoc@2.11.1': {}
+
   '@protobufjs/aspromise@1.1.2': {}
 
   '@protobufjs/base64@1.1.2': {}
@@ -5872,6 +5969,8 @@ snapshots:
   '@types/unist@2.0.11': {}
 
   '@types/unist@3.0.3': {}
+
+  '@types/uuid@10.0.0': {}
 
   '@ungap/structured-clone@1.3.0': {}
 
@@ -6380,6 +6479,8 @@ snapshots:
 
   commander@15.0.0: {}
 
+  compare-versions@6.1.1: {}
+
   compress-commons@6.0.2:
     dependencies:
       crc-32: 1.2.2
@@ -6815,6 +6916,8 @@ snapshots:
       glob-parent: 5.1.2
       merge2: 1.4.1
       micromatch: 4.0.8
+
+  fast-json-patch@3.1.1: {}
 
   fast-sha256@1.3.0: {}
 
@@ -8523,6 +8626,10 @@ snapshots:
     dependencies:
       queue-microtask: 1.2.3
 
+  rxjs@7.8.1:
+    dependencies:
+      tslib: 2.8.1
+
   sade@1.8.1:
     dependencies:
       mri: 1.2.0
@@ -9054,6 +9161,8 @@ snapshots:
 
   unpipe@1.0.0: {}
 
+  untruncate-json@0.0.1: {}
+
   utf8-byte-length@1.0.5: {}
 
   util-deprecate@1.0.2: {}
@@ -9259,6 +9368,8 @@ snapshots:
   zod-to-json-schema@3.25.2(zod@4.4.3):
     dependencies:
       zod: 4.4.3
+
+  zod@3.25.76: {}
 
   zod@4.4.3: {}
 

--- a/test/generated/run-generated-app.test.ts
+++ b/test/generated/run-generated-app.test.ts
@@ -21,6 +21,7 @@ import { expectBasicAuthoringLane } from "./harness.ts"
 // @dawn-ai workspace packages a generated app may depend on. Used only to build
 // the internal-mode <repo:...> fixture (external mode installs from the registry).
 const SCAFFOLD_PACKAGES: readonly string[] = [
+  "@dawn-ai/ag-ui",
   "@dawn-ai/cli",
   "@dawn-ai/config-typescript",
   "@dawn-ai/core",

--- a/vitest.workspace.ts
+++ b/vitest.workspace.ts
@@ -4,6 +4,7 @@ export default defineConfig({
   test: {
     projects: [
       "./apps/web/vitest.config.ts",
+      "./packages/ag-ui/vitest.config.ts",
       "./packages/cli/vitest.config.ts",
       "./packages/core/vitest.config.ts",
       "./packages/create-dawn-app/vitest.config.ts",


### PR DESCRIPTION
## Summary

Makes Dawn a first-class **AG-UI** agent so UIs can be built on **CopilotKit** (and any AG-UI client) instead of hand-rolled SSE parsing. New `@dawn-ai/ag-ui` package translates Dawn's runtime event stream into the AG-UI protocol, served by a new **additive** `POST /agui/{routeId}` endpoint. The existing Agent-Protocol endpoints and the bespoke SSE envelope are **unchanged** — AG-UI lives only at the edge as a permanent anti-corruption layer, so its pre-1.0 churn never touches Dawn's stable core.

This is **sub-project 1** of the AG-UI + CopilotKit design. The CopilotKit chat and research UIs are follow-up sub-projects.

## What's here
- **`@dawn-ai/ag-ui`** — a pure, isolated translator (`DawnStreamChunk → AG-UI events`) ported from the canonical `@ag-ui/langgraph` mapping: text/tool-call/lifecycle, `plan_update → STATE_SNAPSHOT` (snapshot-only, at parity with upstream), `subagent.* → CUSTOM`, `interrupt → CUSTOM on_interrupt`. IDs synthesized in-adapter; tool results paired FIFO-by-name. Plus `mapRunInput` (RunAgentInput → Dawn run + resume decoding) and an SSE encode helper. **Zero dependency on `@dawn-ai/cli`.**
- **`POST /agui/{routeId}`** in `@dawn-ai/cli` — wires the translator to the existing `streamResolvedRoute` + thread/checkpoint machinery; HITL resume routes into Dawn's existing `/resume` decision path. Marks the thread busy/idle for parity with sibling handlers.
- Registered the new CLI-transitive dependency across the generated-app install lanes (pack lists, `SCAFFOLD_PACKAGES`, `create-dawn-app` overrides).

## De-risking
- Every emitted event is validated against `@ag-ui/core@0.0.57` zod schemas in unit tests.
- **Conformance oracle:** an e2e drives the endpoint with the real `@ag-ui/client` `HttpAgent` piped through the exported `verifyEvents` operator — the stream is accepted with zero translator changes.
- Deterministic endpoint e2e via aimock (no API key). `@ag-ui/*` pinned to `0.0.57`; a schema-validation test fails loudly on a breaking bump.

Design: `docs/superpowers/specs/2026-07-07-ag-ui-copilotkit-ui-design.md`
Plan: `docs/superpowers/plans/2026-07-07-ag-ui-capability.md`

## Test plan
- [x] `pnpm --filter @dawn-ai/ag-ui test` → 16 passed (translator + run-input + conformance)
- [x] `pnpm --filter @dawn-ai/cli test test/agui-endpoint.test.ts` → in-process AG-UI stream, no key
- [x] `pnpm --filter @dawn-ai/cli test test/typegen-command.test.ts` → packaged install resolves the new dep
- [x] turbo build + typecheck clean for `@dawn-ai/ag-ui` and `@dawn-ai/cli`
- [ ] Full `pnpm ci:validate` on CI (new workspace package + harness lanes)

## Release note
First publish of `@dawn-ai/ag-ui` needs the one-time manual OIDC bootstrap before the Version PR merges (same as `@dawn-ai/sandbox`/`@dawn-ai/memory`).

## Follow-ups (not in this PR)
- Decide middleware parity for `/agui` (it currently bypasses app middleware that `runs/stream` runs).
- CopilotKit chat UI, then research UI (sub-projects 2 and 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)