### PR TITLE
fix(testing): await deterministic subprocess shutdown

### DIFF
--- a/.changeset/quiet-process-close.md
+++ b/.changeset/quiet-process-close.md
@@ -1,0 +1,5 @@
+---
+"@dawn-ai/testing": patch
+---
+
+Wait for subprocess applications to finish terminating before `close()` or async disposal resolves.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,6 +104,38 @@ jobs:
           path: artifacts/testing/
           retention-days: 7
 
+  testing-windows:
+    runs-on: windows-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+        with:
+          version: 10.33.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: 24.17.0
+          cache: pnpm
+
+      - name: Install
+        run: pnpm install --frozen-lockfile
+
+      - name: Build testing dependency closure
+        # The focused test starts the CLI from its built dist output. The
+        # trailing ellipsis selects @dawn-ai/testing and its dependencies.
+        run: pnpm --filter @dawn-ai/testing... build
+
+      - name: Native Windows subprocess shutdown tests
+        # This file includes the real win32 taskkill process-tree and orphan
+        # checks. It is deliberately focused, not broader Windows coverage.
+        run: pnpm --filter @dawn-ai/testing exec vitest --run --config vitest.config.ts test/subprocess.test.ts
+
   sandbox-docker:
     runs-on: ubuntu-latest
     timeout-minutes: 20

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,9 +132,9 @@ jobs:
         run: pnpm --filter @dawn-ai/testing... build
 
       - name: Native Windows subprocess shutdown tests
-        # This file includes the real win32 taskkill process-tree and orphan
-        # checks. It is deliberately focused, not broader Windows coverage.
-        run: pnpm --filter @dawn-ai/testing exec vitest --run --config vitest.config.ts test/subprocess.test.ts
+        # Exercise the real win32 taskkill tree and the injected stale-dispatch
+        # guard without running broader Windows HMR coverage.
+        run: pnpm --filter @dawn-ai/testing exec vitest --run --config vitest.config.ts test/subprocess.test.ts --testNamePattern "Windows process tree|injected Windows tree kill"
 
   sandbox-docker:
     runs-on: ubuntu-latest

--- a/docs/superpowers/plans/2026-08-09-subprocess-shutdown-barrier.md
+++ b/docs/superpowers/plans/2026-08-09-subprocess-shutdown-barrier.md
@@ -361,7 +361,12 @@ git commit -m "fix(testing): bound subprocess termination"
 
 On POSIX, spawn `idle`, make only `process.kill(-groupPid, "SIGTERM")` throw, and install a pass-through spy on `child.kill`. Await termination and assert `child.kill("SIGTERM")` was called. Restore spies and forcibly clean up the exact group in `finally`.
 
-On Windows, add platform-gated fixtures and tests for a live process tree and an orphaned descendant. The live-tree test proves `taskkill.exe /PID <saved PID> /T /F` terminates the tree without directly killing the outer child. A deterministic, injected-Windows-dispatch orphan test proves a closed outer child causes bounded rejection without any tree-kill dispatch; the platform-gated orphan test also guards against an unnecessary direct-child kill.
+On Windows, retain the platform-gated live process-tree test. It proves
+`taskkill.exe /PID <saved PID> /T /F` terminates the tree without directly
+killing the outer child. A deterministic cross-platform test closes an idle
+child, keeps an independent TCP server live, injects the Windows dispatcher,
+and proves bounded rejection without any tree-kill dispatch. This covers the
+closed-child guard without assuming a descendant survives outer-child closure.
 
 - [x] **Step 2: Implement platform-specific dispatch**
 
@@ -410,15 +415,23 @@ Add the `testing-windows` job to `.github/workflows/ci.yml`. Run it on
 `windows-latest` with a 20-minute timeout. Use the repository's pinned
 checkout, pnpm setup, and Node 24.17.0 setup actions; install with a frozen
 lockfile; then build `@dawn-ai/testing...` so the testing dependency closure
-includes the CLI `dist` output. Run only the package-configured subprocess
-suite:
+includes the CLI `dist` output. Run only the two shutdown-specific tests from
+the package-configured subprocess suite:
 
 ```bash
-pnpm --filter @dawn-ai/testing exec vitest --run --config vitest.config.ts test/subprocess.test.ts
+pnpm --filter @dawn-ai/testing exec vitest --run --config vitest.config.ts test/subprocess.test.ts --testNamePattern "Windows process tree|injected Windows tree kill"
 ```
 
-This job executes the two real Windows `taskkill.exe` process-tree and orphan
-tests. It is intentionally not a claim of broader Windows coverage.
+This job executes the real Windows `taskkill.exe` process-tree test and the
+injected stale-dispatch guard. The latter closes an idle child and keeps an
+independent TCP server live, so it does not depend on a surviving orphan
+fixture. It is intentionally not a claim of broader Windows coverage.
+
+The prior Windows run provided the RED evidence for the orphan assumption:
+after the outer fixture closed, its descendant port was already unavailable,
+so both orphan-based tests failed their live-port precondition. The same
+full-file run also reached an unrelated Dawn dev/HMR port-restart timeout;
+the name filter deliberately excludes that broader coverage.
 
 - [x] **Step 4: Run repository validation**
 

--- a/docs/superpowers/plans/2026-08-09-subprocess-shutdown-barrier.md
+++ b/docs/superpowers/plans/2026-08-09-subprocess-shutdown-barrier.md
@@ -1,0 +1,430 @@
+# Subprocess Shutdown Barrier Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `createSubprocessApp().close()` and async disposal resolve only after the owned process tree has stopped and its port is unavailable.
+
+**Architecture:** Keep the public API unchanged. Build the shutdown barrier incrementally: first await the spawned CLI's `close` event through one memoized promise, then add bounded TCP observation for surviving descendants, `SIGKILL` escalation, and direct-child fallback. Reuse the same closure function when readiness fails.
+
+**Tech Stack:** TypeScript, Node.js `child_process`/`net`/`timers`, Vitest, pnpm, Changesets.
+
+---
+
+### Task 1: Pin the public completion and readiness-cleanup contracts
+
+**Files:**
+- Modify: `packages/testing/test/subprocess.test.ts`
+- Test: `packages/testing/test/subprocess.test.ts`
+
+- [ ] **Step 1: Build before exercising the real `dist` CLI**
+
+```bash
+pnpm build
+```
+
+Expected: PASS. This is mandatory because `createSubprocessApp()` executes `packages/cli/dist/index.js`.
+
+- [ ] **Step 2: Add deterministic delayed-signal tests**
+
+Import `setTimeout as delay` from `node:timers/promises` and `vi` from Vitest. Add:
+
+```ts
+it("waits for process shutdown and shares one close promise", async () => {
+  const mock = await createAimock({ fixtures: [{ match: {}, response: { content: "ok" } }] })
+  const app = await createSubprocessApp({
+    appRoot,
+    env: { OPENAI_BASE_URL: mock.baseUrl, OPENAI_API_KEY: "test-not-used" },
+  })
+  const realKill = process.kill.bind(process)
+  const killSpy = vi.spyOn(process, "kill").mockImplementation((pid, signal) => {
+    if (typeof pid === "number" && pid < 0 && signal === "SIGTERM") {
+      setTimeout(() => {
+        try {
+          realKill(pid, signal)
+        } catch {}
+      }, 100)
+      return true
+    }
+    return realKill(pid, signal)
+  })
+
+  try {
+    const first = app.close()
+    const second = app.close()
+    const disposed = app[Symbol.asyncDispose]()
+    expect(second).toBe(first)
+    expect(disposed).toBe(first)
+    await expect(
+      Promise.race([first.then(() => "closed"), delay(25, "waiting")]),
+    ).resolves.toBe("waiting")
+    await first
+    await expect(fetch(new URL("/healthz", app.baseUrl))).rejects.toThrow()
+  } finally {
+    killSpy.mockRestore()
+    await app.close()
+    await mock.close()
+  }
+}, 120_000)
+
+it("waits for cleanup when readiness fails", async () => {
+  const realKill = process.kill.bind(process)
+  const killSpy = vi.spyOn(process, "kill").mockImplementation((pid, signal) => {
+    if (typeof pid === "number" && pid < 0 && signal === "SIGTERM") {
+      setTimeout(() => {
+        try {
+          realKill(pid, signal)
+        } catch {}
+      }, 100)
+      return true
+    }
+    return realKill(pid, signal)
+  })
+
+  try {
+    const creating = createSubprocessApp({ appRoot, readyTimeoutMs: 0 })
+    const outcome = creating.then(
+      () => "created",
+      () => "rejected",
+    )
+    await expect(Promise.race([outcome, delay(25, "waiting")])).resolves.toBe("waiting")
+    await expect(creating).rejects.toThrow("within 0ms")
+  } finally {
+    killSpy.mockRestore()
+  }
+}, 120_000)
+```
+
+- [ ] **Step 3: Run each test and verify RED**
+
+```bash
+pnpm --filter @dawn-ai/testing exec vitest --run --config vitest.config.ts test/subprocess.test.ts -t "shares one close promise"
+pnpm --filter @dawn-ai/testing exec vitest --run --config vitest.config.ts test/subprocess.test.ts -t "readiness fails"
+```
+
+Expected: the first fails because `close()` returns immediately and distinct async promises; the second fails because constructor rejection does not await delayed termination.
+
+- [ ] **Step 4: Commit the red tests**
+
+```bash
+git add packages/testing/test/subprocess.test.ts
+git commit -m "test(testing): pin subprocess shutdown barrier"
+```
+
+### Task 2: Await one memoized child-close observation
+
+**Files:**
+- Modify: `packages/testing/src/subprocess.ts`
+- Test: `packages/testing/test/subprocess.test.ts`
+
+- [ ] **Step 1: Establish the `close` observation immediately after spawn**
+
+Add this internal helper; do not resolve from `exitCode` or `signalCode`, because the contract requires stdio closure:
+
+```ts
+function childClosePromise(child: ChildProcess): Promise<void> {
+  return new Promise((resolve) => {
+    child.once("close", () => resolve())
+  })
+}
+```
+
+Immediately after `spawn`, require the PID and create the promise before readiness work:
+
+```ts
+const groupPid = child.pid
+if (groupPid === undefined) throw new Error("dawn dev subprocess has no process id")
+const closed = childClosePromise(child)
+```
+
+- [ ] **Step 2: Add graceful process-group termination**
+
+```ts
+async function terminateSubprocess(
+  child: ChildProcess,
+  groupPid: number,
+  closed: Promise<void>,
+): Promise<void> {
+  if (child.exitCode === null && child.signalCode === null) {
+    process.kill(-groupPid, "SIGTERM")
+  }
+  await closed
+}
+```
+
+This is deliberately the minimum green implementation. Escalation and fallback come only after their own red tests.
+
+- [ ] **Step 3: Memoize one closure function and reuse it everywhere**
+
+After `baseUrl` is known:
+
+```ts
+let closePromise: Promise<void> | undefined
+const close = (): Promise<void> => {
+  closePromise ??= terminateSubprocess(child, groupPid, closed)
+  return closePromise
+}
+```
+
+Replace readiness-failure signal dispatch with `await close()`. Return `close` directly as the app object's `close` property, and make `[Symbol.asyncDispose]()` return `close()`. Remove `stopped` and the `async close()` wrapper so promise identity is preserved.
+
+- [ ] **Step 4: Run Task 1 tests and verify GREEN**
+
+Run both Task 1 commands, then:
+
+```bash
+pnpm --filter @dawn-ai/testing exec vitest --run --config vitest.config.ts test/subprocess.test.ts
+```
+
+Expected: all subprocess tests pass.
+
+- [ ] **Step 5: Commit the minimal barrier**
+
+```bash
+git add packages/testing/src/subprocess.ts
+git commit -m "fix(testing): await subprocess closure"
+```
+
+### Task 3: Observe a surviving descendant through the listening port
+
+**Files:**
+- Create: `packages/testing/test/fixtures/subprocess-tree.mjs`
+- Modify: `packages/testing/test/subprocess.test.ts`
+- Modify: `packages/testing/src/subprocess.ts`
+
+- [ ] **Step 1: Create the disposable process-tree fixture**
+
+Create `packages/testing/test/fixtures/subprocess-tree.mjs`:
+
+```js
+import { spawn } from "node:child_process"
+
+const mode = process.argv[2]
+
+if (mode === "idle" || mode === "ignore-term") {
+  if (mode === "ignore-term") process.on("SIGTERM", () => {})
+  process.stdout.write("ready\n")
+  setInterval(() => {}, 1_000)
+} else if (mode === "leader") {
+  const descendantSource = `
+    import { createServer } from "node:net"
+    const server = createServer((socket) => socket.end())
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address()
+      if (typeof address !== "object" || address === null) process.exit(2)
+      process.stdout.write(String(address.port) + "\\n")
+    })
+  `
+  const descendant = spawn(
+    process.execPath,
+    ["--input-type=module", "--eval", descendantSource],
+    { stdio: ["ignore", "pipe", "inherit"] },
+  )
+  descendant.stdout?.once("data", (chunk) => {
+    process.stdout.write(chunk, () => process.exit(0))
+  })
+} else {
+  throw new Error(`unknown subprocess-tree mode: ${mode}`)
+}
+```
+
+- [ ] **Step 2: Add exact test helpers**
+
+In `subprocess.test.ts`, import `spawn`, `createConnection`, and `terminateSubprocess`. Add:
+
+```ts
+const processTreeFixture = fileURLToPath(
+  new URL("./fixtures/subprocess-tree.mjs", import.meta.url),
+)
+
+async function spawnTree(mode: "idle" | "ignore-term" | "leader") {
+  const child = spawn(process.execPath, [processTreeFixture, mode], {
+    detached: true,
+    stdio: ["ignore", "pipe", "inherit"],
+  })
+  if (child.pid === undefined) throw new Error("fixture process has no pid")
+  const groupPid = child.pid
+  const closed = new Promise<void>((resolve, reject) => {
+    child.once("error", reject)
+    child.once("close", () => resolve())
+  })
+  const line = await new Promise<string>((resolve, reject) => {
+    let output = ""
+    child.once("error", reject)
+    child.once("close", () => {
+      if (!output.includes("\n")) reject(new Error("fixture closed before readiness"))
+    })
+    child.stdout?.on("data", (chunk) => {
+      output += String(chunk)
+      if (output.includes("\n")) resolve(output.trim())
+    })
+  })
+  return { child, closed, groupPid, line }
+}
+
+function canConnect(baseUrl: string): Promise<boolean> {
+  const url = new URL(baseUrl)
+  return new Promise((resolve) => {
+    const socket = createConnection({ host: url.hostname, port: Number(url.port) })
+    socket.once("connect", () => {
+      socket.destroy()
+      resolve(true)
+    })
+    socket.once("error", () => resolve(false))
+  })
+}
+```
+
+- [ ] **Step 3: Add and run the surviving-descendant RED test**
+
+```ts
+it("waits for a surviving descendant to release the port", async () => {
+  const realKill = process.kill.bind(process)
+  const { child, closed, groupPid, line } = await spawnTree("leader")
+  const baseUrl = `http://127.0.0.1:${Number(line)}`
+  await closed
+  expect(await canConnect(baseUrl)).toBe(true)
+  try {
+    await terminateSubprocess(child, groupPid, closed, baseUrl, TEST_TERMINATION_TIMINGS)
+    expect(await canConnect(baseUrl)).toBe(false)
+  } finally {
+    try {
+      realKill(-groupPid, "SIGKILL")
+    } catch {}
+  }
+})
+```
+
+Add `TEST_TERMINATION_TIMINGS` with grace 100 ms, force 100 ms, probe interval 5 ms, and probe timeout 10 ms.
+
+Run:
+
+```bash
+pnpm --filter @dawn-ai/testing exec vitest --run --config vitest.config.ts test/subprocess.test.ts -t "surviving descendant"
+```
+
+Expected: RED at compile time because the internal helper does not yet accept `baseUrl`/timings, or behaviorally because it returns after the already-closed leader while the port remains live.
+
+- [ ] **Step 4: Implement bounded joint observation**
+
+Import `createConnection` from `node:net`. Add internal defaults of 2,000 ms graceful/forced deadlines, 25 ms polling, and 100 ms probe timeout. Export `TerminationTimings` and `terminateSubprocess` from this source module for direct tests, but do not re-export either from `src/index.ts`.
+
+Implement `portAcceptsConnections()` with a TCP socket that resolves `true` on connect or timeout and `false` on socket error. Implement `waitUntilStopped()` that, until its deadline, requires both the previously established child-close promise and a failed port connection; it must not leave a polling promise running after timeout.
+
+Update `terminateSubprocess()` to accept `baseUrl` and timings. Resolve immediately only when the child is closed and the port is unavailable; otherwise signal the saved group with `SIGTERM`, wait the grace deadline, and throw a PID/deadline error for now. Update the public close call to pass `baseUrl` and defaults.
+
+- [ ] **Step 5: Verify GREEN and commit**
+
+Run the Task 3 test and the whole subprocess file. Expected: PASS.
+
+```bash
+git add packages/testing/src/subprocess.ts packages/testing/test/subprocess.test.ts packages/testing/test/fixtures/subprocess-tree.mjs
+git commit -m "fix(testing): observe subprocess port shutdown"
+```
+
+### Task 4: Escalate and reject on bounded failure
+
+**Files:**
+- Modify: `packages/testing/test/subprocess.test.ts`
+- Modify: `packages/testing/src/subprocess.ts`
+
+- [ ] **Step 1: Add and run the escalation RED test**
+
+Use `spawnTree("ignore-term")` with an unavailable base URL obtained by binding a temporary `createServer()` to port zero and closing it. Add one pass-through `process.kill` spy test that expects `terminateSubprocess()` to resolve and observes `[-groupPid, "SIGKILL"]`. Restore the spy and forcibly clean up the exact process group in `finally`.
+
+Run only the escalation test. Expected: RED because the current graceful deadline throws without attempting `SIGKILL`.
+
+- [ ] **Step 2: Add and run the final-timeout RED test**
+
+Add the second test described above whose exact negative-PID `SIGTERM` and `SIGKILL` calls return `true` without delivering signals. Run only that test. Expected: RED because the current error is raised after the graceful deadline and does not represent a failed forced-termination deadline. Every spawned process and spy must be restored and the exact group forcibly cleaned up in `finally`.
+
+The escalation assertion must prove `SIGKILL` was delivered. The final-timeout assertion must prove the error names the group PID and the combined `graceMs + forceMs` deadline.
+
+- [ ] **Step 3: Implement forced termination**
+
+After the graceful wait expires, signal the group with `SIGKILL`. Await the same joint child-close/port-unavailable condition for `forceMs`. Return on success; otherwise throw an error containing the group PID and `graceMs + forceMs`.
+
+- [ ] **Step 4: Verify GREEN and commit**
+
+```bash
+pnpm --filter @dawn-ai/testing exec vitest --run --config vitest.config.ts test/subprocess.test.ts -t "SIGKILL|bounded failure"
+git add packages/testing/src/subprocess.ts packages/testing/test/subprocess.test.ts
+git commit -m "fix(testing): bound subprocess termination"
+```
+
+### Task 5: Fall back when group signalling is unavailable
+
+**Files:**
+- Modify: `packages/testing/test/subprocess.test.ts`
+- Modify: `packages/testing/src/subprocess.ts`
+
+- [ ] **Step 1: Add the fallback RED test**
+
+Spawn `idle`, make only `process.kill(-groupPid, "SIGTERM")` throw, and install a pass-through spy on `child.kill`. Await termination and assert `child.kill("SIGTERM")` was called. Restore spies and forcibly clean up the exact group in `finally`.
+
+Run the test. Expected: RED because group-signalling failure currently escapes.
+
+- [ ] **Step 2: Implement direct-child fallback**
+
+Extract `signalProcessTree(child, groupPid, signal)`: try `process.kill(-groupPid, signal)` and, on error, call `child.kill(signal)`. Use it for both graceful and forced signals.
+
+- [ ] **Step 3: Verify GREEN and commit**
+
+```bash
+pnpm --filter @dawn-ai/testing exec vitest --run --config vitest.config.ts test/subprocess.test.ts
+git add packages/testing/src/subprocess.ts packages/testing/test/subprocess.test.ts
+git commit -m "fix(testing): fall back to direct process signals"
+```
+
+### Task 6: Add release metadata and verify
+
+**Files:**
+- Create: `.changeset/quiet-process-close.md`
+- Verify: `packages/testing/src/subprocess.ts`
+- Verify: `packages/testing/test/subprocess.test.ts`
+
+- [ ] **Step 1: Add the exact patch changeset**
+
+```md
+---
+"@dawn-ai/testing": patch
+---
+
+Wait for subprocess applications to finish terminating before `close()` or async disposal resolves.
+```
+
+- [ ] **Step 2: Run package verification**
+
+```bash
+pnpm --filter @dawn-ai/testing build
+pnpm --filter @dawn-ai/testing typecheck
+pnpm --filter @dawn-ai/testing lint
+pnpm --filter @dawn-ai/testing test
+```
+
+Expected: all commands pass.
+
+- [ ] **Step 3: Run repository validation**
+
+```bash
+pnpm ci:validate
+```
+
+Expected: all Definition of Done lanes pass. Environment-gated Docker/Kubernetes lanes remain PR CI responsibilities.
+
+- [ ] **Step 4: Review tracked and uncommitted changes**
+
+```bash
+git diff --check main...HEAD
+git diff --check
+git diff --cached --check
+git status --short
+```
+
+Expected: no whitespace errors; only the approved spec/plan, testing source/tests/fixture, and exact changeset are changed.
+
+- [ ] **Step 5: Commit release metadata and plan progress**
+
+```bash
+git add .changeset/quiet-process-close.md docs/superpowers/plans/2026-08-09-subprocess-shutdown-barrier.md
+git commit -m "chore(testing): document subprocess shutdown fix"
+```

--- a/docs/superpowers/plans/2026-08-09-subprocess-shutdown-barrier.md
+++ b/docs/superpowers/plans/2026-08-09-subprocess-shutdown-barrier.md
@@ -379,6 +379,7 @@ git commit -m "fix(testing): fall back to direct process signals"
 
 **Files:**
 - Create: `.changeset/quiet-process-close.md`
+- Modify: `.github/workflows/ci.yml`
 - Verify: `packages/testing/src/subprocess.ts`
 - Verify: `packages/testing/test/subprocess.test.ts`
 
@@ -403,7 +404,23 @@ pnpm --filter @dawn-ai/testing test
 
 Expected: all commands pass.
 
-- [x] **Step 3: Run repository validation**
+- [x] **Step 3: Add focused native Windows CI coverage**
+
+Add the `testing-windows` job to `.github/workflows/ci.yml`. Run it on
+`windows-latest` with a 20-minute timeout. Use the repository's pinned
+checkout, pnpm setup, and Node 24.17.0 setup actions; install with a frozen
+lockfile; then build `@dawn-ai/testing...` so the testing dependency closure
+includes the CLI `dist` output. Run only the package-configured subprocess
+suite:
+
+```bash
+pnpm --filter @dawn-ai/testing exec vitest --run --config vitest.config.ts test/subprocess.test.ts
+```
+
+This job executes the two real Windows `taskkill.exe` process-tree and orphan
+tests. It is intentionally not a claim of broader Windows coverage.
+
+- [x] **Step 4: Run repository validation**
 
 ```bash
 pnpm ci:validate
