### PR TITLE
fix(ci): pack the full workspace closure in the TypeScript tooling smoke

### DIFF
--- a/scripts/typescript-tooling-pack-smoke.mjs
+++ b/scripts/typescript-tooling-pack-smoke.mjs
@@ -22,11 +22,51 @@ export const TYPESCRIPT_VERSION = "7.0.2"
 export const TSX_VERSION = "4.23.0"
 export const ZOD_VERSION = "4.4.3"
 
+/**
+ * The packed set must be CLOSED over workspace dependencies — see
+ * `assertPackedClosureIsComplete`, which enforces exactly that.
+ */
 export const TOOLING_PACKAGES = [
   { dir: "packages/sdk", name: "@dawn-ai/sdk" },
+  { dir: "packages/permissions", name: "@dawn-ai/permissions" },
+  { dir: "packages/sqlite-storage", name: "@dawn-ai/sqlite-storage" },
+  { dir: "packages/workspace", name: "@dawn-ai/workspace" },
   { dir: "packages/core", name: "@dawn-ai/core" },
   { dir: "packages/vite-plugin", name: "@dawn-ai/vite-plugin" },
 ]
+
+/**
+ * Asserts every workspace dependency of a packed package is ALSO packed.
+ *
+ * `pnpm pack` rewrites `workspace:*` to the workspace's current version, so an
+ * unpacked workspace dependency gets resolved from the public registry at that exact
+ * version. On an ordinary commit that version is already published and the install
+ * quietly succeeds — but on a RELEASE commit it is the version being published by the
+ * very run performing this check, so npm fails with `ETARGET` and the smoke breaks in
+ * the one place it cannot be allowed to. Deriving the requirement from the manifests
+ * keeps a newly added dependency from silently reintroducing that hole.
+ */
+export async function assertPackedClosureIsComplete({
+  packages = TOOLING_PACKAGES,
+  repoRoot = defaultRepoRoot,
+} = {}) {
+  const packedNames = new Set(packages.map(({ name }) => name))
+  const unpacked = []
+  for (const packageConfig of packages) {
+    const manifestPath = resolve(repoRoot, packageConfig.dir, "package.json")
+    const manifest = JSON.parse(await readFile(manifestPath, "utf8"))
+    for (const [dependency, range] of Object.entries(manifest.dependencies ?? {})) {
+      if (String(range).startsWith("workspace:") && !packedNames.has(dependency)) {
+        unpacked.push(`${packageConfig.name} -> ${dependency}`)
+      }
+    }
+  }
+  if (unpacked.length > 0) {
+    throw new Error(
+      `TypeScript tooling pack smoke would resolve workspace dependencies from the registry: ${unpacked.join(", ")}. Add them to TOOLING_PACKAGES.`,
+    )
+  }
+}
 
 const defaultRepoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..")
 
