### PR TITLE
fix(postgres-storage): republish with the pool error handler

### DIFF
--- a/.changeset/postgres-storage-republish-pool-fix.md
+++ b/.changeset/postgres-storage-republish-pool-fix.md
@@ -1,0 +1,18 @@
+---
+"@dawn-ai/postgres-storage": patch
+---
+
+Republish with the `pg` pool `'error'` handler.
+
+**`@dawn-ai/postgres-storage@0.8.19` does not contain that fix, despite its changelog
+entry saying so.** 0.8.19 was the package's first release, so it had to be published
+by hand to create the name on npm before OIDC trusted publishing could take over — and
+that tarball was built from a release branch that had not yet absorbed the fix. npm does
+not allow a published version to be replaced, and the automated release skips any
+version already on the registry, so 0.8.19 shipped and stayed the pre-fix build.
+
+This release is the first one whose published artifact actually carries it. Anyone on
+`@dawn-ai/postgres-storage@0.8.19` should upgrade: without the listener, `pg` raises an
+unhandled `'error'` when an idle client is dropped — a server restart, failover,
+`idle_session_timeout` — and an EventEmitter `'error'` with no listener terminates the
+process. See the 0.8.19 entry for the full description of the fix itself.


### PR DESCRIPTION
**`@dawn-ai/postgres-storage@0.8.19` on npm does not contain the `pg` pool `'error'` handler — even though its 0.8.19 changelog entry describes it.**

Verified against the published tarball:

```
$ npm pack @dawn-ai/postgres-storage@0.8.19 && tar -xzf *.tgz
$ cat package/dist/options.js
export {};
$ grep -rc resolvePool package/dist/*.js   # -> 0
```

`threads.js` still constructs the pool inline with no listener.

## How it happened

0.8.19 was this package's **first** release. OIDC trusted publishing cannot create a package that does not exist, so the name had to be hand-published first (GOTCHA 1/7) — and the tarball for that bootstrap was built from `changeset-release/main` at a moment when the release branch had not yet absorbed #415.

Two things then combined to hide it:

1. npm does not permit replacing an already-published version.
2. `publishRelease()` **skips** anything already on the registry:
   ```js
   const unpublished = packageStates.filter((state) => !state.versions.includes(state.version))
   ```

So the 0.8.19 release ran green, published the other 20 packages, silently skipped this one, and generated a changelog entry claiming a fix that its artifact does not have.

## This PR

The source fix is already on `main` (#415). This adds only a changeset, so the next version bump produces the first published artifact that actually carries it, and corrects the record for anyone reading the changelog.

No code change, so nothing to test beyond the existing suites; the fix itself is covered by the `pg_terminate_backend` tests added in #415, which run in both gated Postgres lanes.

## Preventing a repeat

The bootstrap step for a brand-new package should verify the tarball **contains the change it is supposed to ship**, not just that it is well-formed and non-hollow. Checking name/version/`exports`/dist-present passes happily on a stale build. Worth folding a content assertion into the bootstrap checklist.