### PR TITLE
fix(cli): drain in-flight runs in close() before releasing sandboxes

### DIFF
--- a/.changeset/close-drains-inflight-runs.md
+++ b/.changeset/close-drains-inflight-runs.md
@@ -1,0 +1,9 @@
+---
+"@dawn-ai/cli": patch
+---
+
+`close()` now drains in-flight runs, not just in-flight HTTP requests, before releasing sandboxes.
+
+A cancelled `/runs/wait` answers with plain JSON, and the fetch wrapper only holds an in-flight slot for `text/event-stream` bodies — so `activeRequests` had already dropped to zero while the abandoned route was still executing against its sandbox. A routine `close()` (a rolling deploy, say) could therefore call `releaseAll()` mid-tool-call. The same applied to a cancelled stream whose route ignores `ctx.signal`.
+
+The run registry already tracks exactly this — a run holds its slot for as long as its route may still be running, including after the response was sent — so `close()` now waits on both counters. The wait stays bounded by the existing drain deadline, and cancelling a run can now delay shutdown by up to that deadline rather than returning immediately.

--- a/packages/cli/src/lib/dev/run-registry.ts
+++ b/packages/cli/src/lib/dev/run-registry.ts
@@ -38,6 +38,15 @@ export interface RunRegistry {
   /** Aborts the in-flight run. Returns false when there is nothing to cancel. */
   cancel(threadId: string, reason?: string): boolean
   has(threadId: string): boolean
+  /**
+   * How many runs still hold a slot.
+   *
+   * A slot is held for as long as route work may still be executing — including
+   * after the HTTP response has been sent, when a cancelled or abandoned run was
+   * detached rather than stopped. `close()` drains on this so sandboxes are not
+   * released out from under work that is still running.
+   */
+  activeCount(): number
 }
 
 export function createRunRegistry(): RunRegistry {
@@ -96,6 +105,9 @@ export function createRunRegistry(): RunRegistry {
     },
     has(threadId) {
       return entries.has(threadId)
+    },
+    activeCount() {
+      return entries.size
     },
   }
 }

--- a/packages/cli/src/lib/dev/runtime-fetch-core.ts
+++ b/packages/cli/src/lib/dev/runtime-fetch-core.ts
@@ -212,6 +212,17 @@ export async function createRuntimeFetchHandler(
     closed: false,
   }
   const shutdownController = new AbortController()
