### PR TITLE
feat(inspector): filter status and kind from the column funnels

### DIFF
--- a/.changeset/inspector-column-filters.md
+++ b/.changeset/inspector-column-filters.md
@@ -1,0 +1,21 @@
+---
+"@dawn-ai/inspector": patch
+---
+
+Memory Inspector: filter status and kind from the grid's column funnels.
+
+The two header selects are gone. Each funnel is a checklist of that column's
+values, so you can ask for "candidate or superseded" — which the selects, being
+single-choice, could not express.
+
+Filtering stays server-side: the funnels only decide the query, which sends the
+filter repeated (`?status=candidate&status=superseded`). Narrowing only the rows
+already loaded would quietly answer a different question, since the list is one
+page of a larger store. For the same reason only status and kind carry funnels —
+the other columns are not translated into the query, and a control that filtered
+the current page would mislead. Content is what search is for; namespace is what
+the facet rail scopes, with real counts.
+
+`is none of` is resolved against the column's options rather than needing
+negation downstream, and a filter that matches nothing now says "No memories
+match these filters" instead of claiming nothing has been stored yet.

--- a/packages/inspector/src/components/memory/column-filters.ts
+++ b/packages/inspector/src/components/memory/column-filters.ts
@@ -1,0 +1,56 @@
+import type { ColumnFilter } from "@pretable/react"
+
+/**
+ * The grid's funnel speaks operators over a closed set of options; the store
+ * speaks a set of values. `undefined` means unfiltered, and `[]` means match
+ * nothing — the same distinction `BrowseQuery` draws, kept rather than
+ * collapsed so an emptied funnel does not read as "show everything".
+ */
+export type ValueSet<T extends string> = readonly T[] | undefined
+
+/**
+ * Resolve one funnel filter against the column's full option list.
+ *
+ * `isNoneOf` becomes the complement rather than needing negation support
+ * downstream: these columns are closed enums, so "not any of these" is exactly
+ * "any of the others". `isEmpty`/`isNotEmpty` are offered for every column type
+ * but are degenerate here — the values are non-nullable, so nothing is empty
+ * and everything is non-empty.
+ */
+export function resolveFilter<T extends string>(
+  filter: ColumnFilter | undefined,
+  all: readonly T[],
+): ValueSet<T> {
+  if (!filter) return undefined
+  const selected = toValues<T>(filter.value).filter((value) => all.includes(value))
+
+  switch (filter.operator) {
+    case "isAnyOf":
+      // A funnel with nothing ticked is a filter that matches nothing.
+      return selected
+    case "isNoneOf":
+      return all.filter((value) => !selected.includes(value))
+    case "isEmpty":
+      return []
+    case "isNotEmpty":
+      return undefined
+    default:
+      // Any other operator would be a text-style predicate the store cannot
+      // express as a set; leaving it unfiltered beats guessing.
+      return undefined
+  }
+}
+
+/** The funnel state that displays a resolved set — the inverse of `resolveFilter`. */
+export function toFilter<T extends string>(
+  values: ValueSet<T>,
+  all: readonly T[],
+): ColumnFilter | undefined {
+  if (values === undefined || values.length === all.length) return undefined
+  return { operator: "isAnyOf", value: [...values] }
+}
+
+function toValues<T extends string>(value: ColumnFilter["value"]): T[] {
+  if (Array.isArray(value)) return value.filter((v): v is T => typeof v === "string")
+  return typeof value === "string" ? [value as T] : []
+}

--- a/packages/inspector/src/components/memory/list-page.tsx
+++ b/packages/inspector/src/components/memory/list-page.tsx
@@ -1,13 +1,15 @@
 "use client"
-import type { MemoryRecord, MemoryStats } from "@dawn-ai/memory"
-import { useCallback, useEffect, useState } from "react"
+import type { MemoryKind, MemoryRecord, MemoryStats, MemoryStatus } from "@dawn-ai/memory"
+import type { ColumnFilter } from "@pretable/react"
+import { useCallback, useEffect, useMemo, useState } from "react"
 import { Badge } from "../ui/badge"
 import { Input } from "../ui/input"
 import { usePolling } from "../use-polling"
 import { BulkBar } from "./bulk-bar"
+import { resolveFilter, toFilter, type ValueSet } from "./column-filters"
 import { DetailSheet } from "./detail-sheet"
 import { FacetRail } from "./facet-rail"
