### PR TITLE
test: stop two guards from failing open as the code grows

### DIFF
--- a/packages/cli/test/memory-command-parsing.test.ts
+++ b/packages/cli/test/memory-command-parsing.test.ts
@@ -1,3 +1,7 @@
+import { readFile } from "node:fs/promises"
+import { dirname, join } from "node:path"
+import { fileURLToPath } from "node:url"
+
 import { describe, expect, it } from "vitest"
 
 import { createProgram } from "../src/index.js"
@@ -92,5 +96,28 @@ describe("dawn memory --help", () => {
     ]) {
       expect(help).toContain(expected)
     }
+  })
+})
+
+describe("dawn memory help text covers the real dispatch table", () => {
+  it("lists every subcommand the command actually handles", async () => {
+    // `--help` renders a hand-written USAGE string while dispatch happens in a
+    // `switch`. Nothing ties them together, so a subcommand added to the switch is
+    // invisible in help — which is the bug fixed for `consolidate`/`reflect`, able to
+    // return through a different door. Reading the source keeps the two honest.
+    const source = await readFile(
+      join(dirname(fileURLToPath(import.meta.url)), "../src/commands/memory.ts"),
+      "utf8",
+    )
+
+    const dispatched = [...source.matchAll(/^\s+case "([a-z-]+)":/gm)].flatMap((m) =>
+      m[1] ? [m[1]] : [],
+    )
+    expect(dispatched.length).toBeGreaterThan(0)
+
+    const usage = source.slice(source.indexOf("const USAGE"), source.indexOf("export function"))
+    const missing = dispatched.filter((name) => !usage.includes(name))
+
+    expect(missing).toEqual([])
   })
 })

--- a/packages/devkit/test/templates.test.ts
+++ b/packages/devkit/test/templates.test.ts
@@ -1,4 +1,4 @@
-import { readFile } from "node:fs/promises"
+import { readdir, readFile } from "node:fs/promises"
 import { dirname, join, resolve } from "node:path"
 import { fileURLToPath } from "node:url"
 
@@ -6,9 +6,11 @@ import { describe, expect, it } from "vitest"
 import { resolveTemplateDir, TEMPLATE_NAMES } from "../src/templates.js"
 
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../../..")
+const exampleTestDir = resolve(repoRoot, "examples/research/server/test")
 
 /**
- * Test files the research template shares VERBATIM with `examples/research/server`.
+ * Every test file the research template shares VERBATIM with `examples/research/server`,
+ * DERIVED from what is on disk rather than listed here.
  *
  * The example is dogfooded by the repo's own suites, so a behavior change gets caught
  * there and fixed there — while the template copy, which only ever runs inside a
@@ -16,10 +18,25 @@ const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../../..")
  * rewording (`Approved: <id>` -> `approved <id> (activated)`) shipped a research
  * scaffold whose `npm test` failed out of the box from 0.8.14 through 0.8.17.
  *
- * `package.json` is deliberately NOT listed: the example depends on the workspace and
- * the template on published versions, so those two legitimately differ.
+ * Derived, because a hard-coded list fails OPEN: add a third shared test file and a
+ * literal list silently stops covering it while still reporting green — the same rot
+ * that `assertPackedClosureIsComplete` exists to prevent on the packing side.
+ *
+ * `package.json` is deliberately excluded: the example depends on the workspace and the
+ * template on published versions, so those two legitimately differ.
  */
