### PR TITLE
feat(sdk): agent recursionLimit option

### DIFF
--- a/.changeset/agent-recursion-limit.md
+++ b/.changeset/agent-recursion-limit.md
@@ -1,0 +1,9 @@
+---
+"@dawn-ai/sdk": patch
+"@dawn-ai/langchain": patch
+---
+
+Add a `recursionLimit` option to `agent()`. It maps to LangGraph's per-run
+super-step ceiling (default 25), so deep agents — a coordinator that dispatches
+subagents and makes many tool calls — can raise the limit instead of aborting
+with a recursion error.

--- a/packages/langchain/src/agent-adapter.ts
+++ b/packages/langchain/src/agent-adapter.ts
@@ -506,6 +506,12 @@ function prepareAgentCall(options: AgentOptions): {
   const config: Record<string, unknown> = {
     signal: options.signal,
   }
+  // Per-agent super-step ceiling. LangGraph's Pregel reads config.recursionLimit
+  // (default 25); deep agents (coordinator + subagents + many tool calls) can
+  // legitimately need more. Sourced from the DawnAgent descriptor, mirroring retry.
+  if (isDawnAgent(options.entry) && typeof options.entry.recursionLimit === "number") {
+    config.recursionLimit = options.entry.recursionLimit
+  }
 
   const configurable: Record<string, unknown> = { ...params }
   if (options.threadId !== undefined && options.threadId.length > 0) {

--- a/packages/langchain/test/agent-adapter.test.ts
+++ b/packages/langchain/test/agent-adapter.test.ts
@@ -225,4 +225,66 @@ describe("executeAgent with DawnAgent descriptors", () => {
     expect(invokeInput?.messages[0]?.content).toBe("hello")
     expect(invokeConfig?.configurable).toEqual({ tenant: "acme" })
   })
+
+  test("recursionLimit from the descriptor is passed into the graph config", async () => {
+    const invoke = vi.fn().mockResolvedValue(new AIMessage({ content: "ok" }))
+    vi.doMock("@langchain/langgraph/prebuilt", () => ({
+      createReactAgent: vi.fn(() => ({ invoke })),
+    }))
+    vi.doMock("@langchain/openai", () => ({
+      ChatOpenAI: class {
+        constructor(public options: Record<string, unknown>) {}
+      },
+    }))
+
+    const descriptor = agent({
+      model: "gpt-4o-mini",
+      systemPrompt: "You are helpful.",
+      recursionLimit: 123,
+    })
+
+    await executeAgent({
+      checkpointer: new MemorySaver(),
+      entry: descriptor,
+      input: { question: "hi" },
+      routeParamNames: [],
+      signal: new AbortController().signal,
+      tools: [],
+    }).finally(() => {
+      vi.doUnmock("@langchain/langgraph/prebuilt")
+      vi.doUnmock("@langchain/openai")
+    })
+
+    const invokeConfig = invoke.mock.calls[0]?.[1] as { recursionLimit?: number }
+    expect(invokeConfig?.recursionLimit).toBe(123)
+  })
+
+  test("no recursionLimit leaves the graph config default (unset)", async () => {
+    const invoke = vi.fn().mockResolvedValue(new AIMessage({ content: "ok" }))
+    vi.doMock("@langchain/langgraph/prebuilt", () => ({
+      createReactAgent: vi.fn(() => ({ invoke })),
+    }))
+    vi.doMock("@langchain/openai", () => ({
+      ChatOpenAI: class {
+        constructor(public options: Record<string, unknown>) {}
+      },
+    }))
+
+    const descriptor = agent({ model: "gpt-4o-mini", systemPrompt: "You are helpful." })
+
+    await executeAgent({
+      checkpointer: new MemorySaver(),
+      entry: descriptor,
+      input: { question: "hi" },
+      routeParamNames: [],
+      signal: new AbortController().signal,
+      tools: [],
+    }).finally(() => {
+      vi.doUnmock("@langchain/langgraph/prebuilt")
+      vi.doUnmock("@langchain/openai")
+    })
+
+    const invokeConfig = invoke.mock.calls[0]?.[1] as { recursionLimit?: number }
+    expect(invokeConfig?.recursionLimit).toBeUndefined()
+  })
 })

--- a/packages/sdk/src/agent.ts
+++ b/packages/sdk/src/agent.ts
@@ -69,6 +69,7 @@ export interface DawnAgent {
   readonly provider?: ModelProviderId
   readonly reasoning?: ReasoningConfig
   readonly retry?: RetryConfig
+  readonly recursionLimit?: number
   readonly subagents?: readonly DawnAgent[]
   readonly tools?: ToolScope
   readonly systemPrompt: string
@@ -80,6 +81,13 @@ export interface AgentConfig {
   readonly provider?: ModelProviderId
   readonly reasoning?: ReasoningConfig
   readonly retry?: RetryConfig
+  /**
+   * Maximum number of LangGraph super-steps for one run before it aborts with a
+   * recursion error. Defaults to LangGraph's own limit (25). Raise it for deep
+   * agents — e.g. a coordinator that dispatches subagents and makes many tool
+   * calls — that legitimately need more steps to reach a stop condition.
+   */
+  readonly recursionLimit?: number
   readonly subagents?: readonly DawnAgent[]
   readonly tools?: ToolScope
   readonly systemPrompt: string
@@ -92,6 +100,7 @@ export function agent(config: AgentConfig): DawnAgent {
     ...(config.provider !== undefined ? { provider: config.provider } : {}),
     ...(config.reasoning ? { reasoning: config.reasoning } : {}),
     ...(config.retry ? { retry: config.retry } : {}),
+    ...(config.recursionLimit !== undefined ? { recursionLimit: config.recursionLimit } : {}),
     ...(config.description !== undefined ? { description: config.description } : {}),
     ...(config.subagents !== undefined ? { subagents: config.subagents } : {}),
     ...(config.tools !== undefined ? { tools: config.tools } : {}),


### PR DESCRIPTION
## Summary

Adds a `recursionLimit` option to `agent()` that maps to LangGraph's per-run super-step ceiling (default **25**). Deep agents — a coordinator that dispatches subagents and makes many tool calls — can raise the limit instead of aborting with `Recursion limit of 25 reached without hitting a stop condition`.

Surfaced by dogfooding the flagship research demo (coordinator → per-sub-question researcher → many corpus tool calls → synthesize legitimately exceeds 25 steps).

## Change (2 files + tests)
- `packages/sdk/src/agent.ts` — `recursionLimit?: number` on `AgentConfig`/`DawnAgent`, spread in the `agent()` factory (mirrors the existing `retry` option).
- `packages/langchain/src/agent-adapter.ts` — in `prepareAgentCall`, set `config.recursionLimit` from the DawnAgent descriptor when present; LangGraph's `Pregel` reads it. Sourced from `options.entry`, exactly like `retry`.

## Test plan
- `packages/langchain/test/agent-adapter.test.ts` — 2 new tests: the descriptor's `recursionLimit` reaches the graph config; absent by default. (8/8 in the suite.)
- Verified live: the research demo's deep run completes end-to-end with `recursionLimit: 100` instead of erroring at 25.

🤖 Generated with [Claude Code](https://claude.com/claude-code)