### PR TITLE
fix(build): give test tasks the build edge they already depend on

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -32,10 +32,10 @@
       "inputs": ["$TURBO_DEFAULT$", "$TURBO_ROOT$/packages/config-biome/biome.json"]
     },
     "test": {
-      "dependsOn": ["^test"]
+      "dependsOn": ["build", "^test"]
     },
     "@dawn-ai/cli#test": {
-      "dependsOn": ["^test"],
+      "dependsOn": ["build", "^test", "@dawn-ai/testing#build"],
       "inputs": [
         "$TURBO_DEFAULT$",
         "$TURBO_ROOT$/apps/web/content/docs/**",
@@ -51,7 +51,7 @@
       ]
     },
     "@dawn-ai/core#test": {
-      "dependsOn": ["^test"],
+      "dependsOn": ["build", "^test"],
       "inputs": [
         "$TURBO_DEFAULT$",
         "$TURBO_ROOT$/package.json",
@@ -60,7 +60,7 @@
       ]
     },
     "@dawn-ai/inspector#test": {
-      "dependsOn": ["^test"],
+      "dependsOn": ["build", "^test"],
       "inputs": [
         "$TURBO_DEFAULT$",
         "$TURBO_ROOT$/apps/web/next.config.ts",
@@ -73,7 +73,7 @@
       ]
     },
     "@dawn-ai/sandbox#test": {
-      "dependsOn": ["^test"],
+      "dependsOn": ["build", "^test"],
       "inputs": [
         "$TURBO_DEFAULT$",
         "$TURBO_ROOT$/.github/workflows/ci.yml",
@@ -81,7 +81,7 @@
       ]
     },
     "@dawn-ai/testing#test": {
-      "dependsOn": ["^test"],
+      "dependsOn": ["build", "^test"],
       "inputs": [
         "$TURBO_DEFAULT$",
         "$TURBO_ROOT$/examples/memory/server/dawn.config.ts",
@@ -94,7 +94,7 @@
       ]
     },
     "create-dawn-ai-app#test": {
-      "dependsOn": ["^test"],
+      "dependsOn": ["build", "^test"],
       "inputs": ["$TURBO_DEFAULT$", "$TURBO_ROOT$/test/harness/**"]
     },
     "typecheck": {


### PR DESCRIPTION
Follow-up to #438, which fixed cache *keys*. This one fixes the missing edge in the task graph.

## What's broken

`turbo run test` across the repo is **27 tasks, zero build tasks**. Nothing in the test graph produces a `dist/`, yet every cross-package import resolves through `exports` to `dist/`. It works today only because `ci:validate` runs `pnpm build` before `pnpm test`, and local checkouts have a stale `dist/` lying around — `pnpm test` on its own runs against whatever happens to be on disk.

For *declared* dependencies, `^test` papers over the hashing half: each dependency's own test task hashes its sources, so editing `packages/core/src` does invalidate `@dawn-ai/cli#test`. That is why this hasn't bitten harder.

## The hole: `@dawn-ai/testing`

Twenty-four files under `packages/cli/test/` import `../../testing/dist/*.js` by relative path. `@dawn-ai/testing` is not a dependency of `@dawn-ai/cli`, is not symlinked into `packages/cli/node_modules/@dawn-ai/`, and appears nowhere in cli's test graph — no task, no input:

```
cli#test hash before editing packages/testing/src/index.ts: e3d8955808d910ba
cli#test hash after:                                        e3d8955808d910ba
```

`createAimock` / `script` from that package is the harness under most cli integration tests, so a change to the aimock runner can leave all of them replaying a cached green.

**The relative import is deliberate, not an oversight.** `@dawn-ai/testing` declares `@dawn-ai/cli` in both `devDependencies` and `peerDependencies`; declaring the reverse edge would create the package cycle cli → testing → cli, which `^build` turns into a task cycle. "Just declare the dependency" is not available, so this PR uses a task-level edge instead — legal where the package-level one is not.

## The change

```json
"test": { "dependsOn": ["build", "^test"] }
```

plus `"@dawn-ai/testing#build"` on `@dawn-ai/cli#test`, and `"build"` on every other package-scoped `#test` entry — scoped task configs *replace* the generic one rather than merging, so they would otherwise miss it.

`build` rather than `^build` on purpose: `docs-bundle.test.ts` asserts on `packages/cli/docs/`, which `@dawn-ai/cli#build` generates. Self-build covers `^build` transitively anyway.

## Verification

| Check | Result |
|---|---|
| Cycle? | None — graph goes 27 → 54 tasks (27 builds added), turbo emits a valid graph |
| Closes the hole? | Yes — testing edit now moves `cli#test` `73d21039512c5faa` → `722950ba3eb6c50b` |
| CI cost | **~978ms** — after `pnpm build`, a warm full build is `FULL TURBO` 25/25 |
| `@dawn-ai/cli` suite under the new graph | 111 files / 881 tests pass |

No `inputs` addition is needed for `@dawn-ai/testing`: the hash propagates through the task edge.

Two `@dawn-ai/cli` failures showed up locally and are **not** from this change — `vitest` never reads `turbo.json`, and both reproduce on unmodified `main`: `hono-node-roundtrip.test.ts` fails on a local Docker container health check (`Health check failed: unhealthy`), and one `dev-command` case timed out under a loaded machine and passes in isolation. Both lanes were green on #438.

No changeset: no `packages/*/src` or package README touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)