### PR TITLE
fix(inspector): let the records grid fill its container

### DIFF
--- a/.changeset/inspector-flex-columns.md
+++ b/.changeset/inspector-flex-columns.md
@@ -1,0 +1,14 @@
+---
+"@dawn-ai/inspector": patch
+---
+
+Memory Inspector: the records grid now fills its container at any window width.
+
+Column widths were hand-tuned to sum to ~1030px so a row fit beside the facet
+rail on a 1280px screen — a number that was wrong on every other screen, leaving
+dead space on wide ones and overflowing narrow ones. The `content` column now
+takes whatever the other columns leave over, down to a 240px floor below which
+the grid scrolls instead of squeezing the text.
+
+Requires `@pretable/react` 0.0.6 for `column.flex`, added upstream for this
+(cacheplane/pretable#249) — nothing in the grid could size to its container.

--- a/packages/inspector/package.json
+++ b/packages/inspector/package.json
@@ -37,8 +37,8 @@
   "dependencies": {
     "@dawn-ai/core": "workspace:*",
     "@dawn-ai/memory": "workspace:*",
-    "@pretable/core": "0.0.5",
-    "@pretable/react": "0.0.5",
+    "@pretable/core": "0.0.6",
+    "@pretable/react": "0.0.6",
     "@pretable/ui": "0.0.3",
     "class-variance-authority": "^0.7.1",
     "next": "16.3.0",

--- a/packages/inspector/src/components/memory/memory-grid.tsx
+++ b/packages/inspector/src/components/memory/memory-grid.tsx
@@ -23,10 +23,10 @@ interface GridRow extends Record<string, unknown> {
  *  fit so a two-hit search group doesn't reserve a screenful of empty rows. */
 const MAX_VIEWPORT_PX = 560
 
-/** Column widths are fixed (pretable sizes to content or to `widthPx`, never to
- *  fill its container) and sum to ~1030px so the whole row fits beside the facet
- *  rail on a 1280px screen. Wider than that is the grid's own scroll; `content`
- *  carries the slack because it's the only column with unbounded text. */
+/** Everything but `content` is sized to what it holds — a status badge, a
+ *  namespace, a timestamp — and `content` takes whatever is left over, so the
+ *  row ends on the container's edge at any window width. It carries the slack
+ *  because it's the only column with unbounded text. */
 const COLUMNS: PretableColumn<GridRow>[] = [
   {
     id: "status",
@@ -38,7 +38,8 @@ const COLUMNS: PretableColumn<GridRow>[] = [
   {
     id: "content",
     header: "content",
-    widthPx: 360,
+    flex: 1,
+    minWidthPx: 240,
     value: (row) => row.content,
     // Cells are flex containers, and text-overflow does nothing on one — so the
     // ellipsis has to live on an inner box. min-w-0 lets it shrink below its

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -497,11 +497,11 @@ importers:
         specifier: workspace:*
         version: link:../memory
       '@pretable/core':
-        specifier: 0.0.5
-        version: 0.0.5
+        specifier: 0.0.6
+        version: 0.0.6
       '@pretable/react':
-        specifier: 0.0.5
-        version: 0.0.5(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        specifier: 0.0.6
+        version: 0.0.6(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@pretable/ui':
         specifier: 0.0.3
         version: 0.0.3
@@ -2320,11 +2320,11 @@ packages:
   '@preact/signals-core@1.14.4':
     resolution: {integrity: sha512-HNB6HYeYKhQbJ1aKl+YRjrS4+QWHLKX6qKoUsfS/m0vqzsVaEBiZiaKbG/e+NKk2ch5ALQr/ihWaMHxiCuuWHA==}
 
-  '@pretable/core@0.0.5':
-    resolution: {integrity: sha512-kt9V3yogNQBZ3v845MzV7Z2fxRprji511UUfKuHiqFv+F0yLbEX/wZz/LcvcY/fJxL/+KS+DtrSIe4VzutkqFw==}
+  '@pretable/core@0.0.6':
+    resolution: {integrity: sha512-VUCX6hef2e/ljQJqtDwIl6xnw1iy/tJdXIiR0oa0/bchADAXULNQ72AGKcthheKAzDNivCMOj7s90YYqtLoeaA==}
 
-  '@pretable/react@0.0.5':
-    resolution: {integrity: sha512-fKfCHqyuu0S+VqVNcnJea6rJ09JavK6d+eImhYkiqGycy5HbGBHLDCSXjWO1vBiUXdGZqlsWcZH0TkW1+Tl7/g==}
+  '@pretable/react@0.0.6':
+    resolution: {integrity: sha512-ywKwscvWNxzBD5A8JfdQf9ko1lC1zW5uiCwjiumTP+Z9bkeepwd2ukCApLtNlMIoldhmyibiNKD3yfa73kbzBA==}
     peerDependencies:
       react: ^19.0.0
       react-dom: ^19.0.0
@@ -9124,11 +9124,11 @@ snapshots:
 
   '@preact/signals-core@1.14.4': {}
 
-  '@pretable/core@0.0.5': {}
+  '@pretable/core@0.0.6': {}
 
-  '@pretable/react@0.0.5(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+  '@pretable/react@0.0.6(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
-      '@pretable/core': 0.0.5
+      '@pretable/core': 0.0.6
       '@pretable/ui': 0.0.3
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)


### PR DESCRIPTION
The grid's column widths were hand-tuned to sum to ~1030px so a row fit beside the facet rail on a 1280px screen. That number was wrong on every other screen — at 1800px it left ~500px of dead space, at 1024px it overflowed. (My first pass at that file cut off the `updated` column entirely.)

`content` now takes whatever the other columns leave over, with a 240px floor below which the grid scrolls rather than squeezing the text to nothing.

## Verified in a browser at two widths

| window | available | result |
|---|---|---|
| 1800px | 1574px | columns total **exactly 1574**, no horizontal scroll — `content` took 864px |
| 1024px | 798px | `content` clamps to its 240px floor and the grid scrolls, instead of collapsing |

Previously `content` was a flat 360px at both, which is simultaneously too narrow at 1800 and too wide at 1024.

## Upstream

Requires `@pretable/react` **0.0.6** for `column.flex`, added upstream for this ([cacheplane/pretable#249](https://github.com/cacheplane/pretable/pull/249)). Every column there was fixed — `widthPx`, a renderer fallback, or a one-off `autosize` measurement — and nothing could size to the *container*, so the magic number in this file was the only option available.

## Verification

`build` (zero warnings), `typecheck`, `lint`, 66 tests including the gated `DAWN_TEST_INSPECTOR=1` e2e.

🤖 Generated with [Claude Code](https://claude.com/claude-code)