### PR TITLE
docs: drop a banned phrase from the 0.8.18 changelog

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -21,7 +21,7 @@
   commander's parsing layer. Added tests that drive the real program.
 
   **A fresh `create-dawn-ai-app` research app failed `npm test` out of the box.** The
-  research template's `test/research.test.ts.template` is kept byte-identical to the
+  research template's `test/research.test.ts.template` is kept exactly in sync with the
   dogfooded `examples/research/server/test/research.test.ts`, but the Memory Inspector
   change that reworded CLI approve output to `approved <id> (activated)` updated only the
   example. The template kept asserting `Approved: <id>`, so the default template — the one

--- a/packages/devkit/CHANGELOG.md
+++ b/packages/devkit/CHANGELOG.md
@@ -21,7 +21,7 @@
   commander's parsing layer. Added tests that drive the real program.
 
   **A fresh `create-dawn-ai-app` research app failed `npm test` out of the box.** The
-  research template's `test/research.test.ts.template` is kept byte-identical to the
+  research template's `test/research.test.ts.template` is kept exactly in sync with the
   dogfooded `examples/research/server/test/research.test.ts`, but the Memory Inspector
   change that reworded CLI approve output to `approved <id> (activated)` updated only the
   example. The template kept asserting `Approved: <id>`, so the default template — the one


### PR DESCRIPTION
The 0.8.18 Release run ([31177673305](https://github.com/cacheplane/dawnai/actions/runs/31177673305)) failed at **Validate Release Candidate** — pre-publish, so **nothing was published and npm is cleanly at 0.8.17** (verified against the registry).

```
Docs completeness check failed.
- packages/cli/CHANGELOG.md overstates local/prod protocol or deployment parity
```

## Cause

`scripts/check-docs.mjs` bans the literal token `byte-identical` (alongside "What works locally works in production", "speaks the LangSmith protocol natively", "without translation"). It's a deliberate, documented rule — `AGENTS.md:176` lists it and the implementation plans repeatedly warn about it.

My smoke-fix changeset used the phrase to describe two template files matching each other. That use is literal and has nothing to do with deployment parity, but it is exactly the token the guard rejects, and changesets flowed it into `packages/cli/CHANGELOG.md` and `packages/devkit/CHANGELOG.md`.

Mine to own: the rule is documented and I didn't check it before writing the changeset.

## Fix

Reworded to "kept exactly in sync with" in both changelogs. Same meaning, no banned token.

**The guard is deliberately left untouched.** Loosening it to admit my wording would weaken a rule that exists to stop real overclaiming, and there is an equally clear alternative phrasing. If the substring match is later judged too blunt for literal file-comparison uses, that's a separate change with its own justification — not something to slip in to unblock a release.

## Verification

`node scripts/check-docs.mjs` → `Docs completeness check passed.` (fails on main).

Changelog-only; no changeset (this edits already-generated changelogs for the version being released).