### PR TITLE
Keep Agent Protocol SSE streams alive

### DIFF
--- a/.changeset/ap-sse-keepalives.md
+++ b/.changeset/ap-sse-keepalives.md
@@ -1,0 +1,7 @@
+---
+"@dawn-ai/cli": patch
+---
+
+Keep Agent Protocol SSE streams alive during silent runs with periodic comment
+frames, and prevent intermediaries from transforming either run or resume
+streams.

--- a/.changeset/ap-sse-keepalives.md
+++ b/.changeset/ap-sse-keepalives.md
@@ -3,5 +3,4 @@
 ---
 
 Keep Agent Protocol SSE streams alive during silent runs with periodic comment
-frames, and prevent intermediaries from transforming either run or resume
-streams.
+frames, and mark run and resume streams `no-transform` for intermediaries.

--- a/docs/superpowers/plans/2026-08-08-ap-sse-keepalives.md
+++ b/docs/superpowers/plans/2026-08-08-ap-sse-keepalives.md
@@ -1,0 +1,665 @@
+# Agent Protocol SSE Keepalives Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Keep durable Agent Protocol SSE connections alive during silent runs and make both AP streaming endpoints advertise the same non-transforming cache policy.
+
+**Architecture:** Add one web-runtime-compatible heartbeat helper inside the transport-agnostic fetch core. Thread an internal interval override from `createRuntimeFetchHandler` through the route table to both AP stream handlers, start the helper with each stream, and stop it in the outer stream `finally`; leave route iteration, explicit cancellation, durable disconnect semantics, and AG-UI untouched.
+
+**Tech Stack:** TypeScript 7, Web `ReadableStream`/`Response`, Server-Sent Events, Vitest 4, pnpm/Turbo, Dawn CLI dev runtime, Chrome browser automation.
+
+---
+
+## File map
+
+- Modify `packages/cli/src/lib/dev/runtime-fetch-core.ts` — define the AP heartbeat constants/helper, thread the internal test interval, start/stop heartbeats in both AP handlers, and align response headers.
+- Modify `packages/cli/test/run-cancellation.test.ts` — exercise controlled idle `/runs/stream` and `/resume` responses, exact headers, unchanged application framing, and heartbeat teardown.
+- Create `.changeset/ap-sse-keepalives.md` — publishable patch note for `@dawn-ai/cli`.
+- Use a disposable `/private/tmp/dawn-ap-sse-browser-smoke` fixture for Chrome verification; do not commit it.
+
+## Task 0: Establish the required local runtime and dependencies
+
+**Files:**
+- No source changes.
+
+- [ ] **Step 1: Select the repository's Node 24 runtime**
+
+This machine's default shell resolves Node 22, below the repository floor. Run
+from the feature worktree root:
+
+```bash
+export PATH="/Users/blove/.nvm/versions/node/v24.18.0/bin:$PATH"
+node --version
+pnpm --version
+```
+
+Expected: Node reports `v24.18.0` (or a newer 24.x runtime) and pnpm reports
+`10.33.0`. Every later command tool invocation starts a fresh shell, so begin
+each one with the same `export PATH=...` line (or run that task's commands in
+the same shell session). Apply it to the long-running dev-server session too.
+
+- [ ] **Step 2: Install the exact locked workspace dependencies**
+
+The dedicated worktree begins without `node_modules`. Run:
+
+```bash
+pnpm install --frozen-lockfile
+```
+
+Expected: exit 0 with no lockfile rewrite. Confirm `git status --short` still
+lists only the uncommitted plan file before implementation starts.
+
+## Task 1: Pin `/runs/stream` heartbeat and header behavior
+
+**Files:**
+- Modify: `packages/cli/test/run-cancellation.test.ts:105-141`
+- Modify: `packages/cli/test/run-cancellation.test.ts:222-245`
+- Modify: `packages/cli/test/run-cancellation.test.ts:355-359`
+
+- [ ] **Step 1: Make the blocking fixture accept the internal heartbeat interval**
+
+Change the setup signature and handler construction without changing existing callers:
+
+```ts
+async function setupBlockingRoute(options: { readonly apSseHeartbeatIntervalMs?: number } = {}) {
+  // existing fixture setup remains unchanged
+  const handler = await createRuntimeFetchHandler({
+    appRoot,
+    drainDeadlineMs: 250,
+    ...(options.apSseHeartbeatIntervalMs !== undefined
+      ? { apSseHeartbeatIntervalMs: options.apSseHeartbeatIntervalMs }
+      : {}),
+  })
+  // existing return remains unchanged
+}
+```
+
+- [ ] **Step 2: Add a reader helper that can continue after the first frame**
+
+Place this beside `readSseText`:
+
+```ts
+async function readRemainingSseText(
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+): Promise<string> {
+  const decoder = new TextDecoder()
+  let text = ""
+  for (;;) {
+    const { done, value } = await reader.read()
+    if (done) return text + decoder.decode()
+    text += decoder.decode(value, { stream: true })
+  }
+}
+```
+
+- [ ] **Step 3: Write the failing `/runs/stream` transport test**
+
+Add a new `describe("AP SSE keepalives", ...)` before the concurrency tests:
+
+```ts
+describe("AP SSE keepalives", () => {
+  it("keeps an idle run stream alive without changing application events", async () => {
+    const { handler, startedFile, releaseFile, releaseRoute } = await setupBlockingRoute({
+      apSseHeartbeatIntervalMs: 10,
+    })
+    const response = await handler.fetch(
+      runStreamRequest("t-heartbeat-stream", startedFile, releaseFile),
+    )
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get("content-type")).toBe("text/event-stream")
+    expect(response.headers.get("cache-control")).toBe("no-cache, no-transform")
+
+    const reader = response.body?.getReader()
+    if (!reader) throw new Error("expected AP stream body")
+    const first = await reader.read()
+    expect(first.done).toBe(false)
+    expect(new TextDecoder().decode(first.value)).toBe(": ping\n\n")
+    expect(handler.state.activeRequests).toBe(1)
+
+    await releaseRoute()
+    const remaining = await readRemainingSseText(reader)
+    expect(remaining.replaceAll(": ping\n\n", "")).toBe(
+      'event: done\ndata: {"output":{"ok":true}}\n\n',
+    )
+    await expect.poll(() => handler.state.activeRequests).toBe(0)
+  }, 10_000)
+})
+```
+
+- [ ] **Step 4: Run the focused test and verify the red state**
+
+Run:
+
+```bash
+pnpm --filter @dawn-ai/cli exec vitest --run --config vitest.config.ts test/run-cancellation.test.ts -t "keeps an idle run stream alive"
+```
+
+Expected: FAIL at compile time because `apSseHeartbeatIntervalMs` is not an
+accepted option. Vitest transpilation may instead reach runtime and fail first
+on the old `/runs/stream` cache header; if that assertion is temporarily
+bypassed, the first-frame read waits until timeout because the old
+implementation emits no idle bytes.
+
+## Task 2: Pin `/resume` heartbeat and heartbeat cleanup
+
+**Files:**
+- Modify: `packages/cli/test/run-cancellation.test.ts:310-342`
+- Modify: `packages/cli/test/run-cancellation.test.ts` in the new `AP SSE keepalives` describe block
+
+- [ ] **Step 1: Make the resume fixture accept the same internal interval**
+
+```ts
+async function setupResumeInterrupt(
+  options: { readonly apSseHeartbeatIntervalMs?: number } = {},
+) {
+  // existing fixture setup remains unchanged
+  const handler = await createRuntimeFetchHandler({
+    appRoot,
+    drainDeadlineMs: 250,
+    ...(options.apSseHeartbeatIntervalMs !== undefined
+      ? { apSseHeartbeatIntervalMs: options.apSseHeartbeatIntervalMs }
+      : {}),
+  })
+  // existing return remains unchanged
+}
+```
+
+- [ ] **Step 2: Write the failing `/resume` parity test**
+
+```ts
+it("keeps an idle resume stream alive with the same transport headers", async () => {
+  const { handler, releaseRoute } = await setupResumeInterrupt({
+    apSseHeartbeatIntervalMs: 10,
+  })
+  const response = await handler.fetch(resumeRequest("t-heartbeat-resume"))
+
+  expect(response.status).toBe(200)
+  expect(response.headers.get("content-type")).toBe("text/event-stream")
+  expect(response.headers.get("cache-control")).toBe("no-cache, no-transform")
+
+  const reader = response.body?.getReader()
+  if (!reader) throw new Error("expected resume stream body")
+  const first = await reader.read()
+  expect(first.done).toBe(false)
+  expect(new TextDecoder().decode(first.value)).toBe(": ping\n\n")
+
+  await releaseRoute()
+  const remaining = await readRemainingSseText(reader)
+  expect(remaining.replaceAll(": ping\n\n", "")).toBe(
+    'event: done\ndata: {"output":{"ok":true}}\n\n',
+  )
+}, 10_000)
+```
+
+- [ ] **Step 3: Write the failing explicit-cancellation cleanup test**
+
+Use a long heartbeat interval so explicit cancellation wins before any ping, and observe that the helper clears its interval:
+
+```ts
+it("clears the heartbeat when an explicitly cancelled stream ends", async () => {
+  const clearIntervalSpy = vi.spyOn(globalThis, "clearInterval")
+  try {
+    const { handler, startedFile, releaseFile } = await setupBlockingRoute({
+      apSseHeartbeatIntervalMs: 60_000,
+    })
+    const response = await handler.fetch(
+      runStreamRequest("t-heartbeat-cancel", startedFile, releaseFile),
+    )
+    await waitForFile(startedFile)
+
+    expect((await handler.fetch(cancelRequest("t-heartbeat-cancel"))).status).toBe(200)
+    expect(await readSseText(response)).toBe(
+      'event: done\ndata: {"output":{"cancelled":true}}\n\n',
+    )
+    expect(clearIntervalSpy).toHaveBeenCalledTimes(1)
+  } finally {
+    clearIntervalSpy.mockRestore()
+  }
+}, 10_000)
+```
+
+- [ ] **Step 4: Write the failing consumer-disconnect lifecycle test**
+
+This pins the durable split directly: cancelling the viewer settles the body,
+but must not clear the heartbeat until the underlying route completes.
+
+```ts
+it("keeps the heartbeat lifecycle until a disconnected run completes", async () => {
+  const clearIntervalSpy = vi.spyOn(globalThis, "clearInterval")
+  try {
+    const { handler, startedFile, releaseFile, releaseRoute } = await setupBlockingRoute({
+      apSseHeartbeatIntervalMs: 60_000,
+    })
+    const response = await handler.fetch(
+      runStreamRequest("t-heartbeat-disconnect", startedFile, releaseFile),
+    )
+    await waitForFile(startedFile)
+
+    await response.body?.cancel()
+    expect(handler.state.activeRequests).toBe(0)
+    expect(clearIntervalSpy).not.toHaveBeenCalled()
+
+    await releaseRoute()
+    await expect.poll(() => clearIntervalSpy).toHaveBeenCalledTimes(1)
+  } finally {
+    clearIntervalSpy.mockRestore()
+  }
+}, 10_000)
+```
+
+- [ ] **Step 5: Run all four new tests and verify they fail for the intended reasons**
+
+Run:
+
+```bash
+pnpm --filter @dawn-ai/cli exec vitest --run --config vitest.config.ts test/run-cancellation.test.ts -t "AP SSE keepalives"
+```
+
+Expected: FAIL because no heartbeat interval exists and `/runs/stream` has the old cache header.
+
+## Task 3: Implement the shared AP heartbeat lifecycle
+
+**Files:**
+- Modify: `packages/cli/src/lib/dev/runtime-fetch-core.ts:98-105`
+- Modify: `packages/cli/src/lib/dev/runtime-fetch-core.ts:228-244`
+- Modify: `packages/cli/src/lib/dev/runtime-fetch-core.ts:401-430`
+- Modify: `packages/cli/src/lib/dev/runtime-fetch-core.ts:568-586`
+- Modify: `packages/cli/src/lib/dev/runtime-fetch-core.ts:713-732`
+- Modify: `packages/cli/src/lib/dev/runtime-fetch-core.ts:776-809`
+- Modify: `packages/cli/src/lib/dev/runtime-fetch-core.ts:905-978`
+- Modify: `packages/cli/src/lib/dev/runtime-fetch-core.ts:988-995`
+- Modify: `packages/cli/src/lib/dev/runtime-fetch-core.ts:1231-1266`
+- Modify: `packages/cli/src/lib/dev/runtime-fetch-core.ts:1374-1441`
+- Modify: `packages/cli/src/lib/dev/runtime-fetch-core.ts:1537-1552`
+
+- [ ] **Step 1: Add production constants and the internal test hook**
+
+Near `CLOSE_DRAIN_DEADLINE_MS`, add:
+
+```ts
+const AP_SSE_HEARTBEAT_INTERVAL_MS = 15_000
+const AP_SSE_HEARTBEAT = new TextEncoder().encode(": ping\n\n")
+```
+
+Extend only the fetch-core option intersection:
+
+```ts
+/** Internal/test hook: override the AP SSE heartbeat interval (default 15s). */
+readonly apSseHeartbeatIntervalMs?: number
+```
+
+Resolve the interval when building routes:
+
+```ts
+apSseHeartbeatIntervalMs:
+  options.apSseHeartbeatIntervalMs ?? AP_SSE_HEARTBEAT_INTERVAL_MS,
+```
+
+- [ ] **Step 2: Thread the resolved interval through the existing route table**
+
+Add required `readonly apSseHeartbeatIntervalMs: number` fields to the
+`buildRouteTable`, `handleApStreamRequest`, and `handleResumeRequest` option
+objects. Destructure it in each function and pass it at both handler call sites.
+Do not pass it to AG-UI or `/runs/wait`.
+
+- [ ] **Step 3: Add the shared web-compatible helper**
+
+Place it beside `safeEnqueue`/`safeClose`:
+
+```ts
+function startSseHeartbeat(
+  controller: ReadableStreamDefaultController<Uint8Array>,
+  intervalMs: number,
+): () => void {
+  const timer = setInterval(() => {
+    safeEnqueue(controller, AP_SSE_HEARTBEAT)
+  }, intervalMs)
+  return () => clearInterval(timer)
+}
+```
+
+Do not call Node's `unref()`; this module is part of the edge fetch graph.
+
+- [ ] **Step 4: Start and stop the heartbeat in `/runs/stream`**
+
+At the beginning of the stream's `start(controller)`, before the outer `try`, add:
+
+```ts
+const stopHeartbeat = startSseHeartbeat(controller, apSseHeartbeatIntervalMs)
+```
+
+At the beginning of the outer `finally`, before release/close logic, add:
+
+```ts
+stopHeartbeat()
+```
+
+Keep `safeClose(controller)` last. This means an explicit cancellation closes
+the viewer immediately and clears its heartbeat even when `sourceCleanup`
+continues holding the run slot until the underlying route unwinds.
+
+- [ ] **Step 5: Apply the identical lifecycle to `/resume`**
+
+Use the same helper and cleanup placement in the resume stream. Do not change
+resume-claim or run-slot release ordering.
+
+- [ ] **Step 6: Align `/runs/stream` cache-control**
+
+Change only the stream response's cache header:
+
+```ts
+"cache-control": "no-cache, no-transform",
+```
+
+The resume response already has the target value. Leave AG-UI's `no-cache`
+header unchanged.
+
+- [ ] **Step 7: Run the new tests and verify green**
+
+Run:
+
+```bash
+pnpm --filter @dawn-ai/cli exec vitest --run --config vitest.config.ts test/run-cancellation.test.ts -t "AP SSE keepalives"
+```
+
+Expected: 4 tests PASS.
+
+- [ ] **Step 8: Run the complete cancellation/resume regression files**
+
+Run:
+
+```bash
+pnpm --filter @dawn-ai/cli exec vitest --run --config vitest.config.ts test/run-cancellation.test.ts test/resume-endpoint.test.ts test/runtime-fetch-parity.test.ts
+```
+
+Expected: all selected test files PASS, including exact cancelled-event assertions and deliberate disconnect behavior.
+
+- [ ] **Step 9: Inspect and commit the implementation**
+
+Run `git diff --check`, inspect the focused diff, then:
+
+```bash
+git add packages/cli/src/lib/dev/runtime-fetch-core.ts packages/cli/test/run-cancellation.test.ts
+git commit -m "fix(cli): keep Agent Protocol streams alive"
+```
+
+## Task 4: Add release metadata and package-level verification
+
+**Files:**
+- Create: `.changeset/ap-sse-keepalives.md`
+
+- [ ] **Step 1: Add the patch changeset**
+
+```md
+---
+"@dawn-ai/cli": patch
+---
+
+Keep Agent Protocol SSE streams alive during silent runs with periodic comment
+frames, and prevent intermediaries from transforming either run or resume
+streams.
+```
+
+- [ ] **Step 2: Run the CLI package gates**
+
+Run from the repository root:
+
+```bash
+pnpm --filter @dawn-ai/cli lint
+pnpm --filter @dawn-ai/cli typecheck
+pnpm --filter @dawn-ai/cli build
+pnpm --filter @dawn-ai/cli test
+```
+
+Expected: every command exits 0. Build before any later smoke against `dist/`.
+
+- [ ] **Step 3: Run changeset validation**
+
+Run:
+
+```bash
+node scripts/check-changesets.mjs
+```
+
+Expected: exits 0 and recognizes the CLI patch changeset.
+
+- [ ] **Step 4: Commit release metadata**
+
+```bash
+git add .changeset/ap-sse-keepalives.md
+git commit -m "chore: record Agent Protocol keepalive fix"
+```
+
+## Task 5: Exercise the production 15-second interval through Chrome
+
+**Files:**
+- Create temporarily: `/private/tmp/dawn-ap-sse-browser-smoke/package.json`
+- Create temporarily: `/private/tmp/dawn-ap-sse-browser-smoke/dawn.config.ts`
+- Create temporarily: `/private/tmp/dawn-ap-sse-browser-smoke/src/app/idle/index.ts`
+- Do not commit any smoke fixture file.
+
+- [ ] **Step 1: Invoke the browser-control skill**
+
+Use `@chrome:control-chrome` because the user explicitly requested real Chrome
+smoke testing. If the Chrome connector is unavailable, stop and ask the user
+whether the in-app browser is an acceptable substitute; do not silently weaken
+this acceptance criterion.
+
+- [ ] **Step 2: Create a disposable idle-route fixture**
+
+Create `/private/tmp/dawn-ap-sse-browser-smoke` only after confirming it does
+not contain unrelated files. Use the file-editing tool, not shell redirection.
+
+`package.json`:
+
+```json
+{
+  "name": "dawn-ap-sse-browser-smoke",
+  "private": true,
+  "type": "module"
+}
+```
+
+`dawn.config.ts`:
+
+```ts
+const pendingWrites = [
+  [
+    "33a12321-3ec2-56a7-b4d7-0337886c4386",
+    "__interrupt__",
+    {
+      id: "3336d0e0a2d4f198ef9aecd09cd7ac27",
+      value: { interruptId: "browser-permission" },
+    },
+  ],
+]
+
+export default {
+  checkpointer: {
+    getTuple: async () => ({ pendingWrites }),
+  },
+}
+```
+
+`src/app/idle/index.ts`:
+
+```ts
+export const graph = async () => {
+  await new Promise((resolve) => setTimeout(resolve, 18_000))
+  return { ok: true, source: "browser-smoke" }
+}
+```
+
+- [ ] **Step 3: Start the real Dawn dev command on a stable port**
+
+From the fixture directory, start the built CLI from the feature worktree:
+
+```bash
+node /private/tmp/dawn-sse/packages/cli/dist/index.js dev --port 8123
+```
+
+Wait for `http://127.0.0.1:8123/healthz` to return 200. Keep the server session
+open for the browser checks.
+
+- [ ] **Step 4: Open the same-origin Dawn page in Chrome**
+
+Navigate Chrome to `http://127.0.0.1:8123/healthz`. Use browser evaluation to
+replace the JSON document body with a small visible `<pre id="log">` smoke
+panel and define this streaming probe:
+
+```js
+window.probe = async (label, url, body) => {
+  const log = document.querySelector("#log")
+  const started = performance.now()
+  const response = await fetch(url, {
+    body: JSON.stringify(body),
+    headers: { "content-type": "application/json" },
+    method: "POST",
+  })
+  log.textContent += `${label} status=${response.status} cache=${response.headers.get("cache-control")}\n`
+  const reader = response.body.getReader()
+  const decoder = new TextDecoder()
+  for (;;) {
+    const { done, value } = await reader.read()
+    if (done) {
+      log.textContent += `${label} closed @ ${Math.round(performance.now() - started)}ms\n`
+      return
+    }
+    log.textContent += `${label} @ ${Math.round(performance.now() - started)}ms ${JSON.stringify(decoder.decode(value))}\n`
+  }
+}
+```
+
+- [ ] **Step 5: Smoke `/runs/stream` at the real production interval**
+
+Run in the page:
+
+```js
+await window.probe("run", "/threads/browser-run/runs/stream", {
+  input: {},
+  route: "/idle#graph",
+})
+```
+
+Observe and capture evidence that:
+
+- status is 200;
+- cache header is `no-cache, no-transform`;
+- `: ping\n\n` arrives at roughly 15 seconds, before application output;
+- the final `done` event contains `browser-smoke` at roughly 18 seconds;
+- the response closes normally after the final event.
+
+- [ ] **Step 6: Smoke `/resume` at the real production interval**
+
+Run:
+
+```js
+await window.probe("resume", "/threads/browser-resume/resume", {
+  resume: [
+    {
+      interruptId: "browser-permission",
+      payload: "once",
+      status: "resolved",
+    },
+  ],
+  route: "/idle#graph",
+})
+```
+
+Verify the same header, heartbeat timing, final event, and clean closure.
+
+- [ ] **Step 7: Inspect visible browser state**
+
+Capture a screenshot of the completed smoke panel. Inspect the page console and
+browser-visible request state for errors, truncated frames, duplicate Dawn
+events, or a request left pending after the terminal event. Record exact timing
+and headers in the handoff.
+
+- [ ] **Step 8: Stop the server and remove only the disposable fixture**
+
+Stop the dev server, verify the exact temp path, and remove
+`/private/tmp/dawn-ap-sse-browser-smoke`. Do not remove the active feature
+worktree or any unrelated worktree.
+
+## Task 6: Run repository verification and inspect the packed CLI
+
+**Files:**
+- No expected source changes.
+
+- [ ] **Step 1: Run the repository Definition of Done**
+
+Reconfirm the Node 24+ runtime selected in Task 0, then run from the repository root:
+
+```bash
+node --version
+pnpm ci:validate
+```
+
+Expected: Node is at least 24 and the complete local validation sequence exits
+0. If an environment-gated lane is unavailable, record the exact skipped lane
+and run every available required lane separately; do not describe a partial run
+as full validation.
+
+- [ ] **Step 2: Inspect the packed artifact for the promised change**
+
+After the build, run from the repository root:
+
+```bash
+set -e
+dawn_pack_dir="$(mktemp -d /private/tmp/dawn-cli-pack.XXXXXX)"
+trap 'rm -rf "$dawn_pack_dir"' EXIT
+pnpm --filter @dawn-ai/cli pack --pack-destination "$dawn_pack_dir"
+dawn_tarball="$(find "$dawn_pack_dir" -maxdepth 1 -type f -name '*.tgz' -print -quit)"
+tar -xzf "$dawn_tarball" -C "$dawn_pack_dir" package/dist/lib/dev/runtime-fetch-core.js
+rg -F ': ping' "$dawn_pack_dir/package/dist/lib/dev/runtime-fetch-core.js"
+rg -F 'no-cache, no-transform' "$dawn_pack_dir/package/dist/lib/dev/runtime-fetch-core.js"
+```
+
+Expected: the pack succeeds, the built fetch core contains both promised
+behaviors, and the exit trap removes only the freshly created pack directory
+whether a check passes or fails. This
+specifically closes the release-validation gap identified during 0.8.19.
+
+- [ ] **Step 3: Review repository state**
+
+Run:
+
+```bash
+git diff --check
+git status --short --branch
+git log --oneline origin/main..HEAD
+```
+
+Expected: no uncommitted source or smoke-fixture changes; only the intentional
+design, implementation, changeset, and plan commits are ahead of `origin/main`.
+
+- [ ] **Step 4: Confirm old temporary worktrees are absent**
+
+Use `git worktree list --porcelain` and confirm the previously identified merged
+worktrees `dawn-activereq`, `dawn-bootstrap`, `dawn-csguard`, and
+`dawn-followups` are not registered. Leave all unrelated worktrees untouched.
+The active `/private/tmp/dawn-sse` worktree remains until the feature branch is
+integrated or explicitly handed off.
+
+## Task 7: Final review checkpoint
+
+**Files:**
+- Review all files changed by `origin/main...HEAD`.
+
+- [ ] **Step 1: Invoke verification-before-completion**
+
+Use `@superpowers:verification-before-completion` and verify every success claim
+against fresh command output.
+
+- [ ] **Step 2: Request code review**
+
+Use `@superpowers:requesting-code-review` for the complete branch diff. Address
+only evidence-backed findings and rerun affected verification.
+
+- [ ] **Step 3: Report the completed result**
+
+Summarize production behavior, automated test counts, full-validation result,
+Chrome evidence (headers, heartbeat timings, completion, console state), packed
+artifact inspection, commits, and worktree hygiene. Do not push or open a PR
+unless the user requests publication.

