### PR TITLE
fix(cli): cache bundled documentation correctly

### DIFF
--- a/.changeset/bright-docs-cache.md
+++ b/.changeset/bright-docs-cache.md
@@ -1,0 +1,5 @@
+---
+"@dawn-ai/cli": patch
+---
+
+Invalidate and restore the CLI's bundled documentation correctly through the Turbo build cache.

--- a/docs/superpowers/plans/2026-08-09-cli-docs-turbo-cache.md
+++ b/docs/superpowers/plans/2026-08-09-cli-docs-turbo-cache.md
@@ -16,7 +16,7 @@
 - Modify: `scripts/check-build-cache-config.mjs`
 - Test: `scripts/check-build-cache-config.mjs` through `pnpm check:build-cache`
 
-- [ ] **Step 1: Add effective-task inspection**
+- [x] **Step 1: Add effective-task inspection**
 
 Import `execFileSync` from `node:child_process`. Add paths for the CLI package,
 website docs source, navigation file, and local Turbo binary:
@@ -30,7 +30,7 @@ const turboPath = join(repoRoot, "node_modules", ".bin", "turbo")
 
 Add a recursive MDX inventory helper using `readdirSync(..., { withFileTypes: true })` and a normalizer that resolves Turbo input keys relative to `cliRoot` before converting them to repository-relative POSIX paths.
 
-- [ ] **Step 2: Parse the effective CLI build task**
+- [x] **Step 2: Parse the effective CLI build task**
 
 Run Turbo without executing the build:
 
@@ -65,7 +65,7 @@ pnpm check:build-cache
 
 Expected: FAIL. The output identifies all website MDX inputs, the navigation input, and `docs/**` as missing. `packages/cli/src/index.ts` and `dist/**` should already be present, proving the default inputs and existing output are visible.
 
-- [ ] **Step 4: Commit the red guard**
+- [x] **Step 4: Commit the red guard**
 
 ```bash
 git add scripts/check-build-cache-config.mjs
@@ -78,7 +78,7 @@ git commit -m "test(cli): guard bundled docs cache contract"
 - Modify: `turbo.json`
 - Test: `scripts/check-build-cache-config.mjs` through `pnpm check:build-cache`
 
-- [ ] **Step 1: Add the package-qualified build task**
+- [x] **Step 1: Add the package-qualified build task**
 
 Add this sibling of the generic `build` task:
 
@@ -94,7 +94,7 @@ Add this sibling of the generic `build` task:
 }
 ```
 
