### PR TITLE
fix(cli): run app middleware for the /agui endpoint

### DIFF
--- a/.changeset/agui-middleware-parity.md
+++ b/.changeset/agui-middleware-parity.md
@@ -1,0 +1,9 @@
+---
+"@dawn-ai/cli": patch
+---
+
+Run app middleware for the `POST /agui/{routeId}` endpoint, matching
+`runs/stream` / `runs/wait` / `resume`. A middleware that rejects now blocks an
+AG-UI run (returning its status/body), and a middleware that returns `context`
+has it threaded into the run — so auth, rate-limiting, and context injection
+apply to AG-UI clients too, not just the Agent-Protocol endpoints.

--- a/packages/cli/src/lib/dev/agui-handler.ts
+++ b/packages/cli/src/lib/dev/agui-handler.ts
@@ -1,13 +1,16 @@
 import type { IncomingMessage, ServerResponse } from "node:http"
 import { EventType, RunAgentInputSchema } from "@ag-ui/core"
 import { createAgUiTranslator, encodeAgUiSse, mapRunInput } from "@dawn-ai/ag-ui"
+import type { DawnMiddleware, MiddlewareRequest } from "@dawn-ai/sdk"
 import type { ThreadsStore } from "@dawn-ai/sqlite-storage"
 import { streamResolvedRoute } from "../runtime/execute-route.js"
 import type { SandboxManager } from "../runtime/sandbox-manager.js"
