### PR TITLE
fix(charts): harden Kubernetes PVC reaper compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -340,6 +340,9 @@ jobs:
           helm install dawn-sandbox-infra charts/dawn-sandbox-infra --wait
           kubectl -n dawn-sandboxes get role,rolebinding,networkpolicy,resourcequota,limitrange,cronjob,serviceaccount
 
+      - name: Prepare chart NetworkPolicy control
+        run: sh test/k8s-smoke/setup-network-policy-control.sh
+
       - name: Assert orchestrator RBAC (least privilege)
         run: |
           SA=system:serviceaccount:dawn-sandboxes:dawn-orchestrator
@@ -352,6 +355,8 @@ jobs:
           kubectl auth can-i create secrets --as=$SA -n dawn-sandboxes | grep -qx no
 
       - name: Real-cluster sandbox conformance + e2e
+        env:
+          DAWN_TEST_K8S_EGRESS_CONTROL_URL: http://dawn-egress-control:8080/
         run: DAWN_TEST_K8S=1 pnpm --filter @dawn-ai/sandbox test kube-sandbox.integration
 
   sandbox-k8s-e2e:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -359,6 +359,9 @@ jobs:
           DAWN_TEST_K8S_EGRESS_CONTROL_URL: http://dawn-egress-control:8080/
         run: DAWN_TEST_K8S=1 pnpm --filter @dawn-ai/sandbox test kube-sandbox.integration
 
+      - name: Exercise PVC reaper
+        run: sh test/k8s-smoke/assert-reaper.sh
+
   sandbox-k8s-e2e:
     # Full-arc smoke: a deployed Dawn app (built the user-facing way via
     # `dawn build`'s node target, run as `node .dawn/build/server.mjs`) drives

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -327,6 +327,7 @@ jobs:
         uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
         with:
           config: .github/kind/kind-calico.yaml
+          node_image: kindest/node:v1.35.0@sha256:4613778f3cfcd10e615029370f5786704559103cf27bef934597ba562b269661
 
       - name: Install Calico (enforces NetworkPolicy)
         run: |
@@ -400,6 +401,7 @@ jobs:
         with:
           config: .github/kind/kind-calico.yaml
           cluster_name: dawn-smoke
+          node_image: kindest/node:v1.35.0@sha256:4613778f3cfcd10e615029370f5786704559103cf27bef934597ba562b269661
 
       - name: Install Calico (enforces NetworkPolicy)
         run: |
@@ -577,6 +579,8 @@ jobs:
 
       - name: Create kind cluster
         uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
+        with:
+          node_image: kindest/node:v1.35.0@sha256:4613778f3cfcd10e615029370f5786704559103cf27bef934597ba562b269661
 
       - name: Install dawn-app (placeholder image) and verify it serves
         # nginx-unprivileged runs as non-root (UID 101, port 8080), so it satisfies

--- a/apps/web/content/docs/sandbox.mdx
+++ b/apps/web/content/docs/sandbox.mdx
@@ -185,7 +185,7 @@ What it provisions:
 
 - **Namespace** (`dawn-sandboxes` by default) with configurable Pod Security Standard labels.
 - **Least-privilege RBAC** — a `dawn-orchestrator` ServiceAccount, Role, and RoleBinding scoped to exactly what the provider needs: creating/getting/deleting Pods and PersistentVolumeClaims, `pods/exec`, and managing NetworkPolicies. No access to Secrets or any other resource.
