### PR TITLE
feat(memory): browse by a set of statuses or kinds

### DIFF
--- a/.changeset/browse-multi-value-filters.md
+++ b/.changeset/browse-multi-value-filters.md
@@ -1,0 +1,23 @@
+---
+"@dawn-ai/memory": patch
+"@dawn-ai/memory-pgvector": patch
+"@dawn-ai/testing": patch
+"@dawn-ai/inspector": patch
+---
+
+`BrowseQuery.status` and `.kind` now accept a set, not just one value.
+
+`browse({ status: ["candidate", "superseded"] })` matches any of them. A bare
+value behaves exactly as before, so every existing caller is unaffected.
+
+An **empty** set matches nothing rather than everything: "any of none" is false,
+and reading it as "unfiltered" would show every row to a caller that had just
+narrowed its filter to zero. Both backends implement it — sqlite via `IN (…)`,
+Postgres via `= ANY($n::text[])`, where an empty array is already false — and
+five new contract tests in `runMemoryStoreConformance` hold them to the same
+reading, including that `total` counts the whole matching set.
+
+The Inspector's list route accepts the filter repeated (`?status=a&status=b`).
+One bad value rejects the request rather than being silently dropped. A param
+that appears zero times is absent, not an empty set, so the empty-set rule is
+unreachable over HTTP.

--- a/packages/inspector/app/api/memory/list/route.ts
+++ b/packages/inspector/app/api/memory/list/route.ts
@@ -22,6 +22,34 @@ function parseEnum<T extends string>(
   )
 }
 