-- [ ] **Step 2: Run the guard and verify GREEN**
+- [x] **Step 2: Run the guard and verify GREEN**
 
 ```bash
 pnpm check:build-cache
@@ -102,7 +102,7 @@ pnpm check:build-cache
 
 Expected: PASS. The success message states that the generic `dist/**` contract and CLI bundled-docs contract were checked.
 
-- [ ] **Step 3: Inspect the effective task**
+- [x] **Step 3: Inspect the effective task**
 
 ```bash
 pnpm exec turbo run build --filter=@dawn-ai/cli --dry=json
@@ -110,7 +110,7 @@ pnpm exec turbo run build --filter=@dawn-ai/cli --dry=json
 
 Expected: `@dawn-ai/cli#build` contains all 42 current MDX files and the navigation file in `inputs`, retains `src/index.ts`, and lists `dist/**` plus `docs/**` in outputs.
 
-- [ ] **Step 4: Commit the configuration fix**
+- [x] **Step 4: Commit the configuration fix**
 
 ```bash
 git add turbo.json
@@ -123,7 +123,7 @@ git commit -m "fix(cli): cache generated documentation"
 - Generated then remove/restore: `packages/cli/docs/**`
 - Verify: `turbo.json`
 
-- [ ] **Step 1: Populate a fresh cache entry with generated docs**
+- [x] **Step 1: Populate a fresh cache entry with generated docs**
 
 ```bash
 pnpm exec turbo run build --filter=@dawn-ai/cli... --force
@@ -131,7 +131,7 @@ pnpm exec turbo run build --filter=@dawn-ai/cli... --force
 
 Expected: the CLI build executes and writes 42 topics plus `README.md`; `packages/cli/docs/README.md` exists.
 
-- [ ] **Step 2: Remove only the generated docs output**
+- [x] **Step 2: Remove only the generated docs output**
 
 Validate the exact target, then remove it:
 
@@ -143,7 +143,7 @@ test ! -d packages/cli/docs
 
 Expected: the gitignored generated directory is absent; tracked files are untouched.
 
-- [ ] **Step 3: Restore from an unchanged cache hit**
+- [x] **Step 3: Restore from an unchanged cache hit**
 
 ```bash
 pnpm exec turbo run build --filter=@dawn-ai/cli...
@@ -154,7 +154,7 @@ test -f packages/cli/docs/tools.md
 
 Expected: Turbo reports cache hits, and representative bundled docs are restored without executing the generator.
 
-- [ ] **Step 4: Confirm no generated files are tracked**
+- [x] **Step 4: Confirm no generated files are tracked**
 
 ```bash
 git status --short
@@ -169,7 +169,7 @@ Expected: `packages/cli/docs/**` does not appear; it remains gitignored.
 - Verify: `scripts/check-build-cache-config.mjs`
 - Verify: `turbo.json`
 
-- [ ] **Step 1: Add a patch changeset**
+- [x] **Step 1: Add a patch changeset**
 
 Create:
 
@@ -181,7 +181,7 @@ Create:
 Invalidate and restore the CLI's bundled documentation correctly through the Turbo build cache.
 ```
 
-- [ ] **Step 2: Run focused verification**
+- [x] **Step 2: Run focused verification**
 
 ```bash
 pnpm lint
@@ -193,7 +193,7 @@ pnpm pack:check
 
 Expected: all commands pass, the CLI docs are present after build/cache restoration, and the packed CLI contains its required documentation.
 
-- [ ] **Step 3: Run repository validation**
+- [x] **Step 3: Run repository validation**
 
 ```bash
 pnpm ci:validate
@@ -201,7 +201,7 @@ pnpm ci:validate
 
 Expected: all Definition of Done lanes pass. Environment-gated Docker/Kubernetes lanes remain PR CI responsibilities.
 
-- [ ] **Step 4: Review the final diff**
+- [x] **Step 4: Review the final diff**
 
 ```bash
 git diff --check main...HEAD
@@ -212,7 +212,7 @@ git status --short
 
 Expected: no whitespace errors; only the approved spec/plan, cache-check script, Turbo configuration, and changeset are tracked changes.
 
-- [ ] **Step 5: Commit release metadata and any plan checkmarks**
+- [x] **Step 5: Commit release metadata and any plan checkmarks**
 
 ```bash
 git add .changeset/bright-docs-cache.md docs/superpowers/plans/2026-08-09-cli-docs-turbo-cache.md

--- a/docs/superpowers/plans/2026-08-09-cli-docs-turbo-cache.md
+++ b/docs/superpowers/plans/2026-08-09-cli-docs-turbo-cache.md
@@ -25,7 +25,7 @@ website docs source, navigation file, and local Turbo binary:
 const cliRoot = join(packageRoot, "cli")
 const docsSourceRoot = join(repoRoot, "apps", "web", "content", "docs")
 const docsNavPath = join(repoRoot, "apps", "web", "app", "components", "docs", "nav.ts")
-const turboPath = join(repoRoot, "node_modules", ".bin", "turbo")
+const turboPath = join(repoRoot, "node_modules", "turbo", "bin", "turbo")
 ```
 
 Add a recursive MDX inventory helper using `readdirSync(..., { withFileTypes: true })` and a normalizer that resolves Turbo input keys relative to `cliRoot` before converting them to repository-relative POSIX paths.
@@ -37,8 +37,8 @@ Run Turbo without executing the build:
 ```js
 const dryRun = JSON.parse(
   execFileSync(
-    turboPath,
-    ["run", "build", "--filter=@dawn-ai/cli", "--dry=json"],
+    process.execPath,
+    [turboPath, "run", "build", "--filter=@dawn-ai/cli", "--dry=json"],
     { cwd: repoRoot, encoding: "utf8" },
   ),
 )
@@ -57,7 +57,7 @@ docs/**
 
 Accumulate all missing elements into the existing `errors` array. Wrap command execution and JSON parsing so failures add an actionable cache-check error instead of an unhandled stack trace.
 
-- [ ] **Step 3: Run the guard and verify RED**
+- [x] **Step 3: Run the guard and verify RED**
 
 ```bash
 pnpm check:build-cache

--- a/docs/superpowers/plans/2026-08-09-cli-docs-turbo-cache.md
+++ b/docs/superpowers/plans/2026-08-09-cli-docs-turbo-cache.md
@@ -1,0 +1,220 @@
+# CLI Documentation Turbo Cache Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make Turbo invalidate and restore the CLI's generated documentation whenever its website documentation sources change.
+
+**Architecture:** Add a package-qualified `@dawn-ai/cli#build` override that retains default CLI inputs, adds the cross-package MDX/navigation inputs, and caches both `dist/**` and `docs/**`. Strengthen the existing repository build-cache check by parsing Turbo's effective dry-run task so future configuration drift fails before the build.
+
+**Tech Stack:** Node.js ESM, Turbo 2.10.8, pnpm, JSON configuration, Changesets.
+
+---
+
+### Task 1: Make the cache-contract guard fail on the current configuration
+
+**Files:**
+- Modify: `scripts/check-build-cache-config.mjs`
+- Test: `scripts/check-build-cache-config.mjs` through `pnpm check:build-cache`
+
+- [ ] **Step 1: Add effective-task inspection**
+
+Import `execFileSync` from `node:child_process`. Add paths for the CLI package,
+website docs source, navigation file, and local Turbo binary:
+
+```js
+const cliRoot = join(packageRoot, "cli")
+const docsSourceRoot = join(repoRoot, "apps", "web", "content", "docs")
+const docsNavPath = join(repoRoot, "apps", "web", "app", "components", "docs", "nav.ts")
+const turboPath = join(repoRoot, "node_modules", ".bin", "turbo")
+```
+
+Add a recursive MDX inventory helper using `readdirSync(..., { withFileTypes: true })` and a normalizer that resolves Turbo input keys relative to `cliRoot` before converting them to repository-relative POSIX paths.
+
+- [ ] **Step 2: Parse the effective CLI build task**
+
+Run Turbo without executing the build:
+
+```js
+const dryRun = JSON.parse(
+  execFileSync(
+    turboPath,
+    ["run", "build", "--filter=@dawn-ai/cli", "--dry=json"],
+    { cwd: repoRoot, encoding: "utf8" },
+  ),
+)
+const cliBuildTask = dryRun.tasks?.find((task) => task.taskId === "@dawn-ai/cli#build")
+```
+
+If the task is absent, append a focused error. Otherwise create normalized input and output sets and require:
+
+```text
+apps/web/content/docs/**/*.mdx  (every current file)
+apps/web/app/components/docs/nav.ts
+packages/cli/src/index.ts
+dist/**
+docs/**
+```
+
+Accumulate all missing elements into the existing `errors` array. Wrap command execution and JSON parsing so failures add an actionable cache-check error instead of an unhandled stack trace.
+
+- [ ] **Step 3: Run the guard and verify RED**
+
+```bash
+pnpm check:build-cache
+```
+
+Expected: FAIL. The output identifies all website MDX inputs, the navigation input, and `docs/**` as missing. `packages/cli/src/index.ts` and `dist/**` should already be present, proving the default inputs and existing output are visible.
+
+- [ ] **Step 4: Commit the red guard**
+
+```bash
+git add scripts/check-build-cache-config.mjs
+git commit -m "test(cli): guard bundled docs cache contract"
+```
+
+### Task 2: Declare the CLI documentation cache contract
+
+**Files:**
+- Modify: `turbo.json`
+- Test: `scripts/check-build-cache-config.mjs` through `pnpm check:build-cache`
+
+- [ ] **Step 1: Add the package-qualified build task**
+
+Add this sibling of the generic `build` task:
+
+```json
+"@dawn-ai/cli#build": {
+  "dependsOn": ["^build"],
+  "inputs": [
+    "$TURBO_DEFAULT$",
+    "$TURBO_ROOT$/apps/web/content/docs/**/*.mdx",
+    "$TURBO_ROOT$/apps/web/app/components/docs/nav.ts"
+  ],
+  "outputs": ["dist/**", "docs/**"]
+}
+```
+
+- [ ] **Step 2: Run the guard and verify GREEN**
+
+```bash
+pnpm check:build-cache
+```
+
+Expected: PASS. The success message states that the generic `dist/**` contract and CLI bundled-docs contract were checked.
+
+- [ ] **Step 3: Inspect the effective task**
+
+```bash
+pnpm exec turbo run build --filter=@dawn-ai/cli --dry=json
+```
+
+Expected: `@dawn-ai/cli#build` contains all 42 current MDX files and the navigation file in `inputs`, retains `src/index.ts`, and lists `dist/**` plus `docs/**` in outputs.
+
+- [ ] **Step 4: Commit the configuration fix**
+
+```bash
+git add turbo.json
+git commit -m "fix(cli): cache generated documentation"
+```
+
+### Task 3: Prove clean cache restoration
+
+**Files:**
+- Generated then remove/restore: `packages/cli/docs/**`
+- Verify: `turbo.json`
+
+- [ ] **Step 1: Populate a fresh cache entry with generated docs**
+
+```bash
+pnpm exec turbo run build --filter=@dawn-ai/cli... --force
+```
+
+Expected: the CLI build executes and writes 42 topics plus `README.md`; `packages/cli/docs/README.md` exists.
+
+- [ ] **Step 2: Remove only the generated docs output**
+
+Validate the exact target, then remove it:
+
+```bash
+test "$(git rev-parse --show-toplevel)" = "$PWD"
+node -e "require('node:fs').rmSync('packages/cli/docs', { recursive: true, force: true })"
+test ! -d packages/cli/docs
+```
+
+Expected: the gitignored generated directory is absent; tracked files are untouched.
+
+- [ ] **Step 3: Restore from an unchanged cache hit**
+
+```bash
+pnpm exec turbo run build --filter=@dawn-ai/cli...
+test -f packages/cli/docs/README.md
+test -f packages/cli/docs/getting-started.md
+test -f packages/cli/docs/tools.md
+```
+
+Expected: Turbo reports cache hits, and representative bundled docs are restored without executing the generator.
+
+- [ ] **Step 4: Confirm no generated files are tracked**
+
+```bash
+git status --short
+```
+
+Expected: `packages/cli/docs/**` does not appear; it remains gitignored.
+
+### Task 4: Add release metadata and verify
+
+**Files:**
+- Create: `.changeset/bright-docs-cache.md`
+- Verify: `scripts/check-build-cache-config.mjs`
+- Verify: `turbo.json`
+
+- [ ] **Step 1: Add a patch changeset**
+
+Create:
+
+```md
+---
+"@dawn-ai/cli": patch
+---
+
+Invalidate and restore the CLI's bundled documentation correctly through the Turbo build cache.
+```
+
+- [ ] **Step 2: Run focused verification**
+
+```bash
+pnpm lint
+pnpm check:build-cache
+pnpm build
+node scripts/check-docs.mjs
+pnpm pack:check
+```
+
+Expected: all commands pass, the CLI docs are present after build/cache restoration, and the packed CLI contains its required documentation.
+
+- [ ] **Step 3: Run repository validation**
+
+```bash
+pnpm ci:validate
+```
+
+Expected: all Definition of Done lanes pass. Environment-gated Docker/Kubernetes lanes remain PR CI responsibilities.
+
+- [ ] **Step 4: Review the final diff**
+
+```bash
+git diff --check main...HEAD
+git diff --check
+git diff --cached --check
+git status --short
+```
+
+Expected: no whitespace errors; only the approved spec/plan, cache-check script, Turbo configuration, and changeset are tracked changes.
+
+- [ ] **Step 5: Commit release metadata and any plan checkmarks**
+
+```bash
+git add .changeset/bright-docs-cache.md docs/superpowers/plans/2026-08-09-cli-docs-turbo-cache.md
+git commit -m "chore(cli): document bundled docs cache fix"
+```

--- a/docs/superpowers/specs/2026-08-09-cli-docs-turbo-cache-design.md
+++ b/docs/superpowers/specs/2026-08-09-cli-docs-turbo-cache-design.md
@@ -97,7 +97,8 @@ Parse the effective `@dawn-ai/cli#build` task and require:
   effective inputs;
 - `apps/web/app/components/docs/nav.ts` appears;
 - ordinary CLI package inputs remain present, detecting accidental loss of
-  `$TURBO_DEFAULT$`;
+  `$TURBO_DEFAULT$`; use `packages/cli/src/index.ts` as a representative source
+  input rather than a metadata file;
 - `dist/**` and `docs/**` both appear in effective outputs.
 
 The check fails with a focused list of missing cache-contract elements. Running
@@ -124,7 +125,9 @@ test; adding the task override turns it green.
    inputs, and both output trees are present.
 4. Build the CLI dependency closure and verify `packages/cli/docs/**` is
    generated.
-5. Run lint, build-cache, build, typecheck, tests, docs check, pack check, and
+5. Remove the generated docs, rerun the unchanged CLI build as a cache hit, and
+   verify the complete `packages/cli/docs/**` tree is restored.
+6. Run lint, build-cache, build, typecheck, tests, docs check, pack check, and
    the repository Definition of Done.
 
 ## Files

--- a/docs/superpowers/specs/2026-08-09-cli-docs-turbo-cache-design.md
+++ b/docs/superpowers/specs/2026-08-09-cli-docs-turbo-cache-design.md
@@ -1,0 +1,141 @@
+# CLI Documentation Turbo Cache Design
+
+**Status:** Approved 2026-08-09
+
+## Summary
+
+The `@dawn-ai/cli` build generates its bundled Markdown documentation from the
+website MDX tree and navigation file. Those inputs live outside the CLI package,
+and the generated `packages/cli/docs/**` tree is outside Turbo's declared build
+outputs. Turbo can therefore reuse the CLI build after source documentation
+changes or restore `dist/**` without restoring the bundled docs.
+
+Give the CLI build an explicit package-qualified cache contract: retain normal
+package inputs, add the external website documentation inputs, and cache both
+`dist/**` and generated `docs/**`. Extend the existing build-cache guard to
+validate Turbo's effective task configuration.
+
+## Goals
+
+- Invalidate only the CLI build when website MDX or documentation navigation
+  changes.
+- Restore generated CLI documentation on a clean Turbo cache hit.
+- Preserve all default package-local inputs in the CLI build hash.
+- Guard the effective cache contract against future source or configuration
+  drift.
+- Keep the configuration centralized in the repository's root `turbo.json`.
+
+## Non-Goals
+
+- Making website documentation a global dependency of every build task.
+- Introducing the repository's first package-local Turbo configuration.
+- Changing the documentation generator or its Markdown transformations.
+- Committing the generated, gitignored `packages/cli/docs/**` tree.
+- Changing packaging behavior outside the CLI package.
+
+## Root Cause
+
+`packages/cli/package.json` runs TypeScript compilation followed by
+`packages/cli/scripts/generate-docs.mjs`. The generator reads:
+
+- `apps/web/content/docs/**/*.mdx`
+- `apps/web/app/components/docs/nav.ts`
+
+and writes `packages/cli/docs/**`.
+
+Turbo's default task inputs cover Git-tracked files inside the workspace
+package. A dry run for `@dawn-ai/cli#build` currently reports 227 package-local
+inputs, zero website MDX files, and zero navigation inputs. The generic build
+task declares `dist/**` and Next.js outputs but not CLI `docs/**`.
+
+This produces two independent failure modes:
+
+1. A website-doc-only change leaves the CLI task hash unchanged, so stale
+   generated docs can remain in a developer or CI workspace.
+2. A clean cache hit restores `dist/**` but not `docs/**`, so `dawn docs` can
+   report that bundled docs are missing and a cached build can be incomplete for
+   packaging.
+
+The pack check masks the bug by rebuilding packages directly before packing.
+
+## Turbo Task Contract
+
+Add a package-qualified task override in root `turbo.json`:
+
+```json
+"@dawn-ai/cli#build": {
+  "dependsOn": ["^build"],
+  "inputs": [
+    "$TURBO_DEFAULT$",
+    "$TURBO_ROOT$/apps/web/content/docs/**/*.mdx",
+    "$TURBO_ROOT$/apps/web/app/components/docs/nav.ts"
+  ],
+  "outputs": ["dist/**", "docs/**"]
+}
+```
+
+`$TURBO_DEFAULT$` retains the normal package-local hash inputs. `$TURBO_ROOT$`
+makes the cross-package source relationship explicit. Repeating `dependsOn`
+and `dist/**` keeps the complete effective contract visible without relying on
+task-override merging behavior.
+
+The override affects only `@dawn-ai/cli#build`; unrelated packages keep their
+existing hashes when website documentation changes.
+
+## Regression Guard
+
+Extend `scripts/check-build-cache-config.mjs`, which already runs in the main CI
+lane, to inspect:
+
+```text
+turbo run build --filter=@dawn-ai/cli --dry=json
+```
+
+Parse the effective `@dawn-ai/cli#build` task and require:
+
+- every current tracked `apps/web/content/docs/**/*.mdx` source appears in its
+  effective inputs;
+- `apps/web/app/components/docs/nav.ts` appears;
+- ordinary CLI package inputs remain present, detecting accidental loss of
+  `$TURBO_DEFAULT$`;
+- `dist/**` and `docs/**` both appear in effective outputs.
+
+The check fails with a focused list of missing cache-contract elements. Running
+the strengthened guard before editing `turbo.json` provides the required red
+test; adding the task override turns it green.
+
+## Error Handling
+
+- Failure to execute or parse Turbo's dry run fails the cache-config check with
+  the underlying command or parse error.
+- A missing CLI task is reported directly rather than producing a generic
+  property error.
+- Missing external inputs and outputs are accumulated so one run reports the
+  complete drift.
+- The guard derives the MDX inventory from the filesystem so newly added topics
+  are automatically covered by the configured glob.
+
+## Testing
+
+1. Strengthen `check-build-cache-config.mjs` first and observe it fail against
+   the current effective CLI task.
+2. Add the package-qualified Turbo task and observe the guard pass.
+3. Inspect the dry run to confirm the website docs, navigation file, normal CLI
+   inputs, and both output trees are present.
+4. Build the CLI dependency closure and verify `packages/cli/docs/**` is
+   generated.
+5. Run lint, build-cache, build, typecheck, tests, docs check, pack check, and
+   the repository Definition of Done.
+
+## Files
+
+- Modify `turbo.json` with the `@dawn-ai/cli#build` cache contract.
+- Modify `scripts/check-build-cache-config.mjs` with the effective-configuration
+  regression guard.
+- Add a patch changeset for `@dawn-ai/cli`.
+
+## Release
+
+This is a patch fix for the CLI package. The release note will state that CLI
+documentation generation now invalidates and restores correctly through the
+Turbo build cache.

--- a/scripts/check-build-cache-config.mjs
+++ b/scripts/check-build-cache-config.mjs
@@ -1,140 +1,140 @@
-import { execFileSync } from "node:child_process"
-import { readdirSync, readFileSync, statSync } from "node:fs"
-import { dirname, join, posix, resolve } from "node:path"
-import { fileURLToPath } from "node:url"
+import { execFileSync } from "node:child_process";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { dirname, join, posix, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 
-const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..")
-const packageRoot = join(repoRoot, "packages")
-const cliRoot = join(repoRoot, "packages/cli")
-const docsSourceRoot = join(repoRoot, "apps/web/content/docs")
-const docsNavPath = join(repoRoot, "apps/web/app/components/docs/nav.ts")
-const turboPath = join(repoRoot, "node_modules/.bin/turbo")
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const packageRoot = join(repoRoot, "packages");
+const cliRoot = join(repoRoot, "packages/cli");
+const docsSourceRoot = join(repoRoot, "apps/web/content/docs");
+const docsNavPath = join(repoRoot, "apps/web/app/components/docs/nav.ts");
+const turboPath = join(repoRoot, "node_modules/.bin/turbo");
 
-const readJson = (path) => JSON.parse(readFileSync(path, "utf8"))
-const toPosix = (path) => path.split(/[/\\]+/).join(posix.sep)
-const toRepoRelativePath = (path) => toPosix(path.slice(repoRoot.length + 1))
+const readJson = (path) => JSON.parse(readFileSync(path, "utf8"));
+const toPosix = (path) => path.split(/[/\\]+/).join(posix.sep);
+const toRepoRelativePath = (path) => toPosix(path.slice(repoRoot.length + 1));
 
 const listMdxFiles = (directory) =>
-  readdirSync(directory, { withFileTypes: true })
-    .sort((left, right) => left.name.localeCompare(right.name))
-    .flatMap((entry) => {
-      const path = join(directory, entry.name)
+	readdirSync(directory, { withFileTypes: true })
+		.sort((left, right) => left.name.localeCompare(right.name))
+		.flatMap((entry) => {
+			const path = join(directory, entry.name);
 
-      if (entry.isDirectory()) {
-        return listMdxFiles(path)
-      }
+			if (entry.isDirectory()) {
+				return listMdxFiles(path);
+			}
 
-      return entry.isFile() && entry.name.endsWith(".mdx") ? [path] : []
-    })
+			return entry.isFile() && entry.name.endsWith(".mdx") ? [path] : [];
+		});
 
-const errors = []
-const checkedConfigs = []
+const errors = [];
+const checkedConfigs = [];
 
 for (const packageDirName of readdirSync(packageRoot).sort()) {
-  const packageDir = join(packageRoot, packageDirName)
+	const packageDir = join(packageRoot, packageDirName);
 
-  if (!statSync(packageDir).isDirectory()) {
-    continue
-  }
+	if (!statSync(packageDir).isDirectory()) {
+		continue;
+	}
 
-  for (const fileName of readdirSync(packageDir).sort()) {
-    if (!/^tsconfig(?:\..+)?\.json$/.test(fileName)) {
-      continue
-    }
+	for (const fileName of readdirSync(packageDir).sort()) {
+		if (!/^tsconfig(?:\..+)?\.json$/.test(fileName)) {
+			continue;
+		}
 
-    const configPath = join(packageDir, fileName)
-    const relativeConfigPath = toRepoRelativePath(configPath)
-    const config = readJson(configPath)
-    const compilerOptions = config.compilerOptions ?? {}
-    const outDir = compilerOptions.outDir
-    const tsBuildInfoFile = compilerOptions.tsBuildInfoFile
+		const configPath = join(packageDir, fileName);
+		const relativeConfigPath = toRepoRelativePath(configPath);
+		const config = readJson(configPath);
+		const compilerOptions = config.compilerOptions ?? {};
+		const outDir = compilerOptions.outDir;
+		const tsBuildInfoFile = compilerOptions.tsBuildInfoFile;
 
-    if (typeof outDir === "string" && compilerOptions.noEmit !== true) {
-      const expectedBuildInfoFile = `${outDir.replace(/\/+$/, "")}/tsconfig.tsbuildinfo`
+		if (typeof outDir === "string" && compilerOptions.noEmit !== true) {
+			const expectedBuildInfoFile = `${outDir.replace(/\/+$/, "")}/tsconfig.tsbuildinfo`;
 
-      checkedConfigs.push(relativeConfigPath)
+			checkedConfigs.push(relativeConfigPath);
 
-      if (tsBuildInfoFile !== expectedBuildInfoFile) {
-        errors.push(
-          `${relativeConfigPath} must set compilerOptions.tsBuildInfoFile to ${expectedBuildInfoFile}`,
-        )
-      }
-    }
+			if (tsBuildInfoFile !== expectedBuildInfoFile) {
+				errors.push(
+					`${relativeConfigPath} must set compilerOptions.tsBuildInfoFile to ${expectedBuildInfoFile}`,
+				);
+			}
+		}
 
-    if (
-      typeof tsBuildInfoFile === "string" &&
-      !toPosix(tsBuildInfoFile).startsWith(`${toPosix(outDir ?? "dist")}/`)
-    ) {
-      errors.push(
-        `${relativeConfigPath} writes compilerOptions.tsBuildInfoFile outside its build output: ${tsBuildInfoFile}`,
-      )
-    }
-  }
+		if (
+			typeof tsBuildInfoFile === "string" &&
+			!toPosix(tsBuildInfoFile).startsWith(`${toPosix(outDir ?? "dist")}/`)
+		) {
+			errors.push(
+				`${relativeConfigPath} writes compilerOptions.tsBuildInfoFile outside its build output: ${tsBuildInfoFile}`,
+			);
+		}
+	}
 }
 
-const turboConfig = readJson(join(repoRoot, "turbo.json"))
-const buildOutputs = turboConfig.tasks?.build?.outputs ?? []
+const turboConfig = readJson(join(repoRoot, "turbo.json"));
+const buildOutputs = turboConfig.tasks?.build?.outputs ?? [];
 
 if (!buildOutputs.includes("dist/**")) {
-  errors.push('turbo.json build task must include "dist/**" in outputs')
+	errors.push('turbo.json build task must include "dist/**" in outputs');
 }
 
 try {
-  const dryRun = JSON.parse(
-    execFileSync(
-      turboPath,
-      ["run", "build", "--filter=@dawn-ai/cli", "--dry=json"],
-      { cwd: repoRoot, encoding: "utf8" },
-    ),
-  )
-  const cliBuildTask = dryRun.tasks?.find(
-    (task) => task.taskId === "@dawn-ai/cli#build",
-  )
+	const dryRun = JSON.parse(
+		execFileSync(
+			turboPath,
+			["run", "build", "--filter=@dawn-ai/cli", "--dry=json"],
+			{ cwd: repoRoot, encoding: "utf8" },
+		),
+	);
+	const cliBuildTask = dryRun.tasks?.find(
+		(task) => task.taskId === "@dawn-ai/cli#build",
+	);
 
-  if (cliBuildTask === undefined) {
-    errors.push("Turbo dry run did not include the @dawn-ai/cli#build task")
-  } else {
-    const taskInputs = new Set(
-      Object.keys(cliBuildTask.inputs ?? {}).map((input) =>
-        toRepoRelativePath(resolve(cliRoot, input)),
-      ),
-    )
-    const requiredInputs = [
-      ...listMdxFiles(docsSourceRoot),
-      docsNavPath,
-      join(cliRoot, "src/index.ts"),
-    ].map(toRepoRelativePath)
+	if (cliBuildTask === undefined) {
+		errors.push("Turbo dry run did not include the @dawn-ai/cli#build task");
+	} else {
+		const taskInputs = new Set(
+			Object.keys(cliBuildTask.inputs ?? {}).map((input) =>
+				toRepoRelativePath(resolve(cliRoot, input)),
+			),
+		);
+		const requiredInputs = [
+			...listMdxFiles(docsSourceRoot),
+			docsNavPath,
+			join(cliRoot, "src/index.ts"),
+		].map(toRepoRelativePath);
 
-    for (const input of requiredInputs) {
-      if (!taskInputs.has(input)) {
-        errors.push(`@dawn-ai/cli#build is missing cache input: ${input}`)
-      }
-    }
+		for (const input of requiredInputs) {
+			if (!taskInputs.has(input)) {
+				errors.push(`@dawn-ai/cli#build is missing cache input: ${input}`);
+			}
+		}
 
-    for (const output of ["dist/**", "docs/**"]) {
-      if (!(cliBuildTask.outputs ?? []).includes(output)) {
-        errors.push(`@dawn-ai/cli#build is missing cache output: ${output}`)
-      }
-    }
-  }
+		for (const output of ["dist/**", "docs/**"]) {
+			if (!(cliBuildTask.outputs ?? []).includes(output)) {
+				errors.push(`@dawn-ai/cli#build is missing cache output: ${output}`);
+			}
+		}
+	}
 } catch (error) {
-  const message = error instanceof Error ? error.message : String(error)
-  errors.push(
-    `Unable to inspect @dawn-ai/cli#build with Turbo dry run; run \`${turboPath} run build --filter=@dawn-ai/cli --dry=json\` from the repository root. (${message})`,
-  )
+	const message = error instanceof Error ? error.message : String(error);
+	errors.push(
+		`Unable to inspect @dawn-ai/cli#build with Turbo dry run; run \`${turboPath} run build --filter=@dawn-ai/cli --dry=json\` from the repository root. (${message})`,
+	);
 }
 
 if (errors.length > 0) {
-  console.error("Build cache config check failed.")
-  console.error("")
+	console.error("Build cache config check failed.");
+	console.error("");
 
-  for (const error of errors) {
-    console.error(`- ${error}`)
-  }
+	for (const error of errors) {
+		console.error(`- ${error}`);
+	}
 
-  process.exit(1)
+	process.exit(1);
 }
 
 console.log(
-  `Build cache config check passed (${checkedConfigs.length} emitting tsconfig file(s), dist/** cached).`,
-)
+	`Build cache config check passed (${checkedConfigs.length} emitting tsconfig file(s), dist/** cached).`,
+);

--- a/scripts/check-build-cache-config.mjs
+++ b/scripts/check-build-cache-config.mjs
@@ -1,140 +1,137 @@
-import { execFileSync } from "node:child_process";
-import { readdirSync, readFileSync, statSync } from "node:fs";
-import { dirname, join, posix, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
+import { execFileSync } from "node:child_process"
+import { readdirSync, readFileSync, statSync } from "node:fs"
+import { dirname, join, posix, resolve } from "node:path"
+import { fileURLToPath } from "node:url"
 
-const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
-const packageRoot = join(repoRoot, "packages");
-const cliRoot = join(repoRoot, "packages/cli");
-const docsSourceRoot = join(repoRoot, "apps/web/content/docs");
-const docsNavPath = join(repoRoot, "apps/web/app/components/docs/nav.ts");
-const turboPath = join(repoRoot, "node_modules/.bin/turbo");
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..")
+const packageRoot = join(repoRoot, "packages")
+const cliRoot = join(repoRoot, "packages/cli")
+const docsSourceRoot = join(repoRoot, "apps/web/content/docs")
+const docsNavPath = join(repoRoot, "apps/web/app/components/docs/nav.ts")
+const turboPath = join(repoRoot, "node_modules/.bin/turbo")
 
-const readJson = (path) => JSON.parse(readFileSync(path, "utf8"));
-const toPosix = (path) => path.split(/[/\\]+/).join(posix.sep);
-const toRepoRelativePath = (path) => toPosix(path.slice(repoRoot.length + 1));
+const readJson = (path) => JSON.parse(readFileSync(path, "utf8"))
+const toPosix = (path) => path.split(/[/\\]+/).join(posix.sep)
+const toRepoRelativePath = (path) => toPosix(path.slice(repoRoot.length + 1))
 
 const listMdxFiles = (directory) =>
-	readdirSync(directory, { withFileTypes: true })
-		.sort((left, right) => left.name.localeCompare(right.name))
-		.flatMap((entry) => {
-			const path = join(directory, entry.name);
+  readdirSync(directory, { withFileTypes: true })
+    .sort((left, right) => left.name.localeCompare(right.name))
+    .flatMap((entry) => {
+      const path = join(directory, entry.name)
 
-			if (entry.isDirectory()) {
-				return listMdxFiles(path);
-			}
+      if (entry.isDirectory()) {
+        return listMdxFiles(path)
+      }
 
-			return entry.isFile() && entry.name.endsWith(".mdx") ? [path] : [];
-		});
+      return entry.isFile() && entry.name.endsWith(".mdx") ? [path] : []
+    })
 
-const errors = [];
-const checkedConfigs = [];
+const errors = []
+const checkedConfigs = []
 
 for (const packageDirName of readdirSync(packageRoot).sort()) {
-	const packageDir = join(packageRoot, packageDirName);
+  const packageDir = join(packageRoot, packageDirName)
 
-	if (!statSync(packageDir).isDirectory()) {
-		continue;
-	}
+  if (!statSync(packageDir).isDirectory()) {
+    continue
+  }
 
-	for (const fileName of readdirSync(packageDir).sort()) {
-		if (!/^tsconfig(?:\..+)?\.json$/.test(fileName)) {
-			continue;
-		}
+  for (const fileName of readdirSync(packageDir).sort()) {
+    if (!/^tsconfig(?:\..+)?\.json$/.test(fileName)) {
+      continue
+    }
 
-		const configPath = join(packageDir, fileName);
-		const relativeConfigPath = toRepoRelativePath(configPath);
-		const config = readJson(configPath);
-		const compilerOptions = config.compilerOptions ?? {};
-		const outDir = compilerOptions.outDir;
-		const tsBuildInfoFile = compilerOptions.tsBuildInfoFile;
+    const configPath = join(packageDir, fileName)
+    const relativeConfigPath = toRepoRelativePath(configPath)
+    const config = readJson(configPath)
+    const compilerOptions = config.compilerOptions ?? {}
+    const outDir = compilerOptions.outDir
+    const tsBuildInfoFile = compilerOptions.tsBuildInfoFile
 
-		if (typeof outDir === "string" && compilerOptions.noEmit !== true) {
-			const expectedBuildInfoFile = `${outDir.replace(/\/+$/, "")}/tsconfig.tsbuildinfo`;
+    if (typeof outDir === "string" && compilerOptions.noEmit !== true) {
+      const expectedBuildInfoFile = `${outDir.replace(/\/+$/, "")}/tsconfig.tsbuildinfo`
 
-			checkedConfigs.push(relativeConfigPath);
+      checkedConfigs.push(relativeConfigPath)
 
-			if (tsBuildInfoFile !== expectedBuildInfoFile) {
-				errors.push(
-					`${relativeConfigPath} must set compilerOptions.tsBuildInfoFile to ${expectedBuildInfoFile}`,
-				);
-			}
-		}
+      if (tsBuildInfoFile !== expectedBuildInfoFile) {
+        errors.push(
+          `${relativeConfigPath} must set compilerOptions.tsBuildInfoFile to ${expectedBuildInfoFile}`,
+        )
+      }
+    }
 
-		if (
-			typeof tsBuildInfoFile === "string" &&
-			!toPosix(tsBuildInfoFile).startsWith(`${toPosix(outDir ?? "dist")}/`)
-		) {
-			errors.push(
-				`${relativeConfigPath} writes compilerOptions.tsBuildInfoFile outside its build output: ${tsBuildInfoFile}`,
-			);
-		}
-	}
+    if (
+      typeof tsBuildInfoFile === "string" &&
+      !toPosix(tsBuildInfoFile).startsWith(`${toPosix(outDir ?? "dist")}/`)
+    ) {
+      errors.push(
+        `${relativeConfigPath} writes compilerOptions.tsBuildInfoFile outside its build output: ${tsBuildInfoFile}`,
+      )
+    }
+  }
 }
 
-const turboConfig = readJson(join(repoRoot, "turbo.json"));
-const buildOutputs = turboConfig.tasks?.build?.outputs ?? [];
+const turboConfig = readJson(join(repoRoot, "turbo.json"))
+const buildOutputs = turboConfig.tasks?.build?.outputs ?? []
 
 if (!buildOutputs.includes("dist/**")) {
-	errors.push('turbo.json build task must include "dist/**" in outputs');
+  errors.push('turbo.json build task must include "dist/**" in outputs')
 }
 
 try {
-	const dryRun = JSON.parse(
-		execFileSync(
-			turboPath,
-			["run", "build", "--filter=@dawn-ai/cli", "--dry=json"],
-			{ cwd: repoRoot, encoding: "utf8" },
-		),
-	);
-	const cliBuildTask = dryRun.tasks?.find(
-		(task) => task.taskId === "@dawn-ai/cli#build",
-	);
+  const dryRun = JSON.parse(
+    execFileSync(turboPath, ["run", "build", "--filter=@dawn-ai/cli", "--dry=json"], {
+      cwd: repoRoot,
+      encoding: "utf8",
+    }),
+  )
+  const cliBuildTask = dryRun.tasks?.find((task) => task.taskId === "@dawn-ai/cli#build")
 
-	if (cliBuildTask === undefined) {
-		errors.push("Turbo dry run did not include the @dawn-ai/cli#build task");
-	} else {
-		const taskInputs = new Set(
-			Object.keys(cliBuildTask.inputs ?? {}).map((input) =>
-				toRepoRelativePath(resolve(cliRoot, input)),
-			),
-		);
-		const requiredInputs = [
-			...listMdxFiles(docsSourceRoot),
-			docsNavPath,
-			join(cliRoot, "src/index.ts"),
-		].map(toRepoRelativePath);
+  if (cliBuildTask === undefined) {
+    errors.push("Turbo dry run did not include the @dawn-ai/cli#build task")
+  } else {
+    const taskInputs = new Set(
+      Object.keys(cliBuildTask.inputs ?? {}).map((input) =>
+        toRepoRelativePath(resolve(cliRoot, input)),
+      ),
+    )
+    const requiredInputs = [
+      ...listMdxFiles(docsSourceRoot),
+      docsNavPath,
+      join(cliRoot, "src/index.ts"),
+    ].map(toRepoRelativePath)
 
-		for (const input of requiredInputs) {
-			if (!taskInputs.has(input)) {
-				errors.push(`@dawn-ai/cli#build is missing cache input: ${input}`);
-			}
-		}
+    for (const input of requiredInputs) {
+      if (!taskInputs.has(input)) {
+        errors.push(`@dawn-ai/cli#build is missing cache input: ${input}`)
+      }
+    }
 
-		for (const output of ["dist/**", "docs/**"]) {
-			if (!(cliBuildTask.outputs ?? []).includes(output)) {
-				errors.push(`@dawn-ai/cli#build is missing cache output: ${output}`);
-			}
-		}
-	}
+    for (const output of ["dist/**", "docs/**"]) {
+      if (!(cliBuildTask.outputs ?? []).includes(output)) {
+        errors.push(`@dawn-ai/cli#build is missing cache output: ${output}`)
+      }
+    }
+  }
 } catch (error) {
-	const message = error instanceof Error ? error.message : String(error);
-	errors.push(
-		`Unable to inspect @dawn-ai/cli#build with Turbo dry run; run \`${turboPath} run build --filter=@dawn-ai/cli --dry=json\` from the repository root. (${message})`,
-	);
+  const message = error instanceof Error ? error.message : String(error)
+  errors.push(
+    `Unable to inspect @dawn-ai/cli#build with Turbo dry run; run \`${turboPath} run build --filter=@dawn-ai/cli --dry=json\` from the repository root. (${message})`,
+  )
 }
 
 if (errors.length > 0) {
-	console.error("Build cache config check failed.");
-	console.error("");
+  console.error("Build cache config check failed.")
+  console.error("")
 
-	for (const error of errors) {
-		console.error(`- ${error}`);
-	}
+  for (const error of errors) {
+    console.error(`- ${error}`)
+  }
 
-	process.exit(1);
+  process.exit(1)
 }
 
 console.log(
-	`Build cache config check passed (${checkedConfigs.length} emitting tsconfig file(s), dist/** cached).`,
-);
+  `Build cache config check passed (${checkedConfigs.length} emitting tsconfig file(s), dist/** cached).`,
+)

--- a/scripts/check-build-cache-config.mjs
+++ b/scripts/check-build-cache-config.mjs
@@ -1,12 +1,31 @@
+import { execFileSync } from "node:child_process"
 import { readdirSync, readFileSync, statSync } from "node:fs"
 import { dirname, join, posix, resolve } from "node:path"
 import { fileURLToPath } from "node:url"
 
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..")
 const packageRoot = join(repoRoot, "packages")
+const cliRoot = join(repoRoot, "packages/cli")
+const docsSourceRoot = join(repoRoot, "apps/web/content/docs")
+const docsNavPath = join(repoRoot, "apps/web/app/components/docs/nav.ts")
+const turboPath = join(repoRoot, "node_modules/.bin/turbo")
 
 const readJson = (path) => JSON.parse(readFileSync(path, "utf8"))
 const toPosix = (path) => path.split(/[/\\]+/).join(posix.sep)
+const toRepoRelativePath = (path) => toPosix(path.slice(repoRoot.length + 1))
+
+const listMdxFiles = (directory) =>
+  readdirSync(directory, { withFileTypes: true })
+    .sort((left, right) => left.name.localeCompare(right.name))
+    .flatMap((entry) => {
+      const path = join(directory, entry.name)
+
+      if (entry.isDirectory()) {
+        return listMdxFiles(path)
+      }
+
+      return entry.isFile() && entry.name.endsWith(".mdx") ? [path] : []
+    })
 
 const errors = []
 const checkedConfigs = []
@@ -24,7 +43,7 @@ for (const packageDirName of readdirSync(packageRoot).sort()) {
     }
 
     const configPath = join(packageDir, fileName)
-    const relativeConfigPath = toPosix(configPath.slice(repoRoot.length + 1))
+    const relativeConfigPath = toRepoRelativePath(configPath)
     const config = readJson(configPath)
     const compilerOptions = config.compilerOptions ?? {}
     const outDir = compilerOptions.outDir
@@ -58,6 +77,51 @@ const buildOutputs = turboConfig.tasks?.build?.outputs ?? []
 
 if (!buildOutputs.includes("dist/**")) {
   errors.push('turbo.json build task must include "dist/**" in outputs')
+}
+
+try {
+  const dryRun = JSON.parse(
+    execFileSync(
+      turboPath,
+      ["run", "build", "--filter=@dawn-ai/cli", "--dry=json"],
+      { cwd: repoRoot, encoding: "utf8" },
+    ),
+  )
+  const cliBuildTask = dryRun.tasks?.find(
+    (task) => task.taskId === "@dawn-ai/cli#build",
+  )
+
+  if (cliBuildTask === undefined) {
+    errors.push("Turbo dry run did not include the @dawn-ai/cli#build task")
+  } else {
+    const taskInputs = new Set(
+      Object.keys(cliBuildTask.inputs ?? {}).map((input) =>
+        toRepoRelativePath(resolve(cliRoot, input)),
+      ),
+    )
+    const requiredInputs = [
+      ...listMdxFiles(docsSourceRoot),
+      docsNavPath,
+      join(cliRoot, "src/index.ts"),
+    ].map(toRepoRelativePath)
+
+    for (const input of requiredInputs) {
+      if (!taskInputs.has(input)) {
+        errors.push(`@dawn-ai/cli#build is missing cache input: ${input}`)
+      }
+    }
+
+    for (const output of ["dist/**", "docs/**"]) {
+      if (!(cliBuildTask.outputs ?? []).includes(output)) {
+        errors.push(`@dawn-ai/cli#build is missing cache output: ${output}`)
+      }
+    }
+  }
+} catch (error) {
+  const message = error instanceof Error ? error.message : String(error)
+  errors.push(
+    `Unable to inspect @dawn-ai/cli#build with Turbo dry run; run \`${turboPath} run build --filter=@dawn-ai/cli --dry=json\` from the repository root. (${message})`,
+  )
 }
 
 if (errors.length > 0) {

--- a/scripts/check-build-cache-config.mjs
+++ b/scripts/check-build-cache-config.mjs
@@ -8,7 +8,7 @@ const packageRoot = join(repoRoot, "packages")
 const cliRoot = join(repoRoot, "packages/cli")
 const docsSourceRoot = join(repoRoot, "apps/web/content/docs")
 const docsNavPath = join(repoRoot, "apps/web/app/components/docs/nav.ts")
-const turboPath = join(repoRoot, "node_modules/.bin/turbo")
+const turboPath = join(repoRoot, "node_modules/turbo/bin/turbo")
 
 const readJson = (path) => JSON.parse(readFileSync(path, "utf8"))
 const toPosix = (path) => path.split(/[/\\]+/).join(posix.sep)
@@ -81,10 +81,14 @@ if (!buildOutputs.includes("dist/**")) {
 
 try {
   const dryRun = JSON.parse(
-    execFileSync(turboPath, ["run", "build", "--filter=@dawn-ai/cli", "--dry=json"], {
-      cwd: repoRoot,
-      encoding: "utf8",
-    }),
+    execFileSync(
+      process.execPath,
+      [turboPath, "run", "build", "--filter=@dawn-ai/cli", "--dry=json"],
+      {
+        cwd: repoRoot,
+        encoding: "utf8",
+      },
+    ),
   )
   const cliBuildTask = dryRun.tasks?.find((task) => task.taskId === "@dawn-ai/cli#build")
 
@@ -117,7 +121,7 @@ try {
 } catch (error) {
   const message = error instanceof Error ? error.message : String(error)
   errors.push(
-    `Unable to inspect @dawn-ai/cli#build with Turbo dry run; run \`${turboPath} run build --filter=@dawn-ai/cli --dry=json\` from the repository root. (${message})`,
+    `Unable to inspect @dawn-ai/cli#build with Turbo dry run; run \`${process.execPath} ${turboPath} run build --filter=@dawn-ai/cli --dry=json\` from the repository root. (${message})`,
   )
 }
 
@@ -133,5 +137,5 @@ if (errors.length > 0) {
 }
 
 console.log(
-  `Build cache config check passed (${checkedConfigs.length} emitting tsconfig file(s), dist/** cached).`,
+  `Build cache config check passed (${checkedConfigs.length} emitting tsconfig file(s), generic dist/** cache and CLI bundled-docs contract checked).`,
 )

--- a/turbo.json
+++ b/turbo.json
@@ -1,34 +1,34 @@
 {
-	"$schema": "https://turbo.build/schema.json",
-	"tasks": {
-		"build": {
-			"dependsOn": ["^build"],
-			"outputs": ["dist/**", ".next/**", "!.next/cache/**"]
-		},
-		"@dawn-ai/cli#build": {
-			"dependsOn": ["^build"],
-			"inputs": [
-				"$TURBO_DEFAULT$",
-				"$TURBO_ROOT$/apps/web/content/docs/**/*.mdx",
-				"$TURBO_ROOT$/apps/web/app/components/docs/nav.ts"
-			],
-			"outputs": ["dist/**", "docs/**"]
-		},
-		"check": {
-			"dependsOn": ["^check"]
-		},
-		"dev": {
-			"cache": false,
-			"persistent": true
-		},
-		"lint": {
-			"dependsOn": ["^lint"]
-		},
-		"test": {
-			"dependsOn": ["^test"]
-		},
-		"typecheck": {
-			"dependsOn": ["^typecheck"]
-		}
-	}
+  "$schema": "https://turbo.build/schema.json",
+  "tasks": {
+    "build": {
+      "dependsOn": ["^build"],
+      "outputs": ["dist/**", ".next/**", "!.next/cache/**"]
+    },
+    "@dawn-ai/cli#build": {
+      "dependsOn": ["^build"],
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "$TURBO_ROOT$/apps/web/content/docs/**/*.mdx",
+        "$TURBO_ROOT$/apps/web/app/components/docs/nav.ts"
+      ],
+      "outputs": ["dist/**", "docs/**"]
+    },
+    "check": {
+      "dependsOn": ["^check"]
+    },
+    "dev": {
+      "cache": false,
+      "persistent": true
+    },
+    "lint": {
+      "dependsOn": ["^lint"]
+    },
+    "test": {
+      "dependsOn": ["^test"]
+    },
+    "typecheck": {
+      "dependsOn": ["^typecheck"]
+    }
+  }
 }

