### PR TITLE
fix(scaffold): caret vitest pin — exact 4.1.4 crashes npm install (arborist bug)

### DIFF
--- a/.changeset/scaffold-vitest-pin.md
+++ b/.changeset/scaffold-vitest-pin.md
@@ -1,0 +1,12 @@
+---
+"@dawn-ai/devkit": patch
+"create-dawn-ai-app": patch
+---
+
+Scaffold templates now pin `vitest` with a caret (`^4.1.10`) instead of an exact
+stale version. The old exact `4.1.4` pin made fresh `npm install`s crash with
+npm's arborist `edgesOut` bug after an upstream peer-landscape change (vitest
+≤4.1.9 became uninstallable under npm's strict peer resolution) — a failure
+mode a caret range rides out automatically. Existing broken scaffolds can fix
+themselves with `npm install --legacy-peer-deps` or by bumping `vitest` to
+`^4.1.10`.

--- a/packages/devkit/templates/app-basic/package.json.template
+++ b/packages/devkit/templates/app-basic/package.json.template
@@ -23,7 +23,7 @@
     "@dawn-ai/testing": "{{dawnTestingSpecifier}}",
     "@types/node": "25.6.0",
     "typescript": "6.0.2",
-    "vitest": "4.1.4"
+    "vitest": "^4.1.10"
   },
   "engines": {
     "node": ">=24.0.0"

--- a/packages/devkit/templates/app-research/package.json.template
+++ b/packages/devkit/templates/app-research/package.json.template
@@ -27,7 +27,7 @@
     "@dawn-ai/testing": "{{dawnTestingSpecifier}}",
     "@types/node": "25.6.0",
     "typescript": "6.0.2",
-    "vitest": "4.1.4"
+    "vitest": "^4.1.10"
   },
   "engines": {
     "node": ">=24.0.0"

--- a/test/generated/run-generated-app.test.ts
+++ b/test/generated/run-generated-app.test.ts
@@ -488,7 +488,7 @@ function normalizeForFixture(
     [context.dawnVersion, "<dawn-version>"],
     ["25.6.0", "<version:@types/node>"],
     ["6.0.2", "<version:typescript>"],
-    ["4.1.4", "<version:vitest>"],
+    ["^4.1.10", "<version:vitest>"],
     // Runtime check emits the live Node version (process.versions.node). Normalize
     // it so the fixture stays stable across Node patch releases.
     [process.versions.node, "<version:node>"],
@@ -521,7 +521,7 @@ function normalizeForInternalFixture(
     ...repoPairs,
     ["25.6.0", "<version:@types/node>"],
     ["6.0.2", "<version:typescript>"],
-    ["4.1.4", "<version:vitest>"],
+    ["^4.1.10", "<version:vitest>"],
     // Runtime check emits the live Node version (process.versions.node). Normalize
     // it so the fixture stays stable across Node patch releases.
     [process.versions.node, "<version:node>"],


### PR DESCRIPTION
Found by the 0.8.15 published-artifact smoke: **every fresh `create-dawn-ai-app` scaffold currently fails `npm install`** with npm's arborist crash (`Cannot read properties of null (reading 'edgesOut')` in `#loadPeerSet`).

Root cause is upstream, not our artifacts: `npm install vitest@4.1.4` **alone** crashes (so does 4.1.9; 4.1.10 works) — an upstream peer-landscape change (vite 8.2 era) made older vitest 4.1.x versions uninstallable under npm's strict peer resolution. Our templates exact-pin `vitest: "4.1.4"`, so scaffolds inherited the breakage with no Dawn release involved — 0.8.14 scaffolds fail identically today. The pnpm-based Verdaccio harness can never see npm-resolver-only failures, which is why CI stayed green.

Fix: templates pin `vitest: "^4.1.10"` (caret) — proven to ride out this failure class (`^4.1.4` resolves to 4.1.10 and installs clean). Fixture remaps updated. Changeset patch for devkit + create-dawn-ai-app.

Interim workaround for existing scaffolds (docs'd in the changeset): `npm install --legacy-peer-deps` or bump `vitest` to `^4.1.10`.

Note: `create-dawn-ai-app` unit tests show 6 pre-existing failures locally on Node 22 — that's the just-merged Node-24 floor (#384) rejecting the local runtime, reproduced on clean main; CI (Node 24) is unaffected. devkit tests 10/10 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)