### PR TITLE
feat(inspector): real pretable grid, with sorting

### DIFF
--- a/.changeset/inspector-pretable-grid.md
+++ b/.changeset/inspector-pretable-grid.md
@@ -1,0 +1,9 @@
+---
+"@dawn-ai/inspector": patch
+---
+
+Memory Inspector: the records list is now a real `@pretable/react` grid, with column sorting.
+
+It shipped as a semantic `<table>` stand-in because `@pretable/react@0.0.2` was uninstallable — it hard-depended on `@pretable/ui@0.0.2`, which had never been published. `@pretable/ui` is on npm now, so the grid goes in behind the same `MemoryGrid` props and sorting arrives with it. Clicking a column header sorts by it; the `updated` column sorts chronologically rather than by its formatted text.
+
+Requires `@pretable/react`/`@pretable/ui` 0.0.3, which carry the fixes this integration prompted upstream: row activation via `onRowActivate`, columns reconciled in place rather than rebuilding the grid (so a sort survives live polling), and the header/cell CSS corrections.

--- a/packages/inspector/app/globals.css
+++ b/packages/inspector/app/globals.css
@@ -1,1 +1,17 @@
+/* grid.css self-declares `@layer pretable` and uses :where(), so its defaults
+   are specificity (0,0,0) and need no wrapping here — this only fixes where
+   that layer sits: above Tailwind's preflight, which would otherwise zero out
+   the grid's borders, and below its utilities, so the per-cell status tints in
+   memory-grid.tsx win over `[data-pretable-cell] { background: … }`. */
+@layer theme, base, components, pretable, utilities;
+
 @import "tailwindcss";
+@import "@pretable/ui/themes/excel.css";
+@import "@pretable/ui/grid.css";
+
+/* The Excel theme ships no row hover on purpose ("consumers opt in") — but every
+   row here opens a record on click, so it needs the affordance. Unlayered, so it
+   beats the theme's own token regardless of import order. */
+:root {
+  --pretable-bg-hover: var(--color-zinc-50);
+}