--- a/docs/superpowers/specs/2026-08-08-ap-sse-keepalives-design.md
+++ b/docs/superpowers/specs/2026-08-08-ap-sse-keepalives-design.md
@@ -1,0 +1,183 @@
+# Agent Protocol SSE keepalives and cache-control parity
+
+Status: approved (2026-08-08)
+Author: Brian Love
+
+## Problem
+
+Dawn's durable Agent Protocol streams can be silent while a route waits on a
+model, tool, permission decision, or other long-running operation. During that
+silence an HTTP proxy may close the connection as idle. The runtime cannot tell
+that transport failure from a deliberate client disconnect, so the durable run
+correctly continues in the background. Dawn does not yet expose stream
+reattachment, however, which leaves the caller unable to observe the remainder
+of the run.
+
+The two Agent Protocol SSE responses also advertise inconsistent cache policy:
+
+- `POST /threads/{thread_id}/runs/stream` returns `no-cache`.
+- `POST /threads/{thread_id}/resume` returns `no-cache, no-transform`.
+
+The difference is accidental. Intermediaries should neither cache nor transform
+either live event stream.
+
+## Scope
+
+Add a periodic SSE comment heartbeat to both durable Agent Protocol stream
+responses and give both responses the same cache-control value. Keep the wire
+shape of application events, run cancellation, disconnect behavior, and AG-UI
+unchanged.
+
+## Design
+
+### Heartbeat behavior
+
+Both Agent Protocol stream handlers emit this standards-compliant SSE comment
+frame after each 15 seconds of elapsed stream lifetime:
+
+```text
+: ping
+
+```
+
+The encoded bytes are `: ping\n\n`. SSE clients ignore comment frames, while
+proxies and other intermediaries observe traffic and do not classify the
+connection as idle.
+
+The interval begins when the response stream starts. It is independent of
+application events: regular output does not reset the interval. This keeps the
+implementation deterministic and avoids coupling heartbeat lifecycle to route
+chunk timing. At one seven-byte frame every 15 seconds, the extra traffic is
+negligible.
+
+### Shared lifecycle helper
+
+One internal helper in `runtime-fetch-core.ts` owns heartbeat setup and teardown.
+It receives the stream controller and encoded heartbeat, starts the interval,
+and returns a cleanup function. Each AP handler starts it at stream startup and
+calls cleanup in its outer `finally` before closing the controller.
+
+The helper uses the existing `safeEnqueue` behavior, so a client that has
+already cancelled its readable side does not turn a background durable run into
+an exception. No Node-only timer methods are used; the fetch core must remain
+compatible with edge runtimes.
+
+`createRuntimeFetchHandler` gains an internal/test-only heartbeat interval
+override alongside its existing drain-deadline test hook. The production
+default remains fixed at 15 seconds, and no public Dawn configuration surface is
+added.
+
+### Cache headers
+
+Both Agent Protocol responses return:
+
+```text
+Cache-Control: no-cache, no-transform
+Connection: keep-alive
+Content-Type: text/event-stream
+```
+
+`no-transform` prevents intermediaries from buffering, compressing, or otherwise
+rewriting a live stream. AG-UI remains outside this change because the defect is
+specifically the durable Agent Protocol pair and AG-UI retains different
+disconnect semantics.
+
+### Run and error semantics
+
+Heartbeat frames carry no Dawn event and never mutate thread state. Existing
+application events retain their exact framing and order. A normal completion,
+route error, explicit cancellation, or source cleanup clears the heartbeat
+timer through the stream's outer `finally`.
+
+Client disconnect behavior remains deliberate:
+
+- Agent Protocol runs continue until completion or explicit cancellation.
+- AG-UI runs abort on disconnect.
+
+This change keeps the viewer connection alive when possible; it does not add
+reattachment, change cancellation, or solve a route whose source never unwinds.
+
+## Alternatives considered
+
+### Duplicate an interval in each handler
+
+This is the smallest initial diff, but the two handlers already drifted on
+cache-control. Duplicating another transport concern makes future divergence
+more likely.
+
+### Race each iterator read against a timeout
+
+This avoids a standing interval, but it inserts new concurrency into the route
+iterator and its cancellation/source-cleanup handshake. That path deliberately
+distinguishes response lifetime from run lifetime and should not be complicated
+for a transport heartbeat.
+
+### Wrap each response with a transform stream
+
+A response-level transform could inject heartbeats, but introduces another
+cancel/close propagation layer and makes the durable-disconnect semantics harder
+to audit. A small shared controller helper is more direct.
+
+## Test strategy
+
+### Automated tests
+
+Use a short internal heartbeat interval with controlled routes so the suite does
+not wait 15 seconds.
+
+1. `/runs/stream`: hold a route before its first application event and assert a
+   `: ping\n\n` frame arrives while the run remains active.
+2. `/resume`: hold a resumed route and assert the same idle heartbeat.
+3. Both endpoints: assert `cache-control` is exactly
+   `no-cache, no-transform` and existing SSE event frames remain parseable.
+4. Lifecycle: complete or cancel a controlled stream and prove no heartbeat
+   interval survives stream teardown.
+5. Run the focused CLI tests, package lint/typecheck/build as appropriate, and
+   the repository's broader validation lane if time and local prerequisites
+   permit.
+
+### Real-user browser smoke
+
+Run a local Dawn fixture whose AP route intentionally remains silent for longer
+than 15 seconds. Use the connected browser to exercise the same HTTP surface a
+user-facing client consumes:
+
+1. Create a thread and start `/runs/stream` from a small local smoke page.
+2. Observe the response remain open and record at least one heartbeat before the
+   first application event.
+3. Release the route and confirm normal Dawn events arrive and the stream closes
+   cleanly.
+4. Exercise a permission/resume-style parked route through
+   `/threads/{thread_id}/resume`, observe its heartbeat, then release it and
+   confirm completion.
+5. Inspect the browser-visible response headers for
+   `no-cache, no-transform` on both paths.
+6. Confirm no console errors, truncated final event, duplicated application
+   event, or request left open after normal completion.
+
+The smoke page and fixture are disposable verification aids, not repository
+artifacts. Automated tests remain the regression guard.
+
+## Packaging
+
+Add a patch changeset for `@dawn-ai/cli`. This is a user-visible reliability fix
+to the local and built Dawn runtime, with no new public configuration or API.
+
+## Non-goals
+
+- Run-stream reattachment or replay.
+- Configurable heartbeat intervals.
+- Changing Agent Protocol or AG-UI disconnect policy.
+- Cross-replica run routing or cancellation.
+- A bounded timeout for route sources that never unwind.
+- Heartbeats on non-SSE or AG-UI responses.
+
+## Risks and mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Timer leaks after completion | Start and clear the timer in the same stream lifecycle, with cleanup in the outer `finally`; cover teardown in tests. |
+| Heartbeat changes client event parsing | Use an SSE comment, which conforming clients ignore; keep application frames unchanged and test parsing. |
+| Edge runtime incompatibility | Use web-compatible timers only and avoid Node-specific `unref()`. |
+| A proxy timeout shorter than 15 seconds remains possible | Fifteen seconds is a conservative conventional interval; making it configurable is unnecessary surface area for this fix. |
+| Browser smoke passes but regression coverage is weak | Treat browser testing as end-to-end evidence and automated controlled-route tests as the durable guard. |

