### PR TITLE
fix: list memory subcommands in --help; stop the inspector verifier false-positive

### DIFF
--- a/.changeset/memory-help-and-verifier.md
+++ b/.changeset/memory-help-and-verifier.md
@@ -1,0 +1,10 @@
+---
+"@dawn-ai/cli": patch
+---
+
+`dawn memory --help` now lists the subcommands.
+
+Commander only knew about `--cwd`, so the help output showed the description and that
+one flag — `consolidate`, `reflect`, `prune` and every subcommand flag were discoverable
+only by triggering an error (running no subcommand, or an unknown one). The usage text
+already existed; it is now attached to `--help` as well.

--- a/packages/cli/src/commands/memory.ts
+++ b/packages/cli/src/commands/memory.ts
@@ -43,6 +43,10 @@ export function registerMemoryCommand(program: Command, io: CommandIo): void {
     // subcommand for itself and rejects it as an unknown option before the handler runs,
     // which made EVERY documented subcommand flag unusable from the real CLI.
     .passThroughOptions()
+    // Commander only knows about `--cwd`, so `dawn memory --help` listed no subcommands
+    // at all — `consolidate`, `reflect` and every subcommand flag were discoverable only
+    // by triggering the error paths below. Same text, now reachable the obvious way.
+    .addHelpText("after", `\n${USAGE}`)
     .action(async (subcommand: string | undefined, args: string[], options: MemoryOptions) => {
       const argv = subcommand ? [subcommand, ...args] : []
       await runMemoryCommand(argv, options, io)

--- a/packages/cli/test/memory-command-parsing.test.ts
+++ b/packages/cli/test/memory-command-parsing.test.ts
@@ -64,3 +64,33 @@ describe("dawn memory flag parsing", () => {
     expect(error).toBeUndefined()
   })
 })
+
+describe("dawn memory --help", () => {
+  it("lists the subcommands and their flags", async () => {
+    // `USAGE` already enumerates every subcommand, but it was only reachable by
+    // triggering an error (missing/unknown subcommand). `dawn memory --help` showed
+    // just the description and --cwd, so there was no way to discover `consolidate`,
+    // `reflect`, or any subcommand flag from the CLI itself.
+    const stdout: string[] = []
+    const io: CommandIo = { stderr: () => {}, stdout: (message) => stdout.push(message) }
+    const program = createProgram(io)
+
+    // commander's exitOverride turns `--help` into a thrown CommanderError after it
+    // has already written the help text.
+    await expect(program.parseAsync(["node", "dawn", "memory", "--help"])).rejects.toThrow()
+
+    const help = stdout.join("")
+    for (const expected of [
+      "list",
+      "search",
+      "approve",
+      "prune",
+      "consolidate",
+      "reflect",
+      "--dry-run",
+      "--cap",
+    ]) {
+      expect(help).toContain(expected)
+    }
+  })
+})

--- a/scripts/lib/published-artifacts.mjs
+++ b/scripts/lib/published-artifacts.mjs
@@ -160,8 +160,14 @@ export function validatePackageMetadata(packageName, packageJson, expectedVersio
     )
   }
 
