### PR TITLE
feat(web): add starter suggestions to the example chats

### DIFF
--- a/examples/chat/web/app/components/DemoSuggestions.tsx
+++ b/examples/chat/web/app/components/DemoSuggestions.tsx
@@ -1,0 +1,27 @@
+"use client"
+import { useConfigureSuggestions } from "@copilotkit/react-core/v2"
+
+// Starter prompts for the empty chat. The permission gate in particular is only
+// reachable if the user asks for a command that isn't on dawn.config.ts's
+// allow-list, which is not something a first-time visitor would guess.
+//
+// `useConfigureSuggestions` takes a static list ({ title, message }); `available`
+// defaults to "before-first-message", so these appear on the empty chat only.
+export function DemoSuggestions() {
+  useConfigureSuggestions(
+    {
+      suggestions: [
+        {
+          title: "Explore the workspace",
+          message: "List the files in the workspace and summarize what you find.",
+        },
+        {
+          title: "Trigger a permission prompt",
+          message: "Run `node --version` with runBash.",
+        },
+      ],
+    },
+    [],
+  )
+  return null
+}

--- a/examples/chat/web/app/page.tsx
+++ b/examples/chat/web/app/page.tsx
@@ -1,5 +1,6 @@
 "use client"
 import { CopilotKit, CopilotSidebar } from "@copilotkit/react-core/v2"
+import { DemoSuggestions } from "./components/DemoSuggestions"
 import { PermissionInterrupt } from "./components/PermissionInterrupt"
 
 // Notes (verified against installed @copilotkit/react-core@1.62.3 types):
@@ -14,6 +15,7 @@ import { PermissionInterrupt } from "./components/PermissionInterrupt"
 export default function Home() {
   return (
     <CopilotKit runtimeUrl="/api/copilotkit" defaultThrottleMs={100}>
+      <DemoSuggestions />
       <PermissionInterrupt />
       <main style={{ height: "100vh" }}>
         <CopilotSidebar defaultOpen labels={{ modalHeaderTitle: "Dawn chat" }} />

--- a/examples/research/web/app/components/DemoSuggestions.tsx
+++ b/examples/research/web/app/components/DemoSuggestions.tsx
@@ -1,0 +1,41 @@
+"use client"
+import { useConfigureSuggestions } from "@copilotkit/react-core/v2"
+
+// Starter prompts for the empty chat. The research agent's most interesting
+// behavior is model-driven — it only dispatches a subagent, hits the permission
+// gate, or proposes a memory if the question steers it there — so without a nudge
+// a new user is unlikely to discover any of it.
+//
+// `useConfigureSuggestions` takes a static list ({ title, message }); `available`
+// defaults to "before-first-message", so these appear on the empty chat and go
+// away once the conversation starts.
+//
+// Each prompt is grounded in the bundled corpus (workspace/corpus/*.md) so the
+// first click actually works:
+// - "agent architectures" IS in the corpus  -> plan, researcher subagent, citations
+// - "quantum computing" is deliberately NOT -> forces the gated external fetch,
+//   which is what makes the approve/deny flow discoverable
+// - the preference prompt drives remember() -> a candidate to approve in the panel
+export function DemoSuggestions() {
+  useConfigureSuggestions(
+    {
+      suggestions: [
+        {
+          title: "Research a topic",
+          message: "What are common agent architectures? Write a short cited report.",
+        },
+        {
+          title: "Trigger a permission prompt",
+          message:
+            "The corpus has nothing on quantum computing — run the external fetch script for it with runBash.",
+        },
+        {
+          title: "Teach it a preference",
+          message: "Remember that I prefer concise, cited reports.",
+        },
+      ],
+    },
+    [],
+  )
+  return null
+}

--- a/examples/research/web/app/page.tsx
+++ b/examples/research/web/app/page.tsx
@@ -1,5 +1,6 @@
 "use client"
 import { CopilotKit, CopilotSidebar } from "@copilotkit/react-core/v2"
+import { DemoSuggestions } from "./components/DemoSuggestions"
 import { MemoryCandidates } from "./components/MemoryCandidates"
 import { PermissionInterrupt } from "./components/PermissionInterrupt"
 import { ToolCallCard } from "./components/ToolCallCard"
@@ -24,6 +25,7 @@ import { ToolCallCard } from "./components/ToolCallCard"
 export default function Home() {
   return (
     <CopilotKit runtimeUrl="/api/copilotkit" defaultThrottleMs={100}>
+      <DemoSuggestions />
       <PermissionInterrupt />
       <ToolCallCard />
       <div style={{ display: "flex", height: "100vh" }}>


### PR DESCRIPTION
## Why

Both demos open on a blank "How can I help you today?", and their most interesting behavior is **model-driven** — the agent only dispatches a subagent, hits the permission gate, or proposes a durable memory if the question steers it there. So the headline capabilities were effectively hidden from a first-time visitor.

Concretely: to trigger the permission gate while verifying #365, I had to write *"Corpus lacks quantum computing. Run the external fetch script for it via runBash now."* Nobody would guess that.

## What

Static starter prompts via CopilotKit's own `useConfigureSuggestions` (the library's extension point — no hand-rolled UI, consistent with the canonical-minimal direction). They render as pills on the empty chat only; `available` defaults to `"before-first-message"`.

**Research** — one per headline capability, each grounded in the bundled 5-doc corpus so the first click actually works:

| Pill | Demonstrates |
|---|---|
| Research a topic | in-corpus → plan/todos, `researcher` subagent, citations, tool cards |
| Trigger a permission prompt | deliberately **not** in corpus → forces the gated fetch → approve/deny |
| Teach it a preference | `remember()` → a candidate to approve in the memory panel |

The second is the trick: the corpus miss is what drives the agent to the gated fetch, making the HITL flow discoverable instead of secret.

**Chat** — "Explore the workspace" and "Trigger a permission prompt".

## Test plan — verified end-to-end in Chrome against a real model

- **Research:** all three pills render on the empty chat. Clicked **"Trigger a permission prompt"** → sent its full message → run started → **"Permission required"** card appeared with `command: node scripts/fetch-source.mjs quantum-computing` → clicked **Allow once** → `runBash done` (`exitCode:0`) and the run continued. One click took a new user from empty chat to the full HITL flow.
- **Chat:** both pills render. Clicked **"Explore the workspace"** → agent listed and summarized the workspace files.
- No console errors; `build` + `typecheck` green for both web apps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)