@@ -411,7 +428,7 @@ pnpm ci:validate
 
 Expected: all Definition of Done lanes pass. Environment-gated Docker/Kubernetes lanes remain PR CI responsibilities.
 
-- [x] **Step 4: Review tracked and uncommitted changes**
+- [x] **Step 5: Review tracked and uncommitted changes**
 
 ```bash
 git diff --check main...HEAD
@@ -422,7 +439,7 @@ git status --short
 
 Expected: no whitespace errors; only the approved spec/plan, testing source/tests/fixture, and exact changeset are changed.
 
-- [x] **Step 5: Commit release metadata and plan progress**
+- [x] **Step 6: Commit release metadata and plan progress**
 
 ```bash
 git add .changeset/quiet-process-close.md docs/superpowers/plans/2026-08-09-subprocess-shutdown-barrier.md docs/superpowers/specs/2026-08-09-subprocess-shutdown-barrier-design.md

--- a/docs/superpowers/plans/2026-08-09-subprocess-shutdown-barrier.md
+++ b/docs/superpowers/plans/2026-08-09-subprocess-shutdown-barrier.md
@@ -4,7 +4,7 @@
 
 **Goal:** Make `createSubprocessApp().close()` and async disposal resolve only after the owned process tree has stopped and its port is unavailable.
 
-**Architecture:** Keep the public API unchanged. Build the shutdown barrier incrementally: first await the spawned CLI's `close` event through one memoized promise, then add bounded TCP observation for surviving descendants, `SIGKILL` escalation, and direct-child fallback. Reuse the same closure function when readiness fails.
+**Architecture:** Keep the public API unchanged. Build the shutdown barrier incrementally: first await the spawned CLI's `close` event through one memoized promise, then add bounded TCP observation for surviving descendants and forced termination. On POSIX, signal the detached group and fall back to the direct child. On Windows, use bounded `taskkill.exe /PID <saved PID> /T /F` before any last-resort direct-child kill. Reuse the same closure function when readiness fails.
 
 **Tech Stack:** TypeScript, Node.js `child_process`/`net`/`timers`, Vitest, pnpm, Changesets.
 
@@ -16,7 +16,7 @@
 - Modify: `packages/testing/test/subprocess.test.ts`
 - Test: `packages/testing/test/subprocess.test.ts`
 
-- [ ] **Step 1: Build before exercising the real `dist` CLI**
+- [x] **Step 1: Build before exercising the real `dist` CLI**
 
 ```bash
 pnpm build
@@ -24,7 +24,7 @@ pnpm build
 
 Expected: PASS. This is mandatory because `createSubprocessApp()` executes `packages/cli/dist/index.js`.
 
-- [ ] **Step 2: Add deterministic delayed-signal tests**
+- [x] **Step 2: Add deterministic delayed-signal tests**
 
 Import `setTimeout as delay` from `node:timers/promises` and `vi` from Vitest. Add:
 
@@ -94,7 +94,7 @@ it("waits for cleanup when readiness fails", async () => {
 }, 120_000)
 ```
 
-- [ ] **Step 3: Run each test and verify RED**
+- [x] **Step 3: Run each test and verify RED**
 
 ```bash
 pnpm --filter @dawn-ai/testing exec vitest --run --config vitest.config.ts test/subprocess.test.ts -t "shares one close promise"
@@ -103,7 +103,7 @@ pnpm --filter @dawn-ai/testing exec vitest --run --config vitest.config.ts test/
 
 Expected: the first fails because `close()` returns immediately and distinct async promises; the second fails because constructor rejection does not await delayed termination.
 
-- [ ] **Step 4: Commit the red tests**
+- [x] **Step 4: Commit the red tests**
 
 ```bash
 git add packages/testing/test/subprocess.test.ts
@@ -116,7 +116,7 @@ git commit -m "test(testing): pin subprocess shutdown barrier"
 - Modify: `packages/testing/src/subprocess.ts`
 - Test: `packages/testing/test/subprocess.test.ts`
 
-- [ ] **Step 1: Establish the `close` observation immediately after spawn**
+- [x] **Step 1: Establish the `close` observation immediately after spawn**
 
 Add this internal helper; do not resolve from `exitCode` or `signalCode`, because the contract requires stdio closure:
 
