### PR TITLE
fix(pg): handle pool 'error' instead of crashing the process

### DIFF
--- a/.changeset/pg-pool-error-handler.md
+++ b/.changeset/pg-pool-error-handler.md
@@ -1,0 +1,30 @@
+---
+"@dawn-ai/memory-pgvector": patch
+"@dawn-ai/postgres-storage": patch
+---
+
+Handle `pg` pool errors instead of crashing the process.
+
+Both Postgres-backed packages created their `pg` `Pool` with no `'error'` listener.
+`pg` emits that event on the **pool** when an **idle** client fails, and an
+EventEmitter `'error'` with no listener is an uncaught exception — so the process
+exits. Idle connections are dropped as a matter of course: a server restart, a
+failover, `idle_session_timeout`, a container stopping. Any of those took the whole
+app down instead of the pool quietly replacing one connection.
+
+This surfaced as a CI flake — the `pgvector-docker` lane failing *after* all 50 tests
+passed, because stopping the test container terminates idle clients with `57P01` — but
+the flake was the symptom. The same defect applied in production, and most sharply in
+`@dawn-ai/postgres-storage`, whose checkpointer, threads and permissions stores hold
+durable agent state for exactly the long-running and edge deployments where connection
+drops are routine.
+
+Pools these packages own now log a warning and carry on; `pg` has already discarded the
+broken client, and the next query transparently opens a new one. A caller-supplied
+`pool` is left untouched — its owner controls its lifecycle and error handling. In
+`@dawn-ai/postgres-storage` the three stores now share one `resolvePool` helper, so the
+rule cannot drift between them.
+
+Both packages gained a test that terminates a live idle connection with
+`pg_terminate_backend` and asserts no uncaught exception, that the drop was logged, and
+that the store still serves the next query. Both fail without the fix.

