### PR TITLE
docs: cover AG-UI and pgvector packages

### DIFF
--- a/.changeset/docs-ag-ui-pgvector-readmes.md
+++ b/.changeset/docs-ag-ui-pgvector-readmes.md
@@ -1,0 +1,4 @@
+---
+---
+
+Document AG-UI and pgvector package surfaces without changing runtime package code.

--- a/apps/web/content/docs/api.mdx
+++ b/apps/web/content/docs/api.mdx
@@ -703,6 +703,184 @@ export type { ThreadsStore } from "@dawn-ai/sqlite-storage"
 
 ---
 
+## @dawn-ai/ag-ui
+
+AG-UI translation utilities used by `dawn dev` to serve `POST /agui/{routeId}` for CopilotKit and other AG-UI clients. The `{routeId}` URL segment is the URL-encoded Dawn assistant id, such as `%2Fchat%23agent` for `/chat#agent`. Most apps use the endpoint through the CLI, not by importing this package directly.
+
+```ts
+import {
+  createAgUiTranslator,
+  encodeAgUiSse,
+  mapRunInput,
+  type AgUiEvent,
+  type DawnStreamChunk,
+  type MappedRunInput,
+  type ResumeDecision,
+  type TranslatorOptions,
+} from "@dawn-ai/ag-ui"
+```
+
+See [Dev Server](/docs/dev-server#ag-ui-endpoint).
+
+### `mapRunInput(input)`
+
+```ts
+export function mapRunInput(input: RunAgentInput): MappedRunInput
+```
+
+Maps an AG-UI `RunAgentInput` to Dawn route input. The newest user message becomes Dawn's `{ messages: [...] }` input because Dawn stores conversation history in the checkpoint keyed by `threadId`. Human-in-the-loop resume decisions are read from `forwardedProps.command.resume`.
+
+```ts
+export type ResumeDecision = "once" | "always" | "deny"
+
+export interface MappedRunInput {
+  readonly dawnInput: { readonly messages: ReadonlyArray<{ role: string; content: string }> }
+  readonly resumeDecision?: ResumeDecision
+  readonly interruptId?: string
+}
+```
+
+### `createAgUiTranslator(options)`
+
+```ts
+export function createAgUiTranslator(options: TranslatorOptions): AgUiTranslator
+```
+
+Creates a per-run translator. Call `begin()` once, pass each Dawn stream chunk to `translate(chunk)`, and call `end()` if the stream completes without a Dawn `done` chunk.
+
+```ts
+export interface TranslatorOptions {
+  readonly threadId: string
+  readonly runId: string
+}
+
+export interface AgUiTranslator {
+  begin(): AgUiEvent[]
+  translate(chunk: DawnStreamChunk): AgUiEvent[]
+  end(): AgUiEvent[]
+}
+```
+
+The translator maps Dawn token/chunk events to AG-UI text events, tool calls/results to AG-UI tool events, `plan_update` chunks to `STATE_SNAPSHOT`, interrupts to `CUSTOM{name:"on_interrupt"}`, and `subagent.*` chunks to `CUSTOM{name:"dawn.<event>"}`.
+
+### `encodeAgUiSse(event, accept?)`
+
+```ts
+export function encodeAgUiSse(event: AgUiEvent, accept?: string): string
+```
+
+Encodes one AG-UI event as an SSE frame using `@ag-ui/encoder`.
+
+### Types
+
+```ts
+export type AgUiEvent = BaseEvent
+
+export interface DawnStreamChunk {
+  readonly type: string
+  readonly data?: unknown
+  readonly name?: string
+  readonly input?: unknown
+  readonly output?: unknown
+}
+```
+
+`DawnStreamChunk` is structural so `@dawn-ai/ag-ui` does not depend on `@dawn-ai/cli`.
+
+---
+
+## @dawn-ai/memory-pgvector
+
+Postgres + pgvector backend for Dawn's typed long-term memory store. Use it through `DawnConfig.memory.store` when an app needs a shared production store, multiple app instances, or indexed vector retrieval.
+
+```ts
+import {
+  assertIdentifier,
+  initSchema,
+  pgvectorMemoryStore,
+  vectorColumnDef,
+  type PgvectorMemoryStore,
+} from "@dawn-ai/memory-pgvector"
+```
+
+See [Memory](/docs/memory#postgres-backend-pgvector).
+
+### `pgvectorMemoryStore(options)`
+
+```ts
+export function pgvectorMemoryStore(opts: {
+  connectionString?: string
+  pool?: Pool
+  dimensions: number
+  index?: { m?: number; efConstruction?: number; efSearch?: number }
+  schema?: string
+  tablePrefix?: string
+  recall?: RecallRankingOptions
+  vector?: VectorRankingOptions
+}): PgvectorMemoryStore
+```
+
+Creates a `MemoryStore` backed by Postgres tables and pgvector indexes. Schema initialization is lazy and idempotent: the first store operation creates the extension, schema, tables, token indexes, and HNSW index if needed.
+
+`dimensions` is validated during construction. Dimensions up to 2000 use `vector(n)`; dimensions from 2001 through 4000 use `halfvec(n)`; larger values throw a config error naming the 4000 halfvec index ceiling.
+
+```ts
+import { config } from "@dawn-ai/core"
+import { openaiEmbedder } from "@dawn-ai/langchain"
+import { pgvectorMemoryStore } from "@dawn-ai/memory-pgvector"
+
+export default config({
+  memory: {
+    store: pgvectorMemoryStore({
+      connectionString: process.env.DATABASE_URL,
+      dimensions: 1536,
+    }),
+    vector: { embedder: openaiEmbedder() },
+  },
+})
+```
+
+### `PgvectorMemoryStore`
+
+```ts
+export interface PgvectorMemoryStore extends MemoryStore {
+  close(): Promise<void>
+}
+```
+
+Implements `put`, `get`, `search`, `update`, `supersede`, `delete`, and `listCandidates` from `@dawn-ai/memory`. `close()` ends the owned `pg.Pool`; it is a no-op when the store was constructed with an injected pool.
+
+Hybrid search runs when the query includes both `queryEmbedding` and `embedderId`. The store retrieves a keyword list and a pgvector nearest-neighbor list, then fuses them with the same shared hybrid ranking core used by SQLite.
+
+### `vectorColumnDef(dimensions)`
+
+```ts
+export function vectorColumnDef(dimensions: number): { type: string; ops: string }
+```
+
+Returns the pgvector column definition and cosine operator class for a dimension count. Throws for non-positive, non-integer, or greater-than-4000 dimensions.
+
+### `initSchema(client, options)`
+
+```ts
+export async function initSchema(
+  client: PoolClient,
+  opts: { prefix: string; schema: string; dimensions: number; m: number; efConstruction: number },
+): Promise<void>
+```
+
+Low-level DDL helper used by the store. Most apps should not call it directly.
+
+### `assertIdentifier(name, value)`
+
+```ts
+export function assertIdentifier(name: string, value: string): void
+```
+
+Rejects malformed schema and table-prefix identifiers before they are interpolated into DDL.
+
+---
+
 ## @dawn-ai/testing
 
 Deterministic testing utilities for Dawn apps. The package replaces live model calls with aimock fixtures while running tools, prompts, capabilities, state, and workspace behavior normally.

--- a/apps/web/content/docs/dev-server.mdx
+++ b/apps/web/content/docs/dev-server.mdx
@@ -1,6 +1,6 @@
 # Dev Server
 
-`dawn dev` starts a local runtime with Agent Protocol (AP) HTTP endpoints. It watches route and tool files, regenerates types when signatures change, and restarts the child route runtime for structural changes.
+`dawn dev` starts a local runtime with Agent Protocol (AP) HTTP endpoints. It also exposes an AG-UI SSE endpoint for web clients such as CopilotKit. It watches route and tool files, regenerates types when signatures change, and restarts the child route runtime for structural changes.
 
 ## Starting the server
 
@@ -26,7 +26,7 @@ echo '{"messages":[{"role":"user","content":"Hello"}]}' | dawn run '/research' -
 
 `dawn run` resolves the route id to a `route` key of the form `<routeId>#<kind>` (e.g. `/research#agent`), POSTs to `/threads/<t-cli-uuid>/runs/wait` with `{route, input}`, and prints the result.
 
-## Protocol endpoints
+## Agent Protocol endpoints
 
 The dev server exposes eight endpoints organized around a thread lifecycle: create thread → run (wait or stream) → read state → resume. Anything else returns 404. Thread state persists in SQLite under `.dawn/` and survives server restarts — see [Configuration](/docs/configuration) for the `checkpointer` and `threadsStore` defaults and override options.
 
@@ -180,13 +180,48 @@ curl http://127.0.0.1:3001/threads/$THREAD_ID/state
 
 The `route` format `<routeId>#<kind>` is the same format `dawn build` writes into the `graphs` map of `.dawn/build/langgraph.json`, so the same client request body works against `dawn dev` and against a deployed runtime.
 
+## AG-UI endpoint
+
+For UI clients that speak [AG-UI](https://github.com/ag-ui-protocol/ag-ui), `dawn dev` also serves:
+
+```http
+POST /agui/{routeId}
+content-type: application/json
+accept: text/event-stream
+```
+
+The body must be an AG-UI `RunAgentInput`. Dawn creates the thread when the incoming `threadId` is new, maps the newest user message to the route input, streams the route, and translates Dawn chunks into AG-UI events with `@dawn-ai/ag-ui`.
+
+The URL segment after `/agui/` is the URL-encoded Dawn assistant id (`<routeId>#<kind>`):
+
+```text
+Dawn route key: /chat#agent
+AG-UI URL:      /agui/%2Fchat%23agent
+```
+
+The endpoint emits `RUN_STARTED`, assistant text events, tool call/result events, `STATE_SNAPSHOT` updates for planning state, `CUSTOM{name:"on_interrupt"}` for HITL permission or memory interrupts, and `RUN_FINISHED` or `RUN_ERROR`.
+
+Human-in-the-loop resume decisions ride on AG-UI `forwardedProps.command.resume`:
+
+```json
+{
+  "forwardedProps": {
+    "command": {
+      "resume": { "decision": "once", "interruptId": "perm-abc123" }
+    }
+  }
+}
+```
+
+The chat example includes a CopilotKit v2 client wired through this endpoint; see `examples/chat/web` and the `@dawn-ai/ag-ui` package README.
+
 ## Tracing
 
 If `LANGSMITH_API_KEY` is present in the loaded environment and `LANGCHAIN_TRACING_V2` is not already set, `dawn dev` automatically sets `LANGCHAIN_TRACING_V2=true`. Set `LANGCHAIN_PROJECT` to name the LangSmith project used for traces. See [Observability](/docs/observability) for a full walkthrough, including how to read traces and the HITL interrupt gotcha.
 
 ## Middleware
 
-`src/middleware.ts` (default-exporting a function returned by `defineMiddleware`) runs before every local `/threads/:thread_id/runs/wait` and `/threads/:thread_id/runs/stream` request handled by `dawn dev`. It can short-circuit a request with `reject(status, body?)`, or continue with `allow(context?)` — the optional `context` flows to every tool as `ctx.middleware` (a `Readonly<Record<string, unknown>>`).
+`src/middleware.ts` (default-exporting a function returned by `defineMiddleware`) runs before every local `/threads/:thread_id/runs/wait` and `/threads/:thread_id/runs/stream` request handled by `dawn dev`. It can short-circuit a request with `reject(status, body?)`, or continue with `allow(context?)` — the optional `context` flows to every tool as `ctx.middleware` (a `Readonly<Record<string, unknown>>`). The AG-UI endpoint is a client-protocol bridge over the same route runtime, but middleware is documented for the Agent Protocol thread endpoints.
 
 `MiddlewareRequest` shape: `{ assistantId, headers, method, params, routeId, url }`. See [Middleware](/docs/middleware) for the full reference.
 
@@ -222,6 +257,7 @@ The parent process keeps the HTTP server alive while child route runtimes restar
   { href: "/docs/middleware", title: "Middleware", subtitle: "how src/middleware.ts gates local runtime requests" },
   { href: "/docs/planning", title: "Planning", subtitle: "plan_update events over /runs/stream" },
   { href: "/docs/subagents", title: "Subagents", subtitle: "child events stream as subagent.*" },
+  { href: "/docs/faq", title: "FAQ", subtitle: "where AG-UI and CopilotKit fit" },
   { href: "/docs/cli", title: "CLI", subtitle: "dawn dev flags and all other commands" },
   { href: "/docs/recipes/stream-output", title: "Stream output", subtitle: "recipe consuming /runs/stream SSE frames" },
 ]} />

--- a/apps/web/content/docs/faq.mdx
+++ b/apps/web/content/docs/faq.mdx
@@ -17,7 +17,7 @@ Yes. The built-in `agent()` route materializes to a LangChain chat model. Dawn i
 They solve different problems.
 
 - **Vercel AI SDK** is a client-and-server toolkit for chat UIs and provider-agnostic LLM calls. Dawn does not compete with it — it sits one layer up, organizing whole agent projects, and you can use the AI SDK inside a Dawn route.
-- **CopilotKit** is a frontend-first framework for embedding copilots in existing apps. Dawn is backend-first; the deliverable is a deployable agent runtime, not in-app UI.
+- **CopilotKit** is a frontend-first framework for embedding copilots in existing apps. Dawn is backend-first; the deliverable is a deployable agent runtime, not in-app UI. They compose through Dawn's AG-UI endpoint: `dawn dev` serves `POST /agui/{routeId}`, and the chat example wires a CopilotKit `HttpAgent` to it.
 - **Mastra** is a general-purpose agent framework with its own runtime and abstractions. Dawn is narrower: it does not replace LangGraph, it deletes the boilerplate around it.
 
 If you are already on LangGraph, Dawn fits. If you are not, pick the framework whose runtime you want to live in.
@@ -49,6 +49,10 @@ A library is something you call. A meta-framework is something you write inside.
 ### Can I deploy outside LangSmith?
 
 Yes, with caveats. `dawn build` emits a standard `langgraph.json` plus entry files; feed `.dawn/build/` to any container that runs the LangGraph runtime. Dawn's in-process dev server is a reference implementation of the same `runs/wait` and `runs/stream` protocol but is not intended as a production runtime itself. See [Deployment](/docs/deployment).
+
+### Can Dawn use Postgres for long-term memory?
+
+Yes. SQLite is the default local store, but `@dawn-ai/memory-pgvector` provides a Postgres + pgvector backend for production and multi-instance deployments. Add `pgvectorMemoryStore({ connectionString, dimensions })` to `memory.store`, and add `openaiEmbedder()` when you want hybrid keyword + vector recall. See [Memory](/docs/memory#postgres-backend-pgvector).
 
 ### How do I gradually migrate an existing LangGraph project?
 

--- a/apps/web/content/docs/memory.mdx
+++ b/apps/web/content/docs/memory.mdx
@@ -217,7 +217,9 @@ Retrieval runs **in Postgres**: an [HNSW](https://github.com/pgvector/pgvector#h
   Both backends retrieve their own candidates (SQL here, in-process there) and then rank through the **same pure hybrid core** — the RRF fusion plus the recency/confidence second stage from [semantic recall](#semantic-recall-opt-in). Recall ordering is the same across backends; switching stores changes where the data lives and how it is retrieved, not how results are ranked. A [shared conformance kit](/docs/testing-agents) runs the same contract against both.
 </Callout>
 
-SQLite stays the local-first default — reach for pgvector when you outgrow a single-file store, not before. See the runnable `examples/memory` app, which switches to pgvector automatically when `DATABASE_URL` is set and falls back to SQLite otherwise.
+SQLite stays the local-first default — reach for pgvector when you need a shared production store, multiple app instances, or indexed vector retrieval over a larger corpus. If you only need single-process local persistence, SQLite is simpler and keeps the no-service path. See the runnable `examples/memory` app, which switches to pgvector automatically when `DATABASE_URL` is set and falls back to SQLite otherwise.
+
+The pgvector package is also smoke-tested as a published tarball outside the Dawn monorepo against real Postgres + pgvector and real OpenAI embeddings. That check asserts `openaiEmbedder()` returns a 1536-dimension `Float32Array` for the default model and that a zero-shared-token paraphrase is recalled through the hybrid vector path, guarding the `encodingFormat: "float"` embedder contract.
 
 ### The injected index
 

--- a/charts/dawn-app/Chart.yaml
+++ b/charts/dawn-app/Chart.yaml
@@ -3,7 +3,7 @@ name: dawn-app
 description: Runs a built Dawn app image (from `langgraphjs dockerfile`) on Kubernetes as a Deployment + Service, with optional Ingress, HorizontalPodAutoscaler, and PodDisruptionBudget, wired to the in-cluster kubernetesSandbox orchestrator ServiceAccount.
 type: application
 version: 0.1.0
-appVersion: "0.8.9"
+appVersion: "0.8.11"
 keywords: [dawn, langgraph, kubernetes, deployment]
 home: https://dawnai.org
 sources: [https://github.com/cacheplane/dawnai]

--- a/charts/dawn-app/test/render.sh
+++ b/charts/dawn-app/test/render.sh
@@ -11,7 +11,7 @@ refute() { if grep -qE "$2"; then echo "FAIL (expected absent): $1"; exit 1; fi;
 # Deployment: image, probes on /healthz, SA, hardened securityContext
 DEPLOY="$(tmpl --show-only templates/deployment.yaml)"
 printf '%s\n' "$DEPLOY" | assert "deployment kind" 'kind: Deployment'
-printf '%s\n' "$DEPLOY" | assert "image repository+tag" 'image: example/app:0.8.9'
+printf '%s\n' "$DEPLOY" | assert "image repository+tag" 'image: example/app:0.8.11'
 printf '%s\n' "$DEPLOY" | assert "named http port" 'containerPort: 8000'
 printf '%s\n' "$DEPLOY" | assert "liveness probe path" 'path: /healthz'
 printf '%s\n' "$DEPLOY" | assert "serviceAccountName default" 'serviceAccountName: dawn-orchestrator'

--- a/charts/dawn-sandbox-infra/Chart.yaml
+++ b/charts/dawn-sandbox-infra/Chart.yaml
@@ -3,7 +3,7 @@ name: dawn-sandbox-infra
 description: Cluster-side infrastructure for the Dawn kubernetesSandbox provider — namespace, least-privilege RBAC, default-deny egress, quotas/limits, Pod Security Standards, and a PVC reaper.
 type: application
 version: 0.1.0
-appVersion: "0.8.9"
+appVersion: "0.8.11"
 keywords: [dawn, sandbox, kubernetes, security]
 home: https://dawnai.org
 sources: [https://github.com/cacheplane/dawnai]

--- a/docs/superpowers/plans/2026-07-09-docs-website-content-verification.md
+++ b/docs/superpowers/plans/2026-07-09-docs-website-content-verification.md
@@ -1,0 +1,113 @@
+# Docs Website Content Verification Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Verify Dawn's docs, website copy, package READMEs, examples, generated docs, and chart docs against the current main branch, then fill accuracy gaps and improve conceptual clarity without drifting from implemented behavior.
+
+**Architecture:** Treat source code, package manifests, generated type declarations, release commits, smoke-test evidence, examples, and existing validation scripts as the source of truth. Update public content in small reviewable slices, and harden docs validation so future package additions and endpoint additions are harder to miss.
+
+**Tech Stack:** Markdown/MDX docs, Next.js website content, package README files, generated CLI docs, Helm chart docs, `rg`, `find`, `node scripts/check-docs.mjs`, pnpm workspace validation.
+
+**Baseline:** `main` at `e9ed1e39` (`chore(deps-dev): bump Node type definitions`) on 2026-07-09.
+
+---
+
+## Current Assessment
+
+The 2026-07-06 docs alignment pass fixed the old scaffold/API drift, and the current core docs are generally strong for routes, CLI, memory, sandbox, testing, evals, and configuration. Since then, main added or shipped several user-facing surfaces that need a fresh docs pass:
+
+- `@dawn-ai/memory-pgvector` shipped and was manually smoke-tested from the real npm registry against real Postgres + pgvector and real OpenAI embeddings.
+- `@dawn-ai/ag-ui` shipped, and the chat example now includes a CopilotKit web client over Dawn's `POST /agui/{routeId}` endpoint.
+- Kubernetes sandbox and app Helm charts landed.
+- Packages are now at `0.8.11`, while some chart metadata still carries `appVersion: "0.8.9"`.
+
+Important strengths to preserve:
+
+- `apps/web/content/docs/memory.mdx` already explains keyword recall, semantic/hybrid recall, pgvector, `openaiEmbedder()`, 1536-dim defaults, HNSW, `vector` versus `halfvec`, and the 4000-dim ceiling.
+- `README.md` and `packages/create-dawn-app/README.md` now describe the research scaffold rather than the old default greeter scaffold.
+- `apps/web/content/docs/sandbox.mdx` is detailed and honest about Docker, Kubernetes, Helm, network policy, and security scope.
+- `apps/web/content/docs/api.mdx` now covers `@dawn-ai/core`, `@dawn-ai/testing`, and `@dawn-ai/evals`, which were prior gaps.
+
+Highest-value gaps found in this assessment:
+
+- `packages/memory-pgvector/README.md` is missing, even though the package is public and its npm homepage points at `packages/memory-pgvector#readme`.
+- `packages/ag-ui/README.md` is missing, and `@dawn-ai/ag-ui` is not covered in the API reference.
+- `apps/web/content/docs/dev-server.mdx` documents the Agent Protocol endpoints but does not appear to document the new `POST /agui/{routeId}` endpoint.
+- `@dawn-ai/langchain` README does not mention `openaiEmbedder()`, the embedding dims, `OPENAI_BASE_URL`, or why `encodingFormat: "float"` matters.
+- The current docs checker catches topology, stale banned phrases, and CLI command drift, but it does not require package READMEs for public packages, API docs for new public exports, or docs coverage for new dev-server endpoints.
+- Website/landing content is still mostly framework-positioning copy; AG-UI/CopilotKit and production memory storage are under-discoverable outside examples/changelogs.
+
+---
+
+## Task 1: Build The Verification Matrix
+
+- [x] Re-run a focused inventory:
+
+```bash
+git status --short
+git log --oneline --decorate --max-count=40
+find packages -maxdepth 2 -name package.json -print | sort
+find packages -maxdepth 2 -name README.md -print | sort
+find apps/web/content/docs -maxdepth 2 -type f -name '*.mdx' -print | sort
+```
+
+- [x] Compare public package exports against docs coverage:
+
+```bash
+rg -n "^export " packages/*/src packages/create-dawn-app/src --glob '*.ts'
+rg -n "@dawn-ai/ag-ui|@dawn-ai/memory-pgvector|openaiEmbedder|pgvectorMemoryStore|POST /agui|CopilotKit" README.md apps/web docs examples packages --glob '!**/dist/**'
+```
+
+- [x] Record findings in a short audit appendix or in the PR description, including the specific source-of-truth files for each claim.
+
+## Task 2: Fix P1 Discoverability And Accuracy
+
+- [x] Add `packages/memory-pgvector/README.md` with install, exact `pgvectorMemoryStore()` options, `put/search/get/update/delete/listCandidates/close` behavior, dimensions and `halfvec` limits, Postgres requirements, pooling/cleanup, and a real-smoke summary.
+- [x] Add `packages/ag-ui/README.md` with exported helpers, `POST /agui/{routeId}`, route id mapping, CopilotKit `HttpAgent` usage, interrupt/resume behavior, and limitations.
+- [x] Update `apps/web/content/docs/dev-server.mdx` to document the AG-UI endpoint as additive to Agent Protocol endpoints.
+- [x] Update `apps/web/content/docs/api.mdx` with `@dawn-ai/ag-ui` and `@dawn-ai/memory-pgvector` public exports.
+- [x] Update `packages/langchain/README.md` to include `openaiEmbedder()`, default `text-embedding-3-small`/1536 dims, `OPENAI_BASE_URL`, and the float encoding contract.
+
+## Task 3: Improve Concepts And Navigation
+
+- [x] Add a concise AG-UI/CopilotKit docs section or page and link it from Dev Server, FAQ, examples, and the docs nav if it becomes a standalone page.
+- [x] Tighten the memory page's "when to use SQLite vs pgvector" decision guidance without duplicating the package README.
+- [x] Add a "published package smoke" note to memory docs or package docs that distinguishes workspace CI from real registry + real service smoke tests.
+- [x] Re-check website landing sections and FAQ for underplayed shipped features: AG-UI, semantic recall, pgvector, Kubernetes sandbox, Helm deployment.
+- [x] Review chart docs and metadata, especially `charts/*/Chart.yaml` `appVersion`, for stale release-version claims.
+
+## Task 4: Harden Docs Validation
+
+- [x] Extend `scripts/check-docs.mjs` to fail when a public package lacks a README unless explicitly allowlisted.
+- [x] Add a lightweight public-export coverage check for new packages, at least requiring a mention in `apps/web/content/docs/api.mdx` or a package README.
+- [x] Add a dev-server endpoint coverage check so route additions like `/agui/:routeId` cannot land without docs.
+- [x] Add targeted forbidden/stale phrase checks for "pgvector planned follow-up" outside historical changelogs and for stale chart app versions if appropriate.
+
+## Task 5: Verify
+
+- [x] Run targeted docs checks:
+
+```bash
+pnpm build
+node scripts/check-docs.mjs
+pnpm --filter @dawn-ai/web typecheck
+pnpm --filter @dawn-ai/web build
+```
+
+- [x] Run package-specific validation for touched packages:
+
+```bash
+pnpm --filter @dawn-ai/ag-ui typecheck
+pnpm --filter @dawn-ai/memory-pgvector typecheck
+pnpm --filter @dawn-ai/langchain typecheck
+```
+
+- [x] If docs include runnable smoke commands, test the no-key paths locally. Do not put `OPENAI_API_KEY` in files.
+
+No new standalone no-key smoke script was added; the runnable docs changes are documentation/config snippets. Verification used docs checks, package typechecks, web build, and full workspace build.
+
+## Task 6: PR Strategy
+
+- [x] Prefer one docs PR if the edit stays focused; split validation-script hardening into a second PR if it grows beyond straightforward checks.
+- [x] In the PR body, include before/after coverage evidence: missing README count, new API sections, AG-UI endpoint docs, and commands run.
+- [ ] Merge on green after `ci:validate` or the equivalent GitHub checks pass.

--- a/examples/chat/README.md
+++ b/examples/chat/README.md
@@ -73,7 +73,7 @@ examples/chat/
     └── app/
         ├── layout.tsx                 # imports @copilotkit/react-ui styles
         ├── page.tsx                   # CopilotKitProvider + CopilotSidebar + TodosPanel
-        ├── api/copilotkit/route.ts    # CopilotRuntime + HttpAgent → Dawn /agui/<chat>
+        ├── api/copilotkit/route.ts    # CopilotRuntime + HttpAgent → Dawn /agui/%2Fchat%23agent
         └── components/
             ├── PermissionInterrupt.tsx  # useInterrupt → approve/deny card
             └── TodosPanel.tsx            # useAgent({agentId:"chat"}) → live plan/todos

--- a/examples/chat/web/README.md
+++ b/examples/chat/web/README.md
@@ -3,8 +3,9 @@
 The canonical reference for **connecting a web client to Dawn over AG-UI**. This is a
 [CopilotKit](https://docs.copilotkit.ai) v2 app (`@copilotkit/react-core/v2` +
 `@copilotkit/runtime`) whose runtime route (`app/api/copilotkit/route.ts`) registers an
-`HttpAgent` pointed at Dawn's `POST /agui/{routeId}` endpoint (see `@dawn-ai/ag-ui`). It
-replaces the previous hand-rolled SSE smoke client.
+`HttpAgent` pointed at Dawn's `POST /agui/{routeId}` endpoint (the URL-encoded
+assistant id, e.g. `%2Fchat%23agent`; see `@dawn-ai/ag-ui`). It replaces the
+previous hand-rolled SSE smoke client.
 
 This app runs **live** against a real model — there is no aimock/demo mode here. The
 deterministic, no-key proof that the AG-UI wire protocol works is the `/agui` endpoint's
@@ -17,25 +18,26 @@ by this client yet.
 
 ```
 browser
-  → CopilotKit runtime (app/api/copilotkit/route.ts, this app, no API key)
-    → HttpAgent → POST /agui/<chat>          (Dawn dev server, holds OPENAI_API_KEY)
-      → live /chat agent (workspace tools, planning, HITL permissions)
-        → AG-UI event stream back to the browser
+  -> CopilotKit runtime (app/api/copilotkit/route.ts, this app, no API key)
+    -> HttpAgent -> POST /agui/%2Fchat%23agent  (Dawn dev server, holds OPENAI_API_KEY)
+      -> live /chat agent (workspace tools, planning, HITL permissions)
+        -> AG-UI event stream back to the browser
 ```
 
-- `app/api/copilotkit/route.ts` — `CopilotRuntime` with `agents: { chat: new HttpAgent(...) }`,
+- `app/api/copilotkit/route.ts` — `CopilotRuntime` with `agents: { default: new HttpAgent(...) }`,
   served via `copilotRuntimeNextJSAppRouterEndpoint`. No LLM credentials live here; the
   Dawn server holds `OPENAI_API_KEY`.
-- `app/page.tsx` — `CopilotKitProvider` (`runtimeUrl="/api/copilotkit"`) wrapping a
+- `app/page.tsx` — `CopilotKit` (`runtimeUrl="/api/copilotkit"`) wrapping a
   `CopilotSidebar` (chat transcript), plus two thin Dawn-specific wrapper components.
 - `app/components/PermissionInterrupt.tsx` — `useInterrupt` renders an approve/deny card
   when Dawn's HITL permission gate pauses a run (`CUSTOM{name:"on_interrupt"}`).
 - `app/components/TodosPanel.tsx` — `useAgent` (v2's coagent-state hook) renders Dawn's
   live plan/todos list as they stream in.
 
-All three CopilotKit components use `agentId="chat"` explicitly — `CopilotKitProvider` has
-no ambient "default agent"; each hook/component falls back to the literal agent id
-`"default"` if not told otherwise, which does not exist in this runtime's `agents` map.
+CopilotKit's sidebar and hooks fall back to the literal agent id `"default"` when
+no `agentId` is provided. This example registers the Dawn `/chat#agent` route
+under `default`, so `CopilotSidebar`, `useAgent`, and `useInterrupt` all bind to
+the same agent without per-component wiring.
 
 ## Running
 
@@ -64,7 +66,8 @@ because this client intentionally has no demo/mock mode.
    `{decision, interruptId}` payload through `forwardedProps.command.resume` into
    `@dawn-ai/ag-ui`'s `mapRunInput`. If the card never appears, the translator's
    `CUSTOM{on_interrupt}` event isn't reaching the hook — check that the runtime route's
-   agent id and the page's `agentId` both say `"chat"`.
+   `agents` map registers `default` and the page components are not pointing at a
+   different `agentId`.
 5. Send a multi-step prompt that makes the agent plan — expect the **TodosPanel** to
    populate and check items off as the plan progresses.
 

--- a/packages/ag-ui/README.md
+++ b/packages/ag-ui/README.md
@@ -1,0 +1,139 @@
+<p align="center">
+  <img src="https://raw.githubusercontent.com/cacheplane/dawnai/main/docs/brand/dawn-logo-horizontal-black-on-white.png" alt="Dawn" width="180" />
+</p>
+
+# @dawn-ai/ag-ui
+
+AG-UI protocol translation for Dawn's local runtime. This package maps Dawn's
+runtime stream chunks to AG-UI events and maps AG-UI run input back to Dawn route
+input, so CopilotKit and other AG-UI clients can drive Dawn agents.
+
+This is part of [Dawn - the TypeScript meta-framework for LangGraph](https://github.com/cacheplane/dawnai).
+Conceptual docs: [Dev Server](https://dawnai.org/docs/dev-server) and the
+[chat web example](https://github.com/cacheplane/dawnai/tree/main/examples/chat/web).
+
+## Install
+
+```bash
+pnpm add @dawn-ai/ag-ui
+```
+
+Most apps do not import this package directly. `@dawn-ai/cli` uses it to serve
+the local dev endpoint:
+
+```text
+POST /agui/{routeId}
+```
+
+The URL segment is the URL-encoded Dawn assistant id (`<routeId>#<kind>`). For
+example, the Dawn route `/chat#agent` is exposed to AG-UI clients as:
+
+```text
+POST http://127.0.0.1:3001/agui/%2Fchat%23agent
+```
+
+## Public API
+
+```ts
+import {
+  createAgUiTranslator,
+  encodeAgUiSse,
+  mapRunInput,
+  type AgUiEvent,
+  type DawnStreamChunk,
+  type MappedRunInput,
+  type ResumeDecision,
+  type TranslatorOptions,
+} from "@dawn-ai/ag-ui"
+```
+
+### `mapRunInput(input)`
+
+Maps an AG-UI `RunAgentInput` to Dawn's route input:
+
+- The newest user message becomes `{ messages: [{ role: "user", content }] }`.
+- Dawn keeps conversation history in the checkpoint keyed by AG-UI `threadId`,
+  so only the newest turn is forwarded.
+- Human-in-the-loop resume decisions are read from
+  `forwardedProps.command.resume`.
+
+Resume accepts either a string decision:
+
+```json
+{ "forwardedProps": { "command": { "resume": "once" } } }
+```
+
+or an object carrying both the decision and interrupt id:
+
+```json
+{
+  "forwardedProps": {
+    "command": {
+      "resume": { "decision": "once", "interruptId": "perm-abc123" }
+    }
+  }
+}
+```
+
+`ResumeDecision` is `"once" | "always" | "deny"`.
+
+### `createAgUiTranslator(options)`
+
+Creates a translator for one AG-UI run:
+
+```ts
+const translator = createAgUiTranslator({ threadId, runId })
+```
+
+Call `begin()` once, feed each Dawn stream chunk to `translate(chunk)`, then call
+`end()` if the stream finishes without a Dawn `done` chunk.
+
+The translator emits:
+
+- `RUN_STARTED` / `RUN_FINISHED`
+- assistant text message start/content/end events
+- tool call start/args/end/result events
+- `STATE_SNAPSHOT` for `plan_update` and other object state chunks
+- `CUSTOM{name:"on_interrupt"}` for Dawn permission or memory interrupts
+- `CUSTOM{name:"dawn.<subagent event>"}` for `subagent.*` chunks
+- `RUN_ERROR` when Dawn reports an error
+
+### `encodeAgUiSse(event, accept?)`
+
+Encodes one AG-UI event as an SSE frame using `@ag-ui/encoder`:
+
+```ts
+response.write(encodeAgUiSse(event, request.headers.accept))
+```
+
+## CopilotKit
+
+The canonical example is `examples/chat/web`. It registers a CopilotKit
+`HttpAgent` that points at Dawn's AG-UI endpoint. The web app does not need
+model credentials; the Dawn server holds `OPENAI_API_KEY`.
+
+```text
+browser
+  -> CopilotKit runtime
+    -> HttpAgent -> POST /agui/%2Fchat%23agent
+      -> Dawn /chat agent
+```
+
+The example also shows how Dawn's `CUSTOM{name:"on_interrupt"}` event flows to a
+CopilotKit interrupt card, and how the card sends `{ decision, interruptId }`
+back through `forwardedProps.command.resume`.
+
+## Limitations
+
+- The AG-UI endpoint is a local `dawn dev` integration surface. It is additive;
+  the Agent Protocol thread endpoints remain unchanged.
+- `POST /agui/{routeId}` expects a URL-encoded Dawn assistant id such as
+  `%2Fchat%23agent` for `/chat#agent`.
+- Dawn middleware currently documents and targets the Agent Protocol
+  `/threads/:thread_id/runs/*` endpoints. Do not rely on middleware behavior as
+  the AG-UI authorization boundary.
+- The package translates protocol events; it does not host a web UI.
+
+## License
+
+MIT

--- a/packages/langchain/README.md
+++ b/packages/langchain/README.md
@@ -8,6 +8,33 @@ LangChain backend adapters for Dawn, the TypeScript meta-framework for LangGraph
 
 `agent()` materialization resolves a LangChain chat model from the route descriptor. Dawn includes `@langchain/openai` for the default/backcompat path and lazy-loads optional provider packages when an agent selects or infers another provider.
 
+## OpenAI embedder
+
+`openaiEmbedder()` provides Dawn's default semantic-memory embedder. Use it in
+`dawn.config.ts` to opt a memory-enabled route into hybrid keyword + vector
+recall:
+
+```ts
+import { config } from "@dawn-ai/core"
+import { openaiEmbedder } from "@dawn-ai/langchain"
+
+export default config({
+  memory: {
+    vector: { embedder: openaiEmbedder() },
+  },
+})
+```
+
+By default it uses `text-embedding-3-small`, reports `dims: 1536`, stores the
+embedder id as `openai:text-embedding-3-small`, and returns `Float32Array`
+vectors. Pass `{ model: "text-embedding-3-large" }` for a 3072-dimension
+embedder.
+
+`openaiEmbedder()` honors `OPENAI_BASE_URL`, the same seam used by Dawn's test
+harness and aimock. It explicitly requests OpenAI's float embedding encoding
+(`encodingFormat: "float"`) so the returned vector length matches the model's
+real dimensionality; this avoids base64 interop quirks in proxies and mocks.
+
 ## Optional provider integrations
 
 Install the provider packages your agents use, as needed:
@@ -25,6 +52,7 @@ pnpm add @langchain/openrouter    # openrouter
 ## Documentation
 
 - [Routes](https://dawnai.org/docs/routes)
+- [Memory](https://dawnai.org/docs/memory)
 - [Getting started](https://dawnai.org/docs/getting-started)
 
 ---

--- a/packages/memory-pgvector/README.md
+++ b/packages/memory-pgvector/README.md
@@ -1,0 +1,195 @@
+<p align="center">
+  <img src="https://raw.githubusercontent.com/cacheplane/dawnai/main/docs/brand/dawn-logo-horizontal-black-on-white.png" alt="Dawn" width="180" />
+</p>
+
+# @dawn-ai/memory-pgvector
+
+Postgres + pgvector backend for Dawn's typed long-term memory store. Use it when
+the default SQLite store is too local for your deployment: multiple app
+instances, a shared production database, or enough embedded memories that
+Postgres HNSW retrieval is a better fit than in-process cosine scans.
+
+This is part of [Dawn - the TypeScript meta-framework for LangGraph](https://github.com/cacheplane/dawnai).
+Conceptual docs: [Memory](https://dawnai.org/docs/memory) and
+[Configuration](https://dawnai.org/docs/configuration#memory).
+
+## Install
+
+```bash
+pnpm add @dawn-ai/memory-pgvector @dawn-ai/memory
+```
+
+For hybrid semantic recall with OpenAI embeddings, also use
+`openaiEmbedder()` from `@dawn-ai/langchain`:
+
+```bash
+pnpm add @dawn-ai/langchain
+```
+
+## Configure Dawn
+
+```ts
+import { config } from "@dawn-ai/core"
+import { openaiEmbedder } from "@dawn-ai/langchain"
+import { pgvectorMemoryStore } from "@dawn-ai/memory-pgvector"
+
+export default config({
+  memory: {
+    store: pgvectorMemoryStore({
+      connectionString: process.env.DATABASE_URL,
+      dimensions: 1536,
+    }),
+    vector: { embedder: openaiEmbedder() },
+  },
+})
+```
+
+`dimensions` must match the embedder's output length. `openaiEmbedder()` defaults
+to `text-embedding-3-small`, which is 1536 dimensions.
+
+## Postgres Requirements
+
+The database must have pgvector available. The store runs
+`CREATE EXTENSION IF NOT EXISTS vector` during lazy schema initialization, so the
+connected role needs permission to create the extension or the extension must
+already exist.
+
+For local development:
+
+```bash
+docker run --rm -e POSTGRES_PASSWORD=postgres -p 5432:5432 pgvector/pgvector:pg16
+export DATABASE_URL="postgres://postgres:postgres@localhost:5432/postgres"
+```
+
+## Public API
+
+```ts
+import {
+  assertIdentifier,
+  initSchema,
+  pgvectorMemoryStore,
+  vectorColumnDef,
+  type PgvectorMemoryStore,
+} from "@dawn-ai/memory-pgvector"
+```
+
+### `pgvectorMemoryStore(options)`
+
+```ts
+const store = pgvectorMemoryStore({
+  connectionString: process.env.DATABASE_URL,
+  dimensions: 1536,
+  schema: "public",
+  tablePrefix: "dawn_memory",
+  index: { m: 16, efConstruction: 64, efSearch: 40 },
+})
+```
+
+Options:
+
+- `connectionString?` - Postgres connection string. Used when the store owns its
+  own `pg.Pool`.
+- `pool?` - Existing `pg.Pool`. When supplied, the caller owns pool lifecycle.
+- `dimensions` - Required embedding dimension count. Values up to 2000 use
+  `vector(n)`; values from 2001 through 4000 use `halfvec(n)`.
+- `index?` - HNSW tuning: `m`, `efConstruction`, and `efSearch`.
+- `schema?` - Postgres schema. Defaults to `public`.
+- `tablePrefix?` - Table/index prefix. Defaults to `dawn_memory`.
+- `recall?` - Keyword ranked-recall tuning from `@dawn-ai/memory`.
+- `vector?` - Store-level hybrid RRF tuning used when a query omits its own
+  `vector` options.
+
+`schema` and `tablePrefix` are interpolated into DDL, so they must be simple SQL
+identifiers matching `/^[a-z_][a-z0-9_]*$/i`.
+
+### Store Methods
+
+`PgvectorMemoryStore` implements `MemoryStore` from `@dawn-ai/memory` and adds
+`close()`:
+
+```ts
+await store.put(record, {
+  embedding: Float32Array.from([...]),
+  embeddingModel: "openai:text-embedding-3-small",
+})
+
+const row = await store.get("memory_abc")
+const hits = await store.search({
+  namespace: "workspace=app|route=/notes|",
+  query: "expedite delivery options",
+  queryEmbedding,
+  embedderId: "openai:text-embedding-3-small",
+})
+
+await store.update("memory_abc", { content: "updated content" })
+await store.supersede("old_id", "new_id")
+await store.delete("memory_abc")
+await store.listCandidates("workspace=app|")
+await store.close()
+```
+
+Behavior notes:
+
+- Schema initialization is lazy, memoized, and idempotent. Every method waits for
+  it before touching tables.
+- `put()` upserts the memory row and refreshes token rows used by keyword
+  search.
+- `search()` defaults to `status: "active"` and `limit: 8`.
+- Query-less `search()` returns newest rows first.
+- Query searches use the same deterministic keyword ranking core as SQLite.
+- When `queryEmbedding` and `embedderId` are present, search runs the hybrid
+  path: keyword candidates plus pgvector HNSW nearest-neighbor candidates,
+  fused by the shared RRF/recency/confidence ranking core.
+- `update()` preserves an existing stored embedding.
+- `close()` ends only a pool created by `pgvectorMemoryStore()`. It is a no-op
+  for an injected pool.
+
+### `vectorColumnDef(dimensions)`
+
+Returns the pgvector column type and cosine operator class:
+
+- `1..2000` -> `vector(n)` with `vector_cosine_ops`
+- `2001..4000` -> `halfvec(n)` with `halfvec_cosine_ops`
+- `>4000` throws an error naming the 4000 halfvec index ceiling
+
+`pgvectorMemoryStore()` calls this during construction, so invalid dimensions
+fail before a pool is opened or schema initialization starts.
+
+### `initSchema(client, options)`
+
+Low-level helper that creates the extension, schema, tables, token indexes, and
+HNSW embedding index. Most apps should let `pgvectorMemoryStore()` call it.
+
+### `assertIdentifier(name, value)`
+
+Validates schema/table-prefix identifiers used by DDL helpers.
+
+## Published-Package Smoke
+
+The high-value local smoke for this package installs the published tarballs from
+the real npm registry outside the monorepo, starts `pgvector/pgvector:pg16`, and
+uses a real OpenAI embedding run. The regression guard is:
+
+- `openaiEmbedder().dims === 1536`
+- `embed(["probe"])` returns a 1536-length `Float32Array`
+- a zero-shared-token paraphrase such as "expedite delivery options" recalls a
+  stored "faster shipping" fact through `queryEmbedding + embedderId`
+
+That smoke specifically protects the `encodingFormat: "float"` path in
+`openaiEmbedder()` and the published pgvector store's real `vector(1536)` path.
+
+Do not commit API keys. Load `OPENAI_API_KEY` only into the local smoke shell.
+
+## Limitations
+
+- The backend requires Postgres with pgvector. It does not fall back to SQLite.
+- HNSW retrieval happens in SQL, but final hybrid fusion still runs in the
+  shared JavaScript ranking core.
+- `halfvec` enables larger embedding models up to 4000 dimensions with reduced
+  precision.
+- Data is stored as plaintext Postgres rows. Treat the database as sensitive
+  application data.
+
+## License
+
+MIT

--- a/scripts/check-docs.mjs
+++ b/scripts/check-docs.mjs
@@ -1,4 +1,4 @@
-import { readdirSync, readFileSync, statSync } from "node:fs"
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs"
 import { join, resolve } from "node:path"
 import { pathToFileURL } from "node:url"
 
@@ -12,6 +12,10 @@ const checks = [
   {
     file: "apps/web/content/docs/cli.mdx",
     patterns: ["dawn.config.ts", "appDir"],
+  },
+  {
+    file: "apps/web/content/docs/dev-server.mdx",
+    patterns: ["/agui/{routeId}", "@dawn-ai/ag-ui"],
   },
 ]
 
@@ -42,6 +46,14 @@ function isDraftBlogPost(filePath, source) {
 function frontmatterDate(source) {
   const match = source.match(/^date:\s*([0-9]{4}-[0-9]{2}-[0-9]{2})$/m)
   return match?.[1] ?? null
+}
+
+function packageManifests() {
+  const packagesDir = resolve(repoRoot, "packages")
+  return readdirSync(packagesDir, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => join(packagesDir, entry.name, "package.json"))
+    .filter((filePath) => existsSync(filePath))
 }
 
 function docHrefToContentPath(href) {
@@ -139,6 +151,75 @@ if (cliEntry?.createProgram) {
   }
 }
 
+// Public package docs check — every package manifest under packages/ must have
+// a sibling README, and packages with source exports must be findable from
+// either the API reference or their own README.
+const apiMdx = readFileSync(resolve(repoRoot, "apps/web/content/docs/api.mdx"), "utf8")
+for (const manifestPath of packageManifests()) {
+  const manifest = JSON.parse(readFileSync(manifestPath, "utf8"))
+  const packageDir = manifestPath.replace(/\/package\.json$/, "")
+  const relPackageDir = relativeToRoot(packageDir)
+  const readmePath = join(packageDir, "README.md")
+  if (!existsSync(readmePath)) {
+    failures.push(`${relPackageDir} is missing README.md`)
+    continue
+  }
+
+  const readme = readFileSync(readmePath, "utf8")
+  if (typeof manifest.name === "string" && manifest.name.startsWith("@dawn-ai/")) {
+    const sourceIndex = join(packageDir, "src", "index.ts")
+    if (existsSync(sourceIndex)) {
+      const source = readFileSync(sourceIndex, "utf8")
+      const hasPublicExports = /^export\s/m.test(source)
+      const mentionedInApi = apiMdx.includes(manifest.name)
+      const mentionedInReadme = readme.includes(manifest.name)
+      if (hasPublicExports && !mentionedInApi && !mentionedInReadme) {
+        failures.push(
+          `${relPackageDir} has public exports but is not mentioned in API docs or its README`,
+        )
+      }
+    }
+  }
+}
+
+// Dev-server endpoint coverage check. Keep explicit endpoint docs in step with
+// runtime-server route additions that expose new client-facing protocols.
+const runtimeServerSource = readFileSync(
+  resolve(repoRoot, "packages/cli/src/lib/dev/runtime-server.ts"),
+  "utf8",
+)
+const devServerDocs = readFileSync(
+  resolve(repoRoot, "apps/web/content/docs/dev-server.mdx"),
+  "utf8",
+)
+if (runtimeServerSource.includes("/agui/:routeId")) {
+  for (const required of [
+    "POST /agui/{routeId}",
+    "%2Fchat%23agent",
+    "@dawn-ai/ag-ui",
+    "forwardedProps.command.resume",
+  ]) {
+    if (!devServerDocs.includes(required)) {
+      failures.push(
+        `apps/web/content/docs/dev-server.mdx is missing AG-UI endpoint text: ${required}`,
+      )
+    }
+  }
+}
+
+// Chart docs drift check — chart appVersion should track the current Dawn
+// package train unless a chart intentionally documents otherwise.
+const cliPackage = JSON.parse(readFileSync(resolve(repoRoot, "packages/cli/package.json"), "utf8"))
+for (const chartYaml of ["charts/dawn-app/Chart.yaml", "charts/dawn-sandbox-infra/Chart.yaml"]) {
+  const source = readFileSync(resolve(repoRoot, chartYaml), "utf8")
+  const match = source.match(/^appVersion:\s*["']?([^"'\n]+)["']?$/m)
+  if (match?.[1] !== cliPackage.version) {
+    failures.push(
+      `${chartYaml} appVersion (${match?.[1] ?? "missing"}) does not match @dawn-ai/cli ${cliPackage.version}`,
+    )
+  }
+}
+
 const userFacingRoots = [
   "README.md",
   "CONTRIBUTING.md",
@@ -198,6 +279,11 @@ const forbiddenContent = [
   {
     pattern: /auto-bound|auto-registered/,
     message: "uses old tool auto-binding wording",
+  },
+  {
+    pattern: /pgvector is a planned follow-up backend/,
+    message: "describes pgvector as planned even though @dawn-ai/memory-pgvector ships",
+    shouldCheck: (filePath) => !/CHANGELOG\.md$/.test(filePath),
   },
 ]
 


### PR DESCRIPTION
## Summary
- Add package READMEs for `@dawn-ai/ag-ui` and `@dawn-ai/memory-pgvector`, including AG-UI route mapping, CopilotKit usage, pgvector store methods, dimensions, and published-package smoke evidence.
- Expand website docs/API reference for AG-UI, pgvector memory, OpenAI embedder behavior, FAQ discoverability, and corrected chat example endpoint copy.
- Harden `scripts/check-docs.mjs` so public packages need READMEs, exported packages remain discoverable, AG-UI endpoint docs cannot drift, chart appVersions track the package train, and stale pgvector-planned wording is blocked.
- Add an empty changeset because the package-facing changes are README/docs-only and do not change runtime package code.

## Coverage Evidence
- Before: public `@dawn-ai/ag-ui` and `@dawn-ai/memory-pgvector` packages had no package READMEs, and `@dawn-ai/ag-ui` was not covered in the API reference.
- After: both packages have READMEs, `apps/web/content/docs/api.mdx` covers both public APIs, and `apps/web/content/docs/dev-server.mdx` documents `POST /agui/{routeId}` with the encoded `/chat#agent` path `%2Fchat%23agent`.
- `@dawn-ai/langchain` README now documents `openaiEmbedder()`, the default 1536-dim `text-embedding-3-small` behavior, `OPENAI_BASE_URL`, and the float embedding encoding contract.
- Helm chart `appVersion` values now match the current `@dawn-ai/cli` package version, and the dawn-app render assertion now expects the matching default image tag.

## Verification
- `node scripts/check-docs.mjs`
- `node scripts/check-changesets.mjs`
- `helm lint --strict charts/dawn-app && sh charts/dawn-app/test/render.sh`
- `corepack pnpm --filter @dawn-ai/ag-ui typecheck`
- `corepack pnpm --filter @dawn-ai/memory-pgvector typecheck`
- `corepack pnpm --filter @dawn-ai/langchain typecheck`
- `corepack pnpm --filter @dawn-ai/web typecheck`
- `corepack pnpm --filter @dawn-ai/web build`
- `corepack pnpm build`
- `corepack pnpm lint`
- `git diff --check`