-  if (!packageJson.exports && !packageJson.bin) {
-    failures.push(`${packageName}: package.json must expose exports or bin`)
+  // A published package must declare SOME way to be consumed. Three shapes qualify:
+  // `exports` (importable), `bin` (executable), and `dawnInspector.server` — a runnable
+  // app whose entry is a built server that `dawn inspect` resolves and launches.
+  // @dawn-ai/inspector is deliberately none of the first two (it is a Next standalone
+  // app, not a library), so requiring exports-or-bin reported a false positive against
+  // every published release from 0.8.14 on.
+  if (!packageJson.exports && !packageJson.bin && !packageJson.dawnInspector?.server) {
+    failures.push(`${packageName}: package.json must expose exports, bin, or dawnInspector.server`)
   }
 
   if (packageJson.exports && exportsRequireTypes(packageJson.exports) && !packageJson.types) {

--- a/scripts/published-artifacts.test.mjs
+++ b/scripts/published-artifacts.test.mjs
@@ -1784,6 +1784,61 @@ describe("validatePackageMetadata", () => {
 
     assert.deepEqual(failures, [])
   })
+
+  it("accepts a runnable app package that declares a dawnInspector server entry", () => {
+    // @dawn-ai/inspector is deliberately neither importable nor a bin: it is a Next
+    // standalone app that `dawn inspect` launches by resolving `dawnInspector.server`.
+    // That IS its entry point, so the "must expose exports or bin" rule was reporting a
+    // false positive on every published release since 0.8.14.
+    const failures = validatePackageMetadata("@dawn-ai/inspector", {
+      name: "@dawn-ai/inspector",
+      version: "1.0.0",
+      license: "MIT",
+      repository: { type: "git", url: "git+https://github.com/cacheplane/dawnai.git" },
+      homepage: "https://github.com/cacheplane/dawnai/tree/main/packages/inspector#readme",
+      bugs: { url: "https://github.com/cacheplane/dawnai/issues" },
+      engines: { node: ">=22.13.0" },
+      publishConfig: { access: "public" },
+      dawnInspector: { server: ".next/standalone/packages/inspector/server.js" },
+    })
+
+    assert.deepEqual(failures, [])
+  })
+
+  it("still rejects a package that declares no entry point at all", () => {
+    const failures = validatePackageMetadata("@dawn-ai/nothing", {
+      name: "@dawn-ai/nothing",
+      version: "1.0.0",
+      license: "MIT",
+      repository: { type: "git", url: "git+https://github.com/cacheplane/dawnai.git" },
+      homepage: "https://github.com/cacheplane/dawnai/tree/main/packages/nothing#readme",
+      bugs: { url: "https://github.com/cacheplane/dawnai/issues" },
+      engines: { node: ">=22.13.0" },
+      publishConfig: { access: "public" },
+    })
+
+    assert.deepEqual(failures, [
+      "@dawn-ai/nothing: package.json must expose exports, bin, or dawnInspector.server",
+    ])
+  })
+
+  it("rejects a dawnInspector field that names no server", () => {
+    const failures = validatePackageMetadata("@dawn-ai/inspector", {
+      name: "@dawn-ai/inspector",
+      version: "1.0.0",
+      license: "MIT",
+      repository: { type: "git", url: "git+https://github.com/cacheplane/dawnai.git" },
+      homepage: "https://github.com/cacheplane/dawnai/tree/main/packages/inspector#readme",
+      bugs: { url: "https://github.com/cacheplane/dawnai/issues" },
+      engines: { node: ">=22.13.0" },
+      publishConfig: { access: "public" },
+      dawnInspector: {},
+    })
+
+    assert.deepEqual(failures, [
+      "@dawn-ai/inspector: package.json must expose exports, bin, or dawnInspector.server",
+    ])
+  })
 })
 
 describe("shouldRunOpenAiSmoke", () => {


### PR DESCRIPTION
The two loose ends left over from smoke-testing 0.8.17/0.8.18.

## 1. `dawn memory --help` listed no subcommands

Commander only knew about `--cwd`, so help showed the description and that single flag. The `USAGE` text enumerating every subcommand and flag already existed — but it was reachable only by triggering an error (no subcommand, or an unknown one). Nothing in the CLI told you `consolidate`, `reflect`, or `--dry-run` existed.

Attached it with `addHelpText`. Now:

```
Usage: dawn memory [options] [subcommand] [args...]

Options:
  --cwd <path>  Path to the Dawn app root
  -h, --help    display help for command

dawn memory <subcommand> [args]
  subcommands: list, search <query>, inspect <id>, approve <id>, reject <id>, forget <id>,
               prune [--cap <n>] [--namespace <prefix>],
               consolidate [--dry-run] [--namespace <prefix>] [--model <id>] [--provider <id>] [--max-batches <n>],
               reflect [--dry-run] [--namespace <prefix>] [--model <id>] [--provider <id>] [--max-batches <n>]
```

## 2. `published:verify` false-positive on `@dawn-ai/inspector`

Every release since 0.8.14 reported:

```
META FAIL @dawn-ai/inspector package metadata failed:
  @dawn-ai/inspector: package.json must expose exports or bin
```

The inspector is deliberately neither importable nor a bin: it is a Next standalone app that `dawn inspect` launches by resolving `dawnInspector.server`. That **is** its entry point, so the package was being flagged for correctly being what it is.

The rule's intent — a published package must declare some way to be consumed — is preserved by accepting that third shape. It still rejects a package declaring no entry point at all, and a `dawnInspector` field that names no server.

## Verification

- `pnpm published:verify -- --version 0.8.18 --package-set public` → no failures (previously flagged the inspector).
- 97/97 `published-artifacts` tests, including three new ones (all three failed before the fix).
- 785/785 `@dawn-ai/cli` tests, including a new one driving the real `createProgram()` for `--help`.
- Full workspace typecheck 25/25, lint 21/21, docs check passing.

Patch changeset for the user-facing `--help` change; the verifier is CI tooling.

> While preparing this I found an unrelated edit to `scripts/check-docs.mjs` sitting in my working tree that would have reverted #407's CHANGELOG exemption. It is not part of this change — I restored the file to match `main`.