### PR TITLE
ci(release): use RELEASE_GITHUB_TOKEN for the Version PR

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,7 +74,11 @@ jobs:
           commit: Version Packages
           createGithubReleases: true
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
+          # A PAT, not the default GITHUB_TOKEN: GitHub does not trigger
+          # workflows on pushes made with GITHUB_TOKEN, so the Version PR this
+          # step opens would never get CI and would block on required checks.
+          # Falls back to GITHUB_TOKEN when the secret is absent.
 
       # Attest the just-published tarballs (kept in release-artifacts/ by
       # release-publish.mjs). Keyless OIDC — registers SLSA in-toto provenance


### PR DESCRIPTION
GitHub does not trigger workflows on pushes made with the default `GITHUB_TOKEN` — a deliberate loop-prevention rule. So the Version PR that `changesets/action` opens never gets CI, and blocks on required checks until someone pushes to it by hand.

This surfaced while fixing the same problem in `cacheplane/pretable`, where version PRs had to be nudged with an empty commit every release.

```diff
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
```

The `RELEASE_GITHUB_TOKEN` secret is already configured on this repo; it was just never referenced, so it sat inert. The fallback keeps the workflow working if the secret is ever removed or expires.

**Scope:** only the `changesets/action` step. The other two `GH_TOKEN` uses in this workflow are in-run API calls that don't create PRs needing CI, so they stay on the default token.

Also related: the stale `NPM_TOKEN` secret was deleted from this repo. This workflow publishes via OIDC trusted publishing and referenced it nowhere except a comment saying it isn't needed — leaving it invited someone to wire a token path back in, which would silently disable the OIDC exchange and drop provenance attestations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)