@@ -37,6 +77,7 @@ const defaultRepoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..")
 export async function runTypeScriptToolingPackSmoke(overrides = {}) {
   const dependencies = {
     assertNoNativeLifecycleScripts,
+    assertPackedClosureIsComplete,
     makeTempDir,
     onPackedArtifactValidated: () => {},
     packWorkspacePackage,
@@ -47,6 +88,8 @@ export async function runTypeScriptToolingPackSmoke(overrides = {}) {
     runTypeScriptToolingProbe: defaultRunTypeScriptToolingProbe,
     ...overrides,
   }
+
+  await dependencies.assertPackedClosureIsComplete({ repoRoot: dependencies.repoRoot })
 
   const tempRoot = await dependencies.makeTempDir("dawn-typescript-tooling-pack-")
   try {
@@ -92,12 +135,12 @@ export async function runTypeScriptToolingPackSmoke(overrides = {}) {
     }
 
     const installedVersions = await assertInstalledVersions(consumerRoot, {
+      // Derived from what was actually packed, so a package added to TOOLING_PACKAGES
+      // is version-asserted too rather than merely installed.
+      ...Object.fromEntries(
+        packedArtifacts.map(({ packageName, packageVersion }) => [packageName, packageVersion]),
+      ),
       "@dawn-ai/core": packedCoreVersion,
-      "@dawn-ai/sdk": packedArtifacts.find(({ packageName }) => packageName === "@dawn-ai/sdk")
-        .packageVersion,
-      "@dawn-ai/vite-plugin": packedArtifacts.find(
-        ({ packageName }) => packageName === "@dawn-ai/vite-plugin",
-      ).packageVersion,
       tsx: TSX_VERSION,
       typescript: TYPESCRIPT_VERSION,
       zod: ZOD_VERSION,

--- a/scripts/typescript-tooling-pack-smoke.test.mjs
+++ b/scripts/typescript-tooling-pack-smoke.test.mjs
@@ -8,6 +8,7 @@ import { describe, it } from "node:test"
 import { fileURLToPath } from "node:url"
 
 import {
+  assertPackedClosureIsComplete,
   packWorkspacePackage,
   runCommand,
   runTypeScriptToolingPackSmoke,
@@ -28,13 +29,19 @@ describe("runTypeScriptToolingPackSmoke", () => {
 
     assert.deepEqual(TOOLING_PACKAGES, [
       { dir: "packages/sdk", name: "@dawn-ai/sdk" },
+      { dir: "packages/permissions", name: "@dawn-ai/permissions" },
+      { dir: "packages/sqlite-storage", name: "@dawn-ai/sqlite-storage" },
+      { dir: "packages/workspace", name: "@dawn-ai/workspace" },
       { dir: "packages/core", name: "@dawn-ai/core" },
       { dir: "packages/vite-plugin", name: "@dawn-ai/vite-plugin" },
     ])
     assert.deepEqual(result.installedVersions, {
       "@dawn-ai/core": PACKAGE_VERSION,
+      "@dawn-ai/permissions": PACKAGE_VERSION,
       "@dawn-ai/sdk": PACKAGE_VERSION,
+      "@dawn-ai/sqlite-storage": PACKAGE_VERSION,
       "@dawn-ai/vite-plugin": PACKAGE_VERSION,
+      "@dawn-ai/workspace": PACKAGE_VERSION,
       tsx: TSX_VERSION,
       typescript: TYPESCRIPT_VERSION,
       zod: ZOD_VERSION,
@@ -62,7 +69,7 @@ describe("runTypeScriptToolingPackSmoke", () => {
       args: ["--filter", "@dawn-ai/vite-plugin...", "build"],
       cwd: harness.repoRoot,
     })
-    assert.equal(packIndexes.length, 3)
+    assert.equal(packIndexes.length, TOOLING_PACKAGES.length)
     assert.ok(packIndexes.every((index) => index > buildIndex && index < installIndex))
     assert.deepEqual(
       packIndexes.map((index) => harness.events[index].packageConfig),
@@ -77,6 +84,9 @@ describe("runTypeScriptToolingPackSmoke", () => {
       "--save-exact",
       "--package-lock=false",
       join(harness.tempRoot, "packs", "dawn-ai-sdk-0.8.14.tgz"),
+      join(harness.tempRoot, "packs", "dawn-ai-permissions-0.8.14.tgz"),
+      join(harness.tempRoot, "packs", "dawn-ai-sqlite-storage-0.8.14.tgz"),
+      join(harness.tempRoot, "packs", "dawn-ai-workspace-0.8.14.tgz"),
       join(harness.tempRoot, "packs", "dawn-ai-core-0.8.14.tgz"),
       join(harness.tempRoot, "packs", "dawn-ai-vite-plugin-0.8.14.tgz"),
       `typescript@${TYPESCRIPT_VERSION}`,
@@ -221,6 +231,56 @@ describe("runCommand", () => {
   })
 })
 
+describe("assertPackedClosureIsComplete", () => {
+  it("accepts the real TOOLING_PACKAGES against the real workspace", async () => {
+    // The regression guard. An unpacked workspace dependency resolves from the public
+    // registry at the version pnpm pack stamped in — which exists on every ordinary
+    // commit and does NOT exist on the release commit, so the hole is invisible until
+    // it fails the publish. 0.8.17 died here on @dawn-ai/permissions.
+    await assertPackedClosureIsComplete()
+  })
+
+  it("rejects a workspace dependency that is not itself packed", async () => {
+    const testRoot = await mkdtemp(join(tmpdir(), "dawn-closure-"))
+    try {
+      await writeWorkspaceManifest(testRoot, "packages/core", "@dawn-ai/core", {
+        "@dawn-ai/permissions": "workspace:*",
+      })
+
+      await assert.rejects(
+        assertPackedClosureIsComplete({
+          packages: [{ dir: "packages/core", name: "@dawn-ai/core" }],
+          repoRoot: testRoot,
+        }),
+        /@dawn-ai\/core -> @dawn-ai\/permissions.*Add them to TOOLING_PACKAGES/s,
+      )
+    } finally {
+      await rm(testRoot, { force: true, recursive: true })
+    }
+  })
+
+  it("accepts a closed set and ignores registry dependencies", async () => {
+    const testRoot = await mkdtemp(join(tmpdir(), "dawn-closure-"))
+    try {
+      await writeWorkspaceManifest(testRoot, "packages/core", "@dawn-ai/core", {
+        "@dawn-ai/permissions": "workspace:*",
+        zod: "^4.4.3",
+      })
+      await writeWorkspaceManifest(testRoot, "packages/permissions", "@dawn-ai/permissions", {})
+
+      await assertPackedClosureIsComplete({
+        packages: [
+          { dir: "packages/core", name: "@dawn-ai/core" },
+          { dir: "packages/permissions", name: "@dawn-ai/permissions" },
+        ],
+        repoRoot: testRoot,
+      })
+    } finally {
+      await rm(testRoot, { force: true, recursive: true })
+    }
+  })
+})
+
 describe("verify:typescript-tooling-pack", () => {
   it("runs unit tests before the real smoke and stops when unit tests fail", async () => {
     const packageJson = JSON.parse(await readFile(join(repoRoot, "package.json"), "utf8"))
@@ -334,6 +394,11 @@ async function createHarness({
 
   const dependencies = {
     repoRoot,
+    // The harness repo is synthetic and has no package manifests. The closure rule
+    // itself is covered directly in the assertPackedClosureIsComplete suite below.
+    async assertPackedClosureIsComplete() {
+      events.push({ type: "closure-check" })
+    },
     async makeTempDir(prefix) {
       assert.equal(prefix, "dawn-typescript-tooling-pack-")
       await mkdir(tempRoot)
@@ -465,8 +530,11 @@ function packedManifest(name, { packedCoreDependency = PACKAGE_VERSION } = {}) {
 async function installFixturePackages(root) {
   const packages = {
     "@dawn-ai/core": PACKAGE_VERSION,
+    "@dawn-ai/permissions": PACKAGE_VERSION,
     "@dawn-ai/sdk": PACKAGE_VERSION,
+    "@dawn-ai/sqlite-storage": PACKAGE_VERSION,
     "@dawn-ai/vite-plugin": PACKAGE_VERSION,
+    "@dawn-ai/workspace": PACKAGE_VERSION,
     tsx: TSX_VERSION,
     typescript: TYPESCRIPT_VERSION,
     zod: ZOD_VERSION,
@@ -543,4 +611,14 @@ function extractedManifestCommand(fixture, manifestSource) {
       await writeFile(join(extractDir, "package", "package.json"), manifestSource, "utf8")
     }
   }
+}
+
+async function writeWorkspaceManifest(root, dir, name, dependencies) {
+  const packageDir = join(root, dir)
+  await mkdir(packageDir, { recursive: true })
+  await writeFile(
+    join(packageDir, "package.json"),
+    JSON.stringify({ dependencies, name, version: PACKAGE_VERSION }),
+    "utf8",
+  )
 }


### PR DESCRIPTION
## The failure

The 0.8.17 Release run [31166807793](https://github.com/cacheplane/dawnai/actions/runs/31166807793) failed at **Validate Release Candidate**, before the publish step — so nothing was partially published and all 20 packages remain at 0.8.16.

```
npm error code ETARGET
npm error notarget No matching version found for @dawn-ai/permissions@0.8.17.
```

## Root cause

`TOOLING_PACKAGES` packed only `sdk`, `core`, and `vite-plugin`. But `@dawn-ai/core` also depends on `@dawn-ai/permissions`, `@dawn-ai/sqlite-storage`, and `@dawn-ai/workspace`.

`pnpm pack` rewrites `workspace:*` to the workspace's current version, so an unpacked workspace dependency gets resolved **from the public registry** at that exact version:

- On an ordinary commit that version is already published, so the install quietly succeeds.
- On a **release commit** it is the version being published by the very run performing the check — so it cannot exist yet, and npm fails with `ETARGET`.

The hole is therefore invisible on every commit except the one where it blocks the release. This smoke was added in #391 (TypeScript 7 migration) and 0.8.17 is the first release since.

## Fix

1. Pack the full workspace-dependency closure.
2. Add `assertPackedClosureIsComplete`, which derives the requirement from the package manifests and fails fast with a named error. A workspace dependency added later can no longer silently reopen the hole.
3. Assert installed versions from what was actually packed, so an added package is version-checked rather than merely installed.

## Verification

- `pnpm run verify:typescript-tooling-pack` **passes against the workspace at 0.8.17 while 0.8.17 is unpublished** — reproducing and then clearing the exact release condition. It fails the old way without the fix.
- 19/19 unit tests pass, including a regression test asserting the real `TOOLING_PACKAGES` is closed over the real workspace, plus positive/negative tests of the rule itself.

## No changeset — intentional

This is CI tooling, not a published package. main is already versioned at 0.8.17 with the changesets consumed; adding a changeset would open a new Version PR for 0.8.18 instead of publishing 0.8.17. Merging this triggers Release, which republishes 0.8.17.