-- **A default-deny egress `NetworkPolicy` backstop** — applies to every Pod in the namespace, with a carve-out for cluster DNS.
+- **A default-deny egress `NetworkPolicy` backstop** — selects Dawn-managed sandbox Pods via `app.kubernetes.io/managed-by=dawn`, with a carve-out for cluster DNS. Helm-managed reaper and control-plane Pods are excluded so they retain Kubernetes API access.
 - **`ResourceQuota` and `LimitRange`** — namespace-wide aggregate caps plus container-level cpu/memory/ephemeral-storage defaults. (PID limiting is node-level on Kubernetes and cannot be set by a namespaced chart — see [Security hardening on Kubernetes](#security-hardening-on-kubernetes).)
 - **Pod Security Standards** — namespace labels controlling what the cluster's built-in admission controller allows.
 - **A PVC reaper** — a CronJob that marks and eventually deletes sandbox PVCs that are no longer referenced by any Pod, so abandoned per-thread volumes don't accumulate.
@@ -208,14 +208,14 @@ helm install dawn-sandbox-infra oci://ghcr.io/cacheplane/charts/dawn-sandbox-inf
 </Callout>
 
 <Callout type="warn" title="The default-deny egress backstop overrides allow-mode">
-  The chart's default-deny egress `NetworkPolicy` applies to every Pod in the namespace, including sandbox Pods configured with `network: { mode: "allow" }`. That combination still has no egress unless you disable the backstop:
+  The chart's default-deny egress `NetworkPolicy` selects Dawn-managed sandbox Pods via `app.kubernetes.io/managed-by=dawn`. It excludes Helm-managed reaper and control-plane Pods so they can reach the Kubernetes API, but sandbox Pods configured with `network: { mode: "allow" }` still have no egress unless you disable the backstop:
 
   ```bash
   helm install dawn-sandbox-infra oci://ghcr.io/cacheplane/charts/dawn-sandbox-infra \
     --set networkPolicy.defaultDenyEgress=false
   ```
 
-  With the backstop disabled, per-thread `deny`-mode NetworkPolicies created by the provider still work as documented — only the namespace-wide backstop is removed.
+  With the backstop disabled, per-thread `deny`-mode NetworkPolicies created by the provider still work as documented — only the chart-managed backstop is removed.
 </Callout>
 
 The PVC reaper's time-to-live is configurable via `reaper.ttlHours` (default `168`, one week) — a PVC with no Pod referencing it for longer than the TTL is deleted:

--- a/charts/dawn-sandbox-infra/Chart.yaml
+++ b/charts/dawn-sandbox-infra/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: dawn-sandbox-infra
 description: Cluster-side infrastructure for the Dawn kubernetesSandbox provider — namespace, least-privilege RBAC, default-deny egress, quotas/limits, Pod Security Standards, and a PVC reaper.
 type: application
-version: 0.1.1
+version: 0.1.2
 appVersion: "0.8.18"
 keywords: [dawn, sandbox, kubernetes, security]
 home: https://dawnai.org

--- a/charts/dawn-sandbox-infra/README.md
+++ b/charts/dawn-sandbox-infra/README.md
@@ -76,8 +76,9 @@ that window, override `reaper.image` with an image containing a compatible
 Kubernetes client. The image must provide `sh`, `date`, `sort`, `grep`, and
 `kubectl`.
 
-Invalid or tampered reaper markers are re-marked, and only trusted PVC metadata
-names drive annotation or deletion operations.
+Invalid or tampered reaper markers on unbound PVCs are re-marked, markers on
+referenced PVCs are cleared, and only trusted PVC metadata names drive annotation
+or deletion operations.
 
 ## PID limits
 

--- a/charts/dawn-sandbox-infra/README.md
+++ b/charts/dawn-sandbox-infra/README.md
@@ -8,9 +8,10 @@ Cluster-side infrastructure for the Dawn `kubernetesSandbox` provider
 - Least-privilege **RBAC** for the orchestrator — exactly the API surface
   the provider needs (pods, pods/exec, persistentvolumeclaims,
   networkpolicies), nothing more.
-- A namespace-wide **default-deny egress NetworkPolicy** backstop (+ DNS
-  carve-out), defense in depth alongside the provider's per-thread
-  policies.
+- A **default-deny egress NetworkPolicy** backstop (+ DNS carve-out) for
+  Dawn-managed sandbox Pods selected by `app.kubernetes.io/managed-by=dawn`.
+  Helm-managed reaper and control-plane Pods are excluded so they retain
+  Kubernetes API access.
 - A **ResourceQuota** + **LimitRange** (default/request cpu, memory,
   ephemeral-storage). Note: PID limiting is **not** namespaced in
   Kubernetes — it is a node-level kubelet setting (`podPidsLimit`), so
@@ -54,10 +55,29 @@ sandbox: {
 | `orchestrator.serviceAccount.create` | `true` | Create the orchestrator ServiceAccount. |
 | `orchestrator.serviceAccount.name` | `dawn-orchestrator` | SA name (also used to bind an existing SA when `create=false`). |
 | `orchestrator.subjects` | `[]` | Extra RoleBinding subjects (e.g. a cross-namespace SA). |
-| `networkPolicy.defaultDenyEgress` | `true` | Namespace-wide egress backstop. **Note:** with this on, the provider's per-thread `network: "allow"` mode is still denied at the namespace level — set this to `false` if you need working allow-mode. |
+| `networkPolicy.defaultDenyEgress` | `true` | Egress backstop for Dawn-managed sandbox Pods selected by `app.kubernetes.io/managed-by=dawn`. Helm-managed reaper/control-plane Pods are excluded. **Note:** provider sandbox Pods using `network: "allow"` are still denied while this is on. |
 | `resourceQuota.enabled` | `true` | Gate the ResourceQuota. |
 | `resourceQuota.hard` | see `values.yaml` | Aggregate namespace caps. |
 | `limitRange.enabled` | `true` | Gate the LimitRange. |
+| `limitRange.default` | `{cpu: "1", memory: 512Mi}` | Container default limits. |
+| `limitRange.defaultRequest` | `{cpu: 100m, memory: 128Mi}` | Container default requests. |
+| `limitRange.maxEphemeralStorage` | `1Gi` | Container default ephemeral-storage limit. |
+| `reaper.enabled` | `true` | Gate the PVC reaper CronJob. |
+| `reaper.schedule` | `"17 * * * *"` | Cron schedule (hourly by default). |
+| `reaper.ttlHours` | `168` | Hours a PVC may stay continuously unbound before deletion. |
+| `reaper.image` | `docker.io/alpine/k8s:1.35.6@sha256:b7a12c5ddf261994c33d2eaaa06fd69a0803ff6b38683bfa3d30a76dcdf92807` | Image bundling `sh`, `date`, `sort`, `grep`, and `kubectl`. |
+
+## Reaper compatibility
+
+The default reaper image provides Kubernetes client 1.35.6. Under the upstream
+[`kubectl` one-minor version-skew policy](https://kubernetes.io/releases/version-skew-policy/#kubectl),
+it supports Kubernetes API servers 1.34 through 1.36. For API servers outside
+that window, override `reaper.image` with an image containing a compatible
+Kubernetes client. The image must provide `sh`, `date`, `sort`, `grep`, and
+`kubectl`.
+
+Invalid or tampered reaper markers are re-marked, and only trusted PVC metadata
+names drive annotation or deletion operations.
 
 ## PID limits
 
@@ -67,13 +87,6 @@ Fork-bomb defense is a **node-level** kubelet setting: set `podPidsLimit` in the
 kubelet configuration (or `--pod-max-pids`) on the nodes that run sandbox Pods.
 The chart cannot template this (it's node config, not a namespaced object). The
 provider's `security.pidsLimit` therefore has no effect on the Kubernetes provider.
-| `limitRange.default` | `{cpu: "1", memory: 512Mi}` | Container default limits. |
-| `limitRange.defaultRequest` | `{cpu: 100m, memory: 128Mi}` | Container default requests. |
-| `limitRange.maxEphemeralStorage` | `1Gi` | Container default ephemeral-storage limit. |
-| `reaper.enabled` | `true` | Gate the PVC reaper CronJob. |
-| `reaper.schedule` | `"17 * * * *"` | Cron schedule (hourly by default). |
-| `reaper.ttlHours` | `168` | Hours a PVC may stay continuously unbound before deletion. |
-| `reaper.image` | `docker.io/alpine/k8s:1.31.1` | Image bundling `sh` + `date` + `kubectl`. |
 
 ## Honest scope
 

--- a/charts/dawn-sandbox-infra/README.md
+++ b/charts/dawn-sandbox-infra/README.md
@@ -95,6 +95,8 @@ provider's `security.pidsLimit` therefore has no effect on the Kubernetes provid
 - NetworkPolicy enforcement (backstop + per-thread) requires a
   policy-capable CNI (e.g. Calico, Cilium) — this chart does not install
   one.
+- Arbitrary non-Dawn pods manually placed in the namespace are not selected by
+  this NetworkPolicy backstop and remain the operator's responsibility.
 - Pod Security Standards, ResourceQuota, and LimitRange are
   Kubernetes-native admission controls; the chart configures them, but
   enforcement is the cluster's.

--- a/charts/dawn-sandbox-infra/README.md
+++ b/charts/dawn-sandbox-infra/README.md
@@ -76,8 +76,9 @@ that window, override `reaper.image` with an image containing a compatible
 Kubernetes client. The image must provide `sh`, `date`, `sort`, `grep`, and
 `kubectl`.
 
-Invalid or tampered reaper markers on unbound PVCs are re-marked, markers on
-referenced PVCs are cleared, and only trusted PVC metadata names drive annotation
+Invalid or tampered reaper markers on unbound PVCs are re-marked, non-empty
+markers on referenced PVCs are cleared (empty annotations may remain and are
+harmless while referenced), and only trusted PVC metadata names drive annotation
 or deletion operations.
 
 ## PID limits

--- a/charts/dawn-sandbox-infra/files/reaper.sh
+++ b/charts/dawn-sandbox-infra/files/reaper.sh
@@ -21,8 +21,14 @@ printf '%s\n' "$PVC_NAMES" | while IFS= read -r NAME; do
 
     if printf '%s\n' "$BOUND" | grep -Fxq "$NAME"; then
       # bound → clear any marker
-      [ -n "${SINCE:-}" ] && kubectl -n "$NS" annotate pvc "$NAME" dawn.sh/unbound-since- >/dev/null 2>&1 || true
-      continue
+      [ -z "${SINCE:-}" ] && continue
+      if kubectl -n "$NS" annotate pvc "$NAME" dawn.sh/unbound-since- >/dev/null; then
+        continue
+      fi
+      PVC_AFTER_CLEAR="$(kubectl -n "$NS" get pvc "$NAME" --ignore-not-found -o name)"
+      [ -z "$PVC_AFTER_CLEAR" ] && continue
+      echo "failed to clear dawn.sh/unbound-since from bound PVC $NAME" >&2
+      exit 1
     fi
 
     # Only canonical positive decimal epochs that fit within NOW's digit width

--- a/charts/dawn-sandbox-infra/files/reaper.sh
+++ b/charts/dawn-sandbox-infra/files/reaper.sh
@@ -14,8 +14,9 @@ PVC_NAMES="$(kubectl -n "$NS" get pvc -l app.kubernetes.io/managed-by=dawn \
 
 printf '%s\n' "$PVC_NAMES" | while IFS= read -r NAME; do
     [ -z "$NAME" ] && continue
-    SINCE_WITH_SENTINEL="$(kubectl -n "$NS" get pvc "$NAME" \
+    SINCE_WITH_SENTINEL="$(kubectl -n "$NS" get pvc "$NAME" --ignore-not-found \
       -o jsonpath='{.metadata.annotations.dawn\.sh/unbound-since}{"x"}')"
+    [ -z "$SINCE_WITH_SENTINEL" ] && continue
     SINCE="${SINCE_WITH_SENTINEL%?}"
 
     if printf '%s\n' "$BOUND" | grep -Fxq "$NAME"; then

--- a/charts/dawn-sandbox-infra/files/reaper.sh
+++ b/charts/dawn-sandbox-infra/files/reaper.sh
@@ -7,29 +7,45 @@ NOW="$(date -u +%s)"
 # claimNames currently referenced by any pod in the namespace
 BOUND="$(kubectl -n "$NS" get pods -o jsonpath='{range .items[*]}{range .spec.volumes[*]}{.persistentVolumeClaim.claimName}{"\n"}{end}{end}' | sort -u)"
 
-# managed PVCs: "<name> <unbound-since-or-empty>"
-kubectl -n "$NS" get pvc -l app.kubernetes.io/managed-by=dawn \
-  -o jsonpath='{range .items[*]}{.metadata.name}{" "}{.metadata.annotations.dawn\.sh/unbound-since}{"\n"}{end}' \
-| while read -r NAME SINCE; do
+# List only trusted Kubernetes metadata names. Annotation values are fetched
+# separately so embedded newlines cannot fabricate additional PVC records.
+PVC_NAMES="$(kubectl -n "$NS" get pvc -l app.kubernetes.io/managed-by=dawn \
+  -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}')"
+
+printf '%s\n' "$PVC_NAMES" | while IFS= read -r NAME; do
     [ -z "$NAME" ] && continue
-    if printf '%s\n' "$BOUND" | grep -qx "$NAME"; then
+    SINCE_WITH_SENTINEL="$(kubectl -n "$NS" get pvc "$NAME" \
+      -o jsonpath='{.metadata.annotations.dawn\.sh/unbound-since}{"x"}')"
+    SINCE="${SINCE_WITH_SENTINEL%?}"
+
+    if printf '%s\n' "$BOUND" | grep -Fxq "$NAME"; then
       # bound → clear any marker
       [ -n "${SINCE:-}" ] && kubectl -n "$NS" annotate pvc "$NAME" dawn.sh/unbound-since- >/dev/null 2>&1 || true
       continue
     fi
-    # Re-mark (reset the clock) when the marker is missing OR not a positive
-    # integer — a corrupted/tampered annotation must never drive a delete.
+
+    # Only canonical positive decimal epochs that fit within NOW's digit width
+    # may reach shell arithmetic. Invalid/tampered markers reset the clock.
     case "${SINCE:-}" in
-      "" | *[!0-9]*)
+      "" | 0* | *[!0-9]*)
         kubectl -n "$NS" annotate --overwrite pvc "$NAME" "dawn.sh/unbound-since=$NOW" >/dev/null
         echo "marked $NAME"
-        ;;
-      *)
-        AGE=$(( NOW - SINCE ))
-        if [ "$AGE" -gt "$TTL_SECONDS" ]; then
-          kubectl -n "$NS" delete pvc "$NAME" >/dev/null
-          echo "reaped $NAME (unbound ${AGE}s)"
-        fi
+        continue
         ;;
     esac
+
+    if [ "${#SINCE}" -gt "${#NOW}" ]; then
+      kubectl -n "$NS" annotate --overwrite pvc "$NAME" "dawn.sh/unbound-since=$NOW" >/dev/null
+      echo "marked $NAME"
+      continue
+    fi
+
+    AGE=$(( NOW - SINCE ))
+    if [ "$AGE" -lt 0 ]; then
+      kubectl -n "$NS" annotate --overwrite pvc "$NAME" "dawn.sh/unbound-since=$NOW" >/dev/null
+      echo "marked $NAME"
+    elif [ "$AGE" -gt "$TTL_SECONDS" ]; then
+      kubectl -n "$NS" delete pvc "$NAME" --wait=false >/dev/null
+      echo "reaped $NAME (unbound ${AGE}s)"
+    fi
   done

--- a/charts/dawn-sandbox-infra/templates/NOTES.txt
+++ b/charts/dawn-sandbox-infra/templates/NOTES.txt
@@ -29,11 +29,12 @@ Pod Security Standards on this namespace:
 
 {{- if .Values.networkPolicy.defaultDenyEgress }}
 
-A namespace-wide default-deny-egress NetworkPolicy is active (+ DNS to
-kube-system). This is a fail-closed backstop: even the provider's
-`network: "allow"` per-thread mode will NOT have open egress unless you
-set `networkPolicy.defaultDenyEgress=false`. Requires a policy-capable CNI
-(e.g. Calico, Cilium) to actually be enforced.
+A default-deny-egress NetworkPolicy selects Dawn-managed sandbox Pods via
+app.kubernetes.io/managed-by=dawn (+ DNS to kube-system). Helm-managed reaper
+and control-plane Pods are excluded so they retain Kubernetes API access.
+The backstop still overrides sandbox `network: "allow"`; disable it with
+`networkPolicy.defaultDenyEgress=false`. Requires a policy-capable CNI (e.g.
+Calico, Cilium) to actually be enforced.
 {{- end }}
 
 {{- if .Values.reaper.enabled }}

--- a/charts/dawn-sandbox-infra/templates/networkpolicy-default-deny.yaml
+++ b/charts/dawn-sandbox-infra/templates/networkpolicy-default-deny.yaml
@@ -7,7 +7,9 @@ metadata:
   labels:
     {{- include "dawn-sandbox-infra.labels" . | nindent 4 }}
 spec:
-  podSelector: {}
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/managed-by: dawn
   policyTypes: [Egress]
   egress:
     - to:

--- a/charts/dawn-sandbox-infra/test/fixtures/pods.jsonpath
+++ b/charts/dawn-sandbox-infra/test/fixtures/pods.jsonpath
@@ -1,1 +1,0 @@
-dawn-sbx-vol-bound

--- a/charts/dawn-sandbox-infra/test/fixtures/pvc.jsonpath
+++ b/charts/dawn-sandbox-infra/test/fixtures/pvc.jsonpath
@@ -1,3 +1,0 @@
-dawn-sbx-vol-bound 1700000000
-dawn-sbx-vol-fresh-unbound
-dawn-sbx-vol-stale-unbound 1000000000

--- a/charts/dawn-sandbox-infra/test/reaper.test.sh
+++ b/charts/dawn-sandbox-infra/test/reaper.test.sh
@@ -1,75 +1,184 @@
 #!/usr/bin/env sh
-# Unit test for files/reaper.sh using a stub kubectl on PATH.
-# Exercises: mark (fresh unbound PVC gets a marker), reap (stale unbound PVC
-# past TTL gets deleted), clear (bound PVC's marker is removed), and
-# leave-alone (unbound PVC within TTL — none of the fixtures fall in this
-# case with only "fresh"/"stale"... see the dedicated leave-alone assertion
-# below using a second run with a within-TTL marker).
+# Unit test for files/reaper.sh using a stateful kubectl stub.
 set -eu
-DIR="$(cd "$(dirname "$0")" && pwd)"
-BIN="$(mktemp -d)"
-export PATH="$BIN:$PATH"
-CALLS="$BIN/calls.log"
-: > "$CALLS"
 
-# stub kubectl: dispatch on args, echo canned data, log mutations
+DIR="$(cd "$(dirname "$0")" && pwd)"
+TMP="$(mktemp -d)"
+BIN="$TMP/bin"
+FIX="$TMP/fixtures"
+CALLS="$TMP/calls.log"
+FAILURES=0
+mkdir -p "$BIN" "$FIX/annotations"
+trap 'rm -rf "$TMP"' 0
+export PATH="$BIN:$PATH" CALLS FIX
+
 cat > "$BIN/kubectl" <<'STUB'
 #!/usr/bin/env sh
-echo "kubectl $*" >> "$CALLS"
-case "$*" in
-  *"get pods"*"jsonpath"*) cat "$FIX/pods.jsonpath" ;;
-  *"get pvc"*"jsonpath"*) cat "$FIX/pvc.jsonpath" ;;
-  *"annotate"*|*"delete"*) : ;;  # mutation: just logged
+set -eu
+printf 'kubectl' >> "$CALLS"
+printf ' %s' "$@" >> "$CALLS"
+printf '\n' >> "$CALLS"
+
+if [ "${1:-}" = "-n" ]; then
+  shift 2
+fi
+
+if [ "${1:-}" = "get" ] && [ "${2:-}" = "pods" ]; then
+  cat "$FIX/pods.jsonpath"
+  exit 0
+fi
+
+if [ "${1:-}" = "get" ] && [ "${2:-}" = "pvc" ]; then
+  if [ "${3:-}" = "-l" ]; then
+    case "$*" in
+      *unbound-since*) cat "$FIX/legacy-pvc-records.jsonpath" ;;
+      *) cat "$FIX/pvc-names.jsonpath" ;;
+    esac
+  else
+    marker="$FIX/annotations/${3:-}"
+    [ ! -f "$marker" ] || cat "$marker"
+    case "$*" in
+      *'{"x"}'*) printf x ;;
+    esac
+  fi
+  exit 0
+fi
+
+case "${1:-}" in
+  annotate | delete) exit 0 ;;
 esac
