### PR TITLE
fix(release): align Helm app versions with 0.8.12

### DIFF
--- a/charts/dawn-app/Chart.yaml
+++ b/charts/dawn-app/Chart.yaml
@@ -3,7 +3,7 @@ name: dawn-app
 description: Runs a built Dawn app image (from `langgraphjs dockerfile`) on Kubernetes as a Deployment + Service, with optional Ingress, HorizontalPodAutoscaler, and PodDisruptionBudget, wired to the in-cluster kubernetesSandbox orchestrator ServiceAccount.
 type: application
 version: 0.1.0
-appVersion: "0.8.11"
+appVersion: "0.8.12"
 keywords: [dawn, langgraph, kubernetes, deployment]
 home: https://dawnai.org
 sources: [https://github.com/cacheplane/dawnai]

--- a/charts/dawn-app/test/render.sh
+++ b/charts/dawn-app/test/render.sh
@@ -11,7 +11,7 @@ refute() { if grep -qE "$2"; then echo "FAIL (expected absent): $1"; exit 1; fi;
 # Deployment: image, probes on /healthz, SA, hardened securityContext
 DEPLOY="$(tmpl --show-only templates/deployment.yaml)"
 printf '%s\n' "$DEPLOY" | assert "deployment kind" 'kind: Deployment'
-printf '%s\n' "$DEPLOY" | assert "image repository+tag" 'image: example/app:0.8.11'
+printf '%s\n' "$DEPLOY" | assert "image repository+tag" 'image: example/app:0.8.12'
 printf '%s\n' "$DEPLOY" | assert "named http port" 'containerPort: 8000'
 printf '%s\n' "$DEPLOY" | assert "liveness probe path" 'path: /healthz'
 printf '%s\n' "$DEPLOY" | assert "serviceAccountName default" 'serviceAccountName: dawn-orchestrator'

--- a/charts/dawn-sandbox-infra/Chart.yaml
+++ b/charts/dawn-sandbox-infra/Chart.yaml
@@ -3,7 +3,7 @@ name: dawn-sandbox-infra
 description: Cluster-side infrastructure for the Dawn kubernetesSandbox provider — namespace, least-privilege RBAC, default-deny egress, quotas/limits, Pod Security Standards, and a PVC reaper.
 type: application
 version: 0.1.0
-appVersion: "0.8.11"
+appVersion: "0.8.12"
 keywords: [dawn, sandbox, kubernetes, security]
 home: https://dawnai.org
 sources: [https://github.com/cacheplane/dawnai]


### PR DESCRIPTION
## Summary

- update both Helm chart `appVersion` values from `0.8.11` to `0.8.12`
- update the dawn-app render assertion for the default image tag

## Root cause

The 0.8.12 Version Packages PR updated npm package manifests, but Changesets does not manage Helm chart metadata. The Release workflow stopped in `Validate Release Candidate` before publishing because the docs completeness gate requires both chart `appVersion` values to match `@dawn-ai/cli`.

No npm packages were published by the failed release run.

## Validation

- `pnpm build`
- `node scripts/check-docs.mjs`
- `helm lint --strict charts/dawn-app`
- `helm lint --strict charts/dawn-sandbox-infra`
- `sh charts/dawn-app/test/render.sh`
- `sh charts/dawn-sandbox-infra/test/render.sh`
- `git diff --check`