-import { MemoryGrid } from "./memory-grid"
+import { KINDS, MemoryGrid, STATUSES } from "./memory-grid"
 import { TimelineView } from "./timeline-view"
 
 interface ListResponse {
@@ -26,9 +28,6 @@ interface SearchResponse {
  *  search failure's banner (they poll on independent cadences). */
 type ErrorSource = "stats" | "list" | "search"
 
-const KINDS = ["semantic", "episodic", "procedural", "reflection"] as const
-const STATUSES = ["candidate", "active", "superseded"] as const
-
 /** Timeline window presets → milliseconds back from now ("all" = unbounded). */
 const WINDOWS = {
   "24h": 24 * 60 * 60 * 1000,
@@ -42,8 +41,10 @@ const selectClass =
 
 export function ListPage() {
   const [namespace, setNamespace] = useState<string>()
-  const [status, setStatus] = useState("")
-  const [kind, setKind] = useState("")
+  // undefined = unfiltered, [] = matches nothing — the same distinction the
+  // store's BrowseQuery draws, so an emptied funnel cannot read as "show all".
+  const [status, setStatus] = useState<ValueSet<MemoryStatus>>(undefined)
+  const [kind, setKind] = useState<ValueSet<MemoryKind>>(undefined)
   const [query, setQuery] = useState("")
   const [view, setView] = useState<"list" | "timeline">("list")
   const [timelineWindow, setTimelineWindow] = useState<TimelineWindow>("all")
@@ -97,16 +98,36 @@ export function ListPage() {
     void refreshKey
     const params = new URLSearchParams({ limit: "200" })
     if (namespace) params.set("namespacePrefix", namespace)
-    if (status) params.set("status", status)
+    for (const value of status ?? []) params.append("status", value)
     // Timeline is an episode view — default the kind filter to episodic there
-    // (the kind select still overrides), and thread the client-computed window.
-    const effectiveKind = kind || (view === "timeline" ? "episodic" : "")
-    if (effectiveKind) params.set("kind", effectiveKind)
+    // (the kind funnel still overrides), and thread the client-computed window.
+    const effectiveKind = kind ?? (view === "timeline" ? (["episodic"] as const) : undefined)
+    for (const value of effectiveKind ?? []) params.append("kind", value)
     if (view === "timeline" && timelineWindow !== "all") {
       params.set("since", new Date(Date.now() - WINDOWS[timelineWindow]).toISOString())
     }
+    // A set narrowed to nothing matches nothing. Over HTTP a param that appears
+    // zero times is *absent*, so the request would come back unfiltered —
+    // answer it here instead of asking a question that means the opposite.
+    if (status?.length === 0 || effectiveKind?.length === 0) {
+      return Promise.resolve<ListResponse>({ records: [], total: 0 })
+    }
     return fetchJson<ListResponse>("list", `/api/memory/list?${params}`)
   }, [fetchJson, namespace, status, kind, view, timelineWindow, refreshKey])
+
+  const filters = useMemo(() => {
+    const next: Record<string, ColumnFilter> = {}
+    const statusFilter = toFilter(status, STATUSES)
+    if (statusFilter) next.status = statusFilter
+    const kindFilter = toFilter(kind, KINDS)
+    if (kindFilter) next.kind = kindFilter
+    return next
+  }, [status, kind])
+
+  const handleFiltersChange = useCallback((next: Record<string, ColumnFilter>) => {
+    setStatus(resolveFilter(next.status, STATUSES))
+    setKind(resolveFilter(next.kind, KINDS))
+  }, [])
 
   const stats = usePolling(statsFn, 2000, live)
   const page = usePolling(pageFn, 2000, live && !query)
@@ -231,32 +252,6 @@ export function ListPage() {
             onChange={(e) => setQuery(e.target.value)}
             className="w-64"
           />
-          <select
-            aria-label="Status"
-            value={status}
-            onChange={(e) => setStatus(e.target.value)}
-            className={selectClass}
-          >
-            <option value="">any status</option>
-            {STATUSES.map((s) => (
-              <option key={s} value={s}>
-                {s}
-              </option>
-            ))}
-          </select>
-          <select
-            aria-label="Kind"
-            value={kind}
-            onChange={(e) => setKind(e.target.value)}
-            className={selectClass}
-          >
-            <option value="">any kind</option>
-            {KINDS.map((k) => (
-              <option key={k} value={k}>
-                {k}
-              </option>
-            ))}
-          </select>
           <label className="flex items-center gap-1.5 text-sm text-zinc-600">
             <input type="checkbox" checked={live} onChange={(e) => setLive(e.target.checked)} />
             live
@@ -300,7 +295,17 @@ export function ListPage() {
               records={pageRecords}
               onSelect={setSelectedId}
               onTickedChange={setTicked}
+              // Filtering is server-side: the funnels only decide the query.
+              filters={filters}
+              onFiltersChange={handleFiltersChange}
             />
+          ) : status !== undefined || kind !== undefined || namespace !== undefined ? (
+            // "Nothing stored" and "nothing matches what you asked for" are
+            // different answers; telling a filtered view to go run its agent
+            // sends you looking for a bug that isn't there.
+            <p className="py-8 text-center text-sm text-zinc-400" data-testid="no-matches">
+              No memories match these filters.
+            </p>
           ) : (
             <p className="py-8 text-center text-sm text-zinc-400">
               No memories yet — run your agent and watch them appear.

--- a/packages/inspector/src/components/memory/memory-grid.tsx
+++ b/packages/inspector/src/components/memory/memory-grid.tsx
@@ -1,6 +1,11 @@
 "use client"
 import type { MemoryKind, MemoryRecord, MemoryStatus } from "@dawn-ai/memory"
-import { type PretableColumn, PretableSurface, type PretableTelemetry } from "@pretable/react"
+import {
+  type ColumnFilter,
+  type PretableColumn,
+  PretableSurface,
+  type PretableTelemetry,
+} from "@pretable/react"
 import { getDensityHeights } from "@pretable/ui"
 import { useCallback, useMemo, useState } from "react"
 import { Badge } from "../ui/badge"
@@ -19,6 +24,11 @@ interface GridRow extends Record<string, unknown> {
   updatedAt: string
 }
 
+/** The closed sets the funnels offer, and what `isNoneOf` is complemented
+ *  against. Kept here beside the columns that use them. */
+export const STATUSES: readonly MemoryStatus[] = ["candidate", "active", "superseded"]
+export const KINDS: readonly MemoryKind[] = ["semantic", "episodic", "procedural", "reflection"]
+
 /** Tallest the grid grows before it scrolls internally; below this it shrinks to
  *  fit so a two-hit search group doesn't reserve a screenful of empty rows. */
 const MAX_VIEWPORT_PX = 560
@@ -32,12 +42,20 @@ const COLUMNS: PretableColumn<GridRow>[] = [
     id: "status",
     header: "status",
     widthPx: 104,
+    type: "enum",
+    filterable: true,
+    options: STATUSES.map((value) => ({ value })),
     value: (row) => row.status,
     render: ({ row }) => <Badge variant={row.status}>{row.status}</Badge>,
   },
   {
     id: "content",
     header: "content",
+    // Only status and kind are translated into the server query, and this list
+    // is one page of a larger store — a funnel here would filter the rows that
+    // happen to be loaded and quietly answer a different question. Search does
+    // content, across everything.
+    filterable: false,
     flex: 1,
     minWidthPx: 240,
     value: (row) => row.content,
@@ -46,12 +64,28 @@ const COLUMNS: PretableColumn<GridRow>[] = [
     // text width; without it the flex item refuses to and the text just clips.
     render: ({ formattedValue }) => <span className="min-w-0 truncate">{formattedValue}</span>,
   },
-  { id: "namespace", header: "namespace", widthPx: 190, value: (row) => row.namespace },
-  { id: "kind", header: "kind", widthPx: 100, value: (row) => row.kind },
+  {
+    id: "namespace",
+    header: "namespace",
+    widthPx: 190,
+    // The facet rail already scopes namespace server-side, with real counts.
+    filterable: false,
+    value: (row) => row.namespace,
+  },
+  {
+    id: "kind",
+    header: "kind",
+    widthPx: 100,
+    type: "enum",
+    filterable: true,
+    options: KINDS.map((value) => ({ value })),
+    value: (row) => row.kind,
+  },
   {
     id: "confidence",
     header: "confidence",
     widthPx: 100,
+    filterable: false,
     value: (row) => row.confidence,
     format: ({ value }) => Number(value).toFixed(2),
   },
@@ -59,6 +93,7 @@ const COLUMNS: PretableColumn<GridRow>[] = [
     id: "updated",
     header: "updated",
     widthPx: 180,
+    filterable: false,
     value: (row) => row.updatedAt,
     format: ({ value }) => new Date(String(value)).toLocaleString(),
   },
@@ -98,6 +133,8 @@ export function MemoryGrid({
   records,
   onSelect,
   onTickedChange,
+  filters,
+  onFiltersChange,
 }: {
   records: readonly MemoryRecord[]
   onSelect: (id: string) => void
@@ -105,6 +142,10 @@ export function MemoryGrid({
    *  rendered order, for bulk actions. Omitted where bulk actions make no
    *  sense (the grouped search results). */
   onTickedChange?: (ids: string[]) => void
+  /** Funnel state to display, and where changes go. Omit both to render without
+   *  column filtering — the grouped search results filter nothing. */
+  filters?: Record<string, ColumnFilter>
+  onFiltersChange?: (next: Record<string, ColumnFilter>) => void
 }) {
   const rows = useMemo(() => records.map(toRow), [records])
 
@@ -134,6 +175,8 @@ export function MemoryGrid({
             onRowSelectionChange: onTickedChange,
           }
         : {})}
+      {...(filters ? { state: { filters } } : {})}
+      {...(onFiltersChange ? { onFiltersChange } : {})}
       // Strict ARIA grid tabbing — the default wraps Tab inside the grid, which
       // traps keyboard focus on a page that has a search box and a detail sheet.
       tabBehavior="exit"

--- a/packages/inspector/test/components/column-filter-wiring.test.tsx
+++ b/packages/inspector/test/components/column-filter-wiring.test.tsx
@@ -1,0 +1,165 @@
+import type { MemoryRecord, MemoryStats } from "@dawn-ai/memory"
+import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react"
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { ListPage } from "../../src/components/memory/list-page"
+
+/**
+ * The grid's funnels replaced the header's status/kind selects. Filtering has
+ * to stay SERVER-side: the list endpoint caps at a page, so narrowing only the
+ * rows already loaded would quietly answer a different question.
+ */
+
+const stats: MemoryStats = {
+  total: 2,
+  byStatus: { candidate: 1, active: 1 },
+  byKind: { semantic: 2 },
+  byNamespace: { "route=/notes": 2 },
+  bySourceType: { tool: 2 },
+}
+
+function record(over: Partial<MemoryRecord> & Pick<MemoryRecord, "id">): MemoryRecord {
+  return {
+    kind: "semantic",
+    namespace: "route=/notes",
+    content: `content ${over.id}`,
+    data: {},
+    source: { type: "tool", id: "remember" },
+    confidence: 0.5,
+    tags: [],
+    status: "active",
+    createdAt: "2026-07-13T00:00:00.000Z",
+    updatedAt: "2026-07-13T00:00:00.000Z",
+    ...over,
+  }
+}
+
+const records = [record({ id: "a1" }), record({ id: "c1", status: "candidate" })]
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  })
+}
+
+function stubApi() {
+  const mock = vi.fn(async (url: RequestInfo | URL) => {
+    const u = String(url)
+    if (u.includes("/api/memory/stats")) return jsonResponse(stats)
+    if (u.includes("/api/memory/list")) return jsonResponse({ records, total: records.length })
+    return jsonResponse({ groups: [] })
+  })
+  vi.stubGlobal("fetch", mock)
+  return mock
+}
+
+/** Every /api/memory/list URL the page has requested. */
+function listUrls(mock: ReturnType<typeof stubApi>): URL[] {
+  return mock.mock.calls
+    .map((call) => String(call[0]))
+    .filter((u) => u.includes("/api/memory/list"))
+    .map((u) => new URL(u, "http://localhost"))
+}
+
+async function tickStatus(value: string) {
+  // The menu stays open between ticks; clicking the funnel again would close it.
+  if (!screen.queryByRole("dialog", { name: "Filter status" })) {
+    fireEvent.click(await screen.findByRole("button", { name: "Filter status" }))
+  }
+  const dialog = await screen.findByRole("dialog", { name: "Filter status" })
+  const box = within(dialog)
+    .getAllByRole("checkbox")
+    .find((cb) => cb.closest("label")?.textContent?.includes(value))
+  if (!box) throw new Error(`no ${value} option in the status funnel`)
+  fireEvent.click(box)
+}
+
+afterEach(() => {
+  cleanup()
+  vi.unstubAllGlobals()
+})
+
+describe("column filters drive the server query", () => {
+  it("offers a funnel on status instead of a header select", async () => {
+    stubApi()
+    render(<ListPage />)
+
+    expect(await screen.findByRole("button", { name: "Filter status" })).toBeDefined()
+    // The selects these replaced are gone.
+    expect(screen.queryByLabelText("Status")).toBeNull()
+    expect(screen.queryByLabelText("Kind")).toBeNull()
+  })
+
+  it("sends the ticked status to the server, not just to the grid", async () => {
+    const mock = stubApi()
+    render(<ListPage />)
+    await screen.findByText("content a1")
+
+    await tickStatus("candidate")
+
+    await waitFor(() => {
+      const scoped = listUrls(mock).filter(
+        (u) => u.searchParams.getAll("status").join(",") === "candidate",
+      )
+      expect(scoped.length).toBeGreaterThan(0)
+    })
+  })
+
+  it("repeats the param when two values are ticked", async () => {
+    const mock = stubApi()
+    render(<ListPage />)
+    await screen.findByText("content a1")
+
+    await tickStatus("candidate")
+    await tickStatus("active")
+
+    await waitFor(() => {
+      const both = listUrls(mock).filter(
+        (u) => u.searchParams.getAll("status").sort().join(",") === "active,candidate",
+      )
+      expect(both.length).toBeGreaterThan(0)
+    })
+  })
+
+  it("returns to unfiltered when the last ticked value is removed", async () => {
+    const mock = stubApi()
+    render(<ListPage />)
+    await screen.findByText("content a1")
+
+    await tickStatus("candidate")
+    await waitFor(() => {
+      expect(listUrls(mock).some((u) => u.searchParams.has("status"))).toBe(true)
+    })
+
+    // An emptied checklist is an INACTIVE filter to the grid, not a filter that
+    // matches nothing — so the query drops the param rather than narrowing to
+    // zero. (`isEmpty` below is the operator that really means "nothing".)
+    await tickStatus("candidate")
+
+    await waitFor(() => {
+      const latest = listUrls(mock).at(-1)
+      expect(latest?.searchParams.has("status")).toBe(false)
+    })
+  })
+
+  it("answers a match-nothing filter locally instead of asking unfiltered", async () => {
+    const mock = stubApi()
+    render(<ListPage />)
+    await screen.findByText("content a1")
+
+    fireEvent.click(await screen.findByRole("button", { name: "Filter status" }))
+    const dialog = await screen.findByRole("dialog", { name: "Filter status" })
+    const operator = dialog.querySelector("select") as HTMLSelectElement
+    // status is never blank, so "is empty" matches no row at all.
+    fireEvent.change(operator, { target: { value: "isEmpty" } })
+
+    const before = listUrls(mock).length
+    await waitFor(() => {
+      expect(screen.getByTestId("no-matches")).toBeDefined()
+    })
+    // Over HTTP a param that appears zero times is *absent*, so re-asking the
+    // server would come back unfiltered — the page must answer it here.
+    expect(listUrls(mock).length).toBe(before)
+    expect(screen.getByTestId("no-matches").textContent).toContain("match these filters")
+  })
+})

--- a/packages/inspector/test/components/column-filters.test.ts
+++ b/packages/inspector/test/components/column-filters.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest"
+import { resolveFilter, toFilter } from "../../src/components/memory/column-filters"
+
+const STATUSES = ["candidate", "active", "superseded"] as const
+
+describe("resolveFilter", () => {
+  it("is unfiltered when the column has no filter", () => {
+    expect(resolveFilter(undefined, STATUSES)).toBeUndefined()
+  })
+
+  it("keeps the ticked values for isAnyOf", () => {
+    expect(
+      resolveFilter({ operator: "isAnyOf", value: ["candidate", "active"] }, STATUSES),
+    ).toEqual(["candidate", "active"])
+  })
+
+  it("turns isNoneOf into the complement, so the store needs no negation", () => {
+    expect(resolveFilter({ operator: "isNoneOf", value: ["candidate"] }, STATUSES)).toEqual([
+      "active",
+      "superseded",
+    ])
+  })
+
+  it("treats an explicitly empty set as matching nothing, not everything", () => {
+    // The distinction the store draws: [] is a filter, undefined is no filter.
+    // The grid drops an emptied checklist before it gets here (an inactive
+    // filter), so this guards the operators that do mean "nothing" — and any
+    // caller that hands the set in directly.
+    expect(resolveFilter({ operator: "isAnyOf", value: [] }, STATUSES)).toEqual([])
+  })
+
+  it("ignores values that are not options on this column", () => {
+    expect(resolveFilter({ operator: "isAnyOf", value: ["candidate", "bogus"] }, STATUSES)).toEqual(
+      ["candidate"],
+    )
+  })
+
+  it("reads isEmpty as matching nothing and isNotEmpty as unfiltered", () => {
+    // These are offered for every column type but degenerate on a non-nullable
+    // enum: nothing is empty, everything is non-empty.
+    expect(resolveFilter({ operator: "isEmpty" }, STATUSES)).toEqual([])
+    expect(resolveFilter({ operator: "isNotEmpty" }, STATUSES)).toBeUndefined()
+  })
+
+  it("leaves a text-style operator unfiltered rather than guessing", () => {
+    expect(resolveFilter({ operator: "contains", value: "cand" }, STATUSES)).toBeUndefined()
+  })
+})
+
+describe("toFilter", () => {
+  it("shows no funnel state when unfiltered", () => {
+    expect(toFilter(undefined, STATUSES)).toBeUndefined()
+  })
+
+  it("shows no funnel state when every option is selected", () => {
+    // All-of-them and no-filter are the same view; keeping the funnel lit would
+    // suggest a narrowing that isn't there.
+    expect(toFilter(["candidate", "active", "superseded"], STATUSES)).toBeUndefined()
+  })
+
+  it("round-trips a narrowed set", () => {
+    const set = ["candidate", "superseded"] as const
+    const filter = toFilter(set, STATUSES)
+    expect(filter).toEqual({ operator: "isAnyOf", value: ["candidate", "superseded"] })
+    expect(resolveFilter(filter, STATUSES)).toEqual(set)
+  })
+
+  it("round-trips the match-nothing set", () => {
+    expect(resolveFilter(toFilter([], STATUSES), STATUSES)).toEqual([])
+  })
+})

--- a/packages/inspector/vitest.components.config.ts
+++ b/packages/inspector/vitest.components.config.ts
@@ -6,6 +6,8 @@ export default defineConfig({
   test: {
     name: "inspector-components",
     environment: "jsdom",
-    include: ["test/components/**/*.test.tsx"],
+    // `.ts` too: not every component-side unit is JSX — the filter mapping is
+    // pure logic that would otherwise have to pretend to be a component file.
+    include: ["test/components/**/*.test.{ts,tsx}"],
   },
 })


### PR DESCRIPTION
The last piece of the arc that started with "the grid's enum funnels are multi-select and `BrowseQuery` isn't". [#432](https://github.com/cacheplane/dawnai/pull/432) widened the contract; this spends it.

The two header selects are gone. Each funnel is a checklist of that column's values, so **"candidate or superseded"** is now expressible — something single-choice selects could not say.

## Filtering stays server-side

The funnels only decide the query, which sends the filter repeated:

```
/api/memory/list?limit=200&status=candidate&status=superseded
```

The list is one page of a larger store, so narrowing only the rows already loaded would quietly answer a different question.

## Only two columns get funnels

The grid offers them on **every** column by default. I caught that by looking at the running app — all six had one — and nothing but status and kind is translated into the query, so a content or namespace funnel would have been reset on the next render. A control that does nothing is worse than no control.

Content is what search is for. Namespace is what the facet rail scopes, with real store-wide counts.

## Two details worth reviewing

- **`is none of` resolves to the complement** against the column's options, so the store needs no negation support — these are closed enums, and "not any of these" is exactly "any of the others".
- **An emptied checklist is an *inactive* filter to the grid**, not one that matches nothing, so it returns to unfiltered. The operator that really means nothing is `is empty`, and that case is answered **locally** — over HTTP a param appearing zero times is *absent*, so re-asking the server would come back unfiltered. Both paths are tested.

A filter matching nothing now says *"No memories match these filters"* rather than telling a filtered view that no memories have been stored yet and sending you after a bug that isn't there.

## Verification

`build` (zero warnings), `typecheck`, `lint`, **84 tests** — 11 unit tests on the operator mapping (including `isNoneOf` complement, out-of-range values, and the degenerate `isEmpty`/`isNotEmpty`), 5 integration tests asserting the funnel reaches the *server* rather than just the grid, plus the gated `DAWN_TEST_INSPECTOR=1` e2e.

Driven in a browser against the built server on the real store: ticking two boxes produced `?status=candidate&status=superseded` and the rows narrowed to match. The repeated-param query was also checked directly against the API (`total 3`, mixed statuses).

One small config change: the components test project now globs `*.test.{ts,tsx}` so the pure mapping logic needn't pretend to be a component file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)