### PR TITLE
fix(ci): scan changesets with the docs guard so bad prose fails at PR time

### DIFF
--- a/scripts/check-docs.mjs
+++ b/scripts/check-docs.mjs
@@ -308,6 +308,11 @@ const userFacingRoots = [
   "apps/web/content",
   "docs",
   "packages",
+  // Changesets become CHANGELOG prose verbatim when the Version PR runs. Scanning
+  // them here is what makes a banned phrase fail on the PR that writes it, rather
+  // than on main after the release bakes it in — the failure mode that took main
+  // red when a changeset described a template as byte-identical to its source.
+  ".changeset",
 ]
 
 const forbiddenContent = [
@@ -364,7 +369,12 @@ const forbiddenContent = [
     // kept byte-identical to its source.
     pattern: /byte-identical/,
     message: "overstates local/prod protocol or deployment parity",
-    shouldCheck: (filePath) => !/CHANGELOG\.md$/.test(filePath),
+    // Exempt in CHANGELOGs and in the changesets they are generated from — the
+    // two must agree, or a phrase would be rejected at authoring time and then
+    // permitted in the file it becomes. See the rule above for why this one
+    // phrase is exempt at all while the genuine parity claims are not.
+    shouldCheck: (filePath) =>
+      !/CHANGELOG\.md$/.test(filePath) && !/[\\/]\.changeset[\\/]/.test(filePath),
   },
   {
     pattern: /auto-bound|auto-registered/,


### PR DESCRIPTION
Closes the invisible-until-release failure mode that took `main` red earlier today.

## The problem

Changesets become CHANGELOG prose **verbatim** when the Version PR runs — but the docs guard only ever scanned the generated `CHANGELOG.md` files, never the `.changeset/*.md` they come from.

So a banned phrase:
1. passes on the PR that writes it (guard doesn't look at changesets),
2. passes on the Version PR (guard runs before the CHANGELOG is regenerated),
3. and turns `main` red on `validate` once the release merges.

That's exactly what happened when a changeset described a scaffold template as `byte-identical` to its source: green twice, then main red — and it blocked every open PR until #406/#407.

It's the same shape as the pack-smoke gotcha: a check that can only fail on the release commit.

## The fix

Add `.changeset` to the scanned roots, so the phrase is rejected on the PR that introduces it, where the author simply rewords it.

**Also extends the `byte-identical` exemption to changesets.** The two must agree — that phrase is deliberately permitted in CHANGELOGs (#407), so rejecting it in the changeset that *becomes* one would block authors from writing text explicitly allowed in the generated output. The genuine parity claims (`speaks the LangSmith protocol natively`, `What works locally works in production`, `without translation`) stay banned everywhere, changesets included. Those are the ones worth catching early.

## Verification

Both directions, against a real build:

| Probe changeset | Result |
| --- | --- |
| contains the genuine parity phrases | ❌ `.changeset/…md overstates local/prod protocol or deployment parity` |
| contains `byte-identical` | ✅ passes, matching the CHANGELOG exemption |
| existing repo changesets | ✅ pass |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
