### PR TITLE
fix(ci): enforce parity wording in changesets

### DIFF
--- a/scripts/check-docs.mjs
+++ b/scripts/check-docs.mjs
@@ -356,25 +356,8 @@ const forbiddenContent = [
   },
   {
     pattern:
-      /speaks the LangSmith protocol natively|What works locally works in production|without translation/,
+      /speaks the LangSmith protocol natively|What works locally works in production|without translation|byte-identical/,
     message: "overstates local/prod protocol or deployment parity",
-  },
-  {
-    // "byte-identical" is banned as a local/prod parity claim, but it is also a
-    // perfectly ordinary way to describe two files having the same contents.
-    // CHANGELOGs are generated from changeset prose and are a historical record,
-    // so a legitimate technical use there should not be rewritten after the fact
-    // — and it must not red main once the Version PR bakes it in, which is
-    // exactly what happened when #399's changeset described a template as being
-    // kept byte-identical to its source.
-    pattern: /byte-identical/,
-    message: "overstates local/prod protocol or deployment parity",
-    // Exempt in CHANGELOGs and in the changesets they are generated from — the
-    // two must agree, or a phrase would be rejected at authoring time and then
-    // permitted in the file it becomes. See the rule above for why this one
-    // phrase is exempt at all while the genuine parity claims are not.
-    shouldCheck: (filePath) =>
-      !/CHANGELOG\.md$/.test(filePath) && !/[\\/]\.changeset[\\/]/.test(filePath),
   },
   {
     pattern: /auto-bound|auto-registered/,


### PR DESCRIPTION
## Summary

- treat byte-identical as banned local/production parity wording in both changeset bodies and generated changelogs
- remove the exemption that let this recurring phrase pass at authoring time
- keep forbidden-content policy centralized in scripts/check-docs.mjs

## Root cause

PR #409 added .changeset to the docs guard scan, but explicitly exempted byte-identical in both changesets and changelogs. That left the exact recurring phrase from the original release failure accepted at authoring time.

## Verification

- confirmed a temporary changeset containing byte-identical passed before this change
- confirmed the same fixture failed afterward with the expected parity diagnostic
- removed the fixture and confirmed node scripts/check-docs.mjs passes
- pnpm lint
- pnpm test: 2,345 passed, 166 skipped
- git diff --check