### PR TITLE
docs(blog): draft Dawn 0.8 and Hono edge posts

### DIFF
--- a/apps/web/content/blog/2026-08-09-dawn-0-8-framework-around-the-agent.mdx
+++ b/apps/web/content/blog/2026-08-09-dawn-0-8-framework-around-the-agent.mdx
@@ -1,0 +1,134 @@
+---
+title: Dawn 0.8 — The framework around the agent
+description: Evals, typed memory, safer tools, isolated execution, standard clients, and production builds from Node and Docker to an opt-in edge target.
+date: 2026-08-09
+tags: [typescript, agents]
+type: release
+version: 0.8.21
+author: brian
+draft: true
+---
+
+The route tree was the beginning of Dawn, not the finished application.
+
+Routes gave agent code a place to live. Tools could sit next to the route that used them, types could follow the source, and the build could turn that tree into a runnable LangGraph.js application.
+
+The releases since then have filled in more of the work around that route: measuring behavior, limiting what tools can do, delegating to specialists, retaining useful memory, connecting a web client, and running the Dawn runtime outside the local dev server.
+
+This post catches up from 0.5 through the current published 0.8.21 release. It is a roundup, not a claim that 0.8.21 introduced every feature below. Several parts landed earlier and have been tightened in later 0.8 releases.
+
+## The short version
+
+The route tree still holds the application together. The practical change is how much more of the application now has an explicit place around it:
+
+- **Measure** agent behavior across a dataset with deterministic eval replay.
+- **Constrain and isolate** tools with scoped access, argument rules, approvals, and an optional sandbox.
+- **Delegate** work through named subagents with parent-owned rules.
+- **Remember** typed facts and episodes across threads, with review before recall by default.
+- **Connect** standard web clients through AG-UI while retaining the thread-scoped Agent Protocol.
+- **Deploy** the Dawn runtime through Node and Docker, or opt into a narrower edge target.
+
+Dawn still builds around LangGraph.js. It does not replace the graph runtime. The goal is to give the rest of the agent application a shape that the editor, tests, clients, operators, and deployment artifact can agree on.
+
+## Measure what the agent does
+
+Evals arrived in 0.5.0 because a passing unit test and a useful agent answer are different claims.
+
+A Dawn eval lives beside its route under `evals/*.eval.ts`. It runs the route over a dataset, scores each result, and can turn the aggregate into a gate. Exact matches, required text, tool calls, token budgets, custom scorers, and model judges cover different kinds of quality without turning the eval file into a second runtime.
+
+The default is deterministic fixture replay. The model response is replaced, while the route's tools, prompts, capabilities, and state still run. That makes a quality gate repeatable enough for CI. `dawn eval --live` calls a real model for local measurement, and `dawn eval --record` calls a real model to capture fixtures for later replay. Both spend real model calls and neither belongs in CI.
+
+The testing package has become more focused at the same time. `createAgentHarness` covers agent behavior. Separate harnesses exercise a route tool, middleware layer, workspace filesystem, or Agent Protocol boundary without starting more of the application than the test needs. Co-located `run.test.ts` scenarios remain useful for route input and output. The result is not one grand test API; it is a set of small boundaries you can choose deliberately. See [Evals](/docs/evals) and [Testing agents](/docs/testing-agents).
+
+## Put a boundary around execution
+
+An agent that can call tools needs more than a prompt asking it to be careful.
+
+Dawn now treats access control as layers. Tool scoping decides which tools reach the model: `allow` can grant a withheld capability tool, `deny` removes one, and deny wins. Argument constraints then inspect a specific call and can allow it, reject it with a reason, or escalate it for approval. Named approval rules pause a run before the tool executes.
+
+The built-in workspace has two more guards. Paths resolve against the app's workspace root, and shell commands plus paths outside that workspace pass through the permission gate. Those controls matter, but a path jail and an approval prompt are not container isolation. Once an operation is approved, it still runs wherever the runtime is running unless you configure a sandbox.
+
+The optional sandbox moves each thread's filesystem and shell work behind a provider boundary. Dawn ships Docker and Kubernetes providers. The Docker provider drops Linux capabilities, prevents privilege escalation, runs as a non-root user, and uses a read-only root filesystem by default. Its deny-network mode provides the strong egress setting; its allow-mode denylist is best-effort. On Kubernetes, network policy depends on a policy-capable CNI, so the provider warns rather than claiming enforcement it cannot verify.
+
+These layers answer different questions: which tool is available, whether this call should run, and what the allowed call can touch. Use the layers the application needs, and keep their boundaries visible in review. The [Access Control](/docs/access-control) and [Sandbox](/docs/sandbox) guides cover the concrete configuration and provider limits.
+
+## Make delegation explicit
+
+The 0.4 preview treated subagents as a useful route boundary. The current API closes that preview story with a keyed `subagents` map and a policy owned by the parent:
+
+```ts
+export default agent({
+  model: "gpt-5-mini",
+  subagents: { researcher, writer },
+  delegation: {
+    default: "deny",
+    rules: {
+      researcher: { action: "allow" },
+      writer: { action: "approve", reason: "Review outbound drafts." },
+    },
+  },
+})
+```
+
+The key is the name the parent sees and the identity its policy governs. A rule can allow, deny, require approval, or run a constraint against the proposed input. Each parent owns only its direct outbound edge, so approval does not silently authorize another parent or a deeper child.
+
+Delegated runs execute as resumable LangGraph subgraphs under the root thread's checkpointer. Nested and parallel calls keep separate checkpoint namespaces, while an interrupt from a child returns to the root stream and resumes through the root thread. That preserves the useful route boundary without hiding delegation authority in a helper function. See [Subagents](/docs/subagents).
+
+## Memory you can review
+
+Dawn's long-term memory is a typed collection, not a longer system prompt. A route declares a Zod schema in `memory.ts`; type generation carries that schema into the `remember` tool, and runtime validation checks model-authored writes again.
+
+The default path is intentionally local and reviewable. Records live in SQLite. Recall uses deterministic keyword relevance blended with recency and confidence, with no embedding call required. Agent-authored writes land as candidates by default, hidden from recall until a human approves them through the CLI or the local Memory Inspector. Contradictions preserve the superseded record instead of erasing history.
+
+You can opt into hybrid recall when keyword overlap is not enough. Dawn fuses the keyword list with vector results instead of replacing exact-token search. The SQLite store can hold vectors for a local application; `@dawn-ai/memory-pgvector` moves the long-term collection and indexed vector search to shared Postgres with pgvector when the corpus or deployment calls for it.
+
+Episodic memory records what happened rather than what the agent believes. The runtime recorder is opt-in, append-only, and subject to time-to-live and per-namespace caps. Distillation is also explicit: `dawn memory consolidate` compacts older episodes, while `dawn memory reflect` derives reviewable insights. Neither command runs automatically; invoke it yourself or schedule it when the cost and review workflow make sense.
+
+The Memory Inspector is a localhost development tool for browsing, searching, approving, rejecting, and following episodic records. It reads the configured memory store, but it is not a general production tracing console. For the full model and its limits, see [Memory](/docs/memory) and [Inspector](/docs/inspector).
+
+## Connect a real client
+
+AG-UI is now Dawn's standard bridge to browser clients. The runtime maps agent text, tool calls, tool results, interrupts, and terminal outcomes into AG-UI events while preserving upstream tool-call ids so a client can correlate each result with the call that produced it. The reference chat application uses this path with CopilotKit.
+
+Agent Protocol remains the direct runtime contract, and its run endpoints are thread-scoped: create a thread, then run, stream, read state, cancel, or resume under that thread id. Interrupts use one canonical, ID-addressed resume shape. A resume must answer the complete pending set, including interruptions raised inside a child; clients resume the root thread rather than inventing a separate child conversation.
+
+Both protocols reach the same route code, thread store, and checkpointer. AG-UI makes a real web client practical without turning the browser adapter into another agent runtime. See [AG-UI and Web Clients](/docs/ag-ui) and the [Dev Server](/docs/dev-server) reference.
+
+## Run the runtime in production
+
+`dawn build` can emit a Node server and hardened Dockerfile, and `dawn start` runs the same Dawn runtime without a container. This path serves Agent Protocol, AG-UI, health checks, middleware, tool policy, permissions, and the configured execution sandbox. It is the direct production path when those Dawn runtime features matter.
+
+For multi-instance deployments or hosts with an ephemeral filesystem, `@dawn-ai/postgres-storage` shares three runtime concerns: LangGraph checkpoints, Agent Protocol threads, and permission grants. It is not the long-term-memory store; that is the separate memory store described above. Cancellation and the one-run-per-thread guard also remain process-local today, even when those durable records are in Postgres, so replica coordination is still an application concern.
+
+The transport-independent fetch core opened the same runtime to another host adapter. The new Hono build target emits a web-standard entry and Postgres wiring for an opt-in edge subset rather than pretending every Node capability works everywhere.
+
+That edge target omits the sandbox, filesystem, shell, skills loaded from disk, and long-term memory, and it has been exercised under local workerd rather than a live Cloudflare deployment. The companion post, [Dawn at the edge](/blog/dawn-at-the-edge), covers the architecture and evidence in detail. The broader production choices remain in [Deployment](/docs/deployment).
+
+## Upgrade deliberately
+
+Dawn is pre-1.0. From 0.8.0 onward, the public packages share one fixed version, so keep every Dawn dependency on the same exact release. Dawn packages require Node 24, and the Node/Docker production target runs on Node 24 as well.
+
+Breaking changes have shipped in 0.8.x patch releases. That is unusual, but a minor bump in this fixed 0.x group would move the whole package set to 1.0.0. Pin exact versions and read every intervening release note rather than only the latest one.
+
+For this release:
+
+```bash
+pnpm add @dawn-ai/cli@0.8.21 @dawn-ai/sdk@0.8.21
+pnpm exec dawn verify
+```
+
+Then run your route tests and evals, and exercise the production target you actually deploy. The [Upgrading](/docs/upgrading) guide calls out the current migrations and the checks worth keeping in that loop.
+
+## The framework around the agent
+
+The route tree is still the organizing idea. Recent releases have made the application around it more explicit: evidence for behavior, boundaries for execution, named delegation, reviewable memory, standard clients, and production runtime choices.
+
+That is the framework around the agent. It is ordinary application work, which is exactly why it belongs in the framework rather than in a private pile of glue.
+
+Start with a runnable scaffold, or take one pinned upgrade step in an existing app:
+
+```bash
+pnpm create dawn-ai-app my-agents
+cd my-agents
+pnpm dev
+```

