### PR TITLE
feat(chart): dawn-app deploy Helm chart (Kubernetes arc, sub-project 3)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -296,10 +296,14 @@ jobs:
         uses: helm/kind-action@a1b0e391336a6ee6713a0583f8c6240d70863de3 # v1.12.0
 
       - name: Install dawn-app (placeholder image) and verify it serves
+        # nginx-unprivileged runs as non-root (UID 101, port 8080), so it satisfies
+        # the chart's hardened runAsNonRoot default — which is exactly what a real
+        # langgraph app image must also do. A root image (e.g. traefik/whoami) would
+        # be rejected by the kubelet, so this doubles as a proof of the non-root default.
         run: |
           helm install dawn-app charts/dawn-app \
-            --set image.repository=traefik/whoami --set image.tag=latest \
-            --set containerPort=80 --set healthPath=/ \
+            --set image.repository=nginxinc/nginx-unprivileged --set image.tag=stable-alpine \
+            --set containerPort=8080 --set healthPath=/ \
             --set serviceAccount.create=true --set serviceAccount.name=dawn-app-smoke \
             --wait --timeout 3m
           kubectl rollout status deploy/dawn-app --timeout=120s

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,6 +218,7 @@ jobs:
           helm template test charts/dawn-app \
             --set image.repository=example/app \
             --set ingress.enabled=true \
+            --set ingress.host=app.example.com \
             --set autoscaling.enabled=true \
             --set podDisruptionBudget.enabled=true \
             | kubeconform -strict -summary -ignore-missing-schemas

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,25 +181,45 @@ jobs:
           sudo install /tmp/kubeconform /usr/local/bin/kubeconform
           kubeconform -v
 
-      - name: Helm lint (strict)
+      - name: Helm lint (strict) — dawn-sandbox-infra
         run: helm lint --strict charts/dawn-sandbox-infra
 
       - name: Reaper unit test
         run: sh charts/dawn-sandbox-infra/test/reaper.test.sh
 
-      - name: Render assertions
+      - name: Render assertions — dawn-sandbox-infra
         run: sh charts/dawn-sandbox-infra/test/render.sh
 
-      - name: kubeconform (default values)
+      - name: kubeconform (default values) — dawn-sandbox-infra
         run: |
           helm template test charts/dawn-sandbox-infra \
             | kubeconform -strict -summary -ignore-missing-schemas
 
-      - name: kubeconform (restricted PSS, reaper disabled)
+      - name: kubeconform (restricted PSS, reaper disabled) — dawn-sandbox-infra
         run: |
           helm template test charts/dawn-sandbox-infra \
             --set podSecurityStandard.enforce=restricted \
             --set reaper.enabled=false \
+            | kubeconform -strict -summary -ignore-missing-schemas
+
+      - name: Helm lint (strict) — dawn-app
+        run: helm lint --strict charts/dawn-app
+
+      - name: Render assertions — dawn-app
+        run: sh charts/dawn-app/test/render.sh
+
+      - name: kubeconform (default values) — dawn-app
+        run: |
+          helm template test charts/dawn-app --set image.repository=example/app \
+            | kubeconform -strict -summary -ignore-missing-schemas
+
+      - name: kubeconform (full override) — dawn-app
+        run: |
+          helm template test charts/dawn-app \
+            --set image.repository=example/app \
+            --set ingress.enabled=true \
+            --set autoscaling.enabled=true \
+            --set podDisruptionBudget.enabled=true \
             | kubeconform -strict -summary -ignore-missing-schemas
 
   sandbox-k8s:
@@ -260,3 +280,28 @@ jobs:
 
       - name: Real-cluster sandbox conformance + e2e
         run: DAWN_TEST_K8S=1 pnpm --filter @dawn-ai/sandbox test kube-sandbox.integration
+
+  chart-apply-smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Setup Helm
+        uses: azure/setup-helm@b9e51907a09c216f16ebe8536097933489208112 # v4.3.0
+
+      - name: Create kind cluster
+        uses: helm/kind-action@a1b0e391336a6ee6713a0583f8c6240d70863de3 # v1.12.0
+
+      - name: Install dawn-app (placeholder image) and verify it serves
+        run: |
+          helm install dawn-app charts/dawn-app \
+            --set image.repository=traefik/whoami --set image.tag=latest \
+            --set containerPort=80 --set healthPath=/ \
+            --set serviceAccount.create=true --set serviceAccount.name=dawn-app-smoke \
+            --wait --timeout 3m
+          kubectl rollout status deploy/dawn-app --timeout=120s
+          kubectl run curl --image=curlimages/curl:8.10.1 --restart=Never --rm -i --quiet -- \
+            curl -sf http://dawn-app.default.svc.cluster.local/ >/dev/null && echo "app served OK"

--- a/.github/workflows/publish-chart.yml
+++ b/.github/workflows/publish-chart.yml
@@ -6,6 +6,7 @@ on:
       - main
     paths:
       - "charts/dawn-sandbox-infra/**"
+      - "charts/dawn-app/**"
 
 permissions:
   contents: read
@@ -15,6 +16,10 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+
+    strategy:
+      matrix:
+        chart: [dawn-sandbox-infra, dawn-app]
 
     steps:
       - name: Checkout
@@ -28,10 +33,11 @@ jobs:
 
       - name: Publish chart if version is new
         run: |
-          VERSION=$(helm show chart charts/dawn-sandbox-infra | awk '/^version:/{print $2}')
-          if helm show chart "oci://ghcr.io/cacheplane/charts/dawn-sandbox-infra" --version "$VERSION" >/dev/null 2>&1; then
-            echo "dawn-sandbox-infra $VERSION already published, skipping"
+          CHART="${{ matrix.chart }}"
+          VERSION=$(helm show chart "charts/$CHART" | awk '/^version:/{print $2}')
+          if helm show chart "oci://ghcr.io/cacheplane/charts/$CHART" --version "$VERSION" >/dev/null 2>&1; then
+            echo "$CHART $VERSION already published, skipping"
             exit 0
           fi
-          helm package charts/dawn-sandbox-infra -d /tmp
-          helm push "/tmp/dawn-sandbox-infra-$VERSION.tgz" oci://ghcr.io/cacheplane/charts
+          helm package "charts/$CHART" -d /tmp
+          helm push "/tmp/$CHART-$VERSION.tgz" oci://ghcr.io/cacheplane/charts

