### PR TITLE
docs(edge): the quickstart snippet actually bundles, and three claims stop overreaching

### DIFF
--- a/.changeset/edge-quickstart-manifest.md
+++ b/.changeset/edge-quickstart-manifest.md
@@ -1,0 +1,39 @@
+---
+"@dawn-ai/cli": patch
+"@dawn-ai/core": patch
+---
+
+**Correction: the edge quickstart named the wrong module manifest, and
+`providerPackages` is not exported from `@dawn-ai/cli/fetch`.**
+
+Two errata against the docs and changelog that shipped with the `hono` build
+target. The bundled CLI docs (`packages/cli/docs/`) carry the fixes.
+
+- **The `@dawn-ai/cli/fetch` snippet under *Edge runtimes* imported
+  `./.dawn/build/modules.mjs`.** That is the `node` target's manifest: it reaches
+  `node:path`, `node:url` and `@dawn-ai/cli/runtime`, which pulls in tsx and
+  esbuild. Bundled the way `wrangler` bundles — browser platform, Workers export
+  conditions — it fails on fourteen unresolved builtins, several of them bare
+  (`fs`, `child_process`), so `nodejs_compat` would not have rescued it either.
+  The snippet now names `modules.edge.mjs`, which is what the generated
+  `app.mjs` already imported. A new ungated test reads that snippet out of the
+  docs page and bundles it under those exact conditions, so the two cannot drift
+  again; a negative control bundles the `node` manifest and requires it to fail.
+
+- **The same section said the fetch entry and the `hono` target could each be
+  used "on its own".** `modules.edge.mjs` is emitted only by the `hono` target,
+  so the fetch entry alone leaves you with no edge-safe manifest. The two are
+  layered, not alternatives: enable `hono`, then compose the pieces it writes
+  however you like. Hand-building the manifest remains possible via the exported
+  `buildStaticRouteModule` and `DawnStaticModules`, and the docs now say so
+  instead of implying the target is optional.
+
+- **The `0.8.21` changelog entry said `seedModelImporter` and `providerPackages`
+  are re-exported from `@dawn-ai/cli/fetch`.** Only `seedModelImporter` is.
+  `providerPackages` maps a provider id to its package name — a build-time
+  lookup the `hono` target uses to generate the static import switch, and of no
+  use to a runtime that needs real static imports rather than package names. It
+  is staying where it is rather than being added to the edge entry to make the
+  sentence true; it remains public from `@dawn-ai/langchain` for anyone writing
+  an import map by hand. Published changelogs are not being rewritten — this is
+  the correction.

--- a/.changeset/route-config-reserved.md
+++ b/.changeset/route-config-reserved.md
@@ -1,0 +1,19 @@
+---
+"@dawn-ai/sdk": patch
+---
+
+**`RouteConfig` is documented as reserved — Dawn reads none of its fields.**
+
+`runtime`, `streaming` and `tags` are accepted on a route's exported `config`,
+type-checked, normalized onto the route module and carried into the static build
+manifest, and then nothing branches on any of them. The API docs described
+effects none of them has: `runtime` did not pin a route to an execution
+environment (the node/edge split comes from `build.targets` and is never decided
+per route), `streaming` did not switch on token streaming (the endpoint the
+caller hits decides that), and `tags` were not displayed by the Dev Server UI or
+anywhere else.
+
+The fields are kept rather than removed — deleting a published field breaks
+every app that set one and buys nothing — but they now carry JSDoc saying they
+are reserved and have no effect, and the API reference says the same. If they
+gain behavior it will be additive.

--- a/.changeset/vercel-runtime-hedge.md
+++ b/.changeset/vercel-runtime-hedge.md
@@ -1,0 +1,11 @@
+---
+"@dawn-ai/postgres-storage": patch
+---
+
+Say which Vercel runtime the `/node` entry works on. The README listed "Vercel
+functions" among the hosts where `pg` opens a raw TCP connection, which is true
+of Vercel's Node.js runtime and false of its Edge runtime — the latter has no
+raw TCP socket, exactly like workerd, and needs the injected
+`@neondatabase/serverless` pool instead. The configuration docs carried the same
+unqualified claim in a *Works* column and now also record that nothing here has
+been run on Vercel: it is inference from the driver, not a measurement.

