### PR TITLE
fix: repair pnpm-lock.yaml after the #397/#401 merge

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -498,7 +498,7 @@ importers:
         version: link:../memory
       '@pretable/react':
         specifier: 0.0.3
-        version: 0.0.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 0.0.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@pretable/ui':
         specifier: 0.0.3
         version: 0.0.3
@@ -9080,12 +9080,12 @@ snapshots:
 
   '@pretable/core@0.0.3': {}
 
-  '@pretable/react@0.0.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@pretable/react@0.0.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
       '@pretable/core': 0.0.3
       '@pretable/ui': 0.0.3
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
 
   '@pretable/ui@0.0.3': {}
 


### PR DESCRIPTION
**main is red at HEAD**, and the pending 0.8.18 Release run would fail the same way — `ci:validate` starts with a frozen-lockfile install.

```
ERR_PNPM_LOCKFILE_MISSING_DEPENDENCY
Broken lockfile: no entry for 'react@19.2.7' in pnpm-lock.yaml
This issue is probably caused by a badly resolved merge conflict.
```

Every lane failed on `37179430` (`validate`, `inspector-e2e`, `pgvector-docker`, all four sandbox lanes) because none of them could install.

## Cause

A semantic conflict in `pnpm-lock.yaml` that git merged cleanly and neither PR could have caught alone:

- **#401** added `@pretable/react@0.0.3`, with its peer resolution pinned to `react@19.2.7`.
- **#397** (Dependabot, 26 packages) bumped `react` to `19.2.8`.

Each was green on its own branch. The merge kept #401's peer references pointing at a react version that #397 had removed from the lockfile.

## Fix

Regenerated with `pnpm install --no-frozen-lockfile`. The diff is four lines, purely realigning `@pretable/react`'s peer resolution:

```
-  '@pretable/react@0.0.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@pretable/react@0.0.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
```

No package versions change beyond that realignment.

## Verification

- `pnpm install --frozen-lockfile` — the exact CI gate — now succeeds (it fails on main).
- build 24/24, typecheck 25/25.
- `@dawn-ai/inspector` suite green (37 passed) — it is the consumer of `@pretable/react`.

No changeset: lockfile-only, no published package changes.

The advisory `review` check fails repo-wide (exhausted org credits) and is expected.