--- a/apps/web/content/docs/deployment.mdx
+++ b/apps/web/content/docs/deployment.mdx
@@ -71,6 +71,8 @@ Dawn does not host or run production traffic itself. It owns local development (
 
 If you can't or won't use LangSmith, build with `dawn build` and feed `.dawn/build/` to your own container. The generated entry files and `langgraph.json` are the canonical interface — the in-process `dawn dev` runtime is a reference for the same protocol surface (`/threads/:id/runs/wait`, `/threads/:id/runs/stream`, `/healthz`), but is not intended as a production runtime itself.
 
+Containerize with `@langchain/langgraph-cli`'s `langgraphjs dockerfile` command against a root-level `langgraph.json`. To run that image on Kubernetes — as a Deployment + Service with optional Ingress, autoscaling, and a PodDisruptionBudget, wired to the sandbox provider's orchestrator ServiceAccount — see [Deploying a Dawn app (Helm)](/docs/sandbox#deploying-a-dawn-app-helm).
+
 ## Troubleshooting
 
 - **Tests pass in-process but fail live-server** — a tool or route isn't serializing cleanly. Check that inputs, outputs, and state are JSON-serializable (no Dates, Maps, classes).

--- a/apps/web/content/docs/sandbox.mdx
+++ b/apps/web/content/docs/sandbox.mdx
@@ -223,7 +223,68 @@ helm install dawn-sandbox-infra oci://ghcr.io/cacheplane/charts/dawn-sandbox-inf
   --set reaper.ttlHours=24
 ```
 
-`dawn-sandbox-infra` is the second of three sub-projects in Dawn's Kubernetes arc: this chart hardens the cluster for the sandbox provider; an app-deploy chart for running the Dawn server itself on Kubernetes follows.
+`dawn-sandbox-infra` is the second of three sub-projects in Dawn's Kubernetes arc: this chart hardens the cluster for the sandbox provider; the `dawn-app` chart below runs the Dawn app itself on Kubernetes, completing the arc.
+
+## Deploying a Dawn app (Helm)
+
+Dawn has no bespoke production server — `dawn build` emits `.dawn/build/langgraph.json` plus per-route entry files, and the documented way to containerize them is `@langchain/langgraph-cli`'s `langgraphjs dockerfile` command, run against a root-level `langgraph.json`. The `dawn-app` Helm chart takes that **user-built image** and runs it on Kubernetes as a Deployment + Service, with optional Ingress, HorizontalPodAutoscaler, and PodDisruptionBudget. It owns only the Kubernetes deploy concerns — it does not build your image, run a Dawn-authored server, or bake `dawn.config.ts`; the image is the runtime contract.
+
+```bash
+# Build the image from your generated langgraph.json
+npx @langchain/langgraph-cli dockerfile . -c langgraph.json
+
+# Install the chart against that image
+helm install dawn-app oci://ghcr.io/cacheplane/charts/dawn-app \
+  --set image.repository=ghcr.io/you/your-app \
+  --set image.tag=latest
+```
+
+Or from a local checkout of the chart:
+
+```bash
+helm install dawn-app ./charts/dawn-app --set image.repository=ghcr.io/you/your-app
+```
+
+`image.repository` is required — install/upgrade fails fast with a clear error if it's unset. `containerPort` (default `8000`) and `healthPath` (default `/healthz`) are also values — verify both against your built image before relying on the defaults, since they drive the liveness/readiness/startup probes.
+
+### ServiceAccount and namespace wiring
+
+If your app's `dawn.config.ts` configures `kubernetesSandbox`, the app process calls the Kubernetes API to create sandbox Pods — so the app's own Pod must run under a ServiceAccount bound to the `dawn-sandbox-infra` chart's `dawn-orchestrator` Role. Two ways to satisfy that, via `values.serviceAccount`:
+
+- **Run the app in the sandbox namespace.** Install `dawn-app` into the same namespace as `dawn-sandbox-infra` (`sandboxNamespace`, default `dawn-sandboxes`) and reuse the existing `dawn-orchestrator` ServiceAccount (`serviceAccount.create=false`, the default).
+- **Add a cross-namespace subject.** Keep the app in its own namespace, set `serviceAccount.create=true` so the chart creates a ServiceAccount there, then bind it to the sandbox-infra Role by adding it to that chart's `orchestrator.subjects`:
+
+  ```bash
+  helm upgrade dawn-sandbox-infra charts/dawn-sandbox-infra \
+    --reuse-values \
+    --set-json 'orchestrator.subjects[0]={"kind":"ServiceAccount","name":"dawn-app","namespace":"default"}'
+  ```
+
+The chart's post-install NOTES print the exact subject to add for your release. Either way, keep `sandboxNamespace` (informational only) in sync with the `namespace` passed to `kubernetesSandbox({ namespace })` in `dawn.config.ts` and with `dawn-sandbox-infra`'s `namespace.name`.
+
+### Env, secrets, and scaling
+
+Supply environment variables directly (`env`) or via an existing Secret (`secretName`, wired as a convenience `envFrom.secretRef` — the chart does not template Secrets itself):
+
+```bash
+helm install dawn-app oci://ghcr.io/cacheplane/charts/dawn-app \
+  --set image.repository=ghcr.io/you/your-app \
+  --set secretName=my-app-secrets
+```
+
+Ingress, autoscaling, and a PodDisruptionBudget are all opt-in:
+
+```bash
+helm install dawn-app oci://ghcr.io/cacheplane/charts/dawn-app \
+  --set image.repository=ghcr.io/you/your-app \
+  --set ingress.enabled=true --set ingress.className=nginx --set ingress.host=app.example.com \
+  --set autoscaling.enabled=true --set autoscaling.maxReplicas=10 \
+  --set podDisruptionBudget.enabled=true
+```
+
+<Callout type="warn" title="A user-built image, not a Dawn-hosted runtime">
+  This chart cannot validate a real Dawn app end-to-end in CI — that needs an app image and model credentials. CI instead validates the chart's manifests (lint, render, `kubeconform`) plus a gated `kind` smoke test that installs the chart with a placeholder image and confirms the Deployment and Service come up and serve traffic. Validating your actual app image against a real model is your responsibility.
+</Callout>
 
 ## Subagents
 

--- a/charts/dawn-app/.helmignore
+++ b/charts/dawn-app/.helmignore
@@ -1,0 +1,25 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*.tmp
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/
+# Local test harness (not part of the packaged chart)
+test/

--- a/charts/dawn-app/Chart.yaml
+++ b/charts/dawn-app/Chart.yaml
@@ -1,0 +1,11 @@
+apiVersion: v2
+name: dawn-app
+description: Runs a built Dawn app image (from `langgraphjs dockerfile`) on Kubernetes as a Deployment + Service, with optional Ingress, HorizontalPodAutoscaler, and PodDisruptionBudget, wired to the in-cluster kubernetesSandbox orchestrator ServiceAccount.
+type: application
+version: 0.1.0
+appVersion: "0.8.9"
+keywords: [dawn, langgraph, kubernetes, deployment]
+home: https://dawnai.org
+sources: [https://github.com/cacheplane/dawnai]
+maintainers:
+  - name: Dawn

--- a/charts/dawn-app/README.md
+++ b/charts/dawn-app/README.md
@@ -1,0 +1,106 @@
+# dawn-app
+
+Runs a **user-built Dawn app image** on Kubernetes as a Deployment + Service
+(+ optional Ingress, HorizontalPodAutoscaler, and PodDisruptionBudget), wired
+to the in-cluster `kubernetesSandbox` provider via the ServiceAccount +
+namespace provisioned by the `dawn-sandbox-infra` chart.
+
+This chart does **not** build your image, own a bespoke Dawn production
+server, or bake `dawn.config.ts`. Dawn has no bespoke production server:
+`dawn build` emits `.dawn/build/langgraph.json` + per-route entry files, and
+the documented containerization path
+([docs/deployment.mdx](../../apps/web/content/docs/deployment.mdx)) is to
+build an image with `@langchain/langgraph-cli` (`langgraphjs dockerfile`)
+against a root-level `langgraph.json`. This chart wraps that image — it owns
+the *Kubernetes deployment* concerns; the image owns the *runtime*.
+
+## Install
+
+```sh
+helm install dawn-app charts/dawn-app --set image.repository=ghcr.io/you/your-app --set image.tag=latest
+```
+
+Or, once published, from GHCR:
+
+```sh
+helm install dawn-app oci://ghcr.io/cacheplane/charts/dawn-app --set image.repository=ghcr.io/you/your-app
+```
+
+`image.repository` is required — `helm install`/`helm upgrade` will fail
+fast with a clear error if it is unset (enforced by a template-level
+`required` guard in `templates/deployment.yaml`, not the JSON Schema, so
+that `helm lint`/`helm template` still pass without `--set` for CI/dev
+convenience).
+
+## Sandbox ServiceAccount wiring (read this)
+
+The app process calls the Kubernetes API to create sandbox Pods, so its Pod
+must run under a ServiceAccount bound to the `dawn-sandbox-infra` chart's
+orchestrator Role. Two modes via `values.serviceAccount`:
+
+- **`create: false` (default)** — reuse the ServiceAccount named
+  `serviceAccount.name` (default `dawn-orchestrator`), the one the
+  `dawn-sandbox-infra` chart creates. This works out of the box only if
+  this app is installed **in the sandbox namespace** (`sandboxNamespace`,
+  default `dawn-sandboxes`), or if the operator has added this app's SA as
+  a cross-namespace subject on the `dawn-sandbox-infra` chart's
+  `orchestrator.subjects`.
+- **`create: true`** — this chart creates a ServiceAccount in the app's own
+  namespace; the operator must then bind it to the `dawn-sandbox-infra`
+  Role via that chart's `orchestrator.subjects`. `helm install`/`upgrade`
+  prints the exact subject to add in the post-install NOTES.
+
+Either way, keep `sandboxNamespace` (informational only) in sync with your
+app's `dawn.config.ts`:
+
+```ts
+sandbox: {
+  provider: kubernetesSandbox({ namespace: "dawn-sandboxes" });
+}
+```
+
+## Values
+
+| Key | Default | Description |
+| --- | --- | --- |
+| `image.repository` | `""` | **Required** at install time (see above). |
+| `image.tag` | `""` | Falls back to `.Chart.AppVersion` when unset. |
+| `image.digest` | `""` | If set, pins `repository@sha256:...` instead of `tag`. |
+| `image.pullPolicy` | `IfNotPresent` | |
+| `imagePullSecrets` | `[]` | |
+| `replicaCount` | `1` | Ignored (omitted) when `autoscaling.enabled=true`. |
+| `containerPort` | `8000` | The port the langgraph API server listens on inside the image — verify against your built image. |
+| `healthPath` | `/healthz` | HTTP path used for liveness/readiness/startup probes. |
+| `probes.*` | see `values.yaml` | Per-probe timing (initialDelaySeconds/periodSeconds/timeoutSeconds/failureThreshold). |
+| `service.type` | `ClusterIP` | |
+| `service.port` | `80` | Maps to the named `http` container port. |
+| `ingress.enabled` | `false` | Gate the Ingress. |
+| `ingress.className` / `host` / `path` / `pathType` / `tls` / `annotations` | see `values.yaml` | Standard Helm ingress idiom. |
+| `autoscaling.enabled` | `false` | Gate the HorizontalPodAutoscaler (`autoscaling/v2`). |
+| `autoscaling.minReplicas` / `maxReplicas` / `targetCPUUtilizationPercentage` / `targetMemoryUtilizationPercentage` | see `values.yaml` | |
+| `podDisruptionBudget.enabled` | `false` | Gate the PodDisruptionBudget (`policy/v1`). |
+| `podDisruptionBudget.minAvailable` | `1` | |
+| `serviceAccount.create` | `false` | See "Sandbox ServiceAccount wiring" above. |
+| `serviceAccount.name` | `dawn-orchestrator` | |
+| `automountServiceAccountToken` | `true` | The app needs the token to call the Kubernetes API. |
+| `sandboxNamespace` | `dawn-sandboxes` | Informational; must match `dawn-sandbox-infra`'s `namespace.name` and the app's `kubernetesSandbox({ namespace })`. |
+| `env` / `envFrom` | `[]` | Standard container env / envFrom. |
+| `secretName` | `""` | Convenience `envFrom.secretRef` (e.g. `OPENAI_API_KEY`, `DATABASE_URL`). The chart does **not** template Secrets — supply them out-of-band. |
+| `resources` | `{}` | |
+| `securityContext.readOnlyRootFilesystem` | `false` | The langgraph runtime likely writes temp state; a writable `/tmp` emptyDir is always mounted regardless. Set `true` if your image tolerates it. |
+| `nodeSelector` / `tolerations` / `affinity` | `{}` / `[]` / `{}` | |
+
+## Honest scope
+
+- This chart runs a **user-built** image; it does not build the image, own
+  a Dawn server, or bake `dawn.config.ts`. The app image is the runtime
+  contract.
+- It cannot validate a *real* Dawn app end-to-end in CI (that needs an app
+  image + model credentials) — CI validates the chart's manifests with a
+  placeholder image; real-app validation is the operator's responsibility.
+- Cross-namespace ServiceAccount binding requires the operator to wire the
+  `dawn-sandbox-infra` chart's `orchestrator.subjects` — this chart
+  documents and prints the exact subject; it does not reach into the other
+  chart's release.
+- Deferred: a Dawn-owned base runtime image, GitOps/ArgoCD manifests,
+  service mesh integration, multi-region, blue/green.

--- a/charts/dawn-app/templates/NOTES.txt
+++ b/charts/dawn-app/templates/NOTES.txt
@@ -1,0 +1,63 @@
+dawn-app installed.
+
+Service URL:
+{{- if .Values.ingress.enabled }}
+{{- range $host := list .Values.ingress.host }}
+{{- if $host }}
+  http{{ if $.Values.ingress.tls.enabled }}s{{ end }}://{{ $host }}{{ $.Values.ingress.path }}
+{{- else }}
+  (ingress.enabled=true but ingress.host is unset — set it to get a URL)
+{{- end }}
+{{- end }}
+{{- else if contains "LoadBalancer" .Values.service.type }}
+  Run:
+    kubectl get svc {{ include "dawn-app.fullname" . }} -n {{ .Release.Namespace }} -w
+  to watch for an EXTERNAL-IP, then browse to http://<EXTERNAL-IP>:{{ .Values.service.port }}
+{{- else if contains "NodePort" .Values.service.type }}
+  Run:
+    kubectl get svc {{ include "dawn-app.fullname" . }} -n {{ .Release.Namespace }} -o jsonpath='{.spec.ports[0].nodePort}'
+  to get the NodePort, then browse to http://<NODE-IP>:<NODE-PORT>
+{{- else }}
+  Cluster-internal only (service.type=ClusterIP). Port-forward to reach it:
+    kubectl port-forward -n {{ .Release.Namespace }} svc/{{ include "dawn-app.fullname" . }} 8080:{{ .Values.service.port }}
+  then browse to http://localhost:8080
+{{- end }}
+
+ServiceAccount / namespace wiring (the sandbox crux):
+
+This app's Pod runs under ServiceAccount "{{ include "dawn-app.serviceAccountName" . }}"
+in namespace "{{ .Release.Namespace }}". For the in-cluster kubernetesSandbox
+provider (baked into your image's dawn.config.ts) to work, that ServiceAccount
+must be bound to the dawn-sandbox-infra chart's orchestrator Role.
+
+{{- if .Values.serviceAccount.create }}
+
+serviceAccount.create=true — this chart created the ServiceAccount above in
+THIS namespace ("{{ .Release.Namespace }}"). You must now bind it to the
+sandbox-infra orchestrator Role by adding it as a cross-namespace subject on
+the dawn-sandbox-infra release:
+
+  helm upgrade dawn-sandbox-infra charts/dawn-sandbox-infra \
+    --reuse-values \
+    --set-json 'orchestrator.subjects[0]={"kind":"ServiceAccount","name":"{{ include "dawn-app.serviceAccountName" . }}","namespace":"{{ .Release.Namespace }}"}'
+{{- else }}
+
+serviceAccount.create=false (default) — this chart is reusing an EXISTING
+ServiceAccount named "{{ include "dawn-app.serviceAccountName" . }}". This
+works out of the box only if one of the following is true:
+
+  1. This app is installed in the sandbox namespace itself
+     (currently: "{{ .Release.Namespace }}"; expected: "{{ .Values.sandboxNamespace }}"),
+     where the dawn-sandbox-infra chart already created that SA; OR
+  2. The operator has added
+       {kind: ServiceAccount, name: {{ include "dawn-app.serviceAccountName" . }}, namespace: {{ .Release.Namespace }}}
+     as a cross-namespace subject on the dawn-sandbox-infra chart's
+     `orchestrator.subjects` (same command shown above).
+{{- end }}
+
+Make sure your app's `dawn.config.ts` points the kubernetesSandbox provider at
+the same namespace as the dawn-sandbox-infra chart:
+
+  sandbox: {
+    provider: kubernetesSandbox({ namespace: "{{ .Values.sandboxNamespace }}" })
+  }

--- a/charts/dawn-app/templates/_helpers.tpl
+++ b/charts/dawn-app/templates/_helpers.tpl
@@ -1,0 +1,50 @@
+{{/*
+Chart name, truncated and trimmed for use in labels.
+*/}}
+{{- define "dawn-app.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Fully qualified app name. Truncated to 63 chars (DNS label limit) since
+this is used to construct Kubernetes object names.
+*/}}
+{{- define "dawn-app.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Standard Helm recommended labels.
+*/}}
+{{- define "dawn-app.labels" -}}
+app.kubernetes.io/name: {{ include "dawn-app.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/managed-by: Helm
+helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end -}}
+
+{{/*
+Selector labels — the stable subset used to match Pods (Deployment
+selector, Service selector, PDB selector). Must NOT change across
+releases/upgrades.
+*/}}
+{{- define "dawn-app.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "dawn-app.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{/*
+The ServiceAccount name to use, honoring create vs. reuse-existing.
+*/}}
+{{- define "dawn-app.serviceAccountName" -}}
+{{- .Values.serviceAccount.name -}}
+{{- end -}}

--- a/charts/dawn-app/templates/_helpers.tpl
+++ b/charts/dawn-app/templates/_helpers.tpl
@@ -48,3 +48,17 @@ The ServiceAccount name to use, honoring create vs. reuse-existing.
 {{- define "dawn-app.serviceAccountName" -}}
 {{- .Values.serviceAccount.name -}}
 {{- end -}}
+
+{{/*
+Full image reference: repository is required (fails fast with a clear
+error if unset, rather than silently rendering `image: :tag`). Pins by
+digest when set, else falls back to tag, else .Chart.AppVersion.
+*/}}
+{{- define "dawn-app.image" -}}
+{{- $repository := required "image.repository is required (e.g. --set image.repository=ghcr.io/you/your-app — see README)" .Values.image.repository -}}
+{{- if .Values.image.digest -}}
+{{- printf "%s@%s" $repository .Values.image.digest -}}
+{{- else -}}
+{{- printf "%s:%s" $repository (default .Chart.AppVersion .Values.image.tag) -}}
+{{- end -}}
+{{- end -}}

--- a/charts/dawn-app/templates/deployment.yaml
+++ b/charts/dawn-app/templates/deployment.yaml
@@ -1,0 +1,100 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "dawn-app.fullname" . }}
+  labels:
+    {{- include "dawn-app.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "dawn-app.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "dawn-app.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "dawn-app.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: {{ include "dawn-app.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.containerPort }}
+              protocol: TCP
+          {{- if or .Values.env .Values.secretName }}
+          env:
+            {{- with .Values.env }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- end }}
+          {{- if or .Values.envFrom .Values.secretName }}
+          envFrom:
+            {{- with .Values.envFrom }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+            {{- if .Values.secretName }}
+            - secretRef:
+                name: {{ .Values.secretName | quote }}
+            {{- end }}
+          {{- end }}
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.healthPath }}
+              port: http
+            initialDelaySeconds: {{ .Values.probes.liveness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.liveness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.liveness.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.liveness.failureThreshold }}
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.healthPath }}
+              port: http
+            initialDelaySeconds: {{ .Values.probes.readiness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.readiness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.readiness.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.readiness.failureThreshold }}
+          startupProbe:
+            httpGet:
+              path: {{ .Values.healthPath }}
+              port: http
+            initialDelaySeconds: {{ .Values.probes.startup.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.startup.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.startup.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.startup.failureThreshold }}
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir: {}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/dawn-app/templates/deployment.yaml
+++ b/charts/dawn-app/templates/deployment.yaml
@@ -34,11 +34,9 @@ spec:
             - name: http
               containerPort: {{ .Values.containerPort }}
               protocol: TCP
-          {{- if or .Values.env .Values.secretName }}
+          {{- with .Values.env }}
           env:
-            {{- with .Values.env }}
             {{- toYaml . | nindent 12 }}
-            {{- end }}
           {{- end }}
           {{- if or .Values.envFrom .Values.secretName }}
           envFrom:

--- a/charts/dawn-app/templates/hpa.yaml
+++ b/charts/dawn-app/templates/hpa.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "dawn-app.fullname" . }}
+  labels:
+    {{- include "dawn-app.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "dawn-app.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/charts/dawn-app/templates/ingress.yaml
+++ b/charts/dawn-app/templates/ingress.yaml
@@ -1,0 +1,37 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "dawn-app.fullname" . }}
+  labels:
+    {{- include "dawn-app.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls.enabled }}
+  tls:
+    - hosts:
+        {{- if .Values.ingress.host }}
+        - {{ .Values.ingress.host | quote }}
+        {{- end }}
+      secretName: {{ .Values.ingress.tls.secretName | quote }}
+  {{- end }}
+  rules:
+    - {{- if .Values.ingress.host }}
+      host: {{ .Values.ingress.host | quote }}
+      {{- end }}
+      http:
+        paths:
+          - path: {{ .Values.ingress.path }}
+            pathType: {{ .Values.ingress.pathType }}
+            backend:
+              service:
+                name: {{ include "dawn-app.fullname" . }}
+                port:
+                  name: http
+{{- end }}

--- a/charts/dawn-app/templates/pdb.yaml
+++ b/charts/dawn-app/templates/pdb.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "dawn-app.fullname" . }}
+  labels:
+    {{- include "dawn-app.labels" . | nindent 4 }}
+spec:
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  selector:
+    matchLabels:
+      {{- include "dawn-app.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/charts/dawn-app/templates/service.yaml
+++ b/charts/dawn-app/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "dawn-app.fullname" . }}
+  labels:
+    {{- include "dawn-app.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "dawn-app.selectorLabels" . | nindent 4 }}

--- a/charts/dawn-app/templates/serviceaccount.yaml
+++ b/charts/dawn-app/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "dawn-app.serviceAccountName" . }}
+  labels:
+    {{- include "dawn-app.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/dawn-app/test/render.sh
+++ b/charts/dawn-app/test/render.sh
@@ -69,4 +69,20 @@ printf '%s\n' "$SVC" | assert "service port name http" 'name: http'
 SVC_LB="$(tmpl --set service.type=LoadBalancer --show-only templates/service.yaml)"
 printf '%s\n' "$SVC_LB" | assert "service type override" 'type: LoadBalancer'
 
+# Ingress: absent by default
+if tmpl --show-only templates/ingress.yaml 2>/dev/null | grep -q 'kind: Ingress'; then
+  echo "FAIL: ingress should be absent when ingress.enabled=false (default)"; exit 1
+fi
+echo "ok: ingress absent by default"
+
+# Ingress: present + shaped correctly when enabled
+ING="$(tmpl --set ingress.enabled=true --set ingress.className=nginx --set ingress.host=app.example.com --set ingress.tls.enabled=true --set ingress.tls.secretName=app-tls --show-only templates/ingress.yaml)"
+printf '%s\n' "$ING" | assert "ingress kind" 'kind: Ingress'
+printf '%s\n' "$ING" | assert "ingress apiVersion networking.k8s.io/v1" 'apiVersion: networking.k8s.io/v1'
+printf '%s\n' "$ING" | assert "ingress className" 'ingressClassName: nginx'
+printf '%s\n' "$ING" | assert "ingress host" 'host: "app.example.com"'
+printf '%s\n' "$ING" | assert "ingress tls secretName" 'secretName: "app-tls"'
+printf '%s\n' "$ING" | assert "ingress pathType default Prefix" 'pathType: Prefix'
+printf '%s\n' "$ING" | assert "ingress backend service port name http" 'name: http'
+
 echo "render checks passed"

--- a/charts/dawn-app/test/render.sh
+++ b/charts/dawn-app/test/render.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env sh
+# Renders the chart and greps assertions. Usage: test/render.sh
+set -eu
+CHART="$(dirname "$0")/.."
+# image.repository is not schema-required (so bare `helm lint` stays green),
+# but every real render needs it set — pass it on every tmpl() call below.
+tmpl() { helm template test "$CHART" --set image.repository=example/app "$@"; }
+assert() { if ! grep -qE "$2"; then echo "FAIL: $1"; exit 1; fi; echo "ok: $1"; }
+refute() { if grep -qE "$2"; then echo "FAIL (expected absent): $1"; exit 1; fi; echo "ok: $1"; }
+
+# Deployment: image, probes on /healthz, SA, hardened securityContext
+DEPLOY="$(tmpl --show-only templates/deployment.yaml)"
+printf '%s\n' "$DEPLOY" | assert "deployment kind" 'kind: Deployment'
+printf '%s\n' "$DEPLOY" | assert "image repository+tag" 'image: example/app:0.8.9'
+printf '%s\n' "$DEPLOY" | assert "named http port" 'containerPort: 8000'
+printf '%s\n' "$DEPLOY" | assert "liveness probe path" 'path: /healthz'
+printf '%s\n' "$DEPLOY" | assert "serviceAccountName default" 'serviceAccountName: dawn-orchestrator'
+printf '%s\n' "$DEPLOY" | assert "automountServiceAccountToken true" 'automountServiceAccountToken: true'
+printf '%s\n' "$DEPLOY" | assert "runAsNonRoot" 'runAsNonRoot: true'
+printf '%s\n' "$DEPLOY" | assert "allowPrivilegeEscalation false" 'allowPrivilegeEscalation: false'
+printf '%s\n' "$DEPLOY" | assert "drop ALL caps" 'drop:'
+printf '%s\n' "$DEPLOY" | assert "drop ALL caps value" '^\s*- ALL$'
+printf '%s\n' "$DEPLOY" | assert "seccomp RuntimeDefault" 'type: RuntimeDefault'
+printf '%s\n' "$DEPLOY" | assert "readOnlyRootFilesystem default false" 'readOnlyRootFilesystem: false'
+printf '%s\n' "$DEPLOY" | assert "tmp emptyDir mount" 'mountPath: /tmp'
+printf '%s\n' "$DEPLOY" | assert "static replicas present by default" 'replicas: 1'
+
+# image.repository is required at template render time (not schema-required,
+# so bare `helm lint --strict` with no --set still passes)
+if helm template test "$CHART" 2>&1 | grep -q "image.repository is required"; then
+  echo "ok: image.repository required guard fires without --set"
+else
+  echo "FAIL: expected a required-guard error when image.repository is unset"; exit 1
+fi
+
+# digest pin overrides tag
+DIGEST_IMG="$(tmpl --set image.digest=sha256:deadbeef --show-only templates/deployment.yaml | grep 'image:')"
+printf '%s\n' "$DIGEST_IMG" | assert "digest pin" 'image: example/app@sha256:deadbeef'
+
+# Custom containerPort/healthPath (build-time-verifiable values)
+CUSTOM="$(tmpl --set containerPort=9000 --set healthPath=/healthz/live --show-only templates/deployment.yaml)"
+printf '%s\n' "$CUSTOM" | assert "custom containerPort" 'containerPort: 9000'
+printf '%s\n' "$CUSTOM" | assert "custom healthPath" 'path: /healthz/live'
+
+# secretName convenience envFrom
+SECRET_ENV="$(tmpl --set secretName=my-app-secrets --show-only templates/deployment.yaml)"
+printf '%s\n' "$SECRET_ENV" | assert "secretName envFrom" 'name: "my-app-secrets"'
+
+# Custom serviceAccount name
+CUSTOM_SA="$(tmpl --set serviceAccount.name=my-custom-sa --show-only templates/deployment.yaml)"
+printf '%s\n' "$CUSTOM_SA" | assert "custom SA name" 'serviceAccountName: my-custom-sa'
+
+# replicas absent when autoscaling on
+AUTOSCALE_DEPLOY="$(tmpl --set autoscaling.enabled=true --show-only templates/deployment.yaml)"
+if printf '%s\n' "$AUTOSCALE_DEPLOY" | grep -qE '^\s*replicas:'; then
+  echo "FAIL: replicas should be absent from Deployment when autoscaling.enabled=true"; exit 1
+fi
+echo "ok: replicas absent from Deployment when autoscaling on"
+
+echo "render checks passed"

--- a/charts/dawn-app/test/render.sh
+++ b/charts/dawn-app/test/render.sh
@@ -45,6 +45,11 @@ printf '%s\n' "$CUSTOM" | assert "custom healthPath" 'path: /healthz/live'
 # secretName convenience envFrom
 SECRET_ENV="$(tmpl --set secretName=my-app-secrets --show-only templates/deployment.yaml)"
 printf '%s\n' "$SECRET_ENV" | assert "secretName envFrom" 'name: "my-app-secrets"'
+# ...and it must NOT emit a bare `env:` (YAML null) when env is unset
+if printf '%s\n' "$SECRET_ENV" | grep -qE '^ +env:'; then
+  echo "FAIL: bare env: rendered when only secretName is set (YAML null)"; exit 1
+fi
+echo "ok: no bare env: when only secretName is set"
 
 # Custom serviceAccount name
 CUSTOM_SA="$(tmpl --set serviceAccount.name=my-custom-sa --show-only templates/deployment.yaml)"

--- a/charts/dawn-app/test/render.sh
+++ b/charts/dawn-app/test/render.sh
@@ -57,4 +57,16 @@ if printf '%s\n' "$AUTOSCALE_DEPLOY" | grep -qE '^\s*replicas:'; then
 fi
 echo "ok: replicas absent from Deployment when autoscaling on"
 
+# Service: ClusterIP default, port -> http
+SVC="$(tmpl --show-only templates/service.yaml)"
+printf '%s\n' "$SVC" | assert "service kind" 'kind: Service'
+printf '%s\n' "$SVC" | assert "service type default ClusterIP" 'type: ClusterIP'
+printf '%s\n' "$SVC" | assert "service port default 80" 'port: 80'
+printf '%s\n' "$SVC" | assert "service targetPort http" 'targetPort: http'
+printf '%s\n' "$SVC" | assert "service port name http" 'name: http'
+
+# Service type override
+SVC_LB="$(tmpl --set service.type=LoadBalancer --show-only templates/service.yaml)"
+printf '%s\n' "$SVC_LB" | assert "service type override" 'type: LoadBalancer'
+
 echo "render checks passed"

--- a/charts/dawn-app/test/render.sh
+++ b/charts/dawn-app/test/render.sh
@@ -120,4 +120,15 @@ printf '%s\n' "$PDB" | assert "pdb apiVersion policy/v1" 'apiVersion: policy/v1'
 printf '%s\n' "$PDB" | assert "pdb minAvailable" 'minAvailable: 2'
 printf '%s\n' "$PDB" | assert "pdb selector matches app labels" 'app.kubernetes.io/name: dawn-app'
 
+# ServiceAccount: absent by default (serviceAccount.create=false)
+if tmpl --show-only templates/serviceaccount.yaml 2>/dev/null | grep -q 'kind: ServiceAccount'; then
+  echo "FAIL: ServiceAccount should be absent when serviceAccount.create=false (default)"; exit 1
+fi
+echo "ok: ServiceAccount absent by default"
+
+# ServiceAccount: present + named correctly when created
+SA="$(tmpl --set serviceAccount.create=true --set serviceAccount.name=dawn-app-smoke --show-only templates/serviceaccount.yaml)"
+printf '%s\n' "$SA" | assert "serviceaccount kind" 'kind: ServiceAccount'
+printf '%s\n' "$SA" | assert "serviceaccount name" 'name: dawn-app-smoke'
+
 echo "render checks passed"

--- a/charts/dawn-app/test/render.sh
+++ b/charts/dawn-app/test/render.sh
@@ -85,4 +85,39 @@ printf '%s\n' "$ING" | assert "ingress tls secretName" 'secretName: "app-tls"'
 printf '%s\n' "$ING" | assert "ingress pathType default Prefix" 'pathType: Prefix'
 printf '%s\n' "$ING" | assert "ingress backend service port name http" 'name: http'
 
+# HPA: absent by default
+if tmpl --show-only templates/hpa.yaml 2>/dev/null | grep -q 'kind: HorizontalPodAutoscaler'; then
+  echo "FAIL: HPA should be absent when autoscaling.enabled=false (default)"; exit 1
+fi
+echo "ok: HPA absent by default"
+
+# HPA: present + shaped correctly when enabled; Deployment omits replicas
+HPA_OUT="$(tmpl --set autoscaling.enabled=true --set autoscaling.minReplicas=2 --set autoscaling.maxReplicas=10 --set autoscaling.targetCPUUtilizationPercentage=70 --set autoscaling.targetMemoryUtilizationPercentage=80)"
+HPA="$(printf '%s\n' "$HPA_OUT" | awk '/^# Source: dawn-app\/templates\/hpa.yaml/,/^---$/')"
+printf '%s\n' "$HPA" | assert "hpa kind" 'kind: HorizontalPodAutoscaler'
+printf '%s\n' "$HPA" | assert "hpa apiVersion autoscaling/v2" 'apiVersion: autoscaling/v2'
+printf '%s\n' "$HPA" | assert "hpa scaleTargetRef Deployment" 'kind: Deployment'
+printf '%s\n' "$HPA" | assert "hpa minReplicas" 'minReplicas: 2'
+printf '%s\n' "$HPA" | assert "hpa maxReplicas" 'maxReplicas: 10'
+printf '%s\n' "$HPA" | assert "hpa target cpu" 'averageUtilization: 70'
+printf '%s\n' "$HPA" | assert "hpa target memory" 'averageUtilization: 80'
+HPA_DEPLOY="$(printf '%s\n' "$HPA_OUT" | awk '/^# Source: dawn-app\/templates\/deployment.yaml/,/^---$/')"
+if printf '%s\n' "$HPA_DEPLOY" | grep -qE '^\s*replicas:'; then
+  echo "FAIL: Deployment must omit replicas when HPA (autoscaling.enabled) is on"; exit 1
+fi
+echo "ok: Deployment omits replicas when HPA is on"
+
+# PDB: absent by default
+if tmpl --show-only templates/pdb.yaml 2>/dev/null | grep -q 'kind: PodDisruptionBudget'; then
+  echo "FAIL: PDB should be absent when podDisruptionBudget.enabled=false (default)"; exit 1
+fi
+echo "ok: PDB absent by default"
+
+# PDB: present + shaped correctly when enabled
+PDB="$(tmpl --set podDisruptionBudget.enabled=true --set podDisruptionBudget.minAvailable=2 --show-only templates/pdb.yaml)"
+printf '%s\n' "$PDB" | assert "pdb kind" 'kind: PodDisruptionBudget'
+printf '%s\n' "$PDB" | assert "pdb apiVersion policy/v1" 'apiVersion: policy/v1'
+printf '%s\n' "$PDB" | assert "pdb minAvailable" 'minAvailable: 2'
+printf '%s\n' "$PDB" | assert "pdb selector matches app labels" 'app.kubernetes.io/name: dawn-app'
+
 echo "render checks passed"

--- a/charts/dawn-app/values.schema.json
+++ b/charts/dawn-app/values.schema.json
@@ -1,0 +1,182 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "dawn-app values",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "image",
+    "replicaCount",
+    "containerPort",
+    "healthPath",
+    "probes",
+    "service",
+    "ingress",
+    "autoscaling",
+    "podDisruptionBudget",
+    "serviceAccount",
+    "automountServiceAccountToken",
+    "sandboxNamespace",
+    "env",
+    "envFrom",
+    "secretName",
+    "resources",
+    "securityContext",
+    "podSecurityContext",
+    "nodeSelector",
+    "tolerations",
+    "affinity"
+  ],
+  "properties": {
+    "image": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["repository", "tag", "digest", "pullPolicy"],
+      "properties": {
+        "repository": {
+          "type": "string",
+          "description": "Not schema-required so `helm lint`/`helm template` pass without --set; enforced at template render time via a `required` guard in deployment.yaml."
+        },
+        "tag": { "type": "string" },
+        "digest": { "type": "string" },
+        "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"] }
+      }
+    },
+    "imagePullSecrets": {
+      "type": "array",
+      "items": { "type": "object" }
+    },
+    "nameOverride": { "type": "string" },
+    "fullnameOverride": { "type": "string" },
+    "replicaCount": { "type": "integer", "minimum": 0 },
+    "containerPort": { "type": "integer", "minimum": 1, "maximum": 65535 },
+    "healthPath": { "type": "string", "minLength": 1 },
+    "probes": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["liveness", "readiness", "startup"],
+      "properties": {
+        "liveness": { "$ref": "#/definitions/probeTiming" },
+        "readiness": { "$ref": "#/definitions/probeTiming" },
+        "startup": { "$ref": "#/definitions/probeTiming" }
+      }
+    },
+    "service": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type", "port"],
+      "properties": {
+        "type": { "type": "string", "enum": ["ClusterIP", "NodePort", "LoadBalancer", "ExternalName"] },
+        "port": { "type": "integer", "minimum": 1, "maximum": 65535 }
+      }
+    },
+    "ingress": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["enabled", "className", "host", "path", "pathType", "tls", "annotations"],
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "className": { "type": "string" },
+        "host": { "type": "string" },
+        "path": { "type": "string", "minLength": 1 },
+        "pathType": { "type": "string", "enum": ["Exact", "Prefix", "ImplementationSpecific"] },
+        "tls": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["enabled", "secretName"],
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "secretName": { "type": "string" }
+          }
+        },
+        "annotations": { "type": "object" }
+      }
+    },
+    "autoscaling": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["enabled", "minReplicas", "maxReplicas", "targetCPUUtilizationPercentage", "targetMemoryUtilizationPercentage"],
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "minReplicas": { "type": "integer", "minimum": 1 },
+        "maxReplicas": { "type": "integer", "minimum": 1 },
+        "targetCPUUtilizationPercentage": { "type": ["integer", "string"] },
+        "targetMemoryUtilizationPercentage": { "type": ["integer", "string"] }
+      }
+    },
+    "podDisruptionBudget": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["enabled", "minAvailable"],
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "minAvailable": { "type": ["integer", "string"] }
+      }
+    },
+    "serviceAccount": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["create", "name", "annotations"],
+      "properties": {
+        "create": { "type": "boolean" },
+        "name": { "type": "string", "minLength": 1 },
+        "annotations": { "type": "object" }
+      }
+    },
+    "automountServiceAccountToken": { "type": "boolean" },
+    "sandboxNamespace": { "type": "string", "minLength": 1 },
+    "env": {
+      "type": "array",
+      "items": { "type": "object" }
+    },
+    "envFrom": {
+      "type": "array",
+      "items": { "type": "object" }
+    },
+    "secretName": { "type": "string" },
+    "resources": { "type": "object" },
+    "securityContext": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["runAsNonRoot", "allowPrivilegeEscalation", "capabilities", "seccompProfile", "readOnlyRootFilesystem"],
+      "properties": {
+        "runAsNonRoot": { "type": "boolean" },
+        "allowPrivilegeEscalation": { "type": "boolean" },
+        "capabilities": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "drop": { "type": "array", "items": { "type": "string" } }
+          }
+        },
+        "seccompProfile": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "type": { "type": "string" }
+          }
+        },
+        "readOnlyRootFilesystem": { "type": "boolean" }
+      }
+    },
+    "podSecurityContext": { "type": "object" },
+    "nodeSelector": { "type": "object" },
+    "tolerations": {
+      "type": "array",
+      "items": { "type": "object" }
+    },
+    "affinity": { "type": "object" }
+  },
+  "definitions": {
+    "probeTiming": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["initialDelaySeconds", "periodSeconds", "timeoutSeconds", "failureThreshold"],
+      "properties": {
+        "initialDelaySeconds": { "type": "integer", "minimum": 0 },
+        "periodSeconds": { "type": "integer", "minimum": 1 },
+        "timeoutSeconds": { "type": "integer", "minimum": 1 },
+        "failureThreshold": { "type": "integer", "minimum": 1 }
+      }
+    }
+  }
+}

--- a/charts/dawn-app/values.schema.json
+++ b/charts/dawn-app/values.schema.json
@@ -99,8 +99,8 @@
         "enabled": { "type": "boolean" },
         "minReplicas": { "type": "integer", "minimum": 1 },
         "maxReplicas": { "type": "integer", "minimum": 1 },
-        "targetCPUUtilizationPercentage": { "type": ["integer", "string"] },
-        "targetMemoryUtilizationPercentage": { "type": ["integer", "string"] }
+        "targetCPUUtilizationPercentage": { "type": ["integer", "string"], "minimum": 1 },
+        "targetMemoryUtilizationPercentage": { "type": ["integer", "string"], "minimum": 1 }
       }
     },
     "podDisruptionBudget": {

--- a/charts/dawn-app/values.yaml
+++ b/charts/dawn-app/values.yaml
@@ -1,0 +1,133 @@
+# Default values for dawn-app.
+# This chart runs a user-built Dawn app image (produced by
+# `langgraphjs dockerfile` against a root-level langgraph.json — see
+# docs/deployment.mdx) as a Deployment + Service, with optional Ingress,
+# HorizontalPodAutoscaler, and PodDisruptionBudget. It does NOT build the
+# image or bake dawn.config.ts — the image is the runtime contract.
+
+image:
+  # repository: REQUIRED at install time. Defaults to "" so `helm lint`
+  # and `helm template` pass without --set; the Deployment template
+  # enforces this with a `required` guard so a real install fails fast
+  # without an image.
+  repository: ""
+  # tag: image tag. Leave "" to fall back to .Chart.AppVersion.
+  tag: ""
+  # digest: if set, pins by digest instead of tag (repository@sha256:...).
+  digest: ""
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+
+nameOverride: ""
+fullnameOverride: ""
+
+replicaCount: 1
+
+# containerPort: the port the langgraph API server listens on inside the
+# image. Verify against your built image's Dockerfile EXPOSE/CMD — this is
+# a value specifically so a mismatch is a one-line fix.
+containerPort: 8000
+
+# healthPath: the HTTP path the langgraph API server serves health checks
+# on. Used for liveness/readiness/startup probes.
+healthPath: /healthz
+
+probes:
+  liveness:
+    initialDelaySeconds: 10
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 3
+  readiness:
+    initialDelaySeconds: 5
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 3
+  startup:
+    # Generous startup allowance for slow cold starts (model/tool init).
+    initialDelaySeconds: 0
+    periodSeconds: 5
+    timeoutSeconds: 5
+    failureThreshold: 60
+
+service:
+  type: ClusterIP
+  port: 80
+
+ingress:
+  enabled: false
+  className: ""
+  host: ""
+  path: /
+  pathType: Prefix
+  tls:
+    enabled: false
+    secretName: ""
+  annotations: {}
+
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 5
+  targetCPUUtilizationPercentage: 80
+  targetMemoryUtilizationPercentage: ""
+
+podDisruptionBudget:
+  enabled: false
+  minAvailable: 1
+
+# serviceAccount: the sandbox wiring. The app process calls the Kubernetes
+# API to create sandbox pods, so its Pod must run under a ServiceAccount
+# bound to the dawn-sandbox-infra chart's orchestrator Role.
+serviceAccount:
+  # create: whether this chart creates a ServiceAccount in the app's
+  # namespace. If true, the operator must bind it to the sandbox-infra
+  # Role via that chart's `orchestrator.subjects` — NOTES.txt prints the
+  # exact subject to add.
+  create: false
+  # name: the ServiceAccount name. When create=false (default), this must
+  # name an existing ServiceAccount — typically the sandbox-infra chart's
+  # orchestrator SA (dawn-orchestrator), which requires this app to run in
+  # the sandbox namespace (see sandboxNamespace) or be added as a
+  # cross-namespace subject.
+  name: dawn-orchestrator
+  annotations: {}
+
+# automountServiceAccountToken: the app needs the token to call the
+# Kubernetes API (unlike sandbox pods, which do not need it).
+automountServiceAccountToken: true
+
+# sandboxNamespace: informational only — must match the app's
+# `kubernetesSandbox({ namespace })` config and the dawn-sandbox-infra
+# chart's `namespace.name`.
+sandboxNamespace: dawn-sandboxes
+
+env: []
+envFrom: []
+# secretName: convenience envFrom secretRef (e.g. for OPENAI_API_KEY,
+# DATABASE_URL). The chart does NOT template Secrets — supply them
+# out-of-band.
+secretName: ""
+
+resources: {}
+
+# securityContext: hardened but app-appropriate. The langgraph API server
+# is not a sandbox pod but should still be least-privilege.
+securityContext:
+  runAsNonRoot: true
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop: ["ALL"]
+  seccompProfile:
+    type: RuntimeDefault
+  # readOnlyRootFilesystem: defaults false — the langgraph runtime likely
+  # writes temp state. A writable /tmp emptyDir is always mounted
+  # regardless of this setting. Set true if your image tolerates it.
+  readOnlyRootFilesystem: false
+
+podSecurityContext: {}
+
+nodeSelector: {}
+tolerations: []
+affinity: {}

--- a/docs/superpowers/plans/2026-07-07-dawn-app-deploy-helm-chart.md
+++ b/docs/superpowers/plans/2026-07-07-dawn-app-deploy-helm-chart.md
@@ -1,0 +1,53 @@
+# Dawn App-Deploy Helm Chart Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development. Steps use checkbox syntax.
+
+**Goal:** `charts/dawn-app/` — a Helm chart that runs a user-built Dawn app image (from `langgraphjs dockerfile`) on Kubernetes as Deployment + Service + optional Ingress/HPA/PDB, wired to the in-cluster `kubernetesSandbox` via the sandbox-infra chart's orchestrator ServiceAccount.
+
+**Architecture:** Templated K8s manifests, schema-validated values. Verification = `helm lint --strict` + a `helm template` render harness + `kubeconform -strict`, and a gated **kind apply-smoke with a placeholder image** (proves Deployment/Service/Ingress/HPA/PDB apply + become Ready without needing a real Dawn app or model key). Publishes to GHCR OCI.
+
+**Tech Stack:** Helm 3, Kubernetes manifests, kubeconform, kind, GHCR OCI.
+
+**Spec:** `docs/superpowers/specs/2026-07-07-dawn-app-deploy-helm-chart-design.md` — READ IT (values surface, SA-wiring modes, honest scope, and the three build-time items to pin down).
+
+**Sibling reference:** `charts/dawn-sandbox-infra/` (SP2, just merged) — mirror its conventions: `_helpers.tpl` labels, `values.schema.json` with `additionalProperties:false`, `test/render.sh` harness, chart layout. The CI `chart-validate` job and `.github/workflows/publish-chart.yml` already exist (from SP2) — EXTEND them, don't duplicate.
+
+**Operating constraints:** work in the worktree on branch `feat/dawn-app-chart`; verify `git branch --show-current` before every commit; do not push (controller pushes). Pin actions/images by SHA/digest. No npm changeset (chart-only). Install `helm`+`kubeconform` locally if missing.
+
+**Build-time items to resolve (from the spec's "Open items"):**
+- Container port: default `containerPort: 8000`, but **check `@langchain/langgraph-cli` docs / a generated `langgraphjs dockerfile`** for the real listen port; if it differs, change the default. It's a value regardless, so a mismatch is one line.
+- Health path: default `/healthz` (docs say the runtime serves it); verify; expose as `values.healthPath`.
+- Writable rootfs: default `readOnlyRootFilesystem: false` for the app container (the langgraph runtime likely writes temp state) with a writable `/tmp` emptyDir — the app pod is least-privilege but not as locked-down as a sandbox pod; document.
+
+---
+
+### Task 1: Scaffold `charts/dawn-app/`
+Create Chart.yaml (name `dawn-app`, version `0.1.0`, appVersion `"0.8.9"`), values.yaml (full surface from the spec), values.schema.json (require `image.repository` non-empty; enums/types; `additionalProperties:false`), templates/_helpers.tpl (names + standard Helm labels), README.md, templates/NOTES.txt (print the Service URL + the exact ServiceAccount/namespace wiring instructions incl. the cross-namespace subject to add to the sandbox-infra chart if applicable), .helmignore. Verify `helm lint --strict` (note: with `image.repository` required by schema, lint/template must be run with `--set image.repository=example/app` or a values default that passes schema — set the schema to require it but let `helm lint` pass by providing a lint-values or making repository default `""` with a template-level `required` guard instead of schema-required; choose whichever keeps `helm lint` green while still failing a real install without an image). Commit `feat(chart): scaffold dawn-app (Chart.yaml, values, schema, helpers)`.
+
+### Task 2: Deployment + render harness
+`templates/deployment.yaml`: image (repository+tag OR digest; `required` guard on repository), `containerPort` (named `http`), liveness+readiness+startup probes on `healthPath`, env + envFrom (+ `secretName` convenience), resources, hardened-but-app-appropriate securityContext (runAsNonRoot, drop ALL caps, seccomp RuntimeDefault, allowPrivilegeEscalation false; `readOnlyRootFilesystem` from a value defaulting false + a `/tmp` emptyDir), `serviceAccountName` from values, `automountServiceAccountToken: true`, nodeSelector/tolerations/affinity, imagePullSecrets. Omit static `replicas` when `autoscaling.enabled`. Create `test/render.sh` (mirror SP2's harness) asserting the deployment shape (image, probes on `/healthz`, SA name, securityContext, and that `replicas` is absent when autoscaling on). Verify render.sh + `helm template --set image.repository=x/y | kubeconform -strict -ignore-missing-schemas`. Commit `feat(chart): app Deployment + probes + sandbox SA wiring`.
+
+### Task 3: Service
+`templates/service.yaml` (type from values default ClusterIP, `port` → `http`). Extend render.sh. Verify. Commit `feat(chart): app Service`.
+
+### Task 4: Ingress (gated)
+`templates/ingress.yaml` gated on `ingress.enabled` (className, host, path/pathType, TLS, annotations; `networking.k8s.io/v1`). Extend render.sh (present when enabled, absent by default). Verify kubeconform. Commit `feat(chart): optional Ingress`.
+
+### Task 5: HPA + PDB (gated)
+`templates/hpa.yaml` (`autoscaling/v2`, gated `autoscaling.enabled`, targets the Deployment, min/max/targetCPU + optional memory) and `templates/pdb.yaml` (`policy/v1`, gated `podDisruptionBudget.enabled`, minAvailable, selector matches app pods). Extend render.sh (both absent by default; present + valid when enabled; Deployment omits `replicas` when HPA on). Verify. Commit `feat(chart): optional HorizontalPodAutoscaler + PodDisruptionBudget`.
+
+### Task 6: CI — extend chart-validate + gated kind apply-smoke
+In `.github/workflows/ci.yml`: (a) extend the existing `chart-validate` job to ALSO lint/render/kubeconform `charts/dawn-app` (default + a full override `--set ingress.enabled=true --set autoscaling.enabled=true --set podDisruptionBudget.enabled=true --set image.repository=traefik/whoami`). (b) Add a gated **`chart-apply-smoke`** job (or a step): spin up a plain kind cluster (no Calico needed — no NetworkPolicy here), `helm install dawn-app charts/dawn-app --set image.repository=traefik/whoami --set image.tag=latest --set containerPort=80 --set healthPath=/ --set serviceAccount.create=true --wait`, then `kubectl rollout status deploy` + `kubectl run` a curl against the Service to get an HTTP 200 — proving the manifests apply and the pod serves. Pin kind-action + images. Validate YAML (`actionlint`). Commit `ci(chart): validate dawn-app + gated kind apply-smoke with placeholder image`.
+
+### Task 7: OCI publish
+Extend `.github/workflows/publish-chart.yml` to also publish `charts/dawn-app` when `charts/dawn-app/**` changes (add to `paths` + a matrix/second step over both charts; same version-guard + `helm push oci://ghcr.io/cacheplane/charts`). Commit `ci(chart): publish dawn-app to GHCR OCI`.
+
+### Task 8: Docs + PR
+Add a "Deploying a Dawn app (Helm)" section to `apps/web/content/docs/deployment.mdx` (or sandbox.mdx): build the image via `langgraphjs dockerfile`, `helm install dawn-app oci://ghcr.io/cacheplane/charts/dawn-app --set image.repository=...`, the ServiceAccount/namespace wiring (must run under the sandbox-infra orchestrator SA; cross-namespace subject instructions), env/secrets, and the honest note that the chart runs a user-built image + owns only K8s deploy concerns. No banned phrases; gpt-5 model ids only. Run `node scripts/check-docs.mjs`. Full local verify (`helm lint --strict`, `test/render.sh`, `kubeconform`, `check-docs`, `pnpm build && pnpm typecheck`). Rebase on origin/main. Push, open PR `feat(chart): dawn-app deploy Helm chart (Kubernetes arc, sub-project 3)` (body: what it deploys, the langgraph-image model, sandbox-SA wiring, ingress/hpa/pdb, kind apply-smoke, OCI publish; Claude Code footer). Watch CI; address findings.
+
+---
+
+## Self-review (author)
+- Spec coverage: image-wrap Deployment (T2) ✓, Service (T3) ✓, Ingress (T4) ✓, HPA+PDB (T5) ✓, sandbox SA wiring (T2/T6/NOTES) ✓, kind apply-smoke (T6) ✓, OCI publish (T7) ✓, docs (T8) ✓. The three open items are resolved as configurable values (T2) so a wrong default is a one-line fix, and the kind smoke uses a placeholder image so it doesn't depend on the real langgraph port.
+- Consistency: mirrors `charts/dawn-sandbox-infra` conventions; extends (not duplicates) the shared `chart-validate` job + `publish-chart.yml`.
+- Risk: the real langgraph server port/health — mitigated by making them values + smoke-testing with a placeholder; a follow-up can tighten defaults once a real image is validated by an operator.

--- a/docs/superpowers/specs/2026-07-07-dawn-app-deploy-helm-chart-design.md
+++ b/docs/superpowers/specs/2026-07-07-dawn-app-deploy-helm-chart-design.md
@@ -1,0 +1,132 @@
+# Dawn App-Deploy Helm Chart — Design
+
+**Date:** 2026-07-07
+**Status:** Approved (brainstorm — foundational decisions locked by the user; execution delegated).
+**Sub-project:** 3 of 3 in the "run Dawn on Kubernetes" arc (provider #317 → sandbox-infra chart #321 → **this chart**).
+
+## Goal
+
+A Helm chart, `charts/dawn-app/`, that runs a **built Dawn app** on Kubernetes as a Deployment + Service (+ optional Ingress, HorizontalPodAutoscaler, PodDisruptionBudget), wired to use the in-cluster `kubernetesSandbox` provider via the ServiceAccount + namespace provisioned by the sandbox-infra chart (#321). It completes the "run Dawn on Kubernetes" story: sandbox-infra makes the cluster sandbox-ready; this chart runs your app on it.
+
+## Context & the production-server reality
+
+Dawn has **no bespoke production server**: `dawn dev` is a localhost-only reference runtime, and `dawn build` emits `.dawn/build/langgraph.json` + per-route entry files — the canonical deploy interface. The documented containerization path (docs/deployment.mdx; [[project_dawn_self_host_docker]], PR #278) is to build an image with `@langchain/langgraph-cli` (`langgraphjs dockerfile`) against a root-level `langgraph.json`. The resulting image runs the **LangGraph API server** exposing the Agent-Protocol surface (`/threads/:id/runs/wait`, `/threads/:id/runs/stream`) and a **`/healthz`** health endpoint.
+
+**Decision (user):** the chart **wraps a user-provided image** (built via that path) — it does NOT invent a Dawn base image or a new server. The chart owns the *Kubernetes deployment* concerns; the image owns the *runtime*.
+
+## Decisions (from the brainstorm)
+
+- **App-deploy model:** wrap the `langgraphjs dockerfile` image (`image` value; the user builds + pushes it). Most honest — leans on Dawn's real container story.
+- **Scope:** Deployment + Service + Ingress + **sandbox wiring** + **HorizontalPodAutoscaler + PodDisruptionBudget**.
+
+## Architecture
+
+### Chart layout
+
+```
+charts/dawn-app/
+  Chart.yaml            # name, version (independent SemVer), appVersion 0.8.9
+  values.yaml
+  values.schema.json
+  README.md
+  templates/
+    _helpers.tpl        # names/labels
+    serviceaccount.yaml # optional: bind an existing SA, or reference the sandbox-infra orchestrator SA
+    deployment.yaml     # the app pod(s)
+    service.yaml
+    ingress.yaml        # gated
+    hpa.yaml            # gated
+    pdb.yaml            # gated
+    NOTES.txt
+```
+
+### Deployment
+
+- **Image:** `values.image.repository` + `values.image.tag` (or `values.image.digest`) — the user's `langgraphjs dockerfile`-built app image. `imagePullSecrets` supported.
+- **Port:** `values.service.port` → container port `values.containerPort` (default `8000` — **the plan must verify the exact port the `langgraphjs dockerfile` image listens on**; expose it as a value so a mismatch is a one-line fix). Named port `http`.
+- **Probes:** liveness + readiness HTTP GET on `values.healthPath` (default `/healthz`) at the container port; timings configurable. A startup probe (generous) covers slow cold starts.
+- **Env / secrets:** `values.env` (list) + `values.envFrom` (secretRef/configMapRef). Convenience: `values.secretName` mounted via `envFrom` for `OPENAI_API_KEY`, `DATABASE_URL`, etc. — the chart does **not** template secrets (operator supplies them). The app's `dawn.config.ts` (baked into the image) references `kubernetesSandbox`; the chart ensures the **namespace + ServiceAccount align** (below).
+- **Resources:** `values.resources` (requests/limits).
+- **SecurityContext:** hardened by default (runAsNonRoot, readOnlyRootFilesystem where the runtime allows, drop ALL caps, seccomp RuntimeDefault, allowPrivilegeEscalation false) — the app pod is not a sandbox but should still be least-privilege. Documented opt-out if the langgraph runtime needs write access (a writable `/tmp` emptyDir is provided).
+- **ServiceAccount (the sandbox wiring — the crux):** the app process calls the Kubernetes API to create sandbox pods, so its pod must run under a ServiceAccount bound to the sandbox-infra orchestrator Role. Two modes via `values.serviceAccount`:
+  - `name: dawn-orchestrator`, `create: false` (default) — reuse the SA the sandbox-infra chart created. **Requires the app to run in the sandbox namespace** (default `dawn-sandboxes`), OR the operator to have added this app's SA as a cross-namespace subject in the sandbox-infra chart's `orchestrator.subjects`. Documented clearly in NOTES.txt + README.
+  - `create: true` — the chart creates a SA in the app's namespace; the operator must bind it to the sandbox-infra Role (via that chart's `orchestrator.subjects`) — the chart prints the exact subject to add.
+  - `automountServiceAccountToken: true` (the app needs the token to call the API — unlike sandbox pods).
+
+### Service / Ingress / HPA / PDB
+
+- **Service:** ClusterIP, `values.service.port` → `http`. Type configurable (ClusterIP default; LoadBalancer/NodePort allowed).
+- **Ingress** (`values.ingress.enabled`, default `false`): `className`, `host`, `path`/`pathType`, TLS (`secretName`), annotations — standard Helm ingress idiom.
+- **HPA** (`values.autoscaling.enabled`, default `false`): `autoscaling/v2` HorizontalPodAutoscaler targeting the Deployment; `minReplicas`/`maxReplicas`/`targetCPUUtilizationPercentage` (+ optional memory). When enabled, the Deployment omits a static `replicas` so the HPA owns it.
+- **PDB** (`values.podDisruptionBudget.enabled`, default `false`): `policy/v1` PodDisruptionBudget with `minAvailable` (default `1`) selecting the app pods — protects availability during node drains.
+
+### Values surface (defaults, abridged)
+
+```yaml
+image:
+  repository: ""          # REQUIRED — the user's built app image
+  tag: ""                 # or digest:
+  pullPolicy: IfNotPresent
+imagePullSecrets: []
+replicaCount: 1
+containerPort: 8000
+healthPath: /healthz
+service:
+  type: ClusterIP
+  port: 80
+ingress:
+  enabled: false
+  className: ""
+  host: ""
+  path: /
+  pathType: Prefix
+  tls: { enabled: false, secretName: "" }
+  annotations: {}
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 5
+  targetCPUUtilizationPercentage: 80
+podDisruptionBudget:
+  enabled: false
+  minAvailable: 1
+serviceAccount:
+  create: false
+  name: dawn-orchestrator      # the sandbox-infra chart's orchestrator SA
+sandboxNamespace: dawn-sandboxes   # informational; must match the app's kubernetesSandbox({ namespace })
+env: []
+envFrom: []
+secretName: ""                 # convenience envFrom secretRef
+resources: {}
+securityContext:               # hardened defaults; see template
+  runAsNonRoot: true
+podSecurityContext: {}
+nodeSelector: {}
+tolerations: []
+affinity: {}
+```
+
+`values.schema.json` requires `image.repository` (fail fast if unset) and validates enums/types.
+
+## Testing
+
+1. **`helm lint --strict`** + a `helm template` render harness (`charts/dawn-app/test/render.sh`) asserting: Deployment with the image + probes + SA + hardened securityContext; Service; Ingress only when enabled; HPA only when enabled (and that `replicas` is omitted from the Deployment then); PDB only when enabled. Both default and a "full" override (ingress+hpa+pdb+custom SA) fixture.
+2. **`helm template | kubeconform -strict`** on default + override (autoscaling/v2, policy/v1, networking/v1 Ingress schemas).
+3. **Gated kind apply-smoke** — a new gated CI step (reuse or mirror the chart-validate job): `helm install dawn-app` with a **placeholder image** (`values.image.repository=traefik/whoami` or similar, `healthPath=/`) into a kind cluster, `kubectl rollout status` the Deployment, curl the Service — proving the Deployment/Service/Ingress/HPA/PDB actually apply and the pod becomes Ready. This validates the manifests end-to-end **without** needing a real Dawn app image or a model key (which CI can't provide). Document that this proves the *chart*, not a real Dawn app.
+
+## Packaging / release
+
+Extend the chart-publishing story from #321: `publish-chart.yml` gains `charts/dawn-app/**` to its `paths` (or a matrix over both charts), publishing `oci://ghcr.io/cacheplane/charts/dawn-app` on chart changes, version from its own `Chart.yaml`. Independent SemVer.
+
+## Honest scope / out of scope
+
+- The chart runs a **user-built** image; it does not build the image, own a Dawn server, or bake `dawn.config.ts`. The app image is the runtime contract.
+- The chart cannot validate a *real* Dawn app end-to-end in CI (needs an app image + model creds) — the kind smoke proves the manifests with a placeholder image; real-app validation is the operator's responsibility, documented.
+- Cross-namespace SA binding (app in a different namespace than the sandbox) requires the operator to wire the sandbox-infra chart's `orchestrator.subjects` — the chart documents + prints the exact subject; it does not reach into the other chart's release.
+- Deferred: a Dawn-owned base runtime image, GitOps/ArgoCD manifests, service mesh integration, multi-region, blue/green.
+
+## Open items for the plan/build to pin down
+
+1. **The exact port** the `langgraphjs dockerfile` image listens on (inspect the generated Dockerfile's `EXPOSE`/`CMD`, or langgraph-cli docs) — set the `containerPort` default accordingly.
+2. **The health endpoint** — confirm `/healthz` is served by the built image (docs say the dev runtime serves it; verify the langgraph-cli production image does too, else use the langgraph server's actual health path).
+3. Whether the langgraph server needs a writable filesystem (affects the `readOnlyRootFilesystem` default) — verify against the built image.


### PR DESCRIPTION
## Dawn app-deploy Helm chart (Kubernetes arc, sub-project 3 of 3 — completes the arc)

`charts/dawn-app/` runs a **built Dawn app** on Kubernetes and wires it to the in-cluster `kubernetesSandbox` (provider #317) via the orchestrator ServiceAccount from the sandbox-infra chart (#321).

**The honest model:** Dawn has no bespoke production server — `dawn build` emits `langgraph.json`, and the documented container path is `@langchain/langgraph-cli`'s `langgraphjs dockerfile`. So this chart **wraps a user-built image** and owns only the Kubernetes deployment concerns; the image owns the runtime.

**Templates:**
- **Deployment** — the user's `image` (tag or digest, with a `required` guard), named `http` port (`containerPort`, default 8000), liveness/readiness/startup probes on `healthPath` (`/healthz`), env + `envFrom`/`secretName`, app-appropriate hardened securityContext (non-root, drop ALL caps, RuntimeDefault seccomp, writable `/tmp` emptyDir), and — the crux — `serviceAccountName: dawn-orchestrator` + `automountServiceAccountToken: true` so the app can create sandbox pods in-cluster. Omits static `replicas` when the HPA is on.
- **Service**, optional **Ingress**, optional **HorizontalPodAutoscaler** (autoscaling/v2) and **PodDisruptionBudget** (policy/v1).
- **ServiceAccount** — create-or-reference, with NOTES.txt printing the exact same-namespace vs cross-namespace (`orchestrator.subjects`) wiring for the sandbox RBAC.

**Verification:** `helm lint --strict`, a 50-assertion render harness, and `kubeconform -strict` (default + full ingress/HPA/PDB override) in the shared `chart-validate` job; plus a gated **`chart-apply-smoke`** — a plain kind cluster `helm install`s the chart with a placeholder image (`traefik/whoami`) and curls the Service, proving the manifests apply and serve **without** needing a real Dawn app image or model key.

**Distribution:** `publish-chart.yml` now matrixes over both charts → `oci://ghcr.io/cacheplane/charts/dawn-app`. Docs: a "Deploying a Dawn app (Helm)" guide in sandbox.mdx. No npm changeset (chart-only).

With this, the Kubernetes arc is complete: **provider (0.8.9) → sandbox-infra chart → app-deploy chart.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