--- a/apps/web/content/blog/2026-08-09-dawn-0-8-framework-around-the-agent.mdx
+++ b/apps/web/content/blog/2026-08-09-dawn-0-8-framework-around-the-agent.mdx
@@ -110,12 +110,14 @@ Dawn is pre-1.0. From 0.8.0 onward, the public packages share one fixed version,
 
 Breaking changes have shipped in 0.8.x patch releases. That is unusual, but a minor bump in this fixed 0.x group would move the whole package set to 1.0.0. Pin exact versions and read every intervening release note rather than only the latest one.
 
-For this release:
+For the minimal CLI and SDK case:
 
 ```bash
 pnpm add @dawn-ai/cli@0.8.21 @dawn-ai/sdk@0.8.21
 pnpm exec dawn verify
 ```
+
+If your app declares other `@dawn-ai/*` packages directly, pin every one of them to exactly 0.8.21 in the same upgrade. That includes packages such as testing, evals, sandbox, and memory; do not leave direct Dawn dependencies on mixed versions.
 
 Then run your route tests and evals, and exercise the production target you actually deploy. The [Upgrading](/docs/upgrading) guide calls out the current migrations and the checks worth keeping in that loop.
 

--- a/apps/web/content/blog/2026-08-09-dawn-0-8-framework-around-the-agent.mdx
+++ b/apps/web/content/blog/2026-08-09-dawn-0-8-framework-around-the-agent.mdx
@@ -50,11 +50,15 @@ The built-in workspace has two more guards. Paths resolve against the app's work
 
 The optional sandbox moves each thread's filesystem and shell work behind a provider boundary. Dawn ships Docker and Kubernetes providers. The Docker provider drops Linux capabilities, prevents privilege escalation, runs as a non-root user, and uses a read-only root filesystem by default. Its deny-network mode provides the strong egress setting; its allow-mode denylist is best-effort. On Kubernetes, network policy depends on a policy-capable CNI, so the provider warns rather than claiming enforcement it cannot verify.
 
+`release()`, including idle reap, drops warm compute but keeps the per-thread volume and workspace; `destroy()` removes both compute and persisted workspace data.
+
 These layers answer different questions: which tool is available, whether this call should run, and what the allowed call can touch. Use the layers the application needs, and keep their boundaries visible in review. The [Access Control](/docs/access-control) and [Sandbox](/docs/sandbox) guides cover the concrete configuration and provider limits.
 
 ## Make delegation explicit
 
 The 0.4 preview treated subagents as a useful route boundary. The current API closes that preview story with a keyed `subagents` map and a policy owned by the parent:
