### PR TITLE
test(build): make the cache declarations guard themselves

### DIFF
--- a/scripts/check-build-cache-config.mjs
+++ b/scripts/check-build-cache-config.mjs
@@ -1,6 +1,6 @@
 import { execFileSync } from "node:child_process"
-import { readdirSync, readFileSync, statSync } from "node:fs"
-import { dirname, join, posix, resolve } from "node:path"
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs"
+import { dirname, join, posix, relative, resolve } from "node:path"
 import { fileURLToPath } from "node:url"
 
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..")
@@ -79,57 +79,249 @@ if (!buildOutputs.includes("dist/**")) {
   errors.push('turbo.json build task must include "dist/**" in outputs')
 }
 
-try {
-  const dryRun = JSON.parse(
-    execFileSync(
-      process.execPath,
-      [turboPath, "run", "build", "--filter=@dawn-ai/cli", "--dry=json"],
-      {
-        cwd: repoRoot,
-        encoding: "utf8",
-      },
-    ),
-  )
-  const cliBuildTask = dryRun.tasks?.find((task) => task.taskId === "@dawn-ai/cli#build")
+// `dawn build` writes the app bundle here. Without it a cache hit reports
+// success and restores nothing — a green `pnpm build` with no server bundle.
+if (!buildOutputs.includes(".dawn/build/**")) {
+  errors.push('turbo.json build task must include ".dawn/build/**" in outputs')
+}
 
-  if (cliBuildTask === undefined) {
-    errors.push("Turbo dry run did not include the @dawn-ai/cli#build task")
-  } else {
-    const taskInputs = new Set(
-      Object.keys(cliBuildTask.inputs ?? {}).map((input) =>
-        toRepoRelativePath(resolve(cliRoot, input)),
-      ),
+// Tests import their workspace dependencies through `exports`, which resolve to
+// `dist/`. Without a build edge the test graph produces no `dist/` at all and
+// runs against whatever happens to be on disk.
+for (const [taskName, task] of Object.entries(turboConfig.tasks ?? {})) {
+  if (taskName !== "test" && !taskName.endsWith("#test")) {
+    continue
+  }
+
+  if (!(task.dependsOn ?? []).includes("build")) {
+    errors.push(
+      `turbo.json ${taskName} must include "build" in dependsOn (package-scoped task configs replace the generic one rather than merging)`,
     )
-    const requiredInputs = [
-      ...listMdxFiles(docsSourceRoot),
-      docsNavPath,
-      join(cliRoot, "src/index.ts"),
-    ].map(toRepoRelativePath)
+  }
+}
 
-    for (const input of requiredInputs) {
-      if (!taskInputs.has(input)) {
-        errors.push(`@dawn-ai/cli#build is missing cache input: ${input}`)
-      }
+/** Every task Turbo would run, keyed by task id, with inputs made repo-relative. */
+const taskIndex = new Map()
+let dryRunFailure
+
+for (const taskName of ["build", "test", "lint"]) {
+  try {
+    const output = execFileSync(process.execPath, [turboPath, "run", taskName, "--dry=json"], {
+      cwd: repoRoot,
+      encoding: "utf8",
+      maxBuffer: 256 * 1024 * 1024,
+    })
+
+    for (const task of JSON.parse(output.slice(output.indexOf("{"))).tasks ?? []) {
+      const directory = join(repoRoot, task.directory)
+
+      taskIndex.set(task.taskId, {
+        directory,
+        dependencies: task.dependencies ?? [],
+        outputs: task.outputs ?? [],
+        packageName: task.package,
+        inputs: new Set(
+          Object.keys(task.inputs ?? {}).map((input) =>
+            toRepoRelativePath(resolve(directory, input)),
+          ),
+        ),
+      })
+    }
+  } catch (error) {
+    dryRunFailure = error instanceof Error ? error.message : String(error)
+    errors.push(
+      `Unable to inspect the ${taskName} task graph; run \`${process.execPath} ${turboPath} run ${taskName} --dry=json\` from the repository root. (${dryRunFailure})`,
+    )
+  }
+}
+
+const cliBuildTask = taskIndex.get("@dawn-ai/cli#build")
+
+if (cliBuildTask === undefined) {
+  if (dryRunFailure === undefined) {
+    errors.push("Turbo dry run did not include the @dawn-ai/cli#build task")
+  }
+} else {
+  const requiredInputs = [
+    ...listMdxFiles(docsSourceRoot),
+    docsNavPath,
+    join(cliRoot, "src/index.ts"),
+  ].map(toRepoRelativePath)
+
+  for (const input of requiredInputs) {
+    if (!cliBuildTask.inputs.has(input)) {
+      errors.push(`@dawn-ai/cli#build is missing cache input: ${input}`)
+    }
+  }
+
+  for (const output of ["dist/**", "docs/**"]) {
+    if (!cliBuildTask.outputs.includes(output)) {
+      errors.push(`@dawn-ai/cli#build is missing cache output: ${output}`)
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Reachability: a task must declare everything it actually reads
+// ---------------------------------------------------------------------------
+
+// `--others` so a brand-new test file is scanned before it is ever staged.
+const trackedFiles = execFileSync(
+  "git",
+  ["ls-files", "--cached", "--others", "--exclude-standard"],
+  { cwd: repoRoot, encoding: "utf8", maxBuffer: 64 * 1024 * 1024 },
+)
+  .split("\n")
+  .filter(Boolean)
+
+/** Workspace package directories, longest first so nested packages win. */
+const workspaceDirectories = [...taskIndex.values()]
+  .map((task) => ({ directory: task.directory, packageName: task.packageName }))
+  .sort((left, right) => right.directory.length - left.directory.length)
+
+const declaredDependencies = new Map()
+
+const dependenciesOf = (packageDirectory) => {
+  if (!declaredDependencies.has(packageDirectory)) {
+    const manifest = readJson(join(packageDirectory, "package.json"))
+
+    declaredDependencies.set(
+      packageDirectory,
+      new Set([
+        ...Object.keys(manifest.dependencies ?? {}),
+        ...Object.keys(manifest.devDependencies ?? {}),
+        ...Object.keys(manifest.peerDependencies ?? {}),
+      ]),
+    )
+  }
+
+  return declaredDependencies.get(packageDirectory)
+}
+
+/** Relative-path string literals: `"../../foo"`, `'./bar'`, `` `../baz` ``. */
+const relativeLiteralPattern = /["'`](\.\.?\/[^"'`\n]*)["'`]/g
+/** `test/` reads belong to the package's test task, `scripts/` to its build. */
+const scannedDirectories = [
+  ["test", "test"],
+  ["scripts", "build"],
+]
+
+let scannedFileCount = 0
+
+for (const { directory, packageName } of workspaceDirectories) {
+  const packageRelativeRoot = toRepoRelativePath(directory)
+
+  for (const [subdirectory, taskName] of scannedDirectories) {
+    const task = taskIndex.get(`${packageName}#${taskName}`)
+
+    if (task === undefined) {
+      continue
     }
 
-    for (const output of ["dist/**", "docs/**"]) {
-      if (!(cliBuildTask.outputs ?? []).includes(output)) {
-        errors.push(`@dawn-ai/cli#build is missing cache output: ${output}`)
+    const prefix = `${packageRelativeRoot}/${subdirectory}/`
+    const sources = trackedFiles.filter(
+      (file) => file.startsWith(prefix) && /\.(ts|tsx|mts|mjs|js)$/.test(file),
+    )
+
+    for (const file of sources) {
+      scannedFileCount += 1
+      const contents = readFileSync(join(repoRoot, file), "utf8")
+
+      for (const [, literal] of contents.matchAll(relativeLiteralPattern)) {
+        const absolute = resolve(dirname(join(repoRoot, file)), literal)
+
+        // Outside the repository, the package itself or an ancestor of it (a
+        // base path for later joins, not a read), or built at runtime rather
+        // than read from the tree: nothing to declare.
+        if (absolute === repoRoot || relative(repoRoot, absolute).startsWith("..")) continue
+        if (absolute === directory || directory.startsWith(`${absolute}${posix.sep}`)) continue
+        if (absolute.startsWith(`${directory}${posix.sep}`)) continue
+        if (!existsSync(absolute)) continue
+
+        const repoRelative = toRepoRelativePath(absolute)
+
+        if (repoRelative.split("/").includes("node_modules")) continue
+
+        const owner = workspaceDirectories.find(
+          (candidate) =>
+            absolute === candidate.directory ||
+            absolute.startsWith(`${candidate.directory}${posix.sep}`),
+        )
+
+        // A declared workspace dependency is already covered: `^test` hashes its
+        // sources and `build` -> `^build` orders its output.
+        if (owner !== undefined && dependenciesOf(directory).has(owner.packageName)) continue
+
+        // Reaching into another package's build output. That package cannot
+        // always be declared as a dependency — `@dawn-ai/testing` peer-depends
+        // on `@dawn-ai/cli`, so the reverse edge would be a cycle — and `dist/`
+        // is gitignored, so it can never be a cache input. An explicit
+        // task-level edge is the only thing that both orders and hashes it.
+        if (
+          owner !== undefined &&
+          repoRelative.startsWith(`${toRepoRelativePath(owner.directory)}/dist/`)
+        ) {
+          if (!task.dependencies.includes(`${owner.packageName}#build`)) {
+            errors.push(
+              `${packageName}#${taskName} reads ${repoRelative} but does not depend on ${owner.packageName}#build — add it to that task's dependsOn in turbo.json (${file})`,
+            )
+          }
+
+          continue
+        }
+
+        const declared = statSync(absolute).isDirectory()
+          ? [...task.inputs].some(
+              (input) => input === repoRelative || input.startsWith(`${repoRelative}/`),
+            )
+          : task.inputs.has(repoRelative)
+
+        if (!declared) {
+          errors.push(
+            `${packageName}#${taskName} reads ${repoRelative} but does not declare it as a cache input — add "$TURBO_ROOT$/${repoRelative}" to that task's inputs in turbo.json (${file})`,
+          )
+        }
       }
     }
   }
-} catch (error) {
-  const message = error instanceof Error ? error.message : String(error)
-  errors.push(
-    `Unable to inspect @dawn-ai/cli#build with Turbo dry run; run \`${process.execPath} ${turboPath} run build --filter=@dawn-ai/cli --dry=json\` from the repository root. (${message})`,
-  )
 }
 
-if (errors.length > 0) {
+// A shared Biome config is read by every lint task and belongs to none of them.
+for (const [taskId, task] of taskIndex) {
+  if (!taskId.endsWith("#lint")) {
+    continue
+  }
+
+  const lintScript = readJson(join(task.directory, "package.json")).scripts?.lint ?? ""
+  const configPath = /--config-path[= ]([^\s]+)/.exec(lintScript)?.[1]
+
+  if (configPath === undefined) {
+    continue
+  }
+
+  const absolute = resolve(task.directory, configPath)
+
+  if (absolute.startsWith(`${task.directory}${posix.sep}`) || !existsSync(absolute)) {
+    continue
+  }
+
+  const repoRelative = toRepoRelativePath(absolute)
+
+  if (!task.inputs.has(repoRelative)) {
+    errors.push(
+      `${taskId} lints with ${repoRelative} but does not declare it as a cache input — add "$TURBO_ROOT$/${repoRelative}" to the lint task's inputs in turbo.json`,
+    )
+  }
+}
+
+// One undeclared path is usually read from several files; report it once.
+const uniqueErrors = [...new Set(errors)]
+
+if (uniqueErrors.length > 0) {
   console.error("Build cache config check failed.")
   console.error("")
 
-  for (const error of errors) {
+  for (const error of uniqueErrors) {
     console.error(`- ${error}`)
   }
 
@@ -137,5 +329,5 @@ if (errors.length > 0) {
 }
 
 console.log(
-  `Build cache config check passed (${checkedConfigs.length} emitting tsconfig file(s), generic dist/** cache and CLI bundled-docs contract checked).`,
+  `Build cache config check passed (${checkedConfigs.length} emitting tsconfig file(s), ${taskIndex.size} task(s) across build/test/lint, ${scannedFileCount} scanned source file(s); generic dist/** and .dawn/build/** caches, the test->build edge, the CLI bundled-docs contract, and every cross-package read declared).`,
 )


### PR DESCRIPTION
Closes the loop on #438 (cache keys) and #440 (the build edge). Both landed declarations that nothing was protecting: they could be deleted silently, and nothing would notice the *next* task that grows a read outside its own package. `check-build-cache-config.mjs` only asserted the `@dawn-ai/cli#build` bundled-docs contract.

## The main addition is a reachability check, not a restatement of turbo.json

It scans every workspace package's `test/` and `scripts/` sources for relative path literals, resolves them, and requires anything landing outside the package to be accounted for — in one of three ways, in order:

1. **The path belongs to a declared workspace dependency.** `^test` already hashes its sources and `build` → `^build` orders its output. (This is why `packages/langgraph/test/_helpers/packed-consumer.ts` reaching into `packages/sdk` is fine — sdk is a declared dep.)
2. **The path is another package's `dist/`.** That is gitignored, so it can never be a cache input; it needs an explicit `<pkg>#build` task edge — the shape `@dawn-ai/cli#test` uses for `@dawn-ai/testing`, whose package-level edge would be a cycle.
3. **Otherwise it must appear in the task's `inputs`.**

Alongside it, three structural assertions for things the scan can't see: the shared Biome config named by each package's `--config-path` must be a declared lint input, `test` tasks must carry the `build` edge, and `build` must capture `.dawn/build/**`.

Errors name the file that reads the path and the exact line to add:

```
- @dawn-ai/sandbox#test reads charts/dawn-sandbox-infra/values.yaml but does not declare it
  as a cache input — add "$TURBO_ROOT$/charts/dawn-sandbox-infra/values.yaml" to that task's
  inputs in turbo.json (packages/sandbox/test/ci-workflow-pins.test.ts)
```

## Verification

Every check was verified by deleting the declaration it protects and confirming the failure:

| Removed | Caught |
|---|---|
| `charts/…/values.yaml` from `@dawn-ai/sandbox#test` inputs | yes |
| `@dawn-ai/testing#build` from `@dawn-ai/cli#test` dependsOn | yes |
| `build` from `test.dependsOn` | yes |
| `.dawn/build/**` from `build.outputs` | yes |
| the Biome config from `lint.inputs` | yes |

And forward-looking: a fresh `packages/sdk/test/` file reading `SECURITY.md` was flagged **while still unstaged** — the scan uses `git ls-files --cached --others --exclude-standard`, so a brand-new test file is covered before it is ever added.

Cost: **~2s** added to `pnpm ci:validate` — 81 tasks, 1191 source files, three `--dry=json` runs.

Passes clean on current `main`, which is the real check that the three resolution rules match how the repo is actually wired: the 24 `packages/testing/dist` reads resolve via rule 2, `packages/sdk` via rule 1, and everything #438 declared via rule 3.

No changeset: no `packages/*/src` or package README touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)