### PR TITLE
fix(ci): stop the docs guard failing main on a legitimate "byte-identical"

### DIFF
--- a/scripts/check-docs.mjs
+++ b/scripts/check-docs.mjs
@@ -351,8 +351,20 @@ const forbiddenContent = [
   },
   {
     pattern:
-      /speaks the LangSmith protocol natively|What works locally works in production|without translation|byte-identical/,
+      /speaks the LangSmith protocol natively|What works locally works in production|without translation/,
     message: "overstates local/prod protocol or deployment parity",
+  },
+  {
+    // "byte-identical" is banned as a local/prod parity claim, but it is also a
+    // perfectly ordinary way to describe two files having the same contents.
+    // CHANGELOGs are generated from changeset prose and are a historical record,
+    // so a legitimate technical use there should not be rewritten after the fact
+    // — and it must not red main once the Version PR bakes it in, which is
+    // exactly what happened when #399's changeset described a template as being
+    // kept byte-identical to its source.
+    pattern: /byte-identical/,
+    message: "overstates local/prod protocol or deployment parity",
+    shouldCheck: (filePath) => !/CHANGELOG\.md$/.test(filePath),
   },
   {
     pattern: /auto-bound|auto-registered/,


### PR DESCRIPTION
**`main` is red on `validate` → Docs Check**, which blocks every PR:

```
- packages/cli/CHANGELOG.md overstates local/prod protocol or deployment parity
- packages/devkit/CHANGELOG.md overstates local/prod protocol or deployment parity
```

## It's a false positive

The guard bans `byte-identical` as a local/prod parity claim. But it's also an ordinary way to say two files have the same contents — and that's how #399's changeset used it, describing a scaffold template kept byte-identical to its source. #400's Version PR baked that prose into the generated CHANGELOGs, and main went red.

**The failure mode is the interesting part:** the guard scans generated `CHANGELOG.md` files but never the `.changeset/*.md` they're generated from. So the authoring PR was green, the Version PR was green, and it only broke *after* the release merged — the same invisible-until-release shape as the pack-smoke gotcha.

## Fix

Split the rule:

- The genuine marketing phrases (`speaks the LangSmith protocol natively`, `What works locally works in production`, `without translation`) still apply **everywhere**.
- `byte-identical` alone now skips `CHANGELOG.md`, reusing the `shouldCheck` precedent the pgvector rule already established.

CHANGELOGs are a historical record generated from prose humans already reviewed at PR time. Rewriting them after the fact to satisfy a guard is the wrong direction; narrowing an over-broad pattern is the right one.

## Verification

Reproduced the failure on unmodified `main` first, then confirmed the fix:

- full package build → exit 0
- `node scripts/check-docs.mjs` → **Docs completeness check passed**

## Follow-up (not in this PR)

Run the same guard over `.changeset/*.md` so this class fails at PR time rather than after the release. Deliberately left out of an urgent unblock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