+
+The migration from 0.4 is breaking: array-form registration must move to keyed `subagents`, and scalar resume bodies must move to the complete, ID-addressed resume shape.
 
 ```ts
 export default agent({

--- a/apps/web/content/blog/2026-08-09-dawn-0-8-framework-around-the-agent.mdx
+++ b/apps/web/content/blog/2026-08-09-dawn-0-8-framework-around-the-agent.mdx
@@ -59,6 +59,7 @@ The 0.4 preview treated subagents as a useful route boundary. The current API cl
 ```ts
 export default agent({
   model: "gpt-5-mini",
+  systemPrompt: "Coordinate research and writing.",
   subagents: { researcher, writer },
   delegation: {
     default: "deny",

--- a/apps/web/content/blog/2026-08-09-dawn-at-the-edge.mdx
+++ b/apps/web/content/blog/2026-08-09-dawn-at-the-edge.mdx
@@ -1,0 +1,116 @@
+---
+title: Dawn at the edge — The Hono target
+description: Dawn now emits a Node-free runtime entry for Cloudflare Workers. Here is the static wiring, per-request Postgres lifecycle, workerd evidence, and honest subset behind it.
+date: 2026-08-09
+tags: [typescript, agents, patterns]
+type: post
+author: brian
+draft: true
+---
+
+One request worked. The second hung.
+
+That was the useful failure. Once Dawn had a `(Request) => Promise<Response>` core, putting Hono around it looked simple. Then workerd exposed everything a clean, single-request bundle did not: I/O owned by one request, bare Node globals, imports a bundler could not analyze, and storage lifetimes that were safe in a long-running server but wrong in an isolate.
+
+## The short version
+
+Dawn 0.8.21 adds an opt-in `hono` build target. Cloudflare Workers is the target host, and local real workerd is the executed proof. We have not deployed this path to a live Cloudflare account.
+
+The generated entry and the Dawn runtime graph it reaches link without `nodejs_compat`. Runtime stores are Postgres-backed and scoped to each request. The target is also a deliberate subset: when an app asks for a capability the edge cannot serve, Dawn names the failure during `dawn check` or `dawn build` instead of shipping a partial application.
+
+This post is about that wiring and its evidence boundary. For the broader 0.8 release, see [Dawn 0.8 — The framework around the agent](/blog/dawn-0-8-framework-around-the-agent).
+
+## What Dawn builds
+
+The target is not part of Dawn's defaults. Naming `build.targets` replaces the default list, so keep every output you still want:
+
+```ts title="dawn.config.ts"
+import { config } from "@dawn-ai/cli"
+
+export default config({
+  build: { targets: ["node", "langsmith", "hono"] },
+})
+```
+
+One discovery pass then produces four edge artifacts:
+
+| Artifact | Purpose |
+| --- | --- |
+| `.dawn/build/modules.edge.mjs` | A static manifest of route, tool, state, and middleware modules, with schemas inlined. |
+| `.dawn/build/stores.mjs` | A per-request Neon WebSocket pool shared by the Postgres checkpoint, thread, and permission stores. |
+| `.dawn/build/app.mjs` | A default-exported Hono app whose catch-all passes requests to Dawn's fetch handler. |
+| `wrangler.toml` | A root scaffold written only when the file is absent. Dawn never overwrites an existing one. |
+
+Dawn emits analyzable source. Wrangler still creates the final deployment bundle. Rebuild after changing a route, tool, model, provider, middleware module, or any inlined configuration. The serializable part of `dawn.config.ts` is baked into `app.mjs`, so secrets belong in host bindings, not in that file.
+
+The generated app is a useful default, not a closed wrapper. You can import the same pieces into a larger Hono application when you need your own routes or middleware around Dawn.
+
+## Node-free on purpose
+
+There are two separate checks behind the Node-free entry. One gates the generated/runtime module graph at zero `node:` specifiers. Another scans Dawn-owned code for bare Node-only globals such as `process`, `Buffer`, and `require`. This is why the emitted Wrangler config deliberately leaves out `nodejs_compat`.
+
+This is not a claim that all of Dawn runs without Node. The CLI, local discovery, filesystem tools, and Node deployment target still use it. The narrower claim is that the graph reachable from the edge entry does not depend on Node built-ins or Dawn-owned bare Node globals.
+
+Environment access had to change too. `readRuntimeEnv` reads from `globalThis.process?.env` on Node and from bindings seeded by the generated entry on workerd. The model layer uses the same seam for provider credentials and settings such as `OPENAI_BASE_URL`, rather than assuming `process.env` exists.
+
+Provider loading is static at the edge. The build scans the models the application can reach and emits a literal switch of provider package imports. If a route cannot be inspected or a model cannot be mapped to a provider, the build fails; a variable dynamic import would leave Wrangler unable to know what belongs in the bundle.
+
+This gate covers Dawn's generated code and runtime graph. It does not police arbitrary imports inside your routes or tools. A route can still import a Node-only package and fail when Wrangler bundles it. Passing Dawn's gate means the framework did not introduce the edge dependency, not that every user dependency has been verified.
+
+## One request, one store lifetime
+
+The first storage design put a Neon WebSocket pool at module scope. Request one returned its client to the idle pool. Request two received that same client, but the socket belonged to the completed request's workerd I/O context. It waited until workerd cancelled it. The next request opened a fresh client and worked, producing the alternating hang that a one-request smoke test could never reveal.
+
+The generated target now creates one pool per request. The Postgres checkpointer, Agent Protocol thread store, and permission store share that pool, then Dawn disposes it only after both the response body and any run started by the request have settled. That second condition matters for streaming and for bookkeeping that finishes after the HTTP response resolves.
+
+Migrations run once per isolate. A module-scope boolean is safe because it owns no I/O; after the first successful pass, request-scoped stores use `assumeMigrated`. Across concurrent instances, the stores still take Postgres advisory locks, so cold starts converge on the same schema instead of racing it.
+
+The verified database path is specific: `@neondatabase/serverless` provides a WebSocket `Pool`, connected to local Postgres through a local WebSocket proxy. It is not the `neon()` HTTP function, and it is not raw TCP through `pg`. Neon Cloud and Cloudflare Hyperdrive have not been tested. These three runtime stores also do not include Dawn's typed long-term memory store.
+
+## The target refuses what it cannot run
+
+An edge build should not quietly drop half an application's behavior. Error `DAWN_E1005` rejects the shapes Dawn knows it cannot preserve:
+
+- an execution sandbox;
+- filesystem or shell backends;
+- an app-level `workspace/` directory;
+- route skills loaded from disk;
+- typed long-term memory declared with `memory.ts`;
+- custom live checkpointer, thread, permission, or memory store instances.
+
+The reasons differ, but the result is the same: these capabilities need a filesystem, process, container, or live object that cannot cross the static build boundary. Dawn reports all detected violations together and points back to the config key or file that introduced each one.
+
+The filesystem markers `memory.md` and `plan.md` may remain in the route shape, but their marker readers are inactive without a filesystem. Do not treat that as supported edge memory or planning. More generally, “not gated” means only that the build does not reject a shape. It does not mean the behavior has been verified in workerd.
+
+## What the tests prove
+
+The gated `edge-workerd` CI lane builds an emitted OpenAI fixture, starts it with `wrangler dev --local`, and runs it inside real Cloudflare workerd. It uses the generated Wrangler file unchanged, with no `nodejs_compat`, no Cloudflare account, and local Postgres behind the WebSocket proxy.
+
+| Build-supported shape | Executed in the workerd lane |
+| --- | --- |
+| Static route, tool, state, middleware, and provider wiring | The emitted OpenAI agent fixture loaded and called the local model fixture. |
+| Dawn fetch runtime, including Agent Protocol and AG-UI routes | `/healthz` and four sequential AG-UI turns completed. Agent Protocol was not exercised there. |
+| Postgres checkpoint, thread, and permission stores | Conversation state reloaded between requests, and thread, checkpoint, and write rows were checked out of band through a separate database connection. |
+| Other ungated runtime features | Tools, subagents, permissions/HITL, and their combinations were not exercised inside workerd. |
+
+Four turns are intentional. They repeatedly enter the same isolate from fresh request contexts and retain the conversation from the first turn through the fourth. The lane has already caught failures that static bundle checks missed, including a provider import that reached `node:async_hooks`, a request-owned `AbortController`, and a credential lookup that assumed `process.env`.
+
+There is still a substantial unverified list: a live Cloudflare deployment and its upload limits; Agent Protocol, tools, subagents, and human-in-the-loop flows inside workerd; providers other than OpenAI; production connection and subrequest limits; WAN database latency; cross-isolate cold starts; startup CPU and bundle-size enforcement; Hyperdrive; Neon Cloud; and the same output on Vercel, Deno, or Bun.
+
+That list is not a disclaimer pasted on at the end. It is the map for the next useful tests and for deciding whether this target fits a real workload today.
+
+## Try it
+
+If your Dawn app fits the subset, pin the current release, check the capability boundary, build a clean artifact, and deploy with your database URL in a binding:
+
+```bash
+pnpm add @dawn-ai/cli@0.8.21 @dawn-ai/postgres-storage@0.8.21 @neondatabase/serverless hono
+pnpm exec dawn check
+pnpm exec dawn build --clean
+wrangler secret put DATABASE_URL
+wrangler deploy
+```
+
+Read [Deployment](/docs/deployment) for the complete target setup and [Postgres backend](/docs/configuration#postgres-backend) for schema and operational details. Then try it with the traffic shape, route tools, provider, and database you actually intend to run.
+
+I would especially like feedback from those real workloads: where the subset is too narrow, where request-scoped connections become expensive, and what Cloudflare's production limits reveal. The local workerd evidence is strong enough to make the target useful and inspectable. It is not a claim that the path is already production-proven.

--- a/apps/web/content/blog/2026-08-09-dawn-at-the-edge.mdx
+++ b/apps/web/content/blog/2026-08-09-dawn-at-the-edge.mdx
@@ -14,7 +14,7 @@ That was the useful failure. Once Dawn had a `(Request) => Promise<Response>` co
 
 ## The short version
 
-Dawn 0.8.21 adds an opt-in `hono` build target. Cloudflare Workers is the target host, and local real workerd is the executed proof. We have not deployed this path to a live Cloudflare account.
+Dawn 0.8.21 adds an opt-in `hono` build target for Cloudflare Workers. The target has been tested locally in real workerd, not live-deployed to Cloudflare.
 
 The generated entry and the Dawn runtime graph it reaches link without `nodejs_compat`. Runtime stores are Postgres-backed and scoped to each request. The target is also a deliberate subset: when an app asks for a capability the edge cannot serve, Dawn names the failure during `dawn check` or `dawn build` instead of shipping a partial application.
 
@@ -41,7 +41,7 @@ One discovery pass then produces four edge artifacts:
 | `.dawn/build/app.mjs` | A default-exported Hono app whose catch-all passes requests to Dawn's fetch handler. |
 | `wrangler.toml` | A root scaffold written only when the file is absent. Dawn never overwrites an existing one. |
 
-Dawn emits analyzable source. Wrangler still creates the final deployment bundle. Rebuild after changing a route, tool, model, provider, middleware module, or any inlined configuration. The serializable part of `dawn.config.ts` is baked into `app.mjs`, so secrets belong in host bindings, not in that file.
+Dawn emits analyzable source. Wrangler still creates the final deployment bundle, so implementation edits inside an existing imported route, tool, or middleware module flow through without another Dawn build. Rerun `dawn build` when discovery or other build-time inputs change: add, remove, or rename a route, tool, or middleware module; change a generated schema or type signature; select another model or provider; or update inlined configuration. The serializable part of `dawn.config.ts` is baked into `app.mjs`, so secrets belong in host bindings, not in that file.
 
 The generated app is a useful default, not a closed wrapper. You can import the same pieces into a larger Hono application when you need your own routes or middleware around Dawn.
 
@@ -63,7 +63,7 @@ The first storage design put a Neon WebSocket pool at module scope. Request one 
 
 The generated target now creates one pool per request. The Postgres checkpointer, Agent Protocol thread store, and permission store share that pool, then Dawn disposes it only after both the response body and any run started by the request have settled. That second condition matters for streaming and for bookkeeping that finishes after the HTTP response resolves.
 
-Migrations run once per isolate. A module-scope boolean is safe because it owns no I/O; after the first successful pass, request-scoped stores use `assumeMigrated`. Across concurrent instances, the stores still take Postgres advisory locks, so cold starts converge on the same schema instead of racing it.
+After a migration pass completes, the generated target memoizes that result per isolate, and subsequent requests build their stores with `assumeMigrated`. A module-scope boolean is safe here because it owns no I/O. Concurrent cold-start requests can each observe that the migration has not completed and enter their own migration transactions; Postgres advisory locks protect those transactions, so the race converges safely on the same schema.
 
 The verified database path is specific: `@neondatabase/serverless` provides a WebSocket `Pool`, connected to local Postgres through a local WebSocket proxy. It is not the `neon()` HTTP function, and it is not raw TCP through `pg`. Neon Cloud and Cloudflare Hyperdrive have not been tested. These three runtime stores also do not include Dawn's typed long-term memory store.
 
@@ -101,14 +101,15 @@ That list is not a disclaimer pasted on at the end. It is the map for the next u
 
 ## Try it
 
-If your Dawn app fits the subset, pin the current release, check the capability boundary, build a clean artifact, and deploy with your database URL in a binding:
+If your Dawn app fits the subset, pin every direct `@dawn-ai/*` dependency to exactly 0.8.21. Then install the edge dependencies and a fixed Wrangler version, check the capability boundary, build a clean artifact, and deploy with your database URL in a binding:
 
 ```bash
-pnpm add @dawn-ai/cli@0.8.21 @dawn-ai/postgres-storage@0.8.21 @neondatabase/serverless hono
+pnpm add @dawn-ai/cli@0.8.21 @dawn-ai/sdk@0.8.21 @dawn-ai/postgres-storage@0.8.21 @neondatabase/serverless hono
+pnpm add --save-dev wrangler@4.120.0
 pnpm exec dawn check
 pnpm exec dawn build --clean
-wrangler secret put DATABASE_URL
-wrangler deploy
+pnpm exec wrangler secret put DATABASE_URL
+pnpm exec wrangler deploy
 ```
 
 Read [Deployment](/docs/deployment) for the complete target setup and [Postgres backend](/docs/configuration#postgres-backend) for schema and operational details. Then try it with the traffic shape, route tools, provider, and database you actually intend to run.

--- a/docs/superpowers/plans/2026-08-09-dawn-0-8-and-edge-blog-posts.md
+++ b/docs/superpowers/plans/2026-08-09-dawn-0-8-and-edge-blog-posts.md
@@ -1,0 +1,533 @@
+# Dawn 0.8 and Edge Blog Posts Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Create two hidden, publication-ready MDX drafts in Brian Love's voice: a narrative Dawn 0.5–0.8.21 roundup and a separate technical announcement for the opt-in Hono edge target.
+
+**Architecture:** The two posts are separate content artifacts with fixed slugs and complementary ownership: the roundup explains the framework's broader maturation, while the edge post owns Hono/workerd architecture and caveats. They share a source hierarchy, cross-link once, and pass through a final fact, voice, MDX-render, and repository verification gate together.
+
+**Tech Stack:** MDX, Next.js blog content loader, gray-matter frontmatter, GitHub Releases, npm package metadata, pnpm, Vitest, and the repository documentation checks.
+
+---
+
+## File map
+
+- Create `apps/web/content/blog/2026-08-09-dawn-0-8-framework-around-the-agent.mdx` — release-style catch-up from 0.5.0 through the published 0.8.21 train.
+- Create `apps/web/content/blog/2026-08-09-dawn-at-the-edge.mdx` — technical Hono/Cloudflare Workers target announcement.
+- Do not modify blog loaders, layouts, tag registries, documentation pages, package source, or tests unless verification reveals an actual pre-existing integration defect and the user separately approves expanding scope.
+- Do not add a changeset: these are draft-only `apps/web` content files, not a publishable package change.
+
+## Authoritative references
+
+- Approved design: `docs/superpowers/specs/2026-08-09-dawn-0-8-and-edge-blog-posts-design.md`
+- Voice: `docs/marketing/author-persona.md` and the three published files under `apps/web/content/blog/`; use `2026-06-02-dawn-0-4-release.mdx` only for release-post structure because its API examples are stale.
+- Release facts: public GitHub Releases and package changelogs at tagged 0.5.0–0.8.21 artifacts.
+- Broad feature docs: `apps/web/content/docs/{evals,testing-agents,workspace,tools,permissions,sandbox,memory,inspector,subagents,ag-ui,deployment,upgrading}.mdx`.
+- Edge facts: `apps/web/content/docs/deployment.mdx`, `packages/cli/CHANGELOG.md`, `packages/postgres-storage/CHANGELOG.md`, `packages/cli/test/{fetch-entry-purity,edge-bundle-purity,hono-node-roundtrip,workerd-lane}.test.ts`, and `packages/cli/src/lib/build/targets/{hono,edge-capabilities}.ts`.
+
+Execute the tasks in order. The two content files are independent while drafting, but Tasks 2 and
+3 each stage and commit through the shared Git index, so parallel execution in one worktree is not
+safe.
+
+### Task 1: Reconfirm the publication baseline
+
+**Files:**
+- Read: `docs/superpowers/specs/2026-08-09-dawn-0-8-and-edge-blog-posts-design.md`
+- Read: `docs/marketing/author-persona.md`
+- Read: `packages/*/CHANGELOG.md`
+- Read: `apps/web/content/docs/*.mdx`
+- Create: none
+
+- [ ] **Step 1: Select the repository's required Node version**
+
+Run from the repository root:
+
+```bash
+export DAWN_NODE_BIN="/Users/blove/.nvm/versions/node/v24.18.0/bin"
+export PATH="$DAWN_NODE_BIN:$PATH"
+node --version
+```
+
+Expected: `v24.18.0`. Re-export this path in every new shell used for the remaining tasks.
+
+- [ ] **Step 2: Verify that 0.8.21 is still the current public release**
+
+```bash
+test "$(npm view @dawn-ai/cli version)" = "0.8.21"
+gh release view '@dawn-ai/cli@0.8.21' --repo cacheplane/dawnai --json tagName,publishedAt
+```
+
+Expected: both commands succeed and the GitHub result names `@dawn-ai/cli@0.8.21`. If npm has moved beyond 0.8.21, stop: update the approved spec and re-run its review before drafting anything described as current or latest.
+
+- [ ] **Step 3: Verify the unpublished 0.8.20 boundary**
+
+```bash
+npm view @dawn-ai/cli time --json
+test -z "$(git tag --list '@dawn-ai/cli@0.8.20')"
+if gh release view '@dawn-ai/cli@0.8.20' --repo cacheplane/dawnai >/dev/null 2>&1; then exit 1; fi
+```
+
+Expected: npm metadata has no 0.8.20 publication, no local 0.8.20 CLI tag is printed, and GitHub reports no release. Generated 0.8.20 changelog entries are not publishable evidence and must not enter either post.
+
+- [ ] **Step 4: Read the voice and fact sources before writing**
+
+Read the authoritative references above, concentrating on:
+
+- `0.5.0`, `0.7.0`, and `0.8.0` headings in `packages/cli/CHANGELOG.md`;
+- `0.8.1` through `0.8.21` across CLI, testing, memory, memory-pgvector, sandbox, inspector, AG-UI, SDK, and Postgres storage changelogs;
+- the current Node 24 engine requirement rather than the stale Node 22 sentence in Deployment;
+- the difference between shipped capability support, local workerd execution evidence, and an inferred host-compatible shape.
+
+Expected: the writer can attach every planned claim to a published release, current doc, or retained test.
+
+- [ ] **Step 5: Confirm a clean starting scope**
+
+```bash
+git status --short --branch
+```
+
+Expected: branch `blove/blog-dawn-0-8-and-edge` with no uncommitted changes. Preserve any unexpected user changes and stop before overlapping them.
+
+### Task 2: Draft the Dawn 0.8 roundup
+
+**Files:**
+- Create: `apps/web/content/blog/2026-08-09-dawn-0-8-framework-around-the-agent.mdx`
+- Reference: `docs/superpowers/specs/2026-08-09-dawn-0-8-and-edge-blog-posts-design.md`
+- Reference: `docs/marketing/author-persona.md`
+
+- [ ] **Step 1: Confirm the target file does not already exist**
+
+```bash
+test ! -e apps/web/content/blog/2026-08-09-dawn-0-8-framework-around-the-agent.mdx
+```
+
+Expected: exit 0. If it exists, read and preserve it; do not overwrite another writer's draft.
+
+- [ ] **Step 2: Create the exact frontmatter and section skeleton**
+
+Create the file with `apply_patch` and this frontmatter:
+
+```mdx
+---
+title: Dawn 0.8 — The framework around the agent
+description: Evals, typed memory, safer tools, isolated execution, standard clients, and production builds from Node and Docker to an opt-in edge target.
+date: 2026-08-09
+tags: [typescript, agents]
+type: release
+version: 0.8.21
+author: brian
+draft: true
+---
+```
+
+Use this heading sequence:
+
+```md
+## The short version
+## Measure what the agent does
+## Put a boundary around execution
+## Make delegation explicit
+## Memory you can review
+## Connect a real client
+## Run the runtime in production
+## Upgrade deliberately
+## The framework around the agent
+```
+
+Expected: the frontmatter parses as a release, automatically gains the `releases` tag, and remains hidden in production because `draft: true` is explicit.
+
+- [ ] **Step 3: Write the opening and practical summary**
+
+Write a short-paragraph opening that returns to the original Dawn thesis: the route tree was the beginning, and recent work filled in the application around it. Explicitly say this is a catch-up from 0.5 through the current 0.8.21 release, so the `version: 0.8.21` field cannot be mistaken for the introduction point of every feature.
+
+Under `## The short version`, use five or six outcome-oriented bullets: measure, constrain/isolate, delegate, remember, connect, and deploy. Do not list packages or every patch.
+
+Expected: the hook sounds like a builder reporting what changed, not a launch slogan.
+
+- [ ] **Step 4: Write eval, safety, and delegation sections**
+
+Cover these exact boundaries:
+
+- Evals arrived in 0.5.0; fixture replay is deterministic by default, while `--live` and `--record` call a real model and do not belong in CI. Mention co-located evals and focused agent/tool/middleware/workspace harnesses.
+- Safety is layered: a path jail and permission gate are not the same as container isolation. Explain tool allow/deny, argument constraints, approvals, Docker, and Kubernetes without calling containers microVMs or promising network enforcement that the provider cannot prove.
+- Close the 0.4 preview story with the current keyed `subagents` map, parent-owned delegation policy, constraints/approval, and resumable subgraphs. Do not reuse `createSubAgent`, `subAgents`, or the old resume envelope.
+
+Expected: each section turns the feature list into a developer outcome and includes no more than one representative code shape if code materially clarifies it.
+
+- [ ] **Step 5: Write memory, clients, and deployment sections**
+
+Cover these exact boundaries:
+
+- Memory defaults to SQLite, keyword recall, and candidate writes. Typed long-term memory, hybrid pgvector recall, episodes, distillation, and the local Memory Inspector should be described with their opt-in/manual boundaries. Do not call the Inspector a general production tracing console.
+- Keep long-term memory separate from `@dawn-ai/postgres-storage`. The Postgres package shares checkpoints, Agent Protocol threads, and permission grants for multi-instance or ephemeral deployments; it is not the long-term-memory store. Cancellation and one-run-per-thread enforcement remain process-local even when those three durable stores use Postgres.
+- AG-UI is the standard web-client bridge; current Agent Protocol examples are thread-scoped. Mention canonical interrupts/resume and tool-call correlation without reproducing the entire protocol reference.
+- The Node/Docker target and `dawn start` run the Dawn runtime in production. The later fetch core made another host adapter possible. Give the Hono target two short paragraphs and link `/blog/dawn-at-the-edge` for the detail.
+
+Expected: the roundup owns the broad product story and leaves edge architecture to the companion post.
+
+- [ ] **Step 6: Write the upgrade section and close**
+
+Include a pinned command such as:
+
+```bash
+pnpm add @dawn-ai/cli@0.8.21 @dawn-ai/sdk@0.8.21
+pnpm exec dawn verify
+```
+
+State all of the following plainly:
+
+- Dawn is pre-1.0.
+- Public packages share one fixed version from 0.8.0 onward.
+- Current Dawn requires Node 24.
+- Breaking changes have shipped in 0.8.x patches, so readers should pin versions and read every intervening release note.
+
+Link `/docs/upgrading`, then close by returning to “the framework around the agent” and a runnable scaffold or upgrade next step.
+
+Expected: no “backward-compatible” promise and no implication that Dawn is a new runtime replacing LangGraph.js.
+
+- [ ] **Step 7: Run targeted content assertions**
+
+```bash
+test "$(rg -c '^draft: true$' apps/web/content/blog/2026-08-09-dawn-0-8-framework-around-the-agent.mdx)" = "1"
+test "$(rg -c '^## ' apps/web/content/blog/2026-08-09-dawn-0-8-framework-around-the-agent.mdx)" -ge "8"
+wc -w apps/web/content/blog/2026-08-09-dawn-0-8-framework-around-the-agent.mdx
+if rg -n 'gpt-4o|createSubAgent|subAgents|/runs/(wait|stream)|backward-compatible|production-ready|0\.8\.20|node:22' apps/web/content/blog/2026-08-09-dawn-0-8-framework-around-the-agent.mdx; then exit 1; fi
+```
+
+Expected: one draft flag, at least eight sections, roughly 1,500–1,900 words, and no stale or overstated matches.
+
+- [ ] **Step 8: Review the diff and commit the roundup**
+
+```bash
+git diff --check
+git diff -- apps/web/content/blog/2026-08-09-dawn-0-8-framework-around-the-agent.mdx
+git add apps/web/content/blog/2026-08-09-dawn-0-8-framework-around-the-agent.mdx
+git commit -m "docs(blog): draft Dawn 0.8 roundup"
+```
+
+Expected: one new MDX file in the commit.
+
+### Task 3: Draft the Hono edge announcement
+
+**Files:**
+- Create: `apps/web/content/blog/2026-08-09-dawn-at-the-edge.mdx`
+- Reference: `apps/web/content/docs/deployment.mdx`
+- Reference: `packages/cli/src/lib/build/targets/hono.ts`
+- Reference: `packages/cli/src/lib/build/targets/edge-capabilities.ts`
+- Reference: `packages/cli/test/workerd-lane.test.ts`
+
+- [ ] **Step 1: Confirm the target file does not already exist**
+
+```bash
+test ! -e apps/web/content/blog/2026-08-09-dawn-at-the-edge.mdx
+```
+
+Expected: exit 0. If it exists, read and preserve it; do not overwrite another writer's draft.
+
+- [ ] **Step 2: Create the exact frontmatter and section skeleton**
+
+Create the file with `apply_patch` and this frontmatter:
+
+```mdx
+---
+title: Dawn at the edge — The Hono target
+description: Dawn now emits a Node-free runtime entry for Cloudflare Workers. Here is the static wiring, per-request Postgres lifecycle, workerd evidence, and honest subset behind it.
+date: 2026-08-09
+tags: [typescript, agents, patterns]
+type: post
+author: brian
+draft: true
+---
+```
+
+Use this heading sequence:
+
+```md
+## The short version
+## What Dawn builds
+## Node-free on purpose
+## One request, one store lifetime
+## The target refuses what it cannot run
+## What the tests prove
+## Try it
+```
+
+Expected: the frontmatter parses as a normal post and remains hidden in production.
+
+- [ ] **Step 3: Write the workerd-led opening and summary**
+
+Open with the observed failure: one request worked, the second hung. Explain that a Hono wrapper looked simple once Dawn had a `(Request) => Promise<Response>` core, but workerd exposed request-owned I/O, Node-global, static-import, and storage-lifetime assumptions that a clean single-request bundle could not reveal.
+
+Under `## The short version`, state:
+
+- 0.8.21 adds the opt-in `hono` build target;
+- Cloudflare Workers is the target host, while local real workerd is the executed proof;
+- the generated/runtime graph links without `nodejs_compat`;
+- stores are request-scoped and Postgres-backed;
+- the target intentionally supports a subset and fails named unsupported configurations.
+
+Expected: the opening is technically specific and does not claim a live Cloudflare deployment.
+
+- [ ] **Step 4: Show the supported build workflow and artifacts**
+
+Use this configuration so readers see that naming targets replaces the defaults:
+
+```ts title="dawn.config.ts"
+import { config } from "@dawn-ai/cli"
+
+export default config({
+  build: { targets: ["node", "langsmith", "hono"] },
+})
+```
+
+Explain the four outputs in a compact table:
+
+- `.dawn/build/modules.edge.mjs` — static route/tool/state/middleware manifest;
+- `.dawn/build/stores.mjs` — per-request Neon WebSocket pool and Postgres stores;
+- `.dawn/build/app.mjs` — default-exported Hono app forwarding to Dawn's fetch handler;
+- root `wrangler.toml` — generated only when absent and never overwritten.
+
+State that Dawn emits analyzable source and Wrangler creates the final edge bundle. Rebuild when route, tool, model, provider, middleware, or inlined config inputs change. Secrets belong in bindings, not `dawn.config.ts`.
+
+Expected: no claim that Dawn itself produces a final universal edge bundle.
+
+- [ ] **Step 5: Explain Node-free linking and static provider wiring**
+
+Explain, in this order:
+
+1. the generated edge/runtime graph is tested for zero `node:` specifiers and Dawn-owned bare Node globals;
+2. `readRuntimeEnv` and seeded bindings replace assumptions about `process.env`;
+3. model providers are emitted as a literal static import switch so an unresolved provider fails the build;
+4. arbitrary user route/tool imports are not statically policed by Dawn and may still fail when Wrangler bundles them.
+
+Say `nodejs_compat` is deliberately absent from the generated scaffold. Do not say “Dawn is Node-free.”
+
+- [ ] **Step 6: Explain the request-scoped storage lifecycle**
+
+Tell the alternating-hang story precisely: a module-scoped Neon WebSocket pool can return a client owned by a completed workerd request, causing the next request to hang until cancellation. The generated target therefore creates one pool per request, shares it across the three Postgres stores, and disposes it only after both the response body and any request-started run settle.
+
+Also state:
+
+- migrations run once per isolate, with advisory locks converging concurrent instances;
+- the verified path uses `@neondatabase/serverless`'s WebSocket `Pool` against local Postgres through a local proxy, not the `neon()` HTTP function or raw TCP `pg`;
+- Neon Cloud and Hyperdrive were not exercised;
+- the shared Postgres stores cover checkpoints, threads, and permissions, not long-term memory.
+
+Expected: no “once globally,” “close when fetch returns,” “any Postgres URL from Workers,” or Neon Cloud claim.
+
+- [ ] **Step 7: Explain the capability and evidence boundaries**
+
+Use a compact table or two short lists to distinguish:
+
+- build-supported shapes from workerd-executed behavior;
+- named `DAWN_E1005` rejections: sandbox, filesystem/shell backends, a workspace directory, route skills, typed long-term memory, and custom live store instances;
+- `memory.md` and `plan.md`, whose filesystem-backed markers remain inactive rather than becoming supported edge capabilities.
+
+Name the gated `edge-workerd` CI lane. Its retained proof is the emitted OpenAI fixture, `/healthz`, four sequential AG-UI turns, conversation reload, and Postgres rows checked out of band. Explicitly list major unverified areas: live Cloudflare deployment/upload limits, Agent Protocol/tools/subagents/HITL inside workerd, other providers, production connection/subrequest limits, WAN latency, cross-isolate cold starts, startup CPU/bundle enforcement, Hyperdrive, Neon Cloud, Vercel, Deno, and Bun.
+
+Expected: “not gated” never becomes “verified.”
+
+- [ ] **Step 8: Write the practical CTA**
+
+Use these install/build steps, keeping the Dawn packages pinned:
+
+```bash
+pnpm add @dawn-ai/cli@0.8.21 @dawn-ai/postgres-storage@0.8.21 @neondatabase/serverless hono
+pnpm exec dawn check
+pnpm exec dawn build --clean
+wrangler secret put DATABASE_URL
+wrangler deploy
+```
+
+Link `/docs/deployment`, `/docs/configuration#postgres-backend`, and the companion roundup at `/blog/dawn-0-8-framework-around-the-agent`. Invite real-workload feedback without calling the target production-proven.
+
+- [ ] **Step 9: Run targeted edge-claim assertions**
+
+```bash
+test "$(rg -c '^draft: true$' apps/web/content/blog/2026-08-09-dawn-at-the-edge.mdx)" = "1"
+test "$(rg -c '^## ' apps/web/content/blog/2026-08-09-dawn-at-the-edge.mdx)" -ge "7"
+wc -w apps/web/content/blog/2026-08-09-dawn-at-the-edge.mdx
+rg -n 'local workerd|once per isolate|per-request|nodejs_compat|not.*Cloudflare|did not.*Cloudflare' apps/web/content/blog/2026-08-09-dawn-at-the-edge.mdx
+if rg -n 'production-ready on Cloudflare|production-proven on Cloudflare|deployed to (a )?live Cloudflare|Dawn is Node-free|migrations run once globally|stores close when fetch|any Postgres URL|0\.8\.20' apps/web/content/blog/2026-08-09-dawn-at-the-edge.mdx; then exit 1; fi
+```
+
+Expected: one draft flag, at least seven sections, roughly 1,300–1,700 words, explicit evidence/boundary language, and no prohibited claims.
+
+- [ ] **Step 10: Review the diff and commit the edge post**
+
+```bash
+git diff --check
+git diff -- apps/web/content/blog/2026-08-09-dawn-at-the-edge.mdx
+git add apps/web/content/blog/2026-08-09-dawn-at-the-edge.mdx
+git commit -m "docs(blog): draft Hono edge announcement"
+```
+
+Expected: one new MDX file in the commit.
+
+### Task 4: Integrate, fact-check, and voice-check both drafts
+
+**Files:**
+- Modify: `apps/web/content/blog/2026-08-09-dawn-0-8-framework-around-the-agent.mdx`
+- Modify: `apps/web/content/blog/2026-08-09-dawn-at-the-edge.mdx`
+- Reference: all authoritative sources listed above
+
+- [ ] **Step 1: Verify the cross-links and docs routes**
+
+```bash
+rg -n '/blog/dawn-at-the-edge' apps/web/content/blog/2026-08-09-dawn-0-8-framework-around-the-agent.mdx
+rg -n '/blog/dawn-0-8-framework-around-the-agent' apps/web/content/blog/2026-08-09-dawn-at-the-edge.mdx
+for slug in evals testing-agents workspace tools permissions sandbox memory inspector subagents ag-ui deployment upgrading configuration; do test -f "apps/web/app/docs/$slug/page.tsx"; done
+```
+
+Expected: one purposeful companion link in each post and every internal docs route exists.
+
+- [ ] **Step 2: Run a published-release fact pass**
+
+For every version number and feature claim in the roundup, locate the corresponding public release/tag and package changelog entry. For every edge implementation/evidence claim, locate the corresponding current source, retained test, or Deployment section. Remove a claim if it can be supported only by an approved design document, an unpublished 0.8.20 section, or an unreleased changeset on `main`.
+
+Use these checks as guardrails:
+
+```bash
+if rg -n '0\.8\.20|gpt-4o|createSubAgent|subAgents|/runs/(wait|stream)|byte-identical|without translation|speaks .* natively|auto-bound|auto-registered' apps/web/content/blog/2026-08-09-*.mdx; then exit 1; fi
+rg -n 'Node 24|pre-1\.0|local workerd|draft: true' apps/web/content/blog/2026-08-09-*.mdx
+```
+
+Expected: no stale phrases or APIs; the required stability, runtime, and evidence boundaries are present.
+
+- [ ] **Step 3: Run a voice and duplication pass**
+
+Read both posts straight through against `docs/marketing/author-persona.md`. Enforce:
+
+- practical builder-to-builder posture;
+- short opening paragraphs followed by medium-detail explanation;
+- first person only for earned judgment or observed implementation lessons;
+- one representative example per idea;
+- ordinary words before abstractions;
+- no stacked manifesto fragments, marketing superlatives, or generic engagement CTA.
+
+Then compare the posts side by side. The roundup may summarize the Hono target in two short paragraphs; all artifact, pool-lifecycle, capability-gate, and workerd-evidence detail belongs only in the edge post.
+
+Expected: either post stands alone, and reading both does not repeat an entire section.
+
+- [ ] **Step 4: Request independent fact and voice reviews in parallel**
+
+Use `@superpowers:dispatching-parallel-agents` to send read-only, context-isolated reviews:
+
+- Reviewer A receives both file paths plus the public-release and edge source hierarchy. Ask it to return only unsupported, misleading, stale, or mis-versioned claims with citations.
+- Reviewer B receives both file paths, `docs/marketing/author-persona.md`, and the existing published blog file paths. Ask it to flag voice drift, parody, duplicated sections, or a CTA that does not sound like Brian.
+
+Apply feedback with `@superpowers:receiving-code-review`: verify every suggestion against the repository before changing prose. Re-run the relevant checks from Steps 1–3.
+
+Expected: no unresolved factual blockers or material voice drift.
+
+- [ ] **Step 5: Commit integration edits**
+
+```bash
+git diff --check
+git add apps/web/content/blog/2026-08-09-dawn-0-8-framework-around-the-agent.mdx apps/web/content/blog/2026-08-09-dawn-at-the-edge.mdx
+git diff --cached --stat
+git commit -m "docs(blog): polish Dawn 0.8 release drafts"
+```
+
+Expected: commit succeeds if review changed either file. If the reviews required no changes, skip the empty commit.
+
+### Task 5: Verify parsing, rendering, and repository gates
+
+**Files:**
+- Verify: `apps/web/content/blog/2026-08-09-dawn-0-8-framework-around-the-agent.mdx`
+- Verify: `apps/web/content/blog/2026-08-09-dawn-at-the-edge.mdx`
+- Test: `apps/web/app/components/blog/post-index.test.ts`
+- Test: `apps/web/app/components/blog/rss-feed.test.ts`
+
+- [ ] **Step 1: Install the locked workspace dependencies under Node 24**
+
+```bash
+export DAWN_NODE_BIN="/Users/blove/.nvm/versions/node/v24.18.0/bin"
+export PATH="$DAWN_NODE_BIN:$PATH"
+pnpm install --frozen-lockfile
+```
+
+Expected: installation succeeds without changing `pnpm-lock.yaml`.
+
+- [ ] **Step 2: Run targeted blog tests and web typechecking**
+
+```bash
+pnpm --filter @dawn-ai/web exec vitest run app/components/blog/post-index.test.ts app/components/blog/rss-feed.test.ts
+pnpm --filter @dawn-ai/web typecheck
+```
+
+Expected: both Vitest files pass and TypeScript exits 0.
+
+- [ ] **Step 3: Run documentation and diff checks**
+
+```bash
+node scripts/check-docs.mjs
+git diff --check origin/main...HEAD
+```
+
+Expected: the documentation check and branch-wide whitespace check exit 0.
+
+- [ ] **Step 4: Render both hidden drafts in the development server**
+
+Start the site in a long-lived terminal:
+
+```bash
+pnpm --filter @dawn-ai/web exec next dev --hostname 127.0.0.1 --port 4173
+```
+
+From another terminal:
+
+```bash
+curl -fsS http://127.0.0.1:4173/blog/dawn-0-8-framework-around-the-agent | rg -q 'The framework around the agent'
+curl -fsS http://127.0.0.1:4173/blog/dawn-at-the-edge | rg -q 'The Hono target'
+```
+
+Expected: both requests return 200 and contain their titles. A production build is not enough for this assertion because production intentionally filters `draft: true` posts.
+
+- [ ] **Step 5: Inspect both rendered posts visually**
+
+Use `@browser:control-in-app-browser` to open both local URLs and verify:
+
+- title, description, author, date, release badge/version, and tags render correctly;
+- headings populate the table of contents;
+- code blocks and the artifact/capability table fit at desktop and mobile widths;
+- companion and documentation links resolve;
+- no raw MDX, clipped content, or horizontal overflow appears.
+
+Expected: both drafts are readable at desktop and mobile widths. Fix any content-level rendering issue with `apply_patch`, re-run Steps 2–5, and commit the fix.
+
+- [ ] **Step 6: Stop the development server**
+
+Send `Ctrl-C` to the long-lived Next.js development-server session, wait for it to exit, and verify
+the port is closed:
+
+```bash
+if curl -fsS http://127.0.0.1:4173/ >/dev/null 2>&1; then exit 1; fi
+```
+
+Expected: the check exits 0 because nothing is listening on port 4173. Do not run the production
+build while `next dev` is writing the same `.next` tree.
+
+- [ ] **Step 7: Run the repository Definition of Done**
+
+```bash
+pnpm ci:validate
+```
+
+Expected: the full lint → build-cache → build → typecheck → test → docs → pack → harness lane exits 0. Do not substitute targeted checks for this final gate.
+
+- [ ] **Step 8: Verify the final scope and draft state**
+
+```bash
+git status --short --branch
+git log --oneline --decorate -6
+git show --stat --oneline HEAD
+test "$(rg -l '^draft: true$' apps/web/content/blog/2026-08-09-*.mdx | wc -l | tr -d ' ')" = "2"
+git diff --check origin/main...HEAD
+```
+
+Expected: only the approved spec, implementation plan, and two blog drafts differ from `origin/main`; both posts remain drafts; no changeset or unrelated file is present; all commits are on `blove/blog-dawn-0-8-and-edge`.
+
+## Completion boundary
+
+Completion means both draft files exist, pass fact and voice review, render correctly in development, and pass the repository gates while retaining `draft: true`. It does **not** include publishing, changing the post dates, removing draft flags, deploying the site, or opening a pull request.

--- a/docs/superpowers/specs/2026-08-09-dawn-0-8-and-edge-blog-posts-design.md
+++ b/docs/superpowers/specs/2026-08-09-dawn-0-8-and-edge-blog-posts-design.md
@@ -1,0 +1,283 @@
+# Dawn 0.8 and edge blog posts — design
+
+**Date:** 2026-08-09
+**Status:** approved (brainstorm)
+**Type:** Two coordinated blog drafts for `apps/web/content/blog/`
+**Author voice:** Brian Love (`docs/marketing/author-persona.md` and the existing Dawn posts)
+
+## Goal
+
+Publish two complementary posts that close the public-blog gap between the Dawn 0.4 post and the
+current 0.8.21 release:
+
+1. a broad release story explaining how Dawn grew from route conventions into the fuller
+   framework around an agent application; and
+2. a focused technical announcement for the opt-in Hono build target and its Cloudflare Workers
+   proof.
+
+The roundup should help existing users understand what is now possible without reading every
+patch note. The edge post should help a technically skeptical reader understand the build output,
+runtime constraints, storage lifecycle, and current verification boundary well enough to decide
+whether to try the target.
+
+## User-approved decisions
+
+- Cover the release line from 0.5.0 through the latest published version, 0.8.21.
+- Use a narrative roundup rather than a release-by-release changelog.
+- Give the edge target its own post instead of letting it dominate the roundup.
+- Write both posts in Brian's established voice and tone.
+- Cross-link the posts and keep duplicated explanation to a minimum.
+- State the edge target's limits plainly: it is opt-in, supports a subset of Dawn, has been tested
+  under local workerd, and has not been validated by a real production Cloudflare deployment.
+
+## Shared editorial posture
+
+Both posts should sound like a builder explaining shipped work to another builder:
+
+- Open with a concrete problem or change in the developer workflow, not a product superlative.
+- Use short paragraphs early, then longer technical explanations after the reader is oriented.
+- Use first person for judgment and implementation lessons; use direct second person for steps the
+  reader can take.
+- Explain the idea before naming the abstraction.
+- Tie each feature to a developer outcome and then show the relevant code, command, or artifact.
+- Name tradeoffs, exclusions, and unverified assumptions without defensive language.
+- Prefer sentence-case headings and compact lists.
+- End with a practical next step rather than a generic marketing close.
+
+The prose may use Brian's recurring moves sparingly: "Not because ...", "The goal is ...",
+"Let’s break that down", and "It is important to be precise here." It should not stack fragments
+or imitate catchphrases so aggressively that the voice becomes a caricature.
+
+## Post 1 — Dawn 0.8 roundup
+
+### Working metadata
+
+- **Filename:** `apps/web/content/blog/2026-08-09-dawn-0-8-framework-around-the-agent.mdx`
+- **Title:** `Dawn 0.8 — The framework around the agent`
+- **Description:** `Evals, typed memory, safer tools, isolated execution, standard clients, and production builds from Node and Docker to an opt-in edge target.`
+- **Type:** `release`
+- **Version:** `0.8.21`
+- **Tags:** `[typescript, agents]` (`releases` is added automatically)
+- **Author:** `brian`
+- **Draft state:** `draft: true` until editorial approval and a publication date are confirmed
+- **Target length:** roughly 1,500–1,900 words
+
+The title uses the 0.8 release line as the story and the version field records the concrete current
+upgrade target. The introduction must say explicitly that this is a catch-up across 0.5–0.8.21,
+not a claim that every feature first appeared in 0.8.21.
+
+### Thesis
+
+The work since 0.4 filled in the operational layers around Dawn's file-based route model. The
+route tree is still the core authoring idea, but developers can now measure behavior, isolate
+execution, persist state across real deployments, connect standard clients, and ship the Dawn
+runtime outside the local dev loop.
+
+### Outline
+
+1. **Hook — the framework grew around the route.** Start with the original bet: an agent
+   application needs a clear place for routes, tools, state, and behavior. Explain that the recent
+   releases did not replace that shape; they made it usable through testing and deployment.
+2. **The short version.** Give a compact outcome-oriented list: measure, isolate, remember,
+   connect, and deploy. Avoid a package inventory.
+3. **Measure agent behavior.** Introduce co-located evals, deterministic fixture replay, opt-in
+   live runs, gates/scorers, and the route/testing harnesses. Focus on the shift from trying an
+   agent manually to putting behavior in CI.
+4. **Give execution a boundary.** Explain permission-gated `ctx.fs`, the provider-backed workspace
+   contract, tool scoping, argument constraints, approval gates, Docker/Kubernetes sandbox options,
+   and the release/destroy lifecycle at a high level. Keep filesystem convenience, policy, and
+   container isolation distinct.
+5. **Make delegation explicit.** Close the loop on the 0.4 subagents preview: current subagents use
+   keyed, parent-owned delegation policy with constraints/approval and resumable LangGraph
+   subgraphs. Name the registration/resume change as breaking instead of reusing the stale 0.4 API.
+6. **Make memory and state durable.** Cover typed long-term memory, candidate-by-default writes,
+   the SQLite and keyword-recall defaults, opt-in pgvector/hybrid recall, episodic memory,
+   distillation, and the local Memory Inspector. Then separate those features from the Postgres
+   checkpointer/thread/permission stores for multi-instance or ephemeral deployments. Do not imply
+   one store package replaces all the others or that any opt-in maintenance pass runs itself.
+7. **Connect real clients.** Explain canonical AG-UI translation, Agent Protocol thread/run
+   endpoints, interrupt/resume handling, correlated tool-call IDs, and the inspector/diagnostic
+   work only to the degree it changes the debugging experience. Describe the Inspector as a local
+   Memory panel, not a general production tracing console.
+8. **Run the runtime in production.** Move from `dawn dev` to the Node/Docker build target and
+   `dawn start`; then introduce the web-standard fetch core and the opt-in Hono edge target in two
+   short paragraphs. Link to the edge post for implementation detail.
+9. **One release train, deliberate upgrades.** Explain the fixed 0.8.x version group, link to
+   GitHub Releases and the upgrading guide, and give the exact pinned upgrade command. State that
+   Dawn is pre-1.0, now requires Node 24, and shipped breaking changes in patches; do not call the
+   release line backward-compatible.
+10. **Close — the application around the agent.** Return to the thesis: Dawn is still not a new
+   model runtime; it is the framework around LangGraph.js that makes the editor, tests, runtime,
+   storage, and deployment artifact agree. End with the scaffold or upgrade CTA.
+
+### Evidence and claims
+
+Every shipped claim must be traceable to a published tag at or before 0.8.21 and its generated
+package changelog. The minimum release anchors are:
+
+- 0.5.0: eval authoring and the `dawn eval` command;
+- 0.6.0–0.7.0: eval-ready/deep-research scaffolds and permission-gated `ctx.fs` for tools and
+  route entries;
+- 0.8.0: one fixed version across public Dawn packages and model-id advisories;
+- 0.8.1–0.8.2: workspace path hardening, eval recording, and focused testing harnesses;
+- 0.8.3–0.8.10: typed memory, layered tool controls, sandbox providers, hybrid recall, and
+  pgvector;
+- 0.8.11: the first AG-UI adapter and endpoint;
+- 0.8.12: the Node/Docker production build target and `dawn start`;
+- 0.8.13: canonical AG-UI behavior, structured Dawn error codes, environment preflight, and the
+  web-standard runtime core;
+- 0.8.14–0.8.18: the Memory Inspector, episodic memory and distillation, cancellation/static
+  builds, and guarded resumable subagents;
+- 0.8.19: Postgres runtime stores and safer shutdown draining;
+- 0.8.21: the opt-in Hono target and workerd fixes.
+
+Features from other 0.8.x releases may appear after checking the relevant package changelog. Do
+not fold the currently unreleased changesets on `main` into the shipped roundup. Do not present
+0.8.20 as a public release: npm and GitHub jump from 0.8.19 to 0.8.21 even though generated
+changelogs contain an empty 0.8.20 section.
+
+Accuracy notes for the prose:
+
+- Before 0.8.0, public packages did not share the CLI's version number. Describe product releases
+  by feature/version without implying every package was already on one fixed train.
+- Evals replay recorded fixtures by default; `--live` and `--record` use a real model and are not
+  CI modes.
+- Docker and Kubernetes provide container isolation, not a microVM guarantee. Docker allow-mode
+  host denylisting is best-effort, and Kubernetes network isolation depends on a policy-capable
+  CNI.
+- Top-level agents are not least-privilege by default. Subagent capability tools are narrower, and
+  an allowlist requires `delegation.default: "deny"`.
+- The Postgres package shares checkpoints, threads, and permissions; the one-run-per-thread gate
+  and cancellation remain process-local.
+- The current Node target requires Node 24 even if an older documentation sentence still mentions
+  a Node 22 image. Use engines, generated artifacts, and current release notes as the authority.
+
+## Post 2 — edge target
+
+### Working metadata
+
+- **Filename:** `apps/web/content/blog/2026-08-09-dawn-at-the-edge.mdx`
+- **Title:** `Dawn at the edge — The Hono target`
+- **Description:** `Dawn now emits a Node-free runtime entry for Cloudflare Workers. Here is the static wiring, per-request Postgres lifecycle, workerd evidence, and honest subset behind it.`
+- **Type:** `post`
+- **Tags:** `[typescript, agents, patterns]`
+- **Author:** `brian`
+- **Draft state:** `draft: true` until editorial approval and a publication date are confirmed
+- **Target length:** roughly 1,300–1,700 words
+
+### Thesis
+
+Putting an agent runtime on the edge was not a matter of wrapping the Node server in Hono. It
+required a web-standard request core, statically analyzable route and provider imports, runtime
+environment injection, request-scoped stores, and build-time refusal of capabilities the target
+cannot safely serve.
+
+### Outline
+
+1. **Hook — one request worked; the second one hung.** Start with the false-simple version of the
+   task: Dawn already had a `(Request) => Promise<Response>` handler, so exporting it from Hono
+   looked easy. Then use the alternating-request failure to introduce the real constraints exposed
+   by workerd: no Node globals, request-bound I/O objects, static bundling, and durable state
+   without local SQLite.
+2. **What ships in 0.8.21.** State the supported workflow and the opt-in nature of
+   the `hono` target. Show `build.targets: ["node", "langsmith", "hono"]` and explain that setting
+   the list replaces the defaults, so readers must retain every output they still need. Name
+   Cloudflare Workers as the verified host while explaining that the default-exported Hono app has
+   a web-standard shape other hosts may be able to consume.
+3. **The build output.** Show one configuration block and the generated files:
+   `.dawn/build/app.mjs`, `modules.edge.mjs`, `stores.mjs`, and the root `wrangler.toml`. Explain
+   the job of each artifact rather than listing filenames alone. State that Dawn emits analyzable
+   source and Wrangler creates the final bundle; a generated root `wrangler.toml` is never
+   overwritten.
+4. **Node-free on purpose.** Explain why the scaffold omits `nodejs_compat`, how static provider
+   imports make bundling exhaustive, and how the runtime environment seam supplies API keys and
+   configuration without assuming `process.env` exists. Qualify the guarantee: Dawn gates its
+   generated/runtime graph, but arbitrary user route and tool imports remain the app author's
+   responsibility and can still fail at Wrangler bundle time.
+5. **One request, one store lifetime.** Describe the workerd failure that made a module-scoped
+   WebSocket pool unsafe, the per-request Neon/Postgres store factory, migration memoization, and
+   disposal only after both the response and the run settle. Say migrations run once per isolate,
+   with advisory locks converging concurrent instances. Keep the explanation practical and avoid
+   presenting one vendor driver as the only possible future design.
+6. **The target refuses what it cannot run.** Give a compact capability-boundary table. The build
+   gate should read as a safety property: sandbox, filesystem/shell backends, a workspace
+   directory, route skills, typed long-term memory, and custom live store instances fail by name
+   instead of being silently dropped. Distinguish those errors from `memory.md` and `plan.md`,
+   whose filesystem-backed markers currently detect false and remain inactive. Do not describe a
+   feature as workerd-verified merely because the build does not gate it.
+7. **What the tests prove.** State that CI bundles the emitted graph without Node specifiers and
+   drives four sequential AG-UI turns plus `/healthz` through local workerd against Postgres. Then
+   state what it does not prove: Agent Protocol/tool/subagent/HITL execution inside workerd, other
+   model providers, a real Cloudflare deployment, Hyperdrive or Neon Cloud, production
+   connection/subrequest limits, WAN query latency, cross-isolate cold starts, or platform
+   bundle/startup quotas.
+8. **Try it.** Show the dependency/config/build/wrangler path, link the deployment docs, and invite
+   feedback from readers trying the target against real workloads. Do not call it generally
+   production-proven.
+
+### Edge claim boundaries
+
+- Say **"Cloudflare Workers target"** only in the context of the emitted Hono/Workers scaffold;
+  the Dawn build target itself is named `hono`.
+- Say **"tested under local workerd"**, not "deployed to Cloudflare" or "production-ready on
+  Cloudflare."
+- Say the emitted Dawn-owned graph contains no `node:` specifiers and that Node-global purity is
+  gated. Do not claim every transitive dependency is universally edge-compatible outside the
+  verified build conditions, or that Dawn statically polices arbitrary user code.
+- Do not imply all Dawn capabilities work at the edge. The supported subset is deliberate and the
+  build must reject unsupported use.
+- Explain that Postgres on the verified Workers path uses `@neondatabase/serverless` over
+  WebSockets against local Postgres through a local proxy. Do not imply raw TCP `pg` works on
+  Workers or that Neon Cloud itself was exercised.
+- Do not promise Vercel, Bun, or Deno parity merely because those hosts can consume a Hono/fetch
+  shape; they are plausible targets, not part of the 0.8.21 proof.
+- Say migrations run once per isolate, not globally, and say stores close after the response body
+  and request-started run settle, not merely when `fetch()` returns.
+- Missing generated runtime dependencies are build warnings. A missing `DATABASE_URL` fails when
+  request-scoped stores are created, not during `dawn build`.
+
+## Relationship between the posts
+
+- The roundup owns the broad history and gives the edge target no more than a short deployment
+  subsection.
+- The edge post owns architecture, artifacts, capability gates, workerd behavior, and operational
+  caveats.
+- The roundup links to `/blog/dawn-at-the-edge` where the Hono target is introduced.
+- The edge post links back to `/blog/dawn-0-8-framework-around-the-agent` when placing the target
+  in the broader release line.
+- Both posts link to `/docs/upgrading` and `/docs/deployment` where relevant; neither duplicates
+  the full reference documentation.
+
+## Source hierarchy
+
+Use sources in this order:
+
+1. published package changelogs and the 0.5.0–0.8.21 GitHub Releases;
+2. current product documentation under `apps/web/content/docs/`;
+3. implementation tests for narrowly worded verification claims;
+4. approved design documents only as background, never as proof that something shipped.
+
+The public version check on 2026-08-09 found `@dawn-ai/cli@0.8.21` on npm and matching 0.8.21
+GitHub Releases. Recheck immediately before removing `draft: true`, because "latest" is a moving
+claim.
+
+## Non-goals
+
+- An exhaustive changelog for every 0.5–0.8.21 package or patch.
+- Announcing unreleased changesets currently on `main`.
+- Rewriting the older 0.4 or Eve posts.
+- Adding new blog tags, layouts, illustrations, or custom Open Graph assets.
+- Changing the product docs or implementation as part of this writing task.
+- Publishing the posts or removing their draft flags without explicit approval.
+
+## Verification
+
+- Fact-check every versioned claim against the tagged changelog or GitHub release body.
+- Check every internal link against an existing docs route or the companion post's fixed slug.
+- Use only current API shapes and gpt-5-family model IDs in examples. In particular, do not reuse
+  the stale 0.4 post's `createSubAgent`, `subAgents`, or unscoped `/runs/*` examples.
+- Run the blog index and RSS tests after adding the MDX files.
+- Run the web package typecheck/build lane needed to compile the MDX.
+- Run `node scripts/check-docs.mjs` to catch banned or overstated wording.
+- Read both drafts straight through for duplicated sections and voice drift.
+- Keep both files marked `draft: true`; publishing is a separate decision.

--- a/docs/superpowers/specs/2026-08-09-dawn-0-8-and-edge-blog-posts-design.md
+++ b/docs/superpowers/specs/2026-08-09-dawn-0-8-and-edge-blog-posts-design.md
@@ -7,7 +7,7 @@
 
 ## Goal
 
-Publish two complementary posts that close the public-blog gap between the Dawn 0.4 post and the
+Draft two complementary posts that close the public-blog gap between the Dawn 0.4 post and the
 current 0.8.21 release:
 
 1. a broad release story explaining how Dawn grew from route conventions into the fuller
@@ -59,6 +59,7 @@ or imitate catchphrases so aggressively that the voice becomes a caricature.
 - **Version:** `0.8.21`
 - **Tags:** `[typescript, agents]` (`releases` is added automatically)
 - **Author:** `brian`
+- **Frontmatter date:** `2026-08-09`
 - **Draft state:** `draft: true` until editorial approval and a publication date are confirmed
 - **Target length:** roughly 1,500–1,900 words
 
@@ -133,8 +134,9 @@ package changelog. The minimum release anchors are:
 
 Features from other 0.8.x releases may appear after checking the relevant package changelog. Do
 not fold the currently unreleased changesets on `main` into the shipped roundup. Do not present
-0.8.20 as a public release: npm and GitHub jump from 0.8.19 to 0.8.21 even though generated
-changelogs contain an empty 0.8.20 section.
+0.8.20 as a public release: npm, tags, and GitHub Releases jump from 0.8.19 to 0.8.21. Some
+generated package changelogs contain 0.8.20 headings or substantive entries, but no corresponding
+public artifact exists; exclude that unpublished material from the post.
 
 Accuracy notes for the prose:
 
@@ -162,6 +164,7 @@ Accuracy notes for the prose:
 - **Type:** `post`
 - **Tags:** `[typescript, agents, patterns]`
 - **Author:** `brian`
+- **Frontmatter date:** `2026-08-09`
 - **Draft state:** `draft: true` until editorial approval and a publication date are confirmed
 - **Target length:** roughly 1,300–1,700 words
 
@@ -182,8 +185,9 @@ cannot safely serve.
 2. **What ships in 0.8.21.** State the supported workflow and the opt-in nature of
    the `hono` target. Show `build.targets: ["node", "langsmith", "hono"]` and explain that setting
    the list replaces the defaults, so readers must retain every output they still need. Name
-   Cloudflare Workers as the verified host while explaining that the default-exported Hono app has
-   a web-standard shape other hosts may be able to consume.
+   Cloudflare Workers as the target host and local real workerd as the verified runtime, while
+   explaining that the default-exported Hono app has a web-standard shape other hosts may be able
+   to consume.
 3. **The build output.** Show one configuration block and the generated files:
    `.dawn/build/app.mjs`, `modules.edge.mjs`, `stores.mjs`, and the root `wrangler.toml`. Explain
    the job of each artifact rather than listing filenames alone. State that Dawn emits analyzable
@@ -205,12 +209,12 @@ cannot safely serve.
    instead of being silently dropped. Distinguish those errors from `memory.md` and `plan.md`,
    whose filesystem-backed markers currently detect false and remain inactive. Do not describe a
    feature as workerd-verified merely because the build does not gate it.
-7. **What the tests prove.** State that CI bundles the emitted graph without Node specifiers and
-   drives four sequential AG-UI turns plus `/healthz` through local workerd against Postgres. Then
-   state what it does not prove: Agent Protocol/tool/subagent/HITL execution inside workerd, other
-   model providers, a real Cloudflare deployment, Hyperdrive or Neon Cloud, production
-   connection/subrequest limits, WAN query latency, cross-isolate cold starts, or platform
-   bundle/startup quotas.
+7. **What the tests prove.** Name the gated `edge-workerd` CI lane: it bundles the emitted graph
+   without Node specifiers and drives four sequential AG-UI turns plus `/healthz` through local
+   workerd against Postgres. Then state what it does not prove: Agent Protocol, tool, subagent, or
+   HITL execution inside workerd; other model providers; a real Cloudflare deployment; Hyperdrive
+   or Neon Cloud; production connection/subrequest limits; WAN query latency; cross-isolate cold
+   starts; or platform bundle/startup quotas.
 8. **Try it.** Show the dependency/config/build/wrangler path, link the deployment docs, and invite
    feedback from readers trying the target against real workloads. Do not call it generally
    production-proven.


### PR DESCRIPTION
## Summary

- Add a Dawn 0.8 roundup covering evals, execution boundaries, delegation, typed memory, web clients, and production targets.
- Add a separate Hono/Cloudflare Workers deep dive covering static wiring, request-scoped Postgres stores, local workerd evidence, and the supported subset.
- Include the approved design and execution plan, with both posts left `draft: true` for publication timing.

## Why

The public blog currently jumps from the early route and subagent story to the current framework without explaining the operational layers added through Dawn 0.8. These paired posts provide a concise release overview and a technically candid edge-target companion.

## Validation

- `pnpm ci:validate` under Node 24.18.0
- 2,514 tests passed; framework, runtime, and smoke harness lanes passed
- Blog index/RSS tests passed (11/11)
- Both local blog routes returned HTTP 200 and rendered without page-level overflow at desktop and mobile widths
- Independent factual, technical, and voice reviews completed with no remaining findings