--- a/packages/inspector/package.json
+++ b/packages/inspector/package.json
@@ -37,6 +37,8 @@
   "dependencies": {
     "@dawn-ai/core": "workspace:*",
     "@dawn-ai/memory": "workspace:*",
+    "@pretable/react": "0.0.3",
+    "@pretable/ui": "0.0.3",
     "class-variance-authority": "^0.7.1",
     "next": "16.2.10",
     "react": "19.2.7",

--- a/packages/inspector/src/components/memory/memory-grid.tsx
+++ b/packages/inspector/src/components/memory/memory-grid.tsx
@@ -1,26 +1,96 @@
 "use client"
-import type { MemoryRecord } from "@dawn-ai/memory"
-import type { KeyboardEvent } from "react"
+import type { MemoryKind, MemoryRecord, MemoryStatus } from "@dawn-ai/memory"
+import { type PretableColumn, PretableSurface, type PretableTelemetry } from "@pretable/react"
+import { getDensityHeights } from "@pretable/ui"
+import { useCallback, useMemo, useState } from "react"
 import { Badge } from "../ui/badge"
 
-// TODO(pretable): switch to @pretable/react's <PretableSurface> once 0.0.2 is
-// installable. The 0.0.2 API is a perfect fit — `onSelectedRowIdChange` for
-// row-click selection and `getRowClassName` for status tinting — but the
-// published 0.0.2 tarball declares hard deps on @pretable/ui@0.0.2 (and its
-// theme CSS at @pretable/ui/themes/excel.css + @pretable/ui/grid.css), and
-// @pretable/ui is not on the npm registry at any version, so `pnpm add
-// @pretable/react@0.0.2` fails resolution outright. Until a fixed publish
-// lands, this semantic <table> is the interim body behind the same props.
-// Column sorting is deliberately deferred to that swap too — the approved
-// wireframe's sort-by-column comes with pretable's header sorting; until then
-// rows arrive server-ordered (updated_at DESC).
+/** Row projection handed to pretable — a plain bag so it satisfies `PretableRow`
+ *  (MemoryRecord is an interface, so it has no implicit index signature). Each
+ *  column's `value` feeds both the rendered cell and the sort comparator, so
+ *  `updated` carries the raw ISO string and formats for display. */
+interface GridRow extends Record<string, unknown> {
+  id: string
+  status: MemoryStatus
+  content: string
+  namespace: string
+  kind: MemoryKind
+  confidence: number
+  updatedAt: string
+}
 
-const COLUMNS = ["status", "content", "namespace", "kind", "confidence", "updated"] as const
+/** Tallest the grid grows before it scrolls internally; below this it shrinks to
+ *  fit so a two-hit search group doesn't reserve a screenful of empty rows. */
+const MAX_VIEWPORT_PX = 560
 
-function rowClass(record: MemoryRecord): string {
-  if (record.status === "candidate") return "bg-amber-50"
-  if (record.status === "superseded") return "text-zinc-400 line-through"
+/** Column widths are fixed (pretable sizes to content or to `widthPx`, never to
+ *  fill its container) and sum to ~1030px so the whole row fits beside the facet
+ *  rail on a 1280px screen. Wider than that is the grid's own scroll; `content`
+ *  carries the slack because it's the only column with unbounded text. */
+const COLUMNS: PretableColumn<GridRow>[] = [
+  {
+    id: "status",
+    header: "status",
+    widthPx: 104,
+    value: (row) => row.status,
+    render: ({ row }) => <Badge variant={row.status}>{row.status}</Badge>,
+  },
+  {
+    id: "content",
+    header: "content",
+    widthPx: 360,
+    value: (row) => row.content,
+    // Cells are flex containers, and text-overflow does nothing on one — so the
+    // ellipsis has to live on an inner box. min-w-0 lets it shrink below its
+    // text width; without it the flex item refuses to and the text just clips.
+    render: ({ formattedValue }) => <span className="min-w-0 truncate">{formattedValue}</span>,
+  },
+  { id: "namespace", header: "namespace", widthPx: 190, value: (row) => row.namespace },
+  { id: "kind", header: "kind", widthPx: 100, value: (row) => row.kind },
+  {
+    id: "confidence",
+    header: "confidence",
+    widthPx: 100,
+    value: (row) => row.confidence,
+    format: ({ value }) => Number(value).toFixed(2),
+  },
+  {
+    id: "updated",
+    header: "updated",
+    widthPx: 180,
+    value: (row) => row.updatedAt,
+    format: ({ value }) => new Date(String(value)).toLocaleString(),
+  },
+]
+
+/** Per-column cell styling, keyed by column id. */
+const CELL_CLASS: Partial<Record<string, string>> = {
+  content: "overflow-hidden",
+  namespace: "font-mono text-xs",
+  confidence: "tabular-nums",
+}
+
+function statusClass(status: MemoryStatus): string {
+  if (status === "candidate") return "bg-amber-50"
+  if (status === "superseded") return "text-zinc-400 line-through"
   return ""
+}
+
+/** Module-level so its identity is stable — `usePretable` keys the grid on it. */
+function rowIdOf(row: GridRow): string {
+  return row.id
+}
+
+function toRow(record: MemoryRecord): GridRow {
+  return {
+    id: record.id,
+    status: record.status,
+    content: record.content,
+    namespace: record.namespace,
+    kind: record.kind,
+    confidence: record.confidence,
+    updatedAt: record.updatedAt,
+  }
 }
 
 export function MemoryGrid({
@@ -30,52 +100,52 @@ export function MemoryGrid({
   records: readonly MemoryRecord[]
   onSelect: (id: string) => void
 }) {
-  const onRowKeyDown = (event: KeyboardEvent<HTMLTableRowElement>, id: string) => {
-    if (event.key === "Enter" || event.key === " ") {
-      event.preventDefault()
-      onSelect(id)
-    }
-  }
+  const rows = useMemo(() => records.map(toRow), [records])
+
+  // The engine reports the exact height of all rows; until the first layout
+  // effect lands, estimate from the theme's density so the initial paint is
+  // close (a too-short first guess would virtualize rows away for one frame).
+  const [contentHeight, setContentHeight] = useState<number>()
+  const onTelemetryChange = useCallback((telemetry: PretableTelemetry) => {
+    setContentHeight(telemetry.totalHeight)
+  }, [])
+  const density = getDensityHeights()
+  const viewportHeight = Math.min(
+    (contentHeight ?? rows.length * density.rowHeight) + density.headerHeight,
+    MAX_VIEWPORT_PX,
+  )
+
   return (
-    <div className="overflow-x-auto rounded-md border border-zinc-200">
-      <table className="w-full border-collapse text-sm">
-        <thead>
-          <tr className="border-b border-zinc-200 bg-zinc-50 text-left text-xs uppercase tracking-wide text-zinc-500">
-            {COLUMNS.map((col) => (
-              <th key={col} className="px-3 py-2 font-medium">
-                {col}
-              </th>
-            ))}
-          </tr>
-        </thead>
-        <tbody>
-          {records.map((record) => (
-            // biome-ignore lint/a11y/useSemanticElements: a real <button> is invalid as a table row; role+tabIndex+keydown is the accessible pattern for clickable <tr>s
-            <tr
-              key={record.id}
-              tabIndex={0}
-              role="button"
-              aria-label={`Open memory: ${record.content}`}
-              onClick={() => onSelect(record.id)}
-              onKeyDown={(event) => onRowKeyDown(event, record.id)}
-              className={`cursor-pointer border-b border-zinc-100 last:border-b-0 hover:bg-zinc-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-zinc-400 ${rowClass(record)}`}
-            >
-              <td className="px-3 py-2">
-                <Badge variant={record.status}>{record.status}</Badge>
-              </td>
-              <td className="max-w-md truncate px-3 py-2" title={record.content}>
-                {record.content}
-              </td>
-              <td className="px-3 py-2 font-mono text-xs">{record.namespace}</td>
-              <td className="px-3 py-2">{record.kind}</td>
-              <td className="px-3 py-2 tabular-nums">{record.confidence.toFixed(2)}</td>
-              <td className="whitespace-nowrap px-3 py-2 text-xs text-zinc-500">
-                {new Date(record.updatedAt).toLocaleString()}
-              </td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
-    </div>
+    <PretableSurface<GridRow>
+      ariaLabel="Memories"
+      columns={COLUMNS}
+      rows={rows}
+      getRowId={rowIdOf}
+      viewportHeight={viewportHeight}
+      // Strict ARIA grid tabbing — the default wraps Tab inside the grid, which
+      // traps keyboard focus on a page that has a search box and a detail sheet.
+      tabBehavior="exit"
+      getRowClassName={() => "cursor-pointer"}
+      getBodyCellClassName={({ column, row }) =>
+        `${CELL_CLASS[column.id] ?? ""} ${statusClass(row.status)}`.trim()
+      }
+      getBodyCellProps={({ column, formattedValue }) =>
+        column.id === "content" ? { title: formattedValue } : undefined
+      }
+      // Row activation is pretable's own concern since 0.0.3: click and
+      // Enter/Space both arrive here, and cell-range gestures correctly don't.
+      onRowActivate={({ rowId }) => onSelect(rowId)}
+      onTelemetryChange={onTelemetryChange}
+      // Lowercase labels to match the rest of the Inspector chrome; pretable's
+      // own default renders the column name plus a ▲/▼ glyph.
+      renderHeaderCell={({ label, sortDirection }) => (
+        <span className="flex items-center gap-1">
+          {label}
+          {sortDirection ? (
+            <span aria-hidden="true">{sortDirection === "asc" ? "▲" : "▼"}</span>
+          ) : null}
+        </span>
+      )}
+    />
   )
 }

--- a/packages/inspector/test/components/memory-grid.test.tsx
+++ b/packages/inspector/test/components/memory-grid.test.tsx
@@ -1,0 +1,168 @@
+import type { MemoryRecord } from "@dawn-ai/memory"
+import { cleanup, fireEvent, render, screen } from "@testing-library/react"
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { MemoryGrid } from "../../src/components/memory/memory-grid"
+
+function record(over: Partial<MemoryRecord> & Pick<MemoryRecord, "id">): MemoryRecord {
+  return {
+    kind: "semantic",
+    namespace: "route=/notes",
+    content: `content ${over.id}`,
+    data: {},
+    source: { type: "tool", id: "remember" },
+    confidence: 0.5,
+    tags: [],
+    status: "active",
+    createdAt: "2026-07-13T00:00:00.000Z",
+    updatedAt: "2026-07-13T00:00:00.000Z",
+    ...over,
+  }
+}
+
+/** Text of every cell in one column, top row first — the rendered row order. */
+function columnText(container: HTMLElement, columnId: string): string[] {
+  return [
+    ...container.querySelectorAll(`[role="gridcell"][data-pretable-column-id="${columnId}"]`),
+  ].map((cell) => cell.textContent ?? "")
+}
+
+function headerFor(container: HTMLElement, label: string): HTMLElement {
+  const header = [...container.querySelectorAll('[role="columnheader"]')].find((el) =>
+    el.textContent?.startsWith(label),
+  )
+  if (!header) throw new Error(`no column header for ${label}`)
+  return header as HTMLElement
+}
+
+afterEach(cleanup)
+
+describe("MemoryGrid", () => {
+  it("renders a row per record", () => {
+    const { container } = render(
+      <MemoryGrid
+        records={[record({ id: "a", content: "acme threshold is 750" }), record({ id: "b" })]}
+        onSelect={vi.fn()}
+      />,
+    )
+    expect(screen.getByText("acme threshold is 750")).toBeDefined()
+    expect(columnText(container, "content")).toEqual(["acme threshold is 750", "content b"])
+    expect(screen.getAllByText("route=/notes")).toHaveLength(2)
+  })
+
+  it("clicking a row selects that record", () => {
+    const onSelect = vi.fn()
+    render(
+      <MemoryGrid
+        records={[record({ id: "a" }), record({ id: "b", content: "second row" })]}
+        onSelect={onSelect}
+      />,
+    )
+    fireEvent.click(screen.getByText("second row"))
+    expect(onSelect.mock.calls).toEqual([["b"]])
+  })
+
+  it("a keyboard user can reach a row and activate it with Enter", () => {
+    const onSelect = vi.fn()
+    const { container } = render(
+      <MemoryGrid records={[record({ id: "a" }), record({ id: "b" })]} onSelect={onSelect} />,
+    )
+    // Tab lands on the first column header; Down moves into the body.
+    const header = headerFor(container, "status")
+    header.focus()
+    fireEvent.keyDown(header, { key: "ArrowDown" })
+    fireEvent.keyDown(document.activeElement ?? header, { key: "Enter" })
+    expect(onSelect.mock.calls).toEqual([["a"]])
+  })
+
+  it("Space activates the focused row too", () => {
+    const onSelect = vi.fn()
+    const { container } = render(
+      <MemoryGrid records={[record({ id: "a" }), record({ id: "b" })]} onSelect={onSelect} />,
+    )
+    const header = headerFor(container, "status")
+    header.focus()
+    fireEvent.keyDown(header, { key: "ArrowDown" })
+    fireEvent.keyDown(document.activeElement ?? header, { key: "ArrowDown" })
+    fireEvent.keyDown(document.activeElement ?? header, { key: " " })
+    expect(onSelect.mock.calls).toEqual([["b"]])
+  })
+
+  it("clicking a column header sorts the rows by that column", () => {
+    const { container } = render(
+      <MemoryGrid
+        records={[
+          record({ id: "a", content: "banana" }),
+          record({ id: "b", content: "apple" }),
+          record({ id: "c", content: "cherry" }),
+        ]}
+        onSelect={vi.fn()}
+      />,
+    )
+    expect(columnText(container, "content")).toEqual(["banana", "apple", "cherry"])
+
+    const header = headerFor(container, "content")
+    fireEvent.click(header)
+    expect(columnText(container, "content")).toEqual(["cherry", "banana", "apple"])
+    expect(header.getAttribute("aria-sort")).toBe("descending")
+
+    fireEvent.click(header)
+    expect(columnText(container, "content")).toEqual(["apple", "banana", "cherry"])
+    expect(header.getAttribute("aria-sort")).toBe("ascending")
+  })
+
+  it("keeps the sort when a poll hands down a fresh records array", () => {
+    const records = [
+      record({ id: "a", content: "banana" }),
+      record({ id: "b", content: "apple" }),
+      record({ id: "c", content: "cherry" }),
+    ]
+    const { container, rerender } = render(<MemoryGrid records={records} onSelect={vi.fn()} />)
+    fireEvent.click(headerFor(container, "content"))
+    expect(columnText(container, "content")).toEqual(["cherry", "banana", "apple"])
+
+    // Live mode refetches every 2s; each response is a new array of equal records.
+    rerender(<MemoryGrid records={records.map((rec) => ({ ...rec }))} onSelect={vi.fn()} />)
+    expect(columnText(container, "content")).toEqual(["cherry", "banana", "apple"])
+    expect(headerFor(container, "content").getAttribute("aria-sort")).toBe("descending")
+  })
+
+  it("sorts the updated column chronologically, not by its displayed text", () => {
+    const { container } = render(
+      <MemoryGrid
+        records={[
+          record({ id: "a", content: "older", updatedAt: "2026-01-02T00:00:00.000Z" }),
+          record({ id: "b", content: "newest", updatedAt: "2026-11-30T00:00:00.000Z" }),
+          record({ id: "c", content: "middle", updatedAt: "2026-03-04T00:00:00.000Z" }),
+        ]}
+        onSelect={vi.fn()}
+      />,
+    )
+    fireEvent.click(headerFor(container, "updated"))
+    expect(columnText(container, "content")).toEqual(["newest", "middle", "older"])
+  })
+
+  it("tints candidate rows and strikes through superseded ones", () => {
+    const { container } = render(
+      <MemoryGrid
+        records={[
+          record({ id: "a", content: "pending", status: "candidate" }),
+          record({ id: "b", content: "replaced", status: "superseded" }),
+          record({ id: "c", content: "live", status: "active" }),
+        ]}
+        onSelect={vi.fn()}
+      />,
+    )
+    // Status styling lives on the CELLS, not the row: pretable's grid.css paints
+    // every cell with an opaque background, which would cover a row-level tint.
+    const cellClasses = (id: string) =>
+      [
+        ...container.querySelectorAll(
+          `[data-pretable-row][data-pretable-row-id="${id}"] [role="gridcell"]`,
+        ),
+      ].map((cell) => cell.className)
+    expect(cellClasses("a").length).toBeGreaterThan(0)
+    expect(cellClasses("a").every((cls) => cls.includes("amber"))).toBe(true)
+    expect(cellClasses("b").every((cls) => cls.includes("line-through"))).toBe(true)
+    expect(cellClasses("c").some((cls) => cls.includes("line-through"))).toBe(false)
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -490,6 +490,12 @@ importers:
       '@dawn-ai/memory':
         specifier: workspace:*
         version: link:../memory
+      '@pretable/react':
+        specifier: 0.0.3
+        version: 0.0.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@pretable/ui':
+        specifier: 0.0.3
+        version: 0.0.3
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -2181,6 +2187,18 @@ packages:
 
   '@preact/signals-core@1.14.4':
     resolution: {integrity: sha512-HNB6HYeYKhQbJ1aKl+YRjrS4+QWHLKX6qKoUsfS/m0vqzsVaEBiZiaKbG/e+NKk2ch5ALQr/ihWaMHxiCuuWHA==}
+
+  '@pretable/core@0.0.3':
+    resolution: {integrity: sha512-zmu6ICJroSt3dWb19fQ8o5g+4p0Np3Rzkw18WuERnWaDjVyCzEMLXJem22D0349g2qNbMh3uZHIcQlB0a9k+wA==}
+
+  '@pretable/react@0.0.3':
+    resolution: {integrity: sha512-GxAeIocUHoLfNB9+BSwSXgeHgNDzE7mEJ1LWr6FN0TjffYuQzYNjOsEvFQ2YlFYwVieDa38GiHIE4MZcXbA7+A==}
+    peerDependencies:
+      react: ^19.0.0
+      react-dom: ^19.0.0
+
+  '@pretable/ui@0.0.3':
+    resolution: {integrity: sha512-9Ic0YE7mTxBs63sq3zLuiUn0gNvX187NwvvMXU0Tu8cCCvcOMLnKLYsMRTQWeZmi9jie4vYii07ah680VTWIPA==}
 
   '@protobuf-ts/protoc@2.11.1':
     resolution: {integrity: sha512-mUZJaV0daGO6HUX90o/atzQ6A7bbN2RSuHtdwo8SSF2Qoe3zHwa4IHyCN1evftTeHfLmdz+45qo47sL+5P8nyg==}
@@ -8591,6 +8609,17 @@ snapshots:
   '@polka/url@1.0.0-next.29': {}
 
   '@preact/signals-core@1.14.4': {}
+
+  '@pretable/core@0.0.3': {}
+
+  '@pretable/react@0.0.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@pretable/core': 0.0.3
+      '@pretable/ui': 0.0.3
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+
+  '@pretable/ui@0.0.3': {}
 
   '@protobuf-ts/protoc@2.11.1': {}
 


### PR DESCRIPTION
The Memory Inspector shipped a semantic `<table>` as a stand-in because `@pretable/react@0.0.2` was uninstallable — it hard-depended on `@pretable/ui@0.0.2`, which had never been published. `@pretable/ui` is on npm now, so the grid this was always meant to use goes in behind the same `MemoryGrid { records, onSelect }` props, and **column sorting** — the feature deliberately deferred to this swap — arrives with it.

Sorting is real sorting: the `updated` column sorts on the raw ISO string, not its formatted text.

## Notes on the non-obvious parts

- **Status styling lives on the cells, not the row.** pretable's `grid.css` paints every cell with an opaque background, so a row-level tint is simply covered.
- **`globals.css` declares the layer order** so the `pretable` layer sits above Tailwind's preflight (which would otherwise zero out the grid's borders) and below its utilities (so those cell tints win).
- **The content column ellipsizes via an inner span** — a cell is a flex container, and `text-overflow` does nothing on one.
- **The Excel theme ships no row hover by design**; these rows open a record on click, so the token is set locally.
- **Column widths are fixed** and sum to ~1030px so a full row fits beside the facet rail on a 1280px screen. pretable sizes columns to content or to `widthPx`, never to fill its container — my first pass overflowed and cut off `updated`.

## Upstream

Integrating this surfaced real gaps in pretable, which were fixed there rather than worked around here — [cacheplane/pretable#211](https://github.com/cacheplane/pretable/pull/211), shipped in **0.0.3**:

- `columns` identity recreated the whole grid, discarding sort/filters/selection/focus/column-layout/in-flight-edit. An inline `columns={[...]}` is a new identity every render.
- No row-activation API — a plain click selects one cell, never a full row, so `onSelectedRowIdChange` never fired for it. Now `onRowActivate`.
- `setRows` never re-ran autosize, so a grid whose first render was empty kept minimum widths forever.
- Header cells were inline `display: grid` (overriding the shipped skin, stacking multi-node headers); the default header read "Newest"/"Oldest"/"Sort"; cells didn't clip, so long values painted over their neighbours.

Without those, this file needed a controlled-`sort` slice and hand-rolled `getRowProps` click plumbing. Both are gone — 27 lines — and the behaviour is now pretable's.

## Verification

`build` (zero warnings), `typecheck`, `lint`, and 54 tests (32 component + gated `DAWN_TEST_INSPECTOR=1` e2e). Driven manually in Chrome against the built standalone server on published 0.0.3: clicking a row opens that record's sheet, Tab → header → ArrowDown → Enter opens one from the keyboard, Tab escapes the grid rather than trapping focus, and a sorted column survives live polling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)