--- a/docs/superpowers/specs/2026-08-08-ap-sse-keepalives-design.md
+++ b/docs/superpowers/specs/2026-08-08-ap-sse-keepalives-design.md
@@ -47,7 +47,7 @@ connection as idle.
 The interval begins when the response stream starts. It is independent of
 application events: regular output does not reset the interval. This keeps the
 implementation deterministic and avoids coupling heartbeat lifecycle to route
-chunk timing. At one seven-byte frame every 15 seconds, the extra traffic is
+chunk timing. At one eight-byte frame every 15 seconds, the extra traffic is
 negligible.
 
 ### Shared lifecycle helper
@@ -130,8 +130,10 @@ not wait 15 seconds.
 2. `/resume`: hold a resumed route and assert the same idle heartbeat.
 3. Both endpoints: assert `cache-control` is exactly
    `no-cache, no-transform` and existing SSE event frames remain parseable.
-4. Lifecycle: complete or cancel a controlled stream and prove no heartbeat
-   interval survives stream teardown.
+4. Lifecycle: complete or explicitly cancel a controlled run and prove no
+   heartbeat interval survives route teardown. Consumer-side stream
+   cancellation remains a disconnect and must not stop the durable run or its
+   heartbeat lifecycle prematurely.
 5. Run the focused CLI tests, package lint/typecheck/build as appropriate, and
    the repository's broader validation lane if time and local prerequisites
    permit.

