### PR TITLE
feat: episodic memory — auto-recorded run history, time-windowed recall, Inspector timeline

### DIFF
--- a/.changeset/episodic-memory.md
+++ b/.changeset/episodic-memory.md
@@ -1,0 +1,20 @@
+---
+"@dawn-ai/memory": patch
+"@dawn-ai/memory-pgvector": patch
+"@dawn-ai/core": patch
+"@dawn-ai/cli": patch
+"@dawn-ai/inspector": patch
+"@dawn-ai/testing": patch
+---
+
+Episodic memory: Dawn apps can now remember what happened. An opt-in runtime
+recorder (`memory.episodes.enabled`) writes one episode per agent run from the
+trace — input, outcome, tools used, duration — with TTL + per-namespace cap
+retention; routes can also author episodes via `defineMemory({ kind: "episodic" })`
+(append-only, never superseded). `recall` gains `since`/`until` time windows
+(ISO or relative like "-24h"); the Inspector gains a timeline view; `dawn memory
+prune` runs retention manually.
+
+BREAKING: `MemoryStore` now requires `prune(opts)`; `search`/`browse` accept
+`since`/`until` and exclude expired rows when `now` is supplied. Custom stores
+must implement `prune` (`runMemoryStoreConformance` enforces the contract).

--- a/apps/web/content/docs/cli.mdx
+++ b/apps/web/content/docs/cli.mdx
@@ -216,6 +216,7 @@ dawn memory inspect <id>
 dawn memory approve <id>
 dawn memory reject <id>
 dawn memory forget <id>
+dawn memory prune [--cap <n>] [--namespace <prefix>]
 ```
 
 Subcommands:
@@ -225,6 +226,10 @@ Subcommands:
 - `approve <id>` — promote a candidate to an `active` record so `recall` surfaces it.
 - `reject <id>` — drop a candidate without promoting it.
 - `forget <id>` — delete a record by id.
+- `prune` — run [episodic retention](/docs/memory#episodic-memory) manually:
+  delete expired records (TTL) and enforce the per-namespace episode cap.
+  `--cap <n>` overrides the cap for this pass; `--namespace <prefix>` scopes
+  the pass to namespaces matching the prefix.
 
 Flags:
 - `--cwd <path>` — operate on a different app root.

--- a/apps/web/content/docs/inspector.mdx
+++ b/apps/web/content/docs/inspector.mdx
@@ -68,6 +68,21 @@ Two caveats follow from the inspector running as a separate process:
 - **Reject / Forget** — hard-delete a candidate or any record, each behind a
   confirmation prompt.
 
+### Timeline view
+
+With [episodic memory](/docs/memory#episodic-memory) enabled, the panel's
+list/timeline toggle switches to a **timeline** of what the agent did: records
+grouped by day, each row showing the time it happened, an outcome badge
+(`ok`/`error` for auto-recorded runs, `authored` for agent-written episodes),
+the episode summary, and the run duration. A window select (24h / 7d / 30d /
+all) narrows the timeline, and the kind filter defaults to `episodic` there.
+Clicking a row opens the same detail sheet as the list.
+
+Like agent recall, the panel excludes **expired** episodes — search does so
+intentionally (it mirrors what the agent's `recall` can see), with no escape
+hatch. For debugging retention, the list API accepts `includeExpired=1` to
+reveal rows that are past their TTL but not yet pruned.
+
 <Callout type="info" title="Headless equivalent">
   The [`dawn memory`](/docs/cli) CLI covers the same governance flow —
   list/search/inspect/approve/reject/forget — without a browser, for CI and

--- a/apps/web/content/docs/memory.mdx
+++ b/apps/web/content/docs/memory.mdx
@@ -77,7 +77,7 @@ export default defineMemory({
 
 `defineMemory({ kind, scope, schema, identity? })`:
 
-- **`kind`** — `"semantic" | "episodic" | "procedural" | "reflection"`. Only `"semantic"` is wired end-to-end today; the other three are typed but deferred.
+- **`kind`** — `"semantic" | "episodic" | "procedural" | "reflection"`. `"semantic"` and [`"episodic"`](#episodic-memory) are wired end-to-end today; the other two are typed but deferred.
 - **`scope`** — a subset of `["workspace", "route", "tenant", "user", "agent"]`. The dimensions a memory is partitioned by; `["workspace", "route"]` namespaces records to the app *and* the specific route, so two routes never read each other's memories.
 - **`schema`** — a Zod schema describing your fact shape.
 - **`identity?`** — the keys used for write reconciliation (in `auto` and `ask` modes). Defaults to `["subject", "predicate"]`.
@@ -97,7 +97,7 @@ Typegen emits two typed tools for any route with a `memory.ts` into `.dawn/dawn.
   Typegen derives `remember`'s `data` type from your route's `defineMemory()` Zod schema, so TypeScript catches missing or misspelled fields in route code. The same schema is still enforced at *runtime* when the model calls `remember`.
 </Callout>
 