+
+  // Process-local in-flight run tracking: enables the concurrency gate, the
+  // per-run abort signal, and POST /threads/:id/cancel. Scoped to this handler
+  // (not module-level) so multiple handler instances in one process — which the
+  // (Request) => Response core exists to allow — stay isolated.
+  //
+  // Lives out here rather than inside buildRouteTable because close() drains on
+  // it: a run whose HTTP response has already been sent can still be executing
+  // (a cancelled stream, or an abandoned wait), and that work must finish before
+  // sandboxes are released.
+  const runRegistry = createRunRegistry()
   const resumeClaims = createPendingResumeClaims()
 
   const routes = buildRouteTable({
@@ -223,6 +234,7 @@ export async function createRuntimeFetchHandler(
     permissionsStore,
     registry,
     resumeClaims,
+    runRegistry,
     ...(sandboxManager ? { sandboxManager } : {}),
     signal: shutdownController.signal,
     // Boot manifest → route execution derives the subagents descriptor maps
@@ -295,20 +307,30 @@ export async function createRuntimeFetchHandler(
 
     if (sandboxReaper) clearInterval(sandboxReaper)
 
-    // Drain in-flight requests — bounded: an SSE body nobody ever reads (or a
+    // Drain in-flight work — bounded: an SSE body nobody ever reads (or a
     // leaked in-flight slot) must not wedge shutdown forever.
+    //
+    // Both counters matter, and neither implies the other. activeRequests
+    // tracks HTTP responses still being produced. runRegistry tracks route work
+    // that may still be executing AFTER its response was sent: a cancelled run
+    // whose route ignored ctx.signal, or an abandoned /runs/wait that returned
+    // 409 while invokeResolvedRoute kept going. Those return plain JSON, so the
+    // fetch wrapper (which only holds the slot for text/event-stream bodies)
+    // has already decremented — draining on activeRequests alone would release
+    // sandboxes out from under work still using them.
     const drainDeadlineMs = options.drainDeadlineMs ?? CLOSE_DRAIN_DEADLINE_MS
     await new Promise<void>((resolve) => {
       const startedAt = Date.now()
       const check = () => {
-        if (state.activeRequests === 0) {
+        const activeRuns = runRegistry.activeCount()
+        if (state.activeRequests === 0 && activeRuns === 0) {
           resolve()
           return
         }
         if (Date.now() - startedAt >= drainDeadlineMs) {
           console.warn(
-            `close(): ${state.activeRequests} request(s) still active after ` +
-              `${Math.round(drainDeadlineMs / 1000)}s — proceeding with shutdown`,
+            `close(): ${state.activeRequests} request(s) and ${activeRuns} run(s) still ` +
+              `active after ${Math.round(drainDeadlineMs / 1000)}s — proceeding with shutdown`,
           )
           resolve()
           return
@@ -385,6 +407,7 @@ function buildRouteTable(ctx: {
   readonly permissionsStore: PermissionsStore | (() => Promise<PermissionsStore>)
   readonly registry: RuntimeRegistry
   readonly resumeClaims: PendingResumeClaims
+  readonly runRegistry: RunRegistry
   readonly sandboxManager?: SandboxManager
   readonly signal: AbortSignal
   readonly staticModules?: DawnStaticModules
@@ -399,6 +422,7 @@ function buildRouteTable(ctx: {
     permissionsStore,
     registry,
     resumeClaims,
+    runRegistry,
     sandboxManager,
     signal,
     staticModules,
@@ -409,12 +433,6 @@ function buildRouteTable(ctx: {
   // Populated by runs/stream and runs/wait; read by the resume endpoint so it
   // can re-invoke the correct route without requiring the client to repeat it.
   const threadRouteMap = new Map<string, string>()
-
-  // Process-local in-flight run tracking: enables the concurrency gate, the
-  // per-run abort signal, and POST /threads/:id/cancel. Scoped to this route
-  // table (not module-level) so multiple handler instances in one process —
-  // which the (Request) => Response core exists to allow — stay isolated.
-  const runRegistry = createRunRegistry()
 
   return [
     // ------------------------------------------------------------------

--- a/packages/cli/test/run-cancellation.test.ts
+++ b/packages/cli/test/run-cancellation.test.ts
@@ -2,7 +2,7 @@ import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { dirname, join } from "node:path"
 import { createThreadsStore } from "@dawn-ai/sqlite-storage"
-import { afterEach, describe, expect, it } from "vitest"
+import { afterEach, describe, expect, it, vi } from "vitest"
 import { createRuntimeFetchHandler } from "../src/lib/dev/runtime-fetch-handler.js"
 
 const cleanup: Array<() => Promise<void> | void> = []
@@ -119,7 +119,11 @@ async function setupBlockingRoute() {
     await writeFile(filePath, body, "utf8")
   }
 
-  const handler = await createRuntimeFetchHandler({ appRoot })
+  // Short drain deadline: these fixtures deliberately leave a route running
+  // after cancellation (that is the property under test), and close() now waits
+  // for in-flight runs. Without a bound, afterEach cleanup would block for the
+  // full 30s default on every cancellation test.
+  const handler = await createRuntimeFetchHandler({ appRoot, drainDeadlineMs: 250 })
   cleanup.push(() => handler.close())
 
   // Unique per setup() call (appRoot itself is unique per mkdtemp), so
@@ -157,7 +161,11 @@ async function setupFaultyThreadsStore() {
     await writeFile(filePath, body, "utf8")
   }
 
-  const handler = await createRuntimeFetchHandler({ appRoot })
+  // Short drain deadline: these fixtures deliberately leave a route running
+  // after cancellation (that is the property under test), and close() now waits
+  // for in-flight runs. Without a bound, afterEach cleanup would block for the
+  // full 30s default on every cancellation test.
+  const handler = await createRuntimeFetchHandler({ appRoot, drainDeadlineMs: 250 })
   cleanup.push(() => handler.close())
 
   return { appRoot, handler }
@@ -317,7 +325,11 @@ async function setupResumeInterrupt() {
     await writeFile(filePath, body, "utf8")
   }
 
-  const handler = await createRuntimeFetchHandler({ appRoot })
+  // Short drain deadline: these fixtures deliberately leave a route running
+  // after cancellation (that is the property under test), and close() now waits
+  // for in-flight runs. Without a bound, afterEach cleanup would block for the
+  // full 30s default on every cancellation test.
+  const handler = await createRuntimeFetchHandler({ appRoot, drainDeadlineMs: 250 })
   cleanup.push(() => handler.close())
 
   return {
@@ -773,6 +785,41 @@ describe("/runs/wait cancellation", () => {
     if (!admitted) throw new Error("run slot was never freed after the abandoned route released")
 
     await drain(admitted)
+  }, 15_000)
+
+  it("close() drains an abandoned wait's run before releasing sandboxes", async () => {
+    // A cancelled /runs/wait answers with plain JSON, so the fetch wrapper —
+    // which only holds an in-flight slot for text/event-stream bodies — has
+    // already decremented activeRequests by the time close() runs. Draining on
+    // activeRequests alone would therefore call sandboxManager.releaseAll()
+    // while the abandoned route is still executing against its sandbox, yanking
+    // it mid-tool-call. close() must drain on in-flight RUNS as well.
+    const { handler, startedFile, releaseFile, releaseRoute } = await setupBlockingRoute()
+    const threadId = "t-close-waits-for-abandoned-wait"
+
+    const waitPromise = handler.fetch(runWaitRequest(threadId, startedFile, releaseFile))
+    await waitForFile(startedFile)
+
+    expect((await handler.fetch(cancelRequest(threadId))).status).toBe(200)
+    expect((await waitPromise).status).toBe(409)
+
+    // The HTTP side has fully settled...
+    expect(handler.state.activeRequests).toBe(0)
+
+    // ...but the run has not, so close() must NOT treat this as drained. The
+    // fixture's 250ms deadline bounds the wait; hitting it (and warning about
+    // runs) is the observable proof that close() waited on the run rather than
+    // returning immediately, which is what it did before this fix.
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {})
+    try {
+      await handler.close()
+      expect(warn).toHaveBeenCalledTimes(1)
+      expect(String(warn.mock.calls[0]?.[0])).toContain("run(s) still")
+    } finally {
+      warn.mockRestore()
+    }
+
+    await releaseRoute()
   }, 15_000)
 })
 

--- a/packages/cli/test/runtime-fetch-parity.test.ts
+++ b/packages/cli/test/runtime-fetch-parity.test.ts
@@ -266,7 +266,7 @@ describe("runtime fetch handler parity", () => {
     try {
       await handler.close() // must resolve (bounded drain), not hang
       expect(warn).toHaveBeenCalledTimes(1)
-      expect(String(warn.mock.calls[0]?.[0])).toContain("request(s) still active")
+      expect(String(warn.mock.calls[0]?.[0])).toContain("1 request(s)")
       expect(String(warn.mock.calls[0]?.[0])).toContain("proceeding with shutdown")
     } finally {
       warn.mockRestore()


### PR DESCRIPTION
Follow-up from the AP run-cancellation review (#390). The reviewer flagged this; I deferred it as out of scope at the time.

## The bug

A cancelled `/runs/wait` answers with **plain JSON**. The fetch wrapper only holds an in-flight slot for `text/event-stream` bodies, so `state.activeRequests` had already dropped to zero while the abandoned `invokeResolvedRoute` was still executing against its sandbox — and `close()` drains on `activeRequests` alone.

So a routine `close()` (a rolling deploy) could call `sandboxManager.releaseAll()` mid-tool-call. A cancelled stream whose route ignores `ctx.signal` has exactly the same shape.

The shape pre-existed for the shutdown race, but **`POST /threads/:id/cancel` made it reachable in ordinary operation** rather than only during an already-in-progress shutdown.

## The fix

No parallel bookkeeping. The run registry already maintains precisely the needed invariant — a run holds its slot for as long as its route may still be executing, *including after the response was sent*, which is what the deferred release on abandoned waits and cancelled streams is for.

So: `activeCount()` on the registry, hoist it from `buildRouteTable` into the handler scope where `close()` can see it, and drain on both counters.

## Consequence worth knowing

Cancelling a run can now delay `close()` by up to the drain deadline, where before it returned immediately. **That is the intent** — the work is genuinely still running — and it stays bounded by the existing deadline.

Six cancellation tests surfaced this by timing out in cleanup (their fixture only self-releases after 15s), so those fixtures now set a short deadline. One parity assertion moved because the drain warning names both counters.

## Verification

- `@dawn-ai/cli` **784/784**, lint clean, typecheck clean
- The new guard is verified in both directions: against the unfixed drain condition it fails with `expected "warn" to be called 1 times, but got 0 times` — i.e. `close()` returning immediately instead of waiting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