+
+printf '%s\n' "unexpected kubectl call: $*" >&2
+exit 1
 STUB
 chmod +x "$BIN/kubectl"
-export CALLS FIX="$DIR/fixtures"
 
-DAWN_SANDBOX_NS=ns DAWN_REAPER_TTL_SECONDS=3600 sh "$DIR/../files/reaper.sh"
+reset_fixtures() {
+  : > "$CALLS"
+  : > "$FIX/pods.jsonpath"
+  : > "$FIX/pvc-names.jsonpath"
+  : > "$FIX/legacy-pvc-records.jsonpath"
+  rm -f "$FIX/annotations"/*
+}
 
-# (a) fresh unbound PVC (no marker) gets annotated with a marker
-grep -q "annotate --overwrite pvc dawn-sbx-vol-fresh-unbound dawn.sh/unbound-since=" "$CALLS" \
-  || { echo "FAIL: mark (fresh unbound PVC should be annotated)"; cat "$CALLS"; exit 1; }
-echo "ok: mark"
+run_reaper() {
+  if DAWN_SANDBOX_NS=ns DAWN_REAPER_TTL_SECONDS=3600 sh "$DIR/../files/reaper.sh"; then
+    return 0
+  fi
+  printf '%s\n' "FAIL: reaper exited non-zero" >&2
+  FAILURES=$((FAILURES + 1))
+  return 0
+}
 
-# (b) stale unbound PVC (marker far in the past, > TTL) gets deleted
-grep -q "delete pvc dawn-sbx-vol-stale-unbound" "$CALLS" \
-  || { echo "FAIL: reap (stale unbound PVC should be deleted)"; cat "$CALLS"; exit 1; }
-echo "ok: reap"
+require_call() {
+  description=$1
+  pattern=$2
+  if grep -Fq "$pattern" "$CALLS"; then
+    printf '%s\n' "ok: $description"
+  else
+    printf '%s\n' "FAIL: $description" >&2
+    FAILURES=$((FAILURES + 1))
+  fi
+}
 
-# (c) bound PVC (referenced by a pod) has its marker cleared
-grep -q "annotate pvc dawn-sbx-vol-bound dawn.sh/unbound-since-" "$CALLS" \
-  || { echo "FAIL: clear (bound PVC's marker should be removed)"; cat "$CALLS"; exit 1; }
-echo "ok: clear"
+reject_call() {
+  description=$1
+  pattern=$2
+  if grep -Fq "$pattern" "$CALLS"; then
+    printf '%s\n' "FAIL: $description" >&2
+    FAILURES=$((FAILURES + 1))
+  else
+    printf '%s\n' "ok: $description"
+  fi
+}
 
-# (d) the fresh-unbound PVC must NOT be deleted (it was only just marked, not reaped in the same run)
-if grep -q "delete pvc dawn-sbx-vol-fresh-unbound" "$CALLS"; then
-  echo "FAIL: leave-alone (freshly-marked PVC should not be deleted in the same run)"
-  cat "$CALLS"
-  exit 1
-fi
-echo "ok: leave-alone (fresh mark not deleted same-run)"
-
-# --- second run: an unbound PVC marked recently (within TTL) must be left alone ---
-: > "$CALLS"
-
-WITHIN_DIR="$(mktemp -d)"
+# Main behavior plus an annotation newline that fabricates a victim record in
+# the legacy combined JSONPath stream.
+reset_fixtures
 NOW_EPOCH="$(date -u +%s)"
-WITHIN_SINCE=$((NOW_EPOCH - 60)) # marked 60s ago, well within the 3600s TTL
-printf 'dawn-sbx-vol-bound\n' > "$WITHIN_DIR/pods.jsonpath"
-printf 'dawn-sbx-vol-within-ttl %s\n' "$WITHIN_SINCE" > "$WITHIN_DIR/pvc.jsonpath"
-FIX="$WITHIN_DIR" DAWN_SANDBOX_NS=ns DAWN_REAPER_TTL_SECONDS=3600 sh "$DIR/../files/reaper.sh"
+WITHIN_SINCE=$((NOW_EPOCH - 60))
+cat > "$FIX/pvc-names.jsonpath" <<'EOF'
+dawn-sbx-vol-bound
+dawn-sbx-vol-fresh-unbound
+dawn-sbx-vol-stale-unbound
+dawn-sbx-vol-attacker
+dawn-sbx-vol-trailing-newline
+dawn-sbx-vol-zero
+dawn-sbx-vol-leading-zero
+dawn-sbx-vol-within-ttl
+EOF
+printf '%s\n' 'dawn-sbx-vol-bound' > "$FIX/pods.jsonpath"
+printf '%s' '1700000000' > "$FIX/annotations/dawn-sbx-vol-bound"
+: > "$FIX/annotations/dawn-sbx-vol-fresh-unbound"
+printf '%s' '1000000000' > "$FIX/annotations/dawn-sbx-vol-stale-unbound"
+printf '0\ndawn-sbx-vol-injected-victim 1000000000' > "$FIX/annotations/dawn-sbx-vol-attacker"
+printf '123\n' > "$FIX/annotations/dawn-sbx-vol-trailing-newline"
+printf '%s' '0' > "$FIX/annotations/dawn-sbx-vol-zero"
+printf '%s' '0123' > "$FIX/annotations/dawn-sbx-vol-leading-zero"
+printf '%s' "$WITHIN_SINCE" > "$FIX/annotations/dawn-sbx-vol-within-ttl"
+cat > "$FIX/legacy-pvc-records.jsonpath" <<EOF
+dawn-sbx-vol-bound 1700000000
+dawn-sbx-vol-fresh-unbound
+dawn-sbx-vol-stale-unbound 1000000000
+dawn-sbx-vol-attacker 0
+dawn-sbx-vol-injected-victim 1000000000
+dawn-sbx-vol-trailing-newline 123
+dawn-sbx-vol-zero 0
+dawn-sbx-vol-leading-zero 0123
+dawn-sbx-vol-within-ttl $WITHIN_SINCE
+EOF
+run_reaper
 
-if grep -q "delete pvc dawn-sbx-vol-within-ttl" "$CALLS"; then
-  echo "FAIL: leave-alone (unbound PVC within TTL should not be deleted)"
-  cat "$CALLS"
+require_call "fresh unbound PVC is marked" \
+  "annotate --overwrite pvc dawn-sbx-vol-fresh-unbound dawn.sh/unbound-since="
+require_call "stale unbound PVC is deleted without waiting for watch permission" \
+  "delete pvc dawn-sbx-vol-stale-unbound --wait=false"
+require_call "bound PVC marker is cleared" \
+  "annotate pvc dawn-sbx-vol-bound dawn.sh/unbound-since-"
+reject_call "within-TTL PVC is not re-marked" \
+  "annotate --overwrite pvc dawn-sbx-vol-within-ttl"
+reject_call "within-TTL PVC is not deleted" \
+  "delete pvc dawn-sbx-vol-within-ttl"
+require_call "multiline marker is re-marked" \
+  "annotate --overwrite pvc dawn-sbx-vol-attacker dawn.sh/unbound-since="
+reject_call "injected victim record is never deleted" \
+  "delete pvc dawn-sbx-vol-injected-victim"
+require_call "trailing-newline marker is re-marked" \
+  "annotate --overwrite pvc dawn-sbx-vol-trailing-newline dawn.sh/unbound-since="
+require_call "zero marker is re-marked" \
+  "annotate --overwrite pvc dawn-sbx-vol-zero dawn.sh/unbound-since="
+require_call "leading-zero marker is re-marked" \
+  "annotate --overwrite pvc dawn-sbx-vol-leading-zero dawn.sh/unbound-since="
+
+# A digit string longer than NOW must be rejected before shell arithmetic.
+reset_fixtures
+printf '%s\n' 'dawn-sbx-vol-oversized' > "$FIX/pvc-names.jsonpath"
+printf '%s' '9999999999999999999999999999999999999999' > "$FIX/annotations/dawn-sbx-vol-oversized"
+printf '%s\n' 'dawn-sbx-vol-oversized 9999999999999999999999999999999999999999' \
+  > "$FIX/legacy-pvc-records.jsonpath"
+run_reaper
+require_call "oversized numeric marker is re-marked" \
+  "annotate --overwrite pvc dawn-sbx-vol-oversized dawn.sh/unbound-since="
+reject_call "oversized numeric marker never drives deletion" \
+  "delete pvc dawn-sbx-vol-oversized"
+
+# A canonical, same-width future epoch is numerically safe but tampered.
+reset_fixtures
+FUTURE_SINCE=$((NOW_EPOCH + 3600))
+printf '%s\n' 'dawn-sbx-vol-future' > "$FIX/pvc-names.jsonpath"
+printf '%s' "$FUTURE_SINCE" > "$FIX/annotations/dawn-sbx-vol-future"
+printf 'dawn-sbx-vol-future %s\n' "$FUTURE_SINCE" > "$FIX/legacy-pvc-records.jsonpath"
+run_reaper
+require_call "future marker is re-marked" \
+  "annotate --overwrite pvc dawn-sbx-vol-future dawn.sh/unbound-since="
+reject_call "future marker never drives deletion" \
+  "delete pvc dawn-sbx-vol-future"
+
+if [ "$FAILURES" -ne 0 ]; then
+  printf '\n%s\n' "kubectl calls from final scenario:" >&2
+  cat "$CALLS" >&2
+  printf '%s\n' "reaper test failed: $FAILURES assertion(s)" >&2
   exit 1
 fi
-if grep -q "annotate --overwrite pvc dawn-sbx-vol-within-ttl" "$CALLS"; then
-  echo "FAIL: leave-alone (already-marked within-TTL PVC should not be re-marked)"
-  cat "$CALLS"
-  exit 1
-fi
-echo "ok: leave-alone (within-TTL unbound PVC untouched)"
 
-echo "reaper test passed"
+printf '%s\n' "reaper test passed"

--- a/charts/dawn-sandbox-infra/test/reaper.test.sh
+++ b/charts/dawn-sandbox-infra/test/reaper.test.sh
@@ -8,7 +8,8 @@ BIN="$TMP/bin"
 FIX="$TMP/fixtures"
 CALLS="$TMP/calls.log"
 FAILURES=0
-mkdir -p "$BIN" "$FIX/annotations" "$FIX/not-found" "$FIX/api-errors"
+mkdir -p "$BIN" "$FIX/annotations" "$FIX/not-found" "$FIX/api-errors" \
+  "$FIX/annotate-errors" "$FIX/gone-after-clear" "$FIX/existence-errors"
 trap 'rm -rf "$TMP"' 0
 export PATH="$BIN:$PATH" CALLS FIX
 
@@ -35,6 +36,19 @@ if [ "${1:-}" = "get" ] && [ "${2:-}" = "pvc" ]; then
       *) cat "$FIX/pvc-names.jsonpath" ;;
     esac
   else
+    case " $* " in
+      *' -o name '*)
+        if [ -f "$FIX/existence-errors/${3:-}" ]; then
+          printf '%s\n' 'Error from server (InternalError): injected existence check failure' >&2
+          exit 1
+        fi
+        if [ -f "$FIX/gone-after-clear/${3:-}" ]; then
+          exit 0
+        fi
+        printf 'persistentvolumeclaim/%s\n' "${3:-}"
+        exit 0
+        ;;
+    esac
     if [ -f "$FIX/api-errors/${3:-}" ]; then
       printf '%s\n' 'Error from server (InternalError): injected API failure' >&2
       exit 1
@@ -55,9 +69,19 @@ if [ "${1:-}" = "get" ] && [ "${2:-}" = "pvc" ]; then
   exit 0
 fi
 
-case "${1:-}" in
-  annotate | delete) exit 0 ;;
-esac
+if [ "${1:-}" = "annotate" ]; then
+  if [ -f "$FIX/gone-after-clear/${3:-}" ]; then
+    printf 'Error from server (NotFound): persistentvolumeclaims "%s" not found\n' "${3:-}" >&2
+    exit 1
+  fi
+  if [ -f "$FIX/annotate-errors/${3:-}" ]; then
+    printf 'Error from server (Conflict): persistentvolumeclaims "%s" was modified\n' "${3:-}" >&2
+    exit 1
+  fi
+  exit 0
+fi
+
+[ "${1:-}" != "delete" ] || exit 0
 
 printf '%s\n' "unexpected kubectl call: $*" >&2
 exit 1
@@ -72,6 +96,9 @@ reset_fixtures() {
   rm -f "$FIX/annotations"/*
   rm -f "$FIX/not-found"/*
   rm -f "$FIX/api-errors"/*
+  rm -f "$FIX/annotate-errors"/*
+  rm -f "$FIX/gone-after-clear"/*
+  rm -f "$FIX/existence-errors"/*
 }
 
 run_reaper() {
@@ -221,6 +248,42 @@ reset_fixtures
 printf '%s\n' 'dawn-sbx-vol-api-error' > "$FIX/pvc-names.jsonpath"
 : > "$FIX/api-errors/dawn-sbx-vol-api-error"
 require_reaper_failure "genuine per-PVC API errors fail the reaper"
+
+# A failed marker clear must fail while the bound PVC still exists.
+reset_fixtures
+printf '%s\n' 'dawn-sbx-vol-bound-clear-error' > "$FIX/pvc-names.jsonpath"
+printf '%s\n' 'dawn-sbx-vol-bound-clear-error' > "$FIX/pods.jsonpath"
+printf '%s' '1700000000' > "$FIX/annotations/dawn-sbx-vol-bound-clear-error"
+: > "$FIX/annotate-errors/dawn-sbx-vol-bound-clear-error"
+require_reaper_failure "bound marker clear failure for an existing PVC fails the reaper"
+require_call "failed marker clear checks whether the PVC still exists" \
+  "get pvc dawn-sbx-vol-bound-clear-error --ignore-not-found -o name"
+
+# NotFound during marker clear is safe only after a follow-up get confirms the
+# PVC disappeared; later PVC names must still be processed.
+reset_fixtures
+cat > "$FIX/pvc-names.jsonpath" <<'EOF'
+dawn-sbx-vol-bound-gone
+dawn-sbx-vol-after-bound-gone
+EOF
+printf '%s\n' 'dawn-sbx-vol-bound-gone' > "$FIX/pods.jsonpath"
+printf '%s' '1700000000' > "$FIX/annotations/dawn-sbx-vol-bound-gone"
+: > "$FIX/gone-after-clear/dawn-sbx-vol-bound-gone"
+: > "$FIX/annotations/dawn-sbx-vol-after-bound-gone"
+run_reaper
+require_call "failed clear confirms concurrent PVC deletion" \
+  "get pvc dawn-sbx-vol-bound-gone --ignore-not-found -o name"
+require_call "processing continues after concurrent bound PVC deletion" \
+  "annotate --overwrite pvc dawn-sbx-vol-after-bound-gone dawn.sh/unbound-since="
+
+# A genuine API error from the follow-up existence check must remain fatal.
+reset_fixtures
+printf '%s\n' 'dawn-sbx-vol-bound-check-error' > "$FIX/pvc-names.jsonpath"
+printf '%s\n' 'dawn-sbx-vol-bound-check-error' > "$FIX/pods.jsonpath"
+printf '%s' '1700000000' > "$FIX/annotations/dawn-sbx-vol-bound-check-error"
+: > "$FIX/annotate-errors/dawn-sbx-vol-bound-check-error"
+: > "$FIX/existence-errors/dawn-sbx-vol-bound-check-error"
+require_reaper_failure "genuine follow-up existence errors fail the reaper"
 
 if [ "$FAILURES" -ne 0 ]; then
   printf '\n%s\n' "kubectl calls from final scenario:" >&2

--- a/charts/dawn-sandbox-infra/test/reaper.test.sh
+++ b/charts/dawn-sandbox-infra/test/reaper.test.sh
@@ -8,7 +8,7 @@ BIN="$TMP/bin"
 FIX="$TMP/fixtures"
 CALLS="$TMP/calls.log"
 FAILURES=0
-mkdir -p "$BIN" "$FIX/annotations"
+mkdir -p "$BIN" "$FIX/annotations" "$FIX/not-found" "$FIX/api-errors"
 trap 'rm -rf "$TMP"' 0
 export PATH="$BIN:$PATH" CALLS FIX
 
@@ -35,6 +35,17 @@ if [ "${1:-}" = "get" ] && [ "${2:-}" = "pvc" ]; then
       *) cat "$FIX/pvc-names.jsonpath" ;;
     esac
   else
+    if [ -f "$FIX/api-errors/${3:-}" ]; then
+      printf '%s\n' 'Error from server (InternalError): injected API failure' >&2
+      exit 1
+    fi
+    if [ -f "$FIX/not-found/${3:-}" ]; then
+      case " $* " in
+        *' --ignore-not-found '*) exit 0 ;;
+      esac
+      printf 'Error from server (NotFound): persistentvolumeclaims "%s" not found\n' "${3:-}" >&2
+      exit 1
+    fi
     marker="$FIX/annotations/${3:-}"
     [ ! -f "$marker" ] || cat "$marker"
     case "$*" in
@@ -59,6 +70,8 @@ reset_fixtures() {
   : > "$FIX/pvc-names.jsonpath"
   : > "$FIX/legacy-pvc-records.jsonpath"
   rm -f "$FIX/annotations"/*
+  rm -f "$FIX/not-found"/*
+  rm -f "$FIX/api-errors"/*
 }
 
 run_reaper() {
@@ -68,6 +81,16 @@ run_reaper() {
   printf '%s\n' "FAIL: reaper exited non-zero" >&2
   FAILURES=$((FAILURES + 1))
   return 0
+}
+
+require_reaper_failure() {
+  description=$1
+  if DAWN_SANDBOX_NS=ns DAWN_REAPER_TTL_SECONDS=3600 sh "$DIR/../files/reaper.sh"; then
+    printf '%s\n' "FAIL: $description" >&2
+    FAILURES=$((FAILURES + 1))
+  else
+    printf '%s\n' "ok: $description"
+  fi
 }
 
 require_call() {
@@ -173,6 +196,31 @@ require_call "future marker is re-marked" \
   "annotate --overwrite pvc dawn-sbx-vol-future dawn.sh/unbound-since="
 reject_call "future marker never drives deletion" \
   "delete pvc dawn-sbx-vol-future"
+
+# A PVC may disappear after the initial list. Confirmed NotFound is skipped and
+# must not prevent later listed PVCs from being processed.
+reset_fixtures
+cat > "$FIX/pvc-names.jsonpath" <<'EOF'
+dawn-sbx-vol-disappeared
+dawn-sbx-vol-after-disappeared
+EOF
+: > "$FIX/not-found/dawn-sbx-vol-disappeared"
+: > "$FIX/annotations/dawn-sbx-vol-after-disappeared"
+run_reaper
+require_call "per-PVC lookup tolerates confirmed NotFound" \
+  "get pvc dawn-sbx-vol-disappeared --ignore-not-found"
+reject_call "disappeared PVC is not annotated" \
+  "annotate --overwrite pvc dawn-sbx-vol-disappeared"
+reject_call "disappeared PVC is not deleted" \
+  "delete pvc dawn-sbx-vol-disappeared"
+require_call "processing continues after a disappeared PVC" \
+  "annotate --overwrite pvc dawn-sbx-vol-after-disappeared dawn.sh/unbound-since="
+
+# --ignore-not-found must not turn genuine API failures into successful reads.
+reset_fixtures
+printf '%s\n' 'dawn-sbx-vol-api-error' > "$FIX/pvc-names.jsonpath"
+: > "$FIX/api-errors/dawn-sbx-vol-api-error"
+require_reaper_failure "genuine per-PVC API errors fail the reaper"
 
 if [ "$FAILURES" -ne 0 ]; then
   printf '\n%s\n' "kubectl calls from final scenario:" >&2

--- a/charts/dawn-sandbox-infra/test/render.sh
+++ b/charts/dawn-sandbox-infra/test/render.sh
@@ -28,7 +28,9 @@ printf '%s\n' "$RBAC" | assert "networkpolicies verbs" '\["create", "get", "list
 # Default-deny egress NetworkPolicy backstop
 NETPOL="$(tmpl --show-only templates/networkpolicy-default-deny.yaml)"
 printf '%s\n' "$NETPOL" | assert "netpol kind" 'kind: NetworkPolicy'
-printf '%s\n' "$NETPOL" | assert "netpol podSelector all" 'podSelector: \{\}'
+printf '%s\n' "$NETPOL" | assert "netpol podSelector" 'podSelector:'
+printf '%s\n' "$NETPOL" | assert "netpol podSelector matchLabels" 'matchLabels:'
+printf '%s\n' "$NETPOL" | assert "netpol selects dawn-managed pods" 'app.kubernetes.io/managed-by: dawn'
 printf '%s\n' "$NETPOL" | assert "netpol policyTypes egress" 'policyTypes: \[Egress\]'
 printf '%s\n' "$NETPOL" | assert "netpol dns to kube-system" 'kubernetes.io/metadata.name: kube-system'
 printf '%s\n' "$NETPOL" | assert "netpol dns port 53" 'port: 53'

--- a/charts/dawn-sandbox-infra/values.yaml
+++ b/charts/dawn-sandbox-infra/values.yaml
@@ -64,4 +64,4 @@ reaper:
   schedule: "17 * * * *"
   ttlHours: 168
   # Pinned by digest (tags are mutable; the reaper SA can patch/delete PVCs).
-  image: docker.io/alpine/k8s:1.31.1@sha256:dfe8c7a06c41d0b6e8757da99531f8f302e9a2687fa0155af4c4087df585c9c8 # sh + date + kubectl
+  image: docker.io/alpine/k8s:1.35.6@sha256:b7a12c5ddf261994c33d2eaaa06fd69a0803ff6b38683bfa3d30a76dcdf92807 # sh + date + sort + grep + kubectl

--- a/charts/dawn-sandbox-infra/values.yaml
+++ b/charts/dawn-sandbox-infra/values.yaml
@@ -34,7 +34,9 @@ orchestrator:
   subjects: []
 
 networkPolicy:
-  # defaultDenyEgress: namespace-wide egress backstop (+ DNS carve-out).
+  # defaultDenyEgress: egress backstop (+ DNS carve-out) for Dawn-managed
+  # sandbox Pods selected by app.kubernetes.io/managed-by=dawn. Helm-managed
+  # reaper/control-plane Pods are excluded; sandbox network:allow is overridden.
   defaultDenyEgress: true
 
 resourceQuota:

--- a/docs/superpowers/plans/2026-08-07-kubernetes-reaper-compatibility.md
+++ b/docs/superpowers/plans/2026-08-07-kubernetes-reaper-compatibility.md
@@ -1,0 +1,372 @@
+# Kubernetes Reaper Compatibility Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Keep the Helm chart's PVC reaper within Kubernetes' supported client skew, preserve default-deny behavior for Dawn sandbox pods, and prove both behaviors in CI.
+
+**Architecture:** Pin the default reaper and Kind node images by multi-architecture digest, then parse those configuration surfaces in the existing sandbox workflow-policy test to enforce the one-minor skew contract. Scope the chart backstop to provider-managed pods so Helm control-plane jobs can reach the API, and extend the existing Calico-enabled lane with deterministic network-policy and reaper runtime checks.
+
+**Tech Stack:** Helm 3, Kubernetes/Kind, Calico, POSIX shell, TypeScript, Vitest, `yaml`, pnpm.
+
+---
+
+### Task 1: Pin and enforce the Kubernetes version contract
+
+**Files:**
+- Modify: `packages/sandbox/test/ci-workflow-pins.test.ts`
+- Modify: `.github/workflows/ci.yml`
+- Modify: `charts/dawn-sandbox-infra/values.yaml`
+
+- [ ] **Step 1: Write failing policy tests**
+
+Extend `collectKubernetesPins` to collect each Kind step's `with.node_image`.
+Load `charts/dawn-sandbox-infra/values.yaml` with `yaml.parse`, validate the
+reaper image shape, and add tests requiring these exact references:
+
+```ts
+const approvedKindNodeImage =
+  "kindest/node:v1.35.0@sha256:4613778f3cfcd10e615029370f5786704559103cf27bef934597ba562b269661"
+const approvedReaperImage =
+  "docker.io/alpine/k8s:1.35.6@sha256:b7a12c5ddf261994c33d2eaaa06fd69a0803ff6b38683bfa3d30a76dcdf92807"
+
+function kubernetesMinor(image: string): number {
+  const match = image.match(/:v?\d+\.(\d+)\.\d+@sha256:[a-f0-9]{64}$/)
+  if (match?.[1] === undefined) throw new Error(`invalid pinned Kubernetes image: ${image}`)
+  return Number.parseInt(match[1], 10)
+}
+```
+
+Assertions:
+
+```ts
+expect(ciPins.kindNodeImages).toEqual(Array.from({ length: 3 }, () => approvedKindNodeImage))
+expect(reaperImage).toBe(approvedReaperImage)
+for (const nodeImage of ciPins.kindNodeImages) {
+  expect(Math.abs(kubernetesMinor(nodeImage) - kubernetesMinor(reaperImage))).toBeLessThanOrEqual(1)
+}
+```
+
+Preserve and extend the synthetic parser test so quoted `node_image` values are
+collected. Add unit cases proving malformed or non-digest references throw.
+
+- [ ] **Step 2: Run the focused test and confirm failure**
+
+Run:
+
+```bash
+pnpm --filter @dawn-ai/sandbox test ci-workflow-pins
+```
+
+Expected: FAIL because active Kind steps have no explicit `node_image` and the
+chart still defaults to reaper 1.31.1.
+
+- [ ] **Step 3: Add the approved pins**
+
+Add this input to all three active `helm/kind-action` steps:
+
+```yaml
+node_image: kindest/node:v1.35.0@sha256:4613778f3cfcd10e615029370f5786704559103cf27bef934597ba562b269661
+```
+
+Change `reaper.image` in `charts/dawn-sandbox-infra/values.yaml` to:
+
+```yaml
+image: docker.io/alpine/k8s:1.35.6@sha256:b7a12c5ddf261994c33d2eaaa06fd69a0803ff6b38683bfa3d30a76dcdf92807
+```
+
+Keep the inline digest-pinning explanation and update the command-dependency
+comment to mention `sh`, `date`, `sort`, `grep`, and `kubectl`.
+
+- [ ] **Step 4: Run focused verification**
+
+```bash
+pnpm --filter @dawn-ai/sandbox test ci-workflow-pins
+sh charts/dawn-sandbox-infra/test/render.sh
+helm lint --strict charts/dawn-sandbox-infra
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/sandbox/test/ci-workflow-pins.test.ts .github/workflows/ci.yml charts/dawn-sandbox-infra/values.yaml
+git commit -m "fix(charts): align reaper Kubernetes client"
+```
+
+### Task 2: Scope and prove the chart egress backstop
+
+**Files:**
+- Modify: `charts/dawn-sandbox-infra/test/render.sh`
+- Modify: `charts/dawn-sandbox-infra/templates/networkpolicy-default-deny.yaml`
+- Create: `test/k8s-smoke/setup-network-policy-control.sh`
+- Modify: `packages/sandbox/test/kube-sandbox.integration.test.ts`
+- Modify: `.github/workflows/ci.yml`
+
+- [ ] **Step 1: Write failing render and integration tests**
+
+Replace the render assertion for `podSelector: {}` with assertions for:
+
+```yaml
+podSelector:
+  matchLabels:
+    app.kubernetes.io/managed-by: dawn
+```
+
+In `kube-sandbox.integration.test.ts`, create a real `NetworkingV1Api` from the
+ambient kubeconfig. Add a gated test that:
+
+1. requires `DAWN_TEST_K8S_EGRESS_CONTROL_URL`;
+2. acquires a fresh sandbox with `network: { mode: "allow" }`;
+3. lists namespace NetworkPolicies and asserts none has the sandbox's
+   `dawn.sh/thread` label;
+4. executes a Node `fetch` to the control URL with a five-second timeout;
+5. first uses Node DNS APIs to resolve the control service hostname and
+   requires success;
+6. expects the HTTP fetch to return a nonzero exit and `BLOCKED` output;
+7. destroys the sandbox in `finally`.
+
+- [ ] **Step 2: Run tests and confirm the render failure**
+
+```bash
+sh charts/dawn-sandbox-infra/test/render.sh
+pnpm --filter @dawn-ai/sandbox test kube-sandbox.integration
+```
+
+Expected: render FAILS because the policy still selects all pods. The gated
+integration file remains skipped locally without `DAWN_TEST_K8S=1`.
+
+- [ ] **Step 3: Scope the NetworkPolicy selector**
+
+Change `templates/networkpolicy-default-deny.yaml` to:
+
+```yaml
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/managed-by: dawn
+  policyTypes: [Egress]
+```
+
+Do not change DNS egress rules or the `defaultDenyEgress` values API.
+
+- [ ] **Step 4: Add the deterministic control service**
+
+Create `test/k8s-smoke/setup-network-policy-control.sh` with `set -eu`. It must:
+
+- use namespace `DAWN_TEST_K8S_NS` or `dawn-sandboxes`;
+- delete stale `dawn-egress-control` client, service, and pod fixtures;
+- create an unlabeled-by-Dawn `node:22-slim` pod running a Node HTTP server on
+  port 8080 with an HTTP readiness probe;
+- expose it as service `dawn-egress-control`;
+- wait for the server pod to become Ready;
+- wait for the readiness probe, then run a separate unlabeled `node:22-slim`
+  client pod that fetches `http://dawn-egress-control:8080/` and requires
+  status 200;
+- print the fully qualified control URL for diagnostics.
+
+The setup script is idempotent and leaves the server running for the Vitest
+suite. Add a cleanup trap for the one-off client.
+
+- [ ] **Step 5: Wire the control into the Calico lane**
+
+After chart installation and before the package integration suite, add:
+
+```yaml
+- name: Prepare chart NetworkPolicy control
+  run: sh test/k8s-smoke/setup-network-policy-control.sh
+
+- name: Real-cluster sandbox conformance + e2e
+  env:
+    DAWN_TEST_K8S_EGRESS_CONTROL_URL: http://dawn-egress-control:8080/
+  run: DAWN_TEST_K8S=1 pnpm --filter @dawn-ai/sandbox test kube-sandbox.integration
+```
+
+- [ ] **Step 6: Run focused verification**
+
+```bash
+sh charts/dawn-sandbox-infra/test/render.sh
+pnpm --filter @dawn-ai/sandbox test
+helm lint --strict charts/dawn-sandbox-infra
+```
+
+Expected: PASS. The real allow-mode assertion runs only in the hosted/local
+Calico lane.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add charts/dawn-sandbox-infra/test/render.sh charts/dawn-sandbox-infra/templates/networkpolicy-default-deny.yaml test/k8s-smoke/setup-network-policy-control.sh packages/sandbox/test/kube-sandbox.integration.test.ts .github/workflows/ci.yml
+git commit -m "fix(charts): scope sandbox egress backstop"
+```
+
+### Task 3: Exercise the installed reaper against real PVCs
+
+**Files:**
+- Create: `test/k8s-smoke/assert-reaper.sh`
+- Modify: `.github/workflows/ci.yml`
+
+- [ ] **Step 1: Add the failing CI smoke entrypoint**
+
+Add a step after the real-cluster provider suite:
+
+```yaml
+- name: Exercise PVC reaper
+  run: sh test/k8s-smoke/assert-reaper.sh
+```
+
+Create a disposable Kind cluster using the approved node image, install the
+chart, then run `sh test/k8s-smoke/assert-reaper.sh` and confirm it fails because
+the script does not exist. Download Kind v0.31.0 to `/tmp` when the binary is
+not installed locally. Keep the cluster for the green run in Step 3.
+
+- [ ] **Step 2: Implement the reaper smoke script**
+
+Create `test/k8s-smoke/assert-reaper.sh` with `set -eu`. Use fixed fixture names
+under `DAWN_TEST_K8S_NS` or `dawn-sandboxes` and a trap that deletes the smoke
+Job, pod, and PVCs.
+
+The script must first delete any stale smoke Job, pod, and PVCs so interrupted
+or repeated runs start clean. It then must:
+
+1. calculate a positive epoch marker older than the chart's 168-hour TTL;
+2. create three `storageClassName: ""` PVCs labeled
+   `app.kubernetes.io/managed-by: dawn`:
+   `dawn-reaper-smoke-stale`, `dawn-reaper-smoke-new`, and
+   `dawn-reaper-smoke-referenced`;
+3. put the old marker on stale and referenced PVCs;
+4. create a pod spec referencing the referenced PVC (it need not become
+   Running; the reaper inspects pod volume references);
+5. run `kubectl create job --from=cronjob/dawn-reaper dawn-reaper-smoke`;
+6. wait up to 120 seconds for Job completion and print logs on failure;
+7. require the stale PVC to be absent;
+8. require the new PVC's marker to be a positive integer;
+9. require the referenced PVC to remain and have no marker;
+10. print the Job logs and a success message.
+
+- [ ] **Step 3: Run the green Kind smoke and focused checks**
+
+```bash
+sh -n test/k8s-smoke/assert-reaper.sh
+pnpm --filter @dawn-ai/sandbox test ci-workflow-pins
+sh test/k8s-smoke/assert-reaper.sh
+```
+
+Expected: PASS against the disposable cluster from Step 1. Delete that cluster
+in a trap or immediately after the smoke succeeds.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add test/k8s-smoke/assert-reaper.sh .github/workflows/ci.yml
+git commit -m "test(charts): exercise PVC reaper in Kind"
+```
+
+### Task 4: Document and release the chart hardening
+
+**Files:**
+- Modify: `charts/dawn-sandbox-infra/README.md`
+- Modify: `charts/dawn-sandbox-infra/Chart.yaml`
+- Modify: `charts/dawn-sandbox-infra/values.yaml`
+- Modify: `charts/dawn-sandbox-infra/templates/NOTES.txt`
+- Modify: `apps/web/content/docs/sandbox.mdx`
+- Regenerate: `packages/cli/docs/sandbox.md`
+
+- [ ] **Step 1: Update documentation assertions first**
+
+Before editing the README, confirm these searches fail:
+
+```bash
+rg -n '1\.34.*1\.36|sort.*grep' charts/dawn-sandbox-infra/README.md
+rg -n '^version: 0\.1\.2$' charts/dawn-sandbox-infra/Chart.yaml
+```
+
+- [ ] **Step 2: Update README and chart version**
+
+Change the chart description from a namespace-wide egress backstop to a
+Dawn-managed sandbox pod backstop. Document:
+
+- the `app.kubernetes.io/managed-by=dawn` selector;
+- the reaper's need for API egress and why Helm-managed pods are excluded;
+- default reaper compatibility with Kubernetes 1.34 through 1.36;
+- the one-minor upstream `kubectl` skew rule;
+- the operator responsibility to override `reaper.image` outside that window;
+- all required image tools: `sh`, `date`, `sort`, `grep`, and `kubectl`;
+- the complete default 1.35.6 tag-plus-digest reference in the values table.
+
+Apply the same narrow wording correction to `values.yaml`, Helm `NOTES.txt`, and
+the website sandbox guide. Then regenerate bundled CLI docs with:
+
+```bash
+pnpm --filter @dawn-ai/cli build
+```
+
+Do not edit `packages/cli/docs/sandbox.md` independently from its website MDX
+source.
+
+Bump `Chart.yaml` from `0.1.1` to `0.1.2`. Do not add an npm changeset.
+
+- [ ] **Step 3: Run chart and docs verification**
+
+```bash
+helm lint --strict charts/dawn-sandbox-infra
+sh charts/dawn-sandbox-infra/test/render.sh
+sh charts/dawn-sandbox-infra/test/reaper.test.sh
+helm template test charts/dawn-sandbox-infra | kubeconform -strict -summary -ignore-missing-schemas
+node scripts/check-docs.mjs
+git diff --check
+```
+
+If `kubeconform` is unavailable locally, record that and rely on the hosted
+`chart-validate` job after running every available command.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add charts/dawn-sandbox-infra/README.md charts/dawn-sandbox-infra/Chart.yaml charts/dawn-sandbox-infra/values.yaml charts/dawn-sandbox-infra/templates/NOTES.txt apps/web/content/docs/sandbox.mdx packages/cli/docs/sandbox.md
+git commit -m "docs(charts): document reaper compatibility"
+```
+
+### Task 5: Full verification and delivery
+
+**Files:**
+- Verify only; modify narrowly if a test exposes a defect.
+
+- [ ] **Step 1: Run repository validation**
+
+```bash
+pnpm ci:validate
+```
+
+Expected: all local Definition of Done gates pass.
+
+- [ ] **Step 2: Run focused chart checks again**
+
+```bash
+pnpm --filter @dawn-ai/sandbox build
+pnpm --filter @dawn-ai/sandbox typecheck
+pnpm --filter @dawn-ai/sandbox lint
+pnpm --filter @dawn-ai/sandbox test
+helm lint --strict charts/dawn-sandbox-infra
+sh charts/dawn-sandbox-infra/test/render.sh
+sh charts/dawn-sandbox-infra/test/reaper.test.sh
+sh -n test/k8s-smoke/setup-network-policy-control.sh
+sh -n test/k8s-smoke/assert-reaper.sh
+git diff --check
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Final review**
+
+Review the complete branch diff against
+`docs/superpowers/specs/2026-08-07-kubernetes-reaper-compatibility-design.md`.
+Confirm no `node:22-slim` sandbox workload references were migrated and no npm
+changeset was added.
+
+- [ ] **Step 4: Publish and merge**
+
+Push `blove/k8s-reaper-compat`, open a ready PR without references to coding
+agents, and monitor required checks. The `sandbox-k8s` lane must prove the
+deterministic policy control and real reaper Job. Merge only after all required
+checks are green. Do not treat optional external review as blocking.

--- a/docs/superpowers/specs/2026-08-07-kubernetes-reaper-compatibility-design.md
+++ b/docs/superpowers/specs/2026-08-07-kubernetes-reaper-compatibility-design.md
@@ -1,0 +1,129 @@
+# Kubernetes Reaper Compatibility Design
+
+## Summary
+
+Align the `dawn-sandbox-infra` PVC reaper's bundled `kubectl` with Dawn's
+tested Kubernetes release and make that compatibility relationship explicit,
+testable, and exercised against a real cluster.
+
+The chart currently defaults to `docker.io/alpine/k8s:1.31.1`, while the
+active Kind lanes use Kubernetes 1.35 through `helm/kind-action` v1.14.0.
+Kubernetes supports `kubectl` within one minor version of `kube-apiserver`, so
+the existing four-minor skew is outside the supported contract even though the
+current smoke tests pass.
+
+## Goals
+
+- Default the reaper to a digest-pinned image containing Kubernetes 1.35
+  `kubectl`, a POSIX shell, and `date`.
+- Make the Kubernetes version used by all active Kind lanes explicit and
+  immutable.
+- Fail fast when the tested Kubernetes minor and default reaper client drift
+  outside Kubernetes' supported one-minor skew.
+- Exercise the installed reaper against real PVCs in Kind.
+- Document the supported default cluster window and operator override.
+
+## Non-goals
+
+- Changing the `reaper.image` values API.
+- Publishing a Dawn-owned reaper image.
+- Supporting every historical Kubernetes release with one default image.
+- Adding a multi-version Kubernetes CI matrix.
+- Changing `node:22-slim` sandbox workload fixtures.
+- Changing the reaper's TTL algorithm or RBAC permissions.
+
+## Design
+
+### Version contract
+
+The default reaper image becomes:
+
+```text
+docker.io/alpine/k8s:1.35.6@sha256:b7a12c5ddf261994c33d2eaaa06fd69a0803ff6b38683bfa3d30a76dcdf92807
+```
+
+The digest is the multi-architecture manifest for linux/amd64 and linux/arm64.
+Version 1.35 is the midpoint of the currently maintained Kubernetes 1.34,
+1.35, and 1.36 releases, placing the client within one minor of all three.
+
+All three `helm/kind-action` steps explicitly set:
+
+```yaml
+node_image: kindest/node:v1.35.0@sha256:4613778f3cfcd10e615029370f5786704559103cf27bef934597ba562b269661
+```
+
+This preserves the Kubernetes version already selected by the action while
+preventing an action-default change from silently changing the tested cluster.
+The digest is the multi-architecture Kind node manifest.
+
+The existing `reaper.image` string remains the complete image reference. It
+already supports arbitrary registries, tags, and digests and avoids a breaking,
+more cumbersome repository/tag/digest split.
+
+### Static policy test
+
+Extend `packages/sandbox/test/ci-workflow-pins.test.ts`, which already parses
+the CI workflow as YAML, to collect the `node_image` input from every active
+`helm/kind-action` step. Parse the chart defaults with the same YAML library and
+extract the Kubernetes minor from both image references.
+
+The tests require:
+
+- all three Kind steps use the approved digest-pinned Kubernetes 1.35 image;
+- the chart's default reaper uses the approved digest-pinned 1.35.6 image;
+- both image references include a `sha256` digest;
+- the absolute minor-version difference is at most one.
+
+Malformed or unversioned image references fail the test instead of being
+ignored. Custom operator overrides are not constrained because compatibility
+then belongs to the operator.
+
+### Real-cluster smoke
+
+Add a focused shell script under `test/k8s-smoke/` and call it from the existing
+`sandbox-k8s` lane after chart installation. The script:
+
+1. Creates a managed, unbound PVC with an old `dawn.sh/unbound-since` marker.
+2. Creates a managed, unbound PVC without a marker.
+3. Creates a managed PVC referenced by a running pod and gives it a stale
+   marker.
+4. Creates a one-off Job from the installed `dawn-reaper` CronJob.
+5. Waits for successful completion.
+6. Verifies the stale unbound PVC was deleted, the newly unbound PVC was marked,
+   and the bound PVC was retained with its stale marker removed.
+7. Deletes smoke fixtures through a shell trap.
+
+The test uses the chart's actual ConfigMap, ServiceAccount, image, security
+context, and RBAC. It does not wait for the hourly schedule or duplicate the
+CronJob manifest.
+
+### Documentation and release metadata
+
+Update the chart README to state that the default 1.35 client supports
+Kubernetes 1.34 through 1.36 under the upstream version-skew policy. Operators
+outside that window must override `reaper.image` with an image containing a
+compatible `kubectl`, POSIX shell, and `date`.
+
+Bump `charts/dawn-sandbox-infra/Chart.yaml` from `0.1.1` to `0.1.2`. This chart
+change does not alter an npm package and therefore does not require a
+Changesets entry.
+
+## Verification
+
+- Run the static workflow/version policy tests.
+- Run the reaper shell unit test and Helm render assertions.
+- Run strict Helm lint and kubeconform against rendered defaults.
+- Run `pnpm --filter @dawn-ai/sandbox test`.
+- Run the full repository validation lane.
+- Confirm the hosted `sandbox-k8s` job completes the real-cluster reaper smoke.
+
+## Risks
+
+`alpine/k8s` remains a third-party runtime image. Digest pinning prevents tag
+mutation from changing deployed bytes, but it does not replace supply-chain
+trust. A Dawn-owned minimal reaper image would require image build, publication,
+security scanning, and release lifecycle work and is intentionally deferred.
+
+One default client cannot support arbitrary old and future clusters. The
+documented override preserves operator control, while the default covers the
+maintained Kubernetes window at the time of this change.

--- a/docs/superpowers/specs/2026-08-07-kubernetes-reaper-compatibility-design.md
+++ b/docs/superpowers/specs/2026-08-07-kubernetes-reaper-compatibility-design.md
@@ -127,14 +127,15 @@ context, RBAC, and network policy on a Calico-enabled cluster. It does not wait
 for the hourly schedule or duplicate the CronJob manifest. The existing
 provider integration suite gains a `network: "allow"` case that attempts
 to reach a deterministic in-cluster HTTP control service. Before the suite,
-the CI lane starts that service in an unlabeled pod and proves an unlabeled
-client can reach it. The integration test then acquires a fresh allow-mode
-sandbox, verifies that no per-thread NetworkPolicy exists for it, and verifies
-that the same service is unreachable. Allow mode emits no per-thread policy,
-the positive control proves the service is healthy, and in-cluster DNS remains
-allowed, so the chart's label-scoped backstop is isolated as the blocker. The
-existing `network: "deny"` test continues to cover the provider's per-thread
-policy separately.
+the CI lane starts that service in an unlabeled pod with an HTTP readiness
+probe and proves an unlabeled client can reach it. The integration test then
+acquires a fresh allow-mode sandbox, verifies that no per-thread NetworkPolicy
+exists for it, separately resolves the short service hostname through cluster
+DNS, and verifies that the same service is unreachable. Allow mode emits no
+per-thread policy, the positive control proves the service is healthy, and the
+DNS assertion excludes name-resolution failure, so the chart's label-scoped
+backstop is isolated as the blocker. The existing `network: "deny"` test
+continues to cover the provider's per-thread policy separately.
 
 ### Documentation and release metadata
 
@@ -143,6 +144,11 @@ Kubernetes 1.34 through 1.36 under the upstream version-skew policy. Operators
 outside that window must override `reaper.image` with an image containing a
 compatible `kubectl`, POSIX shell, `date`, `sort`, and `grep`. The values table
 shows the complete default tag-plus-digest reference.
+
+Correct all active namespace-wide policy claims in chart values comments,
+Helm NOTES, and the website sandbox guide to describe the Dawn-managed pod
+selector. Regenerate the CLI's bundled Markdown from the website source rather
+than editing generated files by hand.
 
 Bump `charts/dawn-sandbox-infra/Chart.yaml` from `0.1.1` to `0.1.2`. This chart
 change does not alter an npm package and therefore does not require a

--- a/docs/superpowers/specs/2026-08-07-kubernetes-reaper-compatibility-design.md
+++ b/docs/superpowers/specs/2026-08-07-kubernetes-reaper-compatibility-design.md
@@ -126,10 +126,15 @@ The test uses the chart's actual ConfigMap, ServiceAccount, image, security
 context, RBAC, and network policy on a Calico-enabled cluster. It does not wait
 for the hourly schedule or duplicate the CronJob manifest. The existing
 provider integration suite gains a `network: "allow"` case that attempts
-external HTTPS access. Allow mode emits no per-thread NetworkPolicy, so its
-failed request proves that the chart's label-scoped backstop still selects and
-blocks Dawn-managed sandbox pods. The existing `network: "deny"` test continues
-to cover the provider's per-thread policy separately.
+to reach a deterministic in-cluster HTTP control service. Before the suite,
+the CI lane starts that service in an unlabeled pod and proves an unlabeled
+client can reach it. The integration test then acquires a fresh allow-mode
+sandbox, verifies that no per-thread NetworkPolicy exists for it, and verifies
+that the same service is unreachable. Allow mode emits no per-thread policy,
+the positive control proves the service is healthy, and in-cluster DNS remains
+allowed, so the chart's label-scoped backstop is isolated as the blocker. The
+existing `network: "deny"` test continues to cover the provider's per-thread
+policy separately.
 
 ### Documentation and release metadata
 

--- a/docs/superpowers/specs/2026-08-07-kubernetes-reaper-compatibility-design.md
+++ b/docs/superpowers/specs/2026-08-07-kubernetes-reaper-compatibility-design.md
@@ -20,6 +20,8 @@ current smoke tests pass.
   immutable.
 - Fail fast when the tested Kubernetes minor and default reaper client drift
   outside Kubernetes' supported one-minor skew.
+- Preserve default-deny egress for Dawn-managed sandbox pods while allowing
+  the Helm-managed reaper to reach the Kubernetes API reliably.
 - Exercise the installed reaper against real PVCs in Kind.
 - Document the supported default cluster window and operator override.
 
@@ -60,6 +62,34 @@ The existing `reaper.image` string remains the complete image reference. It
 already supports arbitrary registries, tags, and digests and avoids a breaking,
 more cumbersome repository/tag/digest split.
 
+The image must provide `kubectl`, a POSIX shell, `date`, `sort`, and `grep`,
+which are all invoked by `files/reaper.sh`.
+
+### Network-policy scope
+
+The existing namespace-wide default-deny policy also selects the reaper. It
+allows DNS only, so a policy-enforcing production cluster can block the
+reaper's Kubernetes API calls even though Kind may exempt node traffic.
+
+Change the policy selector from all pods to:
+
+```yaml
+podSelector:
+  matchLabels:
+    app.kubernetes.io/managed-by: dawn
+```
+
+The Kubernetes sandbox provider applies this label to every sandbox pod. The
+chart deliberately labels its own resources `app.kubernetes.io/managed-by:
+Helm`, so the reaper Job is outside the policy and can use its in-cluster API
+credentials. This preserves the fail-closed backstop for the workloads the
+chart exists to constrain without relying on cluster-specific API-server
+addresses, service translation behavior, or ports.
+
+The README description changes from a namespace-wide backstop to a backstop
+for Dawn-managed sandbox pods. Arbitrary pods manually placed in the dedicated
+namespace are outside this policy and remain the operator's responsibility.
+
 ### Static policy test
 
 Extend `packages/sandbox/test/ci-workflow-pins.test.ts`, which already parses
@@ -85,8 +115,7 @@ Add a focused shell script under `test/k8s-smoke/` and call it from the existing
 
 1. Creates a managed, unbound PVC with an old `dawn.sh/unbound-since` marker.
 2. Creates a managed, unbound PVC without a marker.
-3. Creates a managed PVC referenced by a running pod and gives it a stale
-   marker.
+3. Creates a managed PVC referenced by a pod and gives it a stale marker.
 4. Creates a one-off Job from the installed `dawn-reaper` CronJob.
 5. Waits for successful completion.
 6. Verifies the stale unbound PVC was deleted, the newly unbound PVC was marked,
@@ -94,15 +123,18 @@ Add a focused shell script under `test/k8s-smoke/` and call it from the existing
 7. Deletes smoke fixtures through a shell trap.
 
 The test uses the chart's actual ConfigMap, ServiceAccount, image, security
-context, and RBAC. It does not wait for the hourly schedule or duplicate the
-CronJob manifest.
+context, RBAC, and network policy on a Calico-enabled cluster. It does not wait
+for the hourly schedule or duplicate the CronJob manifest. The existing
+provider integration test continues to prove that labeled sandbox pods remain
+subject to default-deny egress.
 
 ### Documentation and release metadata
 
 Update the chart README to state that the default 1.35 client supports
 Kubernetes 1.34 through 1.36 under the upstream version-skew policy. Operators
 outside that window must override `reaper.image` with an image containing a
-compatible `kubectl`, POSIX shell, and `date`.
+compatible `kubectl`, POSIX shell, `date`, `sort`, and `grep`. The values table
+shows the complete default tag-plus-digest reference.
 
 Bump `charts/dawn-sandbox-infra/Chart.yaml` from `0.1.1` to `0.1.2`. This chart
 change does not alter an npm package and therefore does not require a

--- a/docs/superpowers/specs/2026-08-07-kubernetes-reaper-compatibility-design.md
+++ b/docs/superpowers/specs/2026-08-07-kubernetes-reaper-compatibility-design.md
@@ -125,8 +125,11 @@ Add a focused shell script under `test/k8s-smoke/` and call it from the existing
 The test uses the chart's actual ConfigMap, ServiceAccount, image, security
 context, RBAC, and network policy on a Calico-enabled cluster. It does not wait
 for the hourly schedule or duplicate the CronJob manifest. The existing
-provider integration test continues to prove that labeled sandbox pods remain
-subject to default-deny egress.
+provider integration suite gains a `network: "allow"` case that attempts
+external HTTPS access. Allow mode emits no per-thread NetworkPolicy, so its
+failed request proves that the chart's label-scoped backstop still selects and
+blocks Dawn-managed sandbox pods. The existing `network: "deny"` test continues
+to cover the provider's per-thread policy separately.
 
 ### Documentation and release metadata
 
@@ -146,6 +149,8 @@ Changesets entry.
 - Run the reaper shell unit test and Helm render assertions.
 - Run strict Helm lint and kubeconform against rendered defaults.
 - Run `pnpm --filter @dawn-ai/sandbox test`.
+- Run the gated Kubernetes integration suite and confirm both the label-scoped
+  chart backstop and the one-off reaper Job pass under Calico.
 - Run the full repository validation lane.
 - Confirm the hosted `sandbox-k8s` job completes the real-cluster reaper smoke.
 

--- a/packages/sandbox/test/ci-workflow-pins.test.ts
+++ b/packages/sandbox/test/ci-workflow-pins.test.ts
@@ -3,6 +3,10 @@ import { describe, expect, test } from "vitest"
 import { parse } from "yaml"
 
 const kindActionPrefix = "helm/kind-action@"
+const approvedKindNodeImage =
+  "kindest/node:v1.35.0@sha256:4613778f3cfcd10e615029370f5786704559103cf27bef934597ba562b269661"
+const approvedReaperImage =
+  "docker.io/alpine/k8s:1.35.6@sha256:b7a12c5ddf261994c33d2eaaa06fd69a0803ff6b38683bfa3d30a76dcdf92807"
 const calicoManifestUrl =
   /https:\/\/raw\.githubusercontent\.com\/projectcalico\/calico\/(v[^/]+)\/manifests\/calico\.yaml/g
 
@@ -15,13 +19,54 @@ function isKubectlApplyCommand(command: string): boolean {
   return executable === "kubectl" && args.includes("apply")
 }
 
+function kubernetesMinor(reference: string): number {
+  const digestSeparator = "@sha256:"
+  const digestIndex = reference.indexOf(digestSeparator)
+  if (digestIndex <= 0 || digestIndex !== reference.lastIndexOf(digestSeparator)) {
+    throw new Error(`Invalid Kubernetes image reference: ${reference}`)
+  }
+
+  const digest = reference.slice(digestIndex + digestSeparator.length)
+  if (!/^[0-9a-f]{64}$/.test(digest)) {
+    throw new Error(`Invalid Kubernetes image digest: ${reference}`)
+  }
+
+  const image = reference.slice(0, digestIndex)
+  const tagIndex = image.lastIndexOf(":")
+  if (tagIndex <= image.lastIndexOf("/")) {
+    throw new Error(`Missing Kubernetes image version: ${reference}`)
+  }
+
+  const rawVersion = image.slice(tagIndex + 1)
+  const version = rawVersion.startsWith("v") ? rawVersion.slice(1) : rawVersion
+  const parts = version.split(".")
+  if (parts.length !== 3 || parts.some((part) => part.length === 0 || !/^[0-9]+$/.test(part))) {
+    throw new Error(`Invalid Kubernetes image version: ${reference}`)
+  }
+
+  const minor = Number(parts[1])
+  if (!Number.isSafeInteger(minor)) {
+    throw new Error(`Invalid Kubernetes image minor version: ${reference}`)
+  }
+  return minor
+}
+
+function collectReaperImage(valuesSource: string): string {
+  const values: unknown = parse(valuesSource)
+  if (!isRecord(values) || !isRecord(values.reaper) || typeof values.reaper.image !== "string") {
+    throw new Error("Expected charts/dawn-sandbox-infra reaper.image to be a string")
+  }
+  return values.reaper.image
+}
+
 function collectKubernetesPins(workflowSource: string) {
   const workflow: unknown = parse(workflowSource)
   const kindCommits: string[] = []
+  const kindNodeImages: string[] = []
   const calicoVersions: string[] = []
 
   if (!isRecord(workflow) || !isRecord(workflow.jobs)) {
-    return { calicoVersions, kindCommits }
+    return { calicoVersions, kindCommits, kindNodeImages }
   }
 
   for (const job of Object.values(workflow.jobs)) {
@@ -36,6 +81,9 @@ function collectKubernetesPins(workflowSource: string) {
 
       if (typeof step.uses === "string" && step.uses.startsWith(kindActionPrefix)) {
         kindCommits.push(step.uses.slice(kindActionPrefix.length))
+        if (isRecord(step.with) && typeof step.with.node_image === "string") {
+          kindNodeImages.push(step.with.node_image)
+        }
       }
 
       if (typeof step.run !== "string") {
@@ -59,7 +107,7 @@ function collectKubernetesPins(workflowSource: string) {
     }
   }
 
-  return { calicoVersions, kindCommits }
+  return { calicoVersions, kindCommits, kindNodeImages }
 }
 
 const ciWorkflow = readFileSync(
@@ -67,12 +115,32 @@ const ciWorkflow = readFileSync(
   "utf8",
 )
 const ciPins = collectKubernetesPins(ciWorkflow)
+const chartValues = readFileSync(
+  new URL("../../../charts/dawn-sandbox-infra/values.yaml", import.meta.url),
+  "utf8",
+)
+const reaperImage = collectReaperImage(chartValues)
 
 describe("Kubernetes CI dependency pins", () => {
   test("uses the approved Node 24 Kind action in every active lane", () => {
     expect(ciPins.kindCommits).toEqual(
       Array.from({ length: 3 }, () => "ef37e7f390d99f746eb8b610417061a60e82a6cc"),
     )
+  })
+
+  test("uses the approved Kubernetes node image in every active Kind lane", () => {
+    expect(ciPins.kindNodeImages).toEqual(Array.from({ length: 3 }, () => approvedKindNodeImage))
+  })
+
+  test("uses the approved Kubernetes client image for the reaper", () => {
+    expect(reaperImage).toBe(approvedReaperImage)
+  })
+
+  test("keeps Kind and reaper Kubernetes minors within one release", () => {
+    const reaperMinor = kubernetesMinor(reaperImage)
+    for (const nodeImage of ciPins.kindNodeImages) {
+      expect(Math.abs(kubernetesMinor(nodeImage) - reaperMinor)).toBeLessThanOrEqual(1)
+    }
   })
 
   test("uses the Kubernetes 1.35-compatible Calico release in every active lane", () => {
@@ -85,6 +153,8 @@ jobs:
   synthetic:
     steps:
       - uses: "helm/kind-action@quoted-commit"
+        with:
+          node_image: "kindest/node:v9.9.9@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
       - run: |
           kubectl apply \\
             --filename \\
@@ -94,7 +164,29 @@ jobs:
     expect(pins).toEqual({
       calicoVersions: ["v9.9.9"],
       kindCommits: ["quoted-commit"],
+      kindNodeImages: [
+        "kindest/node:v9.9.9@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      ],
     })
+  })
+
+  test("extracts Kubernetes minors from versioned digest references", () => {
+    expect(kubernetesMinor(approvedKindNodeImage)).toBe(35)
+    expect(
+      kubernetesMinor(
+        "example.invalid/kubectl:1.34.7@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      ),
+    ).toBe(34)
+  })
+
+  test.each([
+    "kindest/node:v1.35.0",
+    "kindest/node:v1.35.0@sha256:abc",
+    "kindest/node:v1.35.0@sha256:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+    "kindest/node:v1.35@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "kindest/node:latest@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  ])("rejects malformed or non-digest Kubernetes reference %s", (reference) => {
+    expect(() => kubernetesMinor(reference)).toThrow()
   })
 
   test("ignores commented and echoed Calico install commands", () => {

--- a/packages/sandbox/test/kube-sandbox.integration.test.ts
+++ b/packages/sandbox/test/kube-sandbox.integration.test.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto"
+import { KubeConfig, NetworkingV1Api } from "@kubernetes/client-node"
 import { describe, expect, test } from "vitest"
 import { kubernetesSandbox } from "../src/index.ts"
 import { runProviderConformance } from "../src/testing/index.ts"
@@ -72,6 +73,55 @@ describe.skipIf(!enabled)("kubernetesSandbox (real cluster)", { timeout: 240_000
       )
       expect(r.exitCode).toBe(7)
       expect(r.stdout).toContain("BLOCKED")
+    } finally {
+      await p.destroy(t)
+    }
+  })
+
+  test("chart backstop blocks allow-mode sandbox egress without a per-thread policy", async () => {
+    const controlUrl = process.env.DAWN_TEST_K8S_EGRESS_CONTROL_URL
+    if (!controlUrl) {
+      throw new Error("DAWN_TEST_K8S_EGRESS_CONTROL_URL is required for real-cluster tests")
+    }
+
+    const controlHostname = new URL(controlUrl).hostname
+    const p = make()
+    const t = `egress-${randomUUID().slice(0, 8)}`
+    try {
+      const h = await p.acquire({
+        threadId: t,
+        policy: { network: { mode: "allow" } },
+        signal: ctx("/").signal,
+      })
+
+      const kc = new KubeConfig()
+      kc.loadFromDefault()
+      const networking = kc.makeApiClient(NetworkingV1Api)
+      const policies = await networking.listNamespacedNetworkPolicy({ namespace: NS })
+      const perThreadPolicy = policies.items.find(
+        (policy) =>
+          policy.metadata?.name === `dawn-sbx-net-${t}` ||
+          policy.metadata?.labels?.["dawn.sh/thread"] === t,
+      )
+      expect(perThreadPolicy).toBeUndefined()
+
+      const dns = await h.exec.runCommand(
+        {
+          command: `node -e 'require("node:dns").promises.lookup(${JSON.stringify(controlHostname)}).then(({ address }) => console.log(address)).catch((error) => { console.error(error); process.exit(1) })'`,
+        },
+        ctx(h.workspaceRoot),
+      )
+      expect(dns.exitCode).toBe(0)
+      expect(dns.stdout.trim()).not.toBe("")
+
+      const fetchResult = await h.exec.runCommand(
+        {
+          command: `node -e 'fetch(${JSON.stringify(controlUrl)}, { signal: AbortSignal.timeout(5000) }).then((response) => { console.log("REACHED " + response.status); process.exit(0) }).catch(() => { console.log("BLOCKED"); process.exit(7) })'`,
+        },
+        ctx(h.workspaceRoot),
+      )
+      expect(fetchResult.exitCode).not.toBe(0)
+      expect(fetchResult.stdout).toContain("BLOCKED")
     } finally {
       await p.destroy(t)
     }

--- a/test/k8s-smoke/assert-reaper.sh
+++ b/test/k8s-smoke/assert-reaper.sh
@@ -136,10 +136,7 @@ if ! kubectl -n "$NS" wait --for=condition=Complete "job/$JOB" --timeout=120s; t
   exit 1
 fi
 
-if kubectl -n "$NS" get pvc "$STALE_PVC" >/dev/null 2>&1; then
-  printf '%s\n' "stale PVC was not reaped: $STALE_PVC" >&2
-  exit 1
-fi
+kubectl -n "$NS" wait --for=delete "pvc/$STALE_PVC" --timeout=30s
 
 NEW_MARKER=$(kubectl -n "$NS" get pvc "$NEW_PVC" -o jsonpath='{.metadata.annotations.dawn\.sh/unbound-since}')
 if ! is_positive_integer "$NEW_MARKER"; then

--- a/test/k8s-smoke/assert-reaper.sh
+++ b/test/k8s-smoke/assert-reaper.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env sh
+set -eu
+
+NS="${DAWN_TEST_K8S_NS:-dawn-sandboxes}"
+JOB="dawn-reaper-smoke"
+STALE_PVC="dawn-reaper-smoke-stale"
+NEW_PVC="dawn-reaper-smoke-new"
+REFERENCED_PVC="dawn-reaper-smoke-referenced"
+REFERENCE_POD="dawn-reaper-smoke-reference"
+DIAGNOSTICS_PRINTED=0
+
+is_positive_integer() {
+  case "$1" in
+    "" | *[!0-9]*) return 1 ;;
+  esac
+  [ "$1" -gt 0 ]
+}
+
+print_diagnostics() {
+  DIAGNOSTICS_PRINTED=1
+  kubectl -n "$NS" describe job "$JOB" || true
+  kubectl -n "$NS" describe pods -l "job-name=$JOB" || true
+  kubectl -n "$NS" logs "job/$JOB" --all-containers=true || true
+}
+
+cleanup() {
+  status=$1
+  trap - 0
+  if [ "$status" -ne 0 ] && [ "$DIAGNOSTICS_PRINTED" -eq 0 ]; then
+    print_diagnostics
+  fi
+  kubectl -n "$NS" delete job "$JOB" --ignore-not-found --wait=true >/dev/null 2>&1 || true
+  kubectl -n "$NS" delete pod "$REFERENCE_POD" --ignore-not-found --wait=true >/dev/null 2>&1 || true
+  kubectl -n "$NS" delete pvc "$STALE_PVC" "$NEW_PVC" "$REFERENCED_PVC" \
+    --ignore-not-found --wait=true >/dev/null 2>&1 || true
+  exit "$status"
+}
+trap 'cleanup "$?"' 0
+
+# Remove fixtures left by an interrupted or repeated run before creating them.
+kubectl -n "$NS" delete job "$JOB" --ignore-not-found --wait=true
+kubectl -n "$NS" delete pod "$REFERENCE_POD" --ignore-not-found --wait=true
+kubectl -n "$NS" delete pvc "$STALE_PVC" "$NEW_PVC" "$REFERENCED_PVC" \
+  --ignore-not-found --wait=true
+
+TTL_SECONDS=604800
+OLD_MARKER=$(( $(date -u +%s) - TTL_SECONDS - 1 ))
+if ! is_positive_integer "$OLD_MARKER"; then
+  printf '%s\n' "invalid stale PVC marker: $OLD_MARKER" >&2
+  exit 1
+fi
+
+kubectl -n "$NS" apply -f - <<EOF
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: $STALE_PVC
+  labels:
+    app.kubernetes.io/managed-by: dawn
+  annotations:
+    dawn.sh/unbound-since: "$OLD_MARKER"
+spec:
+  storageClassName: ""
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Mi
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: $NEW_PVC
+  labels:
+    app.kubernetes.io/managed-by: dawn
+spec:
+  storageClassName: ""
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Mi
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: $REFERENCED_PVC
+  labels:
+    app.kubernetes.io/managed-by: dawn
+  annotations:
+    dawn.sh/unbound-since: "$OLD_MARKER"
+spec:
+  storageClassName: ""
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Mi
+EOF
+
+kubectl -n "$NS" apply -f - <<EOF
+apiVersion: v1
+kind: Pod
+metadata:
+  name: $REFERENCE_POD
+  labels:
+    app.kubernetes.io/name: $REFERENCE_POD
+spec:
+  automountServiceAccountToken: false
+  restartPolicy: Never
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  containers:
+    - name: reference
+      image: registry.k8s.io/pause:3.10
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop: ["ALL"]
+        readOnlyRootFilesystem: true
+        runAsNonRoot: true
+      volumeMounts:
+        - name: referenced
+          mountPath: /data
+  volumes:
+    - name: referenced
+      persistentVolumeClaim:
+        claimName: $REFERENCED_PVC
+EOF
+
+kubectl -n "$NS" create job --from=cronjob/dawn-reaper "$JOB"
+if ! kubectl -n "$NS" wait --for=condition=Complete "job/$JOB" --timeout=120s; then
+  print_diagnostics
+  exit 1
+fi
+
+if kubectl -n "$NS" get pvc "$STALE_PVC" >/dev/null 2>&1; then
+  printf '%s\n' "stale PVC was not reaped: $STALE_PVC" >&2
+  exit 1
+fi
+
+NEW_MARKER=$(kubectl -n "$NS" get pvc "$NEW_PVC" -o jsonpath='{.metadata.annotations.dawn\.sh/unbound-since}')
+if ! is_positive_integer "$NEW_MARKER"; then
+  printf '%s\n' "new PVC marker is not a positive integer: $NEW_MARKER" >&2
+  exit 1
+fi
+
+kubectl -n "$NS" get pvc "$REFERENCED_PVC" >/dev/null
+REFERENCED_MARKER=$(kubectl -n "$NS" get pvc "$REFERENCED_PVC" -o jsonpath='{.metadata.annotations.dawn\.sh/unbound-since}')
+if [ -n "$REFERENCED_MARKER" ]; then
+  printf '%s\n' "referenced PVC marker was not cleared: $REFERENCED_MARKER" >&2
+  exit 1
+fi
+
+kubectl -n "$NS" logs "job/$JOB" --all-containers=true
+printf '%s\n' "PVC reaper smoke passed"

--- a/test/k8s-smoke/setup-network-policy-control.sh
+++ b/test/k8s-smoke/setup-network-policy-control.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env sh
+set -eu
+
+NS="${DAWN_TEST_K8S_NS:-dawn-sandboxes}"
+SERVER="dawn-egress-control"
+SERVICE="dawn-egress-control"
+CLIENT="dawn-egress-control-client"
+IMAGE="node:22-slim"
+
+cleanup_client() {
+  kubectl -n "$NS" delete pod "$CLIENT" --ignore-not-found --wait=false >/dev/null 2>&1 || true
+}
+trap cleanup_client 0
+
+kubectl -n "$NS" delete pod "$CLIENT" "$SERVER" --ignore-not-found --wait=true
+kubectl -n "$NS" delete service "$SERVICE" --ignore-not-found --wait=true
+
+kubectl -n "$NS" apply -f - <<EOF
+apiVersion: v1
+kind: Pod
+metadata:
+  name: $SERVER
+  labels:
+    app: $SERVER
+spec:
+  restartPolicy: Never
+  containers:
+    - name: server
+      image: $IMAGE
+      command: ["node", "-e"]
+      args:
+        - |
+          require("node:http")
+            .createServer((_request, response) => {
+              response.writeHead(200, { "content-type": "text/plain" });
+              response.end("OK");
+            })
+            .listen(8080, "0.0.0.0");
+      readinessProbe:
+        httpGet:
+          path: /
+          port: 8080
+        periodSeconds: 1
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: $SERVICE
+spec:
+  selector:
+    app: $SERVER
+  ports:
+    - port: 8080
+      targetPort: 8080
+EOF
+
+kubectl -n "$NS" wait --for=condition=Ready "pod/$SERVER" --timeout=120s
+
+kubectl -n "$NS" apply -f - <<EOF
+apiVersion: v1
+kind: Pod
+metadata:
+  name: $CLIENT
+spec:
+  restartPolicy: Never
+  containers:
+    - name: client
+      image: $IMAGE
+      command: ["sleep", "infinity"]
+EOF
+
+kubectl -n "$NS" wait --for=condition=Ready "pod/$CLIENT" --timeout=120s
+kubectl -n "$NS" exec "$CLIENT" -- node -e '
+  fetch("http://dawn-egress-control:8080/", { signal: AbortSignal.timeout(5000) })
+    .then((response) => {
+      if (response.status !== 200) {
+        console.error(`expected HTTP 200, received ${response.status}`);
+        process.exit(1);
+      }
+    })
+    .catch((error) => {
+      console.error(error);
+      process.exit(1);
+    });
+'
+
+printf '%s\n' "http://$SERVICE:8080/"


### PR DESCRIPTION
## Summary

- align the `dawn-sandbox-infra` reaper and all Kind CI lanes on digest-pinned Kubernetes 1.35 images, with a parsed one-minor skew policy
- scope the default-deny backstop to Dawn-managed sandbox pods and add deterministic Calico and real CronJob/PVC smoke coverage
- harden reaper marker parsing and mutation races, document the Kubernetes 1.34-1.36 default window, and bump the chart to 0.1.2

## Root cause

The chart bundled kubectl 1.31 while CI exercised Kubernetes 1.35, outside the supported client skew. The namespace-wide egress selector could also block the reaper API path on policy-enforcing clusters, and the live smoke exposed unsafe line-oriented annotation parsing plus mutation races.

## Validation

- `pnpm ci:validate` under Node 24.18.0: 2,395 tests passed; framework, runtime, and smoke harness lanes passed
- `pnpm --filter @dawn-ai/sandbox build`, `typecheck`, `lint`, and `test`
- strict Helm lint, render assertions, reaper adversarial tests, and kubeconform: 12/12 resources valid
- disposable Kind v0.31.0 / Kubernetes v1.35.0 reaper smoke against the installed chart

## Release note

This is a Helm chart-only patch to `dawn-sandbox-infra` 0.1.2; it does not require an npm changeset.