@@ -136,7 +136,7 @@ if (groupPid === undefined) throw new Error("dawn dev subprocess has no process 
 const closed = childClosePromise(child)
 ```
 
-- [ ] **Step 2: Add graceful process-group termination**
+- [x] **Step 2: Add graceful process-group termination**
 
 ```ts
 async function terminateSubprocess(
@@ -153,7 +153,7 @@ async function terminateSubprocess(
 
 This is deliberately the minimum green implementation. Escalation and fallback come only after their own red tests.
 
-- [ ] **Step 3: Memoize one closure function and reuse it everywhere**
+- [x] **Step 3: Memoize one closure function and reuse it everywhere**
 
 After `baseUrl` is known:
 
@@ -167,7 +167,7 @@ const close = (): Promise<void> => {
 
 Replace readiness-failure signal dispatch with `await close()`. Return `close` directly as the app object's `close` property, and make `[Symbol.asyncDispose]()` return `close()`. Remove `stopped` and the `async close()` wrapper so promise identity is preserved.
 
-- [ ] **Step 4: Run Task 1 tests and verify GREEN**
+- [x] **Step 4: Run Task 1 tests and verify GREEN**
 
 Run both Task 1 commands, then:
 
@@ -177,7 +177,7 @@ pnpm --filter @dawn-ai/testing exec vitest --run --config vitest.config.ts test/
 
 Expected: all subprocess tests pass.
 
-- [ ] **Step 5: Commit the minimal barrier**
+- [x] **Step 5: Commit the minimal barrier**
 
 ```bash
 git add packages/testing/src/subprocess.ts
@@ -191,7 +191,7 @@ git commit -m "fix(testing): await subprocess closure"
 - Modify: `packages/testing/test/subprocess.test.ts`
 - Modify: `packages/testing/src/subprocess.ts`
 
-- [ ] **Step 1: Create the disposable process-tree fixture**
+- [x] **Step 1: Create the disposable process-tree fixture**
 
 Create `packages/testing/test/fixtures/subprocess-tree.mjs`:
 
@@ -227,7 +227,7 @@ if (mode === "idle" || mode === "ignore-term") {
 }
 ```
 
-- [ ] **Step 2: Add exact test helpers**
+- [x] **Step 2: Add exact test helpers**
 
 In `subprocess.test.ts`, import `spawn`, `createConnection`, and `terminateSubprocess`. Add:
 
@@ -274,7 +274,7 @@ function canConnect(baseUrl: string): Promise<boolean> {
 }
 ```
 
-- [ ] **Step 3: Add and run the surviving-descendant RED test**
+- [x] **Step 3: Add and run the surviving-descendant RED test**
 
 ```ts
 it("waits for a surviving descendant to release the port", async () => {
@@ -304,7 +304,7 @@ pnpm --filter @dawn-ai/testing exec vitest --run --config vitest.config.ts test/
 
 Expected: RED at compile time because the internal helper does not yet accept `baseUrl`/timings, or behaviorally because it returns after the already-closed leader while the port remains live.
 
-- [ ] **Step 4: Implement bounded joint observation**
+- [x] **Step 4: Implement bounded joint observation**
 
 Import `createConnection` from `node:net`. Add internal defaults of 2,000 ms graceful/forced deadlines, 25 ms polling, and 100 ms probe timeout. Export `TerminationTimings` and `terminateSubprocess` from this source module for direct tests, but do not re-export either from `src/index.ts`.
 
@@ -312,7 +312,7 @@ Implement `portAcceptsConnections()` with a TCP socket that resolves `true` on c
 
 Update `terminateSubprocess()` to accept `baseUrl` and timings. Resolve immediately only when the child is closed and the port is unavailable; otherwise signal the saved group with `SIGTERM`, wait the grace deadline, and throw a PID/deadline error for now. Update the public close call to pass `baseUrl` and defaults.
 
-- [ ] **Step 5: Verify GREEN and commit**
+- [x] **Step 5: Verify GREEN and commit**
 
 Run the Task 3 test and the whole subprocess file. Expected: PASS.
 
@@ -327,23 +327,23 @@ git commit -m "fix(testing): observe subprocess port shutdown"
 - Modify: `packages/testing/test/subprocess.test.ts`
 - Modify: `packages/testing/src/subprocess.ts`
 
-- [ ] **Step 1: Add and run the escalation RED test**
+- [x] **Step 1: Add and run the escalation RED test**
 
 Use `spawnTree("ignore-term")` with an unavailable base URL obtained by binding a temporary `createServer()` to port zero and closing it. Add one pass-through `process.kill` spy test that expects `terminateSubprocess()` to resolve and observes `[-groupPid, "SIGKILL"]`. Restore the spy and forcibly clean up the exact process group in `finally`.
 
 Run only the escalation test. Expected: RED because the current graceful deadline throws without attempting `SIGKILL`.
 
-- [ ] **Step 2: Add and run the final-timeout RED test**
+- [x] **Step 2: Add and run the final-timeout RED test**
 
 Add the second test described above whose exact negative-PID `SIGTERM` and `SIGKILL` calls return `true` without delivering signals. Run only that test. Expected: RED because the current error is raised after the graceful deadline and does not represent a failed forced-termination deadline. Every spawned process and spy must be restored and the exact group forcibly cleaned up in `finally`.
 
 The escalation assertion must prove `SIGKILL` was delivered. The final-timeout assertion must prove the error names the group PID and the combined `graceMs + forceMs` deadline.
 
-- [ ] **Step 3: Implement forced termination**
+- [x] **Step 3: Implement forced termination**
 
 After the graceful wait expires, signal the group with `SIGKILL`. Await the same joint child-close/port-unavailable condition for `forceMs`. Return on success; otherwise throw an error containing the group PID and `graceMs + forceMs`.
 
-- [ ] **Step 4: Verify GREEN and commit**
+- [x] **Step 4: Verify GREEN and commit**
 
 ```bash
 pnpm --filter @dawn-ai/testing exec vitest --run --config vitest.config.ts test/subprocess.test.ts -t "SIGKILL|bounded failure"
@@ -351,23 +351,23 @@ git add packages/testing/src/subprocess.ts packages/testing/test/subprocess.test
 git commit -m "fix(testing): bound subprocess termination"
 ```
 
-### Task 5: Fall back when group signalling is unavailable
+### Task 5: Dispatch termination per platform
 
 **Files:**
 - Modify: `packages/testing/test/subprocess.test.ts`
 - Modify: `packages/testing/src/subprocess.ts`
 
-- [ ] **Step 1: Add the fallback RED test**
+- [x] **Step 1: Add platform-gated RED tests**
 
-Spawn `idle`, make only `process.kill(-groupPid, "SIGTERM")` throw, and install a pass-through spy on `child.kill`. Await termination and assert `child.kill("SIGTERM")` was called. Restore spies and forcibly clean up the exact group in `finally`.
+On POSIX, spawn `idle`, make only `process.kill(-groupPid, "SIGTERM")` throw, and install a pass-through spy on `child.kill`. Await termination and assert `child.kill("SIGTERM")` was called. Restore spies and forcibly clean up the exact group in `finally`.
 
-Run the test. Expected: RED because group-signalling failure currently escapes.
+On Windows, add platform-gated fixtures and tests for a live process tree and an orphaned descendant. The live-tree test proves `taskkill.exe /PID <saved PID> /T /F` terminates the tree without directly killing the outer child. The orphan test proves a closed outer child is never targeted by stale PID.
 
-- [ ] **Step 2: Implement direct-child fallback**
+- [x] **Step 2: Implement platform-specific dispatch**
 
-Extract `signalProcessTree(child, groupPid, signal)`: try `process.kill(-groupPid, signal)` and, on error, call `child.kill(signal)`. Use it for both graceful and forced signals.
+Extract `signalProcessTree(...)`. On POSIX, try `process.kill(-groupPid, signal)` and, on error, call `child.kill(signal)`. On Windows, first run bounded `taskkill.exe /PID <saved PID> /T /F`; charge that command's elapsed time to its grace or force phase. Only after a failed forced-phase command, while time remains and the child is still live, attempt a last-resort direct-child kill. Never target a saved PID after its child has closed.
 
-- [ ] **Step 3: Verify GREEN and commit**
+- [x] **Step 3: Verify GREEN and commit**
 
 ```bash
 pnpm --filter @dawn-ai/testing exec vitest --run --config vitest.config.ts test/subprocess.test.ts
@@ -382,7 +382,7 @@ git commit -m "fix(testing): fall back to direct process signals"
 - Verify: `packages/testing/src/subprocess.ts`
 - Verify: `packages/testing/test/subprocess.test.ts`
 
-- [ ] **Step 1: Add the exact patch changeset**
+- [x] **Step 1: Add the exact patch changeset**
 
 ```md
 ---
@@ -392,7 +392,7 @@ git commit -m "fix(testing): fall back to direct process signals"
 Wait for subprocess applications to finish terminating before `close()` or async disposal resolves.
 ```
 
-- [ ] **Step 2: Run package verification**
+- [x] **Step 2: Run package verification**
 
 ```bash
 pnpm --filter @dawn-ai/testing build
@@ -403,7 +403,7 @@ pnpm --filter @dawn-ai/testing test
 
 Expected: all commands pass.
 
-- [ ] **Step 3: Run repository validation**
+- [x] **Step 3: Run repository validation**
 
 ```bash
 pnpm ci:validate
@@ -411,7 +411,7 @@ pnpm ci:validate
 
 Expected: all Definition of Done lanes pass. Environment-gated Docker/Kubernetes lanes remain PR CI responsibilities.
 
-- [ ] **Step 4: Review tracked and uncommitted changes**
+- [x] **Step 4: Review tracked and uncommitted changes**
 
 ```bash
 git diff --check main...HEAD
@@ -422,9 +422,9 @@ git status --short
 
 Expected: no whitespace errors; only the approved spec/plan, testing source/tests/fixture, and exact changeset are changed.
 
-- [ ] **Step 5: Commit release metadata and plan progress**
+- [x] **Step 5: Commit release metadata and plan progress**
 
 ```bash
-git add .changeset/quiet-process-close.md docs/superpowers/plans/2026-08-09-subprocess-shutdown-barrier.md
+git add .changeset/quiet-process-close.md docs/superpowers/plans/2026-08-09-subprocess-shutdown-barrier.md docs/superpowers/specs/2026-08-09-subprocess-shutdown-barrier-design.md
 git commit -m "chore(testing): document subprocess shutdown fix"
 ```

--- a/docs/superpowers/plans/2026-08-09-subprocess-shutdown-barrier.md
+++ b/docs/superpowers/plans/2026-08-09-subprocess-shutdown-barrier.md
@@ -2,7 +2,7 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Make `createSubprocessApp().close()` and async disposal resolve only after the owned process tree has stopped and its port is unavailable.
+**Goal:** Make `createSubprocessApp().close()` and async disposal resolve only after the spawned CLI child has closed, the `baseUrl` port is unavailable, and bounded process-tree termination attempts have completed.
 
 **Architecture:** Keep the public API unchanged. Build the shutdown barrier incrementally: first await the spawned CLI's `close` event through one memoized promise, then add bounded TCP observation for surviving descendants and forced termination. On POSIX, signal the detached group and fall back to the direct child. On Windows, use bounded `taskkill.exe /PID <saved PID> /T /F` before any last-resort direct-child kill. Reuse the same closure function when readiness fails.
 
@@ -361,11 +361,11 @@ git commit -m "fix(testing): bound subprocess termination"
 
 On POSIX, spawn `idle`, make only `process.kill(-groupPid, "SIGTERM")` throw, and install a pass-through spy on `child.kill`. Await termination and assert `child.kill("SIGTERM")` was called. Restore spies and forcibly clean up the exact group in `finally`.
 
-On Windows, add platform-gated fixtures and tests for a live process tree and an orphaned descendant. The live-tree test proves `taskkill.exe /PID <saved PID> /T /F` terminates the tree without directly killing the outer child. The orphan test proves a closed outer child is never targeted by stale PID.
+On Windows, add platform-gated fixtures and tests for a live process tree and an orphaned descendant. The live-tree test proves `taskkill.exe /PID <saved PID> /T /F` terminates the tree without directly killing the outer child. A deterministic, injected-Windows-dispatch orphan test proves a closed outer child causes bounded rejection without any tree-kill dispatch; the platform-gated orphan test also guards against an unnecessary direct-child kill.
 
 - [x] **Step 2: Implement platform-specific dispatch**
 
-Extract `signalProcessTree(...)`. On POSIX, try `process.kill(-groupPid, signal)` and, on error, call `child.kill(signal)`. On Windows, first run bounded `taskkill.exe /PID <saved PID> /T /F`; charge that command's elapsed time to its grace or force phase. Only after a failed forced-phase command, while time remains and the child is still live, attempt a last-resort direct-child kill. Never target a saved PID after its child has closed.
+Extract `requestProcessTreeTermination(...)`. Its internal test seam accepts an optional platform and Windows tree-kill dispatcher; production defaults remain `process.platform` and bounded `taskkill.exe /PID <saved PID> /T /F`. On POSIX, try `process.kill(-groupPid, signal)` and, on error, call `child.kill(signal)`. On Windows, first run bounded `taskkill.exe /PID <saved PID> /T /F`; charge that command's elapsed time to its grace or force phase. Only after a failed forced-phase command, while time remains and the child is still live, attempt a last-resort direct-child kill. Never target a saved PID after its child has closed.
 
 - [x] **Step 3: Verify GREEN and commit**
 

--- a/docs/superpowers/specs/2026-08-09-subprocess-shutdown-barrier-design.md
+++ b/docs/superpowers/specs/2026-08-09-subprocess-shutdown-barrier-design.md
@@ -62,10 +62,13 @@ Successful resolution guarantees:
 3. A bounded TCP probe confirms that the `baseUrl` port no longer accepts
    connections, covering a descendant that might briefly outlive the outer CLI.
 
-If the process has already closed, `close()` resolves without sending another
-signal. If bounded graceful and forced termination both fail to produce a
-`close` event, `close()` rejects with the process identifier and termination
-context instead of falsely reporting success.
+If the outer process has already closed, that satisfies only the child-closure
+half of the barrier. `close()` still probes the port. If a descendant continues
+serving, the helper signals the saved process-group ID and follows the same
+bounded escalation path. If bounded graceful and forced termination fail to
+produce child closure and port unavailability, `close()` rejects with the
+process identifier and termination context instead of falsely reporting
+success.
 
 ## Termination Algorithm
 
@@ -74,8 +77,9 @@ signal can be sent or exit can be missed.
 
 The shared termination helper:
 
-1. Returns the existing closure result when the child is already closed.
-2. Sends `SIGTERM` to the negative PID so the detached process group is
+1. Checks child closure and port availability independently. It resolves
+   immediately only when the child is closed and the port is unavailable.
+2. Otherwise sends `SIGTERM` to the saved negative PID so the detached process group is
    targeted; if group signalling is unavailable, falls back to `child.kill()`.
 3. Waits up to a 2,000 ms internal grace deadline for both the child `close`
    event and the `baseUrl` port to stop accepting TCP connections.
@@ -125,6 +129,9 @@ short test deadlines to verify the other new branches:
 - a scoped signal stub that leaves a child alive causes the final deadline to
   reject, after which the test forcibly cleans up the child;
 - a negative-PID signal failure falls back to `child.kill()`;
+- a detached group leader that has already exited while a descendant retains
+  the listening port is not treated as closed; the saved process group is
+  terminated and port unavailability is observed;
 - a constructor with an immediate readiness timeout does not reject until its
   delayed termination finishes, proving readiness-failure cleanup is awaited.
 

--- a/docs/superpowers/specs/2026-08-09-subprocess-shutdown-barrier-design.md
+++ b/docs/superpowers/specs/2026-08-09-subprocess-shutdown-barrier-design.md
@@ -147,23 +147,25 @@ short test deadlines to verify the other new branches. POSIX-only tests cover:
 - a constructor with an immediate readiness timeout does not reject until its
   delayed termination finishes, proving readiness-failure cleanup is awaited.
 
-Windows-only tests use a live process-tree fixture to verify `taskkill.exe`
-terminates the tree without an unnecessary direct-child kill. A deterministic
-cross-platform test injects the Windows platform and tree-kill dispatcher for
-an orphan fixture, then verifies bounded rejection and zero dispatcher calls
-after the outer child closes. The shared fixture file is
+One Windows-only live process-tree test verifies `taskkill.exe` terminates the
+tree without an unnecessary direct-child kill. One deterministic cross-platform
+test closes an idle child while an independent TCP server stays live, injects
+the Windows platform and tree-kill dispatcher, then verifies bounded rejection
+and zero dispatcher calls. The shared fixture file is
 `packages/testing/test/fixtures/subprocess-tree.mjs`.
 
 A focused native Windows CI job builds the `@dawn-ai/testing` dependency
-closure, including the CLI distribution the test starts, then runs only
-`packages/testing/test/subprocess.test.ts` through that package's Vitest
-configuration. This validates the two real Windows `taskkill.exe` tree and
-orphan cases; it does not claim broader Windows test coverage.
+closure, including the CLI distribution the test starts, then runs only the
+live Windows process-tree test and injected stale-dispatch guard from
+`packages/testing/test/subprocess.test.ts`. The first covers real
+`taskkill.exe` process-tree shutdown; the second proves the closed-child guard
+without relying on a surviving orphan fixture. It does not claim broader
+Windows test coverage.
 
 The focused test must be observed failing before production code changes and
 passing afterward. Package build, typecheck, lint, and tests plus the repository
-Definition of Done complete verification. The native Windows CI job is the
-platform-specific verification for the real `taskkill.exe` cases.
+Definition of Done complete verification. The native Windows CI job selects the
+one real `taskkill.exe` live-tree test and the injected cross-platform guard.
 
 ## Files
 
@@ -171,8 +173,8 @@ platform-specific verification for the real `taskkill.exe` cases.
   barrier and bounded process-tree termination helper.
 - Modify `packages/testing/test/subprocess.test.ts` for deterministic closure,
   concurrency, and reachability assertions.
-- Add `packages/testing/test/fixtures/subprocess-tree.mjs` for real process
-  tree and orphan scenarios.
+- Add `packages/testing/test/fixtures/subprocess-tree.mjs` for the real
+  process-tree scenario.
 - Modify `.github/workflows/ci.yml` for the focused native Windows subprocess
   shutdown test job.
 - Add a patch changeset for `@dawn-ai/testing`.

--- a/docs/superpowers/specs/2026-08-09-subprocess-shutdown-barrier-design.md
+++ b/docs/superpowers/specs/2026-08-09-subprocess-shutdown-barrier-design.md
@@ -56,7 +56,7 @@ async disposal, receives that promise.
 Successful resolution guarantees:
 
 1. Unless the child was already closed and the port unavailable, teardown
-   dispatched graceful termination and, after the grace deadline, forced
+   dispatched graceful termination or, after the grace deadline, forced
    termination using the platform's process-tree mechanism.
 2. The spawned CLI child's `close` event fired, which occurs after exit and
    stdio closure.
@@ -148,9 +148,11 @@ short test deadlines to verify the other new branches. POSIX-only tests cover:
   delayed termination finishes, proving readiness-failure cleanup is awaited.
 
 Windows-only tests use a live process-tree fixture to verify `taskkill.exe`
-terminates the tree without an unnecessary direct-child kill, and an orphan
-fixture to verify a closed child's saved PID is never targeted. The shared
-fixture file is `packages/testing/test/fixtures/subprocess-tree.mjs`.
+terminates the tree without an unnecessary direct-child kill. A deterministic
+cross-platform test injects the Windows platform and tree-kill dispatcher for
+an orphan fixture, then verifies bounded rejection and zero dispatcher calls
+after the outer child closes. The shared fixture file is
+`packages/testing/test/fixtures/subprocess-tree.mjs`.
 
 The focused test must be observed failing before production code changes and
 passing afterward. Package build, typecheck, lint, and tests plus the repository

--- a/docs/superpowers/specs/2026-08-09-subprocess-shutdown-barrier-design.md
+++ b/docs/superpowers/specs/2026-08-09-subprocess-shutdown-barrier-design.md
@@ -55,9 +55,9 @@ async disposal, receives that promise.
 
 Successful resolution guarantees:
 
-1. Unless the child was already closed and the port unavailable, the detached
-   process group received graceful termination or forced termination after the
-   grace deadline.
+1. Unless the child was already closed and the port unavailable, teardown
+   dispatched graceful termination and, after the grace deadline, forced
+   termination using the platform's process-tree mechanism.
 2. The spawned CLI child's `close` event fired, which occurs after exit and
    stdio closure.
 3. A bounded TCP probe confirms that the `baseUrl` port no longer accepts
@@ -65,11 +65,11 @@ Successful resolution guarantees:
 
 If the outer process has already closed, that satisfies only the child-closure
 half of the barrier. `close()` still probes the port. If a descendant continues
-serving, the helper signals the saved process-group ID and follows the same
-bounded escalation path. If bounded graceful and forced termination fail to
-produce child closure and port unavailability, `close()` rejects with the
-process identifier and termination context instead of falsely reporting
-success.
+serving, POSIX can still target the saved process group; Windows never targets
+a saved PID after its child has closed. If bounded graceful and forced
+termination fail to produce child closure and port unavailability, `close()`
+rejects with the saved process identifier and termination context instead of
+falsely reporting success.
 
 ## Termination Algorithm
 
@@ -80,11 +80,18 @@ The shared termination helper:
 
 1. Checks child closure and port availability independently. It resolves
    immediately only when the child is closed and the port is unavailable.
-2. Otherwise sends `SIGTERM` to the saved negative PID so the detached process group is
-   targeted; if group signalling is unavailable, falls back to `child.kill()`.
+2. Otherwise dispatches the first phase by platform:
+   - On POSIX, sends `SIGTERM` to the saved negative PID so the detached
+     process group is targeted; if group signalling is unavailable, falls back
+     to `child.kill()`.
+   - On Windows, runs `taskkill.exe /PID <saved PID> /T /F` with the phase's
+     remaining time as its command timeout. A closed child is not targeted.
 3. Waits up to a 2,000 ms internal grace deadline for both the child `close`
    event and the `baseUrl` port to stop accepting TCP connections.
-4. On expiry, sends `SIGKILL` to the same target.
+4. On expiry, runs the forced phase. POSIX sends `SIGKILL` through the same
+   group-then-direct-child dispatch. Windows again uses bounded `taskkill.exe`
+   for the saved live child, then may make a last-resort direct-child kill only
+   if that command failed and the phase still has time remaining.
 5. Waits up to a final 2,000 ms for both observations and rejects if the child
    still cannot be reaped or the port still accepts connections.
 
@@ -95,17 +102,21 @@ unavailability. The termination deadlines and probe timings are internal
 defaults, not public API. The internal termination helper accepts shorter
 deadlines for deterministic unit tests.
 
-The helper is also used when readiness fails so a failed constructor does not
-leave the same process tree running in the background.
+Time spent running a Windows `taskkill.exe` command is charged to its grace or
+forced phase; it cannot extend either deadline. The helper is also used when
+readiness fails so a failed constructor does not leave the same process tree
+running in the background.
 
 ## Error Handling
 
-- A signal race with an already-exited process is treated as successful once
-  the closure promise resolves.
-- Group-signal failure falls back to signalling the direct child.
-- A wedged process escalates from `SIGTERM` to `SIGKILL`.
+- A dispatch race with an already-exited process is treated as successful once
+  the closure promise resolves and the port is unavailable.
+- On POSIX, group-signal failure falls back to signalling the direct child.
+- A wedged POSIX process escalates from `SIGTERM` to `SIGKILL`; Windows uses
+  bounded tree termination for both phases.
 - Failure to observe closure after forced termination rejects rather than
   hanging indefinitely.
+- Dispatch failures are retained as the final termination error's cause.
 - Readiness errors are rethrown after bounded cleanup; a teardown failure is
   surfaced when cleanup itself cannot complete.
 
@@ -124,7 +135,7 @@ The regression test will:
 5. Await both calls and prove `/healthz` is unreachable.
 
 Focused internal-helper tests will use disposable real child processes and
-short test deadlines to verify the other new branches:
+short test deadlines to verify the other new branches. POSIX-only tests cover:
 
 - a child that ignores `SIGTERM` receives `SIGKILL` and is reaped;
 - a scoped signal stub that leaves a child alive causes the final deadline to
@@ -136,6 +147,11 @@ short test deadlines to verify the other new branches:
 - a constructor with an immediate readiness timeout does not reject until its
   delayed termination finishes, proving readiness-failure cleanup is awaited.
 
+Windows-only tests use a live process-tree fixture to verify `taskkill.exe`
+terminates the tree without an unnecessary direct-child kill, and an orphan
+fixture to verify a closed child's saved PID is never targeted. The shared
+fixture file is `packages/testing/test/fixtures/subprocess-tree.mjs`.
+
 The focused test must be observed failing before production code changes and
 passing afterward. Package build, typecheck, lint, and tests plus the repository
 Definition of Done complete verification.
@@ -146,6 +162,8 @@ Definition of Done complete verification.
   barrier and bounded process-tree termination helper.
 - Modify `packages/testing/test/subprocess.test.ts` for deterministic closure,
   concurrency, and reachability assertions.
+- Add `packages/testing/test/fixtures/subprocess-tree.mjs` for real process
+  tree and orphan scenarios.
 - Add a patch changeset for `@dawn-ai/testing`.
 
 ## Release

--- a/docs/superpowers/specs/2026-08-09-subprocess-shutdown-barrier-design.md
+++ b/docs/superpowers/specs/2026-08-09-subprocess-shutdown-barrier-design.md
@@ -1,0 +1,129 @@
+# Subprocess Shutdown Barrier Design
+
+**Status:** Approved 2026-08-09
+
+## Summary
+
+`createSubprocessApp()` exposes `close()` and async disposal as asynchronous
+teardown APIs, but the current implementation resolves immediately after
+sending `SIGTERM`. Signal delivery and Dawn's HTTP/process shutdown happen
+later, so callers can observe a live server after `await app.close()`.
+
+Make successful closure a completion barrier: the owned CLI process has
+closed, its process group has been signalled, its stdio has closed, and its
+`baseUrl` no longer serves. Preserve graceful shutdown first, add bounded
+`SIGKILL` escalation, and make repeated or concurrent closure share one result.
+
+## Goals
+
+- Make `await app.close()` mean that subprocess teardown completed.
+- Give `[Symbol.asyncDispose]()` the same completion guarantee.
+- Preserve graceful `SIGTERM` shutdown when Dawn exits promptly.
+- Prevent teardown from hanging forever when a subprocess wedges.
+- Make repeated and concurrent `close()` calls idempotent.
+- Apply the same bounded teardown to readiness-failure cleanup.
+
+## Non-Goals
+
+- Changing Dawn's production `dawn dev` signal handling.
+- Adding a public process ID, signal, or timeout API.
+- Polling the health endpoint as the primary lifecycle signal.
+- Changing how ports are selected or readiness is detected.
+- Refactoring unrelated testing harness factories.
+
+## Root Cause
+
+`packages/testing/src/subprocess.ts` marks the app stopped, sends `SIGTERM` to
+the detached process group, and returns without awaiting a child lifecycle
+event. `process.kill()` requests signal delivery; it does not wait for the
+target to handle the signal or exit.
+
+The outer Dawn CLI handles `SIGTERM` by asynchronously closing its dev session.
+That session in turn stops its dev child and drains the HTTP runtime. The
+testing helper therefore reports completion before the asynchronous work it
+initiated has completed.
+
+The existing disposal test is timing-sensitive. Repeated execution reproduced
+the failure: `/healthz` still returned `200 OK` after disposal. Timing probes
+showed `close()` resolving in less than 0.11 ms while connection rejection
+followed roughly 0.7–3.5 ms later.
+
+## Lifecycle Contract
+
+`SubprocessApp.close()` returns a single memoized promise. Every call, including
+async disposal, receives that promise.
+
+Successful resolution guarantees:
+
+1. The detached process group received graceful termination or forced
+   termination after the grace deadline.
+2. The spawned CLI child's `close` event fired, which occurs after exit and
+   stdio closure.
+3. The helper no longer owns a live server at `baseUrl`.
+
+If the process has already closed, `close()` resolves without sending another
+signal. If bounded graceful and forced termination both fail to produce a
+`close` event, `close()` rejects with the process identifier and termination
+context instead of falsely reporting success.
+
+## Termination Algorithm
+
+Create the child-closure promise immediately after spawning the CLI, before any
+signal can be sent or exit can be missed.
+
+The shared termination helper:
+
+1. Returns the existing closure result when the child is already closed.
+2. Sends `SIGTERM` to the negative PID so the detached process group is
+   targeted; if group signalling is unavailable, falls back to `child.kill()`.
+3. Waits up to a small internal grace deadline for the child `close` event.
+4. On expiry, sends `SIGKILL` to the same target.
+5. Waits for the `close` event with a final bounded deadline and rejects if the
+   process still cannot be reaped.
+
+The deadlines are internal constants, not public options. The helper is also
+used when readiness fails so a failed constructor does not leave the same
+process tree running in the background.
+
+## Error Handling
+
+- A signal race with an already-exited process is treated as successful once
+  the closure promise resolves.
+- Group-signal failure falls back to signalling the direct child.
+- A wedged process escalates from `SIGTERM` to `SIGKILL`.
+- Failure to observe closure after forced termination rejects rather than
+  hanging indefinitely.
+- Readiness errors are rethrown after bounded cleanup; a teardown failure is
+  surfaced when cleanup itself cannot complete.
+
+## Testing
+
+Use the real `createSubprocessApp()` path and make the existing race
+deterministic by temporarily delaying the real negative-PID `SIGTERM` call.
+
+The regression test will:
+
+1. Start a healthy subprocess.
+2. Delay actual group signal delivery for about 100 ms.
+3. Call `close()` twice before termination completes.
+4. Race closure against a shorter timer and prove the timer wins. The current
+   implementation fails because both closure promises resolve immediately.
+5. Await both calls and prove `/healthz` is unreachable.
+
+The focused test must be observed failing before production code changes and
+passing afterward. Package build, typecheck, lint, and tests plus the repository
+Definition of Done complete verification.
+
+## Files
+
+- Modify `packages/testing/src/subprocess.ts` for the memoized completion
+  barrier and bounded process-tree termination helper.
+- Modify `packages/testing/test/subprocess.test.ts` for deterministic closure,
+  concurrency, and reachability assertions.
+- Add a patch changeset for `@dawn-ai/testing`.
+
+## Release
+
+This is a patch fix to the documented testing lifecycle. The release note will
+state that subprocess closure and async disposal now wait for actual process
+termination instead of returning after signal dispatch.

--- a/docs/superpowers/specs/2026-08-09-subprocess-shutdown-barrier-design.md
+++ b/docs/superpowers/specs/2026-08-09-subprocess-shutdown-barrier-design.md
@@ -55,8 +55,9 @@ async disposal, receives that promise.
 
 Successful resolution guarantees:
 
-1. The detached process group received graceful termination or forced
-   termination after the grace deadline.
+1. Unless the child was already closed and the port unavailable, the detached
+   process group received graceful termination or forced termination after the
+   grace deadline.
 2. The spawned CLI child's `close` event fired, which occurs after exit and
    stdio closure.
 3. A bounded TCP probe confirms that the `baseUrl` port no longer accepts

--- a/docs/superpowers/specs/2026-08-09-subprocess-shutdown-barrier-design.md
+++ b/docs/superpowers/specs/2026-08-09-subprocess-shutdown-barrier-design.md
@@ -154,9 +154,16 @@ an orphan fixture, then verifies bounded rejection and zero dispatcher calls
 after the outer child closes. The shared fixture file is
 `packages/testing/test/fixtures/subprocess-tree.mjs`.
 
+A focused native Windows CI job builds the `@dawn-ai/testing` dependency
+closure, including the CLI distribution the test starts, then runs only
+`packages/testing/test/subprocess.test.ts` through that package's Vitest
+configuration. This validates the two real Windows `taskkill.exe` tree and
+orphan cases; it does not claim broader Windows test coverage.
+
 The focused test must be observed failing before production code changes and
 passing afterward. Package build, typecheck, lint, and tests plus the repository
-Definition of Done complete verification.
+Definition of Done complete verification. The native Windows CI job is the
+platform-specific verification for the real `taskkill.exe` cases.
 
 ## Files
 
@@ -166,6 +173,8 @@ Definition of Done complete verification.
   concurrency, and reachability assertions.
 - Add `packages/testing/test/fixtures/subprocess-tree.mjs` for real process
   tree and orphan scenarios.
+- Modify `.github/workflows/ci.yml` for the focused native Windows subprocess
+  shutdown test job.
 - Add a patch changeset for `@dawn-ai/testing`.
 
 ## Release

--- a/docs/superpowers/specs/2026-08-09-subprocess-shutdown-barrier-design.md
+++ b/docs/superpowers/specs/2026-08-09-subprocess-shutdown-barrier-design.md
@@ -59,7 +59,8 @@ Successful resolution guarantees:
    termination after the grace deadline.
 2. The spawned CLI child's `close` event fired, which occurs after exit and
    stdio closure.
-3. The helper no longer owns a live server at `baseUrl`.
+3. A bounded TCP probe confirms that the `baseUrl` port no longer accepts
+   connections, covering a descendant that might briefly outlive the outer CLI.
 
 If the process has already closed, `close()` resolves without sending another
 signal. If bounded graceful and forced termination both fail to produce a
@@ -76,14 +77,21 @@ The shared termination helper:
 1. Returns the existing closure result when the child is already closed.
 2. Sends `SIGTERM` to the negative PID so the detached process group is
    targeted; if group signalling is unavailable, falls back to `child.kill()`.
-3. Waits up to a small internal grace deadline for the child `close` event.
+3. Waits up to a 2,000 ms internal grace deadline for both the child `close`
+   event and the `baseUrl` port to stop accepting TCP connections.
 4. On expiry, sends `SIGKILL` to the same target.
-5. Waits for the `close` event with a final bounded deadline and rejects if the
-   process still cannot be reaped.
+5. Waits up to a final 2,000 ms for both observations and rejects if the child
+   still cannot be reaped or the port still accepts connections.
 
-The deadlines are internal constants, not public options. The helper is also
-used when readiness fails so a failed constructor does not leave the same
-process tree running in the background.
+The TCP observation uses `node:net`, a 100 ms connection-attempt timeout, and a
+25 ms polling interval. A connection timeout is treated as still potentially
+available; only connection refusal or another socket error establishes
+unavailability. The termination deadlines and probe timings are internal
+defaults, not public API. The internal termination helper accepts shorter
+deadlines for deterministic unit tests.
+
+The helper is also used when readiness fails so a failed constructor does not
+leave the same process tree running in the background.
 
 ## Error Handling
 
@@ -109,6 +117,16 @@ The regression test will:
 4. Race closure against a shorter timer and prove the timer wins. The current
    implementation fails because both closure promises resolve immediately.
 5. Await both calls and prove `/healthz` is unreachable.
+
+Focused internal-helper tests will use disposable real child processes and
+short test deadlines to verify the other new branches:
+
+- a child that ignores `SIGTERM` receives `SIGKILL` and is reaped;
+- a scoped signal stub that leaves a child alive causes the final deadline to
+  reject, after which the test forcibly cleans up the child;
+- a negative-PID signal failure falls back to `child.kill()`;
+- a constructor with an immediate readiness timeout does not reject until its
+  delayed termination finishes, proving readiness-failure cleanup is awaited.
 
 The focused test must be observed failing before production code changes and
 passing afterward. Package build, typecheck, lint, and tests plus the repository

--- a/packages/testing/src/subprocess.ts
+++ b/packages/testing/src/subprocess.ts
@@ -61,6 +61,24 @@ function resolveDawnCliEntry(): string {
   return resolve(pkgRoot, "node_modules", "@dawn-ai", "cli", "dist", "index.js")
 }
 
+function childClosePromise(child: ChildProcess): Promise<void> {
+  return new Promise((resolve, reject) => {
+    child.once("error", reject)
+    child.once("close", () => resolve())
+  })
+}
+
+async function terminateSubprocess(
+  child: ChildProcess,
+  groupPid: number,
+  closed: Promise<void>,
+): Promise<void> {
+  if (child.exitCode === null && child.signalCode === null) {
+    process.kill(-groupPid, "SIGTERM")
+  }
+  await closed
+}
+
 export async function createSubprocessApp(opts: {
   readonly appRoot: string
   readonly env?: Record<string, string>
@@ -76,40 +94,36 @@ export async function createSubprocessApp(opts: {
     stdio: "pipe",
     detached: true,
   })
+  const groupPid = child.pid
+  const closed = childClosePromise(child)
+  if (groupPid === undefined) {
+    await closed
+    throw new Error("dawn dev subprocess has no process id")
+  }
+
   // surface server logs for debugging on failure
   child.stdout?.on("data", (b) => process.stdout.write(`[dawn dev] ${b}`))
   child.stderr?.on("data", (b) => process.stderr.write(`[dawn dev] ${b}`))
 
   const baseUrl = `http://127.0.0.1:${port}`
+  let closePromise: Promise<void> | undefined
+  const close = (): Promise<void> => {
+    closePromise ??= terminateSubprocess(child, groupPid, closed)
+    return closePromise
+  }
+
   try {
     await waitReady(`${baseUrl}/healthz`, opts.readyTimeoutMs ?? 60_000)
   } catch (err) {
-    if (child.pid) {
-      try {
-        process.kill(-child.pid, "SIGTERM")
-      } catch {
-        child.kill("SIGTERM")
-      }
-    }
+    await close()
     throw err
   }
 
-  let stopped = false
   const app: SubprocessApp = {
     baseUrl,
-    async close() {
-      if (stopped) return
-      stopped = true
-      if (child.pid) {
-        try {
-          process.kill(-child.pid, "SIGTERM")
-        } catch {
-          child.kill("SIGTERM")
-        }
-      }
-    },
+    close,
     [Symbol.asyncDispose](): Promise<void> {
-      return this.close()
+      return close()
     },
   }
   return app

--- a/packages/testing/src/subprocess.ts
+++ b/packages/testing/src/subprocess.ts
@@ -133,19 +133,25 @@ function taskkillProcessTree(pid: number, timeoutMs: number): Promise<void> {
   })
 }
 
-async function signalProcessTree(
+interface TerminationDependencies {
+  readonly platform: NodeJS.Platform
+  readonly taskkillProcessTree: (pid: number, timeoutMs: number) => Promise<void>
+}
+
+async function requestProcessTreeTermination(
   child: ChildProcess,
   childState: { readonly closed: boolean },
   groupPid: number,
   signal: NodeJS.Signals,
   timeoutMs: number,
   dispatchErrors: unknown[],
+  dependencies: TerminationDependencies,
 ): Promise<void> {
-  if (process.platform === "win32") {
+  if (dependencies.platform === "win32") {
     if (childState.closed || child.exitCode !== null || child.signalCode !== null) return
     const deadline = Date.now() + timeoutMs
     try {
-      await taskkillProcessTree(groupPid, timeoutMs)
+      await dependencies.taskkillProcessTree(groupPid, timeoutMs)
       return
     } catch (error) {
       dispatchErrors.push(error)
@@ -179,7 +185,12 @@ export async function terminateSubprocess(
   closed: Promise<void>,
   baseUrl: string,
   timings: TerminationTimings = DEFAULT_TERMINATION_TIMINGS,
+  injectedDependencies: Partial<TerminationDependencies> = {},
 ): Promise<void> {
+  const dependencies: TerminationDependencies = {
+    platform: injectedDependencies.platform ?? process.platform,
+    taskkillProcessTree: injectedDependencies.taskkillProcessTree ?? taskkillProcessTree,
+  }
   const childState: { closed: boolean; failed: boolean; error: unknown } = {
     closed: false,
     failed: false,
@@ -202,13 +213,14 @@ export async function terminateSubprocess(
   const dispatchErrors: unknown[] = []
   const waitForPhase = async (signal: NodeJS.Signals, phaseMs: number): Promise<boolean> => {
     const deadline = Date.now() + phaseMs
-    await signalProcessTree(
+    await requestProcessTreeTermination(
       child,
       childState,
       groupPid,
       signal,
       Math.max(0, deadline - Date.now()),
       dispatchErrors,
+      dependencies,
     )
     return await waitUntilStopped(childState, baseUrl, Math.max(0, deadline - Date.now()), timings)
   }

--- a/packages/testing/src/subprocess.ts
+++ b/packages/testing/src/subprocess.ts
@@ -1,4 +1,4 @@
-import { type ChildProcess, spawn } from "node:child_process"
+import { type ChildProcess, execFile, spawn } from "node:child_process"
 import { createConnection, createServer } from "node:net"
 import { dirname, resolve } from "node:path"
 import { setTimeout as delay } from "node:timers/promises"
@@ -122,8 +122,59 @@ async function waitUntilStopped(
   }
 }
 
+function taskkillProcessTree(pid: number, timeoutMs: number): Promise<void> {
+  return new Promise((resolve, reject) => {
+    execFile(
+      "taskkill.exe",
+      ["/PID", String(pid), "/T", "/F"],
+      { windowsHide: true, timeout: Math.max(1, timeoutMs), maxBuffer: 64 * 1024 },
+      (error) => (error ? reject(error) : resolve()),
+    )
+  })
+}
+
+async function signalProcessTree(
+  child: ChildProcess,
+  childState: { readonly closed: boolean },
+  groupPid: number,
+  signal: NodeJS.Signals,
+  timeoutMs: number,
+  dispatchErrors: unknown[],
+): Promise<void> {
+  if (process.platform === "win32") {
+    if (childState.closed || child.exitCode !== null || child.signalCode !== null) return
+    const deadline = Date.now() + timeoutMs
+    try {
+      await taskkillProcessTree(groupPid, timeoutMs)
+      return
+    } catch (error) {
+      dispatchErrors.push(error)
+      if (signal !== "SIGKILL") return
+      if (Date.now() >= deadline) return
+      if (childState.closed || child.exitCode !== null || child.signalCode !== null) return
+      try {
+        child.kill(signal)
+      } catch (childError) {
+        dispatchErrors.push(childError)
+      }
+      return
+    }
+  }
+
+  try {
+    process.kill(-groupPid, signal)
+  } catch (error) {
+    dispatchErrors.push(error)
+    try {
+      child.kill(signal)
+    } catch (childError) {
+      dispatchErrors.push(childError)
+    }
+  }
+}
+
 export async function terminateSubprocess(
-  _child: ChildProcess,
+  child: ChildProcess,
   groupPid: number,
   closed: Promise<void>,
   baseUrl: string,
@@ -148,13 +199,29 @@ export async function terminateSubprocess(
   if (childState.failed) throw childState.error
   if (childState.closed && !portAccepting) return
 
-  process.kill(-groupPid, "SIGTERM")
-  if (await waitUntilStopped(childState, baseUrl, timings.graceMs, timings)) return
-  process.kill(-groupPid, "SIGKILL")
-  if (await waitUntilStopped(childState, baseUrl, timings.forceMs, timings)) return
-  throw new Error(
-    `subprocess group ${groupPid} did not stop within ${timings.graceMs + timings.forceMs}ms after SIGTERM and SIGKILL`,
-  )
+  const dispatchErrors: unknown[] = []
+  const waitForPhase = async (signal: NodeJS.Signals, phaseMs: number): Promise<boolean> => {
+    const deadline = Date.now() + phaseMs
+    await signalProcessTree(
+      child,
+      childState,
+      groupPid,
+      signal,
+      Math.max(0, deadline - Date.now()),
+      dispatchErrors,
+    )
+    return await waitUntilStopped(childState, baseUrl, Math.max(0, deadline - Date.now()), timings)
+  }
+
+  if (await waitForPhase("SIGTERM", timings.graceMs)) return
+  if (await waitForPhase("SIGKILL", timings.forceMs)) return
+  const message = `subprocess group ${groupPid} did not stop within ${timings.graceMs + timings.forceMs}ms after SIGTERM and SIGKILL`
+  if (dispatchErrors.length === 0) throw new Error(message)
+  const cause =
+    dispatchErrors.length === 1
+      ? dispatchErrors[0]
+      : new AggregateError(dispatchErrors, "subprocess termination signal dispatch failed")
+  throw new Error(message, { cause })
 }
 
 export async function createSubprocessApp(opts: {

--- a/packages/testing/src/subprocess.ts
+++ b/packages/testing/src/subprocess.ts
@@ -1,5 +1,5 @@
 import { type ChildProcess, spawn } from "node:child_process"
-import { createServer } from "node:net"
+import { createConnection, createServer } from "node:net"
 import { dirname, resolve } from "node:path"
 import { setTimeout as delay } from "node:timers/promises"
 import { fileURLToPath } from "node:url"
@@ -8,6 +8,20 @@ export interface SubprocessApp {
   readonly baseUrl: string
   close(): Promise<void>
   [Symbol.asyncDispose](): Promise<void>
+}
+
+export interface TerminationTimings {
+  readonly graceMs: number
+  readonly forceMs: number
+  readonly probeIntervalMs: number
+  readonly probeTimeoutMs: number
+}
+
+const DEFAULT_TERMINATION_TIMINGS: TerminationTimings = {
+  graceMs: 2_000,
+  forceMs: 2_000,
+  probeIntervalMs: 25,
+  probeTimeoutMs: 100,
 }
 
 /** Bind to port 0, read the OS-assigned port, release it. */
@@ -68,15 +82,77 @@ function childClosePromise(child: ChildProcess): Promise<void> {
   })
 }
 
-async function terminateSubprocess(
-  child: ChildProcess,
+function portAcceptsConnections(baseUrl: string, timeoutMs: number): Promise<boolean> {
+  const url = new URL(baseUrl)
+  return new Promise((resolve) => {
+    let settled = false
+    const socket = createConnection({ host: url.hostname, port: Number(url.port) })
+    const finish = (accepting: boolean): void => {
+      if (settled) return
+      settled = true
+      clearTimeout(timer)
+      socket.destroy()
+      resolve(accepting)
+    }
+    const timer = setTimeout(() => finish(true), timeoutMs)
+    socket.once("connect", () => finish(true))
+    socket.once("error", () => finish(false))
+  })
+}
+
+async function waitUntilStopped(
+  childState: { closed: boolean; failed: boolean; error: unknown },
+  baseUrl: string,
+  timeoutMs: number,
+  timings: TerminationTimings,
+): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs
+  while (true) {
+    const remainingMs = Math.max(0, deadline - Date.now())
+    const accepting = await portAcceptsConnections(
+      baseUrl,
+      Math.min(timings.probeTimeoutMs, remainingMs),
+    )
+    if (childState.failed) throw childState.error
+    if (childState.closed && !accepting) return true
+
+    const waitMs = Math.min(timings.probeIntervalMs, deadline - Date.now())
+    if (waitMs <= 0) return false
+    await delay(waitMs)
+  }
+}
+
+export async function terminateSubprocess(
+  _child: ChildProcess,
   groupPid: number,
   closed: Promise<void>,
+  baseUrl: string,
+  timings: TerminationTimings = DEFAULT_TERMINATION_TIMINGS,
 ): Promise<void> {
-  if (child.exitCode === null && child.signalCode === null) {
-    process.kill(-groupPid, "SIGTERM")
+  const childState: { closed: boolean; failed: boolean; error: unknown } = {
+    closed: false,
+    failed: false,
+    error: undefined,
   }
-  await closed
+  void closed.then(
+    () => {
+      childState.closed = true
+    },
+    (error: unknown) => {
+      childState.failed = true
+      childState.error = error
+    },
+  )
+
+  const portAccepting = await portAcceptsConnections(baseUrl, timings.probeTimeoutMs)
+  if (childState.failed) throw childState.error
+  if (childState.closed && !portAccepting) return
+
+  process.kill(-groupPid, "SIGTERM")
+  if (await waitUntilStopped(childState, baseUrl, timings.graceMs, timings)) return
+  throw new Error(
+    `subprocess group ${groupPid} did not stop within ${timings.graceMs}ms after SIGTERM`,
+  )
 }
 
 export async function createSubprocessApp(opts: {
@@ -108,7 +184,13 @@ export async function createSubprocessApp(opts: {
   const baseUrl = `http://127.0.0.1:${port}`
   let closePromise: Promise<void> | undefined
   const close = (): Promise<void> => {
-    closePromise ??= terminateSubprocess(child, groupPid, closed)
+    closePromise ??= terminateSubprocess(
+      child,
+      groupPid,
+      closed,
+      baseUrl,
+      DEFAULT_TERMINATION_TIMINGS,
+    )
     return closePromise
   }
 

--- a/packages/testing/src/subprocess.ts
+++ b/packages/testing/src/subprocess.ts
@@ -150,8 +150,10 @@ export async function terminateSubprocess(
 
   process.kill(-groupPid, "SIGTERM")
   if (await waitUntilStopped(childState, baseUrl, timings.graceMs, timings)) return
+  process.kill(-groupPid, "SIGKILL")
+  if (await waitUntilStopped(childState, baseUrl, timings.forceMs, timings)) return
   throw new Error(
-    `subprocess group ${groupPid} did not stop within ${timings.graceMs}ms after SIGTERM`,
+    `subprocess group ${groupPid} did not stop within ${timings.graceMs + timings.forceMs}ms after SIGTERM and SIGKILL`,
   )
 }
 

--- a/packages/testing/test/fixtures/subprocess-tree.mjs
+++ b/packages/testing/test/fixtures/subprocess-tree.mjs
@@ -22,7 +22,7 @@ if (mode === "idle" || mode === "ignore-term") {
   descendant.stdout?.once("data", (chunk) => {
     process.stdout.write(chunk, () => process.exit(0))
   })
-} else if (mode === "windows-tree" || mode === "windows-orphan") {
+} else if (mode === "windows-tree") {
   const descendantSource = `
     import { createServer } from "node:net"
     const server = createServer((socket) => socket.end())
@@ -36,11 +36,9 @@ if (mode === "idle" || mode === "ignore-term") {
     stdio: ["ignore", "pipe", "inherit"],
   })
   descendant.stdout?.once("data", (chunk) => {
-    process.stdout.write(chunk, () => {
-      if (mode === "windows-orphan") process.exit(0)
-    })
+    process.stdout.write(chunk)
   })
-  if (mode === "windows-tree") setInterval(() => {}, 1_000)
+  setInterval(() => {}, 1_000)
 } else {
   throw new Error(`unknown subprocess-tree mode: ${mode}`)
 }

--- a/packages/testing/test/fixtures/subprocess-tree.mjs
+++ b/packages/testing/test/fixtures/subprocess-tree.mjs
@@ -22,6 +22,25 @@ if (mode === "idle" || mode === "ignore-term") {
   descendant.stdout?.once("data", (chunk) => {
     process.stdout.write(chunk, () => process.exit(0))
   })
+} else if (mode === "windows-tree" || mode === "windows-orphan") {
+  const descendantSource = `
+    import { createServer } from "node:net"
+    const server = createServer((socket) => socket.end())
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address()
+      if (typeof address !== "object" || address === null) process.exit(2)
+      process.stdout.write(JSON.stringify({ pid: process.pid, port: address.port }) + "\\n")
+    })
+  `
+  const descendant = spawn(process.execPath, ["--input-type=module", "--eval", descendantSource], {
+    stdio: ["ignore", "pipe", "inherit"],
+  })
+  descendant.stdout?.once("data", (chunk) => {
+    process.stdout.write(chunk, () => {
+      if (mode === "windows-orphan") process.exit(0)
+    })
+  })
+  if (mode === "windows-tree") setInterval(() => {}, 1_000)
 } else {
   throw new Error(`unknown subprocess-tree mode: ${mode}`)
 }

--- a/packages/testing/test/fixtures/subprocess-tree.mjs
+++ b/packages/testing/test/fixtures/subprocess-tree.mjs
@@ -1,0 +1,27 @@
+import { spawn } from "node:child_process"
+
+const mode = process.argv[2]
+
+if (mode === "idle" || mode === "ignore-term") {
+  if (mode === "ignore-term") process.on("SIGTERM", () => {})
+  process.stdout.write("ready\n")
+  setInterval(() => {}, 1_000)
+} else if (mode === "leader") {
+  const descendantSource = `
+    import { createServer } from "node:net"
+    const server = createServer((socket) => socket.end())
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address()
+      if (typeof address !== "object" || address === null) process.exit(2)
+      process.stdout.write(String(address.port) + "\\n")
+    })
+  `
+  const descendant = spawn(process.execPath, ["--input-type=module", "--eval", descendantSource], {
+    stdio: ["ignore", "pipe", "inherit"],
+  })
+  descendant.stdout?.once("data", (chunk) => {
+    process.stdout.write(chunk, () => process.exit(0))
+  })
+} else {
+  throw new Error(`unknown subprocess-tree mode: ${mode}`)
+}

--- a/packages/testing/test/subprocess.test.ts
+++ b/packages/testing/test/subprocess.test.ts
@@ -1,11 +1,19 @@
-import { ChildProcess } from "node:child_process"
+import { ChildProcess, spawn } from "node:child_process"
+import { createConnection } from "node:net"
 import { setTimeout as delay } from "node:timers/promises"
 import { fileURLToPath } from "node:url"
 import { expect, it, vi } from "vitest"
 import { createAimock } from "../src/aimock-runner.js"
-import { createSubprocessApp } from "../src/subprocess.js"
+import { createSubprocessApp, terminateSubprocess } from "../src/subprocess.js"
 
 const appRoot = fileURLToPath(new URL("./fixtures/probe-app", import.meta.url))
+const processTreeFixture = fileURLToPath(new URL("./fixtures/subprocess-tree.mjs", import.meta.url))
+const TEST_TERMINATION_TIMINGS = {
+  graceMs: 100,
+  forceMs: 100,
+  probeIntervalMs: 5,
+  probeTimeoutMs: 10,
+}
 
 function hasErrorCode(error: unknown, code: string): boolean {
   return typeof error === "object" && error !== null && "code" in error && error.code === code
@@ -128,6 +136,52 @@ function delaySubprocessTermination() {
   }
 }
 
+async function spawnTree(mode: "idle" | "ignore-term" | "leader") {
+  const child = spawn(process.execPath, [processTreeFixture, mode], {
+    detached: true,
+    stdio: ["ignore", "pipe", "inherit"],
+  })
+  if (child.pid === undefined) throw new Error("fixture process has no pid")
+  const groupPid = child.pid
+  const closed = new Promise<void>((resolve, reject) => {
+    child.once("error", reject)
+    child.once("close", () => resolve())
+  })
+  const line = await new Promise<string>((resolve, reject) => {
+    let output = ""
+    child.once("error", reject)
+    child.once("close", () => {
+      if (!output.includes("\n")) reject(new Error("fixture closed before readiness"))
+    })
+    child.stdout?.on("data", (chunk) => {
+      output += String(chunk)
+      if (output.includes("\n")) resolve(output.trim())
+    })
+  })
+  return { child, closed, groupPid, line }
+}
+
+function canConnect(baseUrl: string): Promise<boolean> {
+  const url = new URL(baseUrl)
+  return new Promise((resolve) => {
+    const socket = createConnection({ host: url.hostname, port: Number(url.port) })
+    socket.once("connect", () => {
+      socket.destroy()
+      resolve(true)
+    })
+    socket.once("error", () => resolve(false))
+  })
+}
+
+async function forceKillProcessGroup(groupPid: number, kill: typeof process.kill): Promise<void> {
+  try {
+    kill(-groupPid, "SIGKILL")
+  } catch (error) {
+    if (!hasErrorCode(error, "ESRCH")) throw error
+  }
+  await waitForProcessGroupExit(-groupPid)
+}
+
 it("boots a real dawn dev subprocess and serves the AP", async () => {
   const mock = await createAimock({ fixtures: [{ match: {}, response: { content: "ok" } }] })
   const app = await createSubprocessApp({
@@ -218,3 +272,20 @@ it("waits for cleanup when readiness fails", async () => {
     await finishDelayedTerminations()
   }
 }, 120_000)
+
+it.skipIf(process.platform === "win32")(
+  "waits for a surviving descendant to release the port",
+  async () => {
+    const realKill = process.kill.bind(process)
+    const { child, closed, groupPid, line } = await spawnTree("leader")
+    const baseUrl = `http://127.0.0.1:${Number(line)}`
+    try {
+      await closed
+      expect(await canConnect(baseUrl)).toBe(true)
+      await terminateSubprocess(child, groupPid, closed, baseUrl, TEST_TERMINATION_TIMINGS)
+      expect(await canConnect(baseUrl)).toBe(false)
+    } finally {
+      await forceKillProcessGroup(groupPid, realKill)
+    }
+  },
+)

--- a/packages/testing/test/subprocess.test.ts
+++ b/packages/testing/test/subprocess.test.ts
@@ -1,9 +1,132 @@
+import { ChildProcess } from "node:child_process"
+import { setTimeout as delay } from "node:timers/promises"
 import { fileURLToPath } from "node:url"
-import { expect, it } from "vitest"
+import { expect, it, vi } from "vitest"
 import { createAimock } from "../src/aimock-runner.js"
 import { createSubprocessApp } from "../src/subprocess.js"
 
 const appRoot = fileURLToPath(new URL("./fixtures/probe-app", import.meta.url))
+
+function hasErrorCode(error: unknown, code: string): boolean {
+  return typeof error === "object" && error !== null && "code" in error && error.code === code
+}
+
+async function waitForProcessGroupExit(target: number): Promise<void> {
+  const observeExit = async (): Promise<boolean> => {
+    for (let attempt = 0; attempt < 200; attempt += 1) {
+      try {
+        process.kill(target, 0)
+      } catch (error) {
+        if (hasErrorCode(error, "ESRCH")) return true
+        if (!hasErrorCode(error, "EPERM")) throw error
+      }
+      await delay(10)
+    }
+    return false
+  }
+
+  if (await observeExit()) return
+  try {
+    process.kill(target, "SIGKILL")
+  } catch (error) {
+    if (hasErrorCode(error, "ESRCH")) return
+    throw error
+  }
+  if (!(await observeExit())) {
+    throw new Error(`process group ${-target} remained after SIGKILL`)
+  }
+}
+
+function childExit(child: ChildProcess): Promise<void> {
+  if (child.exitCode !== null || child.signalCode !== null) return Promise.resolve()
+  return new Promise((resolve) => child.once("close", () => resolve()))
+}
+
+async function waitForChildExit(
+  child: ChildProcess,
+  exited: Promise<void>,
+  forceKill: (this: ChildProcess, signal?: NodeJS.Signals | number) => boolean,
+): Promise<void> {
+  if (await Promise.race([exited.then(() => true), delay(2_000, false)])) return
+  try {
+    forceKill.call(child, "SIGKILL")
+  } catch (error) {
+    if (!hasErrorCode(error, "ESRCH")) throw error
+  }
+  if (!(await Promise.race([exited.then(() => true), delay(2_000, false)]))) {
+    throw new Error(`child process ${child.pid ?? "unknown"} remained after SIGKILL`)
+  }
+}
+
+function delaySubprocessTermination() {
+  const realKill = process.kill.bind(process)
+  const realChildKill = ChildProcess.prototype.kill
+  const delayedGroups: Array<{ readonly target: number; readonly delivered: Promise<void> }> = []
+  const delayedChildren: Array<{
+    readonly child: ChildProcess
+    readonly delivered: Promise<void>
+    readonly exited: Promise<void>
+  }> = []
+  const killSpy = vi.spyOn(process, "kill").mockImplementation((pid, signal) => {
+    if (typeof pid === "number" && pid < 0 && signal === "SIGTERM") {
+      // Windows does not support negative-PID process groups. Let the real call
+      // throw synchronously so createSubprocessApp exercises its child.kill()
+      // fallback, which the ChildProcess spy below delays instead.
+      if (process.platform === "win32") return realKill(pid, signal)
+      const delivered = delay(100).then(() => {
+        try {
+          realKill(pid, signal)
+        } catch (error) {
+          if (!hasErrorCode(error, "ESRCH")) throw error
+        }
+      })
+      delayedGroups.push({ target: pid, delivered })
+      return true
+    }
+    return realKill(pid, signal)
+  })
+  const childKillSpy = vi.spyOn(ChildProcess.prototype, "kill").mockImplementation(function (
+    this: ChildProcess,
+    signal,
+  ) {
+    if (process.platform === "win32" && signal === "SIGTERM") {
+      const exited = childExit(this)
+      const delivered = delay(100).then(() => {
+        if (this.exitCode === null && this.signalCode === null) {
+          realChildKill.call(this, signal)
+        }
+      })
+      delayedChildren.push({ child: this, delivered, exited })
+      return true
+    }
+    return realChildKill.call(this, signal)
+  })
+
+  return async (): Promise<void> => {
+    killSpy.mockRestore()
+    childKillSpy.mockRestore()
+    await Promise.all(
+      [...new Map(delayedGroups.map((entry) => [entry.target, entry])).values()].map(
+        async ({ delivered, target }) => {
+          try {
+            await delivered
+          } finally {
+            await waitForProcessGroupExit(target)
+          }
+        },
+      ),
+    )
+    await Promise.all(
+      delayedChildren.map(async ({ child, delivered, exited }) => {
+        try {
+          await delivered
+        } finally {
+          await waitForChildExit(child, exited, realChildKill)
+        }
+      }),
+    )
+  }
+}
 
 it("boots a real dawn dev subprocess and serves the AP", async () => {
   const mock = await createAimock({ fixtures: [{ match: {}, response: { content: "ok" } }] })
@@ -43,5 +166,55 @@ it("disposes the subprocess via `await using` and leaves it unreachable", async 
     await expect(fetch(new URL("/healthz", baseUrl))).rejects.toThrow()
   } finally {
     await mock.close()
+  }
+}, 120_000)
+
+it("waits for process shutdown and shares one close promise", async () => {
+  let mock: Awaited<ReturnType<typeof createAimock>> | undefined
+  let app: Awaited<ReturnType<typeof createSubprocessApp>> | undefined
+  const finishDelayedTerminations = delaySubprocessTermination()
+
+  try {
+    mock = await createAimock({ fixtures: [{ match: {}, response: { content: "ok" } }] })
+    app = await createSubprocessApp({
+      appRoot,
+      env: { OPENAI_BASE_URL: mock.baseUrl, OPENAI_API_KEY: "test-not-used" },
+    })
+    const first = app.close()
+    const second = app.close()
+    const disposed = app[Symbol.asyncDispose]()
+    expect(second).toBe(first)
+    expect(disposed).toBe(first)
+    await expect(Promise.race([first.then(() => "closed"), delay(25, "waiting")])).resolves.toBe(
+      "waiting",
+    )
+    await first
+    await expect(fetch(new URL("/healthz", app.baseUrl))).rejects.toThrow()
+  } finally {
+    try {
+      if (app) await app.close()
+    } finally {
+      try {
+        await finishDelayedTerminations()
+      } finally {
+        if (mock) await mock.close()
+      }
+    }
+  }
+}, 120_000)
+
+it("waits for cleanup when readiness fails", async () => {
+  const finishDelayedTerminations = delaySubprocessTermination()
+
+  try {
+    const creating = createSubprocessApp({ appRoot, readyTimeoutMs: 0 })
+    const outcome = creating.then(
+      () => "created",
+      () => "rejected",
+    )
+    await expect(Promise.race([outcome, delay(25, "waiting")])).resolves.toBe("waiting")
+    await expect(creating).rejects.toThrow("within 0ms")
+  } finally {
+    await finishDelayedTerminations()
   }
 }, 120_000)

--- a/packages/testing/test/subprocess.test.ts
+++ b/packages/testing/test/subprocess.test.ts
@@ -506,6 +506,50 @@ it.skipIf(process.platform !== "win32")(
   10_000,
 )
 
+it("does not dispatch an injected Windows tree kill after the outer child has closed", async () => {
+  const realKill = process.kill.bind(process)
+  let groupPid: number | undefined
+  let descendantPid: number | undefined
+  let descendantBaseUrl: string | undefined
+  const taskkillSpy = vi.fn(async (_pid: number, _timeoutMs: number) => {})
+
+  try {
+    const tree = await spawnTree("windows-orphan")
+    groupPid = tree.groupPid
+    const topology = JSON.parse(tree.line) as { readonly pid: number; readonly port: number }
+    descendantPid = topology.pid
+    descendantBaseUrl = `http://127.0.0.1:${topology.port}`
+    await tree.closed
+    expect(await canConnect(descendantBaseUrl)).toBe(true)
+
+    await expect(
+      terminateSubprocess(
+        tree.child,
+        tree.groupPid,
+        tree.closed,
+        descendantBaseUrl,
+        TEST_TERMINATION_TIMINGS,
+        { platform: "win32", taskkillProcessTree: taskkillSpy },
+      ),
+    ).rejects.toThrow(`subprocess group ${tree.groupPid} did not stop`)
+
+    expect(taskkillSpy).not.toHaveBeenCalled()
+    expect(await canConnect(descendantBaseUrl)).toBe(true)
+  } finally {
+    if (
+      descendantPid !== undefined &&
+      descendantBaseUrl !== undefined &&
+      (await canConnect(descendantBaseUrl))
+    ) {
+      if (process.platform === "win32") {
+        await taskkill(descendantPid, false)
+      } else if (groupPid !== undefined) {
+        await forceKillProcessGroup(groupPid, realKill)
+      }
+    }
+  }
+})
+
 it.skipIf(process.platform === "win32")(
   "rejects on bounded failure after the forced-termination deadline",
   async () => {

--- a/packages/testing/test/subprocess.test.ts
+++ b/packages/testing/test/subprocess.test.ts
@@ -159,9 +159,7 @@ function delaySubprocessTermination() {
   }
 }
 
-async function spawnTree(
-  mode: "idle" | "ignore-term" | "leader" | "windows-tree" | "windows-orphan",
-) {
+async function spawnTree(mode: "idle" | "ignore-term" | "leader" | "windows-tree") {
   const child = spawn(process.execPath, [processTreeFixture, mode], {
     detached: true,
     stdio: ["ignore", "pipe", "inherit"],
@@ -224,6 +222,31 @@ async function unavailableBaseUrl(): Promise<string> {
     server.close((error) => (error ? reject(error) : resolve())),
   )
   return `http://127.0.0.1:${port}`
+}
+
+async function liveBaseUrl(): Promise<{
+  readonly baseUrl: string
+  readonly close: () => Promise<void>
+}> {
+  const server = createServer((socket) => socket.end())
+  const port = await new Promise<number>((resolve, reject) => {
+    server.once("error", reject)
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address()
+      if (typeof address !== "object" || address === null) {
+        reject(new Error("temporary server did not expose a TCP port"))
+        return
+      }
+      resolve(address.port)
+    })
+  })
+  return {
+    baseUrl: `http://127.0.0.1:${port}`,
+    close: async () =>
+      await new Promise<void>((resolve, reject) =>
+        server.close((error) => (error ? reject(error) : resolve())),
+      ),
+  }
 }
 
 it("boots a real dawn dev subprocess and serves the AP", async () => {
@@ -464,88 +487,42 @@ it.skipIf(process.platform !== "win32")(
   10_000,
 )
 
-it.skipIf(process.platform !== "win32")(
-  "does not dispatch taskkill after a Windows outer child has closed",
-  async () => {
-    let descendantPid: number | undefined
-    let descendantBaseUrl: string | undefined
-    let childKillSpy: ReturnType<typeof vi.spyOn> | undefined
-
-    try {
-      const tree = await spawnTree("windows-orphan")
-      const topology = JSON.parse(tree.line) as { readonly pid: number; readonly port: number }
-      descendantPid = topology.pid
-      descendantBaseUrl = `http://127.0.0.1:${topology.port}`
-      await tree.closed
-      expect(await canConnect(descendantBaseUrl)).toBe(true)
-      childKillSpy = vi.spyOn(tree.child, "kill")
-
-      await expect(
-        terminateSubprocess(
-          tree.child,
-          tree.groupPid,
-          tree.closed,
-          descendantBaseUrl,
-          TEST_TERMINATION_TIMINGS,
-        ),
-      ).rejects.toThrow(`subprocess group ${tree.groupPid} did not stop`)
-
-      expect(childKillSpy).not.toHaveBeenCalled()
-      expect(await canConnect(descendantBaseUrl)).toBe(true)
-    } finally {
-      childKillSpy?.mockRestore()
-      if (
-        descendantPid !== undefined &&
-        descendantBaseUrl !== undefined &&
-        (await canConnect(descendantBaseUrl))
-      ) {
-        await taskkill(descendantPid, false)
-      }
-    }
-  },
-  10_000,
-)
-
-it("does not dispatch an injected Windows tree kill after the outer child has closed", async () => {
-  const realKill = process.kill.bind(process)
-  let groupPid: number | undefined
-  let descendantPid: number | undefined
-  let descendantBaseUrl: string | undefined
+it("does not dispatch an injected Windows tree kill after a child has closed", async () => {
+  const realChildKill = ChildProcess.prototype.kill
   const taskkillSpy = vi.fn(async (_pid: number, _timeoutMs: number) => {})
+  let tree: Awaited<ReturnType<typeof spawnTree>> | undefined
+  let server: Awaited<ReturnType<typeof liveBaseUrl>> | undefined
 
   try {
-    const tree = await spawnTree("windows-orphan")
-    groupPid = tree.groupPid
-    const topology = JSON.parse(tree.line) as { readonly pid: number; readonly port: number }
-    descendantPid = topology.pid
-    descendantBaseUrl = `http://127.0.0.1:${topology.port}`
+    tree = await spawnTree("idle")
+    server = await liveBaseUrl()
+    try {
+      realChildKill.call(tree.child, "SIGTERM")
+    } catch (error) {
+      if (!hasErrorCode(error, "ESRCH")) throw error
+    }
     await tree.closed
-    expect(await canConnect(descendantBaseUrl)).toBe(true)
 
     await expect(
       terminateSubprocess(
         tree.child,
         tree.groupPid,
         tree.closed,
-        descendantBaseUrl,
+        server.baseUrl,
         TEST_TERMINATION_TIMINGS,
         { platform: "win32", taskkillProcessTree: taskkillSpy },
       ),
-    ).rejects.toThrow(`subprocess group ${tree.groupPid} did not stop`)
+    ).rejects.toThrow(
+      `subprocess group ${tree.groupPid} did not stop within ${TEST_TERMINATION_TIMINGS.graceMs + TEST_TERMINATION_TIMINGS.forceMs}ms`,
+    )
 
     expect(taskkillSpy).not.toHaveBeenCalled()
-    expect(await canConnect(descendantBaseUrl)).toBe(true)
+    expect(await canConnect(server.baseUrl)).toBe(true)
   } finally {
-    if (
-      descendantPid !== undefined &&
-      descendantBaseUrl !== undefined &&
-      (await canConnect(descendantBaseUrl))
-    ) {
-      if (process.platform === "win32") {
-        await taskkill(descendantPid, false)
-      } else if (groupPid !== undefined) {
-        await forceKillProcessGroup(groupPid, realKill)
-      }
+    try {
+      if (tree) await waitForChildExit(tree.child, tree.closed, realChildKill)
+    } finally {
+      if (server) await server.close()
     }
   }
 })

--- a/packages/testing/test/subprocess.test.ts
+++ b/packages/testing/test/subprocess.test.ts
@@ -1,5 +1,5 @@
 import { ChildProcess, spawn } from "node:child_process"
-import { createConnection } from "node:net"
+import { createConnection, createServer } from "node:net"
 import { setTimeout as delay } from "node:timers/promises"
 import { fileURLToPath } from "node:url"
 import { expect, it, vi } from "vitest"
@@ -182,6 +182,25 @@ async function forceKillProcessGroup(groupPid: number, kill: typeof process.kill
   await waitForProcessGroupExit(-groupPid)
 }
 
+async function unavailableBaseUrl(): Promise<string> {
+  const server = createServer()
+  const port = await new Promise<number>((resolve, reject) => {
+    server.once("error", reject)
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address()
+      if (typeof address !== "object" || address === null) {
+        reject(new Error("temporary server did not expose a TCP port"))
+        return
+      }
+      resolve(address.port)
+    })
+  })
+  await new Promise<void>((resolve, reject) =>
+    server.close((error) => (error ? reject(error) : resolve())),
+  )
+  return `http://127.0.0.1:${port}`
+}
+
 it("boots a real dawn dev subprocess and serves the AP", async () => {
   const mock = await createAimock({ fixtures: [{ match: {}, response: { content: "ok" } }] })
   const app = await createSubprocessApp({
@@ -285,6 +304,61 @@ it.skipIf(process.platform === "win32")(
       await terminateSubprocess(child, groupPid, closed, baseUrl, TEST_TERMINATION_TIMINGS)
       expect(await canConnect(baseUrl)).toBe(false)
     } finally {
+      await forceKillProcessGroup(groupPid, realKill)
+    }
+  },
+)
+
+it.skipIf(process.platform === "win32")(
+  "escalates an ignoring process group to SIGKILL",
+  async () => {
+    const realKill = process.kill.bind(process)
+    const { child, closed, groupPid } = await spawnTree("ignore-term")
+    const killSpy = vi
+      .spyOn(process, "kill")
+      .mockImplementation((pid, signal) => realKill(pid, signal))
+    try {
+      await terminateSubprocess(
+        child,
+        groupPid,
+        closed,
+        await unavailableBaseUrl(),
+        TEST_TERMINATION_TIMINGS,
+      )
+      expect(killSpy).toHaveBeenCalledWith(-groupPid, "SIGKILL")
+    } finally {
+      killSpy.mockRestore()
+      await forceKillProcessGroup(groupPid, realKill)
+    }
+  },
+)
+
+it.skipIf(process.platform === "win32")(
+  "rejects on bounded failure after the forced-termination deadline",
+  async () => {
+    const realKill = process.kill.bind(process)
+    const { child, closed, groupPid } = await spawnTree("ignore-term")
+    const killSpy = vi.spyOn(process, "kill").mockImplementation((pid, signal) => {
+      if (pid === -groupPid && (signal === "SIGTERM" || signal === "SIGKILL")) {
+        return true
+      }
+      return realKill(pid, signal)
+    })
+    try {
+      await expect(
+        terminateSubprocess(
+          child,
+          groupPid,
+          closed,
+          await unavailableBaseUrl(),
+          TEST_TERMINATION_TIMINGS,
+        ),
+      ).rejects.toThrow(
+        `subprocess group ${groupPid} did not stop within ${TEST_TERMINATION_TIMINGS.graceMs + TEST_TERMINATION_TIMINGS.forceMs}ms`,
+      )
+      expect(killSpy).toHaveBeenCalledWith(-groupPid, "SIGKILL")
+    } finally {
+      killSpy.mockRestore()
       await forceKillProcessGroup(groupPid, realKill)
     }
   },

--- a/packages/testing/test/subprocess.test.ts
+++ b/packages/testing/test/subprocess.test.ts
@@ -1,4 +1,4 @@
-import { ChildProcess, spawn } from "node:child_process"
+import { ChildProcess, execFile, spawn } from "node:child_process"
 import { createConnection, createServer } from "node:net"
 import { setTimeout as delay } from "node:timers/promises"
 import { fileURLToPath } from "node:url"
@@ -13,6 +13,12 @@ const TEST_TERMINATION_TIMINGS = {
   forceMs: 100,
   probeIntervalMs: 5,
   probeTimeoutMs: 10,
+}
+const WINDOWS_TERMINATION_TIMINGS = {
+  graceMs: 1_000,
+  forceMs: 1_000,
+  probeIntervalMs: 20,
+  probeTimeoutMs: 100,
 }
 
 function hasErrorCode(error: unknown, code: string): boolean {
@@ -64,6 +70,23 @@ async function waitForChildExit(
   if (!(await Promise.race([exited.then(() => true), delay(2_000, false)]))) {
     throw new Error(`child process ${child.pid ?? "unknown"} remained after SIGKILL`)
   }
+}
+
+function taskkill(pid: number, tree: boolean): Promise<void> {
+  return new Promise((resolve, reject) => {
+    execFile(
+      "taskkill.exe",
+      ["/PID", String(pid), ...(tree ? ["/T"] : []), "/F"],
+      { windowsHide: true, timeout: 2_000, maxBuffer: 64 * 1024 },
+      (error) => {
+        if (error && error.code !== 128) {
+          reject(error)
+          return
+        }
+        resolve()
+      },
+    )
+  })
 }
 
 function delaySubprocessTermination() {
@@ -136,7 +159,9 @@ function delaySubprocessTermination() {
   }
 }
 
-async function spawnTree(mode: "idle" | "ignore-term" | "leader") {
+async function spawnTree(
+  mode: "idle" | "ignore-term" | "leader" | "windows-tree" | "windows-orphan",
+) {
   const child = spawn(process.execPath, [processTreeFixture, mode], {
     detached: true,
     stdio: ["ignore", "pipe", "inherit"],
@@ -242,55 +267,63 @@ it("disposes the subprocess via `await using` and leaves it unreachable", async 
   }
 }, 120_000)
 
-it("waits for process shutdown and shares one close promise", async () => {
-  let mock: Awaited<ReturnType<typeof createAimock>> | undefined
-  let app: Awaited<ReturnType<typeof createSubprocessApp>> | undefined
-  const finishDelayedTerminations = delaySubprocessTermination()
+it.skipIf(process.platform === "win32")(
+  "waits for process shutdown and shares one close promise",
+  async () => {
+    let mock: Awaited<ReturnType<typeof createAimock>> | undefined
+    let app: Awaited<ReturnType<typeof createSubprocessApp>> | undefined
+    const finishDelayedTerminations = delaySubprocessTermination()
 
-  try {
-    mock = await createAimock({ fixtures: [{ match: {}, response: { content: "ok" } }] })
-    app = await createSubprocessApp({
-      appRoot,
-      env: { OPENAI_BASE_URL: mock.baseUrl, OPENAI_API_KEY: "test-not-used" },
-    })
-    const first = app.close()
-    const second = app.close()
-    const disposed = app[Symbol.asyncDispose]()
-    expect(second).toBe(first)
-    expect(disposed).toBe(first)
-    await expect(Promise.race([first.then(() => "closed"), delay(25, "waiting")])).resolves.toBe(
-      "waiting",
-    )
-    await first
-    await expect(fetch(new URL("/healthz", app.baseUrl))).rejects.toThrow()
-  } finally {
     try {
-      if (app) await app.close()
+      mock = await createAimock({ fixtures: [{ match: {}, response: { content: "ok" } }] })
+      app = await createSubprocessApp({
+        appRoot,
+        env: { OPENAI_BASE_URL: mock.baseUrl, OPENAI_API_KEY: "test-not-used" },
+      })
+      const first = app.close()
+      const second = app.close()
+      const disposed = app[Symbol.asyncDispose]()
+      expect(second).toBe(first)
+      expect(disposed).toBe(first)
+      await expect(Promise.race([first.then(() => "closed"), delay(25, "waiting")])).resolves.toBe(
+        "waiting",
+      )
+      await first
+      await expect(fetch(new URL("/healthz", app.baseUrl))).rejects.toThrow()
     } finally {
       try {
-        await finishDelayedTerminations()
+        if (app) await app.close()
       } finally {
-        if (mock) await mock.close()
+        try {
+          await finishDelayedTerminations()
+        } finally {
+          if (mock) await mock.close()
+        }
       }
     }
-  }
-}, 120_000)
+  },
+  120_000,
+)
 
-it("waits for cleanup when readiness fails", async () => {
-  const finishDelayedTerminations = delaySubprocessTermination()
+it.skipIf(process.platform === "win32")(
+  "waits for cleanup when readiness fails",
+  async () => {
+    const finishDelayedTerminations = delaySubprocessTermination()
 
-  try {
-    const creating = createSubprocessApp({ appRoot, readyTimeoutMs: 0 })
-    const outcome = creating.then(
-      () => "created",
-      () => "rejected",
-    )
-    await expect(Promise.race([outcome, delay(25, "waiting")])).resolves.toBe("waiting")
-    await expect(creating).rejects.toThrow("within 0ms")
-  } finally {
-    await finishDelayedTerminations()
-  }
-}, 120_000)
+    try {
+      const creating = createSubprocessApp({ appRoot, readyTimeoutMs: 0 })
+      const outcome = creating.then(
+        () => "created",
+        () => "rejected",
+      )
+      await expect(Promise.race([outcome, delay(25, "waiting")])).resolves.toBe("waiting")
+      await expect(creating).rejects.toThrow("within 0ms")
+    } finally {
+      await finishDelayedTerminations()
+    }
+  },
+  120_000,
+)
 
 it.skipIf(process.platform === "win32")(
   "waits for a surviving descendant to release the port",
@@ -331,6 +364,146 @@ it.skipIf(process.platform === "win32")(
       await forceKillProcessGroup(groupPid, realKill)
     }
   },
+)
+
+it.skipIf(process.platform === "win32")(
+  "falls back to the direct child when group SIGTERM is unavailable",
+  async () => {
+    const realKill = process.kill.bind(process)
+    const realChildKill = ChildProcess.prototype.kill
+    let cleanupGroupPid: number | undefined
+    let groupKillSpy: ReturnType<typeof vi.spyOn> | undefined
+    let childKillSpy: ReturnType<typeof vi.spyOn> | undefined
+
+    try {
+      const tree = await spawnTree("idle")
+      const { child, closed, groupPid } = tree
+      cleanupGroupPid = groupPid
+      groupKillSpy = vi.spyOn(process, "kill").mockImplementation((pid, signal) => {
+        if (pid === -groupPid && signal === "SIGTERM") {
+          throw new Error("group signalling unavailable")
+        }
+        return realKill(pid, signal)
+      })
+      childKillSpy = vi
+        .spyOn(child, "kill")
+        .mockImplementation((signal) => realChildKill.call(child, signal))
+      await terminateSubprocess(
+        child,
+        groupPid,
+        closed,
+        await unavailableBaseUrl(),
+        TEST_TERMINATION_TIMINGS,
+      )
+      expect(childKillSpy).toHaveBeenCalledWith("SIGTERM")
+    } finally {
+      groupKillSpy?.mockRestore()
+      childKillSpy?.mockRestore()
+      if (cleanupGroupPid !== undefined) {
+        await forceKillProcessGroup(cleanupGroupPid, realKill)
+      }
+    }
+  },
+)
+
+it.skipIf(process.platform !== "win32")(
+  "terminates a live Windows process tree without directly killing its outer child",
+  async () => {
+    let child: ChildProcess | undefined
+    let outerPid: number | undefined
+    let descendantPid: number | undefined
+    let descendantBaseUrl: string | undefined
+    let stopped = false
+    let childKillSpy: ReturnType<typeof vi.spyOn> | undefined
+
+    try {
+      const tree = await spawnTree("windows-tree")
+      child = tree.child
+      outerPid = tree.groupPid
+      const topology = JSON.parse(tree.line) as { readonly pid: number; readonly port: number }
+      descendantPid = topology.pid
+      descendantBaseUrl = `http://127.0.0.1:${topology.port}`
+      expect(await canConnect(descendantBaseUrl)).toBe(true)
+      childKillSpy = vi.spyOn(child, "kill")
+
+      await terminateSubprocess(
+        child,
+        outerPid,
+        tree.closed,
+        descendantBaseUrl,
+        WINDOWS_TERMINATION_TIMINGS,
+      )
+
+      expect(childKillSpy).not.toHaveBeenCalled()
+      expect(await canConnect(descendantBaseUrl)).toBe(false)
+      stopped = true
+    } finally {
+      childKillSpy?.mockRestore()
+      try {
+        if (
+          !stopped &&
+          child &&
+          outerPid !== undefined &&
+          child.exitCode === null &&
+          child.signalCode === null
+        ) {
+          await taskkill(outerPid, true)
+        }
+      } finally {
+        if (
+          !stopped &&
+          descendantPid !== undefined &&
+          descendantBaseUrl !== undefined &&
+          (await canConnect(descendantBaseUrl))
+        ) {
+          await taskkill(descendantPid, false)
+        }
+      }
+    }
+  },
+  10_000,
+)
+
+it.skipIf(process.platform !== "win32")(
+  "does not dispatch taskkill after a Windows outer child has closed",
+  async () => {
+    let descendantPid: number | undefined
+    let descendantBaseUrl: string | undefined
+    let childKillSpy: ReturnType<typeof vi.spyOn> | undefined
+
+    try {
+      const tree = await spawnTree("windows-orphan")
+      const topology = JSON.parse(tree.line) as { readonly pid: number; readonly port: number }
+      descendantPid = topology.pid
+      descendantBaseUrl = `http://127.0.0.1:${topology.port}`
+      await tree.closed
+      expect(await canConnect(descendantBaseUrl)).toBe(true)
+      childKillSpy = vi.spyOn(tree.child, "kill")
+
+      await expect(
+        terminateSubprocess(
+          tree.child,
+          tree.groupPid,
+          tree.closed,
+          descendantBaseUrl,
+          TEST_TERMINATION_TIMINGS,
+        ),
+      ).rejects.toThrow(`subprocess group ${tree.groupPid} did not stop`)
+
+      expect(childKillSpy).not.toHaveBeenCalled()
+      expect(await canConnect(descendantBaseUrl)).toBe(true)
+    } finally {
+      childKillSpy?.mockRestore()
+      if (
+        descendantPid !== undefined &&
+        descendantBaseUrl !== undefined &&
+        (await canConnect(descendantBaseUrl))
+      ) {
+        await taskkill(descendantPid, false)
+      }
+    }
+  },
+  10_000,
 )
 
 it.skipIf(process.platform === "win32")(


### PR DESCRIPTION
## Summary
- make subprocess close and async disposal share one completion promise
- wait for child closure and port refusal, with bounded graceful and forced termination
- handle POSIX process groups and Windows process trees without reusing stale process identifiers
- add deterministic lifecycle fixtures and focused native Windows CI coverage

## Root cause
The testing helper marked itself stopped, sent SIGTERM, and resolved immediately. The actual CLI, runtime child, HTTP server, and stdio shutdown happen asynchronously, so callers could continue while the old server still accepted requests. Readiness failures used the same signal-only cleanup.

## Validation
- pnpm ci:validate under Node 24.14.0
- 2,507 source tests passed
- framework, runtime contract, and smoke harness lanes passed
- repeated focused subprocess stress runs with no leaked test processes
- native Windows subprocess suite runs in the new testing-windows CI job