--- a/packages/cli/src/lib/dev/runtime-fetch-core.ts
+++ b/packages/cli/src/lib/dev/runtime-fetch-core.ts
@@ -491,8 +491,7 @@ export async function createRuntimeFetchHandler(
     return override ? Promise.resolve(override) : getMemoryStore()
   }
 
-  const apSseHeartbeatIntervalMs =
-    options.apSseHeartbeatIntervalMs ?? AP_SSE_HEARTBEAT_INTERVAL_MS
+  const apSseHeartbeatIntervalMs = options.apSseHeartbeatIntervalMs ?? AP_SSE_HEARTBEAT_INTERVAL_MS
   const routes = buildRouteTable({
     appRoot: options.appRoot,
     apSseHeartbeatIntervalMs,
@@ -985,7 +984,9 @@ function buildRouteTable(ctx: {
     // ------------------------------------------------------------------
     {
       handle: async (request) =>
-        handleMemoryListRequest({ memoryStore: await getMemoryStoreFor(request) }),
+        handleMemoryListRequest({
+          memoryStore: await getMemoryStoreFor(request),
+        }),
       method: "GET",
       pattern: /^\/memory\/candidates(?:\?.*)?$/,
     },
@@ -1920,7 +1921,7 @@ function startSseHeartbeat(
   intervalMs: number,
 ): () => void {
   const heartbeat = setInterval(() => {
-    safeEnqueue(controller, AP_SSE_HEARTBEAT)
+    safeEnqueue(controller, AP_SSE_HEARTBEAT.slice())
   }, intervalMs)
   return () => clearInterval(heartbeat)
 }

--- a/packages/cli/src/lib/dev/runtime-fetch-core.ts
+++ b/packages/cli/src/lib/dev/runtime-fetch-core.ts
@@ -169,11 +169,15 @@ export interface RuntimeFetchHandler {
 
 /** How long close() waits for in-flight requests before proceeding anyway. */
 const CLOSE_DRAIN_DEADLINE_MS = 30_000
+const AP_SSE_HEARTBEAT_INTERVAL_MS = 15_000
+const AP_SSE_HEARTBEAT = new TextEncoder().encode(": ping\n\n")
 
 export async function createRuntimeFetchHandler(
   options: StartRuntimeServerOptions & {
     /** Internal/test hook: override the close() drain deadline (default 30s). */
     readonly drainDeadlineMs?: number
+    /** Internal/test hook: override AP SSE heartbeat interval (default 15s). */
+    readonly apSseHeartbeatIntervalMs?: number
   },
 ): Promise<RuntimeFetchHandler> {
   // The node filesystem fallbacks, when this runtime has any. `dawn dev` /
@@ -487,8 +491,11 @@ export async function createRuntimeFetchHandler(
     return override ? Promise.resolve(override) : getMemoryStore()
   }
 
+  const apSseHeartbeatIntervalMs =
+    options.apSseHeartbeatIntervalMs ?? AP_SSE_HEARTBEAT_INTERVAL_MS
   const routes = buildRouteTable({
     appRoot: options.appRoot,
+    apSseHeartbeatIntervalMs,
     boot,
     getCheckpointer,
     getMemoryStoreFor,
@@ -738,6 +745,7 @@ function trackStreamSettled(
  */
 function buildRouteTable(ctx: {
   readonly appRoot: string
+  readonly apSseHeartbeatIntervalMs: number
   readonly boot: RouteBoot
   readonly getCheckpointer: (request: Request) => BaseCheckpointSaver
   readonly getMemoryStoreFor: (request: Request) => Promise<MemoryStore>
@@ -768,6 +776,7 @@ function buildRouteTable(ctx: {
 }): RouteMatcher[] {
   const {
     appRoot,
+    apSseHeartbeatIntervalMs,
     boot,
     getCheckpointer,
     getMemoryStoreFor,
@@ -925,6 +934,7 @@ function buildRouteTable(ctx: {
       handle: async (request, params) =>
         handleApStreamRequest({
           appRoot,
+          apSseHeartbeatIntervalMs,
           boot,
           checkpointer: getCheckpointer(request),
           getMemoryStore: () => getMemoryStoreFor(request),
@@ -1071,6 +1081,7 @@ function buildRouteTable(ctx: {
       handle: async (request, params) =>
         handleResumeRequest({
           appRoot,
+          apSseHeartbeatIntervalMs,
           boot,
           checkpointer: getCheckpointer(request),
           getMemoryStore: () => getMemoryStoreFor(request),
@@ -1128,6 +1139,7 @@ async function dispatch(routes: RouteMatcher[], request: Request): Promise<Respo
 
 async function handleApStreamRequest(options: {
   readonly appRoot: string
+  readonly apSseHeartbeatIntervalMs: number
   readonly boot: RouteBoot
   readonly checkpointer: BaseCheckpointSaver
   readonly getMemoryStore: () => Promise<MemoryStore>
@@ -1145,6 +1157,7 @@ async function handleApStreamRequest(options: {
 }): Promise<Response> {
   const {
     appRoot,
+    apSseHeartbeatIntervalMs,
     boot,
     checkpointer,
     getMemoryStore,
@@ -1264,6 +1277,7 @@ async function handleApStreamRequest(options: {
   let sourceCleanup: Promise<void> | undefined
   const stream = new ReadableStream<Uint8Array>({
     async start(controller) {
+      const stopHeartbeat = startSseHeartbeat(controller, apSseHeartbeatIntervalMs)
       try {
         try {
           const routeStream = streamResolvedRoute({
@@ -1312,6 +1326,7 @@ async function handleApStreamRequest(options: {
             .catch(() => undefined)
         }
       } finally {
+        stopHeartbeat()
         // The client's stream ends here regardless — safeClose below fires on
         // this same tick either way, so cancellation still looks instant to
         // the caller. What differs is when the run SLOT frees.
@@ -1340,7 +1355,7 @@ async function handleApStreamRequest(options: {
 
   return new Response(stream, {
     headers: {
-      "cache-control": "no-cache",
+      "cache-control": "no-cache, no-transform",
       connection: "keep-alive",
       "content-type": "text/event-stream",
     },
@@ -1583,6 +1598,7 @@ async function handleApWaitRequest(options: {
 
 async function handleResumeRequest(options: {
   readonly appRoot: string
+  readonly apSseHeartbeatIntervalMs: number
   readonly boot: RouteBoot
   readonly checkpointer: BaseCheckpointSaver
   readonly getMemoryStore: () => Promise<MemoryStore>
@@ -1601,6 +1617,7 @@ async function handleResumeRequest(options: {
 }): Promise<Response> {
   const {
     appRoot,
+    apSseHeartbeatIntervalMs,
     boot,
     checkpointer,
     getMemoryStore,
@@ -1730,6 +1747,7 @@ async function handleResumeRequest(options: {
     let sourceCleanup: Promise<void> | undefined
     const stream = new ReadableStream<Uint8Array>({
       async start(controller) {
+        const stopHeartbeat = startSseHeartbeat(controller, apSseHeartbeatIntervalMs)
         try {
           try {
             const routeStream = streamResolvedRoute({
@@ -1779,6 +1797,7 @@ async function handleResumeRequest(options: {
               .catch(() => undefined)
           }
         } finally {
+          stopHeartbeat()
           // The client's stream ends here regardless — response lifetime and run
           // lifetime are deliberately different; see handleApStreamRequest.
           const releaseExecutionClaims = () => {
@@ -1894,6 +1913,16 @@ function safeEnqueue(controller: ReadableStreamDefaultController<Uint8Array>, ch
     // The consumer already canceled the stream — writes become no-ops, exactly
     // like `response.write` on a disconnected socket did.
   }
+}
+
+function startSseHeartbeat(
+  controller: ReadableStreamDefaultController<Uint8Array>,
+  intervalMs: number,
+): () => void {
+  const heartbeat = setInterval(() => {
+    safeEnqueue(controller, AP_SSE_HEARTBEAT)
+  }, intervalMs)
+  return () => clearInterval(heartbeat)
 }
 
 function safeClose(controller: ReadableStreamDefaultController<Uint8Array>) {

--- a/packages/cli/test/run-cancellation.test.ts
+++ b/packages/cli/test/run-cancellation.test.ts
@@ -102,7 +102,7 @@ async function waitForFile(path: string, timeoutMs = 15_000): Promise<string> {
   throw new Error(`probe file never appeared: ${path}`)
 }
 
-async function setupBlockingRoute() {
+async function setupBlockingRoute(options: { readonly apSseHeartbeatIntervalMs?: number } = {}) {
   const appRoot = await mkdtemp(join(tmpdir(), "dawn-run-cancellation-"))
   cleanup.push(() => rm(appRoot, { force: true, recursive: true }))
 
@@ -123,7 +123,13 @@ async function setupBlockingRoute() {
   // after cancellation (that is the property under test), and close() now waits
   // for in-flight runs. Without a bound, afterEach cleanup would block for the
   // full 30s default on every cancellation test.
-  const handler = await createRuntimeFetchHandler({ appRoot, drainDeadlineMs: 250 })
+  const handler = await createRuntimeFetchHandler({
+    appRoot,
+    drainDeadlineMs: 250,
+    ...(options.apSseHeartbeatIntervalMs !== undefined
+      ? { apSseHeartbeatIntervalMs: options.apSseHeartbeatIntervalMs }
+      : {}),
+  })
   cleanup.push(() => handler.close())
 
   // Unique per setup() call (appRoot itself is unique per mkdtemp), so
@@ -225,6 +231,11 @@ async function drain(response: Response): Promise<void> {
 async function readSseText(response: Response): Promise<string> {
   const reader = response.body?.getReader()
   if (!reader) return ""
+  return await readSseReaderText(reader)
+}
+
+/** Drains an already-acquired SSE reader, returning its decoded text. */
+async function readSseReaderText(reader: ReadableStreamDefaultReader<Uint8Array>): Promise<string> {
   const decoder = new TextDecoder()
   let text = ""
   for (;;) {
@@ -307,7 +318,7 @@ function resumeBlockingRoute(startedFile: string, releaseFile: string): string {
   ].join("\n")
 }
 
-async function setupResumeInterrupt() {
+async function setupResumeInterrupt(options: { readonly apSseHeartbeatIntervalMs?: number } = {}) {
   const appRoot = await mkdtemp(join(tmpdir(), "dawn-run-cancellation-resume-"))
   cleanup.push(() => rm(appRoot, { force: true, recursive: true }))
 
@@ -329,7 +340,13 @@ async function setupResumeInterrupt() {
   // after cancellation (that is the property under test), and close() now waits
   // for in-flight runs. Without a bound, afterEach cleanup would block for the
   // full 30s default on every cancellation test.
-  const handler = await createRuntimeFetchHandler({ appRoot, drainDeadlineMs: 250 })
+  const handler = await createRuntimeFetchHandler({
+    appRoot,
+    drainDeadlineMs: 250,
+    ...(options.apSseHeartbeatIntervalMs !== undefined
+      ? { apSseHeartbeatIntervalMs: options.apSseHeartbeatIntervalMs }
+      : {}),
+  })
   cleanup.push(() => handler.close())
 
   return {
@@ -355,6 +372,104 @@ function resumeRequest(threadId: string, route = "/resume-blocking#graph"): Requ
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
+
+describe("AP SSE keepalives", () => {
+  it("keeps /runs/stream alive while a blocking route is active", async () => {
+    const { handler, startedFile, releaseFile, releaseRoute } = await setupBlockingRoute({
+      apSseHeartbeatIntervalMs: 10,
+    })
+
+    const response = await handler.fetch(runStreamRequest("t-stream-heartbeat", startedFile, releaseFile))
+    expect(response.status).toBe(200)
+    expect(response.headers.get("content-type")).toBe("text/event-stream")
+    expect(response.headers.get("cache-control")).toBe("no-cache, no-transform")
+
+    await waitForFile(startedFile)
+    const reader = response.body?.getReader()
+    if (!reader) throw new Error("expected /runs/stream response body")
+    const first = await reader.read()
+    expect(first.done).toBe(false)
+    expect(new TextDecoder().decode(first.value)).toBe(": ping\n\n")
+
+    await releaseRoute()
+    const text = await readSseReaderText(reader)
+    expect(text.replaceAll(": ping\n\n", "")).toBe('event: done\ndata: {"output":{"ok":true}}\n\n')
+    expect(handler.state.activeRequests).toBe(0)
+  }, 30_000)
+
+  it("keeps /resume alive while a blocking route is active", async () => {
+    const { handler, startedFile, releaseRoute } = await setupResumeInterrupt({
+      apSseHeartbeatIntervalMs: 10,
+    })
+
+    const response = await handler.fetch(resumeRequest("t-resume-heartbeat"))
+    expect(response.status).toBe(200)
+    expect(response.headers.get("content-type")).toBe("text/event-stream")
+    expect(response.headers.get("cache-control")).toBe("no-cache, no-transform")
+
+    await waitForFile(startedFile)
+    const reader = response.body?.getReader()
+    if (!reader) throw new Error("expected /resume response body")
+    const first = await reader.read()
+    expect(first.done).toBe(false)
+    expect(new TextDecoder().decode(first.value)).toBe(": ping\n\n")
+
+    await releaseRoute()
+    const text = await readSseReaderText(reader)
+    expect(text.replaceAll(": ping\n\n", "")).toBe('event: done\ndata: {"output":{"ok":true}}\n\n')
+    expect(handler.state.activeRequests).toBe(0)
+  }, 30_000)
+
+  it("clears the /runs/stream heartbeat when the server cancels its viewer", async () => {
+    const clearIntervalSpy = vi.spyOn(globalThis, "clearInterval")
+    try {
+      const { handler, startedFile, releaseFile, releaseRoute } = await setupBlockingRoute({
+        apSseHeartbeatIntervalMs: 60_000,
+      })
+      const threadId = "t-stream-heartbeat-server-cancel"
+
+      const response = await handler.fetch(runStreamRequest(threadId, startedFile, releaseFile))
+      await waitForFile(startedFile)
+
+      expect((await handler.fetch(cancelRequest(threadId))).status).toBe(200)
+      expect(await readSseText(response)).toBe(
+        'event: done\ndata: {"output":{"cancelled":true}}\n\n',
+      )
+      expect(clearIntervalSpy).toHaveBeenCalledTimes(1)
+
+      await releaseRoute()
+    } finally {
+      clearIntervalSpy.mockRestore()
+    }
+  }, 30_000)
+
+  it("keeps the heartbeat until a disconnected /runs/stream route ends", async () => {
+    const clearIntervalSpy = vi.spyOn(globalThis, "clearInterval")
+    try {
+      const { handler, startedFile, releaseFile, releaseRoute } = await setupBlockingRoute({
+        apSseHeartbeatIntervalMs: 60_000,
+      })
+
+      const response = await handler.fetch(
+        runStreamRequest("t-stream-heartbeat-disconnect", startedFile, releaseFile),
+      )
+      await waitForFile(startedFile)
+
+      await response.body?.cancel()
+      expect(handler.state.activeRequests).toBe(0)
+      expect(clearIntervalSpy).not.toHaveBeenCalled()
+
+      await releaseRoute()
+      const deadline = Date.now() + 5_000
+      while (clearIntervalSpy.mock.calls.length === 0 && Date.now() < deadline) {
+        await new Promise((resolve) => setTimeout(resolve, 25))
+      }
+      expect(clearIntervalSpy).toHaveBeenCalledTimes(1)
+    } finally {
+      clearIntervalSpy.mockRestore()
+    }
+  }, 30_000)
+})
 
 describe("AP concurrency gate", () => {
   it("returns 409 for a second concurrent run on the same thread", async () => {

--- a/packages/cli/test/run-cancellation.test.ts
+++ b/packages/cli/test/run-cancellation.test.ts
@@ -383,6 +383,7 @@ describe("AP SSE keepalives", () => {
     expect(response.status).toBe(200)
     expect(response.headers.get("content-type")).toBe("text/event-stream")
     expect(response.headers.get("cache-control")).toBe("no-cache, no-transform")
+    expect(response.headers.get("connection")).toBe("keep-alive")
 
     await waitForFile(startedFile)
     const reader = response.body?.getReader()
@@ -406,6 +407,7 @@ describe("AP SSE keepalives", () => {
     expect(response.status).toBe(200)
     expect(response.headers.get("content-type")).toBe("text/event-stream")
     expect(response.headers.get("cache-control")).toBe("no-cache, no-transform")
+    expect(response.headers.get("connection")).toBe("keep-alive")
 
     await waitForFile(startedFile)
     const reader = response.body?.getReader()

--- a/packages/cli/test/run-cancellation.test.ts
+++ b/packages/cli/test/run-cancellation.test.ts
@@ -171,7 +171,10 @@ async function setupFaultyThreadsStore() {
   // after cancellation (that is the property under test), and close() now waits
   // for in-flight runs. Without a bound, afterEach cleanup would block for the
   // full 30s default on every cancellation test.
-  const handler = await createRuntimeFetchHandler({ appRoot, drainDeadlineMs: 250 })
+  const handler = await createRuntimeFetchHandler({
+    appRoot,
+    drainDeadlineMs: 250,
+  })
   cleanup.push(() => handler.close())
 
   return { appRoot, handler }
@@ -246,7 +249,9 @@ async function readSseReaderText(reader: ReadableStreamDefaultReader<Uint8Array>
 }
 
 function cancelRequest(threadId: string): Request {
-  return new Request(`http://localhost/threads/${threadId}/cancel`, { method: "POST" })
+  return new Request(`http://localhost/threads/${threadId}/cancel`, {
+    method: "POST",
+  })
 }
 
 function runWaitRequest(
@@ -361,7 +366,13 @@ async function setupResumeInterrupt(options: { readonly apSseHeartbeatIntervalMs
 function resumeRequest(threadId: string, route = "/resume-blocking#graph"): Request {
   return new Request(`http://localhost/threads/${threadId}/resume`, {
     body: JSON.stringify({
-      resume: [{ interruptId: RESUME_INTERRUPT_ID, payload: "once", status: "resolved" }],
+      resume: [
+        {
+          interruptId: RESUME_INTERRUPT_ID,
+          payload: "once",
+          status: "resolved",
+        },
+      ],
       route,
     }),
     headers: { "content-type": "application/json" },
@@ -374,12 +385,40 @@ function resumeRequest(threadId: string, route = "/resume-blocking#graph"): Requ
 // ---------------------------------------------------------------------------
 
 describe("AP SSE keepalives", () => {
+  it("does not share mutable heartbeat bytes between /runs/stream ticks", async () => {
+    const { handler, startedFile, releaseFile, releaseRoute } = await setupBlockingRoute({
+      apSseHeartbeatIntervalMs: 10,
+    })
+    const response = await handler.fetch(
+      runStreamRequest("t-stream-heartbeat-mutable-bytes", startedFile, releaseFile),
+    )
+    const reader = response.body?.getReader()
+    if (!reader) throw new Error("expected /runs/stream response body")
+
+    try {
+      await waitForFile(startedFile)
+      const first = await reader.read()
+      if (first.done) throw new Error("expected first heartbeat")
+      expect(new TextDecoder().decode(first.value)).toBe(": ping\n\n")
+      first.value[0] = 0
+
+      const second = await reader.read()
+      if (second.done) throw new Error("expected second heartbeat")
+      expect(new TextDecoder().decode(second.value)).toBe(": ping\n\n")
+    } finally {
+      await releaseRoute()
+      await readSseReaderText(reader)
+    }
+  }, 30_000)
+
   it("keeps /runs/stream alive while a blocking route is active", async () => {
     const { handler, startedFile, releaseFile, releaseRoute } = await setupBlockingRoute({
       apSseHeartbeatIntervalMs: 10,
     })
 
-    const response = await handler.fetch(runStreamRequest("t-stream-heartbeat", startedFile, releaseFile))
+    const response = await handler.fetch(
+      runStreamRequest("t-stream-heartbeat", startedFile, releaseFile),
+    )
     expect(response.status).toBe(200)
     expect(response.headers.get("content-type")).toBe("text/event-stream")
     expect(response.headers.get("cache-control")).toBe("no-cache, no-transform")
@@ -440,6 +479,46 @@ describe("AP SSE keepalives", () => {
       expect(clearIntervalSpy).toHaveBeenCalledTimes(1)
 
       await releaseRoute()
+    } finally {
+      clearIntervalSpy.mockRestore()
+    }
+  }, 30_000)
+
+  it("clears the /resume heartbeat when the server cancels its viewer", async () => {
+    const clearIntervalSpy = vi.spyOn(globalThis, "clearInterval")
+    try {
+      const { handler, startedFile, releaseRoute } = await setupResumeInterrupt({
+        apSseHeartbeatIntervalMs: 60_000,
+      })
+      const threadId = "t-resume-heartbeat-server-cancel"
+
+      const response = await handler.fetch(resumeRequest(threadId))
+      await waitForFile(startedFile)
+
+      expect((await handler.fetch(cancelRequest(threadId))).status).toBe(200)
+      expect(await readSseText(response)).toBe(
+        'event: done\ndata: {"output":{"cancelled":true}}\n\n',
+      )
+      expect(clearIntervalSpy).toHaveBeenCalledTimes(1)
+
+      await releaseRoute()
+    } finally {
+      clearIntervalSpy.mockRestore()
+    }
+  }, 30_000)
+
+  it("clears the /runs/stream heartbeat when its route errors", async () => {
+    const clearIntervalSpy = vi.spyOn(globalThis, "clearInterval")
+    try {
+      const { handler, startedFile, releaseFile } = await setupBlockingRoute({
+        apSseHeartbeatIntervalMs: 60_000,
+      })
+
+      const response = await handler.fetch(
+        runStreamRequest("t-stream-heartbeat-error", startedFile, releaseFile, "/boom#graph"),
+      )
+      expect(await readSseText(response)).toBe('event: done\ndata: {"output":{"error":"boom"}}\n\n')
+      expect(clearIntervalSpy).toHaveBeenCalledTimes(1)
     } finally {
       clearIntervalSpy.mockRestore()
     }
@@ -532,7 +611,9 @@ describe("AP concurrency gate", () => {
 
     const threadResponse = await handler.fetch(new Request(`http://localhost/threads/${threadId}`))
     expect(threadResponse.status).toBe(200)
-    const thread = (await threadResponse.json()) as { metadata: Record<string, unknown> }
+    const thread = (await threadResponse.json()) as {
+      metadata: Record<string, unknown>
+    }
     expect(thread.metadata.route).toBe("/blocking#graph")
 
     await releaseRoute()
@@ -577,7 +658,9 @@ describe("AP concurrency gate", () => {
     // the persisted status column, or this thread would be bricked forever.
     const { handler, appRoot, startedFile, releaseFile, releaseRoute } = await setupBlockingRoute()
 
-    const store = createThreadsStore({ path: join(appRoot, ".dawn/threads.sqlite") })
+    const store = createThreadsStore({
+      path: join(appRoot, ".dawn/threads.sqlite"),
+    })
     await store.createThread({ thread_id: "stale-thread" })
     await store.updateStatus("stale-thread", "busy")
 
@@ -596,7 +679,9 @@ describe("POST /threads/:id/cancel", () => {
     // Never referenced by any run or POST /threads call in this test.
     const response = await handler.fetch(cancelRequest("never-seen-thread"))
     expect(response.status).toBe(404)
-    const body = (await response.json()) as { error: { details?: { code?: string } } }
+    const body = (await response.json()) as {
+      error: { details?: { code?: string } }
+    }
     expect(body.error.details?.code).toBe("thread_not_found")
   }, 30_000)
 
@@ -611,7 +696,9 @@ describe("POST /threads/:id/cancel", () => {
 
     const response = await handler.fetch(cancelRequest(thread.thread_id))
     expect(response.status).toBe(409)
-    const body = (await response.json()) as { error: { details?: { code?: string } } }
+    const body = (await response.json()) as {
+      error: { details?: { code?: string } }
+    }
     expect(body.error.details?.code).toBe("no_run_in_flight")
   }, 30_000)
 
@@ -801,14 +888,18 @@ describe("run slot release on setup failure", () => {
     // on this thread for the rest of the process's life).
     const cancelResponse = await handler.fetch(cancelRequest(threadId))
     expect(cancelResponse.status).toBe(409)
-    const cancelBody = (await cancelResponse.json()) as { error: { details?: { code?: string } } }
+    const cancelBody = (await cancelResponse.json()) as {
+      error: { details?: { code?: string } }
+    }
     expect(cancelBody.error.details?.code).toBe("no_run_in_flight")
 
     // A second run attempt must fail for the same setup reason, not because
     // the concurrency gate still thinks a run is in flight.
     const response2 = await handler.fetch(otherRunRequest(threadId))
     expect(response2.status).toBe(500)
-    const body2 = (await response2.json()) as { error: { details?: { code?: string } } }
+    const body2 = (await response2.json()) as {
+      error: { details?: { code?: string } }
+    }
     expect(body2.error.details?.code).not.toBe("run_in_flight")
   }, 10_000)
 })


### PR DESCRIPTION
## Summary

- emit periodic SSE comment frames for silent Agent Protocol run and resume streams
- preserve run/resume streaming headers, including `no-transform`
- cover heartbeat timing, cancellation, disconnect, error, byte-isolation, and endpoint parity behavior

## Why

Long-running routes can remain silent long enough for intermediaries to treat their SSE connection as idle. The Agent Protocol streaming paths previously had no application-level keepalive, and the run endpoint did not match resume's cache directive.

## Impact

Silent `/runs/stream` and `/resume` requests now emit `: ping\n\n` every 15 seconds without changing application events. Heartbeats stop during route teardown and preserve durable-run disconnect semantics.

## Validation

- `pnpm ci:validate` (2,507 tests; framework, runtime, and smoke harnesses passed)
- post-rebase CLI build and typecheck
- 66 focused CLI tests across cancellation, resume, and runtime-fetch parity
- packed CLI artifact inspection
- real Google Chrome smoke for both run and resume streams