+import { extractRouteParams, parseHeaders, runMiddleware } from "./middleware.js"
 import type { RuntimeRegistry } from "./runtime-registry.js"
 
 interface AgUiRequestOptions {
   readonly appRoot: string
+  readonly middleware: DawnMiddleware | undefined
   readonly registry: RuntimeRegistry
   readonly threadsStore: ThreadsStore
   readonly sandboxManager?: SandboxManager
@@ -25,8 +28,17 @@ async function readBody(request: IncomingMessage): Promise<string> {
 }
 
 export async function handleAgUiRequest(options: AgUiRequestOptions): Promise<void> {
-  const { appRoot, registry, threadsStore, sandboxManager, signal, request, response, routeKey } =
-    options
+  const {
+    appRoot,
+    middleware,
+    registry,
+    threadsStore,
+    sandboxManager,
+    signal,
+    request,
+    response,
+    routeKey,
+  } = options
 
   const raw = await readBody(request)
   let parsedJson: unknown
@@ -59,6 +71,24 @@ export async function handleAgUiRequest(options: AgUiRequestOptions): Promise<vo
     return
   }
 
+  // Run app middleware before starting the run — parity with runs/stream and
+  // runs/wait so auth/rate-limit/context middleware applies to /agui too.
+  const mwRequest: MiddlewareRequest = {
+    assistantId: route.assistantId,
+    headers: parseHeaders(request),
+    method: request.method ?? "POST",
+    params: extractRouteParams(route.routeId, input),
+    routeId: route.routeId,
+    url: request.url ?? `/agui/${routeKey}`,
+  }
+  const mwResult = await runMiddleware(middleware, mwRequest)
+  if (mwResult.action === "reject") {
+    response.statusCode = mwResult.status
+    response.setHeader("content-type", "application/json")
+    response.end(JSON.stringify(mwResult.body))
+    return
+  }
+
   const threadId = input.threadId
   const existing = await threadsStore.getThread(threadId)
   if (!existing) await threadsStore.createThread({ thread_id: threadId })
@@ -78,6 +108,7 @@ export async function handleAgUiRequest(options: AgUiRequestOptions): Promise<vo
     for await (const chunk of streamResolvedRoute({
       appRoot,
       input: dawnInput,
+      ...(mwResult.context ? { middlewareContext: mwResult.context } : {}),
       ...(resumeDecision ? { resumeDecision } : {}),
       routeFile: route.routeFile,
       routeId: route.routeId,

--- a/packages/cli/src/lib/dev/middleware.ts
+++ b/packages/cli/src/lib/dev/middleware.ts
@@ -1,3 +1,4 @@
+import type { IncomingMessage } from "node:http"
 import type { DawnMiddleware, MiddlewareRequest, MiddlewareResult } from "@dawn-ai/sdk"
 
 /**
@@ -40,4 +41,36 @@ export async function runMiddleware(
   }
 
   return await middleware(request)
+}
+
+/** Flatten an IncomingMessage's headers into a string map for MiddlewareRequest. */
+export function parseHeaders(request: IncomingMessage): Record<string, string> {
+  const headers: Record<string, string> = {}
+  for (const [key, value] of Object.entries(request.headers)) {
+    if (typeof value === "string") {
+      headers[key] = value
+    } else if (Array.isArray(value)) {
+      headers[key] = value.join(", ")
+    }
+  }
+  return headers
+}
+
+/** Pull `[param]` route-param values out of the run input, for MiddlewareRequest.params. */
+export function extractRouteParams(routeId: string, input: unknown): Record<string, string> {
+  const params: Record<string, string> = {}
+  const matches = routeId.matchAll(/\[(\w+)\]/g)
+  const inputRecord = (typeof input === "object" && input !== null ? input : {}) as Record<
+    string,
+    unknown
+  >
+
+  for (const match of matches) {
+    const name = match[1]
+    if (name && name in inputRecord) {
+      params[name] = String(inputRecord[name])
+    }
+  }
+
+  return params
 }

--- a/packages/cli/src/lib/dev/runtime-server.ts
+++ b/packages/cli/src/lib/dev/runtime-server.ts
@@ -20,7 +20,7 @@ import {
   handleMemoryListRequest,
   handleMemoryRejectRequest,
 } from "./memory-handler.js"
-import { loadMiddleware, runMiddleware } from "./middleware.js"
+import { extractRouteParams, loadMiddleware, parseHeaders, runMiddleware } from "./middleware.js"
 import { createRuntimeRegistry, type RuntimeRegistry } from "./runtime-registry.js"
 import { createExecutionErrorBody, createRequestErrorBody } from "./server-errors.js"
 
@@ -373,6 +373,7 @@ function buildRouteTable(ctx: {
       handle: async (req, res, params) => {
         await handleAgUiRequest({
           appRoot,
+          middleware,
           registry,
           threadsStore,
           ...(sandboxManager ? { sandboxManager } : {}),
@@ -1053,36 +1054,6 @@ async function listen(
       resolve()
     })
   })
-}
-
-function parseHeaders(request: IncomingMessage): Record<string, string> {
-  const headers: Record<string, string> = {}
-  for (const [key, value] of Object.entries(request.headers)) {
-    if (typeof value === "string") {
-      headers[key] = value
-    } else if (Array.isArray(value)) {
-      headers[key] = value.join(", ")
-    }
-  }
-  return headers
-}
-
-function extractRouteParams(routeId: string, input: unknown): Record<string, string> {
-  const params: Record<string, string> = {}
-  const matches = routeId.matchAll(/\[(\w+)\]/g)
-  const inputRecord = (typeof input === "object" && input !== null ? input : {}) as Record<
-    string,
-    unknown
-  >
-
-  for (const match of matches) {
-    const name = match[1]
-    if (name && name in inputRecord) {
-      params[name] = String(inputRecord[name])
-    }
-  }
-
-  return params
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/packages/cli/test/agui-endpoint.test.ts
+++ b/packages/cli/test/agui-endpoint.test.ts
@@ -14,7 +14,7 @@ afterEach(async () => {
   for (const fn of cleanup.splice(0).reverse()) await fn()
 })
 
-async function fixtureApp(): Promise<string> {
+async function fixtureApp(extraFiles: Record<string, string> = {}): Promise<string> {
   const appRoot = await mkdtemp(join(tmpdir(), "dawn-agui-"))
   cleanup.push(() => rm(appRoot, { force: true, recursive: true }))
   const files: Record<string, string> = {
@@ -22,6 +22,7 @@ async function fixtureApp(): Promise<string> {
     "package.json": '{ "name": "agui-fixture", "type": "module" }\n',
     "src/app/chat/index.ts":
       'import { agent } from "@dawn-ai/sdk"\nexport default agent({ model: "gpt-5-mini", systemPrompt: "You are helpful." })\n',
+    ...extraFiles,
   }
   for (const [rel, body] of Object.entries(files)) {
     const p = join(appRoot, rel)
@@ -75,4 +76,40 @@ it("streams AG-UI events from POST /agui/<route>", async () => {
   expect(text).toContain('"type":"TEXT_MESSAGE_CONTENT"')
   expect(text).toContain("Hi there!")
   expect(text).toContain('"type":"RUN_FINISHED"')
+}, 60_000)
+
+it("applies app middleware to /agui — a rejecting middleware blocks the run", async () => {
+  // Parity with runs/stream / runs/wait: /agui must run app middleware. A
+  // middleware that rejects should return its status/body and NOT start a run.
+  const appRoot = await fixtureApp({
+    "src/middleware.ts":
+      "export default async () => ({ action: 'reject', status: 403, body: { error: 'blocked by middleware' } })\n",
+  })
+  const { listener, close } = await createRuntimeRequestListener({ appRoot })
+  cleanup.push(() => close())
+
+  const server: Server = createServer(listener)
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve))
+  cleanup.push(() => new Promise<void>((resolve) => server.close(() => resolve())))
+  const { port } = server.address() as AddressInfo
+
+  const routeKey = encodeURIComponent("/chat#agent")
+  const res = await fetch(`http://127.0.0.1:${port}/agui/${routeKey}`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      threadId: "t-mw",
+      runId: "r-mw",
+      state: {},
+      messages: [{ id: "1", role: "user", content: "hello" }],
+      tools: [],
+      context: [],
+      forwardedProps: {},
+    }),
+  })
+  const text = await res.text()
+  expect(res.status).toBe(403)
+  expect(JSON.parse(text)).toEqual({ error: "blocked by middleware" })
+  // The run never started — no AG-UI stream was written.
+  expect(text).not.toContain("RUN_STARTED")
 }, 60_000)


### PR DESCRIPTION
## Summary

The `POST /agui/{routeId}` AG-UI endpoint (#322) did **not** run app middleware, unlike `runs/stream`, `runs/wait`, and `resume`. That silently bypassed any middleware-based auth, rate-limiting, or context injection for AG-UI (CopilotKit) clients. This wires middleware into `/agui` with parity:

- A **rejecting** middleware returns its `status`/`body` and the run never starts.
- A **continue-with-context** middleware has its `context` threaded into the run (`middlewareContext`).

Flagged in the final review of #322.

## Change
- `packages/cli/src/lib/dev/middleware.ts` — moved the shared `parseHeaders` / `extractRouteParams` helpers here (exported) so both `runtime-server.ts` and the handler can use them without a circular import.
- `packages/cli/src/lib/dev/agui-handler.ts` — build the `MiddlewareRequest`, `runMiddleware`, short-circuit on reject, pass `middlewareContext` to `streamResolvedRoute`.
- `packages/cli/src/lib/dev/runtime-server.ts` — pass `middleware` into the `/agui` route; import the moved helpers.

## Test plan
- New integration test in `agui-endpoint.test.ts`: a fixture app with a rejecting `src/middleware.ts` → `POST /agui/<route>` returns **403** with the middleware body and **no** AG-UI stream. (Existing stream test still passes.)
- Full `@dawn-ai/cli` suite: **349/349**; typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)