### PR TITLE
fix(ci): derive chart render-test image tag from appVersion (unbreak chart-validate on main)

### DIFF
--- a/charts/dawn-app/test/render.sh
+++ b/charts/dawn-app/test/render.sh
@@ -8,10 +8,17 @@ tmpl() { helm template test "$CHART" --set image.repository=example/app "$@"; }
 assert() { if ! grep -qE "$2"; then echo "FAIL: $1"; exit 1; fi; echo "ok: $1"; }
 refute() { if grep -qE "$2"; then echo "FAIL (expected absent): $1"; exit 1; fi; echo "ok: $1"; }
 
+# The default image tag falls back to .Chart.AppVersion, which
+# scripts/sync-chart-appversion.mjs bumps on every release — derive the
+# expectation from Chart.yaml instead of hardcoding (a hardcoded tag broke
+# this lane the first time the sync ran, at 0.8.13).
+APP_VERSION="$(sed -n 's/^appVersion: *"\{0,1\}\([^"]*\)"\{0,1\}$/\1/p' "$CHART/Chart.yaml")"
+[ -n "$APP_VERSION" ] || { echo "FAIL: could not read appVersion from Chart.yaml"; exit 1; }
+
 # Deployment: image, probes on /healthz, SA, hardened securityContext
 DEPLOY="$(tmpl --show-only templates/deployment.yaml)"
 printf '%s\n' "$DEPLOY" | assert "deployment kind" 'kind: Deployment'
-printf '%s\n' "$DEPLOY" | assert "image repository+tag" 'image: example/app:0.8.12'
+printf '%s\n' "$DEPLOY" | assert "image repository+tag" "image: example/app:$APP_VERSION"
 printf '%s\n' "$DEPLOY" | assert "named http port" 'containerPort: 8000'
 printf '%s\n' "$DEPLOY" | assert "liveness probe path" 'path: /healthz'
 printf '%s\n' "$DEPLOY" | assert "serviceAccountName default" 'serviceAccountName: dawn-orchestrator'


### PR DESCRIPTION
chart-validate has been red on main since the 0.8.13 release: the appVersion auto-sync (#376) bumped `charts/dawn-app/Chart.yaml` to 0.8.13, but `test/render.sh` hardcodes `image: example/app:0.8.12` (the default tag falls back to `.Chart.AppVersion`).

Fix: derive the expected tag from Chart.yaml at test time, with a guard if appVersion can't be parsed — the sync can never break this lane again. Verified locally: `sh charts/dawn-app/test/render.sh` → "render checks passed". Swept both charts' tests for other hardcoded versions: none.

Unblocks main CI and every open PR (incl. #377, which carries the broken assertion via its main merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)