-**`recall({ query?, kind?, tags?, limit? })`** searches the store. It defaults `status` to `"active"` and `limit` to `8`, and returns one `id: content` line per match, or `(no memories found)` when empty.
+**`recall({ query?, kind?, tags?, limit?, since?, until? })`** searches the store. It defaults `status` to `"active"` and `limit` to `8`, and returns one `id: content` line per match, or `(no memories found)` when empty. `since`/`until` narrow to a [time window](#time-windowed-recall) — most useful with [episodic memory](#episodic-memory).
 
 **`remember({ data, content?, tags?, confidence? })`** validates `data` against the schema, then writes a record. The id is **data-derived** — `memory_` + the first 16 hex chars of `sha1(namespace | JSON(data))` — so a contradicting value (same identity, different data) gets a distinct id and can coexist with the old row. `content` defaults to `JSON.stringify(data)`, `confidence` to `1`, `tags` to `[]`.
 
@@ -236,6 +236,91 @@ These memories are available — call `recall({ query })` to load full details b
 
 The default store lives at `<appRoot>/.dawn/memory.sqlite`.
 
+## Episodic memory
+
+Semantic memory stores *beliefs* — facts that can be updated or contradicted. **Episodic memory** stores *events*: what the agent did, when. Episodes are append-only (a later event never contradicts an earlier one), carry a time the event happened (`effectiveAt`), and age out via TTL instead of living forever. With episodes recorded, an agent can answer "what did you do in the last day?" from its own history.
+
+### Enabling the run recorder
+
+The zero-effort path is the **runtime episode recorder**: opt in via `memory.episodes` in `dawn.config.ts` and Dawn writes one episodic memory per agent run, for every route that has a `memory.ts`:
+
+```ts title="dawn.config.ts"
+export default {
+  memory: {
+    episodes: {
+      enabled: true,          // default false — episodes are opt-in
+      ttlMs: 30 * 86_400_000, // default 30 days — episodes expire after this
+      cap: 500,               // default 500 — max episodes kept per namespace
+      includeFailedRuns: true, // default true — record runs that errored too
+      embed: false,           // default false — embed: true is not yet supported
+    },
+  },
+} satisfies import("@dawn-ai/core").DawnConfig
+```
+
+### What gets recorded
+
+One episode per completed run, written after the run settles (both the invoke and streaming paths):
+
+- **`content`** — a one-line summary: `run ok: <input> (3 tools, 4.2s)`.
+- **`data`** — `{ input, outcome: "ok" | "error", toolsUsed, durationMs }` (plus the thread/run id when available). `input` is the user's message for the run, truncated to 500 chars.
+- **`source`** — `{ type: "run", id }`, and **`effectiveAt`** is the run's *start* time — recall time windows key on when the event happened.
+- **Deterministic ids** — `memory_ep_` + a hash of the namespace, run id, and start time, so a retried write of the same run's episode is idempotent rather than a duplicate.
+
+Recording **never fails a run**: a store error is logged once and swallowed. Human-in-the-loop turns are handled precisely — a run that *parks* on a [permission interrupt](/docs/permissions) records nothing; the resume turn that completes it records once, with the original user input (not the resume payload).
+
+### Retention
+
+Episodes expire. Each recorded episode carries `expiresAt = start + ttlMs` (default **30 days**), and every write runs a lazy retention pass that deletes expired rows and enforces the per-namespace **cap** (default **500**, oldest-first). Expired rows are excluded from recall, the injected index, and the Inspector's search. You can also run retention manually:
+
+```bash
+dawn memory prune                 # delete expired rows, enforce the default cap
+dawn memory prune --cap 100       # tighter cap for this pass
+dawn memory prune --namespace "route=/support" # scope to a namespace prefix
+```
+
+### Time-windowed recall
+
+The `recall` tool gains `since` and `until` — an ISO timestamp or a relative offset like `"-24h"`, `"-7d"`, `"-30m"`, resolved against the request clock. `since` is **inclusive**, `until` is **exclusive**, and the window compares against when the memory *happened* (`effectiveAt`, falling back to `createdAt`):
+
+```ts
+recall({ since: "-24h" })                    // everything from the last day
+recall({ kind: "episodic", since: "-7d", until: "-24h" }) // last week, minus today
+```
+
+Windows work for any kind, but they exist for episodes — "what did I do recently?" is a time query, not a keyword query. Expired episodes never come back from `recall`, windowed or not.
+
+### Governance
+
+The recorder is **runtime-authored, not agent-authored**, so it does not flow through the `remember` tool's write governance: auto-recorded episodes land `active` immediately in every `writes` mode **except `"off"`**, which disables recording entirely (recall-only means no writes, including Dawn's own). There is no candidate queue for a factual record of what the runtime just did.
+
+Agent-authored episodic writes (below) **do** honor `writes` modes — `candidate` mode holds them for review like any other write. Episodic writes are **append-only**: they never update or supersede an earlier record, and because [`ask` mode](#ask-mode) only gates supersedes, `ask` never prompts for an episodic append.
+
+### Agent-authored episodes
+
+Routes can also let the *agent* record episodes explicitly — declare an episodic collection in `memory.ts`:
+
+```ts title="src/app/ops/memory.ts"
+import { defineMemory } from "@dawn-ai/sdk"
+import { z } from "zod"
+
+export default defineMemory({
+  kind: "episodic",
+  scope: ["route"],
+  schema: z.object({
+    action: z.string(),
+    target: z.string(),
+    result: z.string(),
+  }),
+})
+```
+
+The generated `remember` tool then appends one event per call — identical data on different runs stays two distinct events (ids are salted with the request time), and nothing is ever superseded. `effectiveAt` is stamped with the request time; agent-authored episodes have no automatic TTL (retention is `dawn memory prune`'s business).
+
+<Callout type="info" title="Episodes are not embedded">
+  Auto-recorded episodes are recalled by keyword and time window only — they are not embedded, even when [semantic recall](#semantic-recall-opt-in) is configured, and `episodes.embed: true` is not yet supported (it resolves to `false` with a warning). Time plus keywords is the natural query shape for "what happened"; semantic search over episodes is a follow-up.
+</Callout>
+
 ## Write governance
 
 The `memory.writes` mode in `dawn.config.ts` controls what `remember` does. It defaults to `"candidate"`.
@@ -351,9 +436,10 @@ For deterministic coverage the aimock harness scripts exact tool arguments — w
 
 ## What's deferred
 
-Long-term memory ships with the `semantic` kind, deterministic ranked keyword recall (IDF-weighted relevance blended with recency and confidence), and [opt-in hybrid vector recall](#semantic-recall-opt-in). The following are typed or designed but **not** implemented:
+Long-term memory ships with the `semantic` and [`episodic`](#episodic-memory) kinds, deterministic ranked keyword recall (IDF-weighted relevance blended with recency and confidence), [opt-in hybrid vector recall](#semantic-recall-opt-in), and the [runtime episode recorder](#episodic-memory). The following are typed or designed but **not** implemented:
 
-- The `episodic`, `procedural`, and `reflection` kinds.
+- The `procedural` and `reflection` kinds, and background consolidation (summarizing old episodes into semantic facts).
+- Embedded episodes (`episodes.embed: true`) — auto-episodes are keyword + time-window recall only.
 - Full BM25 (term-frequency / length-normalized) ranking via FTS5, and a memory graph.
 
 A browser UI for the store — the [Dawn Inspector](/docs/inspector)'s Memory panel — ships today via `dawn inspect`.

--- a/apps/web/content/docs/upgrading.mdx
+++ b/apps/web/content/docs/upgrading.mdx
@@ -78,6 +78,42 @@ Two related behavior changes in the same release:
   the same identity key supersedes the old record instead of leaving two active
   rows; approving an identical duplicate dedupes it.
 
+## MemoryStore now requires `prune`
+
+[Episodic memory](/docs/memory#episodic-memory) added a required retention
+method to the `MemoryStore` contract. If you implement a custom store for
+`config.memory.store`, add it:
+
+```ts
+prune(opts: {
+  now: string              // the clock — rows with expiresAt <= now are expired
+  namespacePrefix?: string // scope the pass to matching namespaces
+  cap?: number             // per-namespace cap for episodic records
+}): Promise<{ deletedExpired: number; deletedOverCap: number }>
+```
+
+Semantics:
+
+- **TTL** — delete every record whose `expiresAt` is at or before `now`
+  (records without `expiresAt` never expire).
+- **Cap** — within each namespace, keep at most `cap` **episodic** records,
+  deleting the oldest beyond it. No `cap` means no cap pass.
+
+The runtime episode recorder calls `prune` lazily after each write, and
+`dawn memory prune` runs it manually.
+
+Two related behavior changes in the same release:
+
+- `search` and `browse` accept **`since`/`until`** (ISO instants; `since`
+  inclusive, `until` exclusive) comparing against `effectiveAt` with a
+  `createdAt` fallback.
+- When a query supplies **`now`**, `search` and `browse` must **exclude
+  expired rows** (`expiresAt <= now`). Queries without `now` are unchanged.
+
+The built-in SQLite and pgvector stores already implement all of this, and the
+`runMemoryStoreConformance` kit in `@dawn-ai/testing` covers it — run the kit
+against a custom store to verify the contract.
+
 ## Related
 
 <RelatedCards items={[

--- a/docs/dev/memory-system.md
+++ b/docs/dev/memory-system.md
@@ -294,10 +294,29 @@ RRF-fused, bounded recency/confidence second stage; see §4). Vector recall is e
 supplying `DawnConfig.memory.vector.embedder`; absent, recall is the unchanged keyword path.
 The **Tier-2 Postgres / pgvector store backend** (`@dawn-ai/memory-pgvector`) also ships now:
 HNSW + cosine retrieval in SQL, the same shared ranking core, dimension branch (`vector` ≤2000 /
-`halfvec` ≤4000), enabled via `config.memory.store` (see §4). Explicitly still deferred (spec
-§"Out of scope"):
+`halfvec` ≤4000), enabled via `config.memory.store` (see §4).
 
-- `episodic` / `procedural` / `reflection` kinds; episodic-from-traces; background consolidation.
+**The `episodic` kind ships now too** — both agent-authored (`defineMemory({ kind: "episodic" })`,
+append-only via the `writePolicyFor` kind seam in `reconcile.ts`: never update/supersede, ids
+salted with the request time, `ask` never gates appends) and **episodic-from-runs**: an opt-in
+runtime recorder (`DawnConfig.memory.episodes`) writes one episode per settled agent run.
+Recorder architecture: a post-run hook in `execute-route.ts` covering **both** the invoke and
+stream paths (`recordRunEpisode` → `record-episode.ts`'s pure `buildEpisode`/`recordEpisode`),
+purely-structural extraction of the user input and tool names from the final LangGraph state,
+HITL-safe parked-turn semantics (a pending `__interrupt__` records nothing; the completing
+resume records once with the original input), deterministic `memory_ep_*` ids, and never-fails-
+a-run error containment. Retention: episodes carry `expiresAt` (TTL, default 30d) and a
+per-namespace cap (default 500) enforced by the new required `MemoryStore.prune()` — run lazily
+after each recorded write and manually via `dawn memory prune`. `search`/`browse` gained
+`since`/`until` windows (vs `effectiveAt`, `createdAt` fallback; since inclusive / until
+exclusive) and exclude expired rows when `now` is supplied; the `recall` tool exposes the
+windows (ISO or relative `"-24h"`, resolved by `core`'s pure `time-expr.ts`); the Inspector
+gained a timeline view. All of it is conformance-kit enforced across both stores. Explicitly
+still deferred (spec §"Out of scope"):
+
+- `procedural` / `reflection` kinds; background consolidation (episodes → semantic facts).
+- Embedded episodes (`memory.episodes.embed: true` resolves to `false` with a one-time warning —
+  auto-episodes are keyword + time-window recall only).
 - BM25/FTS5 (term frequency is not stored).
 - Faster ANN over the *local* store — a `sqlite-vec` middle tier. Vector recall on the sqlite
   backend is brute-force cosine in JS over Float32 BLOBs (fine for typical per-namespace corpora;

--- a/docs/superpowers/plans/2026-08-05-episodic-memory.md
+++ b/docs/superpowers/plans/2026-08-05-episodic-memory.md
@@ -1,0 +1,941 @@
+# Episodic Memory Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Wire the episodic memory kind end-to-end — runtime auto-recorder (one episode per run), agent-authored episodes, time-windowed recall, TTL+cap retention via a new required `prune`, and an Inspector timeline view.
+
+**Architecture:** A pure `writePolicyFor(kind)` seam in `@dawn-ai/memory` makes episodic append-only while semantic keeps its reconcile flow; `MemoryQuery`/`BrowseQuery` gain ISO `since`/`until` windows on `COALESCE(effective_at, created_at)` with expiry exclusion when `now` is supplied; a post-run hook in `executeRoute` records episodes deterministically from the trace; the Inspector's Memory panel gains a list/timeline toggle.
+
+**Tech Stack:** node:sqlite + pg (both MemoryStore backends), conformance kit in `@dawn-ai/testing`, aimock harness for recorder integration, Next.js/React 19 inspector, vitest.
+
+**Spec:** `docs/superpowers/specs/2026-08-05-episodic-memory-design.md` — read it first.
+
+**USER DIRECTIVE (applies to every task):** verification and testing must be EXTREMELY robust. Strict TDD with failing-first evidence reported per task. Gated real-backend runs are MANDATORY where marked (`DAWN_TEST_PGVECTOR=1` with real Docker, `DAWN_TEST_INSPECTOR=1` with the built standalone server) — an implementer may not claim DONE without running them. Edge/property tests are enumerated per task and are requirements, not suggestions.
+
+**Working rules (repo memory):** branch-pin (`git rev-parse --abbrev-ref HEAD` → `feat/episodic-memory`) before every commit; never bare `biome check --write`; changesets in the fixed 0.x group are always **patch**; all commands from the worktree root `/Users/blove/repos/dawn/.claude/worktrees/episodic-memory`.
+
+---
+
+## File map
+
+| Area | Files |
+|---|---|
+| Policy seam | `packages/memory/src/reconcile.ts` (writePolicyFor + approveWithReconcile consult), `packages/memory/src/index.ts` |
+| Time windows + expiry | `packages/memory/src/types.ts` (MemoryQuery/BrowseQuery since/until, BrowseQuery.now), `packages/memory/src/sqlite-store.ts` (filters + migration v3 index), `packages/memory-pgvector/src/pgvector-store.ts` + `schema.ts` (filters + index) |
+| prune | `packages/memory/src/types.ts` (required method), both stores, `packages/core/src/capabilities/types.ts` (MemoryStoreLike parity) |
+| Conformance | `packages/testing/src/memory-conformance.ts` |
+| Capability | `packages/core/src/capabilities/built-in/memory.ts` (policy consult in remember, recall since/until, resolveTimeExpr), `packages/core/src/types.ts` (episodes config) |
+| Recorder | `packages/cli/src/lib/runtime/record-episode.ts` (new), `packages/cli/src/lib/runtime/execute-route.ts` (hook), `packages/cli/src/lib/runtime/resolve-memory.ts` (episodes config resolution) |
+| CLI | `packages/cli/src/commands/memory.ts` (prune subcommand) |
+| Inspector | `packages/inspector/app/api/memory/list/route.ts`, `src/components/memory/{list-page,timeline-view}.tsx`, tests |
+| Dogfood/docs | `examples/memory/server/dawn.config.ts`, `apps/web/content/docs/{memory,upgrading,inspector}.mdx`, `docs/dev/memory-system.md`, `.changeset/episodic-memory.md` |
+
+Task order: EP1 → EP2 → EP3 → EP4 → EP5 → EP6 → EP7 → EP8 → EP9 → EP10. EP7 (CLI prune) may interleave after EP4.
+
+---
+
+### Task EP1: `writePolicyFor` seam + policy-aware approve
+
+**Files:**
+- Modify: `packages/memory/src/reconcile.ts`, `packages/memory/src/index.ts`
+- Test: `packages/memory/test/write-policy.test.ts` (create), `packages/memory/test/reconcile-approve.test.ts` (extend)
+
+- [ ] **Step 1: Failing tests**
+
+`packages/memory/test/write-policy.test.ts`:
+```ts
+import { describe, expect, it } from "vitest"
+import { writePolicyFor } from "../src/index.js"
+
+describe("writePolicyFor", () => {
+  it("semantic reconciles", () => {
+    expect(writePolicyFor("semantic")).toEqual({ mode: "reconcile" })
+  })
+  it("episodic appends", () => {
+    expect(writePolicyFor("episodic")).toEqual({ mode: "append" })
+  })
+  it("procedural and reflection throw a not-yet-wired error", () => {
+    expect(() => writePolicyFor("procedural")).toThrow(/not yet wired/)
+    expect(() => writePolicyFor("reflection")).toThrow(/not yet wired/)
+  })
+})
+```
+Extend `packages/memory/test/reconcile-approve.test.ts` (reuse its `makeStore`/`rec` helpers):
+```ts
+  it("approves an episodic candidate as a plain activation (no identity scan, no supersession)", async () => {
+    const s = makeStore()
+    // Two episodic rows with IDENTICAL data — under semantic policy this would
+    // dedupe/supersede; append policy must activate without touching the other.
+    await s.put(rec({ id: "ep-old", status: "active", kind: "episodic" }))
+    await s.put(rec({ id: "ep-cand", status: "candidate", kind: "episodic" }))
+    const res = await approveWithReconcile(s, "ep-cand", { identityKeys: KEYS, now: NOW })
+    expect(res.action).toBe("activated")
+    expect(res.superseded).toEqual([])
+    expect((await s.get("ep-old"))?.status).toBe("active")
+    expect((await s.get("ep-cand"))?.status).toBe("active")
+  })
+```
+
+- [ ] **Step 2: Verify failure**
+
+Run: `pnpm --filter @dawn-ai/memory test write-policy`
+Expected: FAIL — `writePolicyFor` not exported. The approve test fails with action `"deduped"` (semantic policy applied to identical data).
+
+- [ ] **Step 3: Implement**
+
+In `packages/memory/src/reconcile.ts`:
+```ts
+export type WritePolicy = { readonly mode: "reconcile" } | { readonly mode: "append" }
+
+/** Per-kind write discipline. Semantic facts reconcile (identity match →
+ *  update/supersede); episodic events append (a later episode never
+ *  contradicts an earlier one). Procedural/reflection are typed but not yet
+ *  wired — throwing beats baking in accidental semantics. */
+export function writePolicyFor(kind: MemoryKind): WritePolicy {
+  switch (kind) {
+    case "semantic":
+      return { mode: "reconcile" }
+    case "episodic":
+      return { mode: "append" }
+    default:
+      throw new Error(`memory kind '${kind}' is not yet wired (semantic and episodic are)`)
+  }
+}
+```
+In `approveWithReconcile`, immediately after the candidate-status check:
+```ts
+  if (writePolicyFor(candidate.kind).mode === "append") {
+    // Append-only kinds: approval is a plain activation — no identity scan.
+    await store.update(id, { status: "active", updatedAt: opts.now })
+    const approved = await store.get(id)
+    if (!approved) throw new Error(`approved memory ${id} vanished`)
+    return { approved, action: "activated", superseded: [], identityKeys: opts.identityKeys }
+  }
+```
+Export `writePolicyFor` + `WritePolicy` from `packages/memory/src/index.ts`.
+
+- [ ] **Step 4: Green + guard**
+
+Run: `pnpm --filter @dawn-ai/memory test` — ALL memory tests green (the existing 90+ must not change).
+Run: `pnpm --filter @dawn-ai/memory typecheck && pnpm --filter @dawn-ai/memory lint`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git rev-parse --abbrev-ref HEAD
+git add packages/memory
+git commit -m "feat(memory): writePolicyFor kind seam; approve treats append kinds as plain activation"
+```
+
+---
+
+### Task EP2: time windows + expiry exclusion — types + sqlite (+ migration v3 index)
+
+**Files:**
+- Modify: `packages/memory/src/types.ts`, `packages/memory/src/sqlite-store.ts`
+- Test: `packages/memory/test/time-window.test.ts` (create)
+
+- [ ] **Step 1: Types**
+
+`packages/memory/src/types.ts` — add to `MemoryQuery` AND `BrowseQuery`:
+```ts
+  /** ISO lower bound (inclusive) on COALESCE(effectiveAt, createdAt). */
+  readonly since?: string
+  /** ISO upper bound (exclusive) on COALESCE(effectiveAt, createdAt). */
+  readonly until?: string
+```
+`BrowseQuery` additionally gains:
+```ts
+  /** When supplied, rows with expiresAt <= now are excluded (matches search's `now`). */
+  readonly now?: string
+```
+(`MemoryQuery.now` already exists for ranking; its meaning EXTENDS to expiry exclusion — documented on the field: append to its doc comment "Also excludes rows with expiresAt <= now.")
+
+- [ ] **Step 2: Failing tests** — `packages/memory/test/time-window.test.ts`
+
+```ts
+import { mkdtempSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { afterEach, describe, expect, it } from "vitest"
+import { type MemoryRecord, sqliteMemoryStore } from "../src/index.js"
+
+const dirs: string[] = []
+function makeStore() {
+  const dir = mkdtempSync(join(tmpdir(), "dawn-tw-"))
+  dirs.push(dir)
+  return sqliteMemoryStore({ path: join(dir, "m.sqlite") })
+}
+afterEach(() => {
+  for (const d of dirs.splice(0)) rmSync(d, { recursive: true, force: true })
+})
+
+function rec(over: Partial<MemoryRecord> & Pick<MemoryRecord, "id">): MemoryRecord {
+  return {
+    kind: "episodic",
+    namespace: "route=/n",
+    content: over.id,
+    data: {},
+    source: { type: "run", id: "r" },
+    confidence: 1,
+    tags: [],
+    status: "active",
+    createdAt: "2026-08-01T00:00:00.000Z",
+    updatedAt: "2026-08-01T00:00:00.000Z",
+    ...over,
+  }
+}
+const D = (day: number) => `2026-08-0${day}T00:00:00.000Z`
+
+describe("search time windows", () => {
+  it("filters on effectiveAt with inclusive since / exclusive until", async () => {
+    const s = makeStore()
+    await s.put(rec({ id: "d1", effectiveAt: D(1) }))
+    await s.put(rec({ id: "d2", effectiveAt: D(2) }))
+    await s.put(rec({ id: "d3", effectiveAt: D(3) }))
+    const out = await s.search({ namespace: "route=/n", since: D(2), until: D(3) })
+    expect(out.map((r) => r.id)).toEqual(["d2"]) // since inclusive, until exclusive
+  })
+  it("falls back to createdAt for legacy rows without effectiveAt", async () => {
+    const s = makeStore()
+    await s.put(rec({ id: "legacy", createdAt: D(2), updatedAt: D(2) })) // no effectiveAt
+    await s.put(rec({ id: "outside", createdAt: D(5), updatedAt: D(5) }))
+    const out = await s.search({ namespace: "route=/n", since: D(1), until: D(3) })
+    expect(out.map((r) => r.id)).toEqual(["legacy"])
+  })
+  it("windowed query-less search returns event-time order (effectiveAt DESC, id ASC)", async () => {
+    const s = makeStore()
+    // updatedAt order is DELIBERATELY the reverse of effectiveAt order —
+    // proves windowed ordering uses event time, not update time.
+    await s.put(rec({ id: "b", effectiveAt: D(3), updatedAt: D(1) }))
+    await s.put(rec({ id: "a", effectiveAt: D(1), updatedAt: D(3) }))
+    await s.put(rec({ id: "c", effectiveAt: D(3), updatedAt: D(2) }))
+    const out = await s.search({ namespace: "route=/n", since: D(1) })
+    expect(out.map((r) => r.id)).toEqual(["b", "c", "a"]) // D3 pair id-ASC, then D1
+  })
+})
+
+describe("expiry exclusion", () => {
+  it("search with now excludes expired rows; without now shows everything", async () => {
+    const s = makeStore()
+    await s.put(rec({ id: "live", expiresAt: D(9) }))
+    await s.put(rec({ id: "dead", expiresAt: D(2) }))
+    const withNow = await s.search({ namespace: "route=/n", now: D(5) })
+    expect(withNow.map((r) => r.id)).toEqual(["live"])
+    const withoutNow = await s.search({ namespace: "route=/n" })
+    expect(withoutNow.map((r) => r.id).sort()).toEqual(["dead", "live"])
+  })
+  it("boundary: expiresAt exactly equal to now is excluded", async () => {
+    const s = makeStore()
+    await s.put(rec({ id: "edge", expiresAt: D(5) }))
+    expect((await s.search({ namespace: "route=/n", now: D(5) })).length).toBe(0)
+  })
+  it("browse honors now + since/until the same way", async () => {
+    const s = makeStore()
+    await s.put(rec({ id: "live", effectiveAt: D(2), expiresAt: D(9) }))
+    await s.put(rec({ id: "dead", effectiveAt: D(2), expiresAt: D(3) }))
+    const page = await s.browse({ since: D(1), until: D(4), now: D(5) })
+    expect(page.records.map((r) => r.id)).toEqual(["live"])
+    expect(page.total).toBe(1) // COUNT shares the full WHERE incl. expiry+window
+  })
+  it("ranked (query) search also excludes expired and honors the window", async () => {
+    const s = makeStore()
+    await s.put(rec({ id: "hit", content: "deploy failed on staging", effectiveAt: D(2), expiresAt: D(9) }))
+    await s.put(rec({ id: "expired", content: "deploy failed on prod", effectiveAt: D(2), expiresAt: D(3) }))
+    await s.put(rec({ id: "outside", content: "deploy failed early", effectiveAt: D(1) }))
+    const out = await s.search({ namespace: "route=/n", query: "deploy failed", since: D(2), now: D(5) })
+    expect(out.map((r) => r.id)).toEqual(["hit"])
+  })
+})
+```
+
+- [ ] **Step 3: Verify failure**
+
+Run: `pnpm --filter @dawn-ai/memory test time-window`
+Expected: FAIL — since/until silently ignored (rows leak through), expiry not excluded.
+
+- [ ] **Step 4: Implement in sqlite-store.ts**
+
+Read the current WHERE assembly in `search` (query-less, ranked, hybrid paths share `baseSql`/`baseParams`) and `browse`. Add to the SHARED base-clause builder used by every search path:
+```ts
+      if (q.since) {
+        conditions.push("COALESCE(m.effective_at, m.created_at) >= ?")
+        params.push(q.since)
+      }
+      if (q.until) {
+        conditions.push("COALESCE(m.effective_at, m.created_at) < ?")
+        params.push(q.until)
+      }
+      if (q.now) {
+        conditions.push("(m.expires_at IS NULL OR m.expires_at > ?)")
+        params.push(q.now)
+      }
+```
+(Adapt alias `m.` to each site's actual alias; browse has no alias.) Query-less ordering: when `since` or `until` is present, ORDER BY becomes
+`COALESCE(effective_at, created_at) DESC, id ASC` (unwindowed query-less path keeps its existing `updated_at DESC, id ASC` — byte-stable for old callers). Ranked/hybrid paths keep relevance ranking; the window/expiry only filter the candidate pool.
+Browse: same three conditions in its dynamic WHERE (shared by rows + COUNT).
+**Migration v3**: in the schema-migration block (read how v2 added embedding columns), bump the version and add
+`CREATE INDEX IF NOT EXISTS idx_mem_ns_kind_effective ON memories (namespace, kind, effective_at DESC)`.
+Migration test: extend the existing migration test file (find it: `grep -rn "schema_version" packages/memory/test/`) with a v2→v3 open-existing-db case asserting the index exists (`SELECT name FROM sqlite_master WHERE type='index'`).
+
+- [ ] **Step 5: Green + full package + commit**
+
+```bash
+pnpm --filter @dawn-ai/memory test          # all green incl. new file
+pnpm --filter @dawn-ai/memory typecheck && pnpm --filter @dawn-ai/memory lint
+git rev-parse --abbrev-ref HEAD
+git add packages/memory
+git commit -m "feat(memory): since/until time windows + expiry exclusion (sqlite, migration v3 index)"
+```
+
+---
+
+### Task EP3: `prune` — required MemoryStore method, sqlite implementation
+
+**Files:**
+- Modify: `packages/memory/src/types.ts`, `packages/memory/src/sqlite-store.ts`
+- Test: `packages/memory/test/prune.test.ts` (create)
+
+- [ ] **Step 1: Type** — add to `MemoryStore` (REQUIRED):
+
+```ts
+  /** Delete (a) rows of any kind with expiresAt <= now, and (b) when cap is
+   *  set, the oldest episodic rows beyond `cap` per namespace (ordered by
+   *  COALESCE(effectiveAt, createdAt), id tiebreak). */
+  prune(opts: {
+    readonly now: string
+    readonly namespacePrefix?: string
+    readonly cap?: number
+  }): Promise<{ readonly deletedExpired: number; readonly deletedOverCap: number }>
+```
+
+- [ ] **Step 2: Failing tests** — `packages/memory/test/prune.test.ts` (same makeStore/rec/D helpers as EP2's file — import nothing across test files; copy the ~20 helper lines):
+
+```ts
+describe("prune", () => {
+  it("deletes expired rows of any kind and reports the count", async () => {
+    const s = makeStore()
+    await s.put(rec({ id: "sem-dead", kind: "semantic", expiresAt: D(2) }))
+    await s.put(rec({ id: "ep-dead", expiresAt: D(2) }))
+    await s.put(rec({ id: "ep-live", expiresAt: D(9) }))
+    const res = await s.prune({ now: D(5) })
+    expect(res).toEqual({ deletedExpired: 2, deletedOverCap: 0 })
+    expect(await s.get("sem-dead")).toBeNull()
+    expect((await s.get("ep-live"))?.id).toBe("ep-live")
+  })
+  it("caps episodic rows per namespace, keeping the newest by event time", async () => {
+    const s = makeStore()
+    for (let i = 1; i <= 5; i++)
+      await s.put(rec({ id: `e${i}`, effectiveAt: D(i) }))
+    const res = await s.prune({ now: D(9), cap: 3 })
+    expect(res.deletedOverCap).toBe(2)
+    expect((await s.browse({ kind: "episodic" })).records.map((r) => r.id).sort()).toEqual(["e3", "e4", "e5"])
+  })
+  it("cap is PER namespace and never touches non-episodic rows", async () => {
+    const s = makeStore()
+    await s.put(rec({ id: "sem", kind: "semantic", namespace: "route=/n" }))
+    for (let i = 1; i <= 3; i++) await s.put(rec({ id: `a${i}`, namespace: "route=/a", effectiveAt: D(i) }))
+    for (let i = 1; i <= 3; i++) await s.put(rec({ id: `b${i}`, namespace: "route=/b", effectiveAt: D(i) }))
+    const res = await s.prune({ now: D(9), cap: 2 })
+    expect(res.deletedOverCap).toBe(2) // one from each namespace
+    expect(await s.get("a1")).toBeNull()
+    expect(await s.get("b1")).toBeNull()
+    expect((await s.get("sem"))?.id).toBe("sem")
+  })
+  it("equal event times evict by id order (deterministic tiebreak)", async () => {
+    const s = makeStore()
+    // Same effectiveAt; codepoint id order decides. Oldest = LOWEST id first out.
+    await s.put(rec({ id: "B10", effectiveAt: D(2) }))
+    await s.put(rec({ id: "a9", effectiveAt: D(2) }))
+    await s.put(rec({ id: "b2", effectiveAt: D(2) }))
+    await s.prune({ now: D(9), cap: 2 })
+    // Keep the NEWEST 2 under (effective DESC, id ASC) ordering ⇒ evict the last
+    // in that ordering: "b2" (0x62 highest codepoint sorts last among equals).
+    expect(await s.get("b2")).toBeNull()
+    expect((await s.get("B10"))?.id).toBe("B10")
+    expect((await s.get("a9"))?.id).toBe("a9")
+  })
+  it("namespacePrefix narrows both TTL and cap passes", async () => {
+    const s = makeStore()
+    await s.put(rec({ id: "in", namespace: "route=/a", expiresAt: D(2) }))
+    await s.put(rec({ id: "out", namespace: "route=/b", expiresAt: D(2) }))
+    const res = await s.prune({ now: D(5), namespacePrefix: "route=/a" })
+    expect(res.deletedExpired).toBe(1)
+    expect((await s.get("out"))?.id).toBe("out")
+  })
+  it("is idempotent — a second identical prune deletes nothing", async () => {
+    const s = makeStore()
+    for (let i = 1; i <= 4; i++) await s.put(rec({ id: `e${i}`, effectiveAt: D(i), expiresAt: i === 1 ? D(2) : undefined }))
+    await s.prune({ now: D(5), cap: 2 })
+    const second = await s.prune({ now: D(5), cap: 2 })
+    expect(second).toEqual({ deletedExpired: 0, deletedOverCap: 0 })
+  })
+})
+```
+
+- [ ] **Step 3: Verify failure** — `pnpm --filter @dawn-ai/memory test prune` → FAIL (`s.prune is not a function`).
+
+- [ ] **Step 4: Implement** in sqlite-store.ts (next to browse/stats; byte-exact prefix pattern from browse):
+
+```ts
+    async prune(opts) {
+      const prefixCond = opts.namespacePrefix ? " AND substr(namespace, 1, length(?)) = ?" : ""
+      const prefixParams: SQLInputValue[] = opts.namespacePrefix
+        ? [opts.namespacePrefix, opts.namespacePrefix]
+        : []
+      const expired = db
+        .prepare(`DELETE FROM memories WHERE expires_at IS NOT NULL AND expires_at <= ?${prefixCond}`)
+        .run(opts.now, ...prefixParams)
+      let deletedOverCap = 0
+      if (opts.cap !== undefined) {
+        const cap = Math.max(0, Math.trunc(opts.cap))
+        // Rank episodic rows per namespace by event time (newest first, id ASC
+        // tiebreak — the established cross-backend ordering) and delete beyond cap.
+        const over = db
+          .prepare(
+            `DELETE FROM memories WHERE id IN (
+               SELECT id FROM (
+                 SELECT id, ROW_NUMBER() OVER (
+                   PARTITION BY namespace
+                   ORDER BY COALESCE(effective_at, created_at) DESC, id ASC
+                 ) AS rn
+                 FROM memories WHERE kind = 'episodic'${prefixCond.replace(" AND ", " AND ")}
+               ) WHERE rn > ?
+             )`,
+          )
+          .run(...prefixParams, cap)
+        deletedOverCap = Number(over.changes)
+      }
+      return { deletedExpired: Number(expired.changes), deletedOverCap }
+    },
+```
+ADAPT: the inner `${prefixCond}` inside the window subquery needs `WHERE kind='episodic' AND substr(...)` — construct the two SQL strings explicitly rather than string-replacing (the snippet marks intent; write it clean). node:sqlite supports window functions (SQLite ≥3.25) — verify with the test run.
+
+- [ ] **Step 5: Green + typecheck + lint + commit**
+
+Note: `@dawn-ai/memory-pgvector` typecheck now BREAKS (missing prune) — expected, EP4 fixes it; do not touch it.
+```bash
+pnpm --filter @dawn-ai/memory test && pnpm --filter @dawn-ai/memory typecheck && pnpm --filter @dawn-ai/memory lint
+git rev-parse --abbrev-ref HEAD
+git add packages/memory
+git commit -m "feat(memory): required MemoryStore.prune — TTL expiry + per-namespace episodic cap (sqlite)"
+```
+
+---
+
+### Task EP4: pgvector windows/expiry/prune + conformance kit (GATED RUN MANDATORY)
+
+**Files:**
+- Modify: `packages/memory-pgvector/src/pgvector-store.ts`, `packages/memory-pgvector/src/schema.ts`, `packages/testing/src/memory-conformance.ts`
+
+- [ ] **Step 1: Conformance kit FIRST** (the cross-backend contract is the test). Add to `packages/testing/src/memory-conformance.ts`, mirroring EP2/EP3's cases in kit style (`rec()` helper, try/finally close). REQUIRED cases (port each from EP2/EP3 with kit fixtures — write them out fully in the kit):
+  1. window inclusive/exclusive bounds
+  2. legacy-row createdAt fallback
+  3. windowed query-less event-time ordering (use the mixed-case id fixture style `["b2","B10","a9"]` to keep pinning C-collation)
+  4. expiry exclusion with `now` / visibility without `now` / boundary `expiresAt == now`
+  5. browse window+expiry with total sharing the clause
+  6. prune TTL count + cap-per-namespace + non-episodic immunity + equal-time id tiebreak + idempotency
+  7. episodic approve = plain activation (from EP1)
+
+- [ ] **Step 2: Run kit vs sqlite** — `pnpm --filter @dawn-ai/memory build && pnpm --filter @dawn-ai/testing test` → sqlite conformance green (sqlite already implements everything; if any kit case fails against sqlite, fix the EP2/EP3 implementation NOW — the kit is authoritative).
+
+- [ ] **Step 3: pgvector implementation** — in `pgvector-store.ts` (match its `$n` param, `COUNT(*)::int`, `COLLATE "C"` conventions):
+  - search/browse WHERE additions: `COALESCE(effective_at, created_at) >= $n` / `< $n` / `(expires_at IS NULL OR expires_at > $n)`.
+  - windowed query-less ordering `COALESCE(effective_at, created_at) DESC, id COLLATE "C" ASC`.
+  - `prune`: expired DELETE + cap via `ROW_NUMBER() OVER (PARTITION BY namespace ORDER BY COALESCE(effective_at, created_at) DESC, id COLLATE "C" ASC)`, `left(namespace, length($n)) = $n+1` prefix narrowing, counts via `RETURNING`-free `rowCount`.
+  - `schema.ts`: idempotent `CREATE INDEX IF NOT EXISTS <prefix>_ns_kind_effective ON <prefix>_memories (namespace, kind, effective_at DESC)` in `initSchema`.
+
+- [ ] **Step 4: MANDATORY gated run (real Docker — do NOT skip; report the counts)**
+
+```bash
+DAWN_TEST_PGVECTOR=1 pnpm --filter @dawn-ai/memory-pgvector test
+```
+Expected: all green, count grows by the new kit cases (was 32 passed/1 skipped). If Docker is down, start it (`open -a Docker`, wait) — a DONE report without this run is invalid.
+
+- [ ] **Step 5: Typecheck heals + commit**
+
+```bash
+pnpm turbo run typecheck --filter=@dawn-ai/memory --filter=@dawn-ai/memory-pgvector --filter=@dawn-ai/testing
+pnpm --filter @dawn-ai/memory-pgvector lint && pnpm --filter @dawn-ai/testing lint
+git rev-parse --abbrev-ref HEAD
+git add packages/memory-pgvector packages/testing packages/memory
+git commit -m "feat(memory-pgvector): windows/expiry/prune; conformance kit enforces the episodic contract"
+```
+
+---
+
+### Task EP5: config type, capability — policy-aware remember, windowed recall, resolveTimeExpr
+
+**Files:**
+- Modify: `packages/core/src/types.ts` (episodes config), `packages/core/src/capabilities/types.ts` (MemoryStoreLike parity: since/until/now on search+browse, prune), `packages/core/src/capabilities/built-in/memory.ts`
+- Create: `packages/core/src/capabilities/built-in/time-expr.ts`
+- Test: `packages/core/test/time-expr.test.ts`, `packages/core/test/memory-capability-episodic.test.ts` (create; model on the existing memory-capability tests' fake-store pattern)
+
+- [ ] **Step 1: Config type** — `DawnConfig.memory` gains:
+
+```ts
+  episodes?: {
+    readonly enabled?: boolean
+    readonly ttlMs?: number
+    readonly cap?: number
+    readonly includeFailedRuns?: boolean
+    readonly embed?: boolean
+  }
+```
+`MemoryStoreLike`: add `since`/`until` to its search q + browse q, `now` to browse q, and the full `prune` signature (structural mirror — keep the no-core-imports-memory rule; extend the parity tripwire expectations implicitly, the mutual-assignability test in packages/testing will enforce).
+
+- [ ] **Step 2: resolveTimeExpr (TDD)** — `packages/core/test/time-expr.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest"
+import { resolveTimeExpr } from "../src/capabilities/built-in/time-expr.js"
+
+const NOW = "2026-08-05T12:00:00.000Z"
+describe("resolveTimeExpr", () => {
+  it("passes ISO timestamps through unchanged", () => {
+    expect(resolveTimeExpr("2026-08-01T00:00:00.000Z", NOW)).toBe("2026-08-01T00:00:00.000Z")
+  })
+  it("resolves relative offsets against now", () => {
+    expect(resolveTimeExpr("-24h", NOW)).toBe("2026-08-04T12:00:00.000Z")
+    expect(resolveTimeExpr("-7d", NOW)).toBe("2026-07-29T12:00:00.000Z")
+    expect(resolveTimeExpr("-30m", NOW)).toBe("2026-08-05T11:30:00.000Z")
+  })
+  it("rejects garbage with an actionable error", () => {
+    expect(() => resolveTimeExpr("yesterday", NOW)).toThrow(/ISO timestamp or relative/)
+    expect(() => resolveTimeExpr("-3y", NOW)).toThrow(/ISO timestamp or relative/)
+  })
+})
+```
+Implementation (`time-expr.ts`):
+```ts
+const RELATIVE = /^-(\d+)([mhd])$/
+const UNIT_MS = { m: 60_000, h: 3_600_000, d: 86_400_000 } as const
+
+/** "-24h" | "-7d" | "-30m" | ISO → ISO, resolved against `now`. Pure. */
+export function resolveTimeExpr(expr: string, now: string): string {
+  const rel = RELATIVE.exec(expr)
+  if (rel) {
+    const [, n, unit] = rel
+    return new Date(Date.parse(now) - Number(n) * UNIT_MS[unit as keyof typeof UNIT_MS]).toISOString()
+  }
+  const parsed = Date.parse(expr)
+  if (Number.isNaN(parsed)) {
+    throw new Error(
+      `invalid time '${expr}' — use an ISO timestamp or relative offset like "-24h", "-7d", "-30m"`,
+    )
+  }
+  return new Date(parsed).toISOString()
+}
+```
+
+- [ ] **Step 3: Capability changes** (`built-in/memory.ts`) — read the file top-to-bottom first:
+  - `recallSchema` gains `since: z.string().optional().describe('ISO timestamp or relative offset ("-24h", "-7d") — inclusive lower bound on when the memory happened.')` and matching `until` (exclusive). In `run`, resolve via `resolveTimeExpr` inside try/catch → on error return the tool-error message (not a throw), then thread `since`/`until` into `store.search`.
+  - `remember`: consult `writePolicyFor` — BUT core cannot import `@dawn-ai/memory`. Duplicate the 12-line policy switch locally (mirror-comment both sides: `// mirrored in packages/memory/src/reconcile.ts writePolicyFor — keep in sync`), OR (preferred if trivially possible) inline: `const append = mem.defined.kind === "episodic"`. Choose the inline boolean + comment — the full policy fn's throw-on-deferred already happens because remember only runs for the route's declared kind, and `loadRouteMemory` accepts all four; so ADD an explicit guard: if kind is procedural/reflection, return a tool error "kind not yet wired". For `append`: skip the identity/reconcile block entirely; put as active (auto/ask) or candidate; set `effectiveAt: new Date(now).toISOString()` (request time — the capability already has a now source; check how updatedAt is stamped and reuse), NO expiresAt.
+  - `ask` mode + append: no gate fires (no supersede branch) — add the doc comment.
+
+- [ ] **Step 4: Capability tests** — `packages/core/test/memory-capability-episodic.test.ts` (copy the fake-store scaffolding from `memory-capability-recall.test.ts`; the fake must now also implement prune):
+  1. episodic remember appends twice with identical data → two puts, zero supersede/update calls (assert via fake-store call log)
+  2. candidate mode → status candidate
+  3. procedural kind → tool result contains "not yet wired", no store calls
+  4. recall passes resolved ISO since/until to search (fake asserts args; relative "-24h" resolved against the request clock)
+  5. recall with garbage since → tool result contains the actionable message, search NOT called
+
+- [ ] **Step 5: Green + commit**
+
+```bash
+pnpm --filter @dawn-ai/core test && pnpm --filter @dawn-ai/core typecheck && pnpm --filter @dawn-ai/core lint
+pnpm --filter @dawn-ai/testing test   # parity tripwire must still hold
+git rev-parse --abbrev-ref HEAD
+git add packages/core packages/testing
+git commit -m "feat(core): episodic remember appends; recall gains since/until with relative time parsing"
+```
+
+---
+
+### Task EP6: runtime auto-recorder (+ concurrency + burst tests)
+
+**Files:**
+- Create: `packages/cli/src/lib/runtime/record-episode.ts`
+- Modify: `packages/cli/src/lib/runtime/execute-route.ts`, `packages/cli/src/lib/runtime/resolve-memory.ts` (export a `resolveEpisodesConfig(appRoot)` reading `config.memory.episodes` with defaults)
+- Test: `packages/cli/test/record-episode.test.ts` (unit), `packages/cli/test/episodic-recorder.test.ts` (harness integration; model on existing aimock harness tests — read `packages/testing/src/harness.ts` usage in `packages/cli/test/` first)
+
+- [ ] **Step 1: Pure unit — episode construction (TDD)** — `record-episode.test.ts` against an exported pure builder:
+
+```ts
+import { describe, expect, it } from "vitest"
+import { buildEpisode } from "../src/lib/runtime/record-episode.js"
+
+const BASE = {
+  namespace: "workspace=app|route=/chat",
+  input: "Please summarize the Q3 report and email it to the team",
+  outcome: "ok" as const,
+  toolsUsed: ["readFile", "sendEmail"],
+  startedAt: 1754630400000, // 2026-08-08T04:40:00.000Z? use real: Date "2026-08-08..." — compute in test via Date.parse
+  finishedAt: 1754630404200,
+  ttlMs: 30 * 86_400_000,
+  runId: "run-123",
+  threadId: "th-9",
+}
+
+describe("buildEpisode", () => {
+  it("builds a deterministic, idempotent record", () => {
+    const a = buildEpisode(BASE)
+    const b = buildEpisode(BASE)
+    expect(a.id).toBe(b.id)
+    expect(a.id).toMatch(/^memory_ep_[0-9a-f]{16}$/)
+    expect(a.kind).toBe("episodic")
+    expect(a.status).toBe("active")
+    expect(a.source).toEqual({ type: "run", id: "run-123" })
+    expect(a.effectiveAt).toBe(new Date(BASE.startedAt).toISOString())
+    expect(a.expiresAt).toBe(new Date(BASE.startedAt + BASE.ttlMs).toISOString())
+    expect(a.data.durationMs).toBe(4200)
+    expect(a.content).toMatch(/^run ok: /)
+    expect(a.content).toContain("(2 tools, 4.2s)")
+  })
+  it("truncates input in content (~80 chars) and data (~500 chars)", () => {
+    const long = buildEpisode({ ...BASE, input: "x".repeat(1000) })
+    expect(long.content.length).toBeLessThan(120)
+    expect((long.data.input as string).length).toBeLessThanOrEqual(500)
+  })
+  it("failure outcome renders and records", () => {
+    const f = buildEpisode({ ...BASE, outcome: "error" })
+    expect(f.content).toMatch(/^run error: /)
+    expect(f.data.outcome).toBe("error")
+  })
+  it("different runIds produce different ids", () => {
+    expect(buildEpisode(BASE).id).not.toBe(buildEpisode({ ...BASE, runId: "run-124" }).id)
+  })
+})
+```
+
+- [ ] **Step 2: Implement `record-episode.ts`**
+
+```ts
+import { createHash } from "node:crypto"
+import type { MemoryRecord, MemoryStore } from "@dawn-ai/memory"
+
+export interface EpisodeInput {
+  readonly namespace: string
+  readonly input: string
+  readonly outcome: "ok" | "error"
+  readonly toolsUsed: readonly string[]
+  readonly startedAt: number
+  readonly finishedAt: number
+  readonly ttlMs: number
+  readonly runId?: string
+  readonly threadId?: string
+}
+
+export function buildEpisode(ep: EpisodeInput): MemoryRecord {
+  const startedIso = new Date(ep.startedAt).toISOString()
+  const sourceId = ep.runId ?? ep.threadId ?? startedIso
+  const id = `memory_ep_${createHash("sha1")
+    .update(`${ep.namespace}|${sourceId}|${startedIso}`)
+    .digest("hex")
+    .slice(0, 16)}`
+  const durationMs = Math.max(0, ep.finishedAt - ep.startedAt)
+  const seconds = (durationMs / 1000).toFixed(1)
+  const inputLine = ep.input.replaceAll("\n", " ").slice(0, 80)
+  const writtenAt = new Date(ep.finishedAt).toISOString()
+  return {
+    id,
+    kind: "episodic",
+    namespace: ep.namespace,
+    content: `run ${ep.outcome}: ${inputLine} (${ep.toolsUsed.length} tools, ${seconds}s)`,
+    data: {
+      input: ep.input.slice(0, 500),
+      outcome: ep.outcome,
+      toolsUsed: [...ep.toolsUsed],
+      durationMs,
+      ...(ep.threadId ? { threadId: ep.threadId } : {}),
+      ...(ep.runId ? { runId: ep.runId } : {}),
+    },
+    source: { type: "run", id: sourceId },
+    confidence: 1,
+    tags: [],
+    status: "active",
+    createdAt: writtenAt,
+    updatedAt: writtenAt,
+    effectiveAt: startedIso,
+    expiresAt: new Date(ep.startedAt + ep.ttlMs).toISOString(),
+  }
+}
+
+/** Write an episode + lazy retention. NEVER throws — recorder failures must not
+ *  fail a user's run; logged once per process. */
+let warnedOnce = false
+export async function recordEpisode(
+  store: MemoryStore,
+  ep: EpisodeInput,
+  opts: { readonly cap: number },
+): Promise<void> {
+  try {
+    const record = buildEpisode(ep)
+    await store.put(record)
+    await store.prune({
+      now: new Date(ep.finishedAt).toISOString(),
+      namespacePrefix: ep.namespace,
+      cap: opts.cap,
+    })
+  } catch (error) {
+    if (!warnedOnce) {
+      warnedOnce = true
+      console.warn(`[dawn] episode recording failed (further failures muted): ${String(error)}`)
+    }
+  }
+}
+```
+
+- [ ] **Step 3: executeRoute wiring** — read `execute-route.ts`'s success/failure return sites (~1097/1110) and the memory-context block (~784-793). Requirements (adapt precisely to the file):
+  - Resolve episodes config alongside the memory context (only when a memory context exists). `resolveEpisodesConfig(appRoot)` in resolve-memory.ts: reads `loadDawnConfig` (same cached loader), returns `{ enabled: false }` defaults; DEFAULTS: ttlMs 30d, cap 500, includeFailedRuns true, embed false.
+  - After the run settles (both the success return and the execution-error catch), when `episodes.enabled && memoryContext && writes !== "off"` and (outcome === "ok" || includeFailedRuns): fire `recordEpisode` with namespace from the memory context, input = the user's message text (extract the same way the run input was built — find where the human message text is available; truncation happens in the builder), toolsUsed = tool names extracted from the output messages (AIMessage tool_calls / ToolMessage names — write a small pure `extractToolNames(output): string[]` in record-episode.ts with its own unit test: AIMessage with 2 tool_calls + unrelated messages → 2 unique names), outcome, startedAt = options.startedAt, finishedAt = Date.now(), runId = <the run/thread identifier available — investigate what execute-route has; threadId exists>, ttl/cap from config. AWAIT it (it never throws) — do not fire-and-forget (test determinism + process exit safety).
+  - `embed: false` this cycle means: recorder never calls the embedder (episodes are keyword+time recalled). The config flag exists but only `false` ships; a `true` value logs a one-line "not yet supported" warning at resolve time (honest, forward-compatible).
+
+- [ ] **Step 4: Harness integration tests** — `packages/cli/test/episodic-recorder.test.ts`, aimock harness + a probe app fixture with memory.ts (copy the memory probe fixture pattern from existing memory e2e tests — find with `grep -rn "memory-chat" packages/cli/test packages/testing/test`). REQUIRED cases:
+  1. enabled run → exactly one episode in the store, correct namespace/kind/source.type "run", effectiveAt==run start, expiresAt==start+ttl, toolsUsed non-empty when the fixture calls a tool
+  2. default (episodes absent) → zero episodes
+  3. `writes: "off"` + enabled → zero episodes
+  4. failed run (fixture that throws) with includeFailedRuns default → episode with outcome "error"; with includeFailedRuns false → none
+  5. idempotent retry: call the recorder twice with the same inputs (unit-level via recordEpisode against a real sqlite store) → one row
+  6. burst + cap: config cap 3, run 5 harness runs → store holds exactly 3 episodes, newest by event time
+  7. CONCURRENCY: `Promise.all` of 8 `recordEpisode` calls (distinct runIds, same namespace, real sqlite store, cap 5) → no throw, exactly 5 rows remain, all rows well-formed (WAL handles concurrent writers in-process; this pins no-lost-write/no-crash behavior)
+
+- [ ] **Step 5: Green + full cli suite + commit**
+
+```bash
+pnpm --filter @dawn-ai/cli test record-episode episodic-recorder
+pnpm --filter @dawn-ai/cli test        # FULL suite — no regressions
+pnpm --filter @dawn-ai/cli typecheck && pnpm --filter @dawn-ai/cli lint
+git rev-parse --abbrev-ref HEAD
+git add packages/cli
+git commit -m "feat(cli): episodic auto-recorder — one episode per run, TTL+cap retention, never fails a run"
+```
+
+---
+
+### Task EP7: `dawn memory prune` command
+
+**Files:**
+- Modify: `packages/cli/src/commands/memory.ts`
+- Test: `packages/cli/test/memory-command.test.ts` (extend)
+
+- [ ] **Step 1: Failing test** (reuse the file's seeding pattern):
+
+```ts
+  test("prune deletes expired rows and reports counts", async () => {
+    // Seed: one expired row (expiresAt in the past), one live episodic row.
+    // Run: runMemoryCommand(["prune"], { cwd: appRoot }, io)
+    // Assert: stdout contains "deleted 1 expired" and "0 over-cap"; live row remains.
+  })
+  test("prune --cap enforces the episodic cap", async () => {
+    // Seed 4 episodic rows with ascending effectiveAt; run ["prune", "--cap", "2"];
+    // assert 2 oldest gone, stdout reports "2 over-cap".
+  })
+```
+Write both fully against the file's real helpers (same instruction as the approve tests — the harness exists in the file).
+
+- [ ] **Step 2: Implement** — new subcommand in `runMemoryCommand` dispatch: `prune` with optional `--cap <n>` and `--namespace <prefix>` args (parse from argv the way the file parses subcommand args; commander options exist only for --cwd, so parse `--cap`/`--namespace` from the args array — read how other subcommands take args first and match). Calls `store.prune({ now: new Date().toISOString(), ...(cap ? { cap } : {}), ...(ns ? { namespacePrefix: ns } : {}) })`, prints `pruned: N expired, M over-cap`. Update the USAGE string.
+
+- [ ] **Step 3: Green + commit**
+
+```bash
+pnpm --filter @dawn-ai/cli test memory-command && pnpm --filter @dawn-ai/cli typecheck && pnpm --filter @dawn-ai/cli lint
+git rev-parse --abbrev-ref HEAD
+git add packages/cli
+git commit -m "feat(cli): dawn memory prune — manual TTL + cap retention pass"
+```
+
+---
+
+### Task EP8: Inspector — API windows + timeline view (GATED RUN MANDATORY)
+
+**Files:**
+- Modify: `packages/inspector/app/api/memory/list/route.ts`, `packages/inspector/src/components/memory/list-page.tsx`
+- Create: `packages/inspector/src/components/memory/timeline-view.tsx`
+- Test: `packages/inspector/test/components/timeline.test.tsx` (create), `packages/inspector/test/api.e2e.test.ts` (extend)
+
+- [ ] **Step 1: API** — list route passes through `since`/`until` (validate: `Date.parse` finite else 400 `{error}`), supplies `now: new Date().toISOString()` to browse by DEFAULT; `includeExpired=1` omits `now`. (Mirror the route's existing parseEnum/400 style.)
+
+- [ ] **Step 2: Timeline component** — `timeline-view.tsx`:
+
+```tsx
+"use client"
+import type { MemoryRecord } from "@dawn-ai/memory"
+import { Badge } from "../ui/badge"
+
+function dayOf(r: MemoryRecord): string {
+  return (r.effectiveAt ?? r.createdAt).slice(0, 10)
+}
+
+export function TimelineView({
+  records,
+  onSelect,
+}: {
+  records: readonly MemoryRecord[]
+  onSelect: (id: string) => void
+}) {
+  const days = new Map<string, MemoryRecord[]>()
+  for (const r of records) {
+    const day = dayOf(r)
+    const bucket = days.get(day)
+    if (bucket) bucket.push(r)
+    else days.set(day, [r])
+  }
+  return (
+    <div className="p-4" data-testid="timeline-view">
+      {[...days.entries()].map(([day, rows]) => (
+        <section key={day} className="mb-6">
+          <h2 className="mb-2 text-xs font-semibold uppercase tracking-wide text-zinc-400">{day}</h2>
+          <ol className="space-y-1">
+            {rows.map((r) => {
+              const outcome = typeof r.data.outcome === "string" ? r.data.outcome : undefined
+              const durationMs = typeof r.data.durationMs === "number" ? r.data.durationMs : undefined
+              return (
+                <li key={r.id}>
+                  <button
+                    type="button"
+                    onClick={() => onSelect(r.id)}
+                    className="flex w-full items-center gap-2 rounded-md px-2 py-1 text-left text-sm hover:bg-zinc-50"
+                    aria-label={`Open episode: ${r.content}`}
+                  >
+                    <span className="w-14 shrink-0 font-mono text-xs text-zinc-400">
+                      {(r.effectiveAt ?? r.createdAt).slice(11, 16)}
+                    </span>
+                    {outcome ? (
+                      <Badge variant={outcome === "ok" ? "active" : "candidate"}>{outcome}</Badge>
+                    ) : (
+                      <Badge>authored</Badge>
+                    )}
+                    <span className="truncate" title={r.content}>{r.content}</span>
+                    {durationMs !== undefined ? (
+                      <span className="ml-auto shrink-0 text-xs text-zinc-400">{(durationMs / 1000).toFixed(1)}s</span>
+                    ) : null}
+                  </button>
+                </li>
+              )
+            })}
+          </ol>
+        </section>
+      ))}
+      {records.length === 0 ? <p className="text-sm text-zinc-400">No episodes in this window.</p> : null}
+    </div>
+  )
+}
+```
+(NOTE: outcome "error" should read as an error — add a `danger` Badge variant `bg-red-100 text-red-800` in badge.tsx and use it for `outcome === "error"`; adjust the snippet accordingly.)
+
+- [ ] **Step 3: list-page toggle** — add `view: "list" | "timeline"` state + toolbar toggle buttons (aria-pressed); timeline mode sets the fetch's `kind` default to `episodic` (still user-overridable via the kind select) and renders `<TimelineView records={records} onSelect={setSelectedId} />` instead of the grid; detail sheet unchanged (episodes open in it). Sorting note: timeline consumes browse's windowed event-time order when since/until set — ALSO thread optional `since` from a small "window" select in timeline mode (`24h | 7d | 30d | all`, computed client-side to ISO with `Date.now()`).
+
+- [ ] **Step 4: Component tests** — `timeline.test.tsx` (stubGlobal fetch pattern from list.test.tsx):
+  1. two records across two days → two day headings, rows under each, ok/error badges + duration rendered
+  2. agent-authored record (no outcome) → "authored" badge
+  3. click row → onSelect wired through ListPage (render ListPage in timeline mode, click, detail-sheet testid appears)
+  4. empty window → "No episodes in this window."
+
+- [ ] **Step 5: e2e extension** (`api.e2e.test.ts`) — seed episodes with distinct effectiveAt + one expired; assert: since/until filtering over HTTP; expired hidden by default; `includeExpired=1` reveals; invalid since → 400 `{error}`.
+
+- [ ] **Step 6: MANDATORY gated run + commit**
+
+```bash
+pnpm --filter @dawn-ai/inspector build           # zero warnings
+DAWN_TEST_INSPECTOR=1 pnpm --filter @dawn-ai/inspector test    # ALL green — do not skip
+pnpm --filter @dawn-ai/inspector typecheck && pnpm --filter @dawn-ai/inspector lint
+git rev-parse --abbrev-ref HEAD
+git add packages/inspector
+git commit -m "feat(inspector): timeline view + since/until/includeExpired on the list API"
+```
+
+---
+
+### Task EP9: dogfood, live smoke, docs, changeset
+
+**Files:**
+- Modify: `examples/memory/server/dawn.config.ts` (enable episodes), `apps/web/content/docs/memory.mdx`, `apps/web/content/docs/upgrading.mdx`, `apps/web/content/docs/inspector.mdx`, `docs/dev/memory-system.md`
+- Create: `packages/testing/test/episodic-live.smoke.test.ts` (doubly-gated), `.changeset/episodic-memory.md`
+
+- [ ] **Step 1: Dogfood** — `examples/memory/server/dawn.config.ts`: add `episodes: { enabled: true }` to the memory block (defaults for the rest). Run the example's tests (`pnpm --filter @dawn-example/memory test`) — must stay green.
+
+- [ ] **Step 2: Live smoke** (model on `packages/testing/test/memory-live.smoke.test.ts` — same gating comment header, `it.skipIf(!live)`, probe-app fixture WITH `episodes: { enabled: true }` in its dawn.config):
+  - Run the harness live twice with distinct inputs; then ask: `"Using your long-term memory, what did you do in the last day? Use recall with since set."`; assert `expectToolCalled(r, "recall")` and the final message references content from at least one recorded episode (assert on a distinctive token from run 1's input).
+  - NEVER add to CI; key loaded only via the established `.env` pattern. This test is run LOCALLY by the controller at the end (doubly-gated: OPENAI_API_KEY).
+
+- [ ] **Step 3: Docs**
+  - `memory.mdx`: new "Episodic memory" section — enabling (`memory.episodes`), what gets recorded (shape, one per run, `source.type: "run"`), retention (TTL 30d + cap 500, `dawn memory prune`), time-windowed recall (`since`/`until`, relative forms), governance (auto-episodes bypass writes modes except `"off"`; agent-authored honor modes; ask never gates appends), agent-authored episodic routes (`defineMemory({ kind: "episodic" })`), auto-episodes not embedded (keyword+time recall).
+  - `upgrading.mdx`: "MemoryStore now requires `prune`" section (signature + semantics; conformance kit covers it; search/browse accept since/until and exclude expired when now supplied).
+  - `inspector.mdx`: timeline view paragraph (+ includeExpired note).
+  - `docs/dev/memory-system.md`: episodic now shipped — recorder architecture, policy seam, deferred list shrinks to procedural/reflection/consolidation/graph.
+  - Run the docs checker (`node scripts/check-docs.mjs`).
+
+- [ ] **Step 4: Changeset** — `.changeset/episodic-memory.md`:
+
+```md
+---
+"@dawn-ai/memory": patch
+"@dawn-ai/memory-pgvector": patch
+"@dawn-ai/core": patch
+"@dawn-ai/cli": patch
+"@dawn-ai/inspector": patch
+"@dawn-ai/testing": patch
+---
+
+Episodic memory: Dawn apps can now remember what happened. An opt-in runtime
+recorder (`memory.episodes.enabled`) writes one episode per agent run from the
+trace — input, outcome, tools used, duration — with TTL + per-namespace cap
+retention; routes can also author episodes via `defineMemory({ kind: "episodic" })`
+(append-only, never superseded). `recall` gains `since`/`until` time windows
+(ISO or relative like "-24h"); the Inspector gains a timeline view; `dawn memory
+prune` runs retention manually.
+
+BREAKING: `MemoryStore` now requires `prune(opts)`; `search`/`browse` accept
+`since`/`until` and exclude expired rows when `now` is supplied. Custom stores
+must implement `prune` (`runMemoryStoreConformance` enforces the contract).
+```
+(PATCH — fixed 0.x group, GOTCHA 6.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git rev-parse --abbrev-ref HEAD
+git add examples apps docs packages/testing .changeset
+git commit -m "docs(memory): episodic docs + upgrade notes; examples/memory records episodes; changeset (patch, breaking prune stated)"
+```
+
+---
+
+### Task EP10: full validate + harness lanes (MANDATORY before final report)
+
+- [ ] **Step 1: Full workspace**
+
+```bash
+pnpm build && pnpm turbo run typecheck && pnpm test 2>&1 | tail -8
+pnpm pack:check 2>&1 | tail -3
+node scripts/check-docs.mjs
+```
+All green.
+
+- [ ] **Step 2: Gated lanes (ALL MANDATORY — report each count)**
+
+```bash
+DAWN_TEST_PGVECTOR=1 pnpm --filter @dawn-ai/memory-pgvector test
+DAWN_TEST_INSPECTOR=1 pnpm --filter @dawn-ai/inspector test
+```
+
+- [ ] **Step 3: All three harness lanes (MANDATORY — the user directive)**
+
+```bash
+pnpm verify:harness:framework
+pnpm verify:harness:runtime
+pnpm verify:harness:smoke
+```
+(macOS /private/tmp known-false runtime failures exempt per repo memory — note if seen.)
+
+- [ ] **Step 4: Commit any stragglers; report full results.** The controller then runs the doubly-gated live smoke locally (`set -a; . ./.env; set +a` in the one smoke shell — key never printed, never in CI) before the PR.
+
+---
+
+## Post-plan notes for the controller
+
+- No new package → NO OIDC bootstrap this cycle. Patch changeset; verify the Version PR shows 0.8.15 for the fixed group before admin-merge.
+- Review cadence per user directive: two-stage review per task + final whole-branch review; reviewers must check the gated-run evidence in implementer reports (a DONE without the mandatory gated counts gets bounced).
+- The concurrency and burst tests (EP6) and the boundary/property tests (EP2-EP4) are the robustness backbone — spec reviewers should verify they exist EXACTLY as enumerated, not sampled.
+- Live smoke (EP9) is controller-run with the local key, after EP10 goes green.

--- a/docs/superpowers/specs/2026-08-05-episodic-memory-design.md
+++ b/docs/superpowers/specs/2026-08-05-episodic-memory-design.md
@@ -1,0 +1,286 @@
+# Episodic Memory Design (Phase 4 — memory follow-up)
+
+Date: 2026-08-05
+Status: approved design, pending implementation plan
+Branch: `feat/episodic-memory` (created off origin/main @ 0.8.14)
+Prior art: long-term memory (#250), hybrid recall (#313), pgvector backend (#318),
+Memory Inspector (#377)
+
+## Goal
+
+Wire the **episodic kind end-to-end**: Dawn apps automatically remember *what
+happened* — one episode per agent run, recorded from the trace the runtime
+already holds — and agents can additionally author salient episodes themselves.
+Episodes accumulate (append-only, never supersede), live in time (`effectiveAt`
+is real, `expiresAt` drives retention), answer temporal questions ("what
+happened in yesterday's runs?") through time-windowed recall, and render as a
+timeline in the Inspector.
+
+Success = a developer flips `memory.episodes.enabled`, runs their agent a few
+times, asks "what did you do for me this week?", and the agent answers from
+recorded episodes — while `dawn inspect` shows the same history as a
+day-grouped timeline.
+
+## Background — what exists today
+
+- `MemoryKind` includes `"episodic"` at every layer (types, `defineMemory`,
+  capability, stores) but **nothing writes or special-cases it**. The only
+  kind-specific behavior anywhere is the semantic identity default
+  (`["subject","predicate"]`).
+- `effectiveAt`/`expiresAt` are **persisted but dormant**: columns exist in both
+  backends (sqlite `effective_at`/`expires_at`, pgvector likewise), typed on
+  `MemoryRecord`, written by nobody, read by no query.
+- Reconciliation is supersede-shaped everywhere (capability auto path,
+  `classifyWrite`, `approveWithReconcile`) — correct for beliefs, wrong for
+  events: an episode is never "contradicted" by a later one.
+- `MemoryQuery` has no time window; recency is decay-based ranking, not
+  filtering. `BrowseQuery` likewise.
+- No producer exists: `remember` writes whatever kind the route declares, and
+  the runtime records nothing.
+- The Inspector (just shipped, #377) gives episodes a free tier automatically:
+  kind filter, browse, detail sheet, `stats.byKind`.
+
+## Decisions (locked in brainstorming)
+
+- **Episodic first** among the deferred items — it is the dependency root:
+  reflection derives from episodes, consolidation consumes them, the graph is
+  orthogonal and speculative. Procedural/reflection stay typed-but-deferred.
+- **Both producers**: a deterministic **runtime auto-recorder** (one episode per
+  run, from the trace, zero model cost) AND **agent-authored** episodes via
+  `remember` on routes that declare `kind: "episodic"`. The auto-recorder ships
+  first inside the cycle; agent-authored rides the same append policy.
+- **Recall extends, no new tool**: the existing `recall` tool gains
+  `since`/`until` (ISO or relative like `"-24h"`, `"-7d"`); `MemoryQuery` gains
+  the window, honored by both backends. One tool, one mental model.
+- **Retention = TTL + cap (belt and braces)**: auto-episodes expire via
+  `expiresAt` (default 30 days) AND a per-namespace cap (default 500) bounds
+  burst traffic. Agent-authored episodes get NO default expiry — the model
+  recorded them as durable.
+- **Inspector timeline view in-cycle**: a list/timeline toggle inside the
+  existing Memory panel (day-grouped, outcome badges, durations) — not a
+  separate panel.
+- **Approach A — post-run hook + per-kind policy seam** (chosen over a
+  middleware recorder and checkpoint-derived batch): `executeRoute` completion
+  fires the recorder in-process (it holds input, tool calls, outcome, timing,
+  and the memory context); per-kind write behavior becomes a pure
+  `writePolicyFor(kind)` seam in `@dawn-ai/memory`. Live, no model cost,
+  smallest new surface, and the seam is what procedural/reflection will need.
+- **Governance**: auto-episodes **bypass** `writes` modes — they are
+  observations, not beliefs; flooding the candidate queue with run logs would
+  bury real candidates. `writes: "off"` still disables ALL memory writes,
+  including the recorder. Agent-authored episodic `remember` honors the normal
+  modes (candidate/auto/ask) but never supersedes; in `ask` mode there is no
+  supersede branch to gate, so episodic asks never interrupt (documented).
+- **Auto-episodes are NOT embedded by default** (`episodes.embed`, default
+  `false`): embedding every run costs an API call per run; keyword + time-window
+  recall is the 90% case. Agent-authored episodes follow the capability's
+  normal embed path (they flow through `remember`).
+
+## Non-goals (deferred, noted)
+
+Procedural/reflection wiring; background consolidation ("summarize then
+delete" — retention here is mechanical TTL/cap only); memory graph; BM25/FTS5;
+sqlite-vec ANN; cross-run correlation or session stitching; a dedicated
+timeline *panel* (this cycle adds a view toggle inside the Memory panel);
+recording episodes for routes without `memory.ts` (no namespace to write into).
+
+## Architecture
+
+### 1. `@dawn-ai/memory` — the pure layer
+
+**`writePolicyFor(kind)`** (new, `reconcile.ts`): returns the write discipline
+for a kind:
+
+```ts
+export type WritePolicy =
+  | { mode: "reconcile" }   // semantic: classifyWrite → add/update/supersede
+  | { mode: "append" }      // episodic: always add; no identity, no supersession
+export function writePolicyFor(kind: MemoryKind): WritePolicy
+```
+
+`"semantic"` → `reconcile`; `"episodic"` → `append`; `"procedural"` /
+`"reflection"` → **throw** a clear "kind not yet wired" error (they are
+deferred, and silently treating them as either policy would bake in accidental
+semantics). `approveWithReconcile` consults the policy: approving an episodic
+candidate is a plain activation (no identity scan).
+
+**Time windows** (`types.ts`): `MemoryQuery` and `BrowseQuery` gain
+`since?: string` / `until?: string` (ISO only — the store stays clock-free and
+parse-free; relative forms are resolved by callers). The filter column is
+`COALESCE(effective_at, created_at)` in both backends, so records that predate
+this feature (no `effectiveAt`) still window correctly. Semantics: `since` is
+inclusive, `until` exclusive.
+
+**Expiry exclusion**: `search` and `browse` exclude rows with
+`expires_at <= :now` when the caller supplies `now` (both queries already/now
+accept it; the library never reads a clock). Callers that omit `now` see
+everything — `dawn memory inspect` and debugging stay honest.
+
+**`prune`** (new REQUIRED `MemoryStore` method — same pre-1.0 no-back-compat
+stance as `browse`/`stats`, conformance-kit enforced):
+
+```ts
+prune(opts: {
+  readonly now: string
+  readonly namespacePrefix?: string
+  readonly cap?: number          // per-namespace: keep newest `cap` episodic rows
+}): Promise<{ readonly deletedExpired: number; readonly deletedOverCap: number }>
+```
+
+Deletes (a) rows of any kind with `expires_at <= now`, (b) when `cap` is set,
+the oldest **episodic** rows beyond `cap` per namespace (ordered by
+`COALESCE(effective_at, created_at)`, tiebreak `id COLLATE "C"` — the
+established cross-backend ordering). Implemented in SQL in both backends;
+byte-identical semantics via the conformance kit.
+
+**Ordering**: query-less `search` with a time window, and the timeline surfaces,
+order by `COALESCE(effective_at, created_at) DESC, id ASC` — event time, not
+update time (id tiebreak uses the established cross-backend discipline:
+BINARY on sqlite, `COLLATE "C"` on Postgres — same as browse/prune). Ranked
+(query) search inside a window keeps relevance ranking.
+
+**Indexes**: sqlite migration v3 adds
+`idx_mem_ns_kind_effective (namespace, kind, effective_at DESC)`; pgvector adds
+the equivalent `CREATE INDEX IF NOT EXISTS` (idempotent init, existing
+pattern). Existing databases migrate transparently (additive index only — no
+row rewrites).
+
+### 2. Auto-recorder — CLI runtime
+
+New `recordEpisode` in `packages/cli/src/lib/runtime/` fired from
+`executeRoute`'s completion path (both success and failure) when:
+`config.memory.episodes?.enabled === true` AND the route has a memory context
+(namespace exists) AND `writes !== "off"`.
+
+Config (`DawnConfig.memory.episodes`):
+
+```ts
+episodes?: {
+  enabled?: boolean        // default false — opt-in
+  ttlMs?: number           // default 30 days
+  cap?: number             // default 500 per namespace
+  includeFailedRuns?: boolean  // default true
+  embed?: boolean          // default false
+}
+```
+
+The episode record:
+
+- `kind: "episodic"`, `status: "active"` (bypasses writes modes by design),
+  `namespace` = the route's memory namespace (same derivation as remember).
+- `content` = one summary line: `run ok: <first ~80 chars of user input> (3 tools, 4.2s)`.
+- `data` = `{ input: string (truncated ~500 chars), outcome: "ok" | "error",
+  toolsUsed: string[], durationMs: number, threadId?: string, runId?: string }`.
+- `source` = `{ type: "run", id: <runId or thread id> }` — the dormant `"run"`
+  source type finally used.
+- `effectiveAt` = run start (ISO); `expiresAt` = start + ttl;
+  `createdAt`/`updatedAt` = write time.
+- `id` = `memory_ep_<sha1(namespace|runId|startedAt)[:16]>` — deterministic, so
+  a retried write is idempotent.
+
+After each write the recorder runs **lazy retention**:
+`store.prune({ now, namespacePrefix: namespace, cap })`. Recorder failures are
+logged and swallowed — an episode write must never fail a user's run.
+
+### 3. Agent-authored episodes — capability
+
+Routes declare `defineMemory({ kind: "episodic", schema, ... })`. The
+capability's `remember` consults `writePolicyFor(kind)`:
+
+- `append` → no identity scan, no supersede; `put` as `active` (auto/ask) or
+  `candidate` (candidate mode). `ask` never gates (no supersede branch) —
+  documented in the mode docs.
+- `effectiveAt` = request time; **no default `expiresAt`**.
+- Embedding follows the existing capability embed path.
+- The route schema is the author's own episode shape (e.g.
+  `{ event, detail, at? }`) — validated exactly like semantic data.
+
+### 4. Recall — capability + tool schema
+
+`recall` gains `since?: string` / `until?: string`, described in the tool
+schema as ISO timestamps or relative offsets (`"-24h"`, `"-7d"`, `"-30m"`).
+The capability parses relative forms against request time into ISO before
+calling `search` (pure helper `resolveTimeExpr(expr, now)` in the capability,
+unit-tested; the store never sees relative forms). `recall` always passes
+`now`, so expired rows are excluded from agent recall automatically. A window
+with no `query` returns timeline order; with a `query`, ranked recall within
+the window.
+
+### 5. Inspector — API + timeline view
+
+- `/api/memory/list` passes through `since`/`until` (ISO; 400 on unparseable)
+  and supplies `now` (expired rows hidden from the UI by default; a
+  `includeExpired=1` param keeps the debugging path open).
+- **Timeline toggle** in the Memory panel toolbar (`list | timeline`).
+  Timeline mode: fetches with `kind=episodic` default (switchable), groups rows
+  by day on `effectiveAt`, renders per-episode rows with an outcome badge
+  (`ok`/`error` from `data.outcome`, neutral for agent-authored), duration when
+  present, and the content line; row click opens the existing detail sheet.
+  Component-tested like the list view; no new route, no new panel.
+- `stats`/facets unchanged (byKind already serves the filter).
+
+### 6. CLI
+
+- `dawn memory prune [--cap N] [--namespace prefix]` — manual retention pass;
+  prints `{deletedExpired, deletedOverCap}`. Uses the same store method.
+- `dawn memory list/search/inspect` already handle episodes (kind-agnostic).
+
+## Error handling
+
+- Recorder: never throws into the run path; failures log once per process kind
+  (no log spam on a broken store).
+- `prune` with an unparseable `now`/window input: store throws (caller bug);
+  CLI/API validate first (400 / CliError).
+- `procedural`/`reflection` writes: `writePolicyFor` throws the "not yet wired"
+  error → `remember` surfaces it as a tool error (visible, not silent).
+- Relative time parse failure in recall: tool returns an actionable message
+  listing accepted forms (not a thrown 500).
+
+## Testing strategy
+
+1. **Pure units** (`@dawn-ai/memory`): `writePolicyFor` (all four kinds),
+   window-filter SQL via store tests, `prune` TTL/cap/tiebreak, COALESCE
+   fallback for legacy rows, inclusive/exclusive bounds.
+2. **Conformance kit** additions (sqlite always, pgvector gated): since/until
+   filtering, expiry exclusion with `now`, `prune` semantics + ordering,
+   append-policy approve (episodic candidate → plain activation).
+3. **Recorder integration** (CLI, aimock harness): run a route with
+   `episodes.enabled` → episode appears with correct shape/namespace/TTL;
+   failure runs recorded with `outcome: "error"`; `enabled: false` (default)
+   and `writes: "off"` record nothing; deterministic id = idempotent retry;
+   cap enforcement after burst of runs.
+4. **Agent-authored e2e** (aimock): episodic route's `remember` appends twice
+   (no supersession between same-identity-looking episodes); candidate mode
+   queues; recall with `since` returns only in-window episodes.
+5. **Inspector**: component tests for the timeline toggle/grouping/badges;
+   gated e2e extends the API tests with since/until + includeExpired.
+6. **Live smoke** (doubly-gated, existing pattern): real model asked "what did
+   you do in the last day?" after two recorded runs → answer cites episode
+   content.
+7. **examples/memory dogfood**: enable `episodes` in the example config so the
+   standing example (and its Inspector script) exercises the recorder
+   continuously.
+
+## Distribution & release
+
+- No new package. Changed: `@dawn-ai/memory` (policy seam, windows, prune,
+  migration v3), `@dawn-ai/memory-pgvector` (windows, prune, index),
+  `@dawn-ai/core` (episodes config type, capability changes, MemoryStoreLike
+  prune/window parity), `@dawn-ai/cli` (recorder, prune command, recall
+  threading), `@dawn-ai/inspector` (API params + timeline), `@dawn-ai/testing`
+  (conformance additions).
+- Changeset: **patch** (fixed 0.x group, GOTCHA 6). Body states the break
+  plainly: *"`MemoryStore` now requires `prune`; `search`/`browse` accept
+  `since`/`until` and exclude expired rows when `now` is supplied. Custom
+  stores must implement `prune`."* — same pattern as browse/stats.
+- Docs: memory.mdx episodic section (producers, retention, time-window recall,
+  governance interaction), upgrading.mdx (`prune` requirement), inspector.mdx
+  (timeline), dev memory-system doc.
+
+## Open questions (validate during build, not blockers)
+
+- Summary-line format for failure outcomes (include error class? keep short).
+- Whether the timeline's default kind filter should show agent-authored
+  episodic alongside auto (yes, likely — same kind).
+- `includeFailedRuns` naming vs `outcomes: ["ok","error"]` allowlist — pick at
+  plan time, default behavior identical.

--- a/examples/memory/server/dawn.config.ts
+++ b/examples/memory/server/dawn.config.ts
@@ -21,6 +21,10 @@ export default {
   appDir: "src/app",
   memory: {
     writes: "auto",
+    // Record one episodic memory per agent run (input, outcome, tools used,
+    // duration) — recallable with `recall({ since: "-24h" })`. Defaults for
+    // TTL (30d) and per-namespace cap (500) apply.
+    episodes: { enabled: true },
     ...(embedder ? { vector: { embedder } } : {}),
     ...(url ? { store: pgvectorMemoryStore({ connectionString: url, dimensions: 1536 }) } : {}),
   },

--- a/packages/cli/src/commands/memory.ts
+++ b/packages/cli/src/commands/memory.ts
@@ -10,7 +10,7 @@ interface MemoryOptions {
 }
 
 const USAGE =
-  "dawn memory <subcommand> [args]\n  subcommands: list, search <query>, inspect <id>, approve <id>, reject <id>, forget <id>"
+  "dawn memory <subcommand> [args]\n  subcommands: list, search <query>, inspect <id>, approve <id>, reject <id>, forget <id>, prune [--cap <n>] [--namespace <prefix>]"
 
 export function registerMemoryCommand(program: Command, io: CommandIo): void {
   program
@@ -70,6 +70,10 @@ export async function runMemoryCommand(
       const id = argv[1]
       if (!id) throw new CliError("Usage: dawn memory forget <id>", 1)
       await runForget(store, id, io)
+      break
+    }
+    case "prune": {
+      await runPrune(store, argv.slice(1), io)
       break
     }
     default: {
@@ -141,6 +145,36 @@ async function runReject(store: MemoryStore, id: string, io: CommandIo): Promise
   if (!rec) throw new CliError(`Record not found: ${id}`, 1)
   await store.delete(id)
   writeLine(io.stdout, `Rejected and deleted: ${id}`)
+}
+
+async function runPrune(store: MemoryStore, args: readonly string[], io: CommandIo): Promise<void> {
+  const usage = "Usage: dawn memory prune [--cap <n>] [--namespace <prefix>]"
+  let cap: number | undefined
+  let namespacePrefix: string | undefined
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i]
+    if (arg === "--cap") {
+      const raw = args[++i]
+      if (raw === undefined) throw new CliError(`Missing value for --cap.\n${usage}`, 1)
+      const parsed = Number(raw)
+      if (!Number.isFinite(parsed) || parsed < 0) {
+        throw new CliError(`Invalid --cap value: "${raw}" (expected a number >= 0).\n${usage}`, 1)
+      }
+      cap = parsed
+    } else if (arg === "--namespace") {
+      const raw = args[++i]
+      if (raw === undefined) throw new CliError(`Missing value for --namespace.\n${usage}`, 1)
+      namespacePrefix = raw
+    } else {
+      throw new CliError(`Unknown argument: "${arg}".\n${usage}`, 1)
+    }
+  }
+  const res = await store.prune({
+    now: new Date().toISOString(),
+    ...(cap !== undefined ? { cap } : {}),
+    ...(namespacePrefix !== undefined ? { namespacePrefix } : {}),
+  })
+  writeLine(io.stdout, `pruned: ${res.deletedExpired} expired, ${res.deletedOverCap} over-cap`)
 }
 
 async function runForget(store: MemoryStore, id: string, io: CommandIo): Promise<void> {

--- a/packages/cli/src/commands/memory.ts
+++ b/packages/cli/src/commands/memory.ts
@@ -3,7 +3,7 @@ import { approveWithReconcile, type MemoryStore } from "@dawn-ai/memory"
 import type { Command } from "commander"
 import { CliError, type CommandIo, writeLine } from "../lib/output.js"
 import { resolveIdentityKeys } from "../lib/runtime/resolve-identity.js"
-import { resolveMemoryStore } from "../lib/runtime/resolve-memory.js"
+import { resolveEpisodesConfig, resolveMemoryStore } from "../lib/runtime/resolve-memory.js"
 
 interface MemoryOptions {
   readonly cwd?: string
@@ -73,7 +73,7 @@ export async function runMemoryCommand(
       break
     }
     case "prune": {
-      await runPrune(store, argv.slice(1), io)
+      await runPrune(store, appRoot, argv.slice(1), io)
       break
     }
     default: {
@@ -147,7 +147,12 @@ async function runReject(store: MemoryStore, id: string, io: CommandIo): Promise
   writeLine(io.stdout, `Rejected and deleted: ${id}`)
 }
 
-async function runPrune(store: MemoryStore, args: readonly string[], io: CommandIo): Promise<void> {
+async function runPrune(
+  store: MemoryStore,
+  appRoot: string,
+  args: readonly string[],
+  io: CommandIo,
+): Promise<void> {
   const usage = "Usage: dawn memory prune [--cap <n>] [--namespace <prefix>]"
   let cap: number | undefined
   let namespacePrefix: string | undefined
@@ -169,9 +174,12 @@ async function runPrune(store: MemoryStore, args: readonly string[], io: Command
       throw new CliError(`Unknown argument: "${arg}".\n${usage}`, 1)
     }
   }
+  // No --cap → enforce the app's resolved episodic cap (memory.episodes.cap,
+  // default 500) so the manual retention pass matches the documented default.
+  const effectiveCap = cap ?? (await resolveEpisodesConfig(appRoot)).cap
   const res = await store.prune({
     now: new Date().toISOString(),
-    ...(cap !== undefined ? { cap } : {}),
+    cap: effectiveCap,
     ...(namespacePrefix !== undefined ? { namespacePrefix } : {}),
   })
   writeLine(io.stdout, `pruned: ${res.deletedExpired} expired, ${res.deletedOverCap} over-cap`)

--- a/packages/cli/src/lib/runtime/execute-route.ts
+++ b/packages/cli/src/lib/runtime/execute-route.ts
@@ -55,7 +55,14 @@ import { checkToolNameUniqueness } from "./check-tool-name-uniqueness.js"
 import { createDawnContext } from "./dawn-context.js"
 import { type LoadedRouteMemory, loadRouteMemory } from "./load-memory.js"
 import { type NormalizedRouteModule, normalizeRouteModule } from "./load-route-kind.js"
-import { buildMemoryContext, resolveMemoryStore, resolveMemoryWrites } from "./resolve-memory.js"
+import { extractToolNames, extractUserInputText, recordEpisode } from "./record-episode.js"
+import {
+  buildMemoryContext,
+  type ResolvedEpisodesConfig,
+  resolveEpisodesConfig,
+  resolveMemoryStore,
+  resolveMemoryWrites,
+} from "./resolve-memory.js"
 import {
   createRuntimeFailureResult,
   createRuntimeSuccessResult,
@@ -354,6 +361,7 @@ export async function* streamResolvedRoute(
     readonly threadId?: string
   },
 ): AsyncGenerator<StreamChunk> {
+  const startedAt = Date.now()
   const prepared = await prepareRouteExecution({
     ...options,
     isSubagent: options.isSubagent ?? false,
@@ -394,66 +402,99 @@ export async function* streamResolvedRoute(
 
   const agentInput = toAgentInput(options.input, options.resume)
 
-  for await (const chunk of streamAgent({
-    checkpointer,
-    entry: normalized.entry,
-    input: agentInput,
-    ...(options.middlewareContext ? { middlewareContext: options.middlewareContext } : {}),
-    routeParamNames,
-    signal: options.signal ?? new AbortController().signal,
-    ...(stateFields ? { stateFields } : {}),
-    tools,
-    ...(offload ? { offload } : {}),
-    ...(summarization ? { summarization } : {}),
-    ...(promptFragments && promptFragments.length > 0 ? { promptFragments } : {}),
-    ...(streamTransformers && streamTransformers.length > 0 ? { streamTransformers } : {}),
-    ...(subagentResolver ? { subagentResolver } : {}),
-    ...(options.threadId ? { threadId: options.threadId } : {}),
-    ...(sandboxed ? { sandboxed: true } : {}),
-  })) {
-    switch (chunk.type) {
-      case "token":
-        yield { type: "chunk", data: chunk.data }
-        break
-      case "tool_call": {
-        const tc = chunk.data as { id?: string; name: string; input: unknown }
-        yield {
-          type: "tool_call",
-          ...(tc.id ? { id: tc.id } : {}),
-          name: tc.name,
-          input: tc.input,
+  // Episode recorder (streaming path): a turn that reaches "done" records an
+  // "ok" episode; a thrown execution error records an "error" episode before
+  // propagating. Interrupted (parked) turns record nothing — the resuming
+  // turn records when it completes.
+  let sawDone = false
+  let finalOutput: unknown
+
+  try {
+    for await (const chunk of streamAgent({
+      checkpointer,
+      entry: normalized.entry,
+      input: agentInput,
+      ...(options.middlewareContext ? { middlewareContext: options.middlewareContext } : {}),
+      routeParamNames,
+      signal: options.signal ?? new AbortController().signal,
+      ...(stateFields ? { stateFields } : {}),
+      tools,
+      ...(offload ? { offload } : {}),
+      ...(summarization ? { summarization } : {}),
+      ...(promptFragments && promptFragments.length > 0 ? { promptFragments } : {}),
+      ...(streamTransformers && streamTransformers.length > 0 ? { streamTransformers } : {}),
+      ...(subagentResolver ? { subagentResolver } : {}),
+      ...(options.threadId ? { threadId: options.threadId } : {}),
+      ...(sandboxed ? { sandboxed: true } : {}),
+    })) {
+      switch (chunk.type) {
+        case "token":
+          yield { type: "chunk", data: chunk.data }
+          break
+        case "tool_call": {
+          const tc = chunk.data as { id?: string; name: string; input: unknown }
+          yield {
+            type: "tool_call",
+            ...(tc.id ? { id: tc.id } : {}),
+            name: tc.name,
+            input: tc.input,
+          }
+          break
         }
-        break
-      }
-      case "tool_result": {
-        const tr = chunk.data as { id?: string; name: string; output: unknown }
-        yield {
-          type: "tool_result",
-          ...(tr.id ? { id: tr.id } : {}),
-          name: tr.name,
-          output: tr.output,
+        case "tool_result": {
+          const tr = chunk.data as { id?: string; name: string; output: unknown }
+          yield {
+            type: "tool_result",
+            ...(tr.id ? { id: tr.id } : {}),
+            name: tr.name,
+            output: tr.output,
+          }
+          break
         }
-        break
-      }
-      case "done":
-        yield { type: "done", output: chunk.data }
-        break
-      case "interrupt": {
-        // The agent-adapter registers the pending entry in
-        // pending-interrupts so the /threads/:thread_id/resume endpoint
-        // can correlate the POST. We just forward the chunk to the SSE
-        // consumer.
-        yield { type: "interrupt", data: chunk.data }
-        break
-      }
-      default: {
-        // Capability-contributed event types (e.g. plan_update from the planning capability).
-        // The langchain layer widened AgentStreamChunk["type"] to allow arbitrary strings;
-        // pass them through verbatim with their literal type as the SSE event name.
-        yield { type: chunk.type, data: chunk.data }
-        break
+        case "done":
+          sawDone = true
+          finalOutput = chunk.data
+          yield { type: "done", output: chunk.data }
+          break
+        case "interrupt": {
+          // The agent-adapter registers the pending entry in
+          // pending-interrupts so the /threads/:thread_id/resume endpoint
+          // can correlate the POST. We just forward the chunk to the SSE
+          // consumer.
+          yield { type: "interrupt", data: chunk.data }
+          break
+        }
+        default: {
+          // Capability-contributed event types (e.g. plan_update from the planning capability).
+          // The langchain layer widened AgentStreamChunk["type"] to allow arbitrary strings;
+          // pass them through verbatim with their literal type as the SSE event name.
+          yield { type: chunk.type, data: chunk.data }
+          break
+        }
       }
     }
+  } catch (error) {
+    await recordRunEpisode({
+      memoryContext: prepared.memoryContext,
+      episodes: prepared.episodes,
+      outcome: "error",
+      input: options.input,
+      startedAt,
+      ...(options.threadId ? { threadId: options.threadId } : {}),
+    })
+    throw error
+  }
+
+  if (sawDone) {
+    await recordRunEpisode({
+      memoryContext: prepared.memoryContext,
+      episodes: prepared.episodes,
+      outcome: "ok",
+      output: finalOutput,
+      input: options.input,
+      startedAt,
+      ...(options.threadId ? { threadId: options.threadId } : {}),
+    })
   }
 }
 
@@ -477,6 +518,13 @@ interface PreparedRoute {
   readonly workspaceFs: WorkspaceFs
   /** The store the route's permission gates consult this request (provided, factory-produced, or freshly constructed). */
   readonly permissionsStore: PermissionsStore
+  /** The memory context built for this route (agent routes with a memory.ts).
+   *  Threaded out so the episode recorder can reuse the exact namespace/store/
+   *  writes the capability used. */
+  readonly memoryContext?: import("@dawn-ai/core").MemoryContext
+  /** Resolved `memory.episodes` config — present only when a memory context
+   *  was built (recorder is a no-op otherwise). */
+  readonly episodes?: ResolvedEpisodesConfig
   /**
    * True when a per-thread sandbox is active for this turn (sandboxManager +
    * threadId resolved a handle). The agent-adapter uses this to bypass its
@@ -662,6 +710,11 @@ export async function prepareRouteExecution(
 
   let subagentResolver: SubagentResolver | undefined
 
+  // Memory context + episode-recorder config, populated in the agent branch
+  // below when the route has a memory.ts; threaded out for the recorder.
+  let memoryContext: import("@dawn-ai/core").MemoryContext | undefined
+  let episodes: ResolvedEpisodesConfig | undefined
+
   // Load dawn.config.ts once — used for checkpointer, threadsStore, backends,
   // and permissions. Falls back to defaults when the config is absent/unreadable.
   let configBackends:
@@ -775,7 +828,6 @@ export async function prepareRouteExecution(
 
     // Build the memory context if this route has a memory.ts (probed and
     // loaded once per route — part of PreparedRouteModules).
-    let memoryContext: import("@dawn-ai/core").MemoryContext | undefined
     if (prepared.memory) {
       const defined = prepared.memory
       // Boot-resolved thunk wins when provided (shared, lazily-opened store —
@@ -828,6 +880,13 @@ export async function prepareRouteExecution(
             }
           : {}),
       })
+    }
+
+    // Episode-recorder config: resolved only when this route built a memory
+    // context (same cached loadDawnConfig — no extra I/O), so routes without
+    // memory.ts and disabled apps pay zero recorder overhead.
+    if (memoryContext) {
+      episodes = await resolveEpisodesConfig(options.appRoot)
     }
 
     const capabilityBackends = sandboxBackends ?? configBackends
@@ -1012,6 +1071,55 @@ export async function prepareRouteExecution(
     tools,
     workspaceFs,
     ...(sandboxBackends !== undefined ? { sandboxed: true } : {}),
+    ...(memoryContext ? { memoryContext } : {}),
+    ...(episodes ? { episodes } : {}),
+  }
+}
+
+/**
+ * Record one episodic memory for a settled run (the auto-recorder seam).
+ *
+ * No-ops unless `memory.episodes.enabled`, a memory context was built for the
+ * route, and writes are not "off"; failed runs are skipped when
+ * `includeFailedRuns` is false. NEVER throws — the recorder must not fail (or
+ * alter the result of) a user's run; it is awaited so the write is durable
+ * before the result is returned.
+ */
+async function recordRunEpisode(args: {
+  readonly memoryContext: import("@dawn-ai/core").MemoryContext | undefined
+  readonly episodes: ResolvedEpisodesConfig | undefined
+  readonly outcome: "ok" | "error"
+  readonly output?: unknown
+  readonly input: unknown
+  readonly startedAt: number
+  readonly threadId?: string
+}): Promise<void> {
+  const { memoryContext, episodes } = args
+  if (!episodes?.enabled || !memoryContext) return
+  if (memoryContext.writes === "off") return
+  if (args.outcome === "error" && !episodes.includeFailedRuns) return
+  try {
+    await recordEpisode(
+      memoryContext.store,
+      {
+        namespace: memoryContext.namespace,
+        input: extractUserInputText(args.input),
+        outcome: args.outcome,
+        // On the failure path the final state is unavailable — record no tools.
+        toolsUsed: args.outcome === "ok" ? extractToolNames(args.output) : [],
+        startedAt: args.startedAt,
+        finishedAt: Date.now(),
+        ttlMs: episodes.ttlMs,
+        // No distinct run id exists in the runtime today; the checkpoint
+        // threadId is the per-run identifier (a fresh `t-run-*` id is minted
+        // per invocation when the caller does not thread one).
+        ...(args.threadId ? { runId: args.threadId, threadId: args.threadId } : {}),
+      },
+      { cap: episodes.cap },
+    )
+  } catch {
+    // recordEpisode already never throws; this guards the extraction helpers
+    // too so the recorder can never fail a user's run.
   }
 }
 
@@ -1033,6 +1141,11 @@ async function executeRouteAtResolvedPath(
   },
 ): Promise<RuntimeExecutionResult> {
   let mode: RuntimeExecutionMode | null = null
+  // Episode-recorder context, captured once prepare succeeds so the catch
+  // path can record failed runs too. Absent (recorder no-op) until then.
+  let epMemoryContext: import("@dawn-ai/core").MemoryContext | undefined
+  let epConfig: ResolvedEpisodesConfig | undefined
+  let epThreadId: string | undefined
 
   try {
     const prepared = await prepareRouteExecution({
@@ -1070,6 +1183,9 @@ async function executeRouteAtResolvedPath(
     const threadId =
       options.threadId ??
       (normalized.kind === "agent" ? `t-run-${randomUUID().slice(0, 8)}` : undefined)
+    epMemoryContext = prepared.memoryContext
+    epConfig = prepared.episodes
+    epThreadId = threadId
 
     const context = createDawnContext({
       ...(options.middlewareContext ? { middleware: options.middlewareContext } : {}),
@@ -1094,6 +1210,18 @@ async function executeRouteAtResolvedPath(
       ...(sandboxed ? { sandboxed: true } : {}),
     })
 
+    // Record the episode BEFORE returning so the write is durable when the
+    // caller observes the result; the result object itself is unchanged.
+    await recordRunEpisode({
+      memoryContext: epMemoryContext,
+      episodes: epConfig,
+      outcome: "ok",
+      output,
+      input: options.input,
+      startedAt: options.startedAt,
+      ...(threadId ? { threadId } : {}),
+    })
+
     return createRuntimeSuccessResult({
       appRoot: options.appRoot,
       executionSource: "in-process",
@@ -1106,6 +1234,15 @@ async function executeRouteAtResolvedPath(
   } catch (error) {
     const kind = isBoundaryError(error) ? "unsupported_route_boundary" : "execution_error"
     const message = formatErrorMessage(error)
+
+    await recordRunEpisode({
+      memoryContext: epMemoryContext,
+      episodes: epConfig,
+      outcome: "error",
+      input: options.input,
+      startedAt: options.startedAt,
+      ...(epThreadId ? { threadId: epThreadId } : {}),
+    })
 
     return createRuntimeFailureResult({
       appRoot: options.appRoot,

--- a/packages/cli/src/lib/runtime/execute-route.ts
+++ b/packages/cli/src/lib/runtime/execute-route.ts
@@ -55,7 +55,12 @@ import { checkToolNameUniqueness } from "./check-tool-name-uniqueness.js"
 import { createDawnContext } from "./dawn-context.js"
 import { type LoadedRouteMemory, loadRouteMemory } from "./load-memory.js"
 import { type NormalizedRouteModule, normalizeRouteModule } from "./load-route-kind.js"
-import { extractToolNames, extractUserInputText, recordEpisode } from "./record-episode.js"
+import {
+  extractToolNames,
+  extractUserInputText,
+  hasPendingInterrupt,
+  recordEpisode,
+} from "./record-episode.js"
 import {
   buildMemoryContext,
   type ResolvedEpisodesConfig,
@@ -402,11 +407,19 @@ export async function* streamResolvedRoute(
 
   const agentInput = toAgentInput(options.input, options.resume)
 
-  // Episode recorder (streaming path): a turn that reaches "done" records an
-  // "ok" episode; a thrown execution error records an "error" episode before
-  // propagating. Interrupted (parked) turns record nothing — the resuming
-  // turn records when it completes.
+  // Episode recorder (streaming path): a COMPLETED turn records an "ok"
+  // episode; a thrown execution error records an "error" episode before
+  // propagating. Parked (HITL-interrupted) turns record NOTHING: the
+  // agent-adapter yields {type:"done"} unconditionally after its event stream
+  // — including parked turns — so "done" alone is not completion. On this
+  // path pending interrupts surface only as "interrupt" chunks (the adapter's
+  // streamEvents output does not carry `__interrupt__`), so we track them
+  // here; once an interrupt is seen the turn is parked and no further model
+  // work happens in it. The resuming turn records when it completes, with the
+  // RESUME turn's own startedAt (honest: the completing invocation's start —
+  // the original turn's start is not reconstructed).
   let sawDone = false
+  let sawInterrupt = false
   let finalOutput: unknown
 
   try {
@@ -461,6 +474,7 @@ export async function* streamResolvedRoute(
           // pending-interrupts so the /threads/:thread_id/resume endpoint
           // can correlate the POST. We just forward the chunk to the SSE
           // consumer.
+          sawInterrupt = true
           yield { type: "interrupt", data: chunk.data }
           break
         }
@@ -485,7 +499,7 @@ export async function* streamResolvedRoute(
     throw error
   }
 
-  if (sawDone) {
+  if (sawDone && !sawInterrupt) {
     await recordRunEpisode({
       memoryContext: prepared.memoryContext,
       episodes: prepared.episodes,
@@ -1098,12 +1112,21 @@ async function recordRunEpisode(args: {
   if (!episodes?.enabled || !memoryContext) return
   if (memoryContext.writes === "off") return
   if (args.outcome === "error" && !episodes.includeFailedRuns) return
+  // A parked (HITL-interrupted) turn is not a completed run: the invoke()
+  // path surfaces pending interrupts as `__interrupt__` on the final state.
+  // Record nothing — the completing resume turn records instead. (The stream
+  // path tracks interrupt chunks separately; see streamResolvedRoute.)
+  if (args.outcome === "ok" && hasPendingInterrupt(args.output)) return
   try {
     await recordEpisode(
       memoryContext.store,
       {
         namespace: memoryContext.namespace,
-        input: extractUserInputText(args.input),
+        // Prefer the final state's message history: on a resume turn the run
+        // input is a Command({resume}) with no human message, while the last
+        // human message in the full state IS the original question. Fall back
+        // to the run input (error path — no final state).
+        input: extractUserInputText(args.output) || extractUserInputText(args.input),
         outcome: args.outcome,
         // On the failure path the final state is unavailable — record no tools.
         toolsUsed: args.outcome === "ok" ? extractToolNames(args.output) : [],

--- a/packages/cli/src/lib/runtime/execute-route.ts
+++ b/packages/cli/src/lib/runtime/execute-route.ts
@@ -420,6 +420,7 @@ export async function* streamResolvedRoute(
   // the original turn's start is not reconstructed).
   let sawDone = false
   let sawInterrupt = false
+  let recordedError = false
   let finalOutput: unknown
 
   try {
@@ -488,6 +489,7 @@ export async function* streamResolvedRoute(
       }
     }
   } catch (error) {
+    recordedError = true
     await recordRunEpisode({
       memoryContext: prepared.memoryContext,
       episodes: prepared.episodes,
@@ -497,18 +499,28 @@ export async function* streamResolvedRoute(
       ...(options.threadId ? { threadId: options.threadId } : {}),
     })
     throw error
-  }
-
-  if (sawDone && !sawInterrupt) {
-    await recordRunEpisode({
-      memoryContext: prepared.memoryContext,
-      episodes: prepared.episodes,
-      outcome: "ok",
-      output: finalOutput,
-      input: options.input,
-      startedAt,
-      ...(options.threadId ? { threadId: options.threadId } : {}),
-    })
+  } finally {
+    // The "ok" record lives in the finally, NOT after the loop: stream
+    // consumers may close the generator early — the AG-UI outbound translator
+    // early-returns on RUN_FINISHED without draining, which cascades a
+    // .return() into this generator while it is suspended at the done yield.
+    // A finally still runs on that close path (sawDone/finalOutput were
+    // assigned BEFORE yielding the done chunk, so they are already set when
+    // the close lands on the yield). `recordedError` prevents a double record
+    // when the catch above already recorded the failure; abandoned (closed
+    // before done) and parked (interrupt seen) turns record nothing.
+    // recordRunEpisode never throws, so this is finally-safe.
+    if (!recordedError && sawDone && !sawInterrupt) {
+      await recordRunEpisode({
+        memoryContext: prepared.memoryContext,
+        episodes: prepared.episodes,
+        outcome: "ok",
+        output: finalOutput,
+        input: options.input,
+        startedAt,
+        ...(options.threadId ? { threadId: options.threadId } : {}),
+      })
+    }
   }
 }
 

--- a/packages/cli/src/lib/runtime/record-episode.ts
+++ b/packages/cli/src/lib/runtime/record-episode.ts
@@ -1,0 +1,176 @@
+import { createHash } from "node:crypto"
+import type { MemoryRecord, MemoryStore } from "@dawn-ai/memory"
+
+/** The two store methods the recorder needs. `Pick`ed so both the memory
+ *  package's `MemoryStore` and core's structural `MemoryStoreLike` satisfy it. */
+export type EpisodeStore = Pick<MemoryStore, "put" | "prune">
+
+export interface EpisodeInput {
+  readonly namespace: string
+  readonly input: string
+  readonly outcome: "ok" | "error"
+  readonly toolsUsed: readonly string[]
+  readonly startedAt: number
+  readonly finishedAt: number
+  readonly ttlMs: number
+  readonly runId?: string
+  readonly threadId?: string
+}
+
+export function buildEpisode(ep: EpisodeInput): MemoryRecord {
+  const startedIso = new Date(ep.startedAt).toISOString()
+  const sourceId = ep.runId ?? ep.threadId ?? startedIso
+  const id = `memory_ep_${createHash("sha1")
+    .update(`${ep.namespace}|${sourceId}|${startedIso}`)
+    .digest("hex")
+    .slice(0, 16)}`
+  const durationMs = Math.max(0, ep.finishedAt - ep.startedAt)
+  const seconds = (durationMs / 1000).toFixed(1)
+  const inputLine = ep.input.replaceAll("\n", " ").slice(0, 80)
+  const writtenAt = new Date(ep.finishedAt).toISOString()
+  return {
+    id,
+    kind: "episodic",
+    namespace: ep.namespace,
+    content: `run ${ep.outcome}: ${inputLine} (${ep.toolsUsed.length} tools, ${seconds}s)`,
+    data: {
+      input: ep.input.slice(0, 500),
+      outcome: ep.outcome,
+      toolsUsed: [...ep.toolsUsed],
+      durationMs,
+      ...(ep.threadId ? { threadId: ep.threadId } : {}),
+      ...(ep.runId ? { runId: ep.runId } : {}),
+    },
+    source: { type: "run", id: sourceId },
+    confidence: 1,
+    tags: [],
+    status: "active",
+    createdAt: writtenAt,
+    updatedAt: writtenAt,
+    effectiveAt: startedIso,
+    expiresAt: new Date(ep.startedAt + ep.ttlMs).toISOString(),
+  }
+}
+
+/** Write an episode + lazy retention. NEVER throws — recorder failures must not
+ *  fail a user's run; logged once per process. */
+let warnedOnce = false
+export async function recordEpisode(
+  store: EpisodeStore,
+  ep: EpisodeInput,
+  opts: { readonly cap: number },
+): Promise<void> {
+  try {
+    const record = buildEpisode(ep)
+    await store.put(record)
+    await store.prune({
+      now: new Date(ep.finishedAt).toISOString(),
+      namespacePrefix: ep.namespace,
+      cap: opts.cap,
+    })
+  } catch (error) {
+    if (!warnedOnce) {
+      warnedOnce = true
+      console.warn(`[dawn] episode recording failed (further failures muted): ${String(error)}`)
+    }
+  }
+}
+
+/**
+ * Collect the unique tool names invoked during a run from the final LangGraph
+ * state's `messages`. Handles both live LangChain message instances (plain
+ * property access: `type: "ai"` + `tool_calls`, `type: "tool"` + `name`) and
+ * the serialized-constructor shape (`id: [..., "AIMessage"|"ToolMessage"]` +
+ * `kwargs`). Purely structural — no instanceof, no LangChain imports.
+ */
+export function extractToolNames(output: unknown): string[] {
+  const messages =
+    output !== null &&
+    typeof output === "object" &&
+    Array.isArray((output as { messages?: unknown }).messages)
+      ? ((output as { messages: unknown[] }).messages as unknown[])
+      : []
+  const seen = new Set<string>()
+  const names: string[] = []
+  const add = (name: unknown): void => {
+    if (typeof name === "string" && name !== "" && !seen.has(name)) {
+      seen.add(name)
+      names.push(name)
+    }
+  }
+  for (const m of messages) {
+    if (m === null || typeof m !== "object") continue
+    const msg = m as Record<string, unknown>
+    const kwargs =
+      msg.kwargs !== null && typeof msg.kwargs === "object"
+        ? (msg.kwargs as Record<string, unknown>)
+        : undefined
+    // AIMessage tool_calls: live/plain shape carries them on the message,
+    // serialized shape nests them under kwargs.
+    const rawToolCalls = Array.isArray(msg.tool_calls)
+      ? msg.tool_calls
+      : Array.isArray(kwargs?.tool_calls)
+        ? kwargs.tool_calls
+        : []
+    for (const call of rawToolCalls) {
+      if (call === null || typeof call !== "object") continue
+      const c = call as { name?: unknown; function?: unknown }
+      const fn =
+        c.function !== null && typeof c.function === "object"
+          ? (c.function as { name?: unknown })
+          : undefined
+      add(c.name ?? fn?.name)
+    }
+    // ToolMessage name fallback (covers tools whose AIMessage was summarized away).
+    const idArr = msg.id
+    const isSerializedToolMessage =
+      Array.isArray(idArr) && idArr[idArr.length - 1] === "ToolMessage"
+    if (msg.type === "tool") add(msg.name)
+    else if (isSerializedToolMessage) add(kwargs?.name)
+  }
+  return names
+}
+
+/**
+ * Extract the user's message text for a run from the raw route input.
+ * Accepts a bare string, or a `{ messages: [...] }` envelope in which the
+ * LAST human message wins ("user" role, "human" type, or a serialized
+ * HumanMessage). Content may be a string or an array of `{type:"text",text}`
+ * parts. Defensive throughout; empty string fallback.
+ */
+export function extractUserInputText(input: unknown): string {
+  if (typeof input === "string") return input
+  if (input === null || typeof input !== "object") return ""
+  const messages = (input as { messages?: unknown }).messages
+  if (!Array.isArray(messages)) return ""
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const m = messages[i]
+    if (m === null || typeof m !== "object") continue
+    const msg = m as Record<string, unknown>
+    const idArr = msg.id
+    const isHuman =
+      msg.role === "user" ||
+      msg.type === "human" ||
+      (Array.isArray(idArr) && idArr[idArr.length - 1] === "HumanMessage")
+    if (!isHuman) continue
+    const kwargs =
+      msg.kwargs !== null && typeof msg.kwargs === "object"
+        ? (msg.kwargs as Record<string, unknown>)
+        : undefined
+    const text = contentText(msg.content ?? kwargs?.content)
+    if (text !== "") return text
+  }
+  return ""
+}
+
+function contentText(content: unknown): string {
+  if (typeof content === "string") return content
+  if (!Array.isArray(content)) return ""
+  const parts: string[] = []
+  for (const part of content) {
+    if (part === null || typeof part !== "object") continue
+    const p = part as { type?: unknown; text?: unknown }
+    if (p.type === "text" && typeof p.text === "string") parts.push(p.text)
+  }
+  return parts.join(" ")
+}

--- a/packages/cli/src/lib/runtime/record-episode.ts
+++ b/packages/cli/src/lib/runtime/record-episode.ts
@@ -132,6 +132,19 @@ export function extractToolNames(output: unknown): string[] {
 }
 
 /**
+ * True when a final LangGraph output represents a PARKED (interrupted) turn
+ * rather than a completed run: LangGraph's invoke() path surfaces pending
+ * HITL interrupts as a non-empty `__interrupt__` array on the final state.
+ * (The streamEvents path does NOT include the key — interrupts surface as
+ * stream chunks there, which the stream-path recorder tracks separately.)
+ */
+export function hasPendingInterrupt(output: unknown): boolean {
+  if (output === null || typeof output !== "object") return false
+  const interrupts = (output as { __interrupt__?: unknown }).__interrupt__
+  return Array.isArray(interrupts) && interrupts.length > 0
+}
+
+/**
  * Extract the user's message text for a run from the raw route input.
  * Accepts a bare string, or a `{ messages: [...] }` envelope in which the
  * LAST human message wins ("user" role, "human" type, or a serialized

--- a/packages/cli/src/lib/runtime/resolve-memory.ts
+++ b/packages/cli/src/lib/runtime/resolve-memory.ts
@@ -64,6 +64,58 @@ export async function resolveMemoryWrites(appRoot: string): Promise<MemoryWrites
   }
 }
 
+/** Resolved `config.memory.episodes` — the runtime episode recorder's knobs. */
+export interface ResolvedEpisodesConfig {
+  readonly enabled: boolean
+  readonly ttlMs: number
+  readonly cap: number
+  readonly includeFailedRuns: boolean
+  readonly embed: boolean
+}
+
+let warnedEmbedUnsupported = false
+
+/**
+ * Resolves the episode-recorder config for the given appRoot.
+ *
+ * Defaults: disabled, 30-day TTL, 500-episode per-namespace cap, failed runs
+ * included, no embeddings. Uses the same cached `loadDawnConfig` loader as the
+ * other resolvers; missing/unreadable config falls back to defaults.
+ *
+ * `embed: true` is not supported this cycle — it resolves to `false` and logs
+ * a one-line warning once per process (honest, forward-compatible).
+ */
+export async function resolveEpisodesConfig(appRoot: string): Promise<ResolvedEpisodesConfig> {
+  let episodes:
+    | {
+        readonly enabled?: boolean
+        readonly ttlMs?: number
+        readonly cap?: number
+        readonly includeFailedRuns?: boolean
+        readonly embed?: boolean
+      }
+    | undefined
+  try {
+    const loaded = await loadDawnConfig({ appRoot })
+    episodes = loaded.config.memory?.episodes
+  } catch {
+    // No dawn.config.ts or unreadable — use defaults.
+  }
+  if (episodes?.embed === true && !warnedEmbedUnsupported) {
+    warnedEmbedUnsupported = true
+    console.warn(
+      "[dawn] memory.episodes.embed is not yet supported; episodes are recorded without embeddings",
+    )
+  }
+  return {
+    enabled: episodes?.enabled ?? false,
+    ttlMs: episodes?.ttlMs ?? 30 * 86_400_000,
+    cap: episodes?.cap ?? 500,
+    includeFailedRuns: episodes?.includeFailedRuns ?? true,
+    embed: false,
+  }
+}
+
 /** Build the per-request memory capability context for a route with a memory.ts. */
 export function buildMemoryContext(args: {
   defined: LoadedRouteMemory

--- a/packages/cli/test/build-memory-context.test.ts
+++ b/packages/cli/test/build-memory-context.test.ts
@@ -12,6 +12,7 @@ const fakeStore: MemoryStoreLike = {
   listCandidates: async () => [],
   browse: async () => ({ records: [], total: 0 }),
   stats: async () => ({ total: 0, byStatus: {}, byKind: {}, byNamespace: {}, bySourceType: {} }),
+  prune: async () => ({ deletedExpired: 0, deletedOverCap: 0 }),
 }
 const schema = {
   safeParse: (d: unknown) =>

--- a/packages/cli/test/episodic-recorder.test.ts
+++ b/packages/cli/test/episodic-recorder.test.ts
@@ -6,6 +6,7 @@ import { fileURLToPath, pathToFileURL } from "node:url"
 import { type MemoryRecord, sqliteMemoryStore } from "@dawn-ai/memory"
 import { afterEach, describe, expect, it } from "vitest"
 
+import { executeRoute } from "../src/lib/runtime/execute-route.js"
 import { type EpisodeInput, recordEpisode } from "../src/lib/runtime/record-episode.js"
 
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..", "..")
@@ -38,16 +39,25 @@ interface ScriptBuilderLike {
   user(text: string): ScriptBuilderLike
   callsTool(name: string, args: Record<string, unknown>): ScriptBuilderLike
   replies(content: string): ScriptBuilderLike
+  build(): ReadonlyArray<unknown>
 }
 
 interface HarnessLike {
   run(opts: { input: string; fixtures?: ScriptBuilderLike }): Promise<HarnessRunResult>
+  resume(opts: {
+    decision: "once" | "always" | "deny"
+    fixtures?: ScriptBuilderLike
+  }): Promise<HarnessRunResult>
   reset(): void
   close(): Promise<void>
 }
 
 interface TestingModule {
-  createAgentHarness(opts: { appRoot: string; route: string }): Promise<HarnessLike>
+  createAgentHarness(opts: {
+    appRoot: string
+    route: string
+    fixtures?: ReadonlyArray<unknown>
+  }): Promise<HarnessLike>
   script(): ScriptBuilderLike
 }
 
@@ -60,7 +70,10 @@ async function loadTesting(): Promise<TestingModule> {
 // Fixture app factory
 // ---------------------------------------------------------------------------
 
-async function makeApp(dawnConfig: string): Promise<string> {
+async function makeApp(
+  dawnConfig: string,
+  opts?: { readonly approveDeploy?: boolean },
+): Promise<string> {
   await mkdir(scratchRoot, { recursive: true })
   const root = await mkdtemp(join(scratchRoot, "app-"))
   tempDirs.push(root)
@@ -77,6 +90,8 @@ async function makeApp(dawnConfig: string): Promise<string> {
       "export default agent({",
       '  model: "gpt-4o-mini",',
       '  systemPrompt: "You are a test agent. Use the provided tools when asked.",',
+      // approve-listed tool → calling it interrupts for a HITL decision.
+      ...(opts?.approveDeploy ? ['  tools: { approve: ["deployProd"] },'] : []),
       "})",
       "",
     ].join("\n"),
@@ -93,6 +108,18 @@ async function makeApp(dawnConfig: string): Promise<string> {
       "",
     ].join("\n"),
   )
+  if (opts?.approveDeploy) {
+    await writeFile(
+      join(routeDir, "tools", "deployProd.ts"),
+      [
+        "/** Deploy to an environment. */",
+        "export default async function deployProd(input: { env: string }): Promise<string> {",
+        "  return `deployed to ${input.env}`",
+        "}",
+        "",
+      ].join("\n"),
+    )
+  }
   // zod is not hoisted to the workspace root; symlink the copy the probe-app
   // fixtures use so the memory.ts schema is a real ZodType (the remember tool
   // schema goes through langchain's zod → JSON-schema conversion).
@@ -268,6 +295,81 @@ describe("episodic auto-recorder (aimock harness)", () => {
       await h.close()
     }
   }, 240_000)
+
+  it("HITL: an interrupted (parked) turn records nothing; the completing resume records exactly one episode with the ORIGINAL input", async () => {
+    const { createAgentHarness, script } = await loadTesting()
+    const appRoot = await makeApp("export default { memory: { episodes: { enabled: true } } }\n", {
+      approveDeploy: true,
+    })
+    const h = await createAgentHarness({ appRoot, route: "/chat#agent" })
+    try {
+      // Turn 1: the model calls the approve-listed tool → the run parks on a
+      // HITL interrupt. The tool did NOT execute — no episode may exist.
+      await h.run({
+        input: "deploy to staging",
+        fixtures: script()
+          .user("deploy to staging")
+          .callsTool("deployProd", { env: "staging" })
+          .replies("Deployed."),
+      })
+      expect(await episodicRecords(appRoot)).toHaveLength(0)
+
+      // Turn 2: approve → the tool executes and the turn completes. Exactly
+      // one episode, whose input is the ORIGINAL question (a resume turn has
+      // no new human message — it comes from the final state's history) and
+      // whose toolsUsed reflects the actually-executed tool.
+      const resumed = await h.resume({ decision: "once" })
+      expect(resumed.finalMessage).toContain("Deployed")
+
+      const episodes = await episodicRecords(appRoot)
+      expect(episodes).toHaveLength(1)
+      const ep = episodes[0] as MemoryRecord
+      expect(ep.data.outcome).toBe("ok")
+      expect(ep.data.input).toBe("deploy to staging")
+      expect(ep.content).toMatch(/^run ok: deploy to staging/)
+      expect(ep.data.toolsUsed).toContain("deployProd")
+    } finally {
+      await h.close()
+    }
+  }, 120_000)
+
+  it("invoke path: a direct executeRoute run records one episode whose source.id is the minted t-run-* threadId", async () => {
+    const { createAgentHarness, script } = await loadTesting()
+    const appRoot = await makeApp("export default { memory: { episodes: { enabled: true } } }\n")
+    // The harness supplies the aimock model server + env plumbing (and its
+    // close() resets the materialized-agent/config caches); the run itself
+    // goes through executeRoute — the non-streaming invoke path.
+    const h = await createAgentHarness({
+      appRoot,
+      route: "/chat#agent",
+      fixtures: script()
+        .user("Filter open items please")
+        .callsTool("applyFilter", { status: "open" })
+        .replies("Found 2 open items.")
+        .build(),
+    })
+    try {
+      const result = await executeRoute({
+        appRoot,
+        routeFile: join(appRoot, "src", "app", "chat", "index.ts"),
+        input: { messages: [{ role: "user", content: "Filter open items please" }] },
+      })
+      expect(result.status).toBe("passed")
+
+      const episodes = await episodicRecords(appRoot)
+      expect(episodes).toHaveLength(1)
+      const ep = episodes[0] as MemoryRecord
+      expect(ep.source.type).toBe("run")
+      // No caller-supplied threadId → the invoke path mints `t-run-<uuid8>`.
+      expect(ep.source.id).toMatch(/^t-run-[0-9a-f]{8}$/)
+      expect(ep.data.runId).toBe(ep.source.id)
+      expect(ep.data.outcome).toBe("ok")
+      expect(ep.content).toMatch(/^run ok: Filter open items please/)
+      expect(ep.data.toolsUsed).toContain("applyFilter")
+    } finally {
+      await h.close()
+    }
+  }, 120_000)
 })
 
 // ---------------------------------------------------------------------------

--- a/packages/cli/test/episodic-recorder.test.ts
+++ b/packages/cli/test/episodic-recorder.test.ts
@@ -6,7 +6,7 @@ import { fileURLToPath, pathToFileURL } from "node:url"
 import { type MemoryRecord, sqliteMemoryStore } from "@dawn-ai/memory"
 import { afterEach, describe, expect, it } from "vitest"
 
-import { executeRoute } from "../src/lib/runtime/execute-route.js"
+import { executeRoute, streamResolvedRoute } from "../src/lib/runtime/execute-route.js"
 import { type EpisodeInput, recordEpisode } from "../src/lib/runtime/record-episode.js"
 
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..", "..")
@@ -364,6 +364,52 @@ describe("episodic auto-recorder (aimock harness)", () => {
       expect(ep.source.id).toMatch(/^t-run-[0-9a-f]{8}$/)
       expect(ep.data.runId).toBe(ep.source.id)
       expect(ep.data.outcome).toBe("ok")
+      expect(ep.content).toMatch(/^run ok: Filter open items please/)
+      expect(ep.data.toolsUsed).toContain("applyFilter")
+    } finally {
+      await h.close()
+    }
+  }, 120_000)
+
+  it("early-closing consumer (AG-UI style): breaking on the done chunk without draining still records the ok episode", async () => {
+    const { createAgentHarness, script } = await loadTesting()
+    const appRoot = await makeApp("export default { memory: { episodes: { enabled: true } } }\n")
+    // Harness supplies aimock + env (and cache resets on close); the stream is
+    // driven directly so the consumer can close early — the AG-UI outbound
+    // translator returns after RUN_FINISHED without draining the generator,
+    // which triggers .return() on it mid-yield.
+    const h = await createAgentHarness({
+      appRoot,
+      route: "/chat#agent",
+      fixtures: script()
+        .user("Filter open items please")
+        .callsTool("applyFilter", { status: "open" })
+        .replies("Found 2 open items.")
+        .build(),
+    })
+    try {
+      const stream = streamResolvedRoute({
+        appRoot,
+        input: { messages: [{ role: "user", content: "Filter open items please" }] },
+        routeFile: join(appRoot, "src", "app", "chat", "index.ts"),
+        routeId: "/chat",
+        routePath: "src/app/chat/index.ts",
+        threadId: "t-early-close",
+      })
+      let sawDoneChunk = false
+      for await (const chunk of stream) {
+        if (chunk.type === "done") {
+          sawDoneChunk = true
+          break // early close WITHOUT draining — triggers generator .return()
+        }
+      }
+      expect(sawDoneChunk).toBe(true)
+
+      const episodes = await episodicRecords(appRoot)
+      expect(episodes).toHaveLength(1)
+      const ep = episodes[0] as MemoryRecord
+      expect(ep.data.outcome).toBe("ok")
+      expect(ep.source).toEqual({ type: "run", id: "t-early-close" })
       expect(ep.content).toMatch(/^run ok: Filter open items please/)
       expect(ep.data.toolsUsed).toContain("applyFilter")
     } finally {

--- a/packages/cli/test/episodic-recorder.test.ts
+++ b/packages/cli/test/episodic-recorder.test.ts
@@ -1,0 +1,337 @@
+import { mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { dirname, join, resolve } from "node:path"
+import { fileURLToPath, pathToFileURL } from "node:url"
+
+import { type MemoryRecord, sqliteMemoryStore } from "@dawn-ai/memory"
+import { afterEach, describe, expect, it } from "vitest"
+
+import { type EpisodeInput, recordEpisode } from "../src/lib/runtime/record-episode.js"
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..", "..")
+
+// Like eval-command.test.ts, temp apps live *inside* the repo tree so node
+// module resolution walks up to the workspace node_modules (@dawn-ai/sdk is
+// resolvable from packages/cli/node_modules).
+const scratchRoot = resolve(repoRoot, "packages", "cli", ".tmp-episodic-apps")
+
+const tempDirs: string[] = []
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { force: true, recursive: true })))
+})
+
+// ---------------------------------------------------------------------------
+// Harness loader: @dawn-ai/testing cannot be a dependency of @dawn-ai/cli
+// (it depends on @dawn-ai/cli — a cycle), so the aimock harness is loaded from
+// its built output, exactly the way the eval-command tests exercise it via the
+// temp app's node_modules. Requires `pnpm build` (CI builds before testing).
+// ---------------------------------------------------------------------------
+
+interface HarnessRunResult {
+  readonly finalMessage: string
+  readonly threadId: string
+  readonly toolResults: ReadonlyArray<{ readonly name: string }>
+}
+
+interface ScriptBuilderLike {
+  user(text: string): ScriptBuilderLike
+  callsTool(name: string, args: Record<string, unknown>): ScriptBuilderLike
+  replies(content: string): ScriptBuilderLike
+}
+
+interface HarnessLike {
+  run(opts: { input: string; fixtures?: ScriptBuilderLike }): Promise<HarnessRunResult>
+  reset(): void
+  close(): Promise<void>
+}
+
+interface TestingModule {
+  createAgentHarness(opts: { appRoot: string; route: string }): Promise<HarnessLike>
+  script(): ScriptBuilderLike
+}
+
+async function loadTesting(): Promise<TestingModule> {
+  const distEntry = join(repoRoot, "packages", "testing", "dist", "index.js")
+  return (await import(pathToFileURL(distEntry).href)) as unknown as TestingModule
+}
+
+// ---------------------------------------------------------------------------
+// Fixture app factory
+// ---------------------------------------------------------------------------
+
+async function makeApp(dawnConfig: string): Promise<string> {
+  await mkdir(scratchRoot, { recursive: true })
+  const root = await mkdtemp(join(scratchRoot, "app-"))
+  tempDirs.push(root)
+
+  await writeFile(join(root, "package.json"), '{ "name": "episodic-temp-app", "type": "module" }\n')
+  await writeFile(join(root, "dawn.config.ts"), dawnConfig)
+
+  const routeDir = join(root, "src", "app", "chat")
+  await mkdir(join(routeDir, "tools"), { recursive: true })
+  await writeFile(
+    join(routeDir, "index.ts"),
+    [
+      'import { agent } from "@dawn-ai/sdk"',
+      "export default agent({",
+      '  model: "gpt-4o-mini",',
+      '  systemPrompt: "You are a test agent. Use the provided tools when asked.",',
+      "})",
+      "",
+    ].join("\n"),
+  )
+  await writeFile(
+    join(routeDir, "tools", "applyFilter.ts"),
+    [
+      "/** Apply a status filter and report how many matched. */",
+      "export default async function applyFilter(input: {",
+      '  status: "open" | "closed"',
+      "}): Promise<{ matched: number }> {",
+      '  return { matched: input.status === "open" ? 2 : 0 }',
+      "}",
+      "",
+    ].join("\n"),
+  )
+  // zod is not hoisted to the workspace root; symlink the copy the probe-app
+  // fixtures use so the memory.ts schema is a real ZodType (the remember tool
+  // schema goes through langchain's zod → JSON-schema conversion).
+  await mkdir(join(root, "node_modules"), { recursive: true })
+  await symlink(
+    join(repoRoot, "packages", "testing", "node_modules", "zod"),
+    join(root, "node_modules", "zod"),
+    "dir",
+  )
+  await writeFile(
+    join(routeDir, "memory.ts"),
+    [
+      'import { defineMemory } from "@dawn-ai/sdk"',
+      'import { z } from "zod"',
+      "export default defineMemory({",
+      '  kind: "semantic",',
+      '  scope: ["route"],',
+      "  schema: z.object({ note: z.string() }),",
+      "})",
+      "",
+    ].join("\n"),
+  )
+  return root
+}
+
+const NAMESPACE = "route=/chat" // scope ["route"] for the /chat route
+
+async function episodicRecords(appRoot: string): Promise<MemoryRecord[]> {
+  const store = sqliteMemoryStore({ path: join(appRoot, ".dawn", "memory.sqlite") })
+  const page = await store.browse({ kind: "episodic", limit: 100 })
+  return [...page.records]
+}
+
+// ---------------------------------------------------------------------------
+// Harness integration
+// ---------------------------------------------------------------------------
+
+describe("episodic auto-recorder (aimock harness)", () => {
+  it("records exactly one well-formed episode for an enabled run", async () => {
+    const { createAgentHarness, script } = await loadTesting()
+    const appRoot = await makeApp(
+      "export default { memory: { episodes: { enabled: true, ttlMs: 3_600_000 } } }\n",
+    )
+    const before = Date.now()
+    const h = await createAgentHarness({ appRoot, route: "/chat#agent" })
+    try {
+      const result = await h.run({
+        input: "Filter open items please",
+        fixtures: script()
+          .user("Filter open items please")
+          .callsTool("applyFilter", { status: "open" })
+          .replies("Found 2 open items."),
+      })
+      expect(result.finalMessage).toContain("Found 2")
+      const after = Date.now()
+
+      const episodes = await episodicRecords(appRoot)
+      expect(episodes).toHaveLength(1)
+      const ep = episodes[0] as MemoryRecord
+      expect(ep.id).toMatch(/^memory_ep_[0-9a-f]{16}$/)
+      expect(ep.kind).toBe("episodic")
+      expect(ep.status).toBe("active")
+      expect(ep.namespace).toBe(NAMESPACE)
+      expect(ep.source.type).toBe("run")
+      expect(ep.source.id).toBe(result.threadId)
+      expect(ep.content).toMatch(/^run ok: Filter open items please/)
+      expect(ep.data.outcome).toBe("ok")
+      expect(ep.data.toolsUsed).toContain("applyFilter")
+      // effectiveAt is the run start; expiresAt is exactly start + configured TTL.
+      const effectiveAt = Date.parse(ep.effectiveAt ?? "")
+      const expiresAt = Date.parse(ep.expiresAt ?? "")
+      expect(effectiveAt).toBeGreaterThanOrEqual(before)
+      expect(effectiveAt).toBeLessThanOrEqual(after)
+      expect(expiresAt - effectiveAt).toBe(3_600_000)
+    } finally {
+      await h.close()
+    }
+  }, 120_000)
+
+  it("records nothing when episodes are not configured (default off)", async () => {
+    const { createAgentHarness, script } = await loadTesting()
+    const appRoot = await makeApp("export default {}\n")
+    const h = await createAgentHarness({ appRoot, route: "/chat#agent" })
+    try {
+      const result = await h.run({
+        input: "Filter open items please",
+        fixtures: script().user("Filter open items please").replies("Done."),
+      })
+      expect(result.finalMessage).toContain("Done")
+      expect(await episodicRecords(appRoot)).toHaveLength(0)
+    } finally {
+      await h.close()
+    }
+  }, 120_000)
+
+  it('records nothing when writes are "off" even with episodes enabled', async () => {
+    const { createAgentHarness, script } = await loadTesting()
+    const appRoot = await makeApp(
+      'export default { memory: { writes: "off", episodes: { enabled: true } } }\n',
+    )
+    const h = await createAgentHarness({ appRoot, route: "/chat#agent" })
+    try {
+      const result = await h.run({
+        input: "Filter open items please",
+        fixtures: script().user("Filter open items please").replies("Done."),
+      })
+      expect(result.finalMessage).toContain("Done")
+      expect(await episodicRecords(appRoot)).toHaveLength(0)
+    } finally {
+      await h.close()
+    }
+  }, 120_000)
+
+  it('records a failed run as outcome "error" by default', async () => {
+    const { createAgentHarness } = await loadTesting()
+    const appRoot = await makeApp("export default { memory: { episodes: { enabled: true } } }\n")
+    const h = await createAgentHarness({ appRoot, route: "/chat#agent" })
+    try {
+      // No fixture registered for this input → aimock replies 404
+      // ("No fixture matched") → the model call throws → the run fails.
+      await expect(h.run({ input: "This run will fail" })).rejects.toThrow()
+
+      const episodes = await episodicRecords(appRoot)
+      expect(episodes).toHaveLength(1)
+      const ep = episodes[0] as MemoryRecord
+      expect(ep.data.outcome).toBe("error")
+      expect(ep.content).toMatch(/^run error: This run will fail/)
+      expect(ep.data.toolsUsed).toEqual([])
+    } finally {
+      await h.close()
+    }
+  }, 120_000)
+
+  it("records nothing for a failed run when includeFailedRuns is false", async () => {
+    const { createAgentHarness } = await loadTesting()
+    const appRoot = await makeApp(
+      "export default { memory: { episodes: { enabled: true, includeFailedRuns: false } } }\n",
+    )
+    const h = await createAgentHarness({ appRoot, route: "/chat#agent" })
+    try {
+      await expect(h.run({ input: "This run will fail" })).rejects.toThrow()
+      expect(await episodicRecords(appRoot)).toHaveLength(0)
+    } finally {
+      await h.close()
+    }
+  }, 120_000)
+
+  it("burst + cap: five runs with cap 3 keep exactly the newest three episodes", async () => {
+    const { createAgentHarness, script } = await loadTesting()
+    const appRoot = await makeApp(
+      "export default { memory: { episodes: { enabled: true, cap: 3 } } }\n",
+    )
+    const h = await createAgentHarness({ appRoot, route: "/chat#agent" })
+    try {
+      const inputs = [1, 2, 3, 4, 5].map((i) => `burst run number ${i}`)
+      for (const input of inputs) {
+        h.reset() // fresh thread per run → distinct episodes
+        const result = await h.run({
+          input,
+          fixtures: script().user(input).replies(`ack: ${input}`),
+        })
+        expect(result.finalMessage).toContain("ack")
+      }
+
+      const episodes = await episodicRecords(appRoot)
+      expect(episodes).toHaveLength(3)
+      // The three newest by event time survive the cap.
+      const kept = new Set(episodes.map((e) => e.data.input))
+      expect(kept).toEqual(new Set(inputs.slice(2)))
+      const times = episodes.map((e) => Date.parse(e.effectiveAt ?? "")).sort((a, b) => a - b)
+      for (const t of times) expect(Number.isFinite(t)).toBe(true)
+    } finally {
+      await h.close()
+    }
+  }, 240_000)
+})
+
+// ---------------------------------------------------------------------------
+// Recorder retention semantics against a real sqlite store (unit-level)
+// ---------------------------------------------------------------------------
+
+function episode(overrides: Partial<EpisodeInput> & { readonly runId: string }): EpisodeInput {
+  const startedAt = overrides.startedAt ?? Date.parse("2026-08-05T10:00:00.000Z")
+  return {
+    namespace: "route=/conc",
+    input: `input for ${overrides.runId}`,
+    outcome: "ok",
+    toolsUsed: ["applyFilter"],
+    startedAt,
+    finishedAt: startedAt + 1500,
+    ttlMs: 30 * 86_400_000,
+    ...overrides,
+  }
+}
+
+describe("recordEpisode against a real sqlite store", () => {
+  it("is idempotent: the same EpisodeInput recorded twice yields ONE row", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "dawn-episodic-idem-"))
+    tempDirs.push(dir)
+    const store = sqliteMemoryStore({ path: join(dir, "memory.sqlite") })
+
+    const ep = episode({ runId: "run-retry" })
+    await recordEpisode(store, ep, { cap: 10 })
+    await recordEpisode(store, ep, { cap: 10 })
+
+    const page = await store.browse({ kind: "episodic" })
+    expect(page.total).toBe(1)
+    expect(page.records[0]?.source).toEqual({ type: "run", id: "run-retry" })
+  })
+
+  it("CONCURRENCY: 8 parallel recordEpisode calls with cap 5 settle to exactly 5 well-formed rows", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "dawn-episodic-conc-"))
+    tempDirs.push(dir)
+    const store = sqliteMemoryStore({ path: join(dir, "memory.sqlite") })
+
+    const base = Date.parse("2026-08-05T10:00:00.000Z")
+    const eps = Array.from({ length: 8 }, (_, i) =>
+      episode({ runId: `run-${i}`, startedAt: base + i * 1000 }),
+    )
+
+    // Must not reject — recordEpisode never throws, and WAL handles the
+    // concurrent in-process writers.
+    await expect(
+      Promise.all(eps.map((ep) => recordEpisode(store, ep, { cap: 5 }))),
+    ).resolves.toBeDefined()
+
+    const page = await store.browse({ kind: "episodic", namespacePrefix: "route=/conc" })
+    expect(page.total).toBe(5)
+    for (const rec of page.records) {
+      expect(rec.id).toMatch(/^memory_ep_[0-9a-f]{16}$/)
+      expect(rec.kind).toBe("episodic")
+      expect(rec.status).toBe("active")
+      expect(rec.source.type).toBe("run")
+      for (const field of [rec.createdAt, rec.updatedAt, rec.effectiveAt, rec.expiresAt]) {
+        expect(Number.isFinite(Date.parse(field ?? ""))).toBe(true)
+      }
+    }
+    // The five newest by event time (startedAt) survive.
+    const survivors = new Set(page.records.map((r) => r.source.id))
+    expect(survivors).toEqual(new Set(["run-3", "run-4", "run-5", "run-6", "run-7"]))
+  })
+})

--- a/packages/cli/test/memory-command.test.ts
+++ b/packages/cli/test/memory-command.test.ts
@@ -346,6 +346,40 @@ describe("dawn memory", () => {
     expect(lines.join("\n")).toMatch(/2 over-cap/)
   })
 
+  it("prune without --cap defaults to the resolved memory.episodes.cap", async () => {
+    const appRoot = await makeApp()
+    // Configure a cap of 2; `dawn memory prune` (no --cap) must enforce it —
+    // the docs promise the default retention pass applies the configured cap.
+    await writeFile(
+      join(appRoot, "dawn.config.ts"),
+      "export default { memory: { episodes: { cap: 2 } } }\n",
+    )
+    const store = sqliteMemoryStore({ path: join(appRoot, ".dawn/memory.sqlite") })
+    for (let i = 1; i <= 4; i++) {
+      await store.put({
+        ...baseRecord,
+        id: `ep-${i}`,
+        kind: "episodic",
+        status: "active",
+        effectiveAt: `2026-08-0${i}T00:00:00.000Z`,
+      })
+    }
+
+    const lines: string[] = []
+    await runMemoryCommand(
+      ["prune"],
+      { cwd: appRoot },
+      { stdout: (m) => lines.push(m), stderr: () => {} },
+    )
+
+    // The two oldest (ep-1, ep-2) are pruned; the two newest survive.
+    expect(await store.get("ep-1")).toBeNull()
+    expect(await store.get("ep-2")).toBeNull()
+    expect(await store.get("ep-3")).not.toBeNull()
+    expect(await store.get("ep-4")).not.toBeNull()
+    expect(lines.join("\n")).toMatch(/2 over-cap/)
+  })
+
   it("unknown subcommand throws CliError", async () => {
     const appRoot = await makeApp()
     const io = { stdout: () => {}, stderr: () => {} }

--- a/packages/cli/test/memory-command.test.ts
+++ b/packages/cli/test/memory-command.test.ts
@@ -287,6 +287,65 @@ describe("dawn memory", () => {
     expect(await store.get("m1")).toBeNull()
   })
 
+  it("prune deletes expired rows and reports counts", async () => {
+    const appRoot = await makeApp()
+    const store = sqliteMemoryStore({ path: join(appRoot, ".dawn/memory.sqlite") })
+    await store.put({
+      ...baseRecord,
+      id: "expired",
+      status: "active",
+      expiresAt: "2020-01-01T00:00:00.000Z",
+    })
+    await store.put({
+      ...baseRecord,
+      id: "live",
+      kind: "episodic",
+      status: "active",
+      effectiveAt: new Date().toISOString(),
+    })
+
+    const lines: string[] = []
+    await runMemoryCommand(
+      ["prune"],
+      { cwd: appRoot },
+      { stdout: (m) => lines.push(m), stderr: () => {} },
+    )
+
+    const output = lines.join("\n")
+    expect(output).toMatch(/1 expired/)
+    expect(output).toMatch(/0 over-cap/)
+    expect(await store.get("expired")).toBeNull()
+    expect(await store.get("live")).not.toBeNull()
+  })
+
+  it("prune --cap enforces the episodic cap", async () => {
+    const appRoot = await makeApp()
+    const store = sqliteMemoryStore({ path: join(appRoot, ".dawn/memory.sqlite") })
+    for (let i = 1; i <= 4; i++) {
+      await store.put({
+        ...baseRecord,
+        id: `ep-${i}`,
+        kind: "episodic",
+        status: "active",
+        effectiveAt: `2026-08-0${i}T00:00:00.000Z`,
+      })
+    }
+
+    const lines: string[] = []
+    await runMemoryCommand(
+      ["prune", "--cap", "2"],
+      { cwd: appRoot },
+      { stdout: (m) => lines.push(m), stderr: () => {} },
+    )
+
+    // The two oldest (ep-1, ep-2) are pruned; the two newest survive.
+    expect(await store.get("ep-1")).toBeNull()
+    expect(await store.get("ep-2")).toBeNull()
+    expect(await store.get("ep-3")).not.toBeNull()
+    expect(await store.get("ep-4")).not.toBeNull()
+    expect(lines.join("\n")).toMatch(/2 over-cap/)
+  })
+
   it("unknown subcommand throws CliError", async () => {
     const appRoot = await makeApp()
     const io = { stdout: () => {}, stderr: () => {} }

--- a/packages/cli/test/record-episode.test.ts
+++ b/packages/cli/test/record-episode.test.ts
@@ -3,6 +3,7 @@ import {
   buildEpisode,
   extractToolNames,
   extractUserInputText,
+  hasPendingInterrupt,
 } from "../src/lib/runtime/record-episode.js"
 
 const START_ISO = "2026-08-08T04:40:00.000Z"
@@ -97,6 +98,20 @@ describe("extractToolNames", () => {
     expect(extractToolNames({})).toEqual([])
     expect(extractToolNames({ messages: "nope" })).toEqual([])
     expect(extractToolNames({ messages: [null, 42, "str"] })).toEqual([])
+  })
+})
+
+describe("hasPendingInterrupt", () => {
+  it("detects a parked invoke() output via a non-empty __interrupt__ array", () => {
+    expect(hasPendingInterrupt({ messages: [], __interrupt__: [{ id: "i1", value: {} }] })).toBe(
+      true,
+    )
+  })
+  it("is false for completed outputs and non-objects", () => {
+    expect(hasPendingInterrupt({ messages: [] })).toBe(false)
+    expect(hasPendingInterrupt({ __interrupt__: [] })).toBe(false)
+    expect(hasPendingInterrupt(undefined)).toBe(false)
+    expect(hasPendingInterrupt("done")).toBe(false)
   })
 })
 

--- a/packages/cli/test/record-episode.test.ts
+++ b/packages/cli/test/record-episode.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from "vitest"
+import {
+  buildEpisode,
+  extractToolNames,
+  extractUserInputText,
+} from "../src/lib/runtime/record-episode.js"
+
+const START_ISO = "2026-08-08T04:40:00.000Z"
+
+const BASE = {
+  namespace: "workspace=app|route=/chat",
+  input: "Please summarize the Q3 report and email it to the team",
+  outcome: "ok" as const,
+  toolsUsed: ["readFile", "sendEmail"],
+  startedAt: Date.parse(START_ISO),
+  finishedAt: Date.parse(START_ISO) + 4200,
+  ttlMs: 30 * 86_400_000,
+  runId: "run-123",
+  threadId: "th-9",
+}
+
+describe("buildEpisode", () => {
+  it("builds a deterministic, idempotent record", () => {
+    const a = buildEpisode(BASE)
+    const b = buildEpisode(BASE)
+    expect(a.id).toBe(b.id)
+    expect(a.id).toMatch(/^memory_ep_[0-9a-f]{16}$/)
+    expect(a.kind).toBe("episodic")
+    expect(a.status).toBe("active")
+    expect(a.source).toEqual({ type: "run", id: "run-123" })
+    expect(a.effectiveAt).toBe(new Date(BASE.startedAt).toISOString())
+    expect(a.expiresAt).toBe(new Date(BASE.startedAt + BASE.ttlMs).toISOString())
+    expect(a.data.durationMs).toBe(4200)
+    expect(a.content).toMatch(/^run ok: /)
+    expect(a.content).toContain("(2 tools, 4.2s)")
+  })
+  it("truncates input in content (~80 chars) and data (~500 chars)", () => {
+    const long = buildEpisode({ ...BASE, input: "x".repeat(1000) })
+    expect(long.content.length).toBeLessThan(120)
+    expect((long.data.input as string).length).toBeLessThanOrEqual(500)
+  })
+  it("failure outcome renders and records", () => {
+    const f = buildEpisode({ ...BASE, outcome: "error" })
+    expect(f.content).toMatch(/^run error: /)
+    expect(f.data.outcome).toBe("error")
+  })
+  it("different runIds produce different ids", () => {
+    expect(buildEpisode(BASE).id).not.toBe(buildEpisode({ ...BASE, runId: "run-124" }).id)
+  })
+})
+
+describe("extractToolNames", () => {
+  it("collects unique, ordered tool names from AIMessage tool_calls and ToolMessage fallbacks", () => {
+    // Fabricated final LangGraph state: mixes live-instance-shaped messages
+    // (plain objects with type/tool_calls) and serialized-constructor-shaped
+    // messages ({ lc, type: "constructor", id: [..., "AIMessage"], kwargs }),
+    // duplicates, and unrelated messages.
+    const output = {
+      messages: [
+        { type: "human", content: "Filter open items then deploy" },
+        {
+          type: "ai",
+          content: "",
+          tool_calls: [
+            { id: "call_1", name: "applyFilter", args: { status: "open" } },
+            { id: "call_2", name: "deployProd", args: {} },
+          ],
+        },
+        { type: "tool", name: "applyFilter", content: '{"matched":2}' },
+        { type: "tool", name: "deployProd", content: "ok" },
+        {
+          lc: 1,
+          type: "constructor",
+          id: ["langchain_core", "messages", "AIMessage"],
+          kwargs: {
+            content: "",
+            // duplicate of applyFilter + one new name, in the serialized shape
+            tool_calls: [
+              { id: "call_3", name: "applyFilter", args: {} },
+              { id: "call_4", name: "sendReport", args: {} },
+            ],
+          },
+        },
+        {
+          lc: 1,
+          type: "constructor",
+          id: ["langchain_core", "messages", "ToolMessage"],
+          kwargs: { name: "sendReport", content: "sent" },
+        },
+        { type: "ai", content: "All done." },
+      ],
+    }
+    expect(extractToolNames(output)).toEqual(["applyFilter", "deployProd", "sendReport"])
+  })
+  it("returns [] for outputs without messages", () => {
+    expect(extractToolNames(undefined)).toEqual([])
+    expect(extractToolNames({})).toEqual([])
+    expect(extractToolNames({ messages: "nope" })).toEqual([])
+    expect(extractToolNames({ messages: [null, 42, "str"] })).toEqual([])
+  })
+})
+
+describe("extractUserInputText", () => {
+  it("returns a bare string input as-is", () => {
+    expect(extractUserInputText("hello there")).toBe("hello there")
+  })
+  it("extracts the LAST human message's text from a messages envelope", () => {
+    const input = {
+      messages: [
+        { role: "user", content: "first question" },
+        { type: "ai", content: "answer" },
+        { role: "user", content: "second question" },
+      ],
+    }
+    expect(extractUserInputText(input)).toBe("second question")
+  })
+  it("joins text content parts and handles serialized HumanMessage shapes", () => {
+    const parts = {
+      messages: [
+        {
+          role: "user",
+          content: [
+            { type: "text", text: "part one" },
+            { type: "text", text: "part two" },
+          ],
+        },
+      ],
+    }
+    expect(extractUserInputText(parts)).toBe("part one part two")
+    const serialized = {
+      messages: [
+        {
+          lc: 1,
+          type: "constructor",
+          id: ["langchain_core", "messages", "HumanMessage"],
+          kwargs: { content: "from kwargs" },
+        },
+      ],
+    }
+    expect(extractUserInputText(serialized)).toBe("from kwargs")
+  })
+  it("falls back to empty string on anything unrecognized", () => {
+    expect(extractUserInputText(undefined)).toBe("")
+    expect(extractUserInputText({ messages: [] })).toBe("")
+    expect(extractUserInputText({ messages: [{ type: "ai", content: "no humans" }] })).toBe("")
+    expect(extractUserInputText(42)).toBe("")
+  })
+})

--- a/packages/cli/test/resolve-memory.test.ts
+++ b/packages/cli/test/resolve-memory.test.ts
@@ -1,9 +1,13 @@
 import { mkdtemp, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
-import { afterEach, describe, expect, test } from "vitest"
+import { afterEach, describe, expect, test, vi } from "vitest"
 
-import { resolveMemoryStore, resolveMemoryWrites } from "../src/lib/runtime/resolve-memory.js"
+import {
+  resolveEpisodesConfig,
+  resolveMemoryStore,
+  resolveMemoryWrites,
+} from "../src/lib/runtime/resolve-memory.js"
 
 const tempDirs: string[] = []
 
@@ -97,5 +101,77 @@ describe("resolveMemoryWrites", () => {
 
     const writes = await resolveMemoryWrites(appRoot)
     expect(writes).toBe("candidate")
+  })
+})
+
+describe("resolveEpisodesConfig", () => {
+  test("returns defaults (disabled) when no dawn.config.ts exists", async () => {
+    const appRoot = await mkdtemp(join(tmpdir(), "dawn-resolve-episodes-"))
+    tempDirs.push(appRoot)
+
+    const episodes = await resolveEpisodesConfig(appRoot)
+    expect(episodes).toEqual({
+      enabled: false,
+      ttlMs: 30 * 86_400_000,
+      cap: 500,
+      includeFailedRuns: true,
+      embed: false,
+    })
+  })
+
+  test("returns defaults when config has memory but no episodes block", async () => {
+    const appRoot = await mkdtemp(join(tmpdir(), "dawn-resolve-episodes-"))
+    tempDirs.push(appRoot)
+    await writeFile(
+      join(appRoot, "dawn.config.ts"),
+      `export default { memory: { writes: "auto" } }\n`,
+    )
+
+    const episodes = await resolveEpisodesConfig(appRoot)
+    expect(episodes.enabled).toBe(false)
+    expect(episodes.ttlMs).toBe(30 * 86_400_000)
+    expect(episodes.cap).toBe(500)
+  })
+
+  test("threads configured values through", async () => {
+    const appRoot = await mkdtemp(join(tmpdir(), "dawn-resolve-episodes-"))
+    tempDirs.push(appRoot)
+    await writeFile(
+      join(appRoot, "dawn.config.ts"),
+      `export default { memory: { episodes: { enabled: true, ttlMs: 3_600_000, cap: 3, includeFailedRuns: false } } }\n`,
+    )
+
+    const episodes = await resolveEpisodesConfig(appRoot)
+    expect(episodes).toEqual({
+      enabled: true,
+      ttlMs: 3_600_000,
+      cap: 3,
+      includeFailedRuns: false,
+      embed: false,
+    })
+  })
+
+  test("embed: true resolves to false and warns exactly once per process", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {})
+    try {
+      const appRoot = await mkdtemp(join(tmpdir(), "dawn-resolve-episodes-"))
+      tempDirs.push(appRoot)
+      await writeFile(
+        join(appRoot, "dawn.config.ts"),
+        `export default { memory: { episodes: { enabled: true, embed: true } } }\n`,
+      )
+
+      const first = await resolveEpisodesConfig(appRoot)
+      expect(first.embed).toBe(false)
+      const second = await resolveEpisodesConfig(appRoot)
+      expect(second.embed).toBe(false)
+
+      const embedWarnings = warn.mock.calls.filter((c) =>
+        String(c[0]).includes("memory.episodes.embed is not yet supported"),
+      )
+      expect(embedWarnings).toHaveLength(1)
+    } finally {
+      warn.mockRestore()
+    }
   })
 })

--- a/packages/core/src/capabilities/built-in/memory.ts
+++ b/packages/core/src/capabilities/built-in/memory.ts
@@ -7,6 +7,7 @@ import type {
   MemoryRecordLike,
   PromptFragment,
 } from "../types.js"
+import { resolveTimeExpr } from "./time-expr.js"
 
 const DEFAULT_SEMANTIC_IDENTITY = ["subject", "predicate"] as const
 
@@ -56,6 +57,11 @@ export function createMemoryMarker(): CapabilityMarker {
         namespace: mem.namespace,
         status: "active",
         limit: mem.indexMaxEntries ?? 20,
+        // The request-time clock (context.memory.now — the same source recall
+        // uses). Without it the index would advertise EXPIRED memories that
+        // recall (which passes now) refuses to return — the model gets told a
+        // memory exists and then can't retrieve it.
+        now: mem.now,
       })
 
       // Tool input schemas exposed to the MODEL (so it knows what to pass). The
@@ -79,6 +85,18 @@ export function createMemoryMarker(): CapabilityMarker {
         kind: z.enum(MEMORY_KINDS).optional().describe("Filter by memory kind."),
         tags: z.array(z.string()).optional(),
         limit: z.number().int().positive().optional(),
+        since: z
+          .string()
+          .optional()
+          .describe(
+            'ISO timestamp or relative offset ("-24h", "-7d") — inclusive lower bound on when the memory happened.',
+          ),
+        until: z
+          .string()
+          .optional()
+          .describe(
+            'ISO timestamp or relative offset ("-24h", "-7d") — exclusive upper bound on when the memory happened.',
+          ),
       })
 
       const recall = {
@@ -91,6 +109,8 @@ export function createMemoryMarker(): CapabilityMarker {
             kind?: string
             tags?: string[]
             limit?: number
+            since?: string
+            until?: string
           }
           // An unknown kind can never match a stored row — answer directly
           // instead of passing an out-of-contract string to the store.
@@ -98,6 +118,17 @@ export function createMemoryMarker(): CapabilityMarker {
           if (q.kind) {
             if (!isMemoryKind(q.kind)) return { result: "(no memories found)" }
             kind = q.kind
+          }
+          // Resolve since/until (ISO or relative "-24h") against the request
+          // clock. A parse failure is a MODEL mistake — return the actionable
+          // message as the tool result (never throw) so it can self-correct.
+          let since: string | undefined
+          let until: string | undefined
+          try {
+            if (q.since) since = resolveTimeExpr(q.since, mem.now)
+            if (q.until) until = resolveTimeExpr(q.until, mem.now)
+          } catch (err) {
+            return { result: err instanceof Error ? err.message : String(err) }
           }
           // Embed the query for the hybrid keyword+vector path when an embedder
           // is configured. Embed FAILURE degrades to keyword-only — never throw,
@@ -123,6 +154,8 @@ export function createMemoryMarker(): CapabilityMarker {
             ...(q.query ? { query: q.query } : {}),
             ...(kind ? { kind } : {}),
             ...(q.tags ? { tags: q.tags } : {}),
+            ...(since ? { since } : {}),
+            ...(until ? { until } : {}),
             limit: q.limit ?? 8,
             // Recency reference for ranked recall — the per-request timestamp,
             // NOT Date.now() (determinism rule; see module docblock).
@@ -154,16 +187,33 @@ export function createMemoryMarker(): CapabilityMarker {
           // All returns below wrap in {result} — see the recall tool's note.
           if (!validated.ok) return { result: `Rejected: ${validated.errors}` }
           const data = validated.value
+
+          // Per-kind write policy. Core cannot import @dawn-ai/memory (its
+          // barrel pulls node:sqlite), so the policy is inlined:
+          // semantic → reconcile, episodic → append, others → not yet wired.
+          // Mirrored in packages/memory/src/reconcile.ts writePolicyFor — keep in sync.
+          if (mem.defined.kind === "procedural" || mem.defined.kind === "reflection") {
+            return {
+              result: `memory kind '${mem.defined.kind}' is not yet wired (semantic and episodic are)`,
+            }
+          }
+          const append = mem.defined.kind === "episodic"
           const identityKeys = mem.defined.identity ?? DEFAULT_SEMANTIC_IDENTITY
 
           // id is DATA-derived so contradicting values (same identity, different
           // value) get distinct ids and can coexist as active/superseded rows.
+          // Append kinds additionally hash the request timestamp: identical
+          // episodic data on different runs is DIFFERENT events, and put() is
+          // an id-keyed upsert in the real stores — same-id appends would
+          // silently collapse into one row.
           const id = `memory_${createHash("sha1")
-            .update(`${mem.namespace}|${JSON.stringify(data)}`)
+            .update(`${mem.namespace}|${JSON.stringify(data)}${append ? `|${mem.now}` : ""}`)
             .digest("hex")
             .slice(0, 16)}`
 
           // "ask" shares auto's write semantics; only its SUPERSEDE branch gates.
+          // Append kinds never supersede, so in "ask" mode no gate ever fires
+          // for them — episodic writes land silently, exactly like "auto".
           const autoLike = mem.writes === "auto" || mem.writes === "ask"
           const status = autoLike ? "active" : "candidate"
           const content =
@@ -185,6 +235,10 @@ export function createMemoryMarker(): CapabilityMarker {
             status,
             createdAt: mem.now,
             updatedAt: mem.now,
+            // Append kinds record WHEN the event happened (the request time —
+            // same clock as createdAt/updatedAt above). No expiresAt: TTL for
+            // agent-authored episodes is the store-level prune's business.
+            ...(append ? { effectiveAt: mem.now } : {}),
           }
 
           // Embed the content for vector recall when an embedder is configured.
@@ -207,6 +261,19 @@ export function createMemoryMarker(): CapabilityMarker {
             }
           }
 
+          // Append-only kinds skip the entire identity/reconcile block: an
+          // episode is an event, not a belief — a later one never contradicts
+          // an earlier one, so nothing is deduped, updated, or superseded (and
+          // the "ask" gate never fires; see the autoLike comment above).
+          if (append) {
+            await mem.store.put(record, putOpts)
+            return {
+              result: autoLike
+                ? `Stored memory ${id}.`
+                : `Stored memory candidate ${id} (pending approval).`,
+            }
+          }
+
           if (autoLike) {
             // Inline identity key helper — avoids importing from @dawn-ai/memory
             const identityKey = (d: Record<string, unknown>) =>
@@ -216,6 +283,8 @@ export function createMemoryMarker(): CapabilityMarker {
               namespace: mem.namespace,
               status: "active",
               limit: 50,
+              // Deliberately NO `now`: an expired-but-still-active row must
+              // remain visible here so a new write can still supersede it.
             })
             const target = existing.find((m) => identityKey(m.data) === identityKey(data))
 

--- a/packages/core/src/capabilities/built-in/time-expr.ts
+++ b/packages/core/src/capabilities/built-in/time-expr.ts
@@ -1,20 +1,26 @@
 const RELATIVE = /^-(\d+)([mhd])$/
 const UNIT_MS = { m: 60_000, h: 3_600_000, d: 86_400_000 } as const
 
+const invalid = (expr: string) =>
+  new Error(
+    `invalid time '${expr}' — use an ISO timestamp or relative offset like "-24h", "-7d", "-30m"`,
+  )
+
 /** "-24h" | "-7d" | "-30m" | ISO → ISO, resolved against `now`. Pure. */
 export function resolveTimeExpr(expr: string, now: string): string {
   const rel = RELATIVE.exec(expr)
   if (rel) {
     const [, n, unit] = rel
-    return new Date(
-      Date.parse(now) - Number(n) * UNIT_MS[unit as keyof typeof UNIT_MS],
-    ).toISOString()
+    const ms = Date.parse(now) - Number(n) * UNIT_MS[unit as keyof typeof UNIT_MS]
+    const d = new Date(ms)
+    // A huge count (e.g. "-999999999999d") overflows the valid Date range;
+    // toISOString on an Invalid Date throws V8's generic RangeError("Invalid
+    // time value") — throw the same actionable message as the garbage path
+    // instead, so callers without a try/catch can't crash uselessly.
+    if (Number.isNaN(d.getTime())) throw invalid(expr)
+    return d.toISOString()
   }
   const parsed = Date.parse(expr)
-  if (Number.isNaN(parsed)) {
-    throw new Error(
-      `invalid time '${expr}' — use an ISO timestamp or relative offset like "-24h", "-7d", "-30m"`,
-    )
-  }
+  if (Number.isNaN(parsed)) throw invalid(expr)
   return new Date(parsed).toISOString()
 }

--- a/packages/core/src/capabilities/built-in/time-expr.ts
+++ b/packages/core/src/capabilities/built-in/time-expr.ts
@@ -1,0 +1,20 @@
+const RELATIVE = /^-(\d+)([mhd])$/
+const UNIT_MS = { m: 60_000, h: 3_600_000, d: 86_400_000 } as const
+
+/** "-24h" | "-7d" | "-30m" | ISO → ISO, resolved against `now`. Pure. */
+export function resolveTimeExpr(expr: string, now: string): string {
+  const rel = RELATIVE.exec(expr)
+  if (rel) {
+    const [, n, unit] = rel
+    return new Date(
+      Date.parse(now) - Number(n) * UNIT_MS[unit as keyof typeof UNIT_MS],
+    ).toISOString()
+  }
+  const parsed = Date.parse(expr)
+  if (Number.isNaN(parsed)) {
+    throw new Error(
+      `invalid time '${expr}' — use an ISO timestamp or relative offset like "-24h", "-7d", "-30m"`,
+    )
+  }
+  return new Date(parsed).toISOString()
+}

--- a/packages/core/src/capabilities/types.ts
+++ b/packages/core/src/capabilities/types.ts
@@ -24,6 +24,10 @@ export interface MemoryRecordLike {
   readonly createdAt: string
   readonly updatedAt: string
   readonly supersedes?: readonly string[]
+  /** When the remembered event actually happened (episodic); defaults to createdAt. */
+  readonly effectiveAt?: string
+  /** When the row stops being recallable (with `now` supplied) and becomes prunable. */
+  readonly expiresAt?: string
 }
 
 /**
@@ -49,8 +53,13 @@ export interface MemoryStoreLike {
     tags?: readonly string[]
     status?: MemoryStatusLike
     limit?: number
-    /** ISO recency reference for ranked searches; stores may ignore it. */
+    /** ISO recency reference for ranked searches; stores may ignore it for
+     *  ranking. Also excludes rows with expiresAt <= now. */
     now?: string
+    /** ISO lower bound (inclusive) on COALESCE(effectiveAt, createdAt). */
+    since?: string
+    /** ISO upper bound (exclusive) on COALESCE(effectiveAt, createdAt). */
+    until?: string
     /** When present, the store runs the hybrid keyword+vector path. */
     queryEmbedding?: Float32Array
     /** Only rows whose stored embedding model equals this are vector-compared. */
@@ -70,6 +79,12 @@ export interface MemoryStoreLike {
     readonly sourceType?: MemorySourceTypeLike
     readonly limit?: number
     readonly offset?: number
+    /** ISO lower bound (inclusive) on COALESCE(effectiveAt, createdAt). */
+    readonly since?: string
+    /** ISO upper bound (exclusive) on COALESCE(effectiveAt, createdAt). */
+    readonly until?: string
+    /** When supplied, rows with expiresAt <= now are excluded (matches search's `now`). */
+    readonly now?: string
   }): Promise<{ readonly records: readonly MemoryRecordLike[]; readonly total: number }>
   /** Aggregate counts for facet UIs. */
   stats(opts?: { readonly namespacePrefix?: string }): Promise<{
@@ -79,6 +94,14 @@ export interface MemoryStoreLike {
     readonly byNamespace: Readonly<Record<string, number>>
     readonly bySourceType: Readonly<Record<string, number>>
   }>
+  /** Delete (a) rows of any kind with expiresAt <= now, and (b) when cap is
+   *  set, the oldest episodic rows beyond `cap` per namespace (ordered by
+   *  COALESCE(effectiveAt, createdAt), id tiebreak). */
+  prune(opts: {
+    readonly now: string
+    readonly namespacePrefix?: string
+    readonly cap?: number
+  }): Promise<{ readonly deletedExpired: number; readonly deletedOverCap: number }>
 }
 
 /**

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -109,6 +109,18 @@ export interface DawnConfig {
       readonly recencyWeight?: number
       readonly confidenceWeight?: number
     }
+    /** Opt-in runtime episode recorder: when enabled, the runtime writes one
+     *  episodic memory per agent run (input, outcome, tools used, duration).
+     *  Defaults: enabled false, ttlMs 30 days, cap 500 episodes per namespace,
+     *  includeFailedRuns true, embed false (embed: true is not yet supported —
+     *  episodes are recalled by keyword + time window). */
+    readonly episodes?: {
+      readonly enabled?: boolean
+      readonly ttlMs?: number
+      readonly cap?: number
+      readonly includeFailedRuns?: boolean
+      readonly embed?: boolean
+    }
     /** Derive the memory namespace scope for a given route. */
     readonly resolveScope?: (ctx: {
       readonly routePath: string

--- a/packages/core/test/memory-capability-episodic.test.ts
+++ b/packages/core/test/memory-capability-episodic.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, it } from "vitest"
+import { createMemoryMarker } from "../src/capabilities/built-in/memory.js"
+import type {
+  CapabilityMarkerContext,
+  MemoryContext,
+  MemoryRecordLike,
+  MemoryStoreLike,
+} from "../src/capabilities/types.js"
+
+const NOW = "2026-08-05T12:00:00.000Z"
+
+interface CallLog {
+  puts: MemoryRecordLike[]
+  updates: number
+  supersedes: number
+  /** Every search q, in call order. The FIRST search is the load-time index query. */
+  searches: Record<string, unknown>[]
+}
+
+function makeStore(log: CallLog): MemoryStoreLike {
+  return {
+    async put(record) {
+      log.puts.push(record)
+    },
+    async get() {
+      return null
+    },
+    async search(q) {
+      log.searches.push(q as Record<string, unknown>)
+      return []
+    },
+    async update() {
+      log.updates += 1
+    },
+    async supersede() {
+      log.supersedes += 1
+    },
+    async delete() {},
+    async listCandidates() {
+      return []
+    },
+    async browse() {
+      return { records: [], total: 0 }
+    },
+    async stats() {
+      return { total: 0, byStatus: {}, byKind: {}, byNamespace: {}, bySourceType: {} }
+    },
+    async prune() {
+      return { deletedExpired: 0, deletedOverCap: 0 }
+    },
+  }
+}
+
+function makeContext(
+  log: CallLog,
+  over: Partial<Pick<MemoryContext, "writes" | "defined">> = {},
+): CapabilityMarkerContext {
+  const memory: MemoryContext = {
+    store: makeStore(log),
+    namespace: "route=/probe",
+    writes: "auto",
+    defined: { kind: "episodic", scope: ["route"] },
+    validate: () => ({ ok: true, value: { event: "deployed" } }),
+    now: NOW,
+    ...over,
+  }
+  return {
+    routeManifest: {} as never,
+    descriptor: undefined,
+    appRoot: "/tmp/nowhere",
+    memory,
+  }
+}
+
+function newLog(): CallLog {
+  return { puts: [], updates: 0, supersedes: 0, searches: [] }
+}
+
+async function loadTools(log: CallLog, over?: Partial<Pick<MemoryContext, "writes" | "defined">>) {
+  const marker = createMemoryMarker()
+  const contribution = await marker.load("/tmp/nowhere", makeContext(log, over))
+  const recall = contribution.tools?.find((t) => t.name === "recall")
+  const remember = contribution.tools?.find((t) => t.name === "remember")
+  return { recall, remember }
+}
+
+const signal = () => ({ signal: new AbortController().signal })
+
+describe("episodic remember (append-only)", () => {
+  it("appends twice with identical data — two puts, zero supersede/update, no identity scan", async () => {
+    const log = newLog()
+    const { remember } = await loadTools(log)
+    const input = { data: { event: "deployed" }, content: "deployed v2 to staging" }
+    const r1 = (await remember?.run(input, signal())) as { result: string }
+    const r2 = (await remember?.run(input, signal())) as { result: string }
+    expect(log.puts.length).toBe(2)
+    expect(log.updates).toBe(0)
+    expect(log.supersedes).toBe(0)
+    // Only the load-time index search ran — the append path never scans actives.
+    expect(log.searches.length).toBe(1)
+    expect(r1.result).toMatch(/Stored memory/)
+    expect(r2.result).toMatch(/Stored memory/)
+    const rec = log.puts[0]
+    expect(rec?.kind).toBe("episodic")
+    expect(rec?.status).toBe("active")
+    expect(rec?.effectiveAt).toBe(NOW)
+    expect(rec?.expiresAt).toBeUndefined()
+  })
+
+  it("candidate mode writes an episodic candidate", async () => {
+    const log = newLog()
+    const { remember } = await loadTools(log, { writes: "candidate" })
+    await remember?.run({ data: { event: "deployed" }, content: "x" }, signal())
+    expect(log.puts.length).toBe(1)
+    expect(log.puts[0]?.status).toBe("candidate")
+    expect(log.puts[0]?.effectiveAt).toBe(NOW)
+  })
+
+  it("procedural kind returns a not-yet-wired tool error with zero store writes", async () => {
+    const log = newLog()
+    const { remember } = await loadTools(log, {
+      defined: { kind: "procedural", scope: ["route"] },
+    })
+    const out = (await remember?.run({ data: { event: "x" }, content: "x" }, signal())) as {
+      result: string
+    }
+    expect(out.result).toContain("not yet wired")
+    expect(log.puts.length).toBe(0)
+    expect(log.updates).toBe(0)
+    expect(log.supersedes).toBe(0)
+    // No store calls beyond the load-time index search.
+    expect(log.searches.length).toBe(1)
+  })
+})
+
+describe("recall since/until time windows", () => {
+  it("passes resolved ISO since/until to store.search (relative resolved against the request clock)", async () => {
+    const log = newLog()
+    const { recall } = await loadTools(log)
+    await recall?.run(
+      { query: "deploy", since: "-24h", until: "2026-08-05T00:00:00.000Z" },
+      signal(),
+    )
+    const q = log.searches.at(-1)
+    expect(q?.since).toBe(new Date(Date.parse(NOW) - 86_400_000).toISOString())
+    expect(q?.until).toBe("2026-08-05T00:00:00.000Z")
+    expect(q?.now).toBe(NOW)
+  })
+
+  it("garbage since returns the actionable message and never hits search", async () => {
+    const log = newLog()
+    const { recall } = await loadTools(log)
+    const before = log.searches.length
+    const out = (await recall?.run({ query: "deploy", since: "yesterday" }, signal())) as {
+      result: string
+    }
+    expect(out.result).toMatch(/ISO timestamp or relative/)
+    expect(log.searches.length).toBe(before)
+  })
+})
+
+describe("memory-index prompt fragment", () => {
+  it("passes the request `now` into the load-time index search (expired rows must not be advertised)", async () => {
+    const log = newLog()
+    const marker = createMemoryMarker()
+    await marker.load("/tmp/nowhere", makeContext(log))
+    // The FIRST search is the index query built at load time.
+    expect(log.searches[0]?.now).toBe(NOW)
+  })
+})

--- a/packages/core/test/memory-capability-episodic.test.ts
+++ b/packages/core/test/memory-capability-episodic.test.ts
@@ -100,6 +100,10 @@ describe("episodic remember (append-only)", () => {
     expect(log.searches.length).toBe(1)
     expect(r1.result).toMatch(/Stored memory/)
     expect(r2.result).toMatch(/Stored memory/)
+    // Accepted same-request id collapse: same data + same mem.now → same id, so
+    // a real store's id-keyed upsert keeps ONE row for this degenerate case.
+    // Distinct real-world episodes always differ in data or request time.
+    expect(log.puts[0]?.id).toBe(log.puts[1]?.id)
     const rec = log.puts[0]
     expect(rec?.kind).toBe("episodic")
     expect(rec?.status).toBe("active")

--- a/packages/core/test/memory-capability-recall.test.ts
+++ b/packages/core/test/memory-capability-recall.test.ts
@@ -28,6 +28,9 @@ function makeContext(captured: { query?: Record<string, unknown> }): CapabilityM
       async stats() {
         return { total: 0, byStatus: {}, byKind: {}, byNamespace: {}, bySourceType: {} }
       },
+      async prune() {
+        return { deletedExpired: 0, deletedOverCap: 0 }
+      },
     },
     namespace: "route=/probe",
     writes: "auto",

--- a/packages/core/test/memory-capability-vector.test.ts
+++ b/packages/core/test/memory-capability-vector.test.ts
@@ -56,6 +56,9 @@ function makeContext(captured: Captured, embedder: Embedder | undefined): Capabi
       async stats() {
         return { total: 0, byStatus: {}, byKind: {}, byNamespace: {}, bySourceType: {} }
       },
+      async prune() {
+        return { deletedExpired: 0, deletedOverCap: 0 }
+      },
     },
     namespace: "route=/probe",
     writes: "auto",

--- a/packages/core/test/time-expr.test.ts
+++ b/packages/core/test/time-expr.test.ts
@@ -15,4 +15,7 @@ describe("resolveTimeExpr", () => {
     expect(() => resolveTimeExpr("yesterday", NOW)).toThrow(/ISO timestamp or relative/)
     expect(() => resolveTimeExpr("-3y", NOW)).toThrow(/ISO timestamp or relative/)
   })
+  it("rejects Date-range overflow with the same actionable error (not a raw RangeError)", () => {
+    expect(() => resolveTimeExpr("-999999999999d", NOW)).toThrow(/ISO timestamp or relative/)
+  })
 })

--- a/packages/core/test/time-expr.test.ts
+++ b/packages/core/test/time-expr.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest"
+import { resolveTimeExpr } from "../src/capabilities/built-in/time-expr.js"
+
+const NOW = "2026-08-05T12:00:00.000Z"
+describe("resolveTimeExpr", () => {
+  it("passes ISO timestamps through unchanged", () => {
+    expect(resolveTimeExpr("2026-08-01T00:00:00.000Z", NOW)).toBe("2026-08-01T00:00:00.000Z")
+  })
+  it("resolves relative offsets against now", () => {
+    expect(resolveTimeExpr("-24h", NOW)).toBe("2026-08-04T12:00:00.000Z")
+    expect(resolveTimeExpr("-7d", NOW)).toBe("2026-07-29T12:00:00.000Z")
+    expect(resolveTimeExpr("-30m", NOW)).toBe("2026-08-05T11:30:00.000Z")
+  })
+  it("rejects garbage with an actionable error", () => {
+    expect(() => resolveTimeExpr("yesterday", NOW)).toThrow(/ISO timestamp or relative/)
+    expect(() => resolveTimeExpr("-3y", NOW)).toThrow(/ISO timestamp or relative/)
+  })
+})

--- a/packages/inspector/app/api/memory/list/route.ts
+++ b/packages/inspector/app/api/memory/list/route.ts
@@ -22,10 +22,14 @@ function parseEnum<T extends string>(
   )
 }
 
-/** undefined when absent, the value when Date.parse-able, a 400 Response otherwise. */
+/** undefined when absent, the value normalized to full-ISO-Z when Date.parse-able,
+ *  a 400 Response otherwise. Normalization matters: the store compares these
+ *  lexicographically against stored full-ISO-Z strings, so raw offset-ISO
+ *  ("...+02:00"), zoneless-local, or loose forms would window silently wrong. */
 function parseInstant(value: string | null, name: string): string | undefined | Response {
   if (value === null) return undefined
-  if (Number.isFinite(Date.parse(value))) return value
+  const t = Date.parse(value)
+  if (Number.isFinite(t)) return new Date(t).toISOString()
   return Response.json(
     { error: `invalid ${name} "${value}" (expected an ISO-8601 date-time)` },
     { status: 400 },

--- a/packages/inspector/app/api/memory/list/route.ts
+++ b/packages/inspector/app/api/memory/list/route.ts
@@ -22,6 +22,16 @@ function parseEnum<T extends string>(
   )
 }
 
+/** undefined when absent, the value when Date.parse-able, a 400 Response otherwise. */
+function parseInstant(value: string | null, name: string): string | undefined | Response {
+  if (value === null) return undefined
+  if (Number.isFinite(Date.parse(value))) return value
+  return Response.json(
+    { error: `invalid ${name} "${value}" (expected an ISO-8601 date-time)` },
+    { status: 400 },
+  )
+}
+
 export async function GET(req: Request): Promise<Response> {
   const denied = assertLocalRequest(req)
   if (denied) return denied
@@ -32,6 +42,14 @@ export async function GET(req: Request): Promise<Response> {
   if (kind instanceof Response) return kind
   const sourceType = parseEnum(sp.get("sourceType"), SOURCE_TYPES, "sourceType")
   if (sourceType instanceof Response) return sourceType
+  const since = parseInstant(sp.get("since"), "since")
+  if (since instanceof Response) return since
+  const until = parseInstant(sp.get("until"), "until")
+  if (until instanceof Response) return until
+  // Supplying `now` makes browse exclude rows with expiresAt <= now; the
+  // inspector is a debugging surface, so includeExpired=1 omits it to reveal
+  // expired-but-not-yet-pruned rows.
+  const includeExpired = sp.get("includeExpired") === "1"
   const namespacePrefix = sp.get("namespacePrefix")
   const limit = Number(sp.get("limit") ?? 50)
   const offset = Number(sp.get("offset") ?? 0)
@@ -42,6 +60,9 @@ export async function GET(req: Request): Promise<Response> {
     ...(status ? { status } : {}),
     ...(kind ? { kind } : {}),
     ...(sourceType ? { sourceType } : {}),
+    ...(since ? { since } : {}),
+    ...(until ? { until } : {}),
+    ...(includeExpired ? {} : { now: new Date().toISOString() }),
     // Store clamps to ≥0 integers; guard NaN from garbage params here.
     limit: Number.isFinite(limit) ? limit : 50,
     offset: Number.isFinite(offset) ? offset : 0,

--- a/packages/inspector/app/api/memory/search/route.ts
+++ b/packages/inspector/app/api/memory/search/route.ts
@@ -30,6 +30,14 @@ export async function GET(req: Request): Promise<Response> {
   const namespaces = namespace ? [namespace] : Object.keys((await store.stats()).byNamespace)
   const groups: { namespace: string; records: readonly MemoryRecord[] }[] = []
   // One recency snapshot for every namespace — consistent ranking across groups.
+  //
+  // Deliberately NO includeExpired escape hatch here (unlike the list API):
+  // the store couples `now` to BOTH expiry exclusion and recency ranking in a
+  // single parameter, so omitting it to reveal expired rows would also skew
+  // ranked search to a data-derived recency reference. More importantly,
+  // search is meant to mirror what the agent's own recall sees — and recall
+  // always excludes expired rows. Expired-but-unpruned rows are a debugging
+  // concern, and the list API (with includeExpired=1) is the debugging surface.
   const now = new Date().toISOString()
   for (const ns of namespaces) {
     const records = await store.search({

--- a/packages/inspector/src/components/memory/list-page.tsx
+++ b/packages/inspector/src/components/memory/list-page.tsx
@@ -7,6 +7,7 @@ import { usePolling } from "../use-polling"
 import { DetailSheet } from "./detail-sheet"
 import { FacetRail } from "./facet-rail"
 import { MemoryGrid } from "./memory-grid"
+import { TimelineView } from "./timeline-view"
 
 interface ListResponse {
   readonly records: readonly MemoryRecord[]
@@ -27,6 +28,14 @@ type ErrorSource = "stats" | "list" | "search"
 const KINDS = ["semantic", "episodic", "procedural", "reflection"] as const
 const STATUSES = ["candidate", "active", "superseded"] as const
 
+/** Timeline window presets → milliseconds back from now ("all" = unbounded). */
+const WINDOWS = {
+  "24h": 24 * 60 * 60 * 1000,
+  "7d": 7 * 24 * 60 * 60 * 1000,
+  "30d": 30 * 24 * 60 * 60 * 1000,
+} as const
+type TimelineWindow = keyof typeof WINDOWS | "all"
+
 const selectClass =
   "h-9 rounded-md border border-zinc-200 bg-white px-2 text-sm text-zinc-700 focus:outline-none focus:ring-2 focus:ring-zinc-300"
 
@@ -35,6 +44,8 @@ export function ListPage() {
   const [status, setStatus] = useState("")
   const [kind, setKind] = useState("")
   const [query, setQuery] = useState("")
+  const [view, setView] = useState<"list" | "timeline">("list")
+  const [timelineWindow, setTimelineWindow] = useState<TimelineWindow>("all")
   const [live, setLive] = useState(true)
   const [selectedId, setSelectedId] = useState<string>()
   const [refreshKey, setRefreshKey] = useState(0)
@@ -85,9 +96,15 @@ export function ListPage() {
     const params = new URLSearchParams({ limit: "200" })
     if (namespace) params.set("namespacePrefix", namespace)
     if (status) params.set("status", status)
-    if (kind) params.set("kind", kind)
+    // Timeline is an episode view — default the kind filter to episodic there
+    // (the kind select still overrides), and thread the client-computed window.
+    const effectiveKind = kind || (view === "timeline" ? "episodic" : "")
+    if (effectiveKind) params.set("kind", effectiveKind)
+    if (view === "timeline" && timelineWindow !== "all") {
+      params.set("since", new Date(Date.now() - WINDOWS[timelineWindow]).toISOString())
+    }
     return fetchJson<ListResponse>("list", `/api/memory/list?${params}`)
-  }, [fetchJson, namespace, status, kind, refreshKey])
+  }, [fetchJson, namespace, status, kind, view, timelineWindow, refreshKey])
 
   const stats = usePolling(statsFn, 2000, live)
   const page = usePolling(pageFn, 2000, live && !query)
@@ -154,6 +171,40 @@ export function ListPage() {
           ))}
         </div>
         <div className="ml-auto flex items-center gap-2">
+          {/* biome-ignore lint/a11y/useSemanticElements: a fieldset carries form semantics and default chrome; this is a segmented view toggle, for which role=group on a div is the standard pattern */}
+          <div
+            role="group"
+            aria-label="View"
+            className="flex overflow-hidden rounded-md border border-zinc-200"
+          >
+            {(["list", "timeline"] as const).map((v) => (
+              <button
+                key={v}
+                type="button"
+                aria-pressed={view === v}
+                onClick={() => setView(v)}
+                className={`h-9 px-3 text-sm ${
+                  view === v ? "bg-zinc-900 text-white" : "bg-white text-zinc-600 hover:bg-zinc-50"
+                }`}
+              >
+                {v}
+              </button>
+            ))}
+          </div>
+          {view === "timeline" ? (
+            <select
+              aria-label="Window"
+              value={timelineWindow}
+              onChange={(e) => setTimelineWindow(e.target.value as TimelineWindow)}
+              className={selectClass}
+            >
+              {(["24h", "7d", "30d", "all"] as const).map((w) => (
+                <option key={w} value={w}>
+                  {w}
+                </option>
+              ))}
+            </select>
+          ) : null}
           <Input
             type="search"
             aria-label="Search memories"
@@ -222,6 +273,9 @@ export function ListPage() {
             ) : (
               <p className="py-8 text-center text-sm text-zinc-400">No matches.</p>
             )
+          ) : view === "timeline" ? (
+            // TimelineView owns its empty state ("No episodes in this window.").
+            <TimelineView records={pageRecords} onSelect={setSelectedId} />
           ) : pageRecords.length > 0 ? (
             <MemoryGrid records={pageRecords} onSelect={setSelectedId} />
           ) : (

--- a/packages/inspector/src/components/memory/timeline-view.tsx
+++ b/packages/inspector/src/components/memory/timeline-view.tsx
@@ -1,0 +1,77 @@
+"use client"
+import type { MemoryRecord } from "@dawn-ai/memory"
+import { Badge } from "../ui/badge"
+
+function dayOf(r: MemoryRecord): string {
+  return (r.effectiveAt ?? r.createdAt).slice(0, 10)
+}
+
+function outcomeVariant(outcome: string): "active" | "danger" | "candidate" {
+  if (outcome === "ok") return "active"
+  if (outcome === "error") return "danger"
+  return "candidate"
+}
+
+export function TimelineView({
+  records,
+  onSelect,
+}: {
+  records: readonly MemoryRecord[]
+  onSelect: (id: string) => void
+}) {
+  const days = new Map<string, MemoryRecord[]>()
+  for (const r of records) {
+    const day = dayOf(r)
+    const bucket = days.get(day)
+    if (bucket) bucket.push(r)
+    else days.set(day, [r])
+  }
+  return (
+    <div className="p-4" data-testid="timeline-view">
+      {[...days.entries()].map(([day, rows]) => (
+        <section key={day} className="mb-6">
+          <h2 className="mb-2 text-xs font-semibold uppercase tracking-wide text-zinc-400">
+            {day}
+          </h2>
+          <ol className="space-y-1">
+            {rows.map((r) => {
+              const outcome = typeof r.data.outcome === "string" ? r.data.outcome : undefined
+              const durationMs =
+                typeof r.data.durationMs === "number" ? r.data.durationMs : undefined
+              return (
+                <li key={r.id}>
+                  <button
+                    type="button"
+                    onClick={() => onSelect(r.id)}
+                    className="flex w-full items-center gap-2 rounded-md px-2 py-1 text-left text-sm hover:bg-zinc-50"
+                    aria-label={`Open episode: ${r.content}`}
+                  >
+                    <span className="w-14 shrink-0 font-mono text-xs text-zinc-400">
+                      {(r.effectiveAt ?? r.createdAt).slice(11, 16)}
+                    </span>
+                    {outcome ? (
+                      <Badge variant={outcomeVariant(outcome)}>{outcome}</Badge>
+                    ) : (
+                      <Badge>authored</Badge>
+                    )}
+                    <span className="truncate" title={r.content}>
+                      {r.content}
+                    </span>
+                    {durationMs !== undefined ? (
+                      <span className="ml-auto shrink-0 text-xs text-zinc-400">
+                        {(durationMs / 1000).toFixed(1)}s
+                      </span>
+                    ) : null}
+                  </button>
+                </li>
+              )
+            })}
+          </ol>
+        </section>
+      ))}
+      {records.length === 0 ? (
+        <p className="text-sm text-zinc-400">No episodes in this window.</p>
+      ) : null}
+    </div>
+  )
+}

--- a/packages/inspector/src/components/memory/timeline-view.tsx
+++ b/packages/inspector/src/components/memory/timeline-view.tsx
@@ -19,8 +19,14 @@ export function TimelineView({
   records: readonly MemoryRecord[]
   onSelect: (id: string) => void
 }) {
+  // browse orders by updated_at DESC, so a mutation on an old record would
+  // hoist a days-old section to the top; re-sort by event time. Plain string
+  // compare is safe — both operands are full-ISO-Z timestamps.
+  const sorted = [...records].sort((a, b) =>
+    (b.effectiveAt ?? b.createdAt) < (a.effectiveAt ?? a.createdAt) ? -1 : 1,
+  )
   const days = new Map<string, MemoryRecord[]>()
-  for (const r of records) {
+  for (const r of sorted) {
     const day = dayOf(r)
     const bucket = days.get(day)
     if (bucket) bucket.push(r)

--- a/packages/inspector/src/components/ui/badge.tsx
+++ b/packages/inspector/src/components/ui/badge.tsx
@@ -8,6 +8,7 @@ const badge = cva("inline-flex items-center rounded-full px-2 py-0.5 text-xs fon
       active: "bg-green-100 text-green-800",
       candidate: "bg-amber-100 text-amber-800",
       superseded: "bg-zinc-100 text-zinc-500 line-through",
+      danger: "bg-red-100 text-red-800",
       neutral: "border border-zinc-200 bg-white text-zinc-600",
     },
   },

--- a/packages/inspector/test/api.e2e.test.ts
+++ b/packages/inspector/test/api.e2e.test.ts
@@ -243,6 +243,97 @@ describe.skipIf(!gated)("memory JSON API", () => {
   })
 })
 
+describe.skipIf(!gated)("list time windows + expiry", () => {
+  let server: InspectorServer
+
+  function episodeSeed(
+    overrides: Partial<MemoryRecord> & Pick<MemoryRecord, "id" | "effectiveAt">,
+  ): MemoryRecord {
+    return record({
+      kind: "episodic",
+      namespace: "route=/chat",
+      status: "active",
+      content: "Ran: summarize the meeting",
+      data: { input: "summarize the meeting", outcome: "ok", durationMs: 1200 },
+      source: { type: "run", id: "run-1" },
+      ...overrides,
+    })
+  }
+
+  beforeAll(async () => {
+    resetDawnDir(fixtureApp)
+    const store = sqliteMemoryStore({ path: join(fixtureApp, ".dawn", "memory.sqlite") })
+    await store.put(episodeSeed({ id: "ep-day1", effectiveAt: "2026-08-01T10:00:00.000Z" }))
+    await store.put(
+      episodeSeed({
+        id: "ep-day2",
+        content: "Ran: draft the release notes",
+        data: { input: "draft the release notes", outcome: "error", durationMs: 500 },
+        effectiveAt: "2026-08-02T12:00:00.000Z",
+      }),
+    )
+    // Already expired relative to any wall clock this test runs under.
+    await store.put(
+      episodeSeed({
+        id: "ep-expired",
+        content: "Ran: an expired episode",
+        effectiveAt: "2026-08-01T09:00:00.000Z",
+        expiresAt: "2020-01-01T00:00:00.000Z",
+      }),
+    )
+    server = await startInspector(fixtureApp)
+  })
+
+  afterAll(async () => {
+    await server?.stop()
+    removeDawnDir(fixtureApp)
+  })
+
+  it("since narrows the list to episodes at or after the bound", async () => {
+    const params = new URLSearchParams({ since: "2026-08-02T00:00:00.000Z" })
+    const res = await fetch(`${server.base}/api/memory/list?${params}`)
+    expect(res.status).toBe(200)
+    const page = (await res.json()) as { records: MemoryRecord[]; total: number }
+    expect(page.records.map((r) => r.id)).toEqual(["ep-day2"])
+    expect(page.total).toBe(1)
+  })
+
+  it("until excludes episodes at or after the bound (exclusive upper)", async () => {
+    const params = new URLSearchParams({ until: "2026-08-02T00:00:00.000Z" })
+    const res = await fetch(`${server.base}/api/memory/list?${params}`)
+    const page = (await res.json()) as { records: MemoryRecord[]; total: number }
+    // ep-expired's effectiveAt is also inside this window — expiry still hides it.
+    expect(page.records.map((r) => r.id)).toEqual(["ep-day1"])
+  })
+
+  it("expired episodes are hidden by default and revealed by includeExpired=1", async () => {
+    const res = await fetch(`${server.base}/api/memory/list`)
+    const page = (await res.json()) as { records: MemoryRecord[]; total: number }
+    expect(page.records.map((r) => r.id).sort()).toEqual(["ep-day1", "ep-day2"])
+
+    const revealed = await fetch(`${server.base}/api/memory/list?includeExpired=1`)
+    const revealedPage = (await revealed.json()) as { records: MemoryRecord[]; total: number }
+    expect(revealedPage.records.map((r) => r.id).sort()).toEqual([
+      "ep-day1",
+      "ep-day2",
+      "ep-expired",
+    ])
+  })
+
+  it("rejects unparseable since/until with a 400 {error}", async () => {
+    const bad = await fetch(`${server.base}/api/memory/list?since=notadate`)
+    expect(bad.status).toBe(400)
+    const badBody = (await bad.json()) as { error: string }
+    expect(badBody.error).toContain('invalid since "notadate"')
+
+    const badUntil = await fetch(`${server.base}/api/memory/list?until=alsonotadate`)
+    expect(badUntil.status).toBe(400)
+    expect(((await badUntil.json()) as { error: string }).error).toContain(
+      'invalid until "alsonotadate"',
+    )
+  })
+})
+
 describe.skipIf(!gated)("identity resolution error discipline", () => {
   let server: InspectorServer
 

--- a/packages/inspector/test/api.e2e.test.ts
+++ b/packages/inspector/test/api.e2e.test.ts
@@ -281,6 +281,21 @@ describe.skipIf(!gated)("list time windows + expiry", () => {
         expiresAt: "2020-01-01T00:00:00.000Z",
       }),
     )
+    // Isolated namespace for the offset-ISO normalization case.
+    await store.put(
+      episodeSeed({
+        id: "ep-tz-before",
+        namespace: "route=/tz",
+        effectiveAt: "2026-08-01T09:30:00.000Z",
+      }),
+    )
+    await store.put(
+      episodeSeed({
+        id: "ep-tz-after",
+        namespace: "route=/tz",
+        effectiveAt: "2026-08-01T10:30:00.000Z",
+      }),
+    )
     server = await startInspector(fixtureApp)
   })
 
@@ -299,7 +314,10 @@ describe.skipIf(!gated)("list time windows + expiry", () => {
   })
 
   it("until excludes episodes at or after the bound (exclusive upper)", async () => {
-    const params = new URLSearchParams({ until: "2026-08-02T00:00:00.000Z" })
+    const params = new URLSearchParams({
+      namespacePrefix: "route=/chat",
+      until: "2026-08-02T00:00:00.000Z",
+    })
     const res = await fetch(`${server.base}/api/memory/list?${params}`)
     const page = (await res.json()) as { records: MemoryRecord[]; total: number }
     // ep-expired's effectiveAt is also inside this window — expiry still hides it.
@@ -307,17 +325,33 @@ describe.skipIf(!gated)("list time windows + expiry", () => {
   })
 
   it("expired episodes are hidden by default and revealed by includeExpired=1", async () => {
-    const res = await fetch(`${server.base}/api/memory/list`)
+    const prefix = new URLSearchParams({ namespacePrefix: "route=/chat" })
+    const res = await fetch(`${server.base}/api/memory/list?${prefix}`)
     const page = (await res.json()) as { records: MemoryRecord[]; total: number }
     expect(page.records.map((r) => r.id).sort()).toEqual(["ep-day1", "ep-day2"])
 
-    const revealed = await fetch(`${server.base}/api/memory/list?includeExpired=1`)
+    const revealed = await fetch(`${server.base}/api/memory/list?${prefix}&includeExpired=1`)
     const revealedPage = (await revealed.json()) as { records: MemoryRecord[]; total: number }
     expect(revealedPage.records.map((r) => r.id).sort()).toEqual([
       "ep-day1",
       "ep-day2",
       "ep-expired",
     ])
+  })
+
+  it("normalizes an offset-ISO since to the correct UTC instant", async () => {
+    // route=/tz isolates the assertion. 2026-08-01T12:00:00+02:00 is
+    // 10:00:00Z — the 09:30Z row falls before it, the 10:30Z row after.
+    // Raw lexicographic pass-through would compare "...T10:30:00.000Z" against
+    // "...T12:00:00+02:00" and wrongly exclude the later row.
+    const params = new URLSearchParams({
+      namespacePrefix: "route=/tz",
+      since: "2026-08-01T12:00:00+02:00",
+    })
+    const res = await fetch(`${server.base}/api/memory/list?${params}`)
+    expect(res.status).toBe(200)
+    const page = (await res.json()) as { records: MemoryRecord[]; total: number }
+    expect(page.records.map((r) => r.id)).toEqual(["ep-tz-after"])
   })
 
   it("rejects unparseable since/until with a 400 {error}", async () => {

--- a/packages/inspector/test/components/timeline.test.tsx
+++ b/packages/inspector/test/components/timeline.test.tsx
@@ -89,6 +89,35 @@ describe("TimelineView", () => {
     expect(screen.getByText("0.5s")).toBeDefined()
   })
 
+  it("sorts by event time (newest first), not fetch order", () => {
+    // browse orders by updated_at DESC — a mutation on an old record hoists it
+    // to the front of the fetch. Supply updated-at order: the OLD-event record
+    // first, then day-2 rows earliest-first. The timeline must re-sort by
+    // (effectiveAt ?? createdAt) descending.
+    const oldEventBumped = episode({
+      id: "ep-old",
+      content: "Ran: an old episode, recently mutated",
+      effectiveAt: "2026-08-01T09:00:00.000Z",
+      updatedAt: "2026-08-03T00:00:00.000Z",
+    })
+    const day2Early = episode({
+      id: "ep-early",
+      content: "Ran: early on day two",
+      effectiveAt: "2026-08-02T12:30:00.000Z",
+    })
+    const day2Late = episode({
+      id: "ep-late",
+      content: "Ran: late on day two",
+      effectiveAt: "2026-08-02T15:45:00.000Z",
+    })
+    render(<TimelineView records={[oldEventBumped, day2Early, day2Late]} onSelect={noop} />)
+    const headings = screen.getAllByRole("heading", { level: 2 }).map((h) => h.textContent)
+    expect(headings).toEqual(["2026-08-02", "2026-08-01"])
+    // Within-day rows descend by event time: 15:45 above 12:30.
+    const times = screen.getAllByText(/^\d{2}:\d{2}$/).map((el) => el.textContent)
+    expect(times).toEqual(["15:45", "12:30", "09:00"])
+  })
+
   it("labels agent-authored episodes (no outcome) as authored", () => {
     const authored = episode({
       id: "ep3",

--- a/packages/inspector/test/components/timeline.test.tsx
+++ b/packages/inspector/test/components/timeline.test.tsx
@@ -1,0 +1,149 @@
+import type { MemoryRecord, MemoryStats } from "@dawn-ai/memory"
+import { cleanup, fireEvent, render, screen } from "@testing-library/react"
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { ListPage } from "../../src/components/memory/list-page"
+import { TimelineView } from "../../src/components/memory/timeline-view"
+
+const stats: MemoryStats = {
+  total: 2,
+  byStatus: { active: 2 },
+  byKind: { episodic: 2 },
+  byNamespace: { "route=/chat": 2 },
+  bySourceType: { run: 2 },
+}
+
+function episode(overrides: Partial<MemoryRecord> & Pick<MemoryRecord, "id">): MemoryRecord {
+  return {
+    kind: "episodic",
+    namespace: "route=/chat",
+    content: "Ran: summarize the meeting",
+    data: { input: "summarize the meeting", outcome: "ok", durationMs: 1234 },
+    source: { type: "run", id: "run-1" },
+    confidence: 1,
+    tags: [],
+    status: "active",
+    createdAt: "2026-08-01T10:00:00.000Z",
+    updatedAt: "2026-08-01T10:00:00.000Z",
+    effectiveAt: "2026-08-01T10:00:00.000Z",
+    ...overrides,
+  }
+}
+
+const epDay1 = episode({ id: "ep1" })
+const epDay2 = episode({
+  id: "ep2",
+  content: "Ran: draft the release notes",
+  data: { input: "draft the release notes", outcome: "error", durationMs: 500 },
+  effectiveAt: "2026-08-02T12:30:00.000Z",
+  createdAt: "2026-08-02T12:30:00.000Z",
+  updatedAt: "2026-08-02T12:30:00.000Z",
+})
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  })
+}
+
+/** Stub fetch with an episodic API surface; returns the mock for call assertions. */
+function stubApi(records: readonly MemoryRecord[] = [epDay1, epDay2]) {
+  const mock = vi.fn(async (url: RequestInfo | URL) => {
+    const u = String(url)
+    if (u.includes("/api/memory/stats")) return jsonResponse(stats)
+    if (u.includes("/api/memory/list")) {
+      return jsonResponse({ records, total: records.length })
+    }
+    if (u.includes("/api/memory/search")) return jsonResponse({ groups: [], hybrid: false })
+    const byId = records.find((r) => u.endsWith(`/api/memory/${r.id}`))
+    if (byId) return jsonResponse(byId)
+    return jsonResponse({ error: "not found" }, 404)
+  })
+  vi.stubGlobal("fetch", mock)
+  return mock
+}
+
+function callsTo(mock: ReturnType<typeof stubApi>, path: string): URL[] {
+  return mock.mock.calls
+    .map((call) => String(call[0]))
+    .filter((u) => u.includes(path))
+    .map((u) => new URL(u, "http://localhost"))
+}
+
+afterEach(() => {
+  cleanup()
+  vi.unstubAllGlobals()
+})
+
+const noop = () => {}
+
+describe("TimelineView", () => {
+  it("groups records by day with outcome badges and durations", () => {
+    render(<TimelineView records={[epDay1, epDay2]} onSelect={noop} />)
+    expect(screen.getByRole("heading", { level: 2, name: "2026-08-01" })).toBeDefined()
+    expect(screen.getByRole("heading", { level: 2, name: "2026-08-02" })).toBeDefined()
+    expect(screen.getByText("ok")).toBeDefined()
+    const errorBadge = screen.getByText("error")
+    expect(errorBadge.className).toContain("bg-red-100")
+    expect(screen.getByText("1.2s")).toBeDefined()
+    expect(screen.getByText("0.5s")).toBeDefined()
+  })
+
+  it("labels agent-authored episodes (no outcome) as authored", () => {
+    const authored = episode({
+      id: "ep3",
+      content: "User prefers expedited shipping",
+      data: {},
+      source: { type: "tool", id: "remember" },
+    })
+    render(<TimelineView records={[authored]} onSelect={noop} />)
+    expect(screen.getByText("authored")).toBeDefined()
+  })
+
+  it("renders the empty state when there are no episodes", () => {
+    render(<TimelineView records={[]} onSelect={noop} />)
+    expect(screen.getByText("No episodes in this window.")).toBeDefined()
+  })
+})
+
+describe("ListPage timeline mode", () => {
+  it("clicking a timeline row opens the detail sheet", async () => {
+    stubApi()
+    render(<ListPage />)
+    fireEvent.click(screen.getByRole("button", { name: "timeline" }))
+    const row = await screen.findByRole("button", {
+      name: "Open episode: Ran: summarize the meeting",
+    })
+    fireEvent.click(row)
+    expect(await screen.findByTestId("detail-sheet")).toBeDefined()
+  })
+
+  it("shows the timeline empty state for an empty window", async () => {
+    stubApi([])
+    render(<ListPage />)
+    fireEvent.click(screen.getByRole("button", { name: "timeline" }))
+    expect(await screen.findByText("No episodes in this window.")).toBeDefined()
+  })
+
+  it("timeline mode defaults kind=episodic and the window select threads since", async () => {
+    const mock = stubApi()
+    render(<ListPage />)
+    fireEvent.click(screen.getByRole("button", { name: "timeline" }))
+    await vi.waitFor(() => {
+      const episodic = callsTo(mock, "/api/memory/list").filter(
+        (u) => u.searchParams.get("kind") === "episodic",
+      )
+      expect(episodic.length).toBeGreaterThan(0)
+    })
+    fireEvent.change(screen.getByLabelText("Window"), { target: { value: "24h" } })
+    await vi.waitFor(() => {
+      const windowed = callsTo(mock, "/api/memory/list").filter((u) => u.searchParams.has("since"))
+      expect(windowed.length).toBeGreaterThan(0)
+      const since = windowed[windowed.length - 1]?.searchParams.get("since") ?? ""
+      expect(Number.isFinite(Date.parse(since))).toBe(true)
+      // Client-computed lower bound: roughly Date.now() - 24h.
+      expect(Date.now() - Date.parse(since)).toBeLessThan(25 * 60 * 60 * 1000)
+      expect(Date.now() - Date.parse(since)).toBeGreaterThan(23 * 60 * 60 * 1000)
+    })
+  })
+})

--- a/packages/memory-pgvector/src/pgvector-store.ts
+++ b/packages/memory-pgvector/src/pgvector-store.ts
@@ -509,6 +509,11 @@ export function pgvectorMemoryStore(opts: {
       // Byte-exact prefix match (see browse) — LIKE metachars stay literal.
       // Two explicit SQL strings per pass (with/without prefix) — no clause
       // splicing, each statement readable on its own.
+      // Two passes are separate autocommit statements (possibly different pool
+      // connections); each is committed before the next is sent, so the cap
+      // pass never sees uncommitted expired rows. Rows written between passes
+      // wait for the next prune — acceptable, and matches sqlite's
+      // non-transactional two-pass shape.
       const expiredBase = `DELETE FROM ${T} WHERE expires_at IS NOT NULL AND expires_at <= $1`
       const expiredPrefixed = `DELETE FROM ${T}
          WHERE expires_at IS NOT NULL AND expires_at <= $1

--- a/packages/memory-pgvector/src/pgvector-store.ts
+++ b/packages/memory-pgvector/src/pgvector-store.ts
@@ -275,18 +275,40 @@ export function pgvectorMemoryStore(opts: {
       const limit = q.limit ?? 8
       const terms = q.query ? tokenize(q.query) : []
 
-      // Shared base filter (namespace + status [+ kind]) — the "corpus".
+      // Shared base filter (namespace + status [+ kind] [+ time window]
+      // [+ expiry]) — the "corpus". Every search path (query-less, ranked,
+      // hybrid) AND the ranked path's df/N corpus stats interpolate this same
+      // clause, so window/expiry filtering and IDF stats stay coherent.
       let baseSql = "m.namespace = $1 AND m.status = $2"
       const baseParams: unknown[] = [q.namespace, status]
       if (q.kind) {
         baseParams.push(q.kind)
         baseSql += ` AND m.kind = $${baseParams.length}`
       }
+      if (q.since) {
+        baseParams.push(q.since)
+        baseSql += ` AND COALESCE(m.effective_at, m.created_at) >= $${baseParams.length}`
+      }
+      if (q.until) {
+        baseParams.push(q.until)
+        baseSql += ` AND COALESCE(m.effective_at, m.created_at) < $${baseParams.length}`
+      }
+      if (q.now) {
+        baseParams.push(q.now)
+        baseSql += ` AND (m.expires_at IS NULL OR m.expires_at > $${baseParams.length})`
+      }
 
       if (terms.length === 0) {
-        // Query-less path: pure recency order (index-fragment behavior).
+        // Query-less path: unwindowed keeps EXACTLY the pre-ranking recency
+        // behavior (byte-stable). A since/until window switches to event-time
+        // order — windowed queries are about "what happened then". COLLATE "C"
+        // pins the id ASC tiebreak to codepoint order (sqlite BINARY parity).
+        const order =
+          q.since || q.until
+            ? `COALESCE(m.effective_at, m.created_at) DESC, m.id COLLATE "C" ASC`
+            : "m.updated_at DESC, m.id ASC"
         const res = await pool.query(
-          `SELECT ${recordColumns("m")} FROM ${T} m WHERE ${baseSql} ORDER BY m.updated_at DESC, m.id ASC LIMIT $${baseParams.length + 1}`,
+          `SELECT ${recordColumns("m")} FROM ${T} m WHERE ${baseSql} ORDER BY ${order} LIMIT $${baseParams.length + 1}`,
           [...baseParams, limit],
         )
         let records = (res.rows as Record<string, unknown>[]).map(rowToRecord)
@@ -419,6 +441,18 @@ export function pgvectorMemoryStore(opts: {
         params.push(q.sourceType)
         where.push(`source->>'type' = $${params.length}`)
       }
+      if (q.since) {
+        params.push(q.since)
+        where.push(`COALESCE(effective_at, created_at) >= $${params.length}`)
+      }
+      if (q.until) {
+        params.push(q.until)
+        where.push(`COALESCE(effective_at, created_at) < $${params.length}`)
+      }
+      if (q.now) {
+        params.push(q.now)
+        where.push(`(expires_at IS NULL OR expires_at > $${params.length})`)
+      }
       const clause = where.length > 0 ? `WHERE ${where.join(" AND ")}` : ""
       // Clamp: sqlite treats LIMIT -1 as unlimited while Postgres throws on
       // negatives — clamping to ≥0 integers unifies backend behavior.
@@ -468,6 +502,59 @@ export function pgvectorMemoryStore(opts: {
         byNamespace,
         bySourceType,
       }
+    },
+
+    async prune(pruneOpts) {
+      await ready()
+      // Byte-exact prefix match (see browse) — LIKE metachars stay literal.
+      // Two explicit SQL strings per pass (with/without prefix) — no clause
+      // splicing, each statement readable on its own.
+      const expiredBase = `DELETE FROM ${T} WHERE expires_at IS NOT NULL AND expires_at <= $1`
+      const expiredPrefixed = `DELETE FROM ${T}
+         WHERE expires_at IS NOT NULL AND expires_at <= $1
+           AND left(namespace, length($2)) = $3`
+      const expired = pruneOpts.namespacePrefix
+        ? await pool.query(expiredPrefixed, [
+            pruneOpts.now,
+            pruneOpts.namespacePrefix,
+            pruneOpts.namespacePrefix,
+          ])
+        : await pool.query(expiredBase, [pruneOpts.now])
+      let deletedOverCap = 0
+      if (pruneOpts.cap !== undefined) {
+        const cap = Math.max(0, Math.trunc(pruneOpts.cap))
+        // Rank episodic rows per namespace by event time (newest first, id ASC
+        // C-collation tiebreak — the established cross-backend ordering) and
+        // delete beyond cap. Status is deliberately ignored: every episodic row
+        // counts against the namespace budget.
+        const overBase = `DELETE FROM ${T} WHERE id IN (
+           SELECT id FROM (
+             SELECT id, ROW_NUMBER() OVER (
+               PARTITION BY namespace
+               ORDER BY COALESCE(effective_at, created_at) DESC, id COLLATE "C" ASC
+             ) AS rn
+             FROM ${T} WHERE kind = 'episodic'
+           ) ranked WHERE rn > $1
+         )`
+        const overPrefixed = `DELETE FROM ${T} WHERE id IN (
+           SELECT id FROM (
+             SELECT id, ROW_NUMBER() OVER (
+               PARTITION BY namespace
+               ORDER BY COALESCE(effective_at, created_at) DESC, id COLLATE "C" ASC
+             ) AS rn
+             FROM ${T} WHERE kind = 'episodic' AND left(namespace, length($1)) = $2
+           ) ranked WHERE rn > $3
+         )`
+        const over = pruneOpts.namespacePrefix
+          ? await pool.query(overPrefixed, [
+              pruneOpts.namespacePrefix,
+              pruneOpts.namespacePrefix,
+              cap,
+            ])
+          : await pool.query(overBase, [cap])
+        deletedOverCap = over.rowCount ?? 0
+      }
+      return { deletedExpired: expired.rowCount ?? 0, deletedOverCap }
     },
 
     async close() {

--- a/packages/memory-pgvector/src/schema.ts
+++ b/packages/memory-pgvector/src/schema.ts
@@ -47,6 +47,11 @@ export async function initSchema(
   await client.query(
     `CREATE INDEX IF NOT EXISTS ${prefix}_ns_status_updated ON ${t} (namespace, status, updated_at DESC)`,
   )
+  // Equality filter for kind-scoped windows; COALESCE(effective_at, created_at)
+  // ordering is intentionally unindexed at this scale.
+  await client.query(
+    `CREATE INDEX IF NOT EXISTS ${prefix}_ns_kind_effective ON ${t} (namespace, kind, effective_at DESC)`,
+  )
   await client.query(`CREATE INDEX IF NOT EXISTS ${prefix}_tok ON ${tk} (token)`)
   await client.query(`CREATE INDEX IF NOT EXISTS ${prefix}_tok_mem ON ${tk} (memory_id)`)
   await client.query(

--- a/packages/memory/src/index.ts
+++ b/packages/memory/src/index.ts
@@ -10,6 +10,8 @@ export {
   approveWithReconcile,
   classifyWrite,
   type WriteOp,
+  type WritePolicy,
+  writePolicyFor,
 } from "./reconcile.js"
 export {
   DEFAULT_CANDIDATE_POOL,

--- a/packages/memory/src/reconcile.ts
+++ b/packages/memory/src/reconcile.ts
@@ -56,6 +56,8 @@ export interface ApproveResult {
  * identity + identical data → the candidate is dropped (dedupe); no identity
  * match → plain activation. Used by `dawn memory approve` and the inspector —
  * the capability's auto-write path keeps its own inline logic by design.
+ * Append-kind candidates (per writePolicyFor, e.g. episodic) bypass
+ * reconciliation entirely — approval is a plain activation, no identity scan.
  *
  * NOT transactional: MemoryStore has no CAS primitive, so the read-classify-
  * write sequence can race a concurrent same-identity auto-write. Worst case is

--- a/packages/memory/src/reconcile.ts
+++ b/packages/memory/src/reconcile.ts
@@ -5,7 +5,9 @@ export type WritePolicy = { readonly mode: "reconcile" } | { readonly mode: "app
 /** Per-kind write discipline. Semantic facts reconcile (identity match →
  *  update/supersede); episodic events append (a later episode never
  *  contradicts an earlier one). Procedural/reflection are typed but not yet
- *  wired — throwing beats baking in accidental semantics. */
+ *  wired — throwing beats baking in accidental semantics.
+ *  Mirrored inline in packages/core/src/capabilities/built-in/memory.ts
+ *  remember (core can't import this package) — keep in sync. */
 export function writePolicyFor(kind: MemoryKind): WritePolicy {
   switch (kind) {
     case "semantic":

--- a/packages/memory/src/reconcile.ts
+++ b/packages/memory/src/reconcile.ts
@@ -1,4 +1,22 @@
-import type { MemoryRecord, MemoryStore } from "./types.js"
+import type { MemoryKind, MemoryRecord, MemoryStore } from "./types.js"
+
+export type WritePolicy = { readonly mode: "reconcile" } | { readonly mode: "append" }
+
+/** Per-kind write discipline. Semantic facts reconcile (identity match →
+ *  update/supersede); episodic events append (a later episode never
+ *  contradicts an earlier one). Procedural/reflection are typed but not yet
+ *  wired — throwing beats baking in accidental semantics. */
+export function writePolicyFor(kind: MemoryKind): WritePolicy {
+  switch (kind) {
+    case "semantic":
+      return { mode: "reconcile" }
+    case "episodic":
+      return { mode: "append" }
+    default:
+      throw new Error(`memory kind '${kind}' is not yet wired (semantic and episodic are)`)
+  }
+}
+
 export type WriteOp =
   | { op: "add" }
   | { op: "update"; targetId: string }
@@ -53,6 +71,13 @@ export async function approveWithReconcile(
   if (!candidate) throw new Error(`memory ${id} not found`)
   if (candidate.status !== "candidate")
     throw new Error(`memory ${id} is '${candidate.status}', not a candidate`)
+  if (writePolicyFor(candidate.kind).mode === "append") {
+    // Append-only kinds: approval is a plain activation — no identity scan.
+    await store.update(id, { status: "active", updatedAt: opts.now })
+    const approved = await store.get(id)
+    if (!approved) throw new Error(`approved memory ${id} vanished`)
+    return { approved, action: "activated", superseded: [], identityKeys: opts.identityKeys }
+  }
   const actives = await store.search({
     namespace: candidate.namespace,
     status: "active",

--- a/packages/memory/src/sqlite-store.ts
+++ b/packages/memory/src/sqlite-store.ts
@@ -84,6 +84,8 @@ const MIGRATIONS: Migration[] = [
     `,
   },
   {
+    // Equality filter for kind-scoped windows; COALESCE(effective_at, created_at)
+    // ordering is intentionally unindexed at this scale.
     version: 3,
     up: `
       CREATE INDEX IF NOT EXISTS idx_mem_ns_kind_effective ON memories (namespace, kind, effective_at DESC);

--- a/packages/memory/src/sqlite-store.ts
+++ b/packages/memory/src/sqlite-store.ts
@@ -502,5 +502,45 @@ export function sqliteMemoryStore(opts: {
         bySourceType: group("json_extract(source, '$.type')"),
       }
     },
+    async prune(opts) {
+      // Byte-exact prefix match (see browse) — LIKE metachars stay literal.
+      const prefixParams: SQLInputValue[] = opts.namespacePrefix
+        ? [opts.namespacePrefix, opts.namespacePrefix]
+        : []
+      const expiredSql = opts.namespacePrefix
+        ? `DELETE FROM memories WHERE expires_at IS NOT NULL AND expires_at <= ?
+           AND substr(namespace, 1, length(?)) = ?`
+        : "DELETE FROM memories WHERE expires_at IS NOT NULL AND expires_at <= ?"
+      const expired = db.prepare(expiredSql).run(opts.now, ...prefixParams)
+      let deletedOverCap = 0
+      if (opts.cap !== undefined) {
+        const cap = Math.max(0, Math.trunc(opts.cap))
+        // Rank episodic rows per namespace by event time (newest first, id ASC
+        // tiebreak — the established cross-backend ordering) and delete beyond cap.
+        const overSql = opts.namespacePrefix
+          ? `DELETE FROM memories WHERE id IN (
+               SELECT id FROM (
+                 SELECT id, ROW_NUMBER() OVER (
+                   PARTITION BY namespace
+                   ORDER BY COALESCE(effective_at, created_at) DESC, id ASC
+                 ) AS rn
+                 FROM memories
+                 WHERE kind = 'episodic' AND substr(namespace, 1, length(?)) = ?
+               ) WHERE rn > ?
+             )`
+          : `DELETE FROM memories WHERE id IN (
+               SELECT id FROM (
+                 SELECT id, ROW_NUMBER() OVER (
+                   PARTITION BY namespace
+                   ORDER BY COALESCE(effective_at, created_at) DESC, id ASC
+                 ) AS rn
+                 FROM memories WHERE kind = 'episodic'
+               ) WHERE rn > ?
+             )`
+        const over = db.prepare(overSql).run(...prefixParams, cap)
+        deletedOverCap = Number(over.changes)
+      }
+      return { deletedExpired: Number(expired.changes), deletedOverCap }
+    },
   }
 }

--- a/packages/memory/src/sqlite-store.ts
+++ b/packages/memory/src/sqlite-store.ts
@@ -83,6 +83,12 @@ const MIGRATIONS: Migration[] = [
       ALTER TABLE memories ADD COLUMN embedding_model TEXT;
     `,
   },
+  {
+    version: 3,
+    up: `
+      CREATE INDEX IF NOT EXISTS idx_mem_ns_kind_effective ON memories (namespace, kind, effective_at DESC);
+    `,
+  },
 ]
 
 // ---------------------------------------------------------------------------
@@ -286,21 +292,40 @@ export function sqliteMemoryStore(opts: {
       const limit = q.limit ?? 8
       const terms = q.query ? tokenize(q.query) : []
 
-      // Shared base filter (namespace + status [+ kind]) — the "corpus".
+      // Shared base filter (namespace + status [+ kind] [+ time window]
+      // [+ expiry]) — the "corpus". Every search path (query-less, ranked,
+      // hybrid) AND the ranked path's df/N corpus stats interpolate this same
+      // clause, so window/expiry filtering and IDF stats stay coherent.
       let baseSql = `m.namespace = ? AND m.status = ?`
       const baseParams: SQLInputValue[] = [q.namespace, status]
       if (q.kind) {
         baseSql += ` AND m.kind = ?`
         baseParams.push(q.kind)
       }
+      if (q.since) {
+        baseSql += ` AND COALESCE(m.effective_at, m.created_at) >= ?`
+        baseParams.push(q.since)
+      }
+      if (q.until) {
+        baseSql += ` AND COALESCE(m.effective_at, m.created_at) < ?`
+        baseParams.push(q.until)
+      }
+      if (q.now) {
+        baseSql += ` AND (m.expires_at IS NULL OR m.expires_at > ?)`
+        baseParams.push(q.now)
+      }
 
       if (terms.length === 0) {
-        // Query-less path: EXACTLY the pre-ranking behavior (index fragment,
-        // listCandidates-adjacent consumers depend on pure recency order).
+        // Query-less path: unwindowed keeps EXACTLY the pre-ranking recency
+        // behavior (index fragment, listCandidates-adjacent consumers depend
+        // on pure recency order). A since/until window switches to event-time
+        // order — windowed queries are about "what happened then".
+        const order =
+          q.since || q.until
+            ? "COALESCE(m.effective_at, m.created_at) DESC, m.id ASC"
+            : "m.updated_at DESC, m.id ASC"
         const rows = db
-          .prepare(
-            `SELECT m.* FROM memories m WHERE ${baseSql} ORDER BY m.updated_at DESC, m.id ASC LIMIT ?`,
-          )
+          .prepare(`SELECT m.* FROM memories m WHERE ${baseSql} ORDER BY ${order} LIMIT ?`)
           .all(...baseParams, limit) as Record<string, unknown>[]
         let records = rows.map(rowToRecord)
         if (q.tags && q.tags.length > 0) {
@@ -420,6 +445,18 @@ export function sqliteMemoryStore(opts: {
       if (q.sourceType) {
         where.push("json_extract(source, '$.type') = ?")
         params.push(q.sourceType)
+      }
+      if (q.since) {
+        where.push("COALESCE(effective_at, created_at) >= ?")
+        params.push(q.since)
+      }
+      if (q.until) {
+        where.push("COALESCE(effective_at, created_at) < ?")
+        params.push(q.until)
+      }
+      if (q.now) {
+        where.push("(expires_at IS NULL OR expires_at > ?)")
+        params.push(q.now)
       }
       const clause = where.length > 0 ? `WHERE ${where.join(" AND ")}` : ""
       // Clamp: sqlite treats LIMIT -1 as unlimited while Postgres throws on

--- a/packages/memory/src/types.ts
+++ b/packages/memory/src/types.ts
@@ -29,8 +29,13 @@ export interface MemoryQuery {
   readonly limit?: number
   /** ISO timestamp used as the recency reference for ranked (query) searches.
    *  Optional; when absent, recency is measured relative to the newest
-   *  candidate's updatedAt (data-derived — the library never reads a clock). */
+   *  candidate's updatedAt (data-derived — the library never reads a clock).
+   *  Also excludes rows with expiresAt <= now. */
   readonly now?: string
+  /** ISO lower bound (inclusive) on COALESCE(effectiveAt, createdAt). */
+  readonly since?: string
+  /** ISO upper bound (exclusive) on COALESCE(effectiveAt, createdAt). */
+  readonly until?: string
   /** When present, the store runs the hybrid path: keyword ∪ vector-nearest, RRF-fused. */
   readonly queryEmbedding?: Float32Array
   /** Only rows whose stored embedding_model equals this are vector-compared. */
@@ -53,6 +58,12 @@ export interface BrowseQuery {
   readonly sourceType?: MemorySource["type"]
   readonly limit?: number
   readonly offset?: number
+  /** ISO lower bound (inclusive) on COALESCE(effectiveAt, createdAt). */
+  readonly since?: string
+  /** ISO upper bound (exclusive) on COALESCE(effectiveAt, createdAt). */
+  readonly until?: string
+  /** When supplied, rows with expiresAt <= now are excluded (matches search's `now`). */
+  readonly now?: string
 }
 export interface BrowsePage {
   readonly records: readonly MemoryRecord[]

--- a/packages/memory/src/types.ts
+++ b/packages/memory/src/types.ts
@@ -91,4 +91,12 @@ export interface MemoryStore {
   browse(q?: BrowseQuery): Promise<BrowsePage>
   /** Aggregate counts for facet UIs. */
   stats(opts?: { readonly namespacePrefix?: string }): Promise<MemoryStats>
+  /** Delete (a) rows of any kind with expiresAt <= now, and (b) when cap is
+   *  set, the oldest episodic rows beyond `cap` per namespace (ordered by
+   *  COALESCE(effectiveAt, createdAt), id tiebreak). */
+  prune(opts: {
+    readonly now: string
+    readonly namespacePrefix?: string
+    readonly cap?: number
+  }): Promise<{ readonly deletedExpired: number; readonly deletedOverCap: number }>
 }

--- a/packages/memory/test/prune.test.ts
+++ b/packages/memory/test/prune.test.ts
@@ -1,0 +1,98 @@
+import { mkdtempSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { afterEach, describe, expect, it } from "vitest"
+import { type MemoryRecord, sqliteMemoryStore } from "../src/index.js"
+
+const dirs: string[] = []
+function makeStore() {
+  const dir = mkdtempSync(join(tmpdir(), "dawn-prune-"))
+  dirs.push(dir)
+  return sqliteMemoryStore({ path: join(dir, "m.sqlite") })
+}
+afterEach(() => {
+  for (const d of dirs.splice(0)) rmSync(d, { recursive: true, force: true })
+})
+
+function rec(over: Partial<MemoryRecord> & Pick<MemoryRecord, "id">): MemoryRecord {
+  return {
+    kind: "episodic",
+    namespace: "route=/n",
+    content: over.id,
+    data: {},
+    source: { type: "run", id: "r" },
+    confidence: 1,
+    tags: [],
+    status: "active",
+    createdAt: "2026-08-01T00:00:00.000Z",
+    updatedAt: "2026-08-01T00:00:00.000Z",
+    ...over,
+  }
+}
+const D = (day: number) => `2026-08-0${day}T00:00:00.000Z`
+
+describe("prune", () => {
+  it("deletes expired rows of any kind and reports the count", async () => {
+    const s = makeStore()
+    await s.put(rec({ id: "sem-dead", kind: "semantic", expiresAt: D(2) }))
+    await s.put(rec({ id: "ep-dead", expiresAt: D(2) }))
+    await s.put(rec({ id: "ep-live", expiresAt: D(9) }))
+    const res = await s.prune({ now: D(5) })
+    expect(res).toEqual({ deletedExpired: 2, deletedOverCap: 0 })
+    expect(await s.get("sem-dead")).toBeNull()
+    expect((await s.get("ep-live"))?.id).toBe("ep-live")
+  })
+  it("caps episodic rows per namespace, keeping the newest by event time", async () => {
+    const s = makeStore()
+    for (let i = 1; i <= 5; i++) await s.put(rec({ id: `e${i}`, effectiveAt: D(i) }))
+    const res = await s.prune({ now: D(9), cap: 3 })
+    expect(res.deletedOverCap).toBe(2)
+    expect((await s.browse({ kind: "episodic" })).records.map((r) => r.id).sort()).toEqual([
+      "e3",
+      "e4",
+      "e5",
+    ])
+  })
+  it("cap is PER namespace and never touches non-episodic rows", async () => {
+    const s = makeStore()
+    await s.put(rec({ id: "sem", kind: "semantic", namespace: "route=/n" }))
+    for (let i = 1; i <= 3; i++)
+      await s.put(rec({ id: `a${i}`, namespace: "route=/a", effectiveAt: D(i) }))
+    for (let i = 1; i <= 3; i++)
+      await s.put(rec({ id: `b${i}`, namespace: "route=/b", effectiveAt: D(i) }))
+    const res = await s.prune({ now: D(9), cap: 2 })
+    expect(res.deletedOverCap).toBe(2) // one from each namespace
+    expect(await s.get("a1")).toBeNull()
+    expect(await s.get("b1")).toBeNull()
+    expect((await s.get("sem"))?.id).toBe("sem")
+  })
+  it("equal event times evict by id order (deterministic tiebreak)", async () => {
+    const s = makeStore()
+    // Same effectiveAt; codepoint id order decides. Oldest = LOWEST id first out.
+    await s.put(rec({ id: "B10", effectiveAt: D(2) }))
+    await s.put(rec({ id: "a9", effectiveAt: D(2) }))
+    await s.put(rec({ id: "b2", effectiveAt: D(2) }))
+    await s.prune({ now: D(9), cap: 2 })
+    // Keep the NEWEST 2 under (effective DESC, id ASC) ordering ⇒ evict the last
+    // in that ordering: "b2" (0x62 highest codepoint sorts last among equals).
+    expect(await s.get("b2")).toBeNull()
+    expect((await s.get("B10"))?.id).toBe("B10")
+    expect((await s.get("a9"))?.id).toBe("a9")
+  })
+  it("namespacePrefix narrows both TTL and cap passes", async () => {
+    const s = makeStore()
+    await s.put(rec({ id: "in", namespace: "route=/a", expiresAt: D(2) }))
+    await s.put(rec({ id: "out", namespace: "route=/b", expiresAt: D(2) }))
+    const res = await s.prune({ now: D(5), namespacePrefix: "route=/a" })
+    expect(res.deletedExpired).toBe(1)
+    expect((await s.get("out"))?.id).toBe("out")
+  })
+  it("is idempotent — a second identical prune deletes nothing", async () => {
+    const s = makeStore()
+    for (let i = 1; i <= 4; i++)
+      await s.put(rec({ id: `e${i}`, effectiveAt: D(i), expiresAt: i === 1 ? D(2) : undefined }))
+    await s.prune({ now: D(5), cap: 2 })
+    const second = await s.prune({ now: D(5), cap: 2 })
+    expect(second).toEqual({ deletedExpired: 0, deletedOverCap: 0 })
+  })
+})

--- a/packages/memory/test/reconcile-approve.test.ts
+++ b/packages/memory/test/reconcile-approve.test.ts
@@ -67,6 +67,19 @@ describe("approveWithReconcile", () => {
     expect(res.approved.id).toBe("old")
     expect(await s.get("cand")).toBeNull()
   })
+  it("approves an episodic candidate as a plain activation (no identity scan, no supersession)", async () => {
+    const s = makeStore()
+    // Two episodic rows with IDENTICAL data — under semantic policy this would
+    // dedupe/supersede; append policy must activate without touching the other.
+    await s.put(rec({ id: "ep-old", status: "active", kind: "episodic" }))
+    await s.put(rec({ id: "ep-cand", status: "candidate", kind: "episodic" }))
+    const res = await approveWithReconcile(s, "ep-cand", { identityKeys: KEYS, now: NOW })
+    expect(res.action).toBe("activated")
+    expect(res.superseded).toEqual([])
+    expect((await s.get("ep-old"))?.status).toBe("active")
+    expect((await s.get("ep-cand"))?.status).toBe("active")
+    expect((await s.get("ep-cand"))?.updatedAt).toBe(NOW)
+  })
   it("rejects a non-candidate", async () => {
     const s = makeStore()
     await s.put(rec({ id: "a", status: "active" }))

--- a/packages/memory/test/sqlite-store.test.ts
+++ b/packages/memory/test/sqlite-store.test.ts
@@ -1,4 +1,8 @@
-import { describe, expect, it } from "vitest"
+import { mkdtempSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { DatabaseSync } from "node:sqlite"
+import { afterEach, describe, expect, it } from "vitest"
 import { sqliteMemoryStore } from "../src/sqlite-store.js"
 import type { MemoryRecord } from "../src/types.js"
 
@@ -615,5 +619,58 @@ describe("sqliteMemoryStore", () => {
     expect(defaultOrder[0]).toBe("old")
     expect(tinyOrder[0]).toBe("new")
     expect(tinyOrder).not.toEqual(defaultOrder)
+  })
+})
+
+describe("schema migrations", () => {
+  const dirs: string[] = []
+  afterEach(() => {
+    for (const d of dirs.splice(0)) rmSync(d, { recursive: true, force: true })
+  })
+
+  it("v2 → v3: opening an existing v2 db adds the episodic event-time index", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "dawn-mig-"))
+    dirs.push(dir)
+    const path = join(dir, "m.sqlite")
+
+    // Hand-build a pre-EP2 (v2) database: v1 schema + v2 embedding columns,
+    // schema_version at 2 — byte-equivalent to what shipped stores wrote.
+    const raw = new DatabaseSync(path)
+    raw.exec(`
+      CREATE TABLE schema_version (version INTEGER PRIMARY KEY);
+      CREATE TABLE memories (
+        id TEXT PRIMARY KEY, kind TEXT NOT NULL, namespace TEXT NOT NULL,
+        content TEXT NOT NULL, data TEXT NOT NULL, source TEXT NOT NULL,
+        confidence REAL NOT NULL, tags TEXT NOT NULL, status TEXT NOT NULL,
+        supersedes TEXT, created_at TEXT NOT NULL, updated_at TEXT NOT NULL,
+        effective_at TEXT, expires_at TEXT
+      );
+      CREATE INDEX idx_mem_ns_status_updated ON memories(namespace, status, updated_at DESC);
+      CREATE TABLE memory_tokens (
+        memory_id TEXT NOT NULL REFERENCES memories(id) ON DELETE CASCADE, token TEXT NOT NULL
+      );
+      CREATE INDEX idx_memtok_token ON memory_tokens(token);
+      CREATE INDEX idx_memtok_mem ON memory_tokens(memory_id);
+      ALTER TABLE memories ADD COLUMN embedding BLOB;
+      ALTER TABLE memories ADD COLUMN embedding_model TEXT;
+      INSERT INTO schema_version(version) VALUES (1);
+      INSERT INTO schema_version(version) VALUES (2);
+    `)
+    raw.close()
+
+    const s = sqliteMemoryStore({ path })
+    await s.put(rec({ id: "kept", namespace: "ns", content: "still here after migration" }))
+    expect((await s.get("kept"))?.content).toBe("still here after migration")
+
+    const db = new DatabaseSync(path)
+    const idx = db
+      .prepare("SELECT name FROM sqlite_master WHERE type='index' AND name=?")
+      .get("idx_mem_ns_kind_effective") as { name?: string } | undefined
+    const version = db.prepare("SELECT max(version) AS v FROM schema_version").get() as {
+      v: number
+    }
+    db.close()
+    expect(idx?.name).toBe("idx_mem_ns_kind_effective")
+    expect(version.v).toBe(3)
   })
 })

--- a/packages/memory/test/time-window.test.ts
+++ b/packages/memory/test/time-window.test.ts
@@ -1,0 +1,97 @@
+import { mkdtempSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { afterEach, describe, expect, it } from "vitest"
+import { type MemoryRecord, sqliteMemoryStore } from "../src/index.js"
+
+const dirs: string[] = []
+function makeStore() {
+  const dir = mkdtempSync(join(tmpdir(), "dawn-tw-"))
+  dirs.push(dir)
+  return sqliteMemoryStore({ path: join(dir, "m.sqlite") })
+}
+afterEach(() => {
+  for (const d of dirs.splice(0)) rmSync(d, { recursive: true, force: true })
+})
+
+function rec(over: Partial<MemoryRecord> & Pick<MemoryRecord, "id">): MemoryRecord {
+  return {
+    kind: "episodic",
+    namespace: "route=/n",
+    content: over.id,
+    data: {},
+    source: { type: "run", id: "r" },
+    confidence: 1,
+    tags: [],
+    status: "active",
+    createdAt: "2026-08-01T00:00:00.000Z",
+    updatedAt: "2026-08-01T00:00:00.000Z",
+    ...over,
+  }
+}
+const D = (day: number) => `2026-08-0${day}T00:00:00.000Z`
+
+describe("search time windows", () => {
+  it("filters on effectiveAt with inclusive since / exclusive until", async () => {
+    const s = makeStore()
+    await s.put(rec({ id: "d1", effectiveAt: D(1) }))
+    await s.put(rec({ id: "d2", effectiveAt: D(2) }))
+    await s.put(rec({ id: "d3", effectiveAt: D(3) }))
+    const out = await s.search({ namespace: "route=/n", since: D(2), until: D(3) })
+    expect(out.map((r) => r.id)).toEqual(["d2"]) // since inclusive, until exclusive
+  })
+  it("falls back to createdAt for legacy rows without effectiveAt", async () => {
+    const s = makeStore()
+    await s.put(rec({ id: "legacy", createdAt: D(2), updatedAt: D(2) })) // no effectiveAt
+    await s.put(rec({ id: "outside", createdAt: D(5), updatedAt: D(5) }))
+    const out = await s.search({ namespace: "route=/n", since: D(1), until: D(3) })
+    expect(out.map((r) => r.id)).toEqual(["legacy"])
+  })
+  it("windowed query-less search returns event-time order (effectiveAt DESC, id ASC)", async () => {
+    const s = makeStore()
+    // updatedAt order is DELIBERATELY the reverse of effectiveAt order —
+    // proves windowed ordering uses event time, not update time.
+    await s.put(rec({ id: "b", effectiveAt: D(3), updatedAt: D(1) }))
+    await s.put(rec({ id: "a", effectiveAt: D(1), updatedAt: D(3) }))
+    await s.put(rec({ id: "c", effectiveAt: D(3), updatedAt: D(2) }))
+    const out = await s.search({ namespace: "route=/n", since: D(1) })
+    expect(out.map((r) => r.id)).toEqual(["b", "c", "a"]) // D3 pair id-ASC, then D1
+  })
+})
+
+describe("expiry exclusion", () => {
+  it("search with now excludes expired rows; without now shows everything", async () => {
+    const s = makeStore()
+    await s.put(rec({ id: "live", expiresAt: D(9) }))
+    await s.put(rec({ id: "dead", expiresAt: D(2) }))
+    const withNow = await s.search({ namespace: "route=/n", now: D(5) })
+    expect(withNow.map((r) => r.id)).toEqual(["live"])
+    const withoutNow = await s.search({ namespace: "route=/n" })
+    expect(withoutNow.map((r) => r.id).sort()).toEqual(["dead", "live"])
+  })
+  it("boundary: expiresAt exactly equal to now is excluded", async () => {
+    const s = makeStore()
+    await s.put(rec({ id: "edge", expiresAt: D(5) }))
+    expect((await s.search({ namespace: "route=/n", now: D(5) })).length).toBe(0)
+  })
+  it("browse honors now + since/until the same way", async () => {
+    const s = makeStore()
+    await s.put(rec({ id: "live", effectiveAt: D(2), expiresAt: D(9) }))
+    await s.put(rec({ id: "dead", effectiveAt: D(2), expiresAt: D(3) }))
+    const page = await s.browse({ since: D(1), until: D(4), now: D(5) })
+    expect(page.records.map((r) => r.id)).toEqual(["live"])
+    expect(page.total).toBe(1) // COUNT shares the full WHERE incl. expiry+window
+  })
+  it("ranked (query) search also excludes expired and honors the window", async () => {
+    const s = makeStore()
+    await s.put(
+      rec({ id: "hit", content: "deploy failed on staging", effectiveAt: D(2), expiresAt: D(9) }),
+    )
+    await s.put(
+      rec({ id: "expired", content: "deploy failed on prod", effectiveAt: D(2), expiresAt: D(3) }),
+    )
+    await s.put(rec({ id: "outside", content: "deploy failed early", effectiveAt: D(1) }))
+    const out = await s.search({ namespace: "route=/n", query: "deploy failed", since: D(2), now: D(5) })
+    expect(out.map((r) => r.id)).toEqual(["hit"])
+  })
+})

--- a/packages/memory/test/write-policy.test.ts
+++ b/packages/memory/test/write-policy.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest"
+import { writePolicyFor } from "../src/index.js"
+
+describe("writePolicyFor", () => {
+  it("semantic reconciles", () => {
+    expect(writePolicyFor("semantic")).toEqual({ mode: "reconcile" })
+  })
+  it("episodic appends", () => {
+    expect(writePolicyFor("episodic")).toEqual({ mode: "append" })
+  })
+  it("procedural and reflection throw a not-yet-wired error", () => {
+    expect(() => writePolicyFor("procedural")).toThrow(/not yet wired/)
+    expect(() => writePolicyFor("reflection")).toThrow(/not yet wired/)
+  })
+})

--- a/packages/testing/src/memory-conformance.ts
+++ b/packages/testing/src/memory-conformance.ts
@@ -1,4 +1,4 @@
-import type { MemoryRecord, MemoryStore } from "@dawn-ai/memory"
+import { approveWithReconcile, type MemoryRecord, type MemoryStore } from "@dawn-ai/memory"
 import { expect, test } from "vitest"
 
 function rec(
@@ -17,6 +17,20 @@ function rec(
   }
 }
 const vec = (...xs: number[]) => new Float32Array(xs)
+const D = (day: number) => `2026-08-0${day}T00:00:00.000Z`
+
+/** Episodic event fixture — the append-only kind windows/expiry/prune govern. */
+function ep(over: Partial<MemoryRecord> & Pick<MemoryRecord, "id">): MemoryRecord {
+  return rec({
+    namespace: "route=/n",
+    content: over.id,
+    kind: "episodic",
+    source: { type: "run", id: "r" },
+    createdAt: D(1),
+    updatedAt: D(1),
+    ...over,
+  })
+}
 
 /**
  * The contract every MemoryStore must satisfy. Run against sqlite (in-process,
@@ -356,6 +370,265 @@ export function runMemoryStoreConformance(opts: {
           now: "2026-07-05T00:00:00.000Z",
         })
         expect(out.map((r) => r.id)).not.toContain("stale")
+      } finally {
+        await close?.(s)
+      }
+    })
+    test("search window: since is inclusive, until is exclusive on effectiveAt", async () => {
+      const s = await makeStore()
+      try {
+        await s.put(ep({ id: "d1", effectiveAt: D(1) }))
+        await s.put(ep({ id: "d2", effectiveAt: D(2) }))
+        await s.put(ep({ id: "d3", effectiveAt: D(3) }))
+        const out = await s.search({ namespace: "route=/n", since: D(2), until: D(3) })
+        expect(out.map((r) => r.id)).toEqual(["d2"])
+      } finally {
+        await close?.(s)
+      }
+    })
+    test("search window falls back to createdAt for legacy rows without effectiveAt", async () => {
+      const s = await makeStore()
+      try {
+        await s.put(ep({ id: "legacy", createdAt: D(2), updatedAt: D(2) })) // no effectiveAt
+        await s.put(ep({ id: "outside", createdAt: D(5), updatedAt: D(5) }))
+        const out = await s.search({ namespace: "route=/n", since: D(1), until: D(3) })
+        expect(out.map((r) => r.id)).toEqual(["legacy"])
+      } finally {
+        await close?.(s)
+      }
+    })
+    test("windowed query-less search orders by event time, not update time", async () => {
+      const s = await makeStore()
+      try {
+        // updatedAt order is DELIBERATELY the reverse of effectiveAt order —
+        // proves windowed ordering uses event time, not update time.
+        await s.put(ep({ id: "b", effectiveAt: D(3), updatedAt: D(1) }))
+        await s.put(ep({ id: "a", effectiveAt: D(1), updatedAt: D(3) }))
+        await s.put(ep({ id: "c", effectiveAt: D(3), updatedAt: D(2) }))
+        const out = await s.search({ namespace: "route=/n", since: D(1) })
+        expect(out.map((r) => r.id)).toEqual(["b", "c", "a"]) // D3 pair id-ASC, then D1
+      } finally {
+        await close?.(s)
+      }
+    })
+    test("windowed query-less equal event times order by codepoint id (C collation)", async () => {
+      const s = await makeStore()
+      try {
+        // Same effectiveAt on every row: id ASC is the sole tiebreak, and both
+        // backends must agree byte-for-byte (BINARY / C collation). Mixed case
+        // distinguishes codepoint order ("B10" < "a9") from locale collation.
+        for (const id of ["b2", "B10", "a9"]) {
+          await s.put(ep({ id, effectiveAt: D(2) }))
+        }
+        const out = await s.search({ namespace: "route=/n", since: D(1) })
+        expect(out.map((r) => r.id)).toEqual(["B10", "a9", "b2"])
+      } finally {
+        await close?.(s)
+      }
+    })
+    test("search with now excludes expired rows; without now shows everything", async () => {
+      const s = await makeStore()
+      try {
+        await s.put(ep({ id: "live", expiresAt: D(9) }))
+        await s.put(ep({ id: "dead", expiresAt: D(2) }))
+        const withNow = await s.search({ namespace: "route=/n", now: D(5) })
+        expect(withNow.map((r) => r.id)).toEqual(["live"])
+        const withoutNow = await s.search({ namespace: "route=/n" })
+        expect(withoutNow.map((r) => r.id).sort()).toEqual(["dead", "live"])
+      } finally {
+        await close?.(s)
+      }
+    })
+    test("expiry boundary: expiresAt exactly equal to now is excluded", async () => {
+      const s = await makeStore()
+      try {
+        await s.put(ep({ id: "edge", expiresAt: D(5) }))
+        expect((await s.search({ namespace: "route=/n", now: D(5) })).length).toBe(0)
+      } finally {
+        await close?.(s)
+      }
+    })
+    test("ranked (query) search shares the window + expiry clause", async () => {
+      const s = await makeStore()
+      try {
+        await s.put(
+          ep({
+            id: "hit",
+            content: "deploy failed on staging",
+            effectiveAt: D(2),
+            expiresAt: D(9),
+          }),
+        )
+        await s.put(
+          ep({
+            id: "expired",
+            content: "deploy failed on prod",
+            effectiveAt: D(2),
+            expiresAt: D(3),
+          }),
+        )
+        await s.put(ep({ id: "outside", content: "deploy failed early", effectiveAt: D(1) }))
+        const out = await s.search({
+          namespace: "route=/n",
+          query: "deploy failed",
+          since: D(2),
+          now: D(5),
+        })
+        expect(out.map((r) => r.id)).toEqual(["hit"])
+      } finally {
+        await close?.(s)
+      }
+    })
+    test("browse honors since/until + now, with total sharing the clause", async () => {
+      const s = await makeStore()
+      try {
+        await s.put(ep({ id: "live", effectiveAt: D(2), expiresAt: D(9) }))
+        await s.put(ep({ id: "dead", effectiveAt: D(2), expiresAt: D(3) }))
+        await s.put(ep({ id: "early", effectiveAt: D(1), expiresAt: D(9) }))
+        const page = await s.browse({ since: D(2), until: D(4), now: D(5) })
+        expect(page.records.map((r) => r.id)).toEqual(["live"])
+        expect(page.total).toBe(1) // COUNT shares the full WHERE incl. expiry+window
+      } finally {
+        await close?.(s)
+      }
+    })
+    test("prune deletes expired rows of any kind and reports the count", async () => {
+      const s = await makeStore()
+      try {
+        await s.put(ep({ id: "sem-dead", kind: "semantic", expiresAt: D(2) }))
+        await s.put(ep({ id: "ep-dead", expiresAt: D(2) }))
+        await s.put(ep({ id: "ep-live", expiresAt: D(9) }))
+        const res = await s.prune({ now: D(5) })
+        expect(res).toEqual({ deletedExpired: 2, deletedOverCap: 0 })
+        expect(await s.get("sem-dead")).toBeNull()
+        expect((await s.get("ep-live"))?.id).toBe("ep-live")
+      } finally {
+        await close?.(s)
+      }
+    })
+    test("prune caps episodic rows per namespace, keeping the newest by event time", async () => {
+      const s = await makeStore()
+      try {
+        for (let i = 1; i <= 5; i++) await s.put(ep({ id: `e${i}`, effectiveAt: D(i) }))
+        const res = await s.prune({ now: D(9), cap: 3 })
+        expect(res.deletedOverCap).toBe(2)
+        expect((await s.browse({ kind: "episodic" })).records.map((r) => r.id).sort()).toEqual([
+          "e3",
+          "e4",
+          "e5",
+        ])
+      } finally {
+        await close?.(s)
+      }
+    })
+    test("prune cap is PER namespace and never touches non-episodic rows", async () => {
+      const s = await makeStore()
+      try {
+        await s.put(ep({ id: "sem", kind: "semantic" }))
+        for (let i = 1; i <= 3; i++) {
+          await s.put(ep({ id: `a${i}`, namespace: "route=/a", effectiveAt: D(i) }))
+        }
+        for (let i = 1; i <= 3; i++) {
+          await s.put(ep({ id: `b${i}`, namespace: "route=/b", effectiveAt: D(i) }))
+        }
+        const res = await s.prune({ now: D(9), cap: 2 })
+        expect(res.deletedOverCap).toBe(2) // one from each namespace
+        expect(await s.get("a1")).toBeNull()
+        expect(await s.get("b1")).toBeNull()
+        expect((await s.get("sem"))?.id).toBe("sem")
+      } finally {
+        await close?.(s)
+      }
+    })
+    test("prune cap ranks episodic rows regardless of status (superseded counts)", async () => {
+      const s = await makeStore()
+      try {
+        // A superseded episodic row sits between two actives by event time. The
+        // cap pass ranks ALL episodic rows — status never exempts a row from the
+        // budget — so cap=2 keeps the two newest (one of them superseded) and
+        // evicts the oldest ACTIVE row.
+        await s.put(ep({ id: "new-active", effectiveAt: D(3) }))
+        await s.put(ep({ id: "mid-superseded", effectiveAt: D(2), status: "superseded" }))
+        await s.put(ep({ id: "old-active", effectiveAt: D(1) }))
+        const res = await s.prune({ now: D(9), cap: 2 })
+        expect(res.deletedOverCap).toBe(1)
+        expect(await s.get("old-active")).toBeNull()
+        expect((await s.get("mid-superseded"))?.id).toBe("mid-superseded")
+        expect((await s.get("new-active"))?.id).toBe("new-active")
+      } finally {
+        await close?.(s)
+      }
+    })
+    test("prune equal event times evict by codepoint id order (deterministic tiebreak)", async () => {
+      const s = await makeStore()
+      try {
+        // Same effectiveAt; codepoint id order decides. Keep the NEWEST 2 under
+        // (effective DESC, id ASC) ordering ⇒ evict the last in that ordering:
+        // "b2" (0x62 highest codepoint sorts last among equals).
+        await s.put(ep({ id: "B10", effectiveAt: D(2) }))
+        await s.put(ep({ id: "a9", effectiveAt: D(2) }))
+        await s.put(ep({ id: "b2", effectiveAt: D(2) }))
+        await s.prune({ now: D(9), cap: 2 })
+        expect(await s.get("b2")).toBeNull()
+        expect((await s.get("B10"))?.id).toBe("B10")
+        expect((await s.get("a9"))?.id).toBe("a9")
+      } finally {
+        await close?.(s)
+      }
+    })
+    test("prune namespacePrefix narrows both TTL and cap passes", async () => {
+      const s = await makeStore()
+      try {
+        await s.put(ep({ id: "in", namespace: "route=/a", expiresAt: D(2) }))
+        await s.put(ep({ id: "out", namespace: "route=/b", expiresAt: D(2) }))
+        for (let i = 1; i <= 3; i++) {
+          await s.put(ep({ id: `ka${i}`, namespace: "route=/a", effectiveAt: D(i + 2) }))
+        }
+        for (let i = 1; i <= 3; i++) {
+          await s.put(ep({ id: `kb${i}`, namespace: "route=/b", effectiveAt: D(i + 2) }))
+        }
+        const res = await s.prune({ now: D(5), cap: 2, namespacePrefix: "route=/a" })
+        expect(res.deletedExpired).toBe(1)
+        expect(res.deletedOverCap).toBe(1)
+        expect((await s.get("out"))?.id).toBe("out")
+        expect(await s.get("ka1")).toBeNull()
+        expect((await s.get("kb1"))?.id).toBe("kb1")
+      } finally {
+        await close?.(s)
+      }
+    })
+    test("prune is idempotent — a second identical prune deletes nothing", async () => {
+      const s = await makeStore()
+      try {
+        for (let i = 1; i <= 4; i++) {
+          await s.put(
+            ep({ id: `e${i}`, effectiveAt: D(i), ...(i === 1 ? { expiresAt: D(2) } : {}) }),
+          )
+        }
+        await s.prune({ now: D(5), cap: 2 })
+        const second = await s.prune({ now: D(5), cap: 2 })
+        expect(second).toEqual({ deletedExpired: 0, deletedOverCap: 0 })
+      } finally {
+        await close?.(s)
+      }
+    })
+    test("episodic candidate approval is plain activation — no reconcile against actives", async () => {
+      const s = await makeStore()
+      try {
+        // Identical data to an existing active row: a reconcile policy would
+        // dedupe (delete the candidate); the episodic append policy activates it.
+        await s.put(ep({ id: "prior", data: { event: "deploy" }, effectiveAt: D(1) }))
+        await s.put(
+          ep({ id: "cand", data: { event: "deploy" }, status: "candidate", effectiveAt: D(2) }),
+        )
+        const res = await approveWithReconcile(s, "cand", {
+          identityKeys: ["event"],
+          now: D(3),
+        })
+        expect(res.action).toBe("activated")
+        expect(res.superseded).toEqual([])
+        expect((await s.get("cand"))?.status).toBe("active")
+        expect((await s.get("prior"))?.status).toBe("active")
       } finally {
         await close?.(s)
       }

--- a/packages/testing/src/memory-conformance.ts
+++ b/packages/testing/src/memory-conformance.ts
@@ -17,9 +17,10 @@ function rec(
   }
 }
 const vec = (...xs: number[]) => new Float32Array(xs)
-const D = (day: number) => `2026-08-0${day}T00:00:00.000Z`
+const D = (day: number) => `2026-08-${String(day).padStart(2, "0")}T00:00:00.000Z`
 
-/** Episodic event fixture — the append-only kind windows/expiry/prune govern. */
+/** Record fixture with episodic defaults (kind overridable, e.g. for prune's
+ *  non-episodic immunity cases). */
 function ep(over: Partial<MemoryRecord> & Pick<MemoryRecord, "id">): MemoryRecord {
   return rec({
     namespace: "route=/n",

--- a/packages/testing/test/episodic-live.smoke.test.ts
+++ b/packages/testing/test/episodic-live.smoke.test.ts
@@ -1,0 +1,66 @@
+// LIVE SMOKE — episodic memory against a real model. Gated on OPENAI_API_KEY:
+// SKIPS in CI (no key) and runs only locally. Never add to a CI lane; never print the key.
+import { rmSync } from "node:fs"
+import { join } from "node:path"
+import { fileURLToPath } from "node:url"
+import { afterEach, beforeEach, expect, it } from "vitest"
+import { createAgentHarness } from "../src/harness.js"
+import { expectToolCalled } from "../src/matchers.js"
+
+const live = Boolean(process.env.OPENAI_API_KEY)
+// Probe app with the runtime episode recorder enabled (episodes: { enabled: true }).
+const episodicRoot = fileURLToPath(new URL("./fixtures/probe-app-episodic", import.meta.url))
+
+function dbPath(root: string): string {
+  return join(root, ".dawn", "memory.sqlite")
+}
+function cleanDb(root: string): void {
+  for (const s of ["", "-wal", "-shm"]) rmSync(`${dbPath(root)}${s}`, { force: true })
+}
+
+beforeEach(() => {
+  cleanDb(episodicRoot)
+})
+afterEach(() => {
+  cleanDb(episodicRoot)
+})
+
+it.skipIf(!live)(
+  "episodic recall: the agent answers what it did recently from recorded episodes",
+  async () => {
+    const h = await createAgentHarness({
+      appRoot: episodicRoot,
+      route: "/memory-chat#agent",
+      live: true,
+    })
+    try {
+      // Two completed runs with distinctive inputs — the auto-recorder writes
+      // one episodic memory per run (input, outcome, tools used, duration).
+      h.reset()
+      await h.run({
+        input: "Check the deployment status of service alpha-rocket",
+      })
+      h.reset()
+      await h.run({
+        input: "Summarize the billing report for acme-corp",
+      })
+
+      // Third run, fresh thread: ask what happened recently. The model must
+      // drive recall's time window itself (since "-24h"); the recorded episodes
+      // — not conversation state — are the only place the earlier inputs live.
+      h.reset()
+      const r = await h.run({
+        input:
+          'Using your long-term memory with recall\'s since parameter set to "-24h", what did you do in the last day?',
+      })
+      expectToolCalled(r, "recall")
+      // A distinctive token from at least one earlier input must surface from
+      // the recall tool result (or the model's summary of it).
+      const recall = String(r.toolResults.find((t) => t.name === "recall")?.content ?? "")
+      expect(`${recall}\n${r.finalMessage}`).toMatch(/alpha-rocket|acme-corp/)
+    } finally {
+      await h.close()
+    }
+  },
+  180_000,
+)

--- a/packages/testing/test/fixtures/probe-app-episodic/dawn.config.ts
+++ b/packages/testing/test/fixtures/probe-app-episodic/dawn.config.ts
@@ -1,0 +1,5 @@
+// Episodic sibling of probe-app: the runtime episode recorder is enabled, so
+// every completed run writes one episodic memory (input, outcome, tools used,
+// duration) the agent can recall with a time window (`since`/`until`). Exists
+// for the gated episodic live smoke.
+export default { memory: { writes: "auto", episodes: { enabled: true } } }

--- a/packages/testing/test/fixtures/probe-app-episodic/package.json
+++ b/packages/testing/test/fixtures/probe-app-episodic/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "probe-app-episodic",
+  "private": true,
+  "type": "module"
+}

--- a/packages/testing/test/fixtures/probe-app-episodic/src/app/memory-chat/index.ts
+++ b/packages/testing/test/fixtures/probe-app-episodic/src/app/memory-chat/index.ts
@@ -1,0 +1,5 @@
+import { agent } from "@dawn-ai/sdk"
+export default agent({
+  model: "gpt-4o-mini",
+  systemPrompt: "You are a test agent with long-term memory. Use remember/recall when asked.",
+})

--- a/packages/testing/test/fixtures/probe-app-episodic/src/app/memory-chat/memory.ts
+++ b/packages/testing/test/fixtures/probe-app-episodic/src/app/memory-chat/memory.ts
@@ -1,0 +1,7 @@
+import { defineMemory } from "@dawn-ai/sdk"
+import { z } from "zod"
+export default defineMemory({
+  kind: "semantic",
+  scope: ["route"],
+  schema: z.object({ subject: z.string(), predicate: z.string(), value: z.string() }),
+})


### PR DESCRIPTION
Dawn apps can now remember *what happened*. An opt-in runtime recorder (`memory.episodes.enabled`) writes one episodic memory per agent run — input, outcome, tools used, duration — from the trace the runtime already holds (zero model cost), with TTL (30d) + per-namespace cap (500) lazy retention. Routes can also author durable episodes via `defineMemory({ kind: "episodic" })`: append-only via the new `writePolicyFor(kind)` seam — never deduped or superseded, and `ask` mode never gates an append. `recall` gains `since`/`until` (ISO or `"-24h"`/`"-7d"`) honored by both backends over `COALESCE(effective_at, created_at)` with expiry exclusion; the Inspector gains a day-grouped timeline view with outcome badges and window presets; `dawn memory prune` runs retention manually (defaulting to the configured cap).

Spec: `docs/superpowers/specs/2026-08-05-episodic-memory-design.md` · Plan: `docs/superpowers/plans/2026-08-05-episodic-memory.md` (10 tasks, subagent-driven, two-stage reviews per task + final whole-branch review with empirical re-verification).

## Breaking (patch under the fixed 0.x group, stated in the changeset)
`MemoryStore` now requires `prune(opts)`; `search`/`browse` accept `since`/`until` and exclude expired rows when `now` is supplied. `runMemoryStoreConformance` enforces the contract (16 new cross-backend tests); sqlite migrates transparently (v3, additive index); pgvector index added idempotently.

## How tested (robustness-first, per directive)
Workspace suite 1410 tests green; gated pgvector lane **48/1-skip on real Docker Postgres**; inspector lane **46/46 against the built standalone server**; all three Verdaccio harness lanes green (framework 2:58 / runtime 2:49 / smoke 1:02); **doubly-gated live smoke against a real model** — after two recorded runs, the agent answered "what did you do in the last day?" from episodes via `recall({ since: "-24h" })`. Concurrency (8 parallel writers, cap holds), burst-with-cap, HITL interrupt/resume, and early-close consumer cases all covered.

## Bugs the layered reviews caught before CI ever saw them
- HITL parked turns double-recorded episodes claiming tools ran that never executed (empirically reproduced + fixed + tested)
- **AG-UI surface recorded nothing**: consumers close the generator early on `done`, skipping the post-loop record — found by whole-branch review through the built AG-UI chain; fixed via `finally` with a gated truth table (drain=1, early-close=1, error=1, abandoned=0, parked=0) + dedicated early-close test
- Timeline relied on `updated_at` fetch order (detail-sheet mutations would hoist old days) → client event-time sort
- `parseInstant` passed offset/loose date forms into lexicographic SQL comparison (silently wrong windows) → ISO normalization
- `resolveTimeExpr` Date-overflow produced V8's generic error → bounded with the actionable message
- Store-layer window/prune SQL verified byte-identical cross-backend (COLLATE "C" tiebreaks, status-blind cap pinned by conformance tests)

Advisory follow-ups recorded (non-blocking): serverless write-durability note for the deploy-anywhere B3 arc (fire-and-forget close in the AG-UI chain); timeline tie-case comparator; pgvector unwindowed-path collation pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)