-const SHARED_TEST_FILES = ["test/research.test.ts", "test/sandbox-docker.test.ts"]
+async function sharedTestFiles(): Promise<string[]> {
+  const templateDir = await resolveTemplateDir("research")
+  const templateNames = await readdir(join(templateDir, "test"))
+  const exampleNames = new Set(await readdir(exampleTestDir))
+
+  return templateNames
+    .filter((name) => name.endsWith(".test.ts.template"))
+    .map((name) => name.slice(0, -".template".length))
+    .filter((name) => exampleNames.has(name))
+    .map((name) => `test/${name}`)
+    .sort()
+}
 
 describe("template registry", () => {
   it("registers the research template", () => {
@@ -33,13 +50,34 @@ describe("template registry", () => {
 })
 
 describe("research template parity with examples/research", () => {
-  it.each(SHARED_TEST_FILES)("keeps %s identical to the dogfooded example", async (relative) => {
+  it("keeps every shared test file identical to the dogfooded example", async () => {
     const templateDir = await resolveTemplateDir("research")
-    const [template, example] = await Promise.all([
-      readFile(join(templateDir, `${relative}.template`), "utf8"),
-      readFile(join(repoRoot, "examples/research/server", relative), "utf8"),
-    ])
+    const shared = await sharedTestFiles()
 
-    expect(template).toBe(example)
+    // An empty list would make every assertion below vacuous, so the guard would
+    // report green precisely when it had stopped guarding anything.
+    expect(shared.length).toBeGreaterThan(0)
+
+    const drifted: string[] = []
+    for (const relative of shared) {
+      const [template, example] = await Promise.all([
+        readFile(join(templateDir, `${relative}.template`), "utf8"),
+        readFile(join(repoRoot, "examples/research/server", relative), "utf8"),
+      ])
+      if (template !== example) drifted.push(relative)
+    }
+
+    expect(drifted).toEqual([])
+  })
+
+  it("covers every test file the example and template both have", async () => {
+    const exampleTests = (await readdir(exampleTestDir))
+      .filter((name) => name.endsWith(".test.ts"))
+      .map((name) => `test/${name}`)
+      .sort()
+
+    // If the example grows a test the template also ships, the parity check must pick
+    // it up automatically. Listing files by hand is what let #377's drift through.
+    expect(await sharedTestFiles()).toEqual(exampleTests)
   })
 })


### PR DESCRIPTION
An audit of the guards added this cycle found both of them working today but pinned to hand-written lists — so each stops covering new cases **silently**, reporting green exactly when it has stopped guarding anything. That is the failure mode each was written to prevent, reintroduced one level up.

No production code changes; tests only.

## 1. Research-template parity listed its files literally

```js
const SHARED_TEST_FILES = ["test/research.test.ts", "test/sandbox-docker.test.ts"]
```

Add a third test file shared between the template and `examples/research/server` and it was simply never compared. The list is now derived from disk — every `*.test.ts.template` with a counterpart in the example — with two assertions that keep the derivation honest:

- the derived list is **non-empty** (an empty list would make every comparison vacuous)
- it **equals** the example's own test files (so a shared file cannot be silently omitted)

## 2. `--help` and dispatch had nothing tying them together

`dawn memory --help` renders a hand-written `USAGE` string while dispatch happens in a `switch`. They agree today (9 and 9), but only by hand. A subcommand added to the switch would be missing from help — which is exactly the bug just fixed for `consolidate`/`reflect`, able to return through a different door.

A test now reads `memory.ts`, extracts every dispatched `case`, and asserts each appears in `USAGE`.

## Verification

Both proven in **both** directions, not just green:

- Parity guard: added a third shared test file with deliberate drift → `expected [ 'test/extra.test.ts' ] to deeply equal []`. Removed → passes.
- Help guard: added an unlisted `vacuum` case to the switch → `expected [ 'vacuum' ] to deeply equal []`. Reverted → passes.

Workspace typecheck 26/26, lint 22/22, `@dawn-ai/cli` 861 passed, `@dawn-ai/devkit` 12 passed.

## Audit result for the rest

The other guards from this cycle were checked and are intact and effective: the pack-closure assertion still holds, both idle-connection resilience tests survived the edge restructure (the postgres-storage one correctly migrated to `../src/node.js`, still exercising the pool that entry builds), and `published:verify` passes 21/21 against published 0.8.21.

Worth noting the pool-`'error'` rule was not just preserved but **extended** by the hono/Workers target, which applies it to `@neondatabase/serverless` on the reasoning that the driver vendors `pg-pool`'s idle re-emit *and* an `events` polyfill that throws on an unhandled `'error'` — so the hazard survives on an edge runtime without `nodejs_compat`.

No changeset: test-only, no published behavior changes.