### PR TITLE
fix(ci): narrow scaffolder build inputs

### DIFF
--- a/packages/create-dawn-app/package.json
+++ b/packages/create-dawn-app/package.json
@@ -26,7 +26,7 @@
     "access": "public"
   },
   "scripts": {
-    "build": "tsc -b ../devkit/tsconfig.json ../core/tsconfig.json ../langgraph/tsconfig.json ../cli/tsconfig.build.json tsconfig.json",
+    "build": "tsc -b tsconfig.json",
     "lint": "biome check --config-path ../config-biome/biome.json package.json src test tsconfig.json vitest.config.ts",
     "test": "vitest --run --config vitest.config.ts",
     "typecheck": "tsc --noEmit -p ../devkit/tsconfig.json && tsc --noEmit -p tsconfig.json"


### PR DESCRIPTION
## Summary
- Narrow `create-dawn-ai-app`'s build script to its own TypeScript project graph.
- Avoid rebuilding unrelated packages from the scaffolder task, which caused fresh CI builds to miss upstream declarations and race package builds.

## Validation
- `corepack pnpm --filter create-dawn-ai-app build` from a fresh local build-output state
- `corepack pnpm build`
- `DAWN_TEST_PGVECTOR=1 corepack pnpm --filter @dawn-ai/memory-pgvector test`
- `corepack pnpm --filter create-dawn-ai-app test`
- `corepack pnpm exec biome check --config-path packages/config-biome/biome.json packages/create-dawn-app/package.json`
- `node scripts/check-changesets.mjs`