### PR TITLE
fix(build): declare cross-package cache inputs and generated outputs

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -3,7 +3,13 @@
   "tasks": {
     "build": {
       "dependsOn": ["^build"],
-      "outputs": ["dist/**", ".next/**", "!.next/cache/**"]
+      "outputs": [
+        "dist/**",
+        ".next/**",
+        "!.next/cache/**",
+        ".dawn/build/**",
+        ".dawn/dawn.generated.d.ts"
+      ]
     },
     "@dawn-ai/cli#build": {
       "dependsOn": ["^build"],
@@ -22,10 +28,74 @@
       "persistent": true
     },
     "lint": {
-      "dependsOn": ["^lint"]
+      "dependsOn": ["^lint"],
+      "inputs": ["$TURBO_DEFAULT$", "$TURBO_ROOT$/packages/config-biome/biome.json"]
     },
     "test": {
       "dependsOn": ["^test"]
+    },
+    "@dawn-ai/cli#test": {
+      "dependsOn": ["^test"],
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "$TURBO_ROOT$/apps/web/content/docs/**",
+        "$TURBO_ROOT$/packages/ag-ui/README.md",
+        "$TURBO_ROOT$/examples/chat/**",
+        "$TURBO_ROOT$/examples/research/**",
+        "!$TURBO_ROOT$/examples/*/**/node_modules/**",
+        "!$TURBO_ROOT$/examples/*/**/.dawn/**",
+        "!$TURBO_ROOT$/examples/*/**/.next/**",
+        "!$TURBO_ROOT$/examples/*/**/.turbo/**",
+        "!$TURBO_ROOT$/examples/*/**/dist/**",
+        "!$TURBO_ROOT$/examples/*/**/*.tsbuildinfo"
+      ]
+    },
+    "@dawn-ai/core#test": {
+      "dependsOn": ["^test"],
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "$TURBO_ROOT$/package.json",
+        "$TURBO_ROOT$/packages/vite-plugin/package.json",
+        "$TURBO_ROOT$/test/fixtures/contracts/manifest.snap.json"
+      ]
+    },
+    "@dawn-ai/inspector#test": {
+      "dependsOn": ["^test"],
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "$TURBO_ROOT$/apps/web/next.config.ts",
+        "$TURBO_ROOT$/apps/web/next-env.d.ts",
+        "$TURBO_ROOT$/apps/web/package.json",
+        "$TURBO_ROOT$/examples/chat/web/next.config.mjs",
+        "$TURBO_ROOT$/examples/chat/web/package.json",
+        "$TURBO_ROOT$/examples/research/web/next.config.mjs",
+        "$TURBO_ROOT$/examples/research/web/package.json"
+      ]
+    },
+    "@dawn-ai/sandbox#test": {
+      "dependsOn": ["^test"],
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "$TURBO_ROOT$/.github/workflows/ci.yml",
+        "$TURBO_ROOT$/charts/dawn-sandbox-infra/values.yaml"
+      ]
+    },
+    "@dawn-ai/testing#test": {
+      "dependsOn": ["^test"],
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "$TURBO_ROOT$/examples/memory/server/dawn.config.ts",
+        "$TURBO_ROOT$/examples/memory/server/package.json",
+        "$TURBO_ROOT$/examples/memory/server/tsconfig.json",
+        "$TURBO_ROOT$/examples/memory/server/src/**",
+        "$TURBO_ROOT$/test/runtime/fixtures/sandbox-app/dawn.config.ts",
+        "$TURBO_ROOT$/test/runtime/fixtures/sandbox-app/package.json",
+        "$TURBO_ROOT$/test/runtime/fixtures/sandbox-app/src/**"
+      ]
+    },
+    "create-dawn-ai-app#test": {
+      "dependsOn": ["^test"],
+      "inputs": ["$TURBO_DEFAULT$", "$TURBO_ROOT$/test/harness/**"]
     },
     "typecheck": {
       "dependsOn": ["^typecheck"]


### PR DESCRIPTION
## Why

`packages/cli/docs/` going stale behind a `FULL TURBO` replay (seen on #423, fixed in ed4ddb5f) is one instance of a general shape: **a task whose real inputs or outputs sit outside its declared cache boundary**. Auditing for the rest turned up three more.

## What changed

All in `turbo.json`. Each was verified by running the task twice (cache hit), editing the external file, and confirming the task flips to a cache miss.

**1. Guard tests that read outside their own package.** These six `#test` tasks had *zero* external declared inputs, confirmed with `turbo run test --filter=<pkg> --dry=json`:

| Task | Really reads |
|---|---|
| `@dawn-ai/cli#test` | `apps/web/content/docs`, `examples/chat`, `examples/research`, `packages/ag-ui/README.md` |
| `@dawn-ai/sandbox#test` | `.github/workflows/ci.yml`, `charts/dawn-sandbox-infra/values.yaml` |
| `@dawn-ai/core#test` | root `package.json`, `packages/vite-plugin/package.json`, `test/fixtures/contracts/manifest.snap.json` |
| `@dawn-ai/inspector#test` | `apps/web` + example `next.config.*`, manifests, `next-env.d.ts` |
| `@dawn-ai/testing#test` | `examples/memory/server`, `test/runtime/fixtures/sandbox-app` |
| `create-dawn-ai-app#test` | `test/harness/**` |

The stale-reference guard in `packages/cli/test/docs-bundle.test.ts` is the sharpest case: it exists to catch retired vocabulary appearing in docs and examples, and a cached green result made it blind to exactly the edits it polices.

**2. Every `lint` task.** They all run `biome check --config-path ../config-biome/biome.json`, and nothing depends on `@dawn-ai/config-biome`, so `dependsOn: ["^lint"]` supplied no edge either — editing the shared Biome config left every cached lint result valid.

**3. Undeclared outputs (the inverse shape).** `dawn build` in `examples/*/server` writes `.dawn/build/**` and `.dawn/dawn.generated.d.ts`, neither in the `build` task's `outputs`. Deleting `.dawn/build` and replaying gave `FULL TURBO` with nothing restored: on a clean checkout against a warm cache, that is a green `pnpm build` and no server bundle.

## Gotcha worth knowing

`$TURBO_ROOT$/**` globs are **not** gitignore-filtered the way `$TURBO_DEFAULT$` is. A plain `$TURBO_ROOT$/examples/chat/**` pulled 4104 inputs into `@dawn-ai/cli#test`, including `.dawn/checkpoints.sqlite-wal`, `node_modules/.bin/*` and `.turbo/*.log` — a hash that changes on every run, so the task would never have cache-hit again. Hence the explicit `!` negations.

## Verification

- `pnpm build` — 25/25 successful
- `@dawn-ai/cli` + `@dawn-ai/core` tests — 861 passed, 1 skipped
- `pnpm check:build-cache` — passes
- Biome clean on `turbo.json`
- Invalidation proofs: chart edit → `sandbox#test` cache miss; `biome.json` edit → `permissions#lint` cache miss; MDX edit → `cli#build` cache miss and `packages/cli/docs/` regenerated; delete `.dawn/build` → now restored from cache

No changeset: no `packages/*/src` or package README touched.

## Left open deliberately

Two related gaps change the task *graph* rather than cache keys, so they are not in this PR:

- `test` declares only `dependsOn: ["^test"]`, yet `packages/cli/test/helpers/*.ts` import `packages/testing/dist` — and `@dawn-ai/testing` is not even a dependency of `@dawn-ai/cli`. CI hides this by running `pnpm build` before `pnpm test`. Fix would be `dependsOn: ["build", "^test"]`.
- `@dawn-ai/cli#test` asserts on `packages/cli/docs/`, which is gitignored and therefore unhashable by Turbo. Declaring the MDX sources fixes the cache key; artifact *freshness* still relies on build having run first, which the edge above would close.

Also unguarded: `scripts/check-build-cache-config.mjs` only asserts the `@dawn-ai/cli#build` contract, so these new declarations can rot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)