+/**
+ * Repeatable enum param: `?status=a&status=b` narrows to either, one value
+ * behaves exactly as before, and absent means unfiltered. Every value is
+ * validated, so one bad entry rejects the request rather than being dropped.
+ *
+ * Note the empty-array case cannot arise here — a param that appears zero
+ * times is absent, not an empty set — so the store's "empty matches nothing"
+ * rule is unreachable over HTTP and callers cannot accidentally blank a list.
+ */
+function parseEnumList<T extends string>(
+  values: readonly string[],
+  allowed: readonly T[],
+  name: string,
+): readonly T[] | undefined | Response {
+  if (values.length === 0) return undefined
+  const seen: T[] = []
+  for (const value of values) {
+    if (!(allowed as readonly string[]).includes(value)) {
+      return Response.json(
+        { error: `invalid ${name} "${value}" (expected one of: ${allowed.join(", ")})` },
+        { status: 400 },
+      )
+    }
+    if (!seen.includes(value as T)) seen.push(value as T)
+  }
+  return seen
+}
+
 /** undefined when absent, the value normalized to full-ISO-Z when Date.parse-able,
  *  a 400 Response otherwise. Normalization matters: the store compares these
  *  lexicographically against stored full-ISO-Z strings, so raw offset-ISO
@@ -40,9 +68,9 @@ export async function GET(req: Request): Promise<Response> {
   const denied = assertLocalRequest(req)
   if (denied) return denied
   const sp = new URL(req.url).searchParams
-  const status = parseEnum(sp.get("status"), STATUSES, "status")
+  const status = parseEnumList(sp.getAll("status"), STATUSES, "status")
   if (status instanceof Response) return status
-  const kind = parseEnum(sp.get("kind"), KINDS, "kind")
+  const kind = parseEnumList(sp.getAll("kind"), KINDS, "kind")
   if (kind instanceof Response) return kind
   const sourceType = parseEnum(sp.get("sourceType"), SOURCE_TYPES, "sourceType")
   if (sourceType instanceof Response) return sourceType

--- a/packages/inspector/test/api.e2e.test.ts
+++ b/packages/inspector/test/api.e2e.test.ts
@@ -101,6 +101,20 @@ describe.skipIf(!gated)("memory JSON API", () => {
     expect(badBody.error).toContain('invalid status "bogus"')
   })
 
+  it("browse narrows to any of several statuses when the param repeats", async () => {
+    const res = await fetch(`${server.base}/api/memory/list?status=candidate&status=active`)
+    const page = (await res.json()) as { records: MemoryRecord[]; total: number }
+    expect(page.records.map((r) => r.id).sort()).toEqual(["active1", "cand1", "cand2", "other1"])
+    expect(page.total).toBe(4)
+  })
+
+  it("browse rejects the whole request when one repeated value is bogus", async () => {
+    // Dropping the bad value silently would answer a question nobody asked.
+    const res = await fetch(`${server.base}/api/memory/list?status=candidate&status=bogus`)
+    expect(res.status).toBe(400)
+    expect(((await res.json()) as { error: string }).error).toContain('invalid status "bogus"')
+  })
+
   it("browse filters by namespacePrefix across namespaces", async () => {
     const params = new URLSearchParams({ namespacePrefix: "route=/notes" })
     const res = await fetch(`${server.base}/api/memory/list?${params}`)

--- a/packages/memory-pgvector/src/pgvector-store.ts
+++ b/packages/memory-pgvector/src/pgvector-store.ts
@@ -5,6 +5,7 @@ import {
   type MemoryQuery,
   type MemoryRecord,
   type MemoryStore,
+  normalizeSetFilter,
   type RecallRankingOptions,
   rankKeywordCandidates,
   tokenize,
@@ -451,13 +452,18 @@ export function pgvectorMemoryStore(opts: {
         params.push(q.namespacePrefix, q.namespacePrefix)
         where.push(`left(namespace, length($${params.length - 1})) = $${params.length}`)
       }
-      if (q.status) {
-        params.push(q.status)
-        where.push(`status = $${params.length}`)
+      // `= ANY($n)` over a text[] rather than expanded placeholders: it keeps
+      // one bind per filter, and an EMPTY array is already false, which is the
+      // contract's "a set of nothing matches nothing" without a special case.
+      const statuses = normalizeSetFilter(q.status)
+      if (statuses) {
+        params.push(statuses)
+        where.push(`status = ANY($${params.length}::text[])`)
       }
-      if (q.kind) {
-        params.push(q.kind)
-        where.push(`kind = $${params.length}`)
+      const kinds = normalizeSetFilter(q.kind)
+      if (kinds) {
+        params.push(kinds)
+        where.push(`kind = ANY($${params.length}::text[])`)
       }
       if (q.sourceType) {
         params.push(q.sourceType)

--- a/packages/memory/src/browse-filter.ts
+++ b/packages/memory/src/browse-filter.ts
@@ -1,0 +1,17 @@
+/**
+ * Normalise a `BrowseQuery` filter that accepts either one value or a set.
+ *
+ * Returns `undefined` when the caller did not filter on the field at all, and
+ * an array otherwise — including the empty array, which is a filter that
+ * matches nothing rather than an absent one. Backends must keep that
+ * distinction: `IN ()` is false, while "no clause" is true for every row.
+ *
+ * Exported so the sqlite and Postgres stores share one reading of the contract
+ * instead of each interpreting the union themselves.
+ */
+export function normalizeSetFilter<T extends string>(
+  value: T | readonly T[] | undefined,
+): readonly T[] | undefined {
+  if (value === undefined) return undefined
+  return typeof value === "string" ? [value] : value
+}

