### PR TITLE
fix(inspector): pick up the pretable 0.0.8 header theme fixes

### DIFF
--- a/.changeset/inspector-pretable-008.md
+++ b/.changeset/inspector-pretable-008.md
@@ -1,0 +1,11 @@
+---
+"@dawn-ai/inspector": patch
+---
+
+Memory Inspector: pick up the pretable 0.0.8 header theme fixes.
+
+Grid header labels were rendering in the body-cell colour, and the header's
+column dividers in a fixed colour rather than the grid's own rule token — both
+because inline styles on the header button beat the skin regardless of how it is
+layered. Headers are dimmer than cell text again, and their dividers match the
+body gridlines.

--- a/packages/inspector/package.json
+++ b/packages/inspector/package.json
@@ -37,9 +37,9 @@
   "dependencies": {
     "@dawn-ai/core": "workspace:*",
     "@dawn-ai/memory": "workspace:*",
-    "@pretable/core": "0.0.6",
-    "@pretable/react": "0.0.6",
-    "@pretable/ui": "0.0.3",
+    "@pretable/core": "0.0.8",
+    "@pretable/react": "0.0.8",
+    "@pretable/ui": "0.0.8",
     "class-variance-authority": "^0.7.1",
     "next": "16.3.0",
     "react": "19.2.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -497,14 +497,14 @@ importers:
         specifier: workspace:*
         version: link:../memory
       '@pretable/core':
-        specifier: 0.0.6
-        version: 0.0.6
+        specifier: 0.0.8
+        version: 0.0.8
       '@pretable/react':
-        specifier: 0.0.6
-        version: 0.0.6(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        specifier: 0.0.8
+        version: 0.0.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@pretable/ui':
-        specifier: 0.0.3
-        version: 0.0.3
+        specifier: 0.0.8
+        version: 0.0.8
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -2320,17 +2320,17 @@ packages:
   '@preact/signals-core@1.14.4':
     resolution: {integrity: sha512-HNB6HYeYKhQbJ1aKl+YRjrS4+QWHLKX6qKoUsfS/m0vqzsVaEBiZiaKbG/e+NKk2ch5ALQr/ihWaMHxiCuuWHA==}
 
-  '@pretable/core@0.0.6':
-    resolution: {integrity: sha512-VUCX6hef2e/ljQJqtDwIl6xnw1iy/tJdXIiR0oa0/bchADAXULNQ72AGKcthheKAzDNivCMOj7s90YYqtLoeaA==}
+  '@pretable/core@0.0.8':
+    resolution: {integrity: sha512-9S2E0hW+RncgqMeZpC5tRTfWOy2KZOIcPOP7jfj8EnVPGDL4O28AtRNItgb3+Hu2CnSfMhhuV+v2lUILyFyswA==}
 
-  '@pretable/react@0.0.6':
-    resolution: {integrity: sha512-ywKwscvWNxzBD5A8JfdQf9ko1lC1zW5uiCwjiumTP+Z9bkeepwd2ukCApLtNlMIoldhmyibiNKD3yfa73kbzBA==}
+  '@pretable/react@0.0.8':
+    resolution: {integrity: sha512-Xv+cBnfFKi+Y6BoZWe+cEu4pYCdUzv3TWTpvBFQKPyIyfLdGrlMuwdDSpYVIemrSGNPnKr7ZqH/+IRFsRSTnxQ==}
     peerDependencies:
       react: ^19.0.0
       react-dom: ^19.0.0
 
-  '@pretable/ui@0.0.3':
-    resolution: {integrity: sha512-9Ic0YE7mTxBs63sq3zLuiUn0gNvX187NwvvMXU0Tu8cCCvcOMLnKLYsMRTQWeZmi9jie4vYii07ah680VTWIPA==}
+  '@pretable/ui@0.0.8':
+    resolution: {integrity: sha512-Zdp48L6htWAR/NjR/jWA618GQVTkbbyWjqkpSz+wpnSZ1S43Wd928gFLr9We4GVSLQXhIryN3wl2/GHOwnMARw==}
 
   '@protobuf-ts/protoc@2.11.1':
     resolution: {integrity: sha512-mUZJaV0daGO6HUX90o/atzQ6A7bbN2RSuHtdwo8SSF2Qoe3zHwa4IHyCN1evftTeHfLmdz+45qo47sL+5P8nyg==}
@@ -9124,16 +9124,16 @@ snapshots:
 
   '@preact/signals-core@1.14.4': {}
 
-  '@pretable/core@0.0.6': {}
+  '@pretable/core@0.0.8': {}
 
-  '@pretable/react@0.0.6(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+  '@pretable/react@0.0.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
-      '@pretable/core': 0.0.6
-      '@pretable/ui': 0.0.3
+      '@pretable/core': 0.0.8
+      '@pretable/ui': 0.0.8
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
 
-  '@pretable/ui@0.0.3': {}
+  '@pretable/ui@0.0.8': {}
 
   '@protobuf-ts/protoc@2.11.1': {}
 


### PR DESCRIPTION
Bumps `@pretable/react`/`core`/`ui` 0.0.6 → **0.0.8**, which carries two theme fixes the Inspector was visibly missing.

Grid header labels were rendering in the **body-cell** colour rather than the header colour, and the header's column dividers in a fixed colour rather than the grid's own rule token. Both were inline styles on the header button beating the skin regardless of how it is layered.

For the record, that is a defect I contributed to leaving in place: [cacheplane/pretable#211](https://github.com/cacheplane/pretable/pull/211) fixed `display` and `align-items` in exactly that style object and left `color: inherit` sitting next to them with the identical problem. [#256](https://github.com/cacheplane/pretable/pull/256) caught it — its commit message notes the line above "had the same defect and was left behind."

## Verified in a browser on the built server

| | before | after |
|---|---|---|
| header text | `#1f1f1f` (cell colour) | **`#5c5c5c`** = `--pretable-text-header` |
| header dividers | fixed inline | **`#d4d4d4`** = `--pretable-rule`, matching body gridlines |

Also re-checked that the earlier work still holds on 0.0.8: flex columns fill exactly (1054px of columns in a 1054px viewport, no horizontal scroll), and ticking a checkbox still raises the bulk bar ("1 selected · Approve 1 · Reject 1 · Forget 1 · Clear").

`@pretable/ui` jumps 0.0.3 → 0.0.8 only because upstream aligned its public package versions in [#253](https://github.com/cacheplane/pretable/pull/253); `react@0.0.6` genuinely depended on `ui@0.0.3`, so the old pins were consistent too.

## Verification

`build` (zero warnings), `typecheck`, `lint`, 66 tests including the gated `DAWN_TEST_INSPECTOR=1` e2e.

🤖 Generated with [Claude Code](https://claude.com/claude-code)