### PR TITLE
chore(charts): bump appVersion to 0.8.13 (unblock the release)

### DIFF
--- a/charts/dawn-app/Chart.yaml
+++ b/charts/dawn-app/Chart.yaml
@@ -3,7 +3,7 @@ name: dawn-app
 description: Runs a built Dawn app image (from `langgraphjs dockerfile`) on Kubernetes as a Deployment + Service, with optional Ingress, HorizontalPodAutoscaler, and PodDisruptionBudget, wired to the in-cluster kubernetesSandbox orchestrator ServiceAccount.
 type: application
 version: 0.1.0
-appVersion: "0.8.12"
+appVersion: "0.8.13"
 keywords: [dawn, langgraph, kubernetes, deployment]
 home: https://dawnai.org
 sources: [https://github.com/cacheplane/dawnai]

--- a/charts/dawn-sandbox-infra/Chart.yaml
+++ b/charts/dawn-sandbox-infra/Chart.yaml
@@ -3,7 +3,7 @@ name: dawn-sandbox-infra
 description: Cluster-side infrastructure for the Dawn kubernetesSandbox provider — namespace, least-privilege RBAC, default-deny egress, quotas/limits, Pod Security Standards, and a PVC reaper.
 type: application
 version: 0.1.1
-appVersion: "0.8.12"
+appVersion: "0.8.13"
 keywords: [dawn, sandbox, kubernetes, security]
 home: https://dawnai.org
 sources: [https://github.com/cacheplane/dawnai]


### PR DESCRIPTION
## Why

The `0.8.13` Release run **failed at "Validate Release Candidate"**:

```
Docs completeness check failed.
- charts/dawn-app/Chart.yaml appVersion (0.8.12) does not match @dawn-ai/cli 0.8.13
- charts/dawn-sandbox-infra/Chart.yaml appVersion (0.8.12) does not match @dawn-ai/cli 0.8.13
```

Changesets bumps the npm packages but **not** the Helm charts' `appVersion`, and `scripts/check-docs.mjs:288` asserts the charts track `@dawn-ai/cli`. So every release needs a manual chart bump.

**No partial publish** — this is a pre-publish gate, and npm is still on `0.8.12` across all packages (verified). The release is simply blocked until the charts match.

## Fix
Bump both charts' `appVersion` to `0.8.13`. Chart `version` (the chart's own semver) is deliberately left alone — only `appVersion` tracks Dawn.

## Test plan
`node scripts/check-docs.mjs` → **Docs completeness check passed.**

## Follow-up worth considering
This will recur every release. Options: have the release workflow bump `appVersion` automatically from `@dawn-ai/cli`, or add it to the release checklist. Filed as a note rather than fixed here so the release isn't held up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)