--- a/turbo.json
+++ b/turbo.json
@@ -1,25 +1,34 @@
 {
-  "$schema": "https://turbo.build/schema.json",
-  "tasks": {
-    "build": {
-      "dependsOn": ["^build"],
-      "outputs": ["dist/**", ".next/**", "!.next/cache/**"]
-    },
-    "check": {
-      "dependsOn": ["^check"]
-    },
-    "dev": {
-      "cache": false,
-      "persistent": true
-    },
-    "lint": {
-      "dependsOn": ["^lint"]
-    },
-    "test": {
-      "dependsOn": ["^test"]
-    },
-    "typecheck": {
-      "dependsOn": ["^typecheck"]
-    }
-  }
+	"$schema": "https://turbo.build/schema.json",
+	"tasks": {
+		"build": {
+			"dependsOn": ["^build"],
+			"outputs": ["dist/**", ".next/**", "!.next/cache/**"]
+		},
+		"@dawn-ai/cli#build": {
+			"dependsOn": ["^build"],
+			"inputs": [
+				"$TURBO_DEFAULT$",
+				"$TURBO_ROOT$/apps/web/content/docs/**/*.mdx",
+				"$TURBO_ROOT$/apps/web/app/components/docs/nav.ts"
+			],
+			"outputs": ["dist/**", "docs/**"]
+		},
+		"check": {
+			"dependsOn": ["^check"]
+		},
+		"dev": {
+			"cache": false,
+			"persistent": true
+		},
+		"lint": {
+			"dependsOn": ["^lint"]
+		},
+		"test": {
+			"dependsOn": ["^test"]
+		},
+		"typecheck": {
+			"dependsOn": ["^typecheck"]
+		}
+	}
 }


### PR DESCRIPTION
## Summary
- make the CLI build hash include website MDX and docs navigation sources
- cache generated CLI docs alongside dist output
- verify effective Turbo inputs and outputs in the build-cache guard

## Root cause
The CLI build reads docs outside packages/cli and writes packages/cli/docs, but Turbo hashed only package-local inputs and cached only dist. Docs-only edits could reuse stale output, and clean cache hits could omit bundled docs entirely.

## Validation
- pnpm ci:validate
- forced CLI build followed by clean 11/11 cache-hit restoration of all 43 generated Markdown files