### PR TITLE
docs: post-arc assessment fixes — reconcile front door, fix stale build/serve framing, add access-control/AG-UI/upgrading pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,45 +106,53 @@ export default async ({ query }: { readonly query: string }) => {
 1. Create a new app.
 
 ```bash
-pnpm create dawn-ai-app my-dawn-app
+npm create dawn-ai-app@latest my-dawn-app
 cd my-dawn-app
-pnpm install
+npm install
 ```
 
-2. Validate the app and generate types in one call.
+Requires Node.js 22.12 or later.
+
+2. Validate the app and generate types.
 
 ```bash
-pnpm exec dawn verify
+npm run check
 ```
 
-3. Run the scaffolded research route with JSON stdin.
-
-Live agent runs require model credentials, such as `OPENAI_API_KEY`. For an offline path with recorded fixtures, run `pnpm test` and `pnpm exec dawn eval` in the scaffolded app.
+Offline path — no API key needed — via recorded fixtures:
 
 ```bash
-echo '{"messages":[{"role":"user","content":"What are common agent architectures?"}]}' | pnpm exec dawn run /research
+npm test
 ```
 
-4. Optionally start the local runtime in one terminal and send the same route through the Agent Protocol from another terminal.
-
-In one terminal:
+3. Run it live. Set your API key and start the dev server:
 
 ```bash
-pnpm exec dawn dev --port 3001
+export OPENAI_API_KEY=sk-...
+npx dawn dev --port 2024
 ```
 
-In another terminal:
+In another terminal, create a thread and run the research route through the Agent Protocol:
 
 ```bash
-THREAD_ID=$(curl -s -X POST http://127.0.0.1:3001/threads -H 'content-type: application/json' -d '{}' | jq -r .thread_id)
-curl -s -X POST http://127.0.0.1:3001/threads/$THREAD_ID/runs/wait \
+THREAD_ID=$(curl -s -X POST http://127.0.0.1:2024/threads -H 'content-type: application/json' -d '{}' | jq -r .thread_id)
+curl -s -X POST http://127.0.0.1:2024/threads/$THREAD_ID/runs/wait \
   -H 'content-type: application/json' \
   -d '{"route":"/research#agent","input":{"messages":[{"role":"user","content":"What are common agent architectures?"}]}}' | jq .
 ```
 
 Use `/threads/$THREAD_ID/runs/stream` with the same body when you want SSE events instead of a blocking JSON response.
 
-The default scaffold is the deep-research app at `/research`. For the smaller greeter scaffold, run `pnpm create dawn-ai-app my-dawn-app -- --template basic`; that optional template uses `/hello/[tenant]`.
+4. Ship it. `dawn build` emits a runnable production server (`server.mjs` plus a hardened `Dockerfile`) alongside the LangSmith `langgraph.json` target; serve it locally with `dawn start`, or build and run the Docker image:
+
+```bash
+dawn build
+npx dawn start
+```
+
+The default scaffold is the deep-research app at `/research`. For the smaller greeter scaffold, run `npm create dawn-ai-app@latest my-dawn-app -- --template basic`; that optional template uses `/hello/[tenant]`.
+
+Prefer pnpm or yarn? Swap `npm create dawn-ai-app@latest` for `pnpm create dawn-ai-app` / `yarn create dawn-ai-app`, and `npm install`/`npm run`/`npx` for your package manager's equivalents.
 
 ## 30-Second Route
 

--- a/apps/web/app/components/docs/nav.ts
+++ b/apps/web/app/components/docs/nav.ts
@@ -32,6 +32,7 @@ export const DOCS_NAV: readonly DocsNavSection[] = [
       { label: "Middleware", href: "/docs/middleware" },
       { label: "Workspace Filesystem", href: "/docs/workspace" },
       { label: "Context Management", href: "/docs/context-management" },
+      { label: "Access Control", href: "/docs/access-control" },
       { label: "Permissions", href: "/docs/permissions" },
       { label: "Sandbox", href: "/docs/sandbox" },
       { label: "Retry", href: "/docs/retry" },
@@ -41,6 +42,7 @@ export const DOCS_NAV: readonly DocsNavSection[] = [
     label: "Tooling",
     items: [
       { label: "Dev Server", href: "/docs/dev-server" },
+      { label: "AG-UI & Web Clients", href: "/docs/ag-ui" },
       { label: "Blueprints", href: "/docs/blueprints" },
       { label: "Testing", href: "/docs/testing" },
       { label: "Testing Agents", href: "/docs/testing-agents" },
@@ -67,6 +69,7 @@ export const DOCS_NAV: readonly DocsNavSection[] = [
       { label: "CLI", href: "/docs/cli" },
       { label: "Configuration", href: "/docs/configuration" },
       { label: "Observability", href: "/docs/observability" },
+      { label: "Upgrading", href: "/docs/upgrading" },
       { label: "FAQ", href: "/docs/faq" },
     ],
   },

--- a/apps/web/app/docs/access-control/page.tsx
+++ b/apps/web/app/docs/access-control/page.tsx
@@ -1,0 +1,9 @@
+import type { Metadata } from "next"
+import Content from "../../../content/docs/access-control.mdx"
+import { DocsPage } from "../../components/docs/DocsPage"
+
+export const metadata: Metadata = { title: "Access Control" }
+
+export default function Page() {
+  return <DocsPage href="/docs/access-control" Content={Content} />
+}

--- a/apps/web/app/docs/ag-ui/page.tsx
+++ b/apps/web/app/docs/ag-ui/page.tsx
@@ -1,0 +1,9 @@
+import type { Metadata } from "next"
+import Content from "../../../content/docs/ag-ui.mdx"
+import { DocsPage } from "../../components/docs/DocsPage"
+
+export const metadata: Metadata = { title: "AG-UI & Web Clients" }
+
+export default function Page() {
+  return <DocsPage href="/docs/ag-ui" Content={Content} />
+}

--- a/apps/web/app/docs/upgrading/page.tsx
+++ b/apps/web/app/docs/upgrading/page.tsx
@@ -1,0 +1,9 @@
+import type { Metadata } from "next"
+import Content from "../../../content/docs/upgrading.mdx"
+import { DocsPage } from "../../components/docs/DocsPage"
+
+export const metadata: Metadata = { title: "Upgrading" }
+
+export default function Page() {
+  return <DocsPage href="/docs/upgrading" Content={Content} />
+}

--- a/apps/web/content/docs/access-control.mdx
+++ b/apps/web/content/docs/access-control.mdx
@@ -1,0 +1,63 @@
+# Access Control
+
+Dawn has three independent layers that each answer a different question about a tool call. They compose — none of them substitutes for another, and most production apps that touch anything sensitive (shell, network, prod data) end up using all three together.
+
+| Layer | Question it answers | Docs |
+|---|---|---|
+| Tool scoping | *Which* tools can the model call? | [Tools](/docs/tools#scoping-a-routes-tools) |
+| Permissions / HITL | *Whether* a given call runs | [Permissions](/docs/permissions) |
+| Execution sandbox | *What* an allowed, approved call can actually touch | [Sandbox](/docs/sandbox) |
+
+## Tool scoping — which tools
+
+`agent({ tools: { allow, deny, approve, constrain } })` controls the surface offered to the model. `deny` revokes a tool so it's never wired into the generated entry; `allow` grants back a withheld capability tool (subagents start least-privilege, so this is how you hand one `readFile` or `runBash`); `deny` wins when a name appears in both. This is enforced at composition time — a denied tool is never wired in, so the model has no way to call it, valid or not.
+
+```ts title="src/app/ops/index.ts"
+export default agent({ model: "gpt-5", systemPrompt: "…", tools: { deny: ["runBash"] } })
+```
+
+Scoping controls the *surface*, not what a granted tool does once invoked — a granted `writeFile` can still write anywhere its implementation permits. See [Tools](/docs/tools#scoping-a-routes-tools).
+
+## Permissions — whether a call runs
+
+Two gates are on by default for the built-in workspace tools: `runBash` commands are matched against allow/deny patterns, and filesystem paths outside `workspace/` are permission-gated. An unmatched ("unknown") call pauses the run and asks a human, unless `permissions.mode` is set to `non-interactive` (fail-closed) or `bypass` (dev/test only).
+
+Two more gates ride the same interrupt machinery: `tools: { approve: [...] }` requires human approval before *any* named tool call, and `memory: { writes: "ask" }` gates belief-contradiction memory writes. See [Permissions](/docs/permissions) for the interrupt payloads and resume flow.
+
+## Execution sandbox — what a call can touch
+
+Even a tool that's allowed and approved still runs somewhere. By default that's the local `workspace/` directory on the host. Adding a `sandbox` key to `dawn.config.ts` routes every `readFile`, `writeFile`, `listDir`, and `runBash` call for a thread into an isolated environment instead — filesystem, shell, and (optionally) network. Dawn ships a Docker reference provider and a Kubernetes provider behind the same `SandboxProvider` contract. See [Sandbox](/docs/sandbox).
+
+## How they compose
+
+A route that lets the model run shell commands, gated by approval, inside an isolated environment stacks all three — `sandbox` in `dawn.config.ts` decides what `runBash` can touch, and the route's `tools` block decides which tools are offered and which need approval:
+
+```ts title="dawn.config.ts"
+import { config } from "@dawn-ai/cli"
+import { dockerSandbox } from "@dawn-ai/sandbox"
+
+export default config({
+  sandbox: { provider: dockerSandbox({ image: "node:22-slim" }) }, // what runBash can touch
+})
+```
+
+```ts title="src/app/ops/index.ts"
+export default agent({
+  model: "gpt-5",
+  systemPrompt: "…",
+  tools: { allow: ["runBash"], approve: ["runBash"] }, // which tools + whether each call runs
+})
+```
+
+<Callout type="info" title="None of the three is optional coverage for another">
+  Tool scoping without a sandbox still lets an allowed `runBash` touch the whole host filesystem. A sandbox without scoping still exposes every tool to the model, just from inside an isolated box. Permissions without a sandbox still pause for approval, but an approved call runs on the host. Layer the ones your app needs — most agents that call `runBash` or write outside `workspace/` want all three.
+</Callout>
+
+## Related
+
+<RelatedCards items={[
+  { href: "/docs/tools", title: "Tools", subtitle: "tool scoping — allow, deny, approve, constrain" },
+  { href: "/docs/permissions", title: "Permissions", subtitle: "human-in-the-loop approval for paths, commands, tools, and memory writes" },
+  { href: "/docs/sandbox", title: "Execution Sandbox", subtitle: "per-thread filesystem, shell, and network isolation" },
+  { href: "/docs/configuration", title: "Configuration", subtitle: "dawn.config.ts reference including permissions and sandbox" },
+]} />

--- a/apps/web/content/docs/ag-ui.mdx
+++ b/apps/web/content/docs/ag-ui.mdx
@@ -1,0 +1,83 @@
+# AG-UI & Web Clients
+
+`dawn dev` (and the `node` build target in production) serves a second protocol alongside Agent Protocol: [AG-UI](https://github.com/ag-ui-protocol/ag-ui), a wire format built for streaming a run to a browser. `@dawn-ai/ag-ui` is the translation layer between the two — it maps Dawn's internal stream chunks to AG-UI events, and maps an AG-UI `RunAgentInput` back to a Dawn route input. This page covers what that translation guarantees; for the endpoint's request/response shape, see [Dev Server](/docs/dev-server#ag-ui-endpoint).
+
+## Why a second protocol
+
+Agent Protocol (`/threads/:id/runs/wait`, `/runs/stream`) is the durable, thread-oriented interface Dawn harnesses and the CLI use. AG-UI is what UI component libraries — CopilotKit chief among them — expect: a single `POST` that opens an SSE stream of typed UI events (message deltas, tool call lifecycle, state snapshots). Both sit on top of the same route runtime and the same thread; a request through either protocol reads and writes the same checkpointed state in `.dawn/threads.sqlite` and `.dawn/checkpoints.sqlite`. AG-UI is not a separate agent runtime — it's a client-facing view onto the one Dawn already runs.
+
+## The endpoint
+
+```http
+POST /agui/{routeId}
+content-type: application/json
+accept: text/event-stream
+```
+
+The URL segment is the URL-encoded `<routeId>#<kind>` assistant id (`/chat#agent` → `/agui/%2Fchat%23agent`). The request body is an AG-UI `RunAgentInput`; Dawn creates the thread when the incoming `threadId` is new, maps the newest user message to the route's input, and streams the translated event sequence back. Full request/response details, including how HITL resume rides on `forwardedProps.command.resume`, live on [Dev Server](/docs/dev-server#ag-ui-endpoint) — this page does not repeat that reference.
+
+## Consuming it from a web UI
+
+`examples/chat/web` is the canonical reference client: a CopilotKit v2 app (`@copilotkit/react-core/v2` + `@copilotkit/runtime`) whose runtime route registers an `HttpAgent` pointed at Dawn's `/agui/{routeId}` endpoint. The browser never talks to Dawn directly — CopilotKit's Next.js runtime route proxies to it, and only the Dawn server holds model credentials.
+
+```text
+browser
+  -> CopilotKit runtime (Next.js route, no API key)
+    -> HttpAgent -> POST /agui/%2Fchat%23agent   (Dawn dev server, holds the model API key)
+      -> the live route (workspace tools, planning, HITL permissions)
+        -> AG-UI event stream back to the browser
+```
+
+CopilotKit's hooks (`useAgent`, `useInterrupt`, `CopilotSidebar`) fall back to the literal agent id `"default"` when none is given — the example registers the Dawn route under that key so the components bind without per-component wiring. See `examples/chat/web/README.md` for the full architecture and a live smoke checklist.
+
+## Event contract
+
+`createAgUiTranslator({ threadId, runId })` from `@dawn-ai/ag-ui` (verified against `packages/ag-ui/src/translate.ts`) emits these AG-UI event types, one Dawn stream chunk at a time:
+
+| Dawn chunk | AG-UI event(s) |
+|---|---|
+| (stream start) | `RUN_STARTED` |
+| `token` / `chunk` | `TEXT_MESSAGE_START` (once) → `TEXT_MESSAGE_CONTENT` per delta |
+| `tool_call` | `TEXT_MESSAGE_END` (if a message was open) → `TOOL_CALL_START` → `TOOL_CALL_ARGS` → `TOOL_CALL_END` |
+| `tool_result` | `TEXT_MESSAGE_END` (if open) → `TOOL_CALL_RESULT` |
+| `plan_update` | `STATE_SNAPSHOT` (merges into a running state object the translator accumulates for the run) |
+| `interrupt` | `CUSTOM` with `name: "on_interrupt"` |
+| `subagent.*` | `CUSTOM` with `name: "dawn.<chunk.type>"` |
+| any other object-shaped chunk | `STATE_SNAPSHOT` (merged into the same running state) |
+| `done` (success) | `RUN_FINISHED` with `{ threadId, runId, result }` |
+| `done` (chunk output has an `error` field) | `RUN_ERROR` |
+| stream ends without a `done` chunk | `RUN_FINISHED` (no result) |
+| stream throws | `RUN_ERROR` |
+
+A text message is always closed (`TEXT_MESSAGE_END`) before a tool call, tool result, state snapshot, or the terminal event is emitted — the translator never interleaves an open text message with another event type.
+
+### Threading
+
+AG-UI's `threadId` on `RunAgentInput` **is** the Dawn thread id — there's no separate mapping table. `mapRunInput` (in `packages/ag-ui/src/run-input.ts`) takes the newest `user`-role message from `RunAgentInput.messages` as the turn's input; Dawn keeps the rest of the conversation in its own checkpoint keyed by that thread id, so only the newest turn is forwarded on the wire.
+
+### Human-in-the-loop resume
+
+A `kind: "on_interrupt"` `CUSTOM` event carries Dawn's permission or memory interrupt payload (the same shapes documented in [Permissions](/docs/permissions)). The client resumes by sending `forwardedProps.command.resume` on the next `RunAgentInput` — either a bare decision string or `{ decision, interruptId }`:
+
+```json
+{ "forwardedProps": { "command": { "resume": { "decision": "once", "interruptId": "perm-abc123" } } } }
+```
+
+### Disconnect and reconnect
+
+<Callout type="warn" title="No reconnect or replay support">
+  The AG-UI handler (`packages/cli/src/lib/dev/agui-handler.ts`) opens one SSE response per `POST` and writes translated events to it as the route streams. There is no server-side buffer, no last-event-id tracking, and no replay mechanism — if the connection drops mid-run, the events already written are gone and the handler has no way to resume that specific stream. This is not a documented guarantee Dawn makes; do not build reconnect-and-catch-up logic that assumes one exists. The route's underlying execution and checkpoint are unaffected by a dropped SSE connection (the run keeps going and the thread state still lands in `.dawn/checkpoints.sqlite`), but the *client* has no protocol-level way to reattach to that in-flight stream — a fresh request starts a new run against the same thread, picking up from the last checkpoint rather than the interrupted stream.
+</Callout>
+
+## Relation to Agent Protocol
+
+AG-UI and Agent Protocol are two protocols in front of the same runtime, not two runtimes. A route invoked via `/agui/{routeId}` and one invoked via `/threads/:id/runs/stream` execute the same route code, share the same thread store and checkpointer, and can be mixed against the same `threadId` — an operator could inspect a thread's state with `GET /threads/:id/state` (Agent Protocol) while a web client drives it over AG-UI. Choose Agent Protocol for harnesses, CLIs, and server-to-server calls; choose AG-UI when the caller is a UI component library that already speaks it.
+
+## Related
+
+<RelatedCards items={[
+  { href: "/docs/dev-server", title: "Dev Server", subtitle: "the /agui endpoint's request/response reference and Agent Protocol thread endpoints" },
+  { href: "/docs/permissions", title: "Permissions", subtitle: "the interrupt payloads carried over CUSTOM{on_interrupt}" },
+  { href: "/docs/planning", title: "Planning", subtitle: "the plan_update chunks translated into STATE_SNAPSHOT" },
+  { href: "/docs/deployment", title: "Deployment", subtitle: "the node build target, the only one that serves AG-UI in production" },
+]} />

--- a/apps/web/content/docs/cli.mdx
+++ b/apps/web/content/docs/cli.mdx
@@ -1,6 +1,6 @@
 # CLI Reference
 
-Dawn ships a single `dawn` binary with twelve commands: `add`, `build`, `check`, `dev`, `docs`, `eval`, `memory`, `routes`, `run`, `test`, `typegen`, and `verify`. Most commands read `dawn.config.ts` from the current working directory or from `--cwd <path>`; `dawn dev` currently uses the current working directory and exposes only its own server flags.
+Dawn ships a single `dawn` binary with thirteen commands: `add`, `build`, `check`, `dev`, `docs`, `eval`, `memory`, `routes`, `run`, `start`, `test`, `typegen`, and `verify`. Most commands read `dawn.config.ts` from the current working directory or from `--cwd <path>`; `dawn dev` currently uses the current working directory and exposes only its own server flags.
 
 ## Running the CLI
 
@@ -189,6 +189,8 @@ dawn dev --port 3001
 Flags:
 - `--port <n>` — HTTP port. Default: dynamically allocated. Pass `--port` for a stable address.
 - `--env-file <path>` — path to a `.env` file (overrides `dawn.config.ts` `env` and the default `./.env`).
+
+Because the default port is chosen dynamically, copy-paste `curl` examples should pass an explicit `--port` (or read the port `dawn dev` prints on startup) rather than assuming a fixed value.
 
 If `LANGSMITH_API_KEY` is present in the loaded environment and `LANGCHAIN_TRACING_V2` is not already set, `dawn dev` automatically enables LangSmith tracing by setting `LANGCHAIN_TRACING_V2=true`. Set `LANGCHAIN_PROJECT` to control which project receives the traces. See [Observability](/docs/observability) for the full tracing guide.
 

--- a/apps/web/content/docs/configuration.mdx
+++ b/apps/web/content/docs/configuration.mdx
@@ -242,6 +242,66 @@ See [Memory](/docs/memory) for the full long-term-memory model and [Permissions]
 
 ---
 
+### `build`
+
+| Type | Default |
+|---|---|
+| `{ targets?: string[] }` | `{ targets: ["node", "langsmith"] }` |
+
+Deployment build configuration for `dawn build`.
+
+```ts
+build?: {
+  targets?: string[]
+}
+```
+
+`targets` selects which deployment artifacts `dawn build` emits. Known targets:
+- `"node"` — a runnable Node server entry (`.dawn/build/server.mjs`, which boots `serveRuntime`) plus a hardened `Dockerfile`. This is the only target that engages the sandbox in production. Run it with `dawn start` or `docker build`/`docker run`.
+- `"langsmith"` — the LangSmith deploy config (`.dawn/build/langgraph.json` and the per-route materialized graph entry files).
+
+Both are emitted by default. Restrict to one target — e.g. `{ build: { targets: ["node"] } }` — if you only deploy that way. See [Deployment](/docs/deployment) for the full bridge.
+
+---
+
+### `sandbox`
+
+| Type | Default |
+|---|---|
+| `SandboxConfig` | none — filesystem/exec run on the host by default |
+
+Routes workspace filesystem and exec calls through an isolated `SandboxProvider` (e.g. `dockerSandbox` or `kubernetesSandbox` from `@dawn-ai/sandbox`) instead of the host process. Opt in per app; omit entirely for the default host-backed behavior.
+
+```ts
+sandbox?: {
+  provider: SandboxProvider
+  network?: { mode: "allow"; denylist?: string[] } | { mode: "deny"; allowlist?: string[] }
+  env?: Record<string, string>
+  resources?: { memoryMb?: number; cpus?: number; timeoutMs?: number; diskGb?: number }
+  security?: {
+    dropAllCapabilities?: boolean
+    noNewPrivileges?: boolean
+    readOnlyRootFilesystem?: boolean
+    runAsNonRoot?: boolean | { uid: number; gid: number }
+    pidsLimit?: number
+  }
+  idleTimeoutMs?: number
+}
+```
+
+| Sub-key | Type | Default | Description |
+|---|---|---|---|
+| `provider` | `SandboxProvider` | — (required) | The sandbox implementation, e.g. `dockerSandbox({ image })` or `kubernetesSandbox({ image, namespace? })`. |
+| `network` | `{ mode: "allow" \| "deny"; denylist?/allowlist? }` | provider-defined | Network egress policy applied inside the sandbox. |
+| `env` | `Record<string, string>` | `{}` | Explicit env injected into the sandbox. The host env is never inherited. |
+| `resources` | `{ memoryMb?; cpus?; timeoutMs?; diskGb? }` | provider-defined | Resource limits and per-command timeout. `diskGb` sizes the per-thread volume on PVC-backed providers (Kubernetes); Docker ignores it. |
+| `security` | `SandboxSecurityPolicy` | hardened (Docker) | Provider-agnostic hardening intent — capability drop, no-new-privileges, read-only rootfs, non-root uid/gid, pids limit. Fields left unset take the provider's secure default. |
+| `idleTimeoutMs` | `number` | `600000` (10 min) | Manager-level idle reap window before a warm sandbox is released. |
+
+See [Execution Sandbox](/docs/sandbox) for provider setup, the security-hardening defaults, and the Kubernetes provider.
+
+---
+
 ## Related
 
 <RelatedCards items={[

--- a/apps/web/content/docs/deployment.mdx
+++ b/apps/web/content/docs/deployment.mdx
@@ -45,7 +45,22 @@ export default config({
 })
 ```
 
-To run the built image on Kubernetes — as a Deployment + Service with optional Ingress, autoscaling, and a PodDisruptionBudget, wired to the sandbox provider's orchestrator ServiceAccount — see [Deploying a Dawn app (Helm)](/docs/sandbox#deploying-a-dawn-app-helm).
+To run the built image on Kubernetes — as a Deployment + Service with optional Ingress, autoscaling, and a PodDisruptionBudget, wired to the sandbox provider's orchestrator ServiceAccount — see [Deploying a Dawn app (Helm)](/docs/sandbox#deploying-a-dawn-app-helm), or the orientation section below.
+
+## Deploying on Kubernetes
+
+Running the `node` target's image on a Kubernetes cluster is a two-chart arc, published as OCI artifacts alongside the `@dawn-ai/*` npm packages:
+
+- **`dawn-sandbox-infra`** — cluster-side infrastructure a [`kubernetesSandbox`](/docs/sandbox#kubernetes-provider) deployment needs: namespace, least-privilege RBAC, a default-deny egress `NetworkPolicy` backstop, `ResourceQuota`/`LimitRange`, Pod Security Standard labels, and a PVC reaper. Install this once per cluster or environment, before pointing `kubernetesSandbox` at it. Full reference: [Deploying the sandbox infrastructure](/docs/sandbox#deploying-the-sandbox-infrastructure-helm).
+- **`dawn-app`** — your built `node`-target image, run as a Deployment + Service with optional Ingress, `HorizontalPodAutoscaler`, and `PodDisruptionBudget`, wired to the sandbox infra chart's orchestrator ServiceAccount when your app configures `kubernetesSandbox`. Full reference: [Deploying a Dawn app](/docs/sandbox#deploying-a-dawn-app-helm).
+
+<Callout type="info" title="Two audiences">
+  **App authors** installing `dawn-app` need only their built image and, if they use `kubernetesSandbox`, a `dawn-sandbox-infra` release already running in the target cluster — see the chart's [ServiceAccount and namespace wiring](/docs/sandbox#serviceaccount-and-namespace-wiring) for how the two connect. **Cluster operators** installing `dawn-sandbox-infra` own the namespace, RBAC, and network-policy posture the whole cluster's sandbox Pods run under, independent of any one app.
+</Callout>
+
+Minimum: a Kubernetes cluster the charts can install into. Recommended: a policy-capable CNI (Calico or Cilium) if you rely on `kubernetesSandbox`'s `deny`-mode `NetworkPolicy` as a hard egress boundary — a CNI that ignores `NetworkPolicy` leaves the Pod's network open regardless of config, which is why `dawn check`'s `preflight()` warns rather than guarantees enforcement. See [Network policy on Kubernetes](/docs/sandbox#network-policy-on-kubernetes).
+
+Neither chart builds your image — build it with `dawn build`'s `node` target first, same as the plain Docker path above, then point `dawn-app` at the resulting `image.repository`/`image.tag`.
 
 ## The LangSmith / LangGraph Platform path
 

--- a/apps/web/content/docs/faq.mdx
+++ b/apps/web/content/docs/faq.mdx
@@ -28,7 +28,7 @@ No. Dawn is TypeScript-only and the type inference is the whole point — tool p
 
 ### Is Dawn production-ready?
 
-Dawn produces deployment artifacts; the framework itself is pre-1.0 and the API surface is still moving. `dawn build` writes a `.dawn/build/langgraph.json` plus per-route entry files for LangGraph/LangSmith deployment. Lock to a pinned version and read release notes between upgrades. See [Deployment](/docs/deployment).
+Dawn produces deployment artifacts; the framework itself is pre-1.0 and the API surface is still moving. `dawn build` emits a runnable `node` target (`server.mjs` plus a hardened `Dockerfile`) and a `langsmith` target (`langgraph.json`) by default; `dawn start` serves the `node` target in production on `0.0.0.0`. Lock to a pinned version and read release notes between upgrades. See [Deployment](/docs/deployment).
 
 ## Working in Dawn
 
@@ -38,7 +38,7 @@ Yes — that is the point. A route's `index.ts` can default-export an `agent()` 
 
 ### What does `dawn build` actually do?
 
-It walks your routes, runs typegen, and writes `.dawn/build/langgraph.json` plus a per-route entry file under `.dawn/build/<routeSlug>.ts`. Each agent route's entry imports your default `agent()` descriptor, materializes it as a LangGraph graph, and wires in discovered tools. Each `assistant_id` is `<routeId>#<kind>` — for example `/research#agent`. See [Deployment](/docs/deployment).
+It walks your routes, runs typegen, then writes deployment artifacts for each configured `build.targets` (both by default). The `node` target emits `.dawn/build/server.mjs` — which boots the real Dawn runtime (Agent Protocol, AG-UI, and the sandbox if configured) — plus a hardened `Dockerfile`; run it with `dawn start` or `docker build`/`docker run`. The `langsmith` target emits `.dawn/build/langgraph.json` plus a per-route entry file under `.dawn/build/<routeSlug>.ts`; each agent route's entry imports your default `agent()` descriptor, materializes it as a LangGraph graph, and wires in discovered tools. Each `assistant_id` is `<routeId>#<kind>` — for example `/research#agent`. See [Deployment](/docs/deployment).
 
 ### Why a meta-framework instead of a library?
 

--- a/apps/web/content/docs/getting-started.mdx
+++ b/apps/web/content/docs/getting-started.mdx
@@ -173,7 +173,24 @@ The `#agent` suffix is required — it selects the agent entry on the route. The
 dawn build
 ```
 
-Discovers routes from the app directory (`appDir`, defaulting to `src/app`), runs typegen, and writes `.dawn/build/langgraph.json` plus per-route entry files. The generated `assistant_id`s match the local ids, such as `/research#agent`.
+Discovers routes from the app directory (`appDir`, defaulting to `src/app`), runs typegen, and writes deployment artifacts for both default `build.targets`: a `node` target (`.dawn/build/server.mjs` plus a hardened `Dockerfile`) and a `langsmith` target (`.dawn/build/langgraph.json` plus per-route entry files). The generated `assistant_id`s match the local ids, such as `/research#agent`.
+
+### Serve it in production
+
+The `node` target is a runnable server, not just a platform artifact. Serve it locally with `dawn start`:
+
+```bash
+npx dawn start
+```
+
+You should now see the agent listening on `0.0.0.0:8000`, serving Agent Protocol and AG-UI and engaging the [execution sandbox](/docs/sandbox) if configured. To ship it as a container instead:
+
+```bash
+docker build -t my-agent .
+docker run -p 8000:8000 --env-file .env my-agent
+```
+
+See [Deploying to production](/docs/deployment) for the full Node/Docker path and the LangSmith alternative.
 
 ## Where to go next
 

--- a/apps/web/content/docs/mental-model.mdx
+++ b/apps/web/content/docs/mental-model.mdx
@@ -35,6 +35,10 @@ Agent route features are discovered from files and descriptors. `workspace/AGENT
 
 *Middleware* runs before route execution in the local Dawn runtime. It lives at `src/middleware.ts` (or root `middleware.ts`) and can reject a request or attach request-scoped context for tools.
 
+### Access control: three layers
+
+Three independent layers govern what a route can do once it's running: [tool scoping](/docs/tools) decides *which* tools the model may call, [permissions](/docs/permissions) decide *whether* a given call runs (human-in-the-loop approval), and the [execution sandbox](/docs/sandbox) decides *what* an allowed, approved call can actually touch. They compose — none substitutes for another. See [Access Control](/docs/access-control) for the combined picture.
+
 ## The runtime
 
 A typical request through Dawn looks like this:

--- a/apps/web/content/docs/sandbox.mdx
+++ b/apps/web/content/docs/sandbox.mdx
@@ -167,6 +167,8 @@ Kubernetes Pod isolation is the same boundary class as Docker's container isolat
 
 ## Deploying the sandbox infrastructure (Helm)
 
+For the orientation-level view of both charts before diving into the reference below, see [Deploying on Kubernetes](/docs/deployment#deploying-on-kubernetes).
+
 `kubernetesSandbox` assumes a namespace already exists with the RBAC, quotas, and network policy the provider's Pods need. The `dawn-sandbox-infra` Helm chart provisions that cluster-side infrastructure — install it once per cluster (or per environment) before pointing `kubernetesSandbox` at it:
 
 ```bash

--- a/apps/web/content/docs/upgrading.mdx
+++ b/apps/web/content/docs/upgrading.mdx
@@ -1,0 +1,60 @@
+# Upgrading
+
+Dawn is pre-1.0. The API surface is still moving, and the safest posture is to pin a version, read what changed, and upgrade deliberately rather than floating on a range. This page is the workflow, not a changelog — the actual list of what changed between any two versions lives on GitHub, not here.
+
+## Fixed-group versioning
+
+Every `@dawn-ai/*` package — `cli`, `core`, `sdk`, `ag-ui`, `sandbox`, `memory`, `memory-pgvector`, `permissions`, `workspace`, `sqlite-storage`, `langchain`, `langgraph`, `testing`, `evals`, `devkit`, `vite-plugin`, `create-dawn-app`, and the rest — is released together under one version number via [Changesets](https://github.com/changesets/changesets)' fixed-group mode. If `@dawn-ai/cli` is at `0.8.12`, so is every other `@dawn-ai/*` package in that release. There's no independent versioning between packages to reason about, and no compatibility matrix to check — install matching versions and you're done.
+
+The two Helm charts (`dawn-sandbox-infra`, `dawn-app`) track the same package train through their `appVersion` field, but they're published separately as OCI artifacts, not npm packages — see [Deploying on Kubernetes](/docs/deployment#deploying-on-kubernetes) for how to pull a specific chart version.
+
+## How to read what changed
+
+Each release is built from the changeset entries merged since the previous one — short, per-change Markdown files that describe what changed and why, written by whoever made the change. Two places to read them:
+
+- **GitHub Releases** — [github.com/cacheplane/dawnai/releases](https://github.com/cacheplane/dawnai/releases) lists every published version with its changeset entries rolled up into release notes. This is the fastest way to scan what changed between two versions.
+- **Per-package `CHANGELOG.md`** — each package under `packages/*/CHANGELOG.md` in the repository carries its own changelog, generated from the same changeset entries but scoped to that package.
+
+<Callout type="info" title="Read the entries between your current and target version">
+  Before bumping `@dawn-ai/cli` (and its siblings) to a new version, skim the GitHub release notes for every version between the one you're on and the one you're moving to — not just the latest. A changeset entry that looks unrelated to your app (a sandbox hardening default, a memory recall tuning change) can still change runtime behavior you depend on.
+</Callout>
+
+## Upgrade workflow
+
+<Steps>
+  <Step title="Check the current version">
+    ```
+    pnpm why @dawn-ai/cli
+    ```
+
+    or check the `@dawn-ai/*` entries in your `package.json`.
+  </Step>
+  <Step title="Read the release notes">
+    Open [GitHub Releases](https://github.com/cacheplane/dawnai/releases) and read every entry between your current version and the target version.
+  </Step>
+  <Step title="Bump and reinstall">
+    Bump every `@dawn-ai/*` dependency in `package.json` to the same target version, then reinstall.
+  </Step>
+  <Step title="Regenerate and verify">
+    ```
+    dawn typegen
+    dawn verify
+    dawn test
+    ```
+
+    `dawn verify` catches app-contract, route-discovery, typegen, and missing-dependency drift in one call; `dawn test` re-runs your scenario coverage against the new version. See [CLI](/docs/cli) and [Testing](/docs/testing).
+  </Step>
+</Steps>
+
+## Pinning
+
+Pin exact versions (no `^` or `~` ranges) for `@dawn-ai/*` packages until the project reaches 1.0 — a floating range means an unreviewed minor bump can land in CI or production without the deliberate read-the-notes step above.
+
+## Related
+
+<RelatedCards items={[
+  { href: "/docs/cli", title: "CLI", subtitle: "dawn verify and dawn typegen for post-upgrade checks" },
+  { href: "/docs/testing", title: "Testing", subtitle: "scenario coverage to re-run after an upgrade" },
+  { href: "/docs/deployment", title: "Deployment", subtitle: "the node and langsmith build targets, and the Helm charts' own versioning" },
+  { href: "/docs/faq", title: "FAQ", subtitle: "the pre-1.0 stability note this page backs" },
+]} />

--- a/examples/README.md
+++ b/examples/README.md
@@ -5,5 +5,7 @@ Canonical, runnable examples of Dawn applications. Each example is a folder cont
 | Example | What it shows |
 |---|---|
 | [chat](./chat) | Foundational agent-harness primitives (filesystem + bash) end-to-end, with a disposable smoke-test web client |
+| [memory](./memory) | Long-term memory with a backend-switchable store — zero-setup SQLite by default, Postgres + pgvector via `DATABASE_URL`, hybrid keyword + vector recall via `OPENAI_API_KEY` |
+| [research](./research) | The flagship deep-research assistant example — routes, tools, subagents, memory, planning, offloading, HITL permissions, and an optional Docker sandbox |
 
 These examples are pnpm workspace members. They consume Dawn via `workspace:*` and are typechecked in CI.


### PR DESCRIPTION
## Developer docs assessment → improvements

A docs assessment after the sandbox / Helm-charts / production-build-serve arc landed, plus lessons cross-referenced against a mature enterprise agent-ops product (CopilotKit Intelligence). The docs were already strong; the gaps were **front-door consistency, staleness vs. what shipped, and discoverability of the production + access-control stories**. Notably, several of Intelligence's own doc anti-patterns (contradictory README-vs-tutorial, copy-paste-breaking first commands) were exactly the issues found here — good corroboration.

### Correctness (were wrong / stale)
- **FAQ** claimed `dawn build` only emits `langgraph.json` for LangSmith — now describes both default targets (`node` → `server.mjs` + Dockerfile, run via `dawn start`; `langsmith` → `langgraph.json`).
- **getting-started §5** gains a "Serve it in production" step (the node target was invisible from the front door).
- **CLI page** said "twelve commands" (there are 13) and omitted `start` from its own list — fixed.

### Front-door consistency
- **README ↔ getting-started reconciled** to one canonical quickstart (npm, matching the `npm create dawn-ai-app` entry point: `npm run check`, `--port 2024`). They previously taught different package managers, validation commands, and ports.

### Discoverability / structure (new pages)
- **`/docs/access-control`** — ties the three layers into one mental model: tool scoping (*which*) / permissions (*whether*) / sandbox (*what it can touch*). Previously this framing lived only inside `sandbox.mdx`; `mental-model.mdx` now points to it.
- **`/docs/ag-ui`** — the AG-UI / CopilotKit web-UI story with a **grounded event contract** (`RUN_STARTED`, `TEXT_MESSAGE_*`, `TOOL_CALL_*`, `STATE_SNAPSHOT`, `on_interrupt`, `RUN_FINISHED/ERROR` — verified in `packages/ag-ui`), and an honest callout that the SSE stream has **no reconnect/replay guarantee** (the code has none; not invented).
- **`/docs/upgrading`** — pre-1.0 fixed-group versioning + how to read changesets/releases (the FAQ pointed at release notes that had no home).
- **"Deploying on Kubernetes"** section in `deployment.mdx` (audience-tagged, CNI note) so K8s deploy isn't buried under *Execution Sandbox*; bidirectional link added.
- **`configuration.mdx`** now documents the shipped `sandbox` and `build` config keys; examples table gains `memory` + `research`.

### Follow-ups worth their own efforts (from the Intelligence scan — not in this PR)
- A documented **error-code registry** (stable `code` + `docsPath` per failure) so sandbox denials / HITL interrupts / tool-scope rejections become linkable docs.
- A **`dawn doctor`** preflight (Node/Docker/keys/config) with colored PASS/FAIL.
- A canonical **`AGENTS.md`** with a workspace map of all packages + a Definition of Done.

Verified: `check-docs` passes; the docs site builds with all three new routes statically generated and no broken links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
