### PR TITLE
fix(memory): type remember data and validate pgvector dims

### DIFF
--- a/.changeset/typed-memory-data-pgvector-validation.md
+++ b/.changeset/typed-memory-data-pgvector-validation.md
@@ -1,0 +1,10 @@
+---
+"@dawn-ai/cli": patch
+"@dawn-ai/memory-pgvector": patch
+---
+
+Type generated `remember.data` from each route's `defineMemory()` Zod schema
+instead of `Record<string, unknown>`, so route code gets compile-time memory fact
+shape checks that match runtime validation. `pgvectorMemoryStore()` now validates
+the dimension ceiling during construction, failing invalid configs before opening
+a pool or initializing schema.

--- a/apps/web/content/docs/memory.mdx
+++ b/apps/web/content/docs/memory.mdx
@@ -93,8 +93,8 @@ Typegen emits two typed tools for any route with a `memory.ts` into `.dawn/dawn.
 - **`recall`** — fetch in-scope memories by keyword, kind, or tags.
 - **`remember`** — store a typed fact (omitted entirely when `writes` is `"off"`).
 
-<Callout type="warn" title="remember.data is loosely typed in v1">
-  Typegen types `remember`'s `data` as `Record<string, unknown>`, not your Zod schema. The schema is still enforced at *runtime* — `remember` validates `data` against it and rejects on failure — but you do not yet get compile-time field types on the write path. Schema-typed `remember.data` is deferred.
+<Callout type="info" title="remember.data follows your schema">
+  Typegen derives `remember`'s `data` type from your route's `defineMemory()` Zod schema, so TypeScript catches missing or misspelled fields in route code. The same schema is still enforced at *runtime* when the model calls `remember`.
 </Callout>
 
 **`recall({ query?, kind?, tags?, limit? })`** searches the store. It defaults `status` to `"active"` and `limit` to `8`, and returns one `id: content` line per match, or `(no memories found)` when empty.
@@ -354,7 +354,6 @@ Long-term memory ships with the `semantic` kind, deterministic ranked keyword re
 - The `episodic`, `procedural`, and `reflection` kinds.
 - Full BM25 (term-frequency / length-normalized) ranking via FTS5, and a memory graph.
 - A dev-server Memory Inspector UI.
-- Schema-typed `remember.data` (typed loosely as `Record<string, unknown>` today).
 
 The SQLite (local-first, default) and [Postgres/pgvector](#postgres-backend-pgvector) (production/multi-instance) store backends both ship today.
 

--- a/docs/dev/memory-system.md
+++ b/docs/dev/memory-system.md
@@ -306,7 +306,9 @@ HNSW + cosine retrieval in SQL, the same shared ranking core, dimension branch (
   SQL (today pgvector retrieves both lists and fuses in the shared JS core).
 - Memory graph (edges/relations).
 - Dev-server Memory Inspector UI (no dev UI host exists today).
-- Schema-typed `remember.data` in typegen.
+
+Typegen now derives `remember.data` from the route's `defineMemory().schema`, so
+route code sees the same fact shape the runtime validates.
 
 ## 14. Where "smarter recall" plugged in (DONE — this branch)
 

--- a/docs/superpowers/specs/2026-06-19-docs-memory-and-audit-design.md
+++ b/docs/superpowers/specs/2026-06-19-docs-memory-and-audit-design.md
@@ -40,9 +40,8 @@ L3 specifics:
     `semantic` is wired end-to-end; the other three are typed-but-deferred.
   - `scope`: subset of `["workspace","route","tenant","user","agent"]`.
   - `schema`: a zod schema; `identity?` defaults to `["subject","predicate"]`.
-- Typegen emits typed `remember`/`recall` into `.dawn/dawn.generated.d.ts`.
-  Caveat: `remember`'s `data` is typed loosely as `Record<string, unknown>` in
-  v1 (not the zod schema).
+- Typegen emits typed `remember`/`recall` into `.dawn/dawn.generated.d.ts`;
+  `remember.data` is derived from the route's `defineMemory()` zod schema.
 - `recall({ query?, kind?, tags?, limit? })` → `store.search`; defaults
   `status="active"`, `limit=8`.
 - `remember({ data, content?, tags?, confidence? })` → validates `data` against

--- a/docs/superpowers/specs/2026-07-07-pgvector-backend-design.md
+++ b/docs/superpowers/specs/2026-07-07-pgvector-backend-design.md
@@ -1,7 +1,7 @@
 # pgvector Memory Backend Design (Phase 4 — memory follow-up)
 
 Date: 2026-07-07
-Status: approved design, pending implementation plan
+Status: implemented and published in `@dawn-ai/memory-pgvector@0.8.9`; published-tarball smoke passed
 Branch: `feat/memory-pgvector`
 Prior art: vector recall (`docs/superpowers/specs/2026-07-06-vector-recall-design.md`, PR #313)
 
@@ -122,8 +122,9 @@ CREATE INDEX ... ON <prefix>_memories USING hnsw (embedding <OPS>) WITH (m=?, ef
 **Dimension branch:** `dimensions ≤ 2000` → `VECTOR_TYPE = vector`, `OPS =
 vector_cosine_ops`. `dimensions ≤ 4000` (i.e. > 2000) → `VECTOR_TYPE = halfvec`,
 `OPS = halfvec_cosine_ops` (enables `text-embedding-3-large` at 3072).
-`dimensions > 4000` → throw a clear config error at construction. Document 1536
-(`-small`) as the smooth default.
+`dimensions > 4000` → throw a clear config error naming the halfvec ceiling.
+Document 1536 (`-small`) as the smooth default. The implementation validates
+this in the store factory so bad config fails before any pool or schema work.
 
 ## Retrieval flow
 

--- a/packages/cli/src/lib/typegen/run-typegen.ts
+++ b/packages/cli/src/lib/typegen/run-typegen.ts
@@ -1,6 +1,6 @@
 import { existsSync, readdirSync, statSync } from "node:fs"
 import { mkdir, writeFile } from "node:fs/promises"
-import { join } from "node:path"
+import { join, relative, sep } from "node:path"
 import type {
   ExtractedToolSchema,
   ExtractedToolType,
@@ -113,24 +113,34 @@ function hasSubagents(routeDir: string): boolean {
   })
 }
 
-const MEMORY_EXTRA_TOOLS: readonly ExtractedToolType[] = [
-  {
-    name: "remember",
-    description: "Store a typed long-term memory for later recall.",
-    // NOTE: `data` is typed loosely for v1; the runtime validates it against the route's defineMemory() zod schema. Typing `data` to the route schema is a deferred refinement.
-    inputType: `{ data: Record<string, unknown>; content: string; tags?: string[]; confidence?: number }`,
-    outputType: `string`,
-  },
-  {
-    name: "recall",
-    description: "Recall typed long-term memories by keyword/kind/tags.",
-    inputType: `{ query?: string; kind?: string; tags?: string[]; limit?: number }`,
-    outputType: `string`,
-  },
-]
-
 function hasMemory(routeDir: string): boolean {
   return existsSync(join(routeDir, "memory.ts"))
+}
+
+function memoryExtraTools(routeDir: string, dawnDir: string): readonly ExtractedToolType[] {
+  const memoryModule = moduleSpecifierFromDts(dawnDir, join(routeDir, "memory.ts"))
+  const dataType = `import("zod").infer<(typeof import(${JSON.stringify(memoryModule)}).default)["schema"]>`
+  return [
+    {
+      name: "remember",
+      description: "Store a typed long-term memory for later recall.",
+      inputType: `{ data: ${dataType}; content: string; tags?: string[]; confidence?: number }`,
+      outputType: `string`,
+    },
+    {
+      name: "recall",
+      description: "Recall typed long-term memories by keyword/kind/tags.",
+      inputType: `{ query?: string; kind?: string; tags?: string[]; limit?: number }`,
+      outputType: `string`,
+    },
+  ]
+}
+
+function moduleSpecifierFromDts(dtsDir: string, targetFile: string): string {
+  let specifier = relative(dtsDir, targetFile).split(sep).join("/")
+  specifier = specifier.replace(/\.[cm]?[tj]sx?$/, "")
+  if (!specifier.startsWith(".")) specifier = `./${specifier}`
+  return specifier
 }
 
 export interface TypegenResult {
@@ -176,7 +186,7 @@ export async function runTypegen(options: {
       extraTools.push(...WORKSPACE_EXTRA_TOOLS)
     }
     if (hasMemory(route.routeDir)) {
-      extraTools.push(...MEMORY_EXTRA_TOOLS)
+      extraTools.push(...memoryExtraTools(route.routeDir, dawnDir))
     }
 
     routeToolTypes.push({

--- a/packages/cli/test/run-typegen.test.ts
+++ b/packages/cli/test/run-typegen.test.ts
@@ -188,7 +188,19 @@ describe("runTypegen", () => {
 
   test("includes remember and recall tools in generated types when memory.ts exists", async () => {
     const { appRoot, routeDir } = await setupApp()
-    await createFile(join(routeDir, "memory.ts"), "export default {};\n")
+    await createFile(
+      join(routeDir, "memory.ts"),
+      [
+        'import { defineMemory } from "@dawn-ai/sdk"',
+        'import { z } from "zod"',
+        "export default defineMemory({",
+        '  kind: "semantic",',
+        '  scope: ["route"],',
+        "  schema: z.object({ subject: z.string(), predicate: z.string(), value: z.string() }),",
+        "})",
+        "",
+      ].join("\n"),
+    )
 
     const manifest = await discoverRoutes({ appRoot })
     await runTypegen({ appRoot, manifest })
@@ -198,6 +210,10 @@ describe("runTypegen", () => {
 
     expect(content).toContain("remember")
     expect(content).toContain("recall")
+    expect(content).toContain(
+      'data: import("zod").infer<(typeof import("../src/app/hello/[tenant]/memory").default)["schema"]>',
+    )
+    expect(content).not.toContain("data: Record<string, unknown>")
     // Existing user tool still present alongside the capability-contributed ones
     expect(content).toContain("greet")
   })

--- a/packages/memory-pgvector/src/pgvector-store.ts
+++ b/packages/memory-pgvector/src/pgvector-store.ts
@@ -19,7 +19,7 @@ import {
   rowToRecord,
   tokensFor,
 } from "./queries.js"
-import { assertIdentifier, initSchema } from "./schema.js"
+import { assertIdentifier, initSchema, vectorColumnDef } from "./schema.js"
 
 // Default HNSW build/search parameters (pgvector defaults; overridable per store).
 const DEFAULT_M = 16
@@ -53,6 +53,7 @@ export function pgvectorMemoryStore(opts: {
   const prefix = opts.tablePrefix ?? "dawn_memory"
   assertIdentifier("schema", schema)
   assertIdentifier("tablePrefix", prefix)
+  vectorColumnDef(opts.dimensions)
   const m = opts.index?.m ?? DEFAULT_M
   const efConstruction = opts.index?.efConstruction ?? DEFAULT_EF_CONSTRUCTION
   const efSearch = opts.index?.efSearch ?? DEFAULT_EF_SEARCH

--- a/packages/memory-pgvector/test/schema.test.ts
+++ b/packages/memory-pgvector/test/schema.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest"
+import { pgvectorMemoryStore } from "../src/index.js"
 import { assertIdentifier, vectorColumnDef } from "../src/schema.js"
 
 describe("vectorColumnDef", () => {
@@ -29,5 +30,11 @@ describe("assertIdentifier", () => {
     expect(() => assertIdentifier("schema", "public; DROP TABLE x")).toThrow(/schema/)
     expect(() => assertIdentifier("prefix", "1leading")).toThrow(/prefix/)
     expect(() => assertIdentifier("schema", "")).toThrow(/schema/)
+  })
+})
+
+describe("pgvectorMemoryStore", () => {
+  it("validates dimensions at construction time", () => {
+    expect(() => pgvectorMemoryStore({ dimensions: 4001 })).toThrow(/4000 halfvec index ceiling/)
   })
 })


### PR DESCRIPTION
## Summary
- Generate `remember.data` from each route's `defineMemory()` Zod schema instead of `Record<string, unknown>`.
- Validate `pgvectorMemoryStore()` dimensions at construction time, before pool/schema work.
- Update memory/pgvector docs and add a patch changeset for the affected packages.

## Validation
- `corepack pnpm --filter @dawn-ai/memory-pgvector test`
- `corepack pnpm --filter @dawn-ai/cli exec vitest run test/run-typegen.test.ts`
- `corepack pnpm --filter @dawn-ai/memory-pgvector typecheck`
- `corepack pnpm --filter @dawn-ai/workspace build`
- `corepack pnpm --filter @dawn-ai/cli typecheck`
- `corepack pnpm --filter @dawn-ai/workspace test`
- `corepack pnpm --filter @dawn-ai/workspace typecheck`
- `node scripts/check-docs.mjs`