### PR TITLE
feat(cli): memory-candidate HTTP endpoints (list/approve/reject)

### DIFF
--- a/.changeset/memory-http-endpoints.md
+++ b/.changeset/memory-http-endpoints.md
@@ -1,0 +1,9 @@
+---
+"@dawn-ai/cli": patch
+---
+
+Add dev-server HTTP endpoints for memory candidates so a web client can review
+durable-memory proposals without the CLI: `GET /memory/candidates`,
+`POST /memory/candidates/:id/approve` (candidate → active, 404/409 guarded), and
+`POST /memory/candidates/:id/reject`. Backed by the same store methods as
+`dawn memory list/approve/reject`.

--- a/packages/cli/src/lib/dev/memory-handler.ts
+++ b/packages/cli/src/lib/dev/memory-handler.ts
@@ -1,0 +1,70 @@
+import type { ServerResponse } from "node:http"
+import type { MemoryStore } from "@dawn-ai/memory"
+import { createRequestErrorBody } from "./server-errors.js"
+
+// Local copy of runtime-server.ts's `sendJson` helper — kept private to each
+// module (like agui-handler.ts does) to avoid a circular import between
+// runtime-server.ts (which wires this handler into the route table) and this
+// file.
+function sendJson(response: ServerResponse, statusCode: number, body: unknown): void {
+  response.statusCode = statusCode
+  response.setHeader("content-type", "application/json")
+  response.end(JSON.stringify(body))
+}
+
+/**
+ * GET /memory/candidates — list every candidate record across all namespaces
+ * (empty prefix = all namespaces), for a web UI to review.
+ */
+export async function handleMemoryListRequest(options: {
+  readonly memoryStore: MemoryStore
+  readonly response: ServerResponse
+}): Promise<void> {
+  const { memoryStore, response } = options
+  const candidates = await memoryStore.listCandidates("")
+  sendJson(response, 200, { candidates })
+}
+
+/**
+ * POST /memory/candidates/:id/approve — flip a candidate to active.
+ * Mirrors `runApprove` in `commands/memory.ts` exactly: 404 if the record is
+ * missing, 409 if it isn't currently a candidate, else update + return the
+ * refreshed record.
+ */
+export async function handleMemoryApproveRequest(options: {
+  readonly memoryStore: MemoryStore
+  readonly response: ServerResponse
+  readonly id: string
+}): Promise<void> {
+  const { memoryStore, response, id } = options
+  const record = await memoryStore.get(id)
+  if (!record) {
+    sendJson(response, 404, createRequestErrorBody(`Record not found: ${id}`))
+    return
+  }
+  if (record.status !== "candidate") {
+    sendJson(
+      response,
+      409,
+      createRequestErrorBody(`Record "${id}" is not a candidate (status: ${record.status})`),
+    )
+    return
+  }
+  await memoryStore.update(id, { status: "active", updatedAt: new Date().toISOString() })
+  const updated = await memoryStore.get(id)
+  sendJson(response, 200, { record: updated })
+}
+
+/**
+ * POST /memory/candidates/:id/reject — delete the record outright (mirrors
+ * `runReject` in `commands/memory.ts`).
+ */
+export async function handleMemoryRejectRequest(options: {
+  readonly memoryStore: MemoryStore
+  readonly response: ServerResponse
+  readonly id: string
+}): Promise<void> {
+  const { memoryStore, response, id } = options
+  await memoryStore.delete(id)
+  sendJson(response, 200, { ok: true })
+}

--- a/packages/cli/src/lib/dev/runtime-server.ts
+++ b/packages/cli/src/lib/dev/runtime-server.ts
@@ -1,5 +1,6 @@
 import { createServer, type IncomingMessage, type ServerResponse } from "node:http"
 import type { AddressInfo } from "node:net"
+import type { MemoryStore } from "@dawn-ai/memory"
 import type { DawnMiddleware, MiddlewareRequest } from "@dawn-ai/sdk"
 import type { Thread, ThreadsStore } from "@dawn-ai/sqlite-storage"
 import type { BaseCheckpointSaver } from "@langchain/langgraph-checkpoint"
