### PR TITLE
fix(deps): repair lockfile react peer resolution for @pretable/react

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -498,7 +498,7 @@ importers:
         version: link:../memory
       '@pretable/react':
         specifier: 0.0.3
-        version: 0.0.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 0.0.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@pretable/ui':
         specifier: 0.0.3
         version: 0.0.3
@@ -9080,12 +9080,12 @@ snapshots:
 
   '@pretable/core@0.0.3': {}
 
-  '@pretable/react@0.0.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@pretable/react@0.0.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
       '@pretable/core': 0.0.3
       '@pretable/ui': 0.0.3
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
 
   '@pretable/ui@0.0.3': {}
 


### PR DESCRIPTION
**Main is red.** `pnpm install --frozen-lockfile` fails at the Install step:

```
ERR_PNPM_LOCKFILE_MISSING_DEPENDENCY  Broken lockfile: no entry for 'react@19.2.7'
```

### Cause

#397 (the npm-minor-and-patch group bump) raised react to 19.2.8. Its lockfile was generated against a base that predated #401, which added `@pretable/react@0.0.3`. On merge, the lockfile kept `@pretable/react`'s react/react-dom peer resolution pinned at 19.2.7 — a version that no longer has a lockfile entry.

This is fallout from my rebuild of #397 on a base that main then moved past; the squash-merge combined a stale lockfile with newer package.json state.

### Fix

Regenerated `pnpm-lock.yaml` on current main. Four lines — only the `@pretable/react` peer resolution.

### Verification

- `pnpm install --frozen-lockfile` → exit 0
- `@langchain/core` still deduped to a single 1.2.5 copy (the fix #397 shipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)