### PR TITLE
fix(web): restore permission approve/deny via standard AG-UI interrupts

### DIFF
--- a/examples/chat/web/app/components/PermissionInterrupt.tsx
+++ b/examples/chat/web/app/components/PermissionInterrupt.tsx
@@ -1,0 +1,58 @@
+"use client"
+import { useInterrupt } from "@copilotkit/react-core/v2"
+
+// Dawn's permission gate surfaces as an AG-UI *standard* interrupt: the run ends
+// with `RUN_FINISHED{ outcome:{ type:"interrupt", interrupts:[…] } }`, and the
+// client resumes via the top-level `RunAgentInput.resume` array. `useInterrupt`
+// handles that path natively — `render` receives the `Interrupt` object, and
+// `resolve(payload)` records `{ status:"resolved", payload }` for it (resuming
+// once every open interrupt is addressed), while `cancel()` records
+// `{ status:"cancelled" }`.
+//
+// @dawn-ai/ag-ui's `toAguiInterrupt` preserves the whole Dawn envelope under
+// `interrupt.metadata`, so the command being gated is at
+// `metadata.detail.command`. For a permission prompt, Dawn reads the resolved
+// payload as its decision ("once" | "always"); cancelling maps to denial.
+type PermissionMetadata = {
+  kind?: string
+  detail?: { command?: string; suggestedPattern?: string }
+}
+
+export function PermissionInterrupt() {
+  useInterrupt({
+    render: ({ interrupt, resolve, cancel }) => {
+      const meta = (interrupt?.metadata ?? {}) as PermissionMetadata
+      const command = meta.detail?.command
+      return (
+        <div
+          style={{
+            border: "1px solid #f0c000",
+            background: "#fffbe6",
+            borderRadius: 8,
+            padding: 12,
+            margin: "8px 0",
+            fontSize: 13,
+          }}
+        >
+          <p style={{ margin: 0, fontWeight: 600 }}>Permission required</p>
+          <p style={{ margin: "4px 0", color: "#665" }}>
+            {interrupt?.reason ? `${interrupt.reason}: ` : ""}
+            <code>{command ?? interrupt?.message ?? JSON.stringify(meta)}</code>
+          </p>
+          <div style={{ display: "flex", gap: 8 }}>
+            <button type="button" onClick={() => resolve("once")}>
+              Allow once
+            </button>
+            <button type="button" onClick={() => resolve("always")}>
+              Allow always
+            </button>
+            <button type="button" onClick={() => cancel()}>
+              Deny
+            </button>
+          </div>
+        </div>
+      )
+    },
+  })
+  return null
+}

--- a/examples/chat/web/app/page.tsx
+++ b/examples/chat/web/app/page.tsx
@@ -1,5 +1,6 @@
 "use client"
 import { CopilotKit, CopilotSidebar } from "@copilotkit/react-core/v2"
+import { PermissionInterrupt } from "./components/PermissionInterrupt"
 
 // Notes (verified against installed @copilotkit/react-core@1.62.3 types):
 // - Use the `CopilotKit` wrapper (not bare `CopilotKitProvider`) per CopilotKit's own v2