@@ -9,10 +10,16 @@ import {
   resolveThreadsStore,
   streamResolvedRoute,
 } from "../runtime/execute-route.js"
+import { resolveMemoryStore } from "../runtime/resolve-memory.js"
 import { resolveSandboxManager } from "../runtime/resolve-sandbox.js"
 import type { SandboxManager } from "../runtime/sandbox-manager.js"
 import { type StreamChunk, toSseEvent } from "../runtime/stream-types.js"
 import { handleAgUiRequest } from "./agui-handler.js"
+import {
+  handleMemoryApproveRequest,
+  handleMemoryListRequest,
+  handleMemoryRejectRequest,
+} from "./memory-handler.js"
 import { loadMiddleware, runMiddleware } from "./middleware.js"
 import { createRuntimeRegistry, type RuntimeRegistry } from "./runtime-registry.js"
 import { createExecutionErrorBody, createRequestErrorBody } from "./server-errors.js"
@@ -62,6 +69,12 @@ export async function createRuntimeRequestListener(
   const threadsStore = await resolveThreadsStore(options.appRoot)
   const checkpointer = await resolveCheckpointer(options.appRoot)
   const sandboxManager = await resolveSandboxManager(options.appRoot)
+  // Cast: resolveMemoryStore's declared return type (MemoryStoreLike, in
+  // @dawn-ai/core) is the narrower capability-facing surface. The concrete
+  // store (sqlite-backed, or user-supplied via dawn.config.ts) also exposes
+  // listCandidates/delete, which the memory-candidate HTTP routes need — the
+  // same cast `commands/memory.ts` uses for the CLI's `dawn memory` commands.
+  const memoryStore = (await resolveMemoryStore(options.appRoot)) as unknown as MemoryStore
 
   let sandboxReaper: ReturnType<typeof setInterval> | undefined
   if (sandboxManager) {
@@ -81,6 +94,7 @@ export async function createRuntimeRequestListener(
   const routes = buildRouteTable({
     appRoot: options.appRoot,
     checkpointer,
+    memoryStore,
     middleware,
     registry,
     ...(sandboxManager ? { sandboxManager } : {}),
@@ -199,13 +213,23 @@ export async function startRuntimeServer(
 function buildRouteTable(ctx: {
   readonly appRoot: string
   readonly checkpointer: BaseCheckpointSaver
+  readonly memoryStore: MemoryStore
   readonly middleware: DawnMiddleware | undefined
   readonly registry: RuntimeRegistry
   readonly sandboxManager?: SandboxManager
   readonly signal: AbortSignal
   readonly threadsStore: ThreadsStore
 }): RouteMatcher[] {
-  const { appRoot, checkpointer, middleware, registry, sandboxManager, signal, threadsStore } = ctx
+  const {
+    appRoot,
+    checkpointer,
+    memoryStore,
+    middleware,
+    registry,
+    sandboxManager,
+    signal,
+    threadsStore,
+  } = ctx
 
   // Server-scoped map: thread_id → last routeKey used for that thread.
   // Populated by runs/stream and runs/wait; read by the resume endpoint so it
@@ -332,6 +356,39 @@ function buildRouteTable(ctx: {
       },
       method: "POST",
       pattern: /^\/agui\/(?<routeId>[^/?#]+)(?:\?.*)?$/,
+    },
+
+    // ------------------------------------------------------------------
+    // GET /memory/candidates — list memory candidates (all namespaces)
+    // ------------------------------------------------------------------
+    {
+      handle: async (_req, res) => {
+        await handleMemoryListRequest({ memoryStore, response: res })
+      },
+      method: "GET",
+      pattern: /^\/memory\/candidates(?:\?.*)?$/,
+    },
+
+    // ------------------------------------------------------------------
+    // POST /memory/candidates/:id/approve — flip a candidate to active
+    // ------------------------------------------------------------------
+    {
+      handle: async (_req, res, params) => {
+        await handleMemoryApproveRequest({ id: params.id ?? "", memoryStore, response: res })
+      },
+      method: "POST",
+      pattern: /^\/memory\/candidates\/(?<id>[^/?#]+)\/approve(?:\?.*)?$/,
+    },
+
+    // ------------------------------------------------------------------
+    // POST /memory/candidates/:id/reject — delete the record
+    // ------------------------------------------------------------------
+    {
+      handle: async (_req, res, params) => {
+        await handleMemoryRejectRequest({ id: params.id ?? "", memoryStore, response: res })
+      },
+      method: "POST",
+      pattern: /^\/memory\/candidates\/(?<id>[^/?#]+)\/reject(?:\?.*)?$/,
     },
 
     // ------------------------------------------------------------------

--- a/packages/cli/test/memory-endpoints.test.ts
+++ b/packages/cli/test/memory-endpoints.test.ts
@@ -1,0 +1,159 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+import type { MemoryRecord } from "@dawn-ai/memory"
+import { sqliteMemoryStore } from "@dawn-ai/memory"
+import { afterEach, describe, expect, test } from "vitest"
+
+import { startRuntimeServer } from "../src/lib/dev/runtime-server.js"
+
+const tempDirs: string[] = []
+const servers: Array<{ close: () => Promise<void> }> = []
+
+afterEach(async () => {
+  await Promise.all(servers.splice(0).map((server) => server.close()))
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { force: true, recursive: true })))
+})
+
+describe("memory-candidate HTTP endpoints", () => {
+  test("GET /memory/candidates lists seeded candidates", async () => {
+    const appRoot = await createFixtureApp()
+    await seedRecord(appRoot, {
+      id: "memory_cand_list",
+      content: "The user prefers concise summaries.",
+      status: "candidate",
+    })
+    const server = await startRuntimeServer({ appRoot })
+    servers.push(server)
+
+    const response = await fetch(new URL("/memory/candidates", server.url))
+    expect(response.status).toBe(200)
+    const body = (await response.json()) as { candidates: MemoryRecord[] }
+    expect(body.candidates).toHaveLength(1)
+    expect(body.candidates[0]?.id).toBe("memory_cand_list")
+    expect(body.candidates[0]?.status).toBe("candidate")
+  })
+
+  test("POST /memory/candidates/:id/approve flips a candidate to active", async () => {
+    const appRoot = await createFixtureApp()
+    await seedRecord(appRoot, {
+      id: "memory_cand_approve",
+      content: "The user wants primary sources cited.",
+      status: "candidate",
+    })
+    const server = await startRuntimeServer({ appRoot })
+    servers.push(server)
+
+    const response = await fetch(
+      new URL("/memory/candidates/memory_cand_approve/approve", server.url),
+      { method: "POST" },
+    )
+    expect(response.status).toBe(200)
+    const body = (await response.json()) as { record: MemoryRecord }
+    expect(body.record.id).toBe("memory_cand_approve")
+    expect(body.record.status).toBe("active")
+
+    // No longer a candidate.
+    const listResponse = await fetch(new URL("/memory/candidates", server.url))
+    const listBody = (await listResponse.json()) as { candidates: MemoryRecord[] }
+    expect(listBody.candidates.find((rec) => rec.id === "memory_cand_approve")).toBeUndefined()
+  })
+
+  test("POST /memory/candidates/:id/approve returns 404 for an unknown id", async () => {
+    const appRoot = await createFixtureApp()
+    const server = await startRuntimeServer({ appRoot })
+    servers.push(server)
+
+    const response = await fetch(new URL("/memory/candidates/no-such-id/approve", server.url), {
+      method: "POST",
+    })
+    expect(response.status).toBe(404)
+    const body = (await response.json()) as { error?: { kind?: string; message?: string } }
+    expect(body.error?.kind).toBe("request_error")
+    expect(body.error?.message).toMatch(/no-such-id/)
+  })
+
+  test("POST /memory/candidates/:id/approve returns 409 for a non-candidate record", async () => {
+    const appRoot = await createFixtureApp()
+    await seedRecord(appRoot, {
+      id: "memory_already_active",
+      content: "Already active, not a candidate.",
+      status: "active",
+    })
+    const server = await startRuntimeServer({ appRoot })
+    servers.push(server)
+
+    const response = await fetch(
+      new URL("/memory/candidates/memory_already_active/approve", server.url),
+      { method: "POST" },
+    )
+    expect(response.status).toBe(409)
+    const body = (await response.json()) as { error?: { kind?: string; message?: string } }
+    expect(body.error?.kind).toBe("request_error")
+    expect(body.error?.message).toMatch(/not a candidate/)
+  })
+
+  test("POST /memory/candidates/:id/reject deletes the record", async () => {
+    const appRoot = await createFixtureApp()
+    await seedRecord(appRoot, {
+      id: "memory_cand_reject",
+      content: "The user wants footnotes.",
+      status: "candidate",
+    })
+    const server = await startRuntimeServer({ appRoot })
+    servers.push(server)
+
+    const response = await fetch(
+      new URL("/memory/candidates/memory_cand_reject/reject", server.url),
+      { method: "POST" },
+    )
+    expect(response.status).toBe(200)
+    const body = (await response.json()) as { ok: boolean }
+    expect(body.ok).toBe(true)
+
+    // Gone: a follow-up approve on the same id now 404s.
+    const approveResponse = await fetch(
+      new URL("/memory/candidates/memory_cand_reject/approve", server.url),
+      { method: "POST" },
+    )
+    expect(approveResponse.status).toBe(404)
+  })
+})
+
+async function seedRecord(
+  appRoot: string,
+  overrides: Pick<MemoryRecord, "id" | "content" | "status">,
+): Promise<void> {
+  const store = sqliteMemoryStore({ path: join(appRoot, ".dawn", "memory.sqlite") })
+  const record: MemoryRecord = {
+    kind: "semantic",
+    namespace: "workspace=fixture|route=/noop",
+    data: {},
+    source: { type: "eval", id: "seed" },
+    confidence: 1,
+    tags: [],
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+    ...overrides,
+  }
+  await store.put(record)
+}
+
+async function createFixtureApp(): Promise<string> {
+  const appRoot = await mkdtemp(join(tmpdir(), "dawn-cli-memory-endpoints-"))
+  tempDirs.push(appRoot)
+  const files: Readonly<Record<string, string>> = {
+    "dawn.config.ts": "export default {};\n",
+    "package.json": "{}\n",
+    "src/app/noop/index.ts": "export const graph = async () => ({ ok: true });\n",
+  }
+  await Promise.all(
+    Object.entries(files).map(async ([relativePath, source]) => {
+      const filePath = join(appRoot, relativePath)
+      await mkdir(join(filePath, ".."), { recursive: true })
+      await writeFile(filePath, source, "utf8")
+    }),
+  )
+  return appRoot
+}


### PR DESCRIPTION
## Summary

Adds three additive dev-server endpoints so a web client can review durable-memory proposals, which today are only approvable via the `dawn memory` CLI:

- `GET /memory/candidates` → `{ candidates }` (all namespaces, via `store.listCandidates("")`)
- `POST /memory/candidates/:id/approve` → flips `candidate → active` (`store.update(id, {status:"active", updatedAt})`); **404** if missing, **409** if not a candidate — same guard as `dawn memory approve`
- `POST /memory/candidates/:id/reject` → `store.delete(id)` → `{ ok: true }`

The memory store is resolved once in `createRuntimeRequestListener` (like `threadsStore`/`checkpointer`) and closed over by the handlers. Existing routes are untouched.

Surfaced by the flagship research demo's web UI, which needs an approval surface for the candidates the coordinator proposes via `remember()`.

## Test plan
- `packages/cli/test/memory-endpoints.test.ts` — 5 deterministic tests (no key): list seeded candidate, approve→active (+ confirm), 404 unknown, 409 non-candidate, reject→gone. Boots the in-process listener and drives it over loopback `fetch` (mirrors `resume-endpoint.test.ts`).
- Full `@dawn-ai/cli` suite: 319/319.
- Verified live: the research web panel lists real candidates and Approve flips one to active (confirmed in sqlite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)