--- a/apps/web/app/components/landing/Ecosystem.tsx
+++ b/apps/web/app/components/landing/Ecosystem.tsx
@@ -59,9 +59,14 @@ const CATEGORIES: readonly Category[] = [
     ],
   },
   {
+    // Every entry here is a target Dawn actually emits for and CI actually
+    // runs. Vercel used to sit at the top of this list and did not clear that
+    // bar: it appeared nowhere in the repo but prose comments — no target, no
+    // fixture, no lane. The `hono` target's output is web-standard and very
+    // likely runs there, but "likely" belongs in the deployment docs, which say
+    // so and say why, not on a landing-page card with no room to hedge.
     label: "Deploy targets",
     items: [
-      { name: "Vercel", href: "https://vercel.com" },
       { name: "Cloudflare Workers", href: "https://workers.cloudflare.com" },
       { name: "Node", href: "https://nodejs.org" },
       { name: "Docker", href: "https://www.docker.com" },

--- a/apps/web/content/docs/api.mdx
+++ b/apps/web/content/docs/api.mdx
@@ -350,7 +350,15 @@ export interface RouteConfig {
 }
 ```
 
-Optional metadata that a route's `index.ts` may export alongside its entry. `runtime` pins the route to a specific execution environment. `streaming` enables token-streaming responses. `tags` are arbitrary labels exposed by the Dev Server UI.
+Optional metadata that a route's `index.ts` may export as `config` alongside its entry.
+
+<Callout type="warn" title="Reserved — Dawn reads none of these fields today">
+  All three are accepted, type-checked, normalized onto the route module and carried into the static build manifest, and then nothing branches on them. Exporting a `config` is inert.
+
+  In particular: `runtime` does **not** pin a route to an execution environment — the node/edge split comes from `build.targets` in `dawn.config.ts` and is never decided per route. `streaming` does not switch anything on; whether a run streams depends on the endpoint the caller hits (`/threads/:id/runs/stream` versus `/threads/:id/runs/wait`). `tags` are not displayed anywhere, including the Dev Server UI.
+
+  The interface is kept rather than removed because deleting a published field breaks every app that set one for no gain. If these gain behavior it will be additive and announced.
+</Callout>
 
 See [Routes](/docs/routes).
 

--- a/apps/web/content/docs/configuration.mdx
+++ b/apps/web/content/docs/configuration.mdx
@@ -375,7 +375,7 @@ import { postgresCheckpointer } from "@dawn-ai/postgres-storage/node"
 const checkpointer = postgresCheckpointer({ connectionString: process.env.DATABASE_URL })
 ```
 
-Reach for `/node` on Node, Bun, or Vercel functions when you want the convenience. Use the main entry with your own pool everywhere else.
+Reach for `/node` on Node, Bun, or a Vercel function running the Node.js runtime when you want the convenience. Use the main entry with your own pool everywhere else.
 
 Note that `permissions.store` receives `mode` explicitly. A custom store owns its own mode and allow/deny lists — see [`permissions.store`](#permissionsstore).
 
@@ -383,8 +383,8 @@ Note that `permissions.store` receives `mode` explicitly. A custom store owns it
 
 | Host | Works | Notes |
 |---|---|---|
-| Node, Bun | Yes | Direct TCP to Postgres. |
-| Vercel functions | Yes | Direct TCP to Postgres. |
+| Node, Bun | Yes | Direct TCP to Postgres. Exercised in CI. |
+| Vercel functions (Node.js runtime) | Should, untested | Direct TCP to Postgres — the runtime is Node, so `pg` behaves as it does above. Nothing here has been run on Vercel, so this is inference from the driver rather than a measurement. Vercel's **Edge** runtime has no raw TCP socket and needs the Cloudflare Workers row's treatment instead. |
 | Cloudflare Workers | **Not with `pg`** | `pg` opens a TCP socket, which workerd does not provide — so the `/node` entry is unusable there. Inject a [`@neondatabase/serverless`](https://github.com/neondatabase/serverless) WebSocket `Pool` into the main entry instead; it satisfies `SqlPool`, and a throwaway spike confirmed inside real workerd that the checkpointer's `BEGIN`/`COMMIT`/`ROLLBACK` are genuine session transactions on that path. That wiring is what `dawn build`'s [`hono` target](/docs/deployment#the-hono-build-target) generates, and a gated CI lane exercises it inside real workerd end to end — at the AG-UI level, [with limits worth reading](/docs/deployment#what-is-proven-and-what-is-not). Build the pool and the stores **per request** — see [why](/docs/deployment#why-the-stores-are-per-request). [Hyperdrive](https://developers.cloudflare.com/hyperdrive/) should also work but is untested; it needs a Cloudflare account. |
 
 ### Your app owns store teardown

--- a/apps/web/content/docs/deployment.mdx
+++ b/apps/web/content/docs/deployment.mdx
@@ -131,10 +131,12 @@ This path targets LangSmith or another runtime that consumes `langgraph.json` an
 
 ## Edge runtimes
 
-Dawn deploys to runtimes that have no filesystem, no child processes, and no TCP sockets — Cloudflare Workers above all. Two pieces make that work, and you can use either on its own:
+Dawn deploys to runtimes that have no filesystem, no child processes, and no TCP sockets — Cloudflare Workers above all. Two pieces make that work, and they are layered rather than alternatives:
 
 - **`@dawn-ai/cli/fetch`**, a node-free entry point you wire up yourself;
 - **the `hono` build target**, which generates a deployable app around that entry point — an edge module manifest, a per-request store factory, a Hono entry, and a `wrangler.toml`.
+
+The `hono` target is the only thing that emits `modules.edge.mjs`, and that manifest is the one input the fetch entry cannot synthesize for itself. So "wire it up yourself" means composing the generated pieces differently — your own Hono app, your own store lifetimes, your own entry shape — rather than skipping the build target: enable `hono`, then import what it wrote. Building the manifest by hand is possible (`buildStaticRouteModule` and the `DawnStaticModules` type are exported for it) but it is a per-route, per-tool, per-state-definition job that `dawn build` already does from the same discovery run.
 
 ### The `@dawn-ai/cli/fetch` entry point
 
@@ -142,7 +144,7 @@ Dawn deploys to runtimes that have no filesystem, no child processes, and no TCP
 
 ```ts
 import { createRuntimeFetchHandler } from "@dawn-ai/cli/fetch"
-import modules from "./.dawn/build/modules.mjs"
+import modules from "./.dawn/build/modules.edge.mjs"
 
 const handler = await createRuntimeFetchHandler({
   appRoot: "my-app", // an opaque namespace id when there is no filesystem
@@ -156,6 +158,8 @@ const handler = await createRuntimeFetchHandler({
 
 export default { fetch: (request: Request) => handler.fetch(request) }
 ```
+
+`modules.edge.mjs` and not `modules.mjs`: the `node` target's manifest reaches `node:path`, `node:url` and `@dawn-ai/cli/runtime` (which pulls in tsx and esbuild), and bundling it for Workers fails on fourteen unresolved builtins — several of them bare, so `nodejs_compat` does not rescue it either. Run `dawn build` with `hono` among your `build.targets` to get the edge flavor. A test bundles this very snippet, read out of this page, to keep the two from drifting.
 
 Anything you do not supply has no filesystem to fall back to, so the handler fails loudly at boot naming the missing piece rather than silently degrading. A few inputs are optional by contract and simply switch their feature off when absent: middleware, the sandbox provider, and the capability markers that read `workspace/AGENTS.md`, `memory.md`, `plan.md`, and `skills/`.
 

--- a/packages/cli/test/docs-edge-entry-snippet.test.ts
+++ b/packages/cli/test/docs-edge-entry-snippet.test.ts
@@ -1,0 +1,208 @@
+import { existsSync } from "node:fs"
+import { readFile, writeFile } from "node:fs/promises"
+import { join } from "node:path"
+
+import { build, type Metafile } from "esbuild"
+import { afterEach, describe, expect, test } from "vitest"
+
+import {
+  buildFixture,
+  createFixtureApp,
+  removeFixtureApp,
+  repoRoot,
+} from "./helpers/hono-edge-fixture.js"
+
+// ---------------------------------------------------------------------------
+// THE DOCS' OWN QUICKSTART, BUNDLED.
+//
+// `edge-bundle-purity.test.ts` bundles the emitted `app.mjs` and proves the
+// GENERATED entry links clean. This one covers the other half of the deployment
+// page: the hand-wired snippet a reader copies when they want the fetch entry
+// without the `hono` target's scaffolding.
+//
+// It exists because that snippet was wrong. It named `./.dawn/build/modules.mjs`
+// — the NODE target's manifest, which imports `node:path`, `node:url` and
+// `@dawn-ai/cli/runtime` (tsx, esbuild). Bundled as wrangler bundles, it pulled
+// in fourteen unresolved builtins, bare `fs` and `child_process` among them, so
+// not even `nodejs_compat` would have rescued it. And it sat directly beneath
+// the callout claiming a bundle from this entry links ZERO `node:` specifiers.
+//
+// Prose cannot be type-checked, so the fix is not to correct the prose and hope.
+// This test READS THE SNIPPET OUT OF THE MDX, takes its import statements
+// verbatim, and bundles them the way `wrangler deploy` would. If someone edits
+// that fence back to `modules.mjs` — or points it at anything else that drags a
+// builtin in — this goes red naming the import and the file that pulled it.
+//
+// Cheap and ungated on purpose: one fixture build, esbuild, no Docker, no
+// workerd, no network. It runs on every CI run.
+// ---------------------------------------------------------------------------
+
+const DEPLOYMENT_DOC = join(repoRoot, "apps", "web", "content", "docs", "deployment.mdx")
+
+/** The heading whose first TypeScript fence is the snippet under test. */
+const SECTION_HEADING = "### The `@dawn-ai/cli/fetch` entry point"
+
+/** Where the docs tell the reader the build artifacts live. */
+const BUILD_DIR_PREFIX = "./.dawn/build/"
+
+/**
+ * The first ```ts fence after {@link SECTION_HEADING}.
+ *
+ * Deliberately brittle about finding the heading: a silent "no snippet, nothing
+ * to check" is exactly how a docs test rots into a no-op.
+ */
+async function readQuickstartSnippet(): Promise<string> {
+  const source = await readFile(DEPLOYMENT_DOC, "utf8")
+  const headingAt = source.indexOf(SECTION_HEADING)
+  if (headingAt === -1) {
+    throw new Error(
+      `${DEPLOYMENT_DOC} no longer contains the heading ${JSON.stringify(SECTION_HEADING)}. ` +
+        "This test pins the snippet under that heading — repoint it rather than deleting it.",
+    )
+  }
+  const fence = /```ts\n([\s\S]*?)```/.exec(source.slice(headingAt))
+  if (fence?.[1] === undefined) {
+    throw new Error(
+      `no \`\`\`ts fence follows ${JSON.stringify(SECTION_HEADING)} in ${DEPLOYMENT_DOC}.`,
+    )
+  }
+  return fence[1]
+}
+
+/** The snippet's `import` lines, verbatim. */
+function importLines(snippet: string): string[] {
+  return snippet.split("\n").filter((line) => line.startsWith("import "))
+}
+
+/** The module specifier an `import` line names. */
+function specifierOf(line: string): string {
+  const quoted = /from\s+"([^"]+)"/.exec(line)
+  if (quoted?.[1] === undefined) throw new Error(`cannot read a specifier from: ${line}`)
+  return quoted[1]
+}
+
+/**
+ * Wrangler's resolution, as closely as esbuild can reproduce it — identical to
+ * `edge-bundle-purity.test.ts`'s, and identical for the same reason: `node:*`
+ * is external ONLY so the bundle completes and the metafile can be read, never
+ * because such an import would be acceptable.
+ */
+async function bundleAsWrangler(entryPoint: string, outfile: string): Promise<Metafile> {
+  const result = await build({
+    bundle: true,
+    conditions: ["workerd", "worker", "browser", "import"],
+    entryPoints: [entryPoint],
+    external: ["node:*"],
+    format: "esm",
+    logLevel: "silent",
+    mainFields: ["module", "main"],
+    metafile: true,
+    outfile,
+    platform: "browser",
+    write: false,
+  })
+  if (!result.metafile) throw new Error("esbuild produced no metafile")
+  return result.metafile
+}
+
+/** Every `node:` specifier in the graph, with the file that imported it. */
+function nodeImports(metafile: Metafile): string[] {
+  const found: string[] = []
+  for (const [file, info] of Object.entries(metafile.inputs)) {
+    for (const imported of info.imports) {
+      if (!imported.path.startsWith("node:")) continue
+      found.push(`${imported.path} ← ${file.replace(/^.*node_modules\//, "")}`)
+    }
+  }
+  return [...new Set(found)].sort()
+}
+
+/**
+ * An entry that imports exactly what the snippet imports, and re-exports the
+ * bindings so nothing is tree-shaken away before the graph is recorded.
+ *
+ * `manifest` overrides the manifest the snippet names — that is the whole
+ * mechanism of the negative control below.
+ */
+function entrySource(lines: readonly string[], manifest?: string): string {
+  const rewritten = lines.map((line) => {
+    const specifier = specifierOf(line)
+    if (!specifier.startsWith(BUILD_DIR_PREFIX)) return line
+    // The snippet is written from the app root; this entry is written INSIDE
+    // `.dawn/build`, so the same file is one directory-free hop away.
+    const target = manifest ?? `./${specifier.slice(BUILD_DIR_PREFIX.length)}`
+    return line.replace(`"${specifier}"`, `"${target}"`)
+  })
+  const names = rewritten.map((line) => {
+    const braced = /import\s+\{([^}]*)\}/.exec(line)
+    if (braced?.[1] !== undefined) {
+      return braced[1]
+        .split(",")
+        .map((name) => name.trim())
+        .filter((name) => name.length > 0)
+    }
+    const bare = /import\s+([A-Za-z_$][\w$]*)\s+from/.exec(line)
+    if (bare?.[1] === undefined) throw new Error(`cannot read bindings from: ${line}`)
+    return [bare[1]]
+  })
+  return `${rewritten.join("\n")}\n\nexport default { ${names.flat().join(", ")} }\n`
+}
+
+const created: string[] = []
+
+afterEach(async () => {
+  await Promise.all(created.splice(0).map(removeFixtureApp))
+})
+
+describe("the deployment docs' `@dawn-ai/cli/fetch` snippet, bundled as wrangler bundles", () => {
+  test("links with zero node: specifiers — and names the edge manifest, not the node one", async () => {
+    const lines = importLines(await readQuickstartSnippet())
+    expect(lines.length).toBeGreaterThan(0)
+
+    // Both targets in one build dir so `modules.mjs` and `modules.edge.mjs` sit
+    // side by side: whichever one the docs name, it resolves, and the answer is
+    // about the manifest's CONTENTS rather than about a missing file.
+    const appRoot = await createFixtureApp("dawn-docs-edge-snippet-", ["node", "hono"])
+    created.push(appRoot)
+    const buildDir = await buildFixture(appRoot)
+    expect(existsSync(join(buildDir, "modules.mjs"))).toBe(true)
+    expect(existsSync(join(buildDir, "modules.edge.mjs"))).toBe(true)
+
+    const entry = join(buildDir, "docs-snippet.entry.mjs")
+    await writeFile(entry, entrySource(lines), "utf8")
+
+    const found = nodeImports(await bundleAsWrangler(entry, join(buildDir, "docs-snippet.mjs")))
+
+    // Named, not counted: "which import, from where" is the only useful failure.
+    expect(found).toEqual([])
+  }, 180_000)
+
+  test("negative control: the node target's modules.mjs drags builtins in, so this can fail", async () => {
+    const lines = importLines(await readQuickstartSnippet())
+
+    const appRoot = await createFixtureApp("dawn-docs-edge-snippet-control-", ["node", "hono"])
+    created.push(appRoot)
+    const buildDir = await buildFixture(appRoot)
+
+    const entry = join(buildDir, "control.entry.mjs")
+    await writeFile(entry, entrySource(lines, "./modules.mjs"), "utf8")
+
+    // The exact defect the docs shipped, and it does not even reach the
+    // metafile: `external: ["node:*"]` covers `node:fs`, not BARE `fs`, so the
+    // node manifest's graph leaves esbuild with builtins it cannot resolve and
+    // the build throws. (`nodejs_compat` would not have helped either — it maps
+    // `node:`-prefixed specifiers.)
+    const outcome = await bundleAsWrangler(entry, join(buildDir, "control.mjs")).then(
+      (metafile) => ({ error: undefined, found: nodeImports(metafile) }),
+      (error: unknown) => ({ error: error as Error, found: [] as string[] }),
+    )
+
+    const clean = outcome.error === undefined && outcome.found.length === 0
+    expect(
+      clean,
+      "the node target's modules.mjs bundled clean under Workers conditions — if that is " +
+        "genuinely now true, this control has stopped controlling for anything and the docs " +
+        "test above proves less than its name claims.",
+    ).toBe(false)
+  }, 180_000)
+})

--- a/packages/cli/test/helpers/hono-edge-fixture.ts
+++ b/packages/cli/test/helpers/hono-edge-fixture.ts
@@ -439,8 +439,18 @@ async function buildLinkedDists(): Promise<void> {
 /**
  * Create a one-route Dawn app configured for the `hono` target, with every
  * runtime package linked in. Returns its root; the caller disposes it.
+ *
+ * `targets` overrides the configured build targets. It exists for
+ * `docs-edge-entry-snippet.test.ts`, whose negative control needs the `node`
+ * target's `modules.mjs` sitting beside the edge one in a single build dir —
+ * that is what makes "the docs named the wrong manifest" reproducible rather
+ * than merely a missing file. Everything else wants the default and should
+ * keep passing the prefix alone.
  */
-export async function createFixtureApp(prefix: string): Promise<string> {
+export async function createFixtureApp(
+  prefix: string,
+  targets: readonly string[] = ["hono"],
+): Promise<string> {
   // Before anything is linked: make the `dist` about to be linked current.
   await ensureLinkedDistsFresh()
 
@@ -449,7 +459,7 @@ export async function createFixtureApp(prefix: string): Promise<string> {
   const appRoot = await realpath(await mkdtemp(join(tmpdir(), prefix)))
 
   const files: Record<string, string> = {
-    "dawn.config.ts": 'export default { build: { targets: ["hono"] } }\n',
+    "dawn.config.ts": `export default { build: { targets: ${JSON.stringify(targets)} } }\n`,
     "package.json": `${JSON.stringify({
       dependencies: {
         "@dawn-ai/cli": "workspace:*",

--- a/packages/postgres-storage/README.md
+++ b/packages/postgres-storage/README.md
@@ -25,7 +25,8 @@ reach it depends on which entry point you use — see
 [Two entry points](#two-entry-points).
 
 The `/node` entry talks to Postgres over the standard `pg` driver, which opens a
-raw TCP connection: Node, Bun, and Vercel functions. workerd has no raw TCP
+raw TCP connection: Node, Bun, and Vercel functions on the Node.js runtime (not
+Vercel's Edge runtime, which has no raw TCP either). workerd has no raw TCP
 socket for `pg` to use, so an edge deploy uses the **main** entry and injects a
 pool built by a driver that speaks something workerd does have.
 `@neondatabase/serverless` over WebSocket is that driver — it is what Dawn's

--- a/packages/sdk/src/route-config.ts
+++ b/packages/sdk/src/route-config.ts
@@ -1,7 +1,34 @@
 export type RouteKind = "agent" | "chain" | "graph" | "workflow"
 
+/**
+ * Optional metadata a route's `index.ts` may export as `config` alongside its
+ * entry.
+ *
+ * **Reserved. Dawn reads none of these fields today.** The shape is accepted,
+ * type-checked, normalized onto the route module and carried into the static
+ * build manifest — and then nothing branches on it. Exporting a `config` is
+ * therefore inert: it will not change how a route builds, deploys, streams, or
+ * is displayed.
+ *
+ * It is kept rather than deleted because removing a published field from a
+ * public interface breaks every app that set one, to no one's benefit. Treat it
+ * as forward-declared surface: if these gain behavior, it will be additive and
+ * announced. Until then, do not reach for them expecting an effect.
+ */
 export interface RouteConfig {
+  /**
+   * Reserved; **no effect**. The node/edge split is decided entirely by
+   * `build.targets` in `dawn.config.ts` — see the `hono` build target — and
+   * never per route. A route marked `"edge"` is not excluded from a node build,
+   * and one marked `"node"` is not excluded from an edge build.
+   */
   readonly runtime?: "node" | "edge"
+  /**
+   * Reserved; **no effect**. Whether a run streams is decided by the endpoint
+   * the caller hits (`/threads/:id/runs/stream` versus `/threads/:id/runs/wait`)
+   * and by AG-UI's own transport, not by route metadata.
+   */
   readonly streaming?: boolean
+  /** Reserved; **no effect**. Nothing reads or displays these. */
   readonly tags?: readonly string[]
 }


### PR DESCRIPTION
Four findings from a post-release audit of the `0.8.21` edge target. One is a broken quickstart; the rest are claims that outran their evidence.

### The edge quickstart could not be bundled

`deployment.mdx` told the reader to `import modules from "./.dawn/build/modules.mjs"`. That is the **node** target's manifest — it imports `node:path`, `node:url`, and `@dawn-ai/cli/runtime`, which reaches tsx and esbuild. Bundled the way wrangler does (`platform: browser`, `workerd,worker,browser,import`, `external: ["node:*"]`) it fails with **14 unresolved builtins**, including bare `fs` and `child_process` — so `nodejs_compat` would not have rescued it either. The edge manifest is `modules.edge.mjs`; the generated `app.mjs` already gets this right. Only the hand-wiring doc was wrong, and it sat directly beneath the callout claiming the entry links zero `node:` specifiers.

**The fix is pinned by a test, not by prose.** `docs-edge-entry-snippet.test.ts` locates the fence under that heading *in the MDX*, takes its import lines verbatim, resolves them against a real built fixture, and bundles with that exact esbuild config. A negative control points the same entry at `modules.mjs` and requires it *not* to link, so the test cannot rot into a no-op. Ungated, ~5s, no Docker.

The adjacent "use either on its own" framing is also corrected: `emitEdgeModulesFile` has exactly one caller, so the two pieces are layered, not independent. The docs now point at `buildStaticRouteModule` for the genuine hand-built case.

### Vercel was listed as a deploy target with nothing behind it

Repo-wide, Vercel appeared only in prose comments — no test, lane, config, or fixture. The landing-page card gave it the same weight as Node and Docker, on the surface least able to carry a hedge, so it is removed. `configuration.mdx` and the `postgres-storage` README keep Vercel but change *Works: Yes* to *Should, untested*, and now name the **Node.js** runtime specifically — noting Vercel's **Edge** runtime has no raw TCP, same as workerd. That distinction was the genuinely misleading part.

There is an unmerged `blove/vercel-deployment` branch adding a vercel target; when it lands, the card is earned.

### A published CHANGELOG names an export that does not exist

`0.8.21`'s entry says `seedModelImporter` **and `providerPackages`** are re-exported from `@dawn-ai/cli/fetch`. Verified against the published tarball: `seedModelImporter` is; `providerPackages` is not.

Corrected by erratum rather than by adding the export. `providerPackages` is a provider-id → package-name map used at *build* time to generate the static import switch; an edge runtime needs the real static imports, not the names. Adding it would grow the public edge surface to make a sentence true — API shaped by an erratum. Published CHANGELOGs are left alone.

### `RouteConfig`'s fields do nothing

`api.mdx` documented `runtime: "node" | "edge"` as pinning a route to an execution environment. No code reads it. The audit widened on inspection: `streaming` and `tags` are inert too — the SSE split is decided by endpoint, and nothing displays tags. The CLI's own normalizer types `config` as `Record<string, unknown>`, so `RouteConfig` is not even structurally connected to the runtime path.

Fields kept (removal is breaking), each given a "Reserved; **no effect**" JSDoc, and the api.mdx sentence — which asserted three effects, all false — replaced with a warning.

### Verification

`pnpm build` 25/25 · `typecheck` 26/26 · `lint` 22/22 · `check-docs` pass · `DAWN_REQUIRE_DOCKER=1 pnpm test` → **2516 passed, 0 failed**.

One disclosed test-helper change: `createFixtureApp` gained an optional `targets` param (defaulting to today's behavior) so the negative control can emit both manifests into one build dir. All three existing suites using it pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)