@@ -13,6 +14,7 @@ import { CopilotKit, CopilotSidebar } from "@copilotkit/react-core/v2"
 export default function Home() {
   return (
     <CopilotKit runtimeUrl="/api/copilotkit" defaultThrottleMs={100}>
+      <PermissionInterrupt />
       <main style={{ height: "100vh" }}>
         <CopilotSidebar defaultOpen labels={{ modalHeaderTitle: "Dawn chat" }} />
       </main>

--- a/examples/research/web/app/components/PermissionInterrupt.tsx
+++ b/examples/research/web/app/components/PermissionInterrupt.tsx
@@ -1,0 +1,58 @@
+"use client"
+import { useInterrupt } from "@copilotkit/react-core/v2"
+
+// Dawn's permission gate surfaces as an AG-UI *standard* interrupt: the run ends
+// with `RUN_FINISHED{ outcome:{ type:"interrupt", interrupts:[…] } }`, and the
+// client resumes via the top-level `RunAgentInput.resume` array. `useInterrupt`
+// handles that path natively — `render` receives the `Interrupt` object, and
+// `resolve(payload)` records `{ status:"resolved", payload }` for it (resuming
+// once every open interrupt is addressed), while `cancel()` records
+// `{ status:"cancelled" }`.
+//
+// @dawn-ai/ag-ui's `toAguiInterrupt` preserves the whole Dawn envelope under
+// `interrupt.metadata`, so the command being gated is at
+// `metadata.detail.command`. For a permission prompt, Dawn reads the resolved
+// payload as its decision ("once" | "always"); cancelling maps to denial.
+type PermissionMetadata = {
+  kind?: string
+  detail?: { command?: string; suggestedPattern?: string }
+}
+
+export function PermissionInterrupt() {
+  useInterrupt({
+    render: ({ interrupt, resolve, cancel }) => {
+      const meta = (interrupt?.metadata ?? {}) as PermissionMetadata
+      const command = meta.detail?.command
+      return (
+        <div
+          style={{
+            border: "1px solid #f0c000",
+            background: "#fffbe6",
+            borderRadius: 8,
+            padding: 12,
+            margin: "8px 0",
+            fontSize: 13,
+          }}
+        >
+          <p style={{ margin: 0, fontWeight: 600 }}>Permission required</p>
+          <p style={{ margin: "4px 0", color: "#665" }}>
+            {interrupt?.reason ? `${interrupt.reason}: ` : ""}
+            <code>{command ?? interrupt?.message ?? JSON.stringify(meta)}</code>
+          </p>
+          <div style={{ display: "flex", gap: 8 }}>
+            <button type="button" onClick={() => resolve("once")}>
+              Allow once
+            </button>
+            <button type="button" onClick={() => resolve("always")}>
+              Allow always
+            </button>
+            <button type="button" onClick={() => cancel()}>
+              Deny
+            </button>
+          </div>
+        </div>
+      )
+    },
+  })
+  return null
+}

--- a/examples/research/web/app/page.tsx
+++ b/examples/research/web/app/page.tsx
@@ -1,6 +1,7 @@
 "use client"
 import { CopilotKit, CopilotSidebar } from "@copilotkit/react-core/v2"
 import { MemoryCandidates } from "./components/MemoryCandidates"
+import { PermissionInterrupt } from "./components/PermissionInterrupt"
 import { ToolCallCard } from "./components/ToolCallCard"
 
 // Notes (verified against installed @copilotkit/react-core@1.62.3 types — see
@@ -23,6 +24,7 @@ import { ToolCallCard } from "./components/ToolCallCard"
 export default function Home() {
   return (
     <CopilotKit runtimeUrl="/api/copilotkit" defaultThrottleMs={100}>
+      <PermissionInterrupt />
       <ToolCallCard />
       <div style={{ display: "flex", height: "100vh" }}>
         <div style={{ display: "flex", flexDirection: "column", minWidth: 240 }}>

--- a/packages/cli/test/docs-bundle.test.ts
+++ b/packages/cli/test/docs-bundle.test.ts
@@ -143,6 +143,12 @@ describe("current AG-UI documentation", () => {
   })
 
   it("does not reference removed adapter APIs or example UI", () => {
+    // Retired Dawn/adapter vocabulary. `useInterrupt` and `PermissionInterrupt`
+    // are deliberately NOT listed: the canonicalized adapter still surfaces
+    // permission gates as AG-UI standard interrupts, and the example UIs render
+    // them with CopilotKit's current `useInterrupt` hook (see each example's
+    // PermissionInterrupt.tsx). What must stay gone is the *legacy* vocabulary
+    // below — the custom-event interrupt and the `forwardedProps` resume path.
     const removed = [
       "createAgUiTranslator",
       "mapRunInput",
@@ -150,8 +156,6 @@ describe("current AG-UI documentation", () => {
       "forwardedProps.command.resume",
       "STATE_SNAPSHOT",
       "dawn.subagent",
-      "useInterrupt",
-      "PermissionInterrupt",
       "TodosPanel",
     ]
     const roots = [


### PR DESCRIPTION
## The regression

#360 canonicalized the Dawn adapter — moving interrupts from the legacy `CUSTOM{on_interrupt}` path to the AG-UI **standard** (`RUN_FINISHED{outcome:interrupt}` out, `RunAgentInput.resume[]` in). Good change. But it also **deleted the example UIs' `PermissionInterrupt`** on the premise that standard interrupts render natively — and left **no interrupt handler registered at all**.

Result: the flagship demo's headline HITL capability was **silently broken**. Hitting a permission gate (the research demo's external-fetch, or any non-allowlisted `runBash`) left a dangling `runBash preparing…` card with **no approve/deny affordance, no error, nothing in the console** — the run just dead-ended. Tests didn't catch it because the gap is on the *client*; #360's 800 lines of endpoint/interrupt tests all pass.

## The fix

Re-add `PermissionInterrupt` to both example UIs using `useInterrupt`'s **standard** path (no legacy vocabulary):
- `render` receives the `Interrupt` object; the gated command is at `interrupt.metadata.detail.command` (preserved by `@dawn-ai/ag-ui`'s `toAguiInterrupt`).
- `resolve("once" | "always")` → records `{status:"resolved", payload}` → the top-level `resume[]`.
- `cancel()` → records `{status:"cancelled"}` → denial.
- `renderInChat` (default) renders the card inside `<CopilotChat>`.

## Test plan — verified live in Chrome against a real model

First confirmed the protocol via curl (gate → `RUN_FINISHED{outcome:interrupt}`; `resolved`/`"once"` → command runs; `cancelled` → command blocked). Then the UI:

- **Card renders** — "Permission required · `command: node scripts/fetch-source.mjs "quantum computing"`" · Allow once / Allow always / Deny.
- **Allow once** → card dismissed, run resumed, a `runBash done` card shows the command executed (`exitCode:0`), agent produced its report.
- **Deny** → card dismissed, run resumed, agent's next `writeTodos` records *"Run the external fetch script (attempted; permission denied)"* and pivots — denial enforced and observed.
- `build` + `typecheck` green for both web apps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)