### PR TITLE
fix(testing): remove unsupported harness modes

### DIFF
--- a/.changeset/testing-harness-mode-cleanup.md
+++ b/.changeset/testing-harness-mode-cleanup.md
@@ -1,0 +1,8 @@
+---
+"@dawn-ai/testing": patch
+---
+
+Remove the unsupported `mode` property from `createAgentHarness()` options. The
+harness remains the in-process testing API; use the existing
+`createAgentProtocolInjector()` or `createSubprocessApp()` factory when testing
+those execution boundaries.

--- a/apps/web/content/docs/testing-agents.mdx
+++ b/apps/web/content/docs/testing-agents.mdx
@@ -133,15 +133,15 @@ expectState(run).field("todos").toEqual([{ content: "ship it", status: "pending"
 
 `run.state` is the full agent state after the run — the same object a checkpointer would persist.
 
-## The three execution modes
+## Choose the execution boundary
 
-`createAgentHarness` supports three modes via the `mode` option (default: `"in-process"`):
+`@dawn-ai/testing` exposes a separate factory for each execution boundary:
 
-- **`"in-process"`** (default) — runs your tools, prompts, capabilities, and state inside the test process via Dawn's runtime. Fastest; covers the vast majority of assertions. No port binding.
-- **`"http-inject"`** — **not yet implemented**. Passing `mode: "http-inject"` throws at harness construction time. `createAgentProtocolInjector` is exported as a standalone factory for advanced use, but the harness `mode` option does not support it yet.
-- **`"subprocess"`** — **not yet implemented**. Passing `mode: "subprocess"` throws at harness construction time. `createSubprocessApp` is exported as a standalone factory for advanced use, but the harness `mode` option does not support it yet.
+- **`createAgentHarness()`** runs tools, prompts, capabilities, and state directly through Dawn's runtime in the test process. It is the default choice for fast agent-behavior tests and does not bind an application port.
+- **`createAgentProtocolInjector()`** drives Agent Protocol requests through the runtime's fetch handler without binding a port. Use it when the HTTP request, response, or SSE contract is the behavior under test.
+- **`createSubprocessApp()`** starts a real `dawn dev` child process. Use it for process-boundary, restart, and persistence tests.
 
-For now, write all harness tests with the default `"in-process"` mode. The standalone `createAgentProtocolInjector` and `createSubprocessApp` factories are available for custom orchestration outside the harness API.
+These factories deliberately have separate option and result types. Choose the factory for the boundary the test needs; `createAgentHarness()` does not accept a `mode` option.
 
 ## CI setup
 

--- a/docs/superpowers/plans/2026-08-08-testing-harness-api-cleanup.md
+++ b/docs/superpowers/plans/2026-08-08-testing-harness-api-cleanup.md
@@ -23,16 +23,24 @@
 
 The default shell may resolve Node 22, while this repository requires Node 24
 or newer. Every Node or pnpm command below is prefixed with the bundled Node 24
-runtime path so the requirement holds across separate shell calls:
+runtime path so the requirement holds across separate shell calls. Use Corepack
+to select the repository's pinned `pnpm@10.33.0`; do not put the bundled
+fallback pnpm on `PATH`, because it is a different major version.
 
 ```bash
-PATH="/Users/blove/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:/Users/blove/.cache/codex-runtimes/codex-primary-runtime/dependencies/bin/fallback:$PATH" \
+PATH="/Users/blove/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH" \
   node -e 'const major = Number(process.versions.node.split(".")[0]); if (major < 24) process.exit(1); console.log(process.version)'
+PATH="/Users/blove/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH" \
+  corepack pnpm --version
+PATH="/Users/blove/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH" \
+  corepack pnpm build
 ```
 
-Expected: prints a version beginning with `v24` or newer. If the bundled path
-changes, call the workspace dependency loader again and substitute the returned
-Node and fallback-bin paths before continuing.
+Expected: prints a Node version beginning with `v24` or newer, prints pnpm
+`10.33.0`, and completes a fresh full workspace build. The build is required
+before the red contract test because workspace packages resolve gitignored
+`dist/` output. If the bundled Node path changes, call the workspace dependency
+loader again and substitute the returned Node path before continuing.
 
 ### Task 1: Remove the unsupported harness option
 
@@ -71,8 +79,8 @@ The existing `packages/testing/tsconfig.contracts.json` already includes
 Run:
 
 ```bash
-PATH="/Users/blove/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:/Users/blove/.cache/codex-runtimes/codex-primary-runtime/dependencies/bin/fallback:$PATH" \
-  pnpm --filter @dawn-ai/testing typecheck
+PATH="/Users/blove/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH" \
+  corepack pnpm --filter @dawn-ai/testing typecheck
 ```
 
 Expected: FAIL with TypeScript `TS2578` on the unused `@ts-expect-error`, proving
@@ -104,10 +112,10 @@ or wiring to the two standalone factories.
 Run:
 
 ```bash
-PATH="/Users/blove/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:/Users/blove/.cache/codex-runtimes/codex-primary-runtime/dependencies/bin/fallback:$PATH" \
-  pnpm --filter @dawn-ai/testing typecheck
-PATH="/Users/blove/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:/Users/blove/.cache/codex-runtimes/codex-primary-runtime/dependencies/bin/fallback:$PATH" \
-  pnpm --filter @dawn-ai/testing test harness-construct
+PATH="/Users/blove/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH" \
+  corepack pnpm --filter @dawn-ai/testing typecheck
+PATH="/Users/blove/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH" \
+  corepack pnpm --filter @dawn-ai/testing test harness-construct
 ```
 
 Expected: both commands PASS. The type lane consumes the `@ts-expect-error`, and
@@ -196,12 +204,12 @@ First rerun the stale-claim search from Step 1. Expected: no matches.
 Run:
 
 ```bash
-rg -n 'three execution modes|mode.*http-inject|mode.*subprocess|default.*in-process|not yet implemented' \
+! rg -n 'three execution modes|mode.*http-inject|mode.*subprocess|default.*in-process|not yet implemented' \
   packages/testing/README.md apps/web/content/docs/testing-agents.mdx
-PATH="/Users/blove/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:/Users/blove/.cache/codex-runtimes/codex-primary-runtime/dependencies/bin/fallback:$PATH" \
-  pnpm --filter @dawn-ai/cli build
-rg -n 'Choose the execution boundary|does not accept a `mode` option' \
-  packages/cli/docs/testing-agents.md
+PATH="/Users/blove/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH" \
+  corepack pnpm --filter @dawn-ai/cli build
+rg -n 'Choose the execution boundary' packages/cli/docs/testing-agents.md
+rg -n 'does not accept a `mode` option' packages/cli/docs/testing-agents.md
 git check-ignore packages/cli/docs/testing-agents.md
 git status --short
 ```
@@ -209,17 +217,15 @@ git status --short
 Expected: the generated guide contains the new section, `git check-ignore`
 prints the path, and `git status` does not list `packages/cli/docs/`.
 
-- [ ] **Step 6: Run documentation and release checks**
+- [ ] **Step 6: Run documentation checks**
 
 Run:
 
 ```bash
-PATH="/Users/blove/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:/Users/blove/.cache/codex-runtimes/codex-primary-runtime/dependencies/bin/fallback:$PATH" \
-  pnpm --filter @dawn-ai/cli test docs-bundle
-PATH="/Users/blove/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:/Users/blove/.cache/codex-runtimes/codex-primary-runtime/dependencies/bin/fallback:$PATH" \
+PATH="/Users/blove/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH" \
+  corepack pnpm --filter @dawn-ai/cli test docs-bundle
+PATH="/Users/blove/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH" \
   node scripts/check-docs.mjs
-PATH="/Users/blove/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:/Users/blove/.cache/codex-runtimes/codex-primary-runtime/dependencies/bin/fallback:$PATH" \
-  node scripts/check-changesets.mjs
 ```
 
 Expected: all commands PASS.
@@ -231,6 +237,18 @@ git add packages/testing/README.md apps/web/content/docs/testing-agents.mdx \
   .changeset/testing-harness-mode-cleanup.md
 git commit -m "docs(testing): clarify harness execution boundaries"
 ```
+
+- [ ] **Step 8: Verify the committed changeset**
+
+Run after Step 7 because `check-changesets.mjs` compares committed changes to
+`origin/main`:
+
+```bash
+PATH="/Users/blove/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH" \
+  node scripts/check-changesets.mjs
+```
+
+Expected: PASS and report the committed patch changeset.
 
 ### Task 3: Complete verification
 
@@ -246,14 +264,14 @@ Rerun the execution-prerequisite version check before final verification.
 Run:
 
 ```bash
-PATH="/Users/blove/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:/Users/blove/.cache/codex-runtimes/codex-primary-runtime/dependencies/bin/fallback:$PATH" \
-  pnpm --filter @dawn-ai/testing build
-PATH="/Users/blove/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:/Users/blove/.cache/codex-runtimes/codex-primary-runtime/dependencies/bin/fallback:$PATH" \
-  pnpm --filter @dawn-ai/testing typecheck
-PATH="/Users/blove/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:/Users/blove/.cache/codex-runtimes/codex-primary-runtime/dependencies/bin/fallback:$PATH" \
-  pnpm --filter @dawn-ai/testing lint
-PATH="/Users/blove/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:/Users/blove/.cache/codex-runtimes/codex-primary-runtime/dependencies/bin/fallback:$PATH" \
-  pnpm --filter @dawn-ai/testing test
+PATH="/Users/blove/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH" \
+  corepack pnpm --filter @dawn-ai/testing build
+PATH="/Users/blove/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH" \
+  corepack pnpm --filter @dawn-ai/testing typecheck
+PATH="/Users/blove/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH" \
+  corepack pnpm --filter @dawn-ai/testing lint
+PATH="/Users/blove/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH" \
+  corepack pnpm --filter @dawn-ai/testing test
 ```
 
 Expected: all commands PASS.
@@ -263,8 +281,8 @@ Expected: all commands PASS.
 Run:
 
 ```bash
-PATH="/Users/blove/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:/Users/blove/.cache/codex-runtimes/codex-primary-runtime/dependencies/bin/fallback:$PATH" \
-  pnpm ci:validate
+PATH="/Users/blove/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH" \
+  corepack pnpm ci:validate
 ```
 
 Expected: lint, build-cache, build, typecheck, tests, documentation, package,

--- a/docs/superpowers/plans/2026-08-08-testing-harness-api-cleanup.md
+++ b/docs/superpowers/plans/2026-08-08-testing-harness-api-cleanup.md
@@ -1,0 +1,251 @@
+# Testing Harness API Cleanup Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove the unsupported `mode` option from `createAgentHarness()` so the public TypeScript API exposes only the in-process behavior it implements.
+
+**Architecture:** Keep `createAgentHarness()`, `createAgentProtocolInjector()`, and `createSubprocessApp()` as three explicit factories with distinct options and lifecycles. Enforce the cleanup at compile time through the package's existing contract-test lane, update the authoritative website documentation, and regenerate the gitignored CLI documentation only for verification.
+
+**Tech Stack:** TypeScript, pnpm, Vitest, TypeScript contract tests, Changesets, generated Markdown docs
+
+---
+
+## File Structure
+
+- `packages/testing/src/harness.ts` owns `AgentHarnessOptions` and the in-process harness implementation.
+- `packages/testing/test/harness-options.contract.ts` proves the public export rejects the removed option.
+- `packages/testing/README.md` documents the package-level API groups.
+- `apps/web/content/docs/testing-agents.mdx` is the authoritative user guide.
+- `packages/cli/docs/testing-agents.md` is gitignored generated output used only during verification.
+- `.changeset/testing-harness-mode-cleanup.md` records the user-facing patch release.
+
+### Task 1: Remove the unsupported harness option
+
+**Files:**
+- Create: `packages/testing/test/harness-options.contract.ts`
+- Modify: `packages/testing/src/harness.ts`
+
+- [ ] **Step 1: Write the failing public contract test**
+
+Create `packages/testing/test/harness-options.contract.ts`:
+
+```ts
+import type { AgentHarnessOptions } from "../src/index.js"
+
+const validOptions: AgentHarnessOptions = {
+  appRoot: "/tmp/dawn-app",
+  route: "/chat#agent",
+}
+
+const removedMode: AgentHarnessOptions = {
+  appRoot: "/tmp/dawn-app",
+  route: "/chat#agent",
+  // @ts-expect-error createAgentHarness has no transport or process mode.
+  mode: "http-inject",
+}
+
+void validOptions
+void removedMode
+```
+
+The existing `packages/testing/tsconfig.contracts.json` already includes
+`test/*.contract.ts`; do not modify its include list.
+
+- [ ] **Step 2: Run the contract lane and confirm it fails for the intended reason**
+
+Run:
+
+```bash
+pnpm --filter @dawn-ai/testing typecheck
+```
+
+Expected: FAIL with TypeScript `TS2578` on the unused `@ts-expect-error`, proving
+the current public type still accepts `mode`.
+
+- [ ] **Step 3: Remove the unsupported option and runtime branch**
+
+In `packages/testing/src/harness.ts`, remove this field from
+`AgentHarnessOptions`:
+
+```ts
+readonly mode?: "in-process" | "http-inject" | "subprocess"
+```
+
+Remove this block from the start of `createAgentHarness()`:
+
+```ts
+const mode = options.mode ?? "in-process"
+if (mode !== "in-process") {
+  throw new Error(`createAgentHarness: mode "${mode}" not yet implemented`)
+}
+```
+
+Do not add unknown-property runtime parsing, an overload, a deprecated alias,
+or wiring to the two standalone factories.
+
+- [ ] **Step 4: Run focused verification**
+
+Run:
+
+```bash
+pnpm --filter @dawn-ai/testing typecheck
+pnpm --filter @dawn-ai/testing test -- harness-construct
+```
+
+Expected: both commands PASS. The type lane consumes the `@ts-expect-error`, and
+the existing harness construction test confirms the supported path still works.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/testing/src/harness.ts packages/testing/test/harness-options.contract.ts
+git commit -m "fix(testing): remove unsupported harness modes"
+```
+
+### Task 2: Document the three explicit factories
+
+**Files:**
+- Modify: `packages/testing/README.md`
+- Modify: `apps/web/content/docs/testing-agents.mdx`
+- Create: `.changeset/testing-harness-mode-cleanup.md`
+- Generate only: `packages/cli/docs/testing-agents.md`
+
+- [ ] **Step 1: Confirm the stale claims exist**
+
+Run:
+
+```bash
+rg -n 'three execution modes|mode.*http-inject|mode.*subprocess|default.*in-process|not yet implemented' \
+  packages/testing/README.md apps/web/content/docs/testing-agents.mdx
+```
+
+Expected: matches in both documents describing the unsupported `mode` values.
+
+- [ ] **Step 2: Rewrite the website guide around execution boundaries**
+
+Replace the `## The three execution modes` section in
+`apps/web/content/docs/testing-agents.mdx` with:
+
+```md
+## Choose the execution boundary
+
+`@dawn-ai/testing` exposes a separate factory for each execution boundary:
+
+- **`createAgentHarness()`** runs tools, prompts, capabilities, and state directly through Dawn's runtime in the test process. It is the default choice for fast agent-behavior tests and does not bind an application port.
+- **`createAgentProtocolInjector()`** drives Agent Protocol requests through the runtime's fetch handler without binding a port. Use it when the HTTP request, response, or SSE contract is the behavior under test.
+- **`createSubprocessApp()`** starts a real `dawn dev` child process. Use it for process-boundary, restart, and persistence tests.
+
+These factories deliberately have separate option and result types. Choose the factory for the boundary the test needs; `createAgentHarness()` does not accept a `mode` option.
+```
+
+- [ ] **Step 3: Correct the package README**
+
+Replace the paragraph below `### Harnesses and protocol helpers` in
+`packages/testing/README.md` with:
+
+```md
+`createAgentHarness()` is the deterministic in-process agent harness.
+`createAgentProtocolInjector()` drives the Agent Protocol fetch boundary without
+opening a port, and `createSubprocessApp()` starts a real `dawn dev` process.
+Each factory has its own options, result, and lifecycle contract; select the
+factory for the boundary the test needs.
+```
+
+- [ ] **Step 4: Add the patch changeset**
+
+Create `.changeset/testing-harness-mode-cleanup.md`:
+
+```md
+---
+"@dawn-ai/testing": patch
+---
+
+Remove the unsupported `mode` property from `createAgentHarness()` options. The
+harness remains the in-process testing API; use the existing
+`createAgentProtocolInjector()` or `createSubprocessApp()` factory when testing
+those execution boundaries.
+```
+
+Do not use a minor changeset: Dawn's fixed 0.x group would advance to 1.0.0.
+
+- [ ] **Step 5: Generate and inspect the CLI docs without committing them**
+
+Run:
+
+```bash
+pnpm --filter @dawn-ai/cli build
+rg -n 'Choose the execution boundary|does not accept a `mode` option' \
+  packages/cli/docs/testing-agents.md
+git check-ignore packages/cli/docs/testing-agents.md
+git status --short
+```
+
+Expected: the generated guide contains the new section, `git check-ignore`
+prints the path, and `git status` does not list `packages/cli/docs/`.
+
+- [ ] **Step 6: Run documentation and release checks**
+
+Run:
+
+```bash
+pnpm --filter @dawn-ai/cli test -- docs-bundle
+node scripts/check-docs.mjs
+node scripts/check-changesets.mjs
+```
+
+Expected: all commands PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/testing/README.md apps/web/content/docs/testing-agents.mdx \
+  .changeset/testing-harness-mode-cleanup.md
+git commit -m "docs(testing): clarify harness execution boundaries"
+```
+
+### Task 3: Complete verification
+
+**Files:**
+- Verify only; no expected source changes
+
+- [ ] **Step 1: Use the repository-supported Node runtime**
+
+Load the workspace's configured dependencies and confirm Node is version 24 or
+newer before final verification. Do not rely on a Node 22 shell override.
+
+- [ ] **Step 2: Run package gates**
+
+Run:
+
+```bash
+pnpm --filter @dawn-ai/testing build
+pnpm --filter @dawn-ai/testing typecheck
+pnpm --filter @dawn-ai/testing lint
+pnpm --filter @dawn-ai/testing test
+```
+
+Expected: all commands PASS.
+
+- [ ] **Step 3: Run the repository Definition of Done**
+
+Run:
+
+```bash
+pnpm ci:validate
+```
+
+Expected: lint, build-cache, build, typecheck, tests, documentation, package,
+release-script, and harness verification all PASS.
+
+- [ ] **Step 4: Inspect the final branch**
+
+Run:
+
+```bash
+git diff --check origin/main...HEAD
+git status --short --branch
+git log --oneline origin/main..HEAD
+```
+
+Expected: no whitespace errors, a clean worktree, and only the approved spec,
+plan, API cleanup, contract test, docs, and changeset commits.

--- a/docs/superpowers/plans/2026-08-08-testing-harness-api-cleanup.md
+++ b/docs/superpowers/plans/2026-08-08-testing-harness-api-cleanup.md
@@ -19,6 +19,21 @@
 - `packages/cli/docs/testing-agents.md` is gitignored generated output used only during verification.
 - `.changeset/testing-harness-mode-cleanup.md` records the user-facing patch release.
 
+## Execution Prerequisite
+
+The default shell may resolve Node 22, while this repository requires Node 24
+or newer. Every Node or pnpm command below is prefixed with the bundled Node 24
+runtime path so the requirement holds across separate shell calls:
+
+```bash
+PATH="/Users/blove/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:/Users/blove/.cache/codex-runtimes/codex-primary-runtime/dependencies/bin/fallback:$PATH" \
+  node -e 'const major = Number(process.versions.node.split(".")[0]); if (major < 24) process.exit(1); console.log(process.version)'
+```
+
+Expected: prints a version beginning with `v24` or newer. If the bundled path
+changes, call the workspace dependency loader again and substitute the returned
+Node and fallback-bin paths before continuing.
+
 ### Task 1: Remove the unsupported harness option
 
 **Files:**
@@ -56,7 +71,8 @@ The existing `packages/testing/tsconfig.contracts.json` already includes
 Run:
 
 ```bash
-pnpm --filter @dawn-ai/testing typecheck
+PATH="/Users/blove/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:/Users/blove/.cache/codex-runtimes/codex-primary-runtime/dependencies/bin/fallback:$PATH" \
+  pnpm --filter @dawn-ai/testing typecheck
 ```
 
 Expected: FAIL with TypeScript `TS2578` on the unused `@ts-expect-error`, proving
@@ -88,8 +104,10 @@ or wiring to the two standalone factories.
 Run:
 
 ```bash
-pnpm --filter @dawn-ai/testing typecheck
-pnpm --filter @dawn-ai/testing test -- harness-construct
+PATH="/Users/blove/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:/Users/blove/.cache/codex-runtimes/codex-primary-runtime/dependencies/bin/fallback:$PATH" \
+  pnpm --filter @dawn-ai/testing typecheck
+PATH="/Users/blove/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:/Users/blove/.cache/codex-runtimes/codex-primary-runtime/dependencies/bin/fallback:$PATH" \
+  pnpm --filter @dawn-ai/testing test harness-construct
 ```
 
 Expected: both commands PASS. The type lane consumes the `@ts-expect-error`, and
@@ -115,8 +133,11 @@ git commit -m "fix(testing): remove unsupported harness modes"
 Run:
 
 ```bash
-rg -n 'three execution modes|mode.*http-inject|mode.*subprocess|default.*in-process|not yet implemented' \
-  packages/testing/README.md apps/web/content/docs/testing-agents.mdx
+if rg -n 'three execution modes|mode.*http-inject|mode.*subprocess|default.*in-process|not yet implemented' \
+  packages/testing/README.md apps/web/content/docs/testing-agents.mdx; then
+  echo "stale harness-mode documentation remains" >&2
+  exit 1
+fi
 ```
 
 Expected: matches in both documents describing the unsupported `mode` values.
@@ -170,10 +191,15 @@ Do not use a minor changeset: Dawn's fixed 0.x group would advance to 1.0.0.
 
 - [ ] **Step 5: Generate and inspect the CLI docs without committing them**
 
+First rerun the stale-claim search from Step 1. Expected: no matches.
+
 Run:
 
 ```bash
-pnpm --filter @dawn-ai/cli build
+rg -n 'three execution modes|mode.*http-inject|mode.*subprocess|default.*in-process|not yet implemented' \
+  packages/testing/README.md apps/web/content/docs/testing-agents.mdx
+PATH="/Users/blove/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:/Users/blove/.cache/codex-runtimes/codex-primary-runtime/dependencies/bin/fallback:$PATH" \
+  pnpm --filter @dawn-ai/cli build
 rg -n 'Choose the execution boundary|does not accept a `mode` option' \
   packages/cli/docs/testing-agents.md
 git check-ignore packages/cli/docs/testing-agents.md
@@ -188,9 +214,12 @@ prints the path, and `git status` does not list `packages/cli/docs/`.
 Run:
 
 ```bash
-pnpm --filter @dawn-ai/cli test -- docs-bundle
-node scripts/check-docs.mjs
-node scripts/check-changesets.mjs
+PATH="/Users/blove/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:/Users/blove/.cache/codex-runtimes/codex-primary-runtime/dependencies/bin/fallback:$PATH" \
+  pnpm --filter @dawn-ai/cli test docs-bundle
+PATH="/Users/blove/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:/Users/blove/.cache/codex-runtimes/codex-primary-runtime/dependencies/bin/fallback:$PATH" \
+  node scripts/check-docs.mjs
+PATH="/Users/blove/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:/Users/blove/.cache/codex-runtimes/codex-primary-runtime/dependencies/bin/fallback:$PATH" \
+  node scripts/check-changesets.mjs
 ```
 
 Expected: all commands PASS.
@@ -208,20 +237,23 @@ git commit -m "docs(testing): clarify harness execution boundaries"
 **Files:**
 - Verify only; no expected source changes
 
-- [ ] **Step 1: Use the repository-supported Node runtime**
+- [ ] **Step 1: Reconfirm the repository-supported Node runtime**
 
-Load the workspace's configured dependencies and confirm Node is version 24 or
-newer before final verification. Do not rely on a Node 22 shell override.
+Rerun the execution-prerequisite version check before final verification.
 
 - [ ] **Step 2: Run package gates**
 
 Run:
 
 ```bash
-pnpm --filter @dawn-ai/testing build
-pnpm --filter @dawn-ai/testing typecheck
-pnpm --filter @dawn-ai/testing lint
-pnpm --filter @dawn-ai/testing test
+PATH="/Users/blove/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:/Users/blove/.cache/codex-runtimes/codex-primary-runtime/dependencies/bin/fallback:$PATH" \
+  pnpm --filter @dawn-ai/testing build
+PATH="/Users/blove/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:/Users/blove/.cache/codex-runtimes/codex-primary-runtime/dependencies/bin/fallback:$PATH" \
+  pnpm --filter @dawn-ai/testing typecheck
+PATH="/Users/blove/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:/Users/blove/.cache/codex-runtimes/codex-primary-runtime/dependencies/bin/fallback:$PATH" \
+  pnpm --filter @dawn-ai/testing lint
+PATH="/Users/blove/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:/Users/blove/.cache/codex-runtimes/codex-primary-runtime/dependencies/bin/fallback:$PATH" \
+  pnpm --filter @dawn-ai/testing test
 ```
 
 Expected: all commands PASS.
@@ -231,7 +263,8 @@ Expected: all commands PASS.
 Run:
 
 ```bash
-pnpm ci:validate
+PATH="/Users/blove/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:/Users/blove/.cache/codex-runtimes/codex-primary-runtime/dependencies/bin/fallback:$PATH" \
+  pnpm ci:validate
 ```
 
 Expected: lint, build-cache, build, typecheck, tests, documentation, package,

--- a/docs/superpowers/specs/2026-08-07-testing-harness-api-cleanup-design.md
+++ b/docs/superpowers/specs/2026-08-07-testing-harness-api-cleanup-design.md
@@ -1,0 +1,125 @@
+# Testing Harness API Cleanup Design
+
+**Status:** Approved 2026-08-07
+
+## Summary
+
+`createAgentHarness()` only implements in-process execution, but its public
+`AgentHarnessOptions` type also accepts `"http-inject"` and `"subprocess"`.
+Those values compile and then fail during construction. Remove the `mode`
+option entirely so the TypeScript surface describes the behavior Dawn actually
+supports.
+
+The existing `createAgentProtocolInjector()` and `createSubprocessApp()`
+factories remain the canonical APIs for their respective execution paths. Dawn
+does not add a compatibility overload, deprecation period, or unified adapter.
+
+## Goals
+
+- Make unsupported harness modes impossible to express through the public
+  `createAgentHarness()` type.
+- Keep each testing factory aligned with one lifecycle and execution model.
+- Preserve the working protocol-injection and subprocess helpers unchanged.
+- Document the three APIs as separate tools rather than incomplete modes of one
+  abstraction.
+
+## Non-Goals
+
+- Integrating protocol injection or subprocess execution into
+  `createAgentHarness()`.
+- Renaming or changing `createAgentProtocolInjector()` or
+  `createSubprocessApp()`.
+- Per-scenario tool mocking.
+- Kubernetes compatibility testing or chart hardening.
+- Backwards compatibility for `AgentHarnessOptions.mode`.
+
+## Public API
+
+`AgentHarnessOptions` changes from:
+
+```ts
+export interface AgentHarnessOptions {
+  readonly appRoot: string
+  readonly route: string
+  readonly fixtures?: FixtureSet
+  readonly mode?: "in-process" | "http-inject" | "subprocess"
+  // ...
+}
+```
+
+to:
+
+```ts
+export interface AgentHarnessOptions {
+  readonly appRoot: string
+  readonly route: string
+  readonly fixtures?: FixtureSet
+  // ...
+}
+```
+
+`createAgentHarness()` no longer branches on `options.mode` or throws the
+`mode ... not yet implemented` error. Its name and documentation define it as
+the deterministic in-process agent harness.
+
+The following exports remain unchanged:
+
+```ts
+createAgentProtocolInjector(options)
+createSubprocessApp(options)
+```
+
+Callers that need those lower-level paths choose the corresponding factory
+directly. The APIs do not share an options union because their configuration,
+results, and lifecycle responsibilities differ.
+
+## Validation And Failure Behavior
+
+The unsupported configuration moves from a runtime failure to a compile-time
+failure. A contract test constructs valid `AgentHarnessOptions` and uses
+`@ts-expect-error` on an object containing `mode`. The package's existing
+`tsconfig.contracts.json` lane verifies the rejection.
+
+JavaScript callers do not receive a special runtime unknown-property check.
+Like other structural TypeScript options, an extra property is ignored at
+runtime. Adding schema parsing only for this removed field would create a new
+validation model and is outside this cleanup.
+
+## Documentation
+
+Update `packages/testing/README.md` to state that `createAgentHarness()` is
+in-process without referring to a default mode or future mode integration.
+Document `createAgentProtocolInjector()` and `createSubprocessApp()` as explicit
+lower-level factories for protocol and process-boundary testing.
+
+The website and mirrored CLI testing guide currently describe unsupported
+mode values. Remove that mode list and replace it with the same three-API model.
+Keep the mirrored files textually aligned.
+
+## Files
+
+- Modify `packages/testing/src/harness.ts` to remove the option and runtime
+  branch.
+- Create `packages/testing/test/harness-options.contract.ts` for the public type
+  contract.
+- Modify `packages/testing/README.md`.
+- Modify `apps/web/content/docs/testing-agents.mdx` and its mirrored
+  `packages/cli/docs/testing-agents.md` copy.
+- Add a patch changeset for `@dawn-ai/testing`.
+
+## Testing
+
+1. Demonstrate the contract test fails before implementation because `mode` is
+   still accepted.
+2. Remove the field and runtime branch; rerun the contract lane to pass.
+3. Run `@dawn-ai/testing` build, typecheck, lint, and test commands.
+4. Run the documentation guard and verify the two testing-agent guides remain
+   synchronized.
+5. Run the repository Definition of Done before publishing the PR.
+
+## Release
+
+Add a patch changeset for `@dawn-ai/testing`. Dawn's fixed 0.x release group
+must remain on the 0.8.x line, so this change does not use a minor changeset.
+The release note should state directly that the unsupported `mode` property was
+removed and point users to the existing dedicated factories.

--- a/docs/superpowers/specs/2026-08-07-testing-harness-api-cleanup-design.md
+++ b/docs/superpowers/specs/2026-08-07-testing-harness-api-cleanup-design.md
@@ -92,19 +92,24 @@ in-process without referring to a default mode or future mode integration.
 Document `createAgentProtocolInjector()` and `createSubprocessApp()` as explicit
 lower-level factories for protocol and process-boundary testing.
 
-The website and mirrored CLI testing guide currently describe unsupported
-mode values. Remove that mode list and replace it with the same three-API model.
-Keep the mirrored files textually aligned.
+The website testing guide currently describes unsupported mode values. Remove
+that mode list and replace it with the same three-API model in
+`apps/web/content/docs/testing-agents.mdx`, then run the existing CLI docs
+generator to update `packages/cli/docs/testing-agents.md`. The generated copy
+is not textually identical because the generator removes website-only
+`RelatedCards`; verification must use the established generation and docs-
+bundle checks rather than a literal file comparison.
 
 ## Files
 
 - Modify `packages/testing/src/harness.ts` to remove the option and runtime
   branch.
 - Create `packages/testing/test/harness-options.contract.ts` for the public type
-  contract.
+  contract, importing `AgentHarnessOptions` through `../src/index.js` so the
+  test exercises the package's public export surface.
 - Modify `packages/testing/README.md`.
-- Modify `apps/web/content/docs/testing-agents.mdx` and its mirrored
-  `packages/cli/docs/testing-agents.md` copy.
+- Modify `apps/web/content/docs/testing-agents.mdx`, then regenerate
+  `packages/cli/docs/testing-agents.md` with the existing CLI docs generator.
 - Add a patch changeset for `@dawn-ai/testing`.
 
 ## Testing
@@ -113,8 +118,9 @@ Keep the mirrored files textually aligned.
    still accepted.
 2. Remove the field and runtime branch; rerun the contract lane to pass.
 3. Run `@dawn-ai/testing` build, typecheck, lint, and test commands.
-4. Run the documentation guard and verify the two testing-agent guides remain
-   synchronized.
+4. Run the CLI docs generator, documentation bundle tests, and documentation
+   guard to verify the generated testing-agent guide matches the supported
+   source transformation.
 5. Run the repository Definition of Done before publishing the PR.
 
 ## Release

--- a/docs/superpowers/specs/2026-08-07-testing-harness-api-cleanup-design.md
+++ b/docs/superpowers/specs/2026-08-07-testing-harness-api-cleanup-design.md
@@ -98,7 +98,8 @@ that mode list and replace it with the same three-API model in
 generator to update `packages/cli/docs/testing-agents.md`. The generated copy
 is not textually identical because the generator removes website-only
 `RelatedCards`; verification must use the established generation and docs-
-bundle checks rather than a literal file comparison.
+bundle checks rather than a literal file comparison. `packages/cli/docs/` is
+gitignored build output: regenerate it for verification, but do not commit it.
 
 ## Files
 
@@ -109,7 +110,8 @@ bundle checks rather than a literal file comparison.
   test exercises the package's public export surface.
 - Modify `packages/testing/README.md`.
 - Modify `apps/web/content/docs/testing-agents.mdx`, then regenerate
-  `packages/cli/docs/testing-agents.md` with the existing CLI docs generator.
+  the gitignored `packages/cli/docs/testing-agents.md` with the existing CLI
+  docs generator for verification only.
 - Add a patch changeset for `@dawn-ai/testing`.
 
 ## Testing

--- a/packages/testing/README.md
+++ b/packages/testing/README.md
@@ -76,10 +76,11 @@ Supporting types include `InterruptInfo`, `SubagentEvent`, `SubagentRun`, and
 - Types include `ToolHarness`, `WorkspaceHarness`, `MiddlewareHarness`,
   `AgentProtocolInjector`, `InjectResult`, and `SubprocessApp`.
 
-The default `createAgentHarness` mode is in-process. The exported protocol and
-subprocess helpers are available for custom orchestration; the harness mode
-options for those paths are intentionally limited until their integrations are
-fully wired.
+`createAgentHarness()` is the deterministic in-process agent harness.
+`createAgentProtocolInjector()` drives the Agent Protocol fetch boundary without
+opening a port, and `createSubprocessApp()` starts a real `dawn dev` process.
+Each factory has its own options, result, and lifecycle contract; select the
+factory for the boundary the test needs.
 
 ### Memory
 

--- a/packages/testing/src/harness.ts
+++ b/packages/testing/src/harness.ts
@@ -47,7 +47,6 @@ export interface AgentHarnessOptions {
   readonly appRoot: string
   readonly route: string
   readonly fixtures?: FixtureSet
-  readonly mode?: "in-process" | "http-inject" | "subprocess"
   /**
    * When true, proxy all LLM requests through a real upstream (OPENAI_API_KEY
    * must be set). Requires OPENAI_API_KEY to be present in the environment.
@@ -74,11 +73,6 @@ export interface AgentHarness {
 }
 
 export async function createAgentHarness(options: AgentHarnessOptions): Promise<AgentHarness> {
-  const mode = options.mode ?? "in-process"
-  if (mode !== "in-process") {
-    throw new Error(`createAgentHarness: mode "${mode}" not yet implemented`)
-  }
-
   const live = options.live ?? false
   const record = options.record ?? false
 

--- a/packages/testing/test/harness-options.contract.ts
+++ b/packages/testing/test/harness-options.contract.ts
@@ -1,0 +1,16 @@
+import type { AgentHarnessOptions } from "../src/index.js"
+
+const validOptions: AgentHarnessOptions = {
+  appRoot: "/tmp/dawn-app",
+  route: "/chat#agent",
+}
+
+const removedMode: AgentHarnessOptions = {
+  appRoot: "/tmp/dawn-app",
+  route: "/chat#agent",
+  // @ts-expect-error createAgentHarness has no transport or process mode.
+  mode: "http-inject",
+}
+
+void validOptions
+void removedMode


### PR DESCRIPTION
## Summary
- remove the unsupported `mode` option from `createAgentHarness`
- keep protocol injection and subprocess testing as separate explicit factories
- add a public type contract, docs, and patch changeset

## Root Cause
`AgentHarnessOptions` accepted `http-inject` and `subprocess` even though both values failed at runtime. The public type exposed an API the implementation did not support.

## Validation
- `pnpm --filter @dawn-ai/testing build`
- `pnpm --filter @dawn-ai/testing typecheck`
- `pnpm --filter @dawn-ai/testing lint`
- `pnpm --filter @dawn-ai/testing test`
- `pnpm ci:validate`