### PR TITLE
fix(release): align @dawn-ai/ag-ui to fixed-group 0.8.10 (unblock red release pipeline)

### DIFF
--- a/packages/ag-ui/package.json
+++ b/packages/ag-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dawn-ai/ag-ui",
-  "version": "0.8.9",
+  "version": "0.8.10",
   "private": false,
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Problem — main's release pipeline is red

The AG-UI capability PR #322 added a new fixed-group package `@dawn-ai/ag-ui` pinned at **0.8.9**, and merged ~18 min *after* the 0.8.10 release. That left it out of step with the rest of the fixed group (now 0.8.10). The release-candidate validation requires one canonical version across all publishable packages, so every release run since fails:

```
Publishable packages must share one canonical version before publishing to the test registry,
found: @dawn-ai/ag-ui@0.8.9, @dawn-ai/cli@0.8.10, ...everything else @0.8.10
```

This is a deadlock: the fix would normally arrive via a Version PR, but the changesets bot can't create one because the release job fails at validate first.

## Fix

Bump `packages/ag-ui/package.json` **0.8.9 → 0.8.10** to match the fixed group. Its only dependent (`@dawn-ai/cli`) references it via `workspace:*`, so nothing else changes. Verified all 19 publishable packages now share `0.8.10`.

The pending `.changeset/ag-ui-capability.md` is untouched — once this lands and validate is green again, the bot rolls the whole group to **0.8.11** as normal, and `@dawn-ai/ag-ui@0.8.11` will be its first npm publish (needs the new-package OIDC bootstrap, GOTCHA 1/7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)