--- a/packages/memory/src/index.ts
+++ b/packages/memory/src/index.ts
@@ -1,3 +1,4 @@
+export { normalizeSetFilter } from "./browse-filter.js"
 export {
   buildConsolidationPrompt,
   buildReflectionPrompt,

--- a/packages/memory/src/sqlite-store.ts
+++ b/packages/memory/src/sqlite-store.ts
@@ -2,6 +2,7 @@ import { mkdirSync } from "node:fs"
 import { dirname } from "node:path"
 import type { SQLInputValue } from "node:sqlite"
 import { DatabaseSync } from "node:sqlite"
+import { normalizeSetFilter } from "./browse-filter.js"
 import { fuseHybrid, rankKeywordCandidates } from "./hybrid.js"
 import { DEFAULT_CANDIDATE_POOL, type RecallRankingOptions, type RecallWeights } from "./score.js"
 import { tokenize } from "./tokenize.js"
@@ -436,13 +437,17 @@ export function sqliteMemoryStore(opts: {
         where.push("substr(namespace, 1, length(?)) = ?")
         params.push(q.namespacePrefix, q.namespacePrefix)
       }
-      if (q.status) {
-        where.push("status = ?")
-        params.push(q.status)
+      // A set becomes IN (?,?,…); an EMPTY set becomes a clause that matches
+      // nothing, which is the contract — not an absent filter.
+      const statuses = normalizeSetFilter(q.status)
+      if (statuses) {
+        where.push(statuses.length > 0 ? `status IN (${statuses.map(() => "?").join(",")})` : "0")
+        params.push(...statuses)
       }
-      if (q.kind) {
-        where.push("kind = ?")
-        params.push(q.kind)
+      const kinds = normalizeSetFilter(q.kind)
+      if (kinds) {
+        where.push(kinds.length > 0 ? `kind IN (${kinds.map(() => "?").join(",")})` : "0")
+        params.push(...kinds)
       }
       if (q.sourceType) {
         where.push("json_extract(source, '$.type') = ?")

--- a/packages/memory/src/types.ts
+++ b/packages/memory/src/types.ts
@@ -53,8 +53,12 @@ export interface VectorRankingOptions {
 }
 export interface BrowseQuery {
   readonly namespacePrefix?: string
-  readonly status?: MemoryStatus
-  readonly kind?: MemoryKind
+  /** One status, or a set matching any of them. An EMPTY set matches nothing —
+   *  "any of none" is false, and reading it as "unfiltered" would show every
+   *  row to a caller that had just narrowed to zero. */
+  readonly status?: MemoryStatus | readonly MemoryStatus[]
+  /** One kind, or a set matching any of them; empty matches nothing. */
+  readonly kind?: MemoryKind | readonly MemoryKind[]
   readonly sourceType?: MemorySource["type"]
   readonly limit?: number
   readonly offset?: number

--- a/packages/testing/src/memory-conformance.ts
+++ b/packages/testing/src/memory-conformance.ts
@@ -217,6 +217,90 @@ export function runMemoryStoreConformance(opts: {
         await close?.(s)
       }
     })
+    test("browse accepts a set of statuses or kinds, matching any of them", async () => {
+      const s = await makeStore()
+      try {
+        await s.put(rec({ id: "act", namespace: "route=/x", content: "act" }))
+        await s.put(
+          rec({ id: "cand", namespace: "route=/x", content: "cand", status: "candidate" }),
+        )
+        await s.put(rec({ id: "sup", namespace: "route=/x", content: "sup", status: "superseded" }))
+        await s.put(rec({ id: "ep", namespace: "route=/x", content: "ep", kind: "episodic" }))
+        await s.put(rec({ id: "proc", namespace: "route=/x", content: "proc", kind: "procedural" }))
+
+        expect(
+          (await s.browse({ status: ["candidate", "superseded"] })).records.map((r) => r.id).sort(),
+        ).toEqual(["cand", "sup"])
+        expect(
+          (await s.browse({ kind: ["episodic", "procedural"] })).records.map((r) => r.id).sort(),
+        ).toEqual(["ep", "proc"])
+      } finally {
+        await close?.(s)
+      }
+    })
+    test("browse treats a one-element set exactly like the bare value", async () => {
+      const s = await makeStore()
+      try {
+        await s.put(rec({ id: "a", namespace: "route=/x", content: "a" }))
+        await s.put(rec({ id: "b", namespace: "route=/x", content: "b", status: "candidate" }))
+        const bare = await s.browse({ status: "candidate" })
+        const set = await s.browse({ status: ["candidate"] })
+        expect(set.records.map((r) => r.id)).toEqual(bare.records.map((r) => r.id))
+        expect(set.total).toBe(bare.total)
+      } finally {
+        await close?.(s)
+      }
+    })
+    test("browse matches nothing for an empty set — not everything", async () => {
+      const s = await makeStore()
+      try {
+        // "none of these" is an OR over zero options, which is false. Reading it
+        // as "no filter" would silently show every row to a UI that had just
+        // unticked its last box.
+        await s.put(rec({ id: "a", namespace: "route=/x", content: "a" }))
+        await s.put(rec({ id: "b", namespace: "route=/x", content: "b", status: "candidate" }))
+        const page = await s.browse({ status: [] })
+        expect(page.records).toEqual([])
+        expect(page.total).toBe(0)
+      } finally {
+        await close?.(s)
+      }
+    })
+    test("browse counts a set with the same clause it selects with", async () => {
+      const s = await makeStore()
+      try {
+        for (let i = 0; i < 5; i += 1) {
+          await s.put(
+            rec({ id: `c${i}`, namespace: "route=/x", content: `c${i}`, status: "candidate" }),
+          )
+        }
+        await s.put(rec({ id: "keep", namespace: "route=/x", content: "keep" }))
+        const page = await s.browse({ status: ["candidate", "superseded"], limit: 2 })
+        expect(page.records).toHaveLength(2)
+        // total reflects the whole matching set, not the page.
+        expect(page.total).toBe(5)
+      } finally {
+        await close?.(s)
+      }
+    })
+    test("browse ANDs a status set with the other filters", async () => {
+      const s = await makeStore()
+      try {
+        await s.put(rec({ id: "hit", namespace: "route=/x", content: "hit", status: "candidate" }))
+        await s.put(
+          rec({ id: "wrongNs", namespace: "route=/y", content: "n", status: "candidate" }),
+        )
+        await s.put(rec({ id: "wrongStatus", namespace: "route=/x", content: "s" }))
+        const page = await s.browse({
+          namespacePrefix: "route=/x",
+          status: ["candidate", "superseded"],
+        })
+        expect(page.records.map((r) => r.id)).toEqual(["hit"])
+        expect(page.total).toBe(1)
+      } finally {
+        await close?.(s)
+      }
+    })
     test("browse combines multiple filters with AND (COUNT shares the clause)", async () => {
       const s = await makeStore()
       try {


### PR DESCRIPTION
`BrowseQuery.status` and `.kind` took exactly one value, so a caller wanting "candidate **or** superseded" had to issue two queries and merge them — losing a correct `total` on the way. They now accept a set as well.

```ts
await store.browse({ status: ["candidate", "superseded"] })
```

A bare value behaves exactly as before, so **no existing caller changes**.

## The empty set matches nothing, not everything

"Any of none" is false. Reading it as "unfiltered" would show every row to a caller that had just narrowed its filter to zero — a failure mode that is silent and looks like data rather than like a bug. There's a contract test pinning it.

## One reading of the contract, two backends

Both implement against a shared `normalizeSetFilter` rather than each interpreting the union themselves:

| | |
|---|---|
| sqlite | `status IN (?,…)`, with an explicit always-false clause for the empty set |
| Postgres | `status = ANY($n::text[])` — an empty array is already false, so no special case |

Five new tests in `runMemoryStoreConformance` hold both to the same behaviour: set matching, a one-element set being identical to the bare value, the empty set, `total` counting the whole matching set rather than the page, and ANDing with the other filters.

**Verified on both**: sqlite (223 passed) and **real Postgres** via the gated Testcontainers lane (`DAWN_TEST_PGVECTOR=1`, 55 passed) — I ran the Postgres lane rather than assuming the `ANY` path worked.

## Over HTTP

The Inspector's list route takes the param repeated — `?status=candidate&status=active`. One bad value rejects the whole request rather than being quietly dropped, since answering a question nobody asked is worse than refusing. A param appearing zero times is *absent*, not an empty set, so the empty-set rule is unreachable over HTTP and no caller can accidentally blank their own list.

## Why

This unblocks adopting pretable's column filter menus in the Memory Inspector. Its enum funnels are multi-select (`isAnyOf`/`isNoneOf`), and with a single-valued query there was nothing to bind them to — the UI could offer a checklist it couldn't honour. Filtering client-side instead would have been wrong past the page limit.

Scope note: `sourceType` is left single-valued — nothing needs a set there yet, and widening it speculatively would just be more surface to keep two backends agreeing on.

## Verification

`build`, `typecheck`, `lint` clean across the workspace; `@dawn-ai/memory` 168, `@dawn-ai/testing` 223, `@dawn-ai/memory-pgvector` 55 (real Postgres), `@dawn-ai/inspector` 68 including two new HTTP-contract tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)