### PR TITLE
fix(deps,test): align @langchain/core pin and harden the fork-bomb liveness wait

### DIFF
--- a/packages/sandbox/test/docker-sandbox.integration.test.ts
+++ b/packages/sandbox/test/docker-sandbox.integration.test.ts
@@ -38,6 +38,13 @@ const FAILED_TO_LAUNCH = /OCI runtime exec failed|unable to start container proc
  * usable, which is only meaningful once it can spawn at all. Any OTHER failure is
  * returned immediately so a genuine regression still fails fast rather than burning
  * the whole window.
+ *
+ * The budget is 120s, not 60s. The drain is bounded by the sleeps' own 30s lifetime,
+ * so 60s looks generous — but on a saturated runner each retry's `docker exec` is
+ * itself slow to round-trip, so the loop gets only a handful of attempts and can
+ * expire while the container is still draining. Observed failing on ~half of runs
+ * with the 60s budget. Anything approaching 120s is a real problem, not slowness,
+ * hence the explicit throw rather than a quiet return.
  */
 type SandboxHandle = Awaited<ReturnType<ReturnType<typeof dockerSandbox>["acquire"]>>
 type ExecResult = Awaited<ReturnType<SandboxHandle["exec"]["runCommand"]>>
@@ -45,13 +52,26 @@ type ExecResult = Awaited<ReturnType<SandboxHandle["exec"]["runCommand"]>>
 async function execUntilSpawnable(
   handle: SandboxHandle,
   command: string,
-  { intervalMs = 1_000, timeoutMs = 60_000 } = {},
+  { intervalMs = 1_000, timeoutMs = 120_000 } = {},
 ): Promise<ExecResult> {
-  const deadline = Date.now() + timeoutMs
+  const startedAt = Date.now()
+  const deadline = startedAt + timeoutMs
+  let attempts = 0
   for (;;) {
+    attempts++
     const result = await handle.exec.runCommand({ command }, ctx(handle.workspaceRoot))
     const output = `${result.stdout ?? ""}${result.stderr ?? ""}`
-    if (!FAILED_TO_LAUNCH.test(output) || Date.now() >= deadline) return result
+    if (!FAILED_TO_LAUNCH.test(output)) return result
+    if (Date.now() >= deadline) {
+      // Deliberately throw rather than return the launch failure. Returning it
+      // surfaced as `expected 'OCI runtime exec failed…' to contain 'alive'`,
+      // which reads like the container came back wrong when in fact it never
+      // became spawnable at all — two very different diagnoses.
+      throw new Error(
+        `container never became spawnable: ${attempts} attempt(s) over ` +
+          `${Date.now() - startedAt}ms all failed to launch. Last output: ${output.trim().slice(0, 300)}`,
+      )
+    }
     await new Promise((resolve) => setTimeout(resolve, intervalMs))
   }
 }
@@ -125,7 +145,10 @@ describe.skipIf(!enabled)("dockerSandbox (real Docker)", { timeout: 120_000 }, (
   // containment. fakeSandbox can't enforce kernel controls (caps/pids/
   // read-only/non-root), so these properties are Docker-lane-only.
 
-  test("hardened defaults contain a fork bomb (pids-limit)", { timeout: 180_000 }, async () => {
+  // 300s, not 180s: the assertion below may spend up to 120s waiting for the
+  // container's pids to drain, and that budget has to fit INSIDE the test's own
+  // timeout or it can never actually be spent.
+  test("hardened defaults contain a fork bomb (pids-limit)", { timeout: 300_000 }, async () => {
     const p = dockerSandbox({ image: IMAGE })
     const threadId = `fork-${randomUUID()}`
     try {

--- a/packages/sqlite-storage/package.json
+++ b/packages/sqlite-storage/package.json
@@ -41,7 +41,7 @@
   },
   "devDependencies": {
     "@dawn-ai/config-typescript": "workspace:*",
-    "@langchain/core": "^1.2.4",
+    "@langchain/core": "1.2.5",
     "@langchain/langgraph-checkpoint": "^1.1.3",
     "@types/node": "26.1.2"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -726,7 +726,7 @@ importers:
         specifier: workspace:*
         version: link:../config-typescript
       '@langchain/core':
-        specifier: ^1.2.4
+        specifier: 1.2.5
         version: 1.2.5(@opentelemetry/api@1.9.1)(openai@6.45.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0)
       '@langchain/langgraph-checkpoint':
         specifier: ^1.1.3


### PR DESCRIPTION
Two CI-stability fixes, both fallout from #397.

## 1. `@langchain/core` could silently duplicate

`packages/cli` and `packages/langchain` pin `@langchain/core` **exactly**; `packages/sqlite-storage`'s devDependency used a **caret**.

Dependabot rewrites an exact spec but leaves a still-satisfied caret alone. So the last group bump moved the exact pins to `1.2.4` while the caret quietly floated to `1.2.5`. Two copies in the tree means TypeScript sees two structurally distinct `RunnableConfig`/`CallbackManager` types, and the CLI build fails with `exactOptionalPropertyTypes` errors — which is what took down `pgvector-docker`, `sandbox-docker-e2e` and `sandbox-k8s-e2e` on #397.

Aligning the devDependency to an exact `1.2.5` means Dependabot rewrites all three together, so they cannot drift. The `peerDependencies` caret is left alone — peer ranges should stay ranges.

**Chosen over a `pnpm.overrides` entry.** An override would work, but it masks the cause, needs manual bumping forever, and Dependabot can't manage it. This removes the divergence itself.

## 2. Fork-bomb liveness wait

`execUntilSpawnable` already retried, but on timeout it **returned** the launch failure, so the flake surfaced as:

```
expected 'OCI runtime exec failed…' to contain 'alive'
```

That reads as "the container came back wrong" when the truth is "it never became spawnable" — a completely different diagnosis, and it sent me chasing the wrong thing earlier today. It now throws with attempt count, elapsed time and last output.

Budget also goes 60s → 120s, and the test timeout 180s → 300s. **Both were required:** a 120s wait budget inside a 180s test can't actually be spent once the fork bomb itself has consumed time, so raising one alone would have been cosmetic.

## Verification

- Single `@langchain/core@1.2.5`; `pnpm install --frozen-lockfile` exit 0
- Real Docker lane **11/11** locally (`DAWN_TEST_DOCKER=1`, Docker 27.4.0)
- Lint clean on both touched packages

**Honest caveat on (2):** this machine cannot reproduce the flake — `pids-limit` is 512 and the storm should saturate, but the shell can't fork fast enough here to sustain it, so the retry path never engages. The local run therefore proves no regression, not that the flake is gone. (2) is a diagnosability and headroom improvement; only repeated CI runs can confirm the effect on flake rate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