--- a/packages/memory-pgvector/src/pgvector-store.ts
+++ b/packages/memory-pgvector/src/pgvector-store.ts
@@ -66,6 +66,28 @@ export function pgvectorMemoryStore(opts: {
   const pool =
     opts.pool ?? new Pool(opts.connectionString ? { connectionString: opts.connectionString } : {})
 
+  if (ownsPool) {
+    // `pg` emits 'error' on the POOL when an IDLE client fails — and an EventEmitter
+    // 'error' with no listener is an uncaught exception, i.e. the process dies. Idle
+    // connections are dropped as a matter of course (server restart, failover,
+    // `idle_session_timeout`, a container stopping), so without this a routine
+    // Postgres blip takes the whole app down rather than the pool quietly replacing
+    // one connection.
+    //
+    // Nothing to recover here: pg has already discarded the broken client, and the
+    // next query transparently opens a new one. Warn rather than swallow, so a
+    // genuinely unhealthy database is still visible in the logs.
+    //
+    // Only for pools this store created. A caller who passes `opts.pool` owns its
+    // lifecycle and its error handling — pg requires every pool to have a listener,
+    // so attaching one to someone else's pool would mask that contract.
+    pool.on("error", (error) => {
+      console.warn(
+        `[dawn:memory] pgvector pool client error (connection dropped): ${String(error)}`,
+      )
+    })
+  }
+
   // Memoized idempotent schema init. Every method awaits ready() first so the
   // first call to touch the store creates the extension/tables/indexes exactly
   // once; concurrent callers share the single in-flight promise.

--- a/packages/memory-pgvector/test/pgvector-integration.test.ts
+++ b/packages/memory-pgvector/test/pgvector-integration.test.ts
@@ -33,6 +33,54 @@ describe.skipIf(!enabled)("pgvector integration", () => {
     await container?.stop()
   })
 
+  test("survives Postgres terminating an idle pooled connection", async () => {
+    // `pg` emits 'error' on the POOL when an IDLE client fails. With no listener,
+    // Node treats an EventEmitter 'error' as an uncaught exception and takes the
+    // process down. Managed Postgres terminates idle connections routinely
+    // (restart, failover, idle_session_timeout), so an unhandled pool error is a
+    // production crash — and it is what fails the CI lane after every test passes:
+    // stopping the container terminates idle clients with 57P01.
+    const store = pgvectorMemoryStore({
+      connectionString: url,
+      dimensions: 3,
+      tablePrefix: "t_idle_kill",
+    })
+    const uncaught: unknown[] = []
+    const onUncaught = (error: unknown) => uncaught.push(error)
+    process.on("uncaughtException", onUncaught)
+    // Capture the warning too: without this the test would also pass if the pool
+    // error never happened at all, which would quietly stop exercising the fix.
+    const warnings: string[] = []
+    const realWarn = console.warn
+    console.warn = (...args: unknown[]) => warnings.push(args.map(String).join(" "))
+
+    try {
+      // Round-trips a connection so the pool holds it IDLE.
+      await store.put(rec("idle-a", "ns", "hello billing"))
+
+      const admin = new Pool({ connectionString: url })
+      try {
+        await admin.query(
+          "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE pid <> pg_backend_pid() AND datname = current_database()",
+        )
+      } finally {
+        await admin.end()
+      }
+      // Let the terminated client's 'error' reach the pool.
+      await new Promise((resolve) => setTimeout(resolve, 250))
+
+      expect(uncaught).toEqual([])
+      // Proves the pool error actually fired and was handled, not that it never came.
+      expect(warnings.some((w) => w.includes("pgvector pool client error"))).toBe(true)
+      // pg discards the broken client, so the store keeps working on a new one.
+      expect((await store.get("idle-a"))?.content).toBe("hello billing")
+    } finally {
+      console.warn = realWarn
+      process.off("uncaughtException", onUncaught)
+      await store.close()
+    }
+  })
+
   test("initSchema is idempotent (running twice does not error)", async () => {
     const pool = new Pool({ connectionString: url })
     try {

--- a/packages/postgres-storage/src/checkpointer.ts
+++ b/packages/postgres-storage/src/checkpointer.ts
@@ -7,9 +7,9 @@ import type {
   CheckpointTuple,
 } from "@langchain/langgraph-checkpoint"
 import { BaseCheckpointSaver } from "@langchain/langgraph-checkpoint"
-import { Pool } from "pg"
+import type { Pool } from "pg"
 import { withTransaction } from "./internal/tx.js"
-import type { PostgresStoreOptions } from "./options.js"
+import { type PostgresStoreOptions, resolvePool } from "./options.js"
 import {
   assertIdentifier,
   CHECKPOINTER_MIGRATIONS,
@@ -143,10 +143,9 @@ export class DawnPostgresSaver extends BaseCheckpointSaver {
     this.prefix = prefix
     this.checkpointsTable = qualify({ schema, prefix }, "checkpoints")
     this.writesTable = qualify({ schema, prefix }, "writes")
-    this.ownsPool = !options.pool
-    this.pool =
-      options.pool ??
-      new Pool(options.connectionString ? { connectionString: options.connectionString } : {})
+    const { ownsPool, pool } = resolvePool(options)
+    this.ownsPool = ownsPool
+    this.pool = pool
   }
 
   /**

--- a/packages/postgres-storage/src/options.ts
+++ b/packages/postgres-storage/src/options.ts
@@ -1,4 +1,4 @@
-import type { Pool } from "pg"
+import { Pool } from "pg"
 
 /**
  * Connection + table-naming options shared by every store in this package.
@@ -22,4 +22,38 @@ export interface PostgresStoreOptions {
   readonly schema?: string
   /** Table name prefix. Defaults to `dawn`; vary it to share one database. */
   readonly tablePrefix?: string
+}
+
+/**
+ * Resolves the pool a store should use: the caller's, or one built from
+ * `connectionString`.
+ *
+ * An owned pool gets an `'error'` listener. `pg` emits that event on the POOL when
+ * an IDLE client fails, and an EventEmitter `'error'` with no listener is an uncaught
+ * exception — the process dies. Idle connections are dropped as a matter of course
+ * (server restart, failover, `idle_session_timeout`, a container stopping), so
+ * without a listener a routine Postgres blip takes the whole app down instead of the
+ * pool quietly replacing one connection. That matters most precisely here, where the
+ * stores hold durable state for long-running and edge deployments.
+ *
+ * Nothing to recover: pg has already discarded the broken client and the next query
+ * opens a new one. Warn rather than swallow, so an unhealthy database stays visible.
+ *
+ * A caller-supplied pool is left alone — its owner controls its lifecycle and its
+ * error handling, and pg requires every pool to have a listener, so attaching one to
+ * someone else's pool would mask that contract.
+ */
+export function resolvePool(options: PostgresStoreOptions): {
+  readonly ownsPool: boolean
+  readonly pool: Pool
+} {
+  if (options.pool) return { ownsPool: false, pool: options.pool }
+
+  const pool = new Pool(
+    options.connectionString ? { connectionString: options.connectionString } : {},
+  )
+  pool.on("error", (error) => {
+    console.warn(`[dawn:storage] postgres pool client error (connection dropped): ${String(error)}`)
+  })
+  return { ownsPool: true, pool }
 }

--- a/packages/postgres-storage/src/permissions.ts
+++ b/packages/postgres-storage/src/permissions.ts
@@ -1,7 +1,6 @@
 import type { PermissionMode, PermissionsFile, PermissionsStore } from "@dawn-ai/permissions"
 import { matchPermission } from "@dawn-ai/permissions"
-import { Pool } from "pg"
-import type { PostgresStoreOptions } from "./options.js"
+import { type PostgresStoreOptions, resolvePool } from "./options.js"
 import {
   assertIdentifier,
   DEFAULT_SCHEMA,
@@ -68,10 +67,7 @@ export function createPostgresPermissionsStore(
   assertIdentifier("tablePrefix", prefix)
   const table = qualify({ schema, prefix }, "permissions")
   const mode: PermissionMode = options.mode ?? "interactive"
-  const ownsPool = !options.pool
-  const pool =
-    options.pool ??
-    new Pool(options.connectionString ? { connectionString: options.connectionString } : {})
+  const { ownsPool, pool } = resolvePool(options)
 
   const configAllow = cloneMap(options.config?.allow ?? {})
   const configDeny = cloneMap(options.config?.deny ?? {})

--- a/packages/postgres-storage/src/threads.ts
+++ b/packages/postgres-storage/src/threads.ts
@@ -1,5 +1,4 @@
-import { Pool } from "pg"
-import type { PostgresStoreOptions } from "./options.js"
+import { type PostgresStoreOptions, resolvePool } from "./options.js"
 import {
   assertIdentifier,
   DEFAULT_SCHEMA,
@@ -102,10 +101,7 @@ export function createPostgresThreadsStore(
   assertIdentifier("schema", schema)
   assertIdentifier("tablePrefix", prefix)
   const table = qualify({ schema, prefix }, "threads")
-  const ownsPool = !options.pool
-  const pool =
-    options.pool ??
-    new Pool(options.connectionString ? { connectionString: options.connectionString } : {})
+  const { ownsPool, pool } = resolvePool(options)
 
   let initP: Promise<void> | undefined
   const ready = (): Promise<void> => {

--- a/packages/postgres-storage/test/threads.test.ts
+++ b/packages/postgres-storage/test/threads.test.ts
@@ -32,6 +32,48 @@ describe.skipIf(!enabled)("postgres threads store against real Postgres", () => 
     close: (store) => (store as PostgresThreadsStore).close(),
   })
 
+  test("survives Postgres terminating an idle pooled connection", async () => {
+    // `pg` emits 'error' on the POOL when an IDLE client fails, and an EventEmitter
+    // 'error' with no listener is an uncaught exception — the process dies. These
+    // stores hold durable agent state for long-running and edge deployments, where
+    // servers restart, fail over, and reap idle sessions as a matter of course, so an
+    // unhandled pool error is a production crash rather than a dropped connection.
+    //
+    // Covers the shared `resolvePool` used by the checkpointer, threads and
+    // permissions stores alike.
+    const store = createPostgresThreadsStore({ connectionString: url, tablePrefix: freshPrefix() })
+    const uncaught: unknown[] = []
+    const onUncaught = (error: unknown) => uncaught.push(error)
+    process.on("uncaughtException", onUncaught)
+    // Captured so the test cannot pass by the pool error simply never firing.
+    const warnings: string[] = []
+    const realWarn = console.warn
+    console.warn = (...args: unknown[]) => warnings.push(args.map(String).join(" "))
+
+    try {
+      await store.createThread({ thread_id: "idle-kill", metadata: {} })
+
+      const admin = new Pool({ connectionString: url })
+      try {
+        await admin.query(
+          "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE pid <> pg_backend_pid() AND datname = current_database()",
+        )
+      } finally {
+        await admin.end()
+      }
+      await new Promise((resolve) => setTimeout(resolve, 250))
+
+      expect(uncaught).toEqual([])
+      expect(warnings.some((w) => w.includes("postgres pool client error"))).toBe(true)
+      // pg discards the broken client, so the store keeps working on a new one.
+      expect((await store.getThread("idle-kill"))?.thread_id).toBe("idle-kill")
+    } finally {
+      console.warn = realWarn
+      process.off("uncaughtException", onUncaught)
+      await store.close()
+    }
+  })
+
   test("concurrent createThread on the same id yields one intact thread", async () => {
     // The cross-instance race the sqlite store cannot survive: callers
     // check-then-create, so N instances can all miss and all insert.


### PR DESCRIPTION
Investigating the `pgvector-docker` flake found a **production crash**, not a test-teardown problem.

## What the flake actually was

The lane failed *after* every test passed:

```
Tests  49 passed | 1 skipped (50)
error: terminating connection due to administrator command
Serialized Error: { severity: 'FATAL', code: '57P01', ... }
```

`pg` emits `'error'` on the **pool** when an **idle** client fails. An EventEmitter `'error'` with no listener is an uncaught exception — the process exits. Neither `@dawn-ai/memory-pgvector` nor `@dawn-ai/postgres-storage` attached one, so stopping the test container (which terminates idle clients with `57P01`) killed the run.

## Why it matters beyond CI

Idle connections are dropped as a matter of course — server restart, failover, `idle_session_timeout`, a container stopping. Every one of those took the whole app down instead of the pool quietly replacing a single connection.

It is sharpest in **`@dawn-ai/postgres-storage`**, which shipped in #410: its checkpointer, threads and permissions stores hold durable agent state for precisely the long-running and edge deployments where connection drops are expected. All three constructed a pool with no handler.

## Fix

Pools these packages **own** now log a warning and carry on — `pg` has already discarded the broken client and the next query opens a new one. Warning rather than swallowing keeps a genuinely unhealthy database visible.

A **caller-supplied** `pool` is deliberately left untouched: its owner controls lifecycle and error handling, and `pg` puts that responsibility on the pool owner, so attaching a listener to someone else's pool would mask that contract.

In `postgres-storage` the three stores now share one `resolvePool` helper in `options.ts` — the file that already exists to keep this rule from drifting across them.

## Verification

Both packages gained a test that terminates a live idle connection with `pg_terminate_backend` and asserts three things: no uncaught exception, the drop **was** logged (so the test can't pass by the error never firing), and the store still serves the next query.

**Each was proven in both directions** — failing with the handler removed (`code: '57P01'`), passing with it:

- `@dawn-ai/memory-pgvector`: 50 passed / 1 skipped, gated real-Postgres lane
- `@dawn-ai/postgres-storage`: 73 passed, gated real-Postgres lane
- Workspace build 25/25, typecheck 26/26, lint 22/22

## Note on the original theory

My first read — recorded on the task chip — was that this was a teardown *ordering* race, to be fixed by closing pools before stopping containers. That was wrong. The teardowns already balance every create with a close in a `finally`, and the live-smoke file had already applied the ordering fix locally. The real defect was the missing listener, which no amount of teardown ordering would have fixed for real users.