### PR TITLE
fix(ci): surface Claude review failures instead of passing green

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -11,6 +11,15 @@ name: Claude Review
 # deadlocked until a maintainer hand-resolved threads (see PR #289).
 # Uses `pull_request` (not pull_request_target) so ANTHROPIC_API_KEY is
 # never exposed to fork PRs.
+#
+# FAILS LOUDLY BY DESIGN. Between 2026-07-08 05:42 and 14:49 UTC every run
+# started failing at the first API call (~300ms, 1 turn, $0.00 cost) and the
+# job still went green for ~4 weeks: claude-code-action derives its conclusion
+# from `resultMessage.subtype === "success"` and never inspects `is_error`, so
+# an `{"subtype":"success","is_error":true}` result looks like a clean run and
+# the tracking comment is left on its "I'll analyze this and get back to you."
+# placeholder. The preflight and result-guard steps below close that hole. The
+# job is still NOT a required check, so a red X here never blocks a merge.
 
 on:
   pull_request:
@@ -36,7 +45,61 @@ jobs:
         with:
           fetch-depth: 1
 
+      # One ~$0.00003 call that names the failure instead of leaving it buried
+      # in a redacted agent log: 401 = key revoked/invalid, 400 with
+      # `credit balance` = org out of credits, 404 = REVIEW_MODEL retired.
+      # Without this the only symptom is a 300ms is_error result with no
+      # message, because the action redacts agent output unless
+      # `show_full_output: true` (which would dump the whole review transcript).
+      - name: Preflight — Anthropic credentials and model
+        id: preflight
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          REVIEW_MODEL: claude-sonnet-4-6
+        run: |
+          set -uo pipefail
+          if [ -z "${ANTHROPIC_API_KEY}" ]; then
+            echo "::warning::ANTHROPIC_API_KEY is unavailable (fork PR — secrets are not exposed to fork \`pull_request\` runs). Skipping review."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+
+          # Keep the key out of argv (and therefore out of the process list) by
+          # passing it through a 0600 curl config file rather than -H.
+          rc="$(mktemp)"; body="$(mktemp)"
+          trap 'rm -f "$rc" "$body"' EXIT
+          printf 'header = "x-api-key: %s"\n' "${ANTHROPIC_API_KEY}" > "$rc"
+
+          code="$(curl -sS -o "$body" -w '%{http_code}' \
+            --config "$rc" \
+            -H 'anthropic-version: 2023-06-01' \
+            -H 'content-type: application/json' \
+            -d "{\"model\":\"${REVIEW_MODEL}\",\"max_tokens\":1,\"messages\":[{\"role\":\"user\",\"content\":\"ping\"}]}" \
+            https://api.anthropic.com/v1/messages)" || {
+              echo "::warning::Preflight request could not be sent; continuing and letting the review step report."
+              exit 0
+            }
+
+          case "$code" in
+            200)
+              echo "Anthropic API reachable; key valid; model ${REVIEW_MODEL} available."
+              ;;
+            429|5??)
+              echo "::warning::Preflight got HTTP ${code} (rate limit / transient). Key looks valid; continuing."
+              ;;
+            *)
+              echo "::error::Anthropic preflight failed with HTTP ${code} for model ${REVIEW_MODEL} — the review agent cannot run."
+              jq -r '.error | "\(.type): \(.message)"' < "$body" 2>/dev/null || head -c 500 "$body"
+              echo
+              echo "401 => rotate ANTHROPIC_API_KEY. 400 mentioning credit balance => top up the Anthropic org. 404 => REVIEW_MODEL is no longer available to this org."
+              exit 1
+              ;;
+          esac
+
       - name: Claude review
+        id: claude
+        if: steps.preflight.outputs.skip != 'true'
         uses: anthropics/claude-code-action@e90deca47693f9457b72f2b53c17d7c445a87342 # v1
         with:
           # Pass GITHUB_TOKEN explicitly (maps to OVERRIDE_GITHUB_TOKEN) so the
@@ -72,3 +135,37 @@ jobs:
             --model claude-sonnet-4-6
             --max-turns 40
             --allowedTools "Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
+
+      # The action reports success whenever the result subtype is "success",
+      # even when that same result carries is_error: true. Re-check the raw
+      # execution log (unredacted, unlike the console output) and fail on it.
+      - name: Verify the review actually ran
+        if: always() && steps.claude.conclusion != 'skipped'
+        env:
+          EXECUTION_FILE: ${{ steps.claude.outputs.execution_file }}
+        run: |
+          set -uo pipefail
+          if [ -z "${EXECUTION_FILE}" ] || [ ! -f "${EXECUTION_FILE}" ]; then
+            echo "::error::No Claude execution log was produced — the review agent never reported a result."
+            exit 1
+          fi
+
+          result="$(jq -c '[.[] | select(.type == "result")] | last // empty' "${EXECUTION_FILE}")"
+          if [ -z "${result}" ]; then
+            echo "::error::Claude execution log contains no result message — the agent did not finish."
+            exit 1
+          fi
+
+          is_error="$(jq -r '.is_error // false' <<<"${result}")"
+          subtype="$(jq -r '.subtype // "unknown"' <<<"${result}")"
+          if [ "${is_error}" = "true" ] || [ "${subtype}" != "success" ]; then
+            echo "::error::Claude review failed (subtype=${subtype}, is_error=${is_error}). No review was posted."
+            echo "--- agent error detail (truncated) ---"
+            jq -r '.result // .error // "no detail in result message"' <<<"${result}" | head -c 2000
+            echo
+            exit 1
+          fi
+
+          turns="$(jq -r '.num_turns // 0' <<<"${result}")"
+          cost="$(jq -r '.total_cost_usd // 0' <<<"${result}")"
+          echo "Review completed: ${turns} turn(s), \$${cost}."


### PR DESCRIPTION
## The advisory review bot has been silently dead for four weeks

It broke abruptly on **2026-07-08, between 05:42 and 14:49 UTC**, and every run since has failed identically. Last healthy run: [`28920386762`](https://github.com/cacheplane/dawnai/actions/runs/28920386762) (85s, 12 turns, $0.27). The next run, at 14:49, shows the signature that's been constant ever since — 260ms, 1 turn, `total_cost_usd: 0`, `is_error: true` — and reported **success**.

~90 PRs have merged since with no review, while `auto-approve` kept asserting "this PR received an intelligent (AI) code review" for the Scorecard Code-Review credit.

### Why it stayed green

`claude-code-action` computes its conclusion in `base-action/src/run-claude-sdk.ts` as:

```ts
const isSuccess = resultMessage.subtype === "success";
result.conclusion = isSuccess ? "success" : "failure";
```

`is_error` is never inspected. Our result is `{"subtype": "success", "is_error": true}` — an API-level rejection that the action classifies as a clean run. It throws nothing, leaves the tracking comment on its `I'll analyze this and get back to you.` placeholder, and exits zero. The agent's error text is separately redacted from the log unless `show_full_output: true` (which would dump the entire review transcript), so nothing said *why*.

### What is not the cause

- **Not the pinned model.** `claude-sonnet-4-6` is still active and ran successfully against that exact string for three weeks before the break.
- **Not a config change.** `claude-review.yml` was last touched 2026-07-06 and next touched 2026-07-09 — the break falls between them.
- **Not the action version.** Both bumps (1.0.159→1.0.165 on 07-09, →1.0.171 on 08-05) landed after it was already failing.

A same-day, permanent, total failure with no repo change is account-side: the `ANTHROPIC_API_KEY` secret (last updated 2026-06-18, never rotated) is revoked, or the org's credit balance is exhausted. **The preflight step added here will name which one on this PR's own run** — `pull_request` workflows execute from the PR head, so the new step runs against the real secret.

## Changes

**Preflight** — one `max_tokens: 1` request (~$0.00003) before the agent starts, mapping HTTP status to a named cause: 401 revoked key, 400 with a credit-balance message, 404 retired model. 429/5xx are transient warnings that continue. A missing secret (fork PRs, where `pull_request` withholds secrets) skips the job with a warning rather than failing it. The key is passed via a mode-600 curl config file, so it never enters argv or the process list.

**Result guard** — reads the action's `execution_file` output (the raw, unredacted log) and fails on `is_error: true` or a non-success subtype, printing up to 2000 chars of the actual error.

The job stays advisory and non-required, so a red X still never blocks a merge.

## Verification

Both scripts were extracted from the workflow and exercised against fixtures rather than assumed correct:

| Case | Result |
|---|---|
| Guard, `is_error: true` | fails, prints error detail |
| Guard, healthy result | passes, logs turns + cost |
| Guard, missing / resultless log | fails |
| Preflight 200 / 429 / 529 | pass, pass with warning, pass with warning |
| Preflight 401 / 400 / 404 | fail, each naming its cause |
| Preflight, no secret | skips the review step |

`actionlint` passes. No changeset — `.github/workflows/` is outside `check-changesets.mjs`'s user-facing patterns.

**Expected on this PR:** the Claude Review check should go **red at the preflight step**, printing the actual API error. That red X is the fix working, and it's the diagnosis. `auto-approve` is a separate workflow with no dependency on this job's conclusion and is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
