### PR TITLE
feat(inspector): browse orchestration and lifecycle UI

### DIFF
--- a/.changeset/inspector-browse-orchestration.md
+++ b/.changeset/inspector-browse-orchestration.md
@@ -1,0 +1,39 @@
+---
+"@dawn-ai/inspector": patch
+---
+
+Make the memory browse honest about what it is showing.
+
+The list is no longer polled through `usePolling`, which documents its own
+last-write-wins hole: a new `useMemoryBrowse` hook owns a desired query revision
+that any canonical-query change bumps, and **every response is discarded whole
+unless its revision is still the desired one**. Aborting the superseded request is
+an optimization on top; correctness never depends on winning that race. Stats keep
+polling as before.
+
+- One browse request in flight at a time, with the contention cases removed rather
+  than handled: a load-more asked for during a poll tick is queued and runs when the
+  tick settles, and a tick that comes due while anything is in flight is skipped.
+- A poll tick refreshes the head of the window and reconciles: updated rows take the
+  server's payload and position, rows that vanished from the refreshed span are
+  dropped, and rows beyond the span are retained rather than evicted because inserts
+  arrived above them.
+- Failures are recorded per request kind, so a succeeding poll tick cannot clear a
+  load-more failure and neither can clear a mutation's. A load failure with nothing
+  loaded holds the grid's error block and suspends polling until retry succeeds, so
+  the failure does not flicker on a two-second cadence.
+- Pausing (live off, hidden tab, held error) replaces the freshness claim with an
+  as-of stamp; resuming ticks immediately instead of waiting out the interval.
+- The grid now receives `dataState` and `resultMeta` from `@pretable/react@0.3.0`,
+  so loading, empty and error blocks are real states and the footer says "N loaded
+  of M matching" using the server's count.
+- The namespace facet sends the exact `namespace` parameter instead of narrowing a
+  prefix answer client-side — otherwise the total and the rows would describe
+  different sets.
+- Keyboard entry into the memory grid is now Tab-only, from `@pretable/react@0.3.0`:
+  Down arrow from a column header no longer moves into the body. Once a row has
+  focus, arrow keys and Enter/Space behave as before.
+
+Column sorting is off in the browse view for now: sorting a server-selected window
+locally presents the wrong sample, not merely the wrong order. It returns with
+server-side ordering.

--- a/.changeset/inspector-browse-orchestration.md
+++ b/.changeset/inspector-browse-orchestration.md
@@ -11,29 +11,36 @@ unless its revision is still the desired one**. Aborting the superseded request 
 an optimization on top; correctness never depends on winning that race. Stats keep
 polling as before.
 
-- One browse request in flight at a time, with the contention cases removed rather
-  than handled: a load-more asked for during a poll tick is queued and runs when the
-  tick settles, and a tick that comes due while anything is in flight is skipped.
+- One browse request in flight at a time, with the contention case removed rather
+  than handled: a tick that comes due while a request is in flight is skipped
+  instead of racing it.
 - A poll tick refreshes the head of the window and reconciles: updated rows take the
   server's payload and position, rows that vanished from the refreshed span are
   dropped, and rows beyond the span are retained rather than evicted because inserts
   arrived above them.
-- Failures are recorded per request kind, so a succeeding poll tick cannot clear a
-  load-more failure and neither can clear a mutation's. A load failure with nothing
-  loaded holds the grid's error block and suspends polling until retry succeeds, so
-  the failure does not flicker on a two-second cadence.
+- A refresh failure does not blank the answer already on screen: those rows stay and
+  the failure arrives as its own banner with a retry. A failure that leaves the
+  desired query with nothing fulfilled — the first load, or a query change whose
+  fetch fails while the previous question's rows are still up — holds the error
+  state and suspends polling until a retry succeeds, so the failure does not flicker
+  on a two-second cadence.
 - Pausing (live off, hidden tab, held error) replaces the freshness claim with an
   as-of stamp; resuming ticks immediately instead of waiting out the interval.
-- The grid now receives `dataState` and `resultMeta` from `@pretable/react@0.3.0`,
-  so loading, empty and error blocks are real states and the footer says "N loaded
-  of M matching" using the server's count.
+- The list grid now receives `dataState` and `resultMeta` from
+  `@pretable/react@0.3.0`, so loading, empty and error are body states of the grid
+  rather than a table that happens to have no rows, and the server's count reaches
+  the screen reader through the results announcement. A status line above both views
+  reads "N loaded of M matching".
+- The timeline view no longer answers "No episodes in this window." while the window
+  is still loading, or after loading it failed.
 - The namespace facet sends the exact `namespace` parameter instead of narrowing a
   prefix answer client-side — otherwise the total and the rows would describe
   different sets.
-- Keyboard entry into the memory grid is now Tab-only, from `@pretable/react@0.3.0`:
-  Down arrow from a column header no longer moves into the body. Once a row has
-  focus, arrow keys and Enter/Space behave as before.
 
 Column sorting is off in the browse view for now: sorting a server-selected window
 locally presents the wrong sample, not merely the wrong order. It returns with
 server-side ordering.
+
+`useMemoryBrowse` also arbitrates load-more against the poll cadence and keeps a
+separate failure slot for it, but nothing in this release asks for one — the
+control arrives with server-side paging.

--- a/packages/inspector/package.json
+++ b/packages/inspector/package.json
@@ -37,9 +37,9 @@
   "dependencies": {
     "@dawn-ai/core": "workspace:*",
     "@dawn-ai/memory": "workspace:*",
-    "@pretable/core": "0.0.8",
-    "@pretable/react": "0.0.8",
-    "@pretable/ui": "0.0.8",
+    "@pretable/core": "0.3.0",
+    "@pretable/react": "0.3.0",
+    "@pretable/ui": "0.3.0",
     "class-variance-authority": "^0.7.1",
     "next": "16.3.0",
     "react": "19.2.8",

--- a/packages/inspector/src/browse/browse-machine.ts
+++ b/packages/inspector/src/browse/browse-machine.ts
@@ -86,12 +86,15 @@ export interface BrowseTransition {
   readonly abort: boolean
 }
 
-const NO_KIND_ERRORS: BrowseKindErrors = {}
+/** Frozen because `readonly` is erased at runtime and this ONE object is installed on
+ *  every state that clears its slots: one widening cast downstream would edit them all.
+ *  Same for the initial state below. */
+const NO_KIND_ERRORS: BrowseKindErrors = Object.freeze({})
 
 /** `revision: 0` is a revision nothing can fulfil and `datasetKey: ""` is a key no
  *  canonical query produces, so the first `query-changed` a mounted hook dispatches
  *  is the SAME transition as any later one. Mount is not a special case. */
-export const INITIAL_BROWSE_STATE: BrowseState = {
+export const INITIAL_BROWSE_STATE: BrowseState = Object.freeze({
   revision: 0,
   datasetKey: "",
   fulfilled: null,
@@ -99,7 +102,7 @@ export const INITIAL_BROWSE_STATE: BrowseState = {
   queuedLoadMore: false,
   initialFailure: null,
   kindErrors: NO_KIND_ERRORS,
-}
+})
 
 /** Records held FOR THE DESIRED REVISION. An older revision's records are on screen
  *  but are not a base anything new is built on. */
@@ -140,13 +143,34 @@ export function browsePhase(state: BrowseState): PretableDataState["phase"] {
   return (state.fulfilled?.records.length ?? 0) > 0 ? "stale" : "loading"
 }
 
+/** One object per message-less phase. A consumer holds this as a dependency, and the
+ *  2 s cadence walks `idle → refreshing → idle` forever: a fresh object on the way back
+ *  reports a change that did not happen. Keyed over the whole phase union, so a phase
+ *  added upstream fails to compile rather than falling through. */
+const PHASE_DATA_STATES: Readonly<Record<PretableDataState["phase"], PretableDataState>> =
+  Object.freeze({
+    idle: Object.freeze({ phase: "idle" as const }),
+    loading: Object.freeze({ phase: "loading" as const }),
+    stale: Object.freeze({ phase: "stale" as const }),
+    refreshing: Object.freeze({ phase: "refreshing" as const }),
+    "loading-more": Object.freeze({ phase: "loading-more" as const }),
+    error: Object.freeze({ phase: "error" as const }),
+  })
+
+/** Keyed on the failure rather than the state: message-equality suppression already
+ *  holds that object still across a repeating failure, so the banner keeps one identity
+ *  for as long as it says the same thing. */
+const ERROR_DATA_STATES = new WeakMap<object, PretableDataState>()
+
 export function browseDataState(state: BrowseState): PretableDataState {
   const phase = browsePhase(state)
-  if (phase !== "error") return { phase }
-  const message = state.initialFailure?.message
-  // Spread rather than `{ phase, message }`: `exactOptionalPropertyTypes` rejects an
-  // explicit `undefined` against `message?: string`.
-  return { phase, ...(message === undefined ? {} : { message }) }
+  const failure = state.initialFailure
+  if (phase !== "error" || failure === null) return PHASE_DATA_STATES[phase]
+  const held = ERROR_DATA_STATES.get(failure)
+  if (held !== undefined) return held
+  const derived: PretableDataState = Object.freeze({ phase, message: failure.message })
+  ERROR_DATA_STATES.set(failure, derived)
+  return derived
 }
 
 function noStart(state: BrowseState): BrowseTransition {
@@ -334,7 +358,9 @@ export function browseReduce(state: BrowseState, event: BrowseEvent): BrowseTran
       if (!browseCanLoadMore(state)) return noStart(state)
       // User intent is never silently dropped: a load-more asked for during a poll
       // tick is QUEUED and runs when the tick settles.
-      if (state.inFlight?.kind === "refresh") return noStart({ ...state, queuedLoadMore: true })
+      if (state.inFlight?.kind === "refresh") {
+        return noStart(state.queuedLoadMore ? state : { ...state, queuedLoadMore: true })
+      }
       if (state.inFlight !== null) return noStart(state)
       return starting(
         state,

--- a/packages/inspector/src/browse/browse-machine.ts
+++ b/packages/inspector/src/browse/browse-machine.ts
@@ -1,0 +1,355 @@
+import type { MemoryRecord } from "@dawn-ai/memory/browse"
+import type { PretableDataState } from "@pretable/react"
+import { dedupeById, reconcileRefreshedWindow } from "./browse-reconcile"
+
+/** Records per window. */
+export const BROWSE_PAGE_SIZE = 200
+
+/** Ceiling on what the client keeps resident. DELIBERATELY equal to the route's
+ *  `BROWSE_MAX_LIMIT`, so one head refresh can always re-derive the entire resident
+ *  span in a single request — which is what makes the convergence guarantee
+ *  arithmetic rather than aspirational. */
+export const BROWSE_RESIDENT_CAP = 1000
+
+export type BrowseRequestKind = "initial" | "refresh" | "load-more"
+
+export interface BrowseWindow {
+  readonly limit: number
+  readonly offset: number
+}
+
+export interface BrowsePageResponse {
+  readonly records: readonly MemoryRecord[]
+  readonly total: number
+}
+
+/** Records, total and dataset key are stored TOGETHER and tagged with the revision
+ *  that produced them. A total that belongs to a different question is the exact
+ *  failure this design exists to prevent. */
+export interface BrowseFulfillment {
+  readonly revision: number
+  readonly datasetKey: string
+  readonly records: readonly MemoryRecord[]
+  readonly total: number
+  /** Epoch ms the response was applied — the as-of instant shown while paused. */
+  readonly at: number
+}
+
+export interface BrowseRequest {
+  readonly revision: number
+  readonly kind: BrowseRequestKind
+  readonly window: BrowseWindow
+}
+
+/** One independent slot per request kind, so a succeeding poll tick can never clear
+ *  a load-more failure. The mutation slot lives with the consumer that owns the
+ *  mutations. */
+export interface BrowseKindErrors {
+  readonly refresh?: string
+  readonly "load-more"?: string
+}
+
+export interface BrowseState {
+  readonly revision: number
+  readonly datasetKey: string
+  readonly fulfilled: BrowseFulfillment | null
+  readonly inFlight: BrowseRequest | null
+  readonly queuedLoadMore: boolean
+  readonly initialFailure: { readonly revision: number; readonly message: string } | null
+  readonly kindErrors: BrowseKindErrors
+}
+
+export type BrowseEvent =
+  | { readonly type: "query-changed"; readonly datasetKey: string }
+  | { readonly type: "poll-tick" }
+  | { readonly type: "load-more-requested" }
+  | { readonly type: "retry" }
+  | {
+      readonly type: "response"
+      readonly revision: number
+      readonly kind: BrowseRequestKind
+      readonly page: BrowsePageResponse
+      readonly at: number
+    }
+  | {
+      readonly type: "failure"
+      readonly revision: number
+      readonly kind: BrowseRequestKind
+      readonly message: string
+    }
+
+export interface BrowseTransition {
+  readonly state: BrowseState
+  /** The request the caller must now issue, or null. */
+  readonly start: BrowseRequest | null
+  /** Whether the caller must abort whatever it had in flight before this event. */
+  readonly abort: boolean
+}
+
+const NO_KIND_ERRORS: BrowseKindErrors = {}
+
+/** `revision: 0` is a revision nothing can fulfil and `datasetKey: ""` is a key no
+ *  canonical query produces, so the first `query-changed` a mounted hook dispatches
+ *  is the SAME transition as any later one. Mount is not a special case. */
+export const INITIAL_BROWSE_STATE: BrowseState = {
+  revision: 0,
+  datasetKey: "",
+  fulfilled: null,
+  inFlight: null,
+  queuedLoadMore: false,
+  initialFailure: null,
+  kindErrors: NO_KIND_ERRORS,
+}
+
+/** Records held FOR THE DESIRED REVISION. An older revision's records are on screen
+ *  but are not a base anything new is built on. */
+export function browseResidentCount(state: BrowseState): number {
+  return state.fulfilled?.revision === state.revision ? state.fulfilled.records.length : 0
+}
+
+export function browseCanLoadMore(state: BrowseState): boolean {
+  const fulfilled = state.fulfilled
+  if (fulfilled === null || fulfilled.revision !== state.revision) return false
+  return (
+    fulfilled.records.length < fulfilled.total && fulfilled.records.length < BROWSE_RESIDENT_CAP
+  )
+}
+
+/**
+ * Phase derivation, mechanical.
+ *
+ * `error` means "the last attempt for the DESIRED revision failed and nothing is
+ * fulfilled for that revision" — which covers an initial failure and a query-change
+ * failure with an older revision's rows still on screen. A refresh or load-more
+ * failure leaves the desired revision fulfilled, so the phase stays `idle` and the
+ * failure reaches the user through a banner slot instead: one failure, one channel.
+ */
+export function browsePhase(state: BrowseState): PretableDataState["phase"] {
+  if (state.fulfilled?.revision === state.revision) {
+    if (state.inFlight?.kind === "refresh") return "refreshing"
+    if (state.inFlight?.kind === "load-more") return "loading-more"
+    return "idle"
+  }
+  // A retry in flight is a fresh attempt, not the held failure: the failure is only
+  // "the LAST attempt" while there is no attempt running.
+  if (state.inFlight === null && state.initialFailure?.revision === state.revision) {
+    return "error"
+  }
+  // Rows on screen answer the previous question (`stale`); nothing on screen means
+  // there is nothing to be stale about (`loading`).
+  return (state.fulfilled?.records.length ?? 0) > 0 ? "stale" : "loading"
+}
+
+export function browseDataState(state: BrowseState): PretableDataState {
+  const phase = browsePhase(state)
+  if (phase !== "error") return { phase }
+  const message = state.initialFailure?.message
+  // Spread rather than `{ phase, message }`: `exactOptionalPropertyTypes` rejects an
+  // explicit `undefined` against `message?: string`.
+  return { phase, ...(message === undefined ? {} : { message }) }
+}
+
+function noStart(state: BrowseState): BrowseTransition {
+  return { state, start: null, abort: false }
+}
+
+function starting(state: BrowseState, request: BrowseRequest, abort: boolean): BrowseTransition {
+  return { state: { ...state, inFlight: request }, start: request, abort }
+}
+
+function initialWindow(): BrowseWindow {
+  return { limit: BROWSE_PAGE_SIZE, offset: 0 }
+}
+
+/** limit = resident count, clamped: never below one page (an empty result still asks
+ *  a real question) and never above the cap the route enforces. */
+function refreshWindow(state: BrowseState): BrowseWindow {
+  const resident = browseResidentCount(state)
+  return {
+    limit: Math.min(Math.max(resident, BROWSE_PAGE_SIZE), BROWSE_RESIDENT_CAP),
+    offset: 0,
+  }
+}
+
+function loadMoreWindow(state: BrowseState): BrowseWindow {
+  return { limit: BROWSE_PAGE_SIZE, offset: browseResidentCount(state) }
+}
+
+/** Success clears only ITS OWN slot. */
+function clearedError(
+  state: BrowseState,
+  kind: BrowseRequestKind,
+): Pick<BrowseState, "initialFailure" | "kindErrors"> {
+  if (kind === "initial") {
+    return { initialFailure: null, kindErrors: state.kindErrors }
+  }
+  if (state.kindErrors[kind] === undefined) {
+    return { initialFailure: state.initialFailure, kindErrors: state.kindErrors }
+  }
+  const next: BrowseKindErrors = {
+    ...(kind !== "refresh" && state.kindErrors.refresh !== undefined
+      ? { refresh: state.kindErrors.refresh }
+      : {}),
+    ...(kind !== "load-more" && state.kindErrors["load-more"] !== undefined
+      ? { "load-more": state.kindErrors["load-more"] }
+      : {}),
+  }
+  return { initialFailure: state.initialFailure, kindErrors: next }
+}
+
+/** Failure records against the kind that failed. Message-equality suppression keeps
+ *  the SAME object when a repeating tick fails the same way, so a 2 s cadence cannot
+ *  re-render — or re-announce — a banner that has not changed. */
+function recordedFailure(
+  state: BrowseState,
+  kind: BrowseRequestKind,
+  message: string,
+): Pick<BrowseState, "initialFailure" | "kindErrors"> {
+  if (kind === "initial") {
+    const previous = state.initialFailure
+    if (previous !== null && previous.revision === state.revision && previous.message === message) {
+      return { initialFailure: previous, kindErrors: state.kindErrors }
+    }
+    return { initialFailure: { revision: state.revision, message }, kindErrors: state.kindErrors }
+  }
+  if (state.kindErrors[kind] === message) {
+    return { initialFailure: state.initialFailure, kindErrors: state.kindErrors }
+  }
+  const kindErrors: BrowseKindErrors =
+    kind === "refresh"
+      ? { ...state.kindErrors, refresh: message }
+      : { ...state.kindErrors, "load-more": message }
+  return { initialFailure: state.initialFailure, kindErrors }
+}
+
+/** A queued load-more runs when the tick it waited on settles — success OR failure.
+ *  The queue clears either way: it was intent about a request that has had its turn. */
+function drainQueuedLoadMore(settled: BrowseState): BrowseTransition {
+  if (!settled.queuedLoadMore) return noStart(settled)
+  const drained: BrowseState = { ...settled, queuedLoadMore: false }
+  if (!browseCanLoadMore(drained)) return noStart(drained)
+  return starting(
+    drained,
+    { revision: drained.revision, kind: "load-more", window: loadMoreWindow(drained) },
+    false,
+  )
+}
+
+export function browseReduce(state: BrowseState, event: BrowseEvent): BrowseTransition {
+  switch (event.type) {
+    case "query-changed": {
+      const revision = state.revision + 1
+      const request: BrowseRequest = { revision, kind: "initial", window: initialWindow() }
+      return {
+        // Records are KEPT: they answer the previous question and stay on screen
+        // (phase `stale`) until the new one is answered. Their revision is behind
+        // now, so nothing can mistake them for the answer. Every error slot is
+        // dropped — each described a dataset that no longer exists.
+        state: {
+          ...state,
+          revision,
+          datasetKey: event.datasetKey,
+          inFlight: request,
+          queuedLoadMore: false,
+          initialFailure: null,
+          kindErrors: NO_KIND_ERRORS,
+        },
+        start: request,
+        abort: state.inFlight !== null,
+      }
+    }
+
+    case "poll-tick": {
+      // Single flight: a tick that comes due while ANYTHING is in flight is skipped
+      // and the next tick covers it. That is the whole of the "tick due during
+      // loading-more" rule — the interleaving case is removed, not handled.
+      if (state.inFlight !== null) return noStart(state)
+      if (state.fulfilled?.revision !== state.revision) return noStart(state)
+      return starting(
+        state,
+        { revision: state.revision, kind: "refresh", window: refreshWindow(state) },
+        false,
+      )
+    }
+
+    case "retry": {
+      if (state.inFlight !== null) return noStart(state)
+      // Re-attempt the failed kind under the CURRENT desired revision: if the query
+      // moved on while the banner was up, that IS the new query's initial fetch.
+      if (state.fulfilled?.revision !== state.revision) {
+        return starting(
+          state,
+          { revision: state.revision, kind: "initial", window: initialWindow() },
+          false,
+        )
+      }
+      if (state.kindErrors["load-more"] !== undefined) {
+        return starting(
+          state,
+          { revision: state.revision, kind: "load-more", window: loadMoreWindow(state) },
+          false,
+        )
+      }
+      return starting(
+        state,
+        { revision: state.revision, kind: "refresh", window: refreshWindow(state) },
+        false,
+      )
+    }
+
+    case "load-more-requested": {
+      if (!browseCanLoadMore(state)) return noStart(state)
+      // User intent is never silently dropped: a load-more asked for during a poll
+      // tick is QUEUED and runs when the tick settles.
+      if (state.inFlight?.kind === "refresh") return noStart({ ...state, queuedLoadMore: true })
+      if (state.inFlight !== null) return noStart(state)
+      return starting(
+        state,
+        { revision: state.revision, kind: "load-more", window: loadMoreWindow(state) },
+        false,
+      )
+    }
+
+    case "response": {
+      // THE stale-suppression mechanism: a response whose revision is no longer
+      // desired is discarded WHOLE — records, total and continuation together.
+      // Aborting is an optimization layered on top; correctness never depends on it.
+      if (event.revision !== state.revision) return noStart(state)
+      const base = state.fulfilled?.revision === state.revision ? state.fulfilled.records : []
+      const records =
+        event.kind === "refresh"
+          ? reconcileRefreshedWindow(base, event.page.records, {
+              // The store issues a continuation exactly when a window fills its limit,
+              // and this event carries no continuation, so the span is re-derived
+              // against the request that produced it — still `inFlight` here, which is
+              // the only place that limit is held.
+              filled:
+                event.page.records.length >= (state.inFlight?.window.limit ?? BROWSE_PAGE_SIZE),
+            })
+          : event.kind === "load-more"
+            ? dedupeById(base, event.page.records)
+            : event.page.records
+      return drainQueuedLoadMore({
+        ...state,
+        inFlight: null,
+        fulfilled: {
+          revision: state.revision,
+          datasetKey: state.datasetKey,
+          records,
+          total: event.page.total,
+          at: event.at,
+        },
+        ...clearedError(state, event.kind),
+      })
+    }
+
+    case "failure": {
+      if (event.revision !== state.revision) return noStart(state)
+      return drainQueuedLoadMore({
+        ...state,
+        inFlight: null,
+        ...recordedFailure(state, event.kind, event.message),
+      })
+    }
+  }
+}

--- a/packages/inspector/src/browse/browse-machine.ts
+++ b/packages/inspector/src/browse/browse-machine.ts
@@ -171,8 +171,23 @@ function refreshWindow(state: BrowseState): BrowseWindow {
   }
 }
 
+/** Never asks past the cap: the resident count is not a multiple of the page size
+ *  whenever `dedupeById` has dropped a paging duplicate, so a fixed page would ask for
+ *  rows the cap then discards. Callers guard on `browseCanLoadMore`, which is what
+ *  keeps the limit above zero. */
 function loadMoreWindow(state: BrowseState): BrowseWindow {
-  return { limit: BROWSE_PAGE_SIZE, offset: browseResidentCount(state) }
+  const resident = browseResidentCount(state)
+  return { limit: Math.min(BROWSE_PAGE_SIZE, BROWSE_RESIDENT_CAP - resident), offset: resident }
+}
+
+/** The cap is enforced HERE because this is the only place the resident set grows, and
+ *  it grows by more than a window: reconciliation rule 3 retains a tail the refresh
+ *  limit never asked for. Past the cap the refresh limit stops growing, so a row there
+ *  falls outside every future window — and `supersede` demotes without touching
+ *  `updatedAt`, so it cannot re-enter the head span either, and renders active for
+ *  good. Dropping from the far end keeps what a later window can still re-cover. */
+function withinCap(records: readonly MemoryRecord[]): readonly MemoryRecord[] {
+  return records.length <= BROWSE_RESIDENT_CAP ? records : records.slice(0, BROWSE_RESIDENT_CAP)
 }
 
 /** Success clears only ITS OWN slot. */
@@ -283,7 +298,11 @@ export function browseReduce(state: BrowseState, event: BrowseEvent): BrowseTran
           false,
         )
       }
-      if (state.kindErrors["load-more"] !== undefined) {
+      // The banner outlives its request: a load-more slot is cleared only by a
+      // load-more success, so the set can complete — or reach the cap — under a
+      // failure that is still on screen. Re-attempting then would ask for rows past
+      // the cap.
+      if (state.kindErrors["load-more"] !== undefined && browseCanLoadMore(state)) {
         return starting(
           state,
           { revision: state.revision, kind: "load-more", window: loadMoreWindow(state) },
@@ -316,7 +335,7 @@ export function browseReduce(state: BrowseState, event: BrowseEvent): BrowseTran
       // Aborting is an optimization layered on top; correctness never depends on it.
       if (event.revision !== state.revision) return noStart(state)
       const base = state.fulfilled?.revision === state.revision ? state.fulfilled.records : []
-      const records =
+      const records = withinCap(
         event.kind === "refresh"
           ? reconcileRefreshedWindow(base, event.page.records, {
               // The store issues a continuation exactly when a window fills its limit,
@@ -328,7 +347,8 @@ export function browseReduce(state: BrowseState, event: BrowseEvent): BrowseTran
             })
           : event.kind === "load-more"
             ? dedupeById(base, event.page.records)
-            : event.page.records
+            : event.page.records,
+      )
       return drainQueuedLoadMore({
         ...state,
         inFlight: null,

--- a/packages/inspector/src/browse/browse-machine.ts
+++ b/packages/inspector/src/browse/browse-machine.ts
@@ -190,6 +190,20 @@ function withinCap(records: readonly MemoryRecord[]): readonly MemoryRecord[] {
   return records.length <= BROWSE_RESIDENT_CAP ? records : records.slice(0, BROWSE_RESIDENT_CAP)
 }
 
+/** The store issues a continuation exactly when a window fills its limit, and this
+ *  event carries no continuation, so the span is re-derived against the request that
+ *  produced it — `inFlight` is the only place that limit is held. Single flight keeps
+ *  it populated until the response is applied, so a null here is a broken caller, not a
+ *  case with a defensible default: either guess decides rule 3, one by dropping a live
+ *  tail and the other by pinning a stale one. */
+function refreshFilledItsWindow(state: BrowseState, records: readonly MemoryRecord[]): boolean {
+  const issued = state.inFlight
+  if (issued === null) {
+    throw new Error("browse: a refresh response arrived with no request in flight")
+  }
+  return records.length >= issued.window.limit
+}
+
 /** Success clears only ITS OWN slot. */
 function clearedError(
   state: BrowseState,
@@ -338,12 +352,7 @@ export function browseReduce(state: BrowseState, event: BrowseEvent): BrowseTran
       const records = withinCap(
         event.kind === "refresh"
           ? reconcileRefreshedWindow(base, event.page.records, {
-              // The store issues a continuation exactly when a window fills its limit,
-              // and this event carries no continuation, so the span is re-derived
-              // against the request that produced it — still `inFlight` here, which is
-              // the only place that limit is held.
-              filled:
-                event.page.records.length >= (state.inFlight?.window.limit ?? BROWSE_PAGE_SIZE),
+              filled: refreshFilledItsWindow(state, event.page.records),
             })
           : event.kind === "load-more"
             ? dedupeById(base, event.page.records)

--- a/packages/inspector/src/browse/browse-reconcile.ts
+++ b/packages/inspector/src/browse/browse-reconcile.ts
@@ -5,12 +5,19 @@ export interface BrowseOrderKey {
 }
 
 /**
- * The default browse order, evaluated client-side.
+ * The default browse order, evaluated client-side. Pinned against the store's
+ * `DEFAULT_BROWSE_ORDER` in browse-reconcile.test.ts — the span comparisons below
+ * only decide anything while this IS the ORDER BY the server ran.
  *
- * `<` on strings is UTF-16 code-unit order. That equals the server's byte order
- * here because both fields are ASCII-uniform by construction — `updatedAt` is
- * full-ISO-Z TEXT and ids are ASCII — which is exactly what lets a client-side
- * span comparison agree with the window the server actually returned.
+ * `<` on strings is UTF-16 code-unit order, which has to agree with the server's
+ * byte order or a client-side span comparison contradicts the window the server
+ * actually returned. `updatedAt` agrees outright: it is full-ISO-Z TEXT. Ids agree
+ * only as far as they stay ASCII, and nothing enforces that — `put()` stores
+ * whatever id the caller hands it and neither schema has a CHECK; it holds today
+ * because every in-repo generator emits `memory_<kind>_<hash>`. The exposure is
+ * narrower than "non-ASCII" though: UTF-16 sorts surrogates BELOW U+E000–U+FFFF
+ * while UTF-8 sorts their bytes above, so only an ASTRAL character in an id can
+ * order differently on the two sides.
  */
 export function compareDefaultBrowseOrder(a: BrowseOrderKey, b: BrowseOrderKey): number {
   if (a.updatedAt !== b.updatedAt) return a.updatedAt < b.updatedAt ? 1 : -1
@@ -18,16 +25,22 @@ export function compareDefaultBrowseOrder(a: BrowseOrderKey, b: BrowseOrderKey):
   return 0
 }
 
-/** Append `next` onto `prev`, dropping ids `prev` already holds — the
- *  belt-and-suspenders against a paging duplicate. Returns `prev` ITSELF when
- *  nothing was added, so an append that changed nothing does not churn the array
- *  identity the grid keys its work on. */
+/** Append `next` onto `prev`, dropping every id already seen — held by `prev` OR
+ *  taken earlier within `next` itself, so the result carries each id once whatever
+ *  arrives. The belt-and-suspenders against a paging duplicate. Returns `prev`
+ *  ITSELF when nothing was added, so an append that changed nothing does not churn
+ *  the array identity the grid keys its work on. */
 export function dedupeById<T extends { readonly id: string }>(
   prev: readonly T[],
   next: readonly T[],
 ): readonly T[] {
   const held = new Set(prev.map((row) => row.id))
-  const added = next.filter((row) => !held.has(row.id))
+  const added: T[] = []
+  for (const row of next) {
+    if (held.has(row.id)) continue
+    held.add(row.id)
+    added.push(row)
+  }
   return added.length === 0 ? prev : [...prev, ...added]
 }
 
@@ -41,17 +54,30 @@ export function dedupeById<T extends { readonly id: string }>(
  *    deleted or moved out of the result: DROP it.
  * 3. A resident row beyond the refreshed span (head inserts pushed coverage up) is
  *    RETAINED as a possibly-stale tail. Rows are never evicted from under the user
- *    because inserts arrived; the next tick's larger limit re-covers them.
+ *    because inserts arrived; the next tick asks for a limit of the grown resident
+ *    count and re-covers them — but only BELOW the caller's resident cap. At the cap
+ *    the limit stops growing while rule 3 keeps appending, so the overflow never
+ *    self-heals: `supersede` demotes a row with an UPDATE that leaves `updated_at`
+ *    alone, so a row parked past the cap cannot move back into the span and renders
+ *    active for good. A caller that polls forever must truncate this result to its
+ *    own cap; this function does not know one.
  *
- * A window that did not FILL its limit reached the end of the matching set, so its
- * span is unbounded and rule 3 has no members.
+ * `span.filled` is the response's OWN statement that it reached its limit — that is
+ * what `BrowsePage.continuation !== null` means — not something to re-derive from a
+ * limit the caller may no longer hold. A window that did not fill reached the end of
+ * the matching set, so its span is unbounded and rule 3 has no members.
+ *
+ * Always allocates, unlike `dedupeById` — deliberately, for want of a sound no-op
+ * check to return `resident` on. The response is freshly parsed, so nothing is
+ * reference-equal, and positional `(id, updatedAt)` equality would read the
+ * `supersede` case above as an unchanged tick and pin a stale status on screen.
  */
 export function reconcileRefreshedWindow<T extends BrowseOrderKey>(
   resident: readonly T[],
   refreshed: readonly T[],
-  requestedLimit: number,
+  span: { readonly filled: boolean },
 ): readonly T[] {
-  const spanEnd = refreshed.length >= requestedLimit ? refreshed.at(-1) : undefined
+  const spanEnd = span.filled ? refreshed.at(-1) : undefined
   if (spanEnd === undefined) return [...refreshed]
   const refreshedIds = new Set(refreshed.map((row) => row.id))
   const tail = resident.filter(

--- a/packages/inspector/src/browse/browse-reconcile.ts
+++ b/packages/inspector/src/browse/browse-reconcile.ts
@@ -1,0 +1,61 @@
+/** The two fields the default browse order (`updatedAt DESC, id ASC`) reads. */
+export interface BrowseOrderKey {
+  readonly id: string
+  readonly updatedAt: string
+}
+
+/**
+ * The default browse order, evaluated client-side.
+ *
+ * `<` on strings is UTF-16 code-unit order. That equals the server's byte order
+ * here because both fields are ASCII-uniform by construction — `updatedAt` is
+ * full-ISO-Z TEXT and ids are ASCII — which is exactly what lets a client-side
+ * span comparison agree with the window the server actually returned.
+ */
+export function compareDefaultBrowseOrder(a: BrowseOrderKey, b: BrowseOrderKey): number {
+  if (a.updatedAt !== b.updatedAt) return a.updatedAt < b.updatedAt ? 1 : -1
+  if (a.id !== b.id) return a.id < b.id ? -1 : 1
+  return 0
+}
+
+/** Append `next` onto `prev`, dropping ids `prev` already holds — the
+ *  belt-and-suspenders against a paging duplicate. Returns `prev` ITSELF when
+ *  nothing was added, so an append that changed nothing does not churn the array
+ *  identity the grid keys its work on. */
+export function dedupeById<T extends { readonly id: string }>(
+  prev: readonly T[],
+  next: readonly T[],
+): readonly T[] {
+  const held = new Set(prev.map((row) => row.id))
+  const added = next.filter((row) => !held.has(row.id))
+  return added.length === 0 ? prev : [...prev, ...added]
+}
+
+/**
+ * Head-anchored refresh reconciliation, rules 1–3:
+ *
+ * 1. A resident row whose id appears in the response takes the response's payload
+ *    AND position — hoists into the head span and stale payloads, in one rule.
+ *    Falls out of placing `refreshed` wholesale at the front.
+ * 2. A resident row inside the refreshed span but absent from the response was
+ *    deleted or moved out of the result: DROP it.
+ * 3. A resident row beyond the refreshed span (head inserts pushed coverage up) is
+ *    RETAINED as a possibly-stale tail. Rows are never evicted from under the user
+ *    because inserts arrived; the next tick's larger limit re-covers them.
+ *
+ * A window that did not FILL its limit reached the end of the matching set, so its
+ * span is unbounded and rule 3 has no members.
+ */
+export function reconcileRefreshedWindow<T extends BrowseOrderKey>(
+  resident: readonly T[],
+  refreshed: readonly T[],
+  requestedLimit: number,
+): readonly T[] {
+  const spanEnd = refreshed.length >= requestedLimit ? refreshed.at(-1) : undefined
+  if (spanEnd === undefined) return [...refreshed]
+  const refreshedIds = new Set(refreshed.map((row) => row.id))
+  const tail = resident.filter(
+    (row) => !refreshedIds.has(row.id) && compareDefaultBrowseOrder(row, spanEnd) > 0,
+  )
+  return tail.length === 0 ? [...refreshed] : [...refreshed, ...tail]
+}

--- a/packages/inspector/src/browse/canonical-query.ts
+++ b/packages/inspector/src/browse/canonical-query.ts
@@ -1,12 +1,21 @@
 import type { MemoryKind, MemoryStatus } from "@dawn-ai/memory/browse"
 
-/** Which surface the records are being browsed for. Part of the dataset identity:
- *  timeline defaults the kind funnel to episodic, so the two views ask different
- *  questions and must never share a fulfilled result. */
+/** Which surface is browsing. Never sent to the server: it selects the kind default
+ *  and the component that consumes the page.
+ *
+ *  It is part of the dataset identity anyway. A timeline query and a list query
+ *  narrowed to episodic serialize to the SAME params, so keying on `view` costs a
+ *  refetch on that one toggle — paid deliberately, because the resident window and
+ *  the offset it implies belong to the surface that paged them, and a switch that
+ *  inherited them would resume another surface's walk. */
 export type BrowseView = "list" | "timeline"
 
 /**
- * The canonical form of everything that decides WHICH records the server returns.
+ * The canonical form of everything that narrows WHICH records the server returns.
+ *
+ * The inverse of `src/store/browse-params.ts`, which decodes what this encodes; the
+ * expiry cutoff is the one narrowing that lives in neither — `browseSearchParams`
+ * switches it off rather than carrying it, for the reason stated there.
  *
  * `null` means unfiltered and `[]` means matches-nothing — the same distinction
  * `BrowseQuery` draws, kept rather than collapsed so an emptied funnel cannot read
@@ -22,16 +31,28 @@ export interface CanonicalBrowseQuery {
 }
 
 /** Timeline is an episode view: the kind funnel still overrides, but with nothing
- *  ticked it asks for episodes rather than for everything. */
-const TIMELINE_DEFAULT_KIND: readonly MemoryKind[] = ["episodic"]
+ *  ticked it asks for episodes rather than for everything. Handed out by reference to
+ *  every call that takes the default, so a mutation would reach all of them. */
+const TIMELINE_DEFAULT_KIND: readonly MemoryKind[] = Object.freeze(["episodic"])
 
 /** Sorted and deduped, so two funnels that tick the same boxes in a different order
- *  produce ONE dataset key rather than two. */
+ *  produce ONE dataset key rather than two. Frozen because `readonly` is erased at
+ *  runtime, and one widening cast downstream would let a `.sort()` or `.push()` edit
+ *  a set the key was already taken over. */
 function normalizeSet<T extends string>(values: readonly T[] | undefined): readonly T[] | null {
   if (values === undefined) return null
-  return [...new Set(values)].sort()
+  return Object.freeze([...new Set(values)].sort())
 }
 
+/**
+ * MEMOIZE the result. Identity is fresh on every call, so `datasetKeyOf` is the only
+ * comparison that answers "same question"; anything keyed on the object itself sees a
+ * new dataset every render.
+ *
+ * A `since` derived from the clock must be pinned to the moment its window changed,
+ * never recomputed per render: it is part of the identity, so a moving `since` bumps
+ * the key on every render and refetches forever.
+ */
 export function canonicalBrowseQuery(input: {
   readonly view: BrowseView
   readonly namespace?: string | undefined
@@ -42,7 +63,9 @@ export function canonicalBrowseQuery(input: {
   const kind = normalizeSet(input.kind)
   return {
     view: input.view,
-    namespace: input.namespace ?? null,
+    // `||`, not `??`: `""` is not a namespace the server can express — `browse-params.ts`
+    // drops a falsy one — so it must not read as a narrowing on this side either.
+    namespace: input.namespace || null,
     status: normalizeSet(input.status),
     // `[] ?? x` is `[]`, so an emptied funnel survives the timeline default intact.
     kind: kind ?? (input.view === "timeline" ? TIMELINE_DEFAULT_KIND : null),
@@ -51,9 +74,10 @@ export function canonicalBrowseQuery(input: {
 }
 
 /**
- * The dataset identity. Two queries share a key exactly when they ask the same
- * question; any change bumps the desired revision, invalidates the loaded records
- * and the total together, and pivots the grid's `resultMeta.datasetKey`.
+ * The dataset identity. One direction only: a shared key guarantees the same
+ * question, while two keys do not guarantee two questions — `view` splits one pair
+ * that serializes identically. Any change bumps the desired revision, invalidates the
+ * loaded records and the total together, and pivots the grid's `resultMeta.datasetKey`.
  *
  * The canonical JSON IS the key. A hash would only shorten a string that nothing
  * but `===` ever reads, and would buy a collision class in exchange — while an
@@ -70,11 +94,20 @@ export function browseMatchesNothing(query: CanonicalBrowseQuery): boolean {
   return query.status?.length === 0 || query.kind?.length === 0
 }
 
-/** One window of `query`, as the params `/api/memory/list` parses. */
+/**
+ * One window of `query`, as the params `/api/memory/list` parses.
+ *
+ * THROWS on a matches-nothing query. `browseMatchesNothing` is the guard, and a
+ * caller that skips it has to fail loudly: the params for an empty set are the params
+ * for no set at all, so the request would come back unfiltered — every record, in
+ * answer to "none of them".
+ */
 export function browseSearchParams(
   query: CanonicalBrowseQuery,
   window: { readonly limit: number; readonly offset: number },
 ): URLSearchParams {
+  if (browseMatchesNothing(query))
+    throw new Error("browseSearchParams: this query matches nothing; resolve it locally")
   const params = new URLSearchParams()
   // EXACT namespace, not `namespacePrefix`: a prefix answer and an exact total
   // describe different sets, and this UI displays the two side by side.
@@ -82,6 +115,13 @@ export function browseSearchParams(
   for (const value of query.status ?? []) params.append("status", value)
   for (const value of query.kind ?? []) params.append("kind", value)
   if (query.since !== null) params.set("since", query.since)
+  // The expiry cutoff is switched OFF rather than pinned, which is what makes the
+  // dataset key total. Left to default, the route stamps `now` per request, so an
+  // episode expiring mid-walk shifts every later offset up by one and that row is
+  // skipped for good — and two requests sharing a key answer different sets. Pinning
+  // a `now` here would instead freeze the cutoff for a view that re-polls every two
+  // seconds, and advancing it would pivot the whole dataset just to move a clock.
+  params.set("includeExpired", "1")
   params.set("limit", String(window.limit))
   params.set("offset", String(window.offset))
   return params

--- a/packages/inspector/src/browse/canonical-query.ts
+++ b/packages/inspector/src/browse/canonical-query.ts
@@ -1,0 +1,88 @@
+import type { MemoryKind, MemoryStatus } from "@dawn-ai/memory/browse"
+
+/** Which surface the records are being browsed for. Part of the dataset identity:
+ *  timeline defaults the kind funnel to episodic, so the two views ask different
+ *  questions and must never share a fulfilled result. */
+export type BrowseView = "list" | "timeline"
+
+/**
+ * The canonical form of everything that decides WHICH records the server returns.
+ *
+ * `null` means unfiltered and `[]` means matches-nothing — the same distinction
+ * `BrowseQuery` draws, kept rather than collapsed so an emptied funnel cannot read
+ * as "show everything". Every field is present rather than optional, so the key
+ * builder below can stringify a fixed field order with no optional-property hole.
+ */
+export interface CanonicalBrowseQuery {
+  readonly view: BrowseView
+  readonly namespace: string | null
+  readonly status: readonly MemoryStatus[] | null
+  readonly kind: readonly MemoryKind[] | null
+  readonly since: string | null
+}
+
+/** Timeline is an episode view: the kind funnel still overrides, but with nothing
+ *  ticked it asks for episodes rather than for everything. */
+const TIMELINE_DEFAULT_KIND: readonly MemoryKind[] = ["episodic"]
+
+/** Sorted and deduped, so two funnels that tick the same boxes in a different order
+ *  produce ONE dataset key rather than two. */
+function normalizeSet<T extends string>(values: readonly T[] | undefined): readonly T[] | null {
+  if (values === undefined) return null
+  return [...new Set(values)].sort()
+}
+
+export function canonicalBrowseQuery(input: {
+  readonly view: BrowseView
+  readonly namespace?: string | undefined
+  readonly status?: readonly MemoryStatus[] | undefined
+  readonly kind?: readonly MemoryKind[] | undefined
+  readonly since?: string | undefined
+}): CanonicalBrowseQuery {
+  const kind = normalizeSet(input.kind)
+  return {
+    view: input.view,
+    namespace: input.namespace ?? null,
+    status: normalizeSet(input.status),
+    // `[] ?? x` is `[]`, so an emptied funnel survives the timeline default intact.
+    kind: kind ?? (input.view === "timeline" ? TIMELINE_DEFAULT_KIND : null),
+    since: input.since ?? null,
+  }
+}
+
+/**
+ * The dataset identity. Two queries share a key exactly when they ask the same
+ * question; any change bumps the desired revision, invalidates the loaded records
+ * and the total together, and pivots the grid's `resultMeta.datasetKey`.
+ *
+ * The canonical JSON IS the key. A hash would only shorten a string that nothing
+ * but `===` ever reads, and would buy a collision class in exchange — while an
+ * unhashed key stays legible in a failing assertion.
+ */
+export function datasetKeyOf(query: CanonicalBrowseQuery): string {
+  return JSON.stringify([query.view, query.namespace, query.status, query.kind, query.since])
+}
+
+/** A set narrowed to nothing matches nothing. Over HTTP a repeated param that
+ *  appears zero times is ABSENT, so asking the server would come back unfiltered —
+ *  the opposite answer. Callers must resolve this locally instead. */
+export function browseMatchesNothing(query: CanonicalBrowseQuery): boolean {
+  return query.status?.length === 0 || query.kind?.length === 0
+}
+
+/** One window of `query`, as the params `/api/memory/list` parses. */
+export function browseSearchParams(
+  query: CanonicalBrowseQuery,
+  window: { readonly limit: number; readonly offset: number },
+): URLSearchParams {
+  const params = new URLSearchParams()
+  // EXACT namespace, not `namespacePrefix`: a prefix answer and an exact total
+  // describe different sets, and this UI displays the two side by side.
+  if (query.namespace !== null) params.set("namespace", query.namespace)
+  for (const value of query.status ?? []) params.append("status", value)
+  for (const value of query.kind ?? []) params.append("kind", value)
+  if (query.since !== null) params.set("since", query.since)
+  params.set("limit", String(window.limit))
+  params.set("offset", String(window.offset))
+  return params
+}

--- a/packages/inspector/src/browse/use-memory-browse.ts
+++ b/packages/inspector/src/browse/use-memory-browse.ts
@@ -32,6 +32,16 @@ export type BrowseFetcher = (
   signal: AbortSignal,
 ) => Promise<BrowsePageResponse>
 
+/** A 200 is not a page. An unparseable body, an HTML error page from a proxy, a JSON
+ *  object shaped like something else — each reaches the reducer as a page it then
+ *  destructures, and the throw lands in a promise handler rather than here. Checked at
+ *  the boundary, the same body becomes an ordinary request failure with a banner. */
+function isBrowsePage(body: unknown): body is BrowsePageResponse {
+  if (body === null || typeof body !== "object") return false
+  const page = body as { records?: unknown; total?: unknown }
+  return Array.isArray(page.records) && typeof page.total === "number"
+}
+
 /** GET one browse window, surfacing the API's `{error}` body as the thrown message. */
 export async function fetchBrowsePage(
   params: URLSearchParams,
@@ -46,7 +56,8 @@ export async function fetchBrowsePage(
         : `request failed (${response.status})`
     throw new Error(message)
   }
-  return body as BrowsePageResponse
+  if (!isBrowsePage(body)) throw new Error(`not a browse page (${response.status})`)
+  return body
 }
 
 export interface UseMemoryBrowseOptions {
@@ -85,22 +96,32 @@ export function useMemoryBrowse(options: UseMemoryBrowseOptions): UseMemoryBrows
 
   const [state, setState] = useState<BrowseState>(INITIAL_BROWSE_STATE)
 
-  // Render-time mirrors of values the async paths read. Each is a pure copy of
-  // something this render already holds, so a re-render can only re-copy the same
-  // thing — the pattern is safe precisely because nothing else writes them.
+  // Mirrors of the options the async paths read, seeded from the mounting render and
+  // written on COMMIT thereafter — NEVER during render. A render React throws away (a
+  // transition that suspends), or a dispatch that lands between a commit and its
+  // effect flush, would otherwise build params from a query no state ever matched
+  // while tagging them with the revision the state still holds — and `browseReduce`
+  // ACCEPTS that response, merging one question's rows and total under the other's
+  // dataset key. Lagging a render behind within one key is harmless: the key is the
+  // JSON of exactly the fields `browseSearchParams` reads.
   const queryRef = useRef(query)
-  queryRef.current = query
-  const fetchRef = useRef<BrowseFetcher>(fetchBrowsePage)
-  fetchRef.current = options.fetchPage ?? fetchBrowsePage
-  const nowRef = useRef<() => number>(Date.now)
-  nowRef.current = options.now ?? Date.now
+  const fetchRef = useRef<BrowseFetcher>(options.fetchPage ?? fetchBrowsePage)
+  const nowRef = useRef<() => number>(options.now ?? Date.now)
+  useEffect(() => {
+    queryRef.current = query
+    fetchRef.current = options.fetchPage ?? fetchBrowsePage
+    nowRef.current = options.now ?? Date.now
+  })
 
   // The machine's state lives in a ref as well as in `useState`: dispatches arrive
   // from timers and promise callbacks that must read the CURRENT state, not the one
   // their closure captured.
   const stateRef = useRef<BrowseState>(INITIAL_BROWSE_STATE)
   const controllerRef = useRef<AbortController | null>(null)
-  const mountedRef = useRef(false)
+  // `dispatch` calls `startRequest` and `startRequest` calls back into `dispatch`, so
+  // one of the two has to reach the other through a ref rather than a closure. This
+  // one keeps `startRequest` dependency-free, which is what makes `dispatch` stable
+  // for the hook's whole lifetime — the interval below depends on that.
   const dispatchRef = useRef<(event: BrowseEvent) => void>(() => {})
 
   const startRequest = useCallback((request: BrowseRequest) => {
@@ -116,13 +137,34 @@ export function useMemoryBrowse(options: UseMemoryBrowseOptions): UseMemoryBrows
       })
       return
     }
+    const failureOf = (error: unknown): BrowseEvent => ({
+      type: "failure",
+      revision: request.revision,
+      kind: request.kind,
+      message: error instanceof Error ? error.message : String(error),
+    })
+    // The reducer asserts its invariants by throwing, and it runs SYNCHRONOUSLY inside
+    // these handlers. An escaping throw resolves nothing and never reaches the
+    // assignment that clears `inFlight`, so single flight would then skip every later
+    // tick, retry and load-more: the hook stops forever, silently, as an unhandled
+    // rejection. The failure branch cannot throw, so one recovery is enough.
+    const settle = (event: BrowseEvent) => {
+      try {
+        dispatchRef.current(event)
+      } catch (error) {
+        dispatchRef.current(failureOf(error))
+      }
+    }
     const controller = new AbortController()
     controllerRef.current = controller
     void fetchRef.current(browseSearchParams(current, request.window), controller.signal).then(
       (page) => {
-        if (controller.signal.aborted || !mountedRef.current) return
+        // The reducer discards a superseded response WHOLE on its own revision check,
+        // so this is not what makes the answer right; it is what keeps an aborted
+        // request from costing anything more, the clock read included.
+        if (controller.signal.aborted) return
         if (controllerRef.current === controller) controllerRef.current = null
-        dispatchRef.current({
+        settle({
           type: "response",
           revision: request.revision,
           kind: request.kind,
@@ -131,14 +173,9 @@ export function useMemoryBrowse(options: UseMemoryBrowseOptions): UseMemoryBrows
         })
       },
       (error: unknown) => {
-        if (controller.signal.aborted || !mountedRef.current) return
+        if (controller.signal.aborted) return
         if (controllerRef.current === controller) controllerRef.current = null
-        dispatchRef.current({
-          type: "failure",
-          revision: request.revision,
-          kind: request.kind,
-          message: error instanceof Error ? error.message : String(error),
-        })
+        settle(failureOf(error))
       },
     )
   }, [])
@@ -161,7 +198,6 @@ export function useMemoryBrowse(options: UseMemoryBrowseOptions): UseMemoryBrows
   // Mount and every canonical-query change are the SAME transition: bump the desired
   // revision, abort what was in flight, fetch the first window.
   useEffect(() => {
-    mountedRef.current = true
     const current = stateRef.current
     if (current.datasetKey !== datasetKey) {
       dispatch({ type: "query-changed", datasetKey })
@@ -176,7 +212,6 @@ export function useMemoryBrowse(options: UseMemoryBrowseOptions): UseMemoryBrows
       dispatch({ type: "retry" })
     }
     return () => {
-      mountedRef.current = false
       if (controllerRef.current !== null) {
         controllerRef.current.abort()
         controllerRef.current = null
@@ -200,38 +235,44 @@ export function useMemoryBrowse(options: UseMemoryBrowseOptions): UseMemoryBrows
   // presentation would flicker on a 2 s cadence.
   const paused = !live || !tabVisible || phase === "error"
 
-  const tickRef = useRef(() => {})
-  tickRef.current = () => dispatch({ type: "poll-tick" })
-
   useEffect(() => {
     if (paused) return
     // Resuming — live back on, tab visible again, a retry that succeeded — ticks NOW
     // rather than up to one interval later. On mount the initial request is already
     // in flight, so the machine skips this tick.
-    tickRef.current()
-    const id = setInterval(() => tickRef.current(), pollIntervalMs)
+    dispatch({ type: "poll-tick" })
+    const id = setInterval(() => dispatch({ type: "poll-tick" }), pollIntervalMs)
     return () => clearInterval(id)
-  }, [paused, pollIntervalMs])
+  }, [paused, pollIntervalMs, dispatch])
 
   const loadMore = useCallback(() => dispatch({ type: "load-more-requested" }), [dispatch])
+  // The same event the interval sends, so a press that lands while anything is in
+  // flight is SKIPPED by single flight rather than queued: nothing here distinguishes
+  // user intent from a timer, and the phase is already `refreshing`, so the press
+  // leaves no trace on screen either.
   const refresh = useCallback(() => dispatch({ type: "poll-tick" }), [dispatch])
   const retry = useCallback(() => dispatch({ type: "retry" }), [dispatch])
 
   const fulfilled = state.fulfilled
+  // Keyed on the two VALUES published rather than on the fulfillment that carries them:
+  // every response allocates a fresh one, so a 2 s cadence would hand the grid a new
+  // `resultMeta` — and with it a dataset pivot — for an answer that did not change.
+  const fulfilledKey = fulfilled === null ? null : fulfilled.datasetKey
+  const fulfilledTotal = fulfilled === null ? null : fulfilled.total
   const resultMeta = useMemo<PretableResultMeta>(
     () =>
-      fulfilled === null
+      fulfilledKey === null || fulfilledTotal === null
         ? UNKNOWN_TOTAL_META
         : {
             // The FULFILLED key, never the desired one: the grid must clear selection
             // and focus when the new answer LANDS, not when the question changes — a
             // selection over the old rows is still valid for the old rows.
-            datasetKey: fulfilled.datasetKey,
-            total: { kind: "exact", count: fulfilled.total },
+            datasetKey: fulfilledKey,
+            total: { kind: "exact", count: fulfilledTotal },
           },
-    [fulfilled],
+    [fulfilledKey, fulfilledTotal],
   )
-  const dataState = useMemo(() => browseDataState(state), [state])
+  const dataState = browseDataState(state)
 
   return {
     records: fulfilled?.records ?? NO_RECORDS,

--- a/packages/inspector/src/browse/use-memory-browse.ts
+++ b/packages/inspector/src/browse/use-memory-browse.ts
@@ -1,0 +1,249 @@
+"use client"
+import type { MemoryRecord } from "@dawn-ai/memory/browse"
+import type { PretableDataState, PretableResultMeta } from "@pretable/react"
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import {
+  type BrowseEvent,
+  type BrowseKindErrors,
+  type BrowsePageResponse,
+  type BrowseRequest,
+  type BrowseState,
+  browseCanLoadMore,
+  browseDataState,
+  browsePhase,
+  browseReduce,
+  INITIAL_BROWSE_STATE,
+} from "./browse-machine"
+import {
+  browseMatchesNothing,
+  browseSearchParams,
+  type CanonicalBrowseQuery,
+  datasetKeyOf,
+} from "./canonical-query"
+
+export const BROWSE_POLL_INTERVAL_MS = 2000
+
+const NO_RECORDS: readonly MemoryRecord[] = []
+const EMPTY_PAGE: BrowsePageResponse = { records: NO_RECORDS, total: 0 }
+const UNKNOWN_TOTAL_META: PretableResultMeta = { total: { kind: "unknown" } }
+
+export type BrowseFetcher = (
+  params: URLSearchParams,
+  signal: AbortSignal,
+) => Promise<BrowsePageResponse>
+
+/** GET one browse window, surfacing the API's `{error}` body as the thrown message. */
+export async function fetchBrowsePage(
+  params: URLSearchParams,
+  signal: AbortSignal,
+): Promise<BrowsePageResponse> {
+  const response = await fetch(`/api/memory/list?${params}`, { signal })
+  const body: unknown = await response.json().catch(() => undefined)
+  if (!response.ok) {
+    const message =
+      body && typeof body === "object" && typeof (body as { error?: unknown }).error === "string"
+        ? (body as { error: string }).error
+        : `request failed (${response.status})`
+    throw new Error(message)
+  }
+  return body as BrowsePageResponse
+}
+
+export interface UseMemoryBrowseOptions {
+  /** MEMOIZE the canonical query. A fresh object per render is harmless (the dataset
+   *  key decides), but a `since` recomputed from `Date.now()` on every render would
+   *  bump the desired revision on every render and refetch forever. */
+  readonly query: CanonicalBrowseQuery
+  readonly live: boolean
+  readonly pollIntervalMs?: number
+  readonly fetchPage?: BrowseFetcher
+  readonly now?: () => number
+}
+
+export interface UseMemoryBrowseResult {
+  readonly records: readonly MemoryRecord[]
+  readonly dataState: PretableDataState
+  readonly resultMeta: PretableResultMeta
+  /** Matching population for the FULFILLED revision, or null when nothing is
+   *  fulfilled. Never the desired revision's — that number does not exist yet. */
+  readonly total: number | null
+  readonly errors: BrowseKindErrors
+  /** Epoch ms of the newest fulfilled response, or null. */
+  readonly updatedAt: number | null
+  /** Polling is suspended: live off, tab hidden, or a held error. */
+  readonly paused: boolean
+  readonly canLoadMore: boolean
+  loadMore(): void
+  refresh(): void
+  retry(): void
+}
+
+export function useMemoryBrowse(options: UseMemoryBrowseOptions): UseMemoryBrowseResult {
+  const { query, live } = options
+  const pollIntervalMs = options.pollIntervalMs ?? BROWSE_POLL_INTERVAL_MS
+  const datasetKey = useMemo(() => datasetKeyOf(query), [query])
+
+  const [state, setState] = useState<BrowseState>(INITIAL_BROWSE_STATE)
+
+  // Render-time mirrors of values the async paths read. Each is a pure copy of
+  // something this render already holds, so a re-render can only re-copy the same
+  // thing — the pattern is safe precisely because nothing else writes them.
+  const queryRef = useRef(query)
+  queryRef.current = query
+  const fetchRef = useRef<BrowseFetcher>(fetchBrowsePage)
+  fetchRef.current = options.fetchPage ?? fetchBrowsePage
+  const nowRef = useRef<() => number>(Date.now)
+  nowRef.current = options.now ?? Date.now
+
+  // The machine's state lives in a ref as well as in `useState`: dispatches arrive
+  // from timers and promise callbacks that must read the CURRENT state, not the one
+  // their closure captured.
+  const stateRef = useRef<BrowseState>(INITIAL_BROWSE_STATE)
+  const controllerRef = useRef<AbortController | null>(null)
+  const mountedRef = useRef(false)
+  const dispatchRef = useRef<(event: BrowseEvent) => void>(() => {})
+
+  const startRequest = useCallback((request: BrowseRequest) => {
+    const current = queryRef.current
+    if (browseMatchesNothing(current)) {
+      // Answered locally, without a request — see `browseMatchesNothing`.
+      dispatchRef.current({
+        type: "response",
+        revision: request.revision,
+        kind: request.kind,
+        page: EMPTY_PAGE,
+        at: nowRef.current(),
+      })
+      return
+    }
+    const controller = new AbortController()
+    controllerRef.current = controller
+    void fetchRef.current(browseSearchParams(current, request.window), controller.signal).then(
+      (page) => {
+        if (controller.signal.aborted || !mountedRef.current) return
+        if (controllerRef.current === controller) controllerRef.current = null
+        dispatchRef.current({
+          type: "response",
+          revision: request.revision,
+          kind: request.kind,
+          page,
+          at: nowRef.current(),
+        })
+      },
+      (error: unknown) => {
+        if (controller.signal.aborted || !mountedRef.current) return
+        if (controllerRef.current === controller) controllerRef.current = null
+        dispatchRef.current({
+          type: "failure",
+          revision: request.revision,
+          kind: request.kind,
+          message: error instanceof Error ? error.message : String(error),
+        })
+      },
+    )
+  }, [])
+
+  const dispatch = useCallback(
+    (event: BrowseEvent) => {
+      const transition = browseReduce(stateRef.current, event)
+      if (transition.abort && controllerRef.current !== null) {
+        controllerRef.current.abort()
+        controllerRef.current = null
+      }
+      stateRef.current = transition.state
+      setState(transition.state)
+      if (transition.start !== null) startRequest(transition.start)
+    },
+    [startRequest],
+  )
+  dispatchRef.current = dispatch
+
+  // Mount and every canonical-query change are the SAME transition: bump the desired
+  // revision, abort what was in flight, fetch the first window.
+  useEffect(() => {
+    mountedRef.current = true
+    const current = stateRef.current
+    if (current.datasetKey !== datasetKey) {
+      dispatch({ type: "query-changed", datasetKey })
+    } else if (
+      current.inFlight === null &&
+      current.fulfilled === null &&
+      current.initialFailure === null
+    ) {
+      // Re-arm after a StrictMode remount: the cleanup below aborted the mount
+      // request without producing a response or a failure, so nothing else would
+      // ever move this hook out of `loading`.
+      dispatch({ type: "retry" })
+    }
+    return () => {
+      mountedRef.current = false
+      if (controllerRef.current !== null) {
+        controllerRef.current.abort()
+        controllerRef.current = null
+        // Ref only — a setState after unmount is pointless, and the branch above
+        // reads this ref to decide whether a remount must re-arm.
+        stateRef.current = { ...stateRef.current, inFlight: null, queuedLoadMore: false }
+      }
+    }
+  }, [datasetKey, dispatch])
+
+  const [tabVisible, setTabVisible] = useState(true)
+  useEffect(() => {
+    const sync = () => setTabVisible(document.visibilityState !== "hidden")
+    sync()
+    document.addEventListener("visibilitychange", sync)
+    return () => document.removeEventListener("visibilitychange", sync)
+  }, [])
+
+  const phase = browsePhase(state)
+  // A held error suspends polling until `retry()` succeeds: without that, the error
+  // presentation would flicker on a 2 s cadence.
+  const paused = !live || !tabVisible || phase === "error"
+
+  const tickRef = useRef(() => {})
+  tickRef.current = () => dispatch({ type: "poll-tick" })
+
+  useEffect(() => {
+    if (paused) return
+    // Resuming — live back on, tab visible again, a retry that succeeded — ticks NOW
+    // rather than up to one interval later. On mount the initial request is already
+    // in flight, so the machine skips this tick.
+    tickRef.current()
+    const id = setInterval(() => tickRef.current(), pollIntervalMs)
+    return () => clearInterval(id)
+  }, [paused, pollIntervalMs])
+
+  const loadMore = useCallback(() => dispatch({ type: "load-more-requested" }), [dispatch])
+  const refresh = useCallback(() => dispatch({ type: "poll-tick" }), [dispatch])
+  const retry = useCallback(() => dispatch({ type: "retry" }), [dispatch])
+
+  const fulfilled = state.fulfilled
+  const resultMeta = useMemo<PretableResultMeta>(
+    () =>
+      fulfilled === null
+        ? UNKNOWN_TOTAL_META
+        : {
+            // The FULFILLED key, never the desired one: the grid must clear selection
+            // and focus when the new answer LANDS, not when the question changes — a
+            // selection over the old rows is still valid for the old rows.
+            datasetKey: fulfilled.datasetKey,
+            total: { kind: "exact", count: fulfilled.total },
+          },
+    [fulfilled],
+  )
+  const dataState = useMemo(() => browseDataState(state), [state])
+
+  return {
+    records: fulfilled?.records ?? NO_RECORDS,
+    dataState,
+    resultMeta,
+    total: fulfilled?.total ?? null,
+    errors: state.kindErrors,
+    updatedAt: fulfilled?.at ?? null,
+    paused,
+    canLoadMore: browseCanLoadMore(state),
+    loadMore,
+    refresh,
+    retry,
+  }
+}

--- a/packages/inspector/src/components/memory/browse-chrome.tsx
+++ b/packages/inspector/src/components/memory/browse-chrome.tsx
@@ -10,32 +10,35 @@ export interface BrowseErrorEntry {
 }
 
 /**
- * One line per failing source, in a single live region.
+ * One line per failing source, with the lines — and only the lines — in a live
+ * region.
  *
  * Keyed by SOURCE and not by message: two sources failing with the same text must
  * not collide as React keys, and a source that succeeds must clear only its own
- * line. The retry control appears only for browse-request failures — the error
- * PHASE's retry lives in the grid's body-state block instead, so exactly one retry
- * control is ever on screen.
+ * line. `role="alert"` is atomic, so the retry control sits outside the region;
+ * within it, the button's label would be announced as part of the failure text.
+ *
+ * Callers pass `onRetry` for browse-REQUEST failures only. The error PHASE's retry
+ * lives in the grid's body-state block, and the two must never be on screen
+ * together — a rule this component cannot enforce.
  */
 export function BrowseErrorBanners({
   errors,
   onRetry,
 }: {
   errors: readonly BrowseErrorEntry[]
-  onRetry?: (() => void) | undefined
+  onRetry?: () => void
 }) {
   if (errors.length === 0) return null
   return (
-    <div
-      role="alert"
-      className="mb-3 space-y-1 rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700"
-    >
-      {errors.map((entry) => (
-        <div key={entry.source} data-testid={`error-${entry.source}`}>
-          {entry.message}
-        </div>
-      ))}
+    <div className="mb-3 rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
+      <div role="alert" className="space-y-1">
+        {errors.map((entry) => (
+          <div key={entry.source} data-testid={`error-${entry.source}`}>
+            {entry.message}
+          </div>
+        ))}
+      </div>
       {onRetry ? (
         <Button variant="outline" className="mt-1 h-7 px-2" onClick={onRetry}>
           Retry
@@ -48,12 +51,10 @@ export function BrowseErrorBanners({
 /**
  * Counts and freshness.
  *
- * `total` is the matching population for the FULFILLED revision, so before the
- * first response the bar says only what it knows. `asOf` is non-null only while
- * polling is paused: a live grid stamping "updated 14:32:07" two seconds before it
- * changes again is noise, while a paused one that says nothing is a lie by
- * omission. With nothing fulfilled there is no instant to quote, so the caller
- * passes null and the stamp stays off.
+ * `total` is the matching population for the FULFILLED revision, and null until the
+ * first response lands. `asOf` is the caller's decision, not this component's: it
+ * passes an instant only while polling is paused, and null whenever no revision has
+ * been fulfilled.
  */
 export function BrowseStatusBar({
   loaded,

--- a/packages/inspector/src/components/memory/browse-chrome.tsx
+++ b/packages/inspector/src/components/memory/browse-chrome.tsx
@@ -1,0 +1,84 @@
+"use client"
+import type { PretableDataState } from "@pretable/react"
+import { Button } from "../ui/button"
+
+export interface BrowseErrorEntry {
+  /** The slot this failure belongs to. Independent per source, so one source's
+   *  success can never clear another's failure. */
+  readonly source: string
+  readonly message: string
+}
+
+/**
+ * One line per failing source, in a single live region.
+ *
+ * Keyed by SOURCE and not by message: two sources failing with the same text must
+ * not collide as React keys, and a source that succeeds must clear only its own
+ * line. The retry control appears only for browse-request failures — the error
+ * PHASE's retry lives in the grid's body-state block instead, so exactly one retry
+ * control is ever on screen.
+ */
+export function BrowseErrorBanners({
+  errors,
+  onRetry,
+}: {
+  errors: readonly BrowseErrorEntry[]
+  onRetry?: (() => void) | undefined
+}) {
+  if (errors.length === 0) return null
+  return (
+    <div
+      role="alert"
+      className="mb-3 space-y-1 rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700"
+    >
+      {errors.map((entry) => (
+        <div key={entry.source} data-testid={`error-${entry.source}`}>
+          {entry.message}
+        </div>
+      ))}
+      {onRetry ? (
+        <Button variant="outline" className="mt-1 h-7 px-2" onClick={onRetry}>
+          Retry
+        </Button>
+      ) : null}
+    </div>
+  )
+}
+
+/**
+ * Counts and freshness.
+ *
+ * `total` is the matching population for the FULFILLED revision, so before the
+ * first response the bar says only what it knows. `asOf` is non-null only while
+ * polling is paused: a live grid stamping "updated 14:32:07" two seconds before it
+ * changes again is noise, while a paused one that says nothing is a lie by
+ * omission. With nothing fulfilled there is no instant to quote, so the caller
+ * passes null and the stamp stays off.
+ */
+export function BrowseStatusBar({
+  loaded,
+  total,
+  phase,
+  asOf,
+}: {
+  loaded: number
+  total: number | null
+  phase: PretableDataState["phase"]
+  asOf: number | null
+}) {
+  return (
+    <p
+      data-testid="browse-status"
+      data-phase={phase}
+      className="mb-2 flex items-center gap-3 text-xs text-zinc-500"
+    >
+      <span>
+        {total === null
+          ? `${loaded.toLocaleString()} loaded`
+          : `${loaded.toLocaleString()} loaded of ${total.toLocaleString()} matching`}
+      </span>
+      {phase === "stale" ? <span>Updating results…</span> : null}
+      {asOf === null ? null : <span>{`Updated ${new Date(asOf).toLocaleTimeString()}`}</span>}
+    </p>
+  )
+}

--- a/packages/inspector/src/components/memory/browse-chrome.tsx
+++ b/packages/inspector/src/components/memory/browse-chrome.tsx
@@ -18,9 +18,11 @@ export interface BrowseErrorEntry {
  * line. `role="alert"` is atomic, so the retry control sits outside the region;
  * within it, the button's label would be announced as part of the failure text.
  *
- * Callers pass `onRetry` for browse-REQUEST failures only. The error PHASE's retry
- * lives in the grid's body-state block, and the two must never be on screen
- * together — a rule this component cannot enforce.
+ * Callers pass `onRetry` only for a failure this banner is the sole channel for: the
+ * browse REQUEST kinds always, and the error PHASE only on a surface with no
+ * body-state block of its own. Wherever the grid is mounted it owns that phase, and
+ * the two retries must never be on screen together — a rule this component cannot
+ * enforce.
  */
 export function BrowseErrorBanners({
   errors,

--- a/packages/inspector/src/components/memory/list-page.tsx
+++ b/packages/inspector/src/components/memory/list-page.tsx
@@ -2,9 +2,12 @@
 import type { MemoryKind, MemoryRecord, MemoryStats, MemoryStatus } from "@dawn-ai/memory"
 import type { ColumnFilter } from "@pretable/react"
 import { useCallback, useEffect, useMemo, useState } from "react"
+import { canonicalBrowseQuery } from "../../browse/canonical-query"
+import { useMemoryBrowse } from "../../browse/use-memory-browse"
 import { Badge } from "../ui/badge"
 import { Input } from "../ui/input"
 import { usePolling } from "../use-polling"
+import { BrowseErrorBanners, type BrowseErrorEntry, BrowseStatusBar } from "./browse-chrome"
 import { BulkBar } from "./bulk-bar"
 import { resolveFilter, toFilter, type ValueSet } from "./column-filters"
 import { DetailSheet } from "./detail-sheet"
@@ -12,10 +15,6 @@ import { FacetRail } from "./facet-rail"
 import { KINDS, MemoryGrid, STATUSES } from "./memory-grid"
 import { TimelineView } from "./timeline-view"
 
-interface ListResponse {
-  readonly records: readonly MemoryRecord[]
-  readonly total: number
-}
 interface SearchResponse {
   readonly groups: readonly {
     readonly namespace: string
@@ -24,9 +23,10 @@ interface SearchResponse {
   readonly hybrid?: boolean
 }
 
-/** Each fetcher owns its own error slot — a stats success must not clear a
- *  search failure's banner (they poll on independent cadences). */
-type ErrorSource = "stats" | "list" | "search"
+/** Each source owns its own error slot — a stats success must not clear a search
+ *  failure's banner, and neither may clear a mutation's. The browse REQUEST kinds
+ *  (refresh, load-more) keep their own slots inside `useMemoryBrowse`. */
+type ErrorSource = "stats" | "search" | "mutation"
 
 /** Timeline window presets → milliseconds back from now ("all" = unbounded). */
 const WINDOWS = {
@@ -51,7 +51,6 @@ export function ListPage() {
   const [live, setLive] = useState(true)
   const [selectedId, setSelectedId] = useState<string>()
   const [ticked, setTicked] = useState<readonly string[]>([])
-  const [refreshKey, setRefreshKey] = useState(0)
   const [errors, setErrors] = useState<Partial<Record<ErrorSource, string>>>({})
   const [search, setSearch] = useState<SearchResponse>()
 
@@ -92,29 +91,6 @@ export function ListPage() {
     [fetchJson],
   )
 
-  const pageFn = useCallback(() => {
-    // refreshKey exists only to change this callback's identity after a
-    // mutation, so usePolling re-runs its immediate tick.
-    void refreshKey
-    const params = new URLSearchParams({ limit: "200" })
-    if (namespace) params.set("namespacePrefix", namespace)
-    for (const value of status ?? []) params.append("status", value)
-    // Timeline is an episode view — default the kind filter to episodic there
-    // (the kind funnel still overrides), and thread the client-computed window.
-    const effectiveKind = kind ?? (view === "timeline" ? (["episodic"] as const) : undefined)
-    for (const value of effectiveKind ?? []) params.append("kind", value)
-    if (view === "timeline" && timelineWindow !== "all") {
-      params.set("since", new Date(Date.now() - WINDOWS[timelineWindow]).toISOString())
-    }
-    // A set narrowed to nothing matches nothing. Over HTTP a param that appears
-    // zero times is *absent*, so the request would come back unfiltered —
-    // answer it here instead of asking a question that means the opposite.
-    if (status?.length === 0 || effectiveKind?.length === 0) {
-      return Promise.resolve<ListResponse>({ records: [], total: 0 })
-    }
-    return fetchJson<ListResponse>("list", `/api/memory/list?${params}`)
-  }, [fetchJson, namespace, status, kind, view, timelineWindow, refreshKey])
-
   const filters = useMemo(() => {
     const next: Record<string, ColumnFilter> = {}
     const statusFilter = toFilter(status, STATUSES)
@@ -129,8 +105,34 @@ export function ListPage() {
     setKind(resolveFilter(next.kind, KINDS))
   }, [])
 
+  // PINNED at the moment the window changes, not recomputed per render: `since` is
+  // part of the dataset identity, so a fresh `Date.now()` on every render would bump
+  // the desired revision on every render and refetch forever.
+  const since = useMemo(
+    () =>
+      view === "timeline" && timelineWindow !== "all"
+        ? new Date(Date.now() - WINDOWS[timelineWindow]).toISOString()
+        : undefined,
+    [view, timelineWindow],
+  )
+
+  const browseQuery = useMemo(
+    () =>
+      canonicalBrowseQuery({
+        view,
+        ...(namespace === undefined ? {} : { namespace }),
+        ...(status === undefined ? {} : { status }),
+        ...(kind === undefined ? {} : { kind }),
+        ...(since === undefined ? {} : { since }),
+      }),
+    [view, namespace, status, kind, since],
+  )
+
+  // Search replaces the browse view entirely, so browse stops polling behind it.
+  const browse = useMemoryBrowse({ query: browseQuery, live: live && !query })
+  const { refresh: refreshBrowse, retry: retryBrowse } = browse
+
   const stats = usePolling(statsFn, 2000, live)
-  const page = usePolling(pageFn, 2000, live && !query)
 
   // Search is fetched once per (debounced) query change, never polled — a
   // hybrid store would call the embedder on every search request.
@@ -165,8 +167,8 @@ export function ListPage() {
   const closeSheet = useCallback(() => setSelectedId(undefined), [])
   const handleMutated = useCallback(() => {
     setSelectedId(undefined)
-    setRefreshKey((k) => k + 1)
-  }, [])
+    refreshBrowse()
+  }, [refreshBrowse])
   // The grid keeps its own checkbox state, so clearing here would leave the
   // boxes ticked. Remounting it (see `key` below) is what actually resets both.
   const [gridEpoch, setGridEpoch] = useState(0)
@@ -176,33 +178,49 @@ export function ListPage() {
   }, [])
   const handleBulkDone = useCallback(
     ({ failed }: { failed: number }) => {
-      // Keep the selection when anything failed: clearing it unmounts the bar,
-      // and the report of what went wrong goes with it.
-      if (failed === 0) clearTicked()
-      setRefreshKey((k) => k + 1)
+      if (failed === 0) {
+        // Keep the selection when anything failed: clearing it unmounts the bar, and
+        // the report of what went wrong goes with it.
+        clearTicked()
+        setError("mutation", undefined)
+      } else {
+        setError("mutation", `${failed} bulk action(s) failed — see the bar for details.`)
+      }
+      refreshBrowse()
     },
-    [clearTicked],
+    [clearTicked, refreshBrowse, setError],
   )
 
   const byStatus = stats?.byStatus ?? {}
-  // The list API narrows by namespace PREFIX (server-side); a selected facet is
-  // an exact namespace, so filter the fetched page exactly — otherwise picking
-  // route=/chat would also show route=/chat2.
-  const pageRecords = namespace
-    ? (page?.records ?? []).filter((rec) => rec.namespace === namespace)
-    : (page?.records ?? [])
-  // Group headers count the rows the grid HOLDS, and the list is capped at a
-  // page. On a truncated page that count is an artifact of where the cap fell —
-  // it read "route=/notes (197)" next to a facet rail saying 250 — so group
-  // only when the page is the whole answer. The rail stays the honest
-  // navigator for anything larger.
-  const pageIsComplete = page !== undefined && page.records.length >= page.total
+  // No client-side narrowing any more: the request carries the EXACT namespace, so
+  // the rows on screen and `total` describe the same set. Filtering here would make
+  // "N loaded of M matching" a lie the moment a facet was clicked.
+  const pageRecords = browse.records
+  // Group headers count the rows the grid HOLDS. On a truncated window that count is
+  // an artifact of where the cap fell, so group only when the window is the whole
+  // answer; the facet rail stays the honest navigator for anything larger.
+  const pageIsComplete = browse.total !== null && pageRecords.length >= browse.total
+  const filtersActive = status !== undefined || kind !== undefined || namespace !== undefined
+  // "Nothing stored" and "nothing matches what you asked for" are different answers;
+  // telling a filtered view to go run its agent sends you looking for a bug that
+  // isn't there.
+  const emptyMessage = filtersActive
+    ? "No memories match these filters."
+    : "No memories yet — run your agent and watch them appear."
   const searching = query.length > 0
-  // Keyed by source, not message — two fetchers failing with the same message
-  // must not produce duplicate React keys (or stacked repeats).
-  const errorEntries = Object.entries(errors).filter((entry): entry is [ErrorSource, string] =>
-    Boolean(entry[1]),
-  )
+  const browseRequestFailed =
+    browse.errors.refresh !== undefined || browse.errors["load-more"] !== undefined
+  const errorEntries: BrowseErrorEntry[] = [
+    ...Object.entries(errors).flatMap(([source, message]) =>
+      message ? [{ source, message }] : [],
+    ),
+    ...(browse.errors.refresh === undefined
+      ? []
+      : [{ source: "refresh", message: `Refresh failed: ${browse.errors.refresh}` }]),
+    ...(browse.errors["load-more"] === undefined
+      ? []
+      : [{ source: "load-more", message: `Loading more failed: ${browse.errors["load-more"]}` }]),
+  ]
 
   return (
     <div className="flex h-screen flex-col">
@@ -267,16 +285,10 @@ export function ListPage() {
       <div className="flex min-h-0 flex-1">
         <FacetRail stats={stats} selected={namespace} onSelect={setNamespace} />
         <main className="min-w-0 flex-1 overflow-y-auto p-4">
-          {errorEntries.length > 0 ? (
-            <div
-              role="alert"
-              className="mb-3 space-y-1 rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700"
-            >
-              {errorEntries.map(([source, message]) => (
-                <div key={source}>{message}</div>
-              ))}
-            </div>
-          ) : null}
+          <BrowseErrorBanners
+            errors={errorEntries}
+            {...(browseRequestFailed ? { onRetry: retryBrowse } : {})}
+          />
           {searching ? (
             search && search.groups.length > 0 ? (
               <div className="space-y-4">
@@ -295,30 +307,31 @@ export function ListPage() {
           ) : view === "timeline" ? (
             // TimelineView owns its empty state ("No episodes in this window.").
             <TimelineView records={pageRecords} onSelect={setSelectedId} />
-          ) : pageRecords.length > 0 ? (
-            <MemoryGrid
-              key={gridEpoch}
-              records={pageRecords}
-              onSelect={setSelectedId}
-              onTickedChange={setTicked}
-              // Only while looking at everything: scoped to one namespace by the
-              // rail, every row would sit under a single group header.
-              groupByNamespace={namespace === undefined && pageIsComplete}
-              // Filtering is server-side: the funnels only decide the query.
-              filters={filters}
-              onFiltersChange={handleFiltersChange}
-            />
-          ) : status !== undefined || kind !== undefined || namespace !== undefined ? (
-            // "Nothing stored" and "nothing matches what you asked for" are
-            // different answers; telling a filtered view to go run its agent
-            // sends you looking for a bug that isn't there.
-            <p className="py-8 text-center text-sm text-zinc-400" data-testid="no-matches">
-              No memories match these filters.
-            </p>
           ) : (
-            <p className="py-8 text-center text-sm text-zinc-400">
-              No memories yet — run your agent and watch them appear.
-            </p>
+            <>
+              <BrowseStatusBar
+                loaded={pageRecords.length}
+                total={browse.total}
+                phase={browse.dataState.phase}
+                asOf={browse.paused ? browse.updatedAt : null}
+              />
+              <MemoryGrid
+                key={gridEpoch}
+                records={pageRecords}
+                onSelect={setSelectedId}
+                onTickedChange={setTicked}
+                // Only while looking at everything: scoped to one namespace by the
+                // rail, every row would sit under a single group header.
+                groupByNamespace={namespace === undefined && pageIsComplete}
+                // Filtering is server-side: the funnels only decide the query.
+                filters={filters}
+                onFiltersChange={handleFiltersChange}
+                dataState={browse.dataState}
+                resultMeta={browse.resultMeta}
+                emptyMessage={emptyMessage}
+                onRetry={retryBrowse}
+              />
+            </>
           )}
         </main>
       </div>

--- a/packages/inspector/src/components/memory/list-page.tsx
+++ b/packages/inspector/src/components/memory/list-page.tsx
@@ -1,7 +1,7 @@
 "use client"
 import type { MemoryKind, MemoryRecord, MemoryStats, MemoryStatus } from "@dawn-ai/memory"
 import type { ColumnFilter } from "@pretable/react"
-import { useCallback, useEffect, useMemo, useState } from "react"
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { canonicalBrowseQuery } from "../../browse/canonical-query"
 import { useMemoryBrowse } from "../../browse/use-memory-browse"
 import { Badge } from "../ui/badge"
@@ -24,9 +24,10 @@ interface SearchResponse {
 }
 
 /** Each source owns its own error slot — a stats success must not clear a search
- *  failure's banner, and neither may clear a mutation's. The browse REQUEST kinds
- *  (refresh, load-more) keep their own slots inside `useMemoryBrowse`. */
-type ErrorSource = "stats" | "search" | "mutation"
+ *  failure's banner. The browse REQUEST kinds (refresh, load-more) keep their own
+ *  slots inside `useMemoryBrowse`, and a bulk mutation's failures stay with the bar
+ *  that lists which ids failed and why. */
+type ErrorSource = "stats" | "search"
 
 /** Timeline window presets → milliseconds back from now ("all" = unbounded). */
 const WINDOWS = {
@@ -131,6 +132,22 @@ export function ListPage() {
   // Search replaces the browse view entirely, so browse stops polling behind it.
   const browse = useMemoryBrowse({ query: browseQuery, live: live && !query })
   const { refresh: refreshBrowse, retry: retryBrowse } = browse
+  const browsePhase = browse.dataState.phase
+
+  // `refreshBrowse` is the same poll tick the interval sends, so single flight DROPS it
+  // whenever a request is already running — and with `live` off there is no next tick
+  // to cover the skip, which leaves the row a mutation just changed on screen for good.
+  // Hold the intent instead and spend it once the browse can take it.
+  const [refreshRequested, setRefreshRequested] = useState(0)
+  const refreshServed = useRef(0)
+  const requestRefresh = useCallback(() => setRefreshRequested((n) => n + 1), [])
+  useEffect(() => {
+    // `idle` is exactly the state a poll tick starts a request from: the desired
+    // revision is fulfilled and nothing is in flight.
+    if (refreshServed.current === refreshRequested || browsePhase !== "idle") return
+    refreshServed.current = refreshRequested
+    refreshBrowse()
+  }, [refreshRequested, browsePhase, refreshBrowse])
 
   const stats = usePolling(statsFn, 2000, live)
 
@@ -167,8 +184,8 @@ export function ListPage() {
   const closeSheet = useCallback(() => setSelectedId(undefined), [])
   const handleMutated = useCallback(() => {
     setSelectedId(undefined)
-    refreshBrowse()
-  }, [refreshBrowse])
+    requestRefresh()
+  }, [requestRefresh])
   // The grid keeps its own checkbox state, so clearing here would leave the
   // boxes ticked. Remounting it (see `key` below) is what actually resets both.
   const [gridEpoch, setGridEpoch] = useState(0)
@@ -178,23 +195,18 @@ export function ListPage() {
   }, [])
   const handleBulkDone = useCallback(
     ({ failed }: { failed: number }) => {
-      if (failed === 0) {
-        // Keep the selection when anything failed: clearing it unmounts the bar, and
-        // the report of what went wrong goes with it.
-        clearTicked()
-        setError("mutation", undefined)
-      } else {
-        setError("mutation", `${failed} bulk action(s) failed — see the bar for details.`)
-      }
-      refreshBrowse()
+      // Keep the selection when anything failed: clearing it unmounts the bar, and the
+      // bar is the only channel carrying WHICH ids failed and why.
+      if (failed === 0) clearTicked()
+      requestRefresh()
     },
-    [clearTicked, refreshBrowse, setError],
+    [clearTicked, requestRefresh],
   )
 
   const byStatus = stats?.byStatus ?? {}
-  // No client-side narrowing any more: the request carries the EXACT namespace, so
-  // the rows on screen and `total` describe the same set. Filtering here would make
-  // "N loaded of M matching" a lie the moment a facet was clicked.
+  // Filtering here would make "N loaded of M matching" a lie the moment a facet was
+  // clicked: the request carries the EXACT namespace, so the rows and `total` already
+  // describe the same set.
   const pageRecords = browse.records
   // Group headers count the rows the grid HOLDS. On a truncated window that count is
   // an artifact of where the cap fell, so group only when the window is the whole
@@ -208,12 +220,21 @@ export function ListPage() {
     ? "No memories match these filters."
     : "No memories yet — run your agent and watch them appear."
   const searching = query.length > 0
+  const dataState = browse.dataState
+  // The grid's body-state block owns the error PHASE, and the timeline has no such
+  // block — this entry is the only channel a timeline failure has. Exactly one of the
+  // two surfaces is mounted, so one failure still gets one retry control.
+  const timelineFailure =
+    !searching && view === "timeline" && dataState.phase === "error"
+      ? (dataState.message ?? "Could not load memories.")
+      : undefined
   const browseRequestFailed =
     browse.errors.refresh !== undefined || browse.errors["load-more"] !== undefined
   const errorEntries: BrowseErrorEntry[] = [
     ...Object.entries(errors).flatMap(([source, message]) =>
       message ? [{ source, message }] : [],
     ),
+    ...(timelineFailure === undefined ? [] : [{ source: "browse", message: timelineFailure }]),
     ...(browse.errors.refresh === undefined
       ? []
       : [{ source: "refresh", message: `Refresh failed: ${browse.errors.refresh}` }]),
@@ -287,8 +308,18 @@ export function ListPage() {
         <main className="min-w-0 flex-1 overflow-y-auto p-4">
           <BrowseErrorBanners
             errors={errorEntries}
-            {...(browseRequestFailed ? { onRetry: retryBrowse } : {})}
+            {...(browseRequestFailed || timelineFailure !== undefined
+              ? { onRetry: retryBrowse }
+              : {})}
           />
+          {searching ? null : (
+            <BrowseStatusBar
+              loaded={pageRecords.length}
+              total={browse.total}
+              phase={browsePhase}
+              asOf={browse.paused ? browse.updatedAt : null}
+            />
+          )}
           {searching ? (
             search && search.groups.length > 0 ? (
               <div className="space-y-4">
@@ -305,33 +336,33 @@ export function ListPage() {
               <p className="py-8 text-center text-sm text-zinc-400">No matches.</p>
             )
           ) : view === "timeline" ? (
-            // TimelineView owns its empty state ("No episodes in this window.").
-            <TimelineView records={pageRecords} onSelect={setSelectedId} />
+            // TimelineView owns its empty state ("No episodes in this window.") — but
+            // that copy is an ANSWER, so it must not stand in for one that has not
+            // arrived, or for one that failed.
+            browsePhase === "loading" ? (
+              <p data-testid="browse-loading" className="p-4 text-sm text-zinc-400">
+                Loading memories…
+              </p>
+            ) : timelineFailure !== undefined && pageRecords.length === 0 ? null : (
+              <TimelineView records={pageRecords} onSelect={setSelectedId} />
+            )
           ) : (
-            <>
-              <BrowseStatusBar
-                loaded={pageRecords.length}
-                total={browse.total}
-                phase={browse.dataState.phase}
-                asOf={browse.paused ? browse.updatedAt : null}
-              />
-              <MemoryGrid
-                key={gridEpoch}
-                records={pageRecords}
-                onSelect={setSelectedId}
-                onTickedChange={setTicked}
-                // Only while looking at everything: scoped to one namespace by the
-                // rail, every row would sit under a single group header.
-                groupByNamespace={namespace === undefined && pageIsComplete}
-                // Filtering is server-side: the funnels only decide the query.
-                filters={filters}
-                onFiltersChange={handleFiltersChange}
-                dataState={browse.dataState}
-                resultMeta={browse.resultMeta}
-                emptyMessage={emptyMessage}
-                onRetry={retryBrowse}
-              />
-            </>
+            <MemoryGrid
+              key={gridEpoch}
+              records={pageRecords}
+              onSelect={setSelectedId}
+              onTickedChange={setTicked}
+              // Only while looking at everything: scoped to one namespace by the
+              // rail, every row would sit under a single group header.
+              groupByNamespace={namespace === undefined && pageIsComplete}
+              // Filtering is server-side: the funnels only decide the query.
+              filters={filters}
+              onFiltersChange={handleFiltersChange}
+              dataState={dataState}
+              resultMeta={browse.resultMeta}
+              emptyMessage={emptyMessage}
+              onRetry={retryBrowse}
+            />
           )}
         </main>
       </div>

--- a/packages/inspector/src/components/memory/memory-grid.tsx
+++ b/packages/inspector/src/components/memory/memory-grid.tsx
@@ -2,13 +2,19 @@
 import type { MemoryKind, MemoryRecord, MemoryStatus } from "@dawn-ai/memory"
 import {
   type ColumnFilter,
+  type PretableBodyStateKind,
   type PretableColumn,
+  type PretableDataState,
+  type PretableProcessingOptions,
+  type PretableResultMeta,
   PretableSurface,
+  type PretableSurfaceMessages,
   type PretableTelemetry,
 } from "@pretable/react"
 import { getDensityHeights } from "@pretable/ui"
 import { useCallback, useMemo, useState } from "react"
 import { Badge } from "../ui/badge"
+import { Button } from "../ui/button"
 
 /** Row projection handed to pretable — a plain bag so it satisfies `PretableRow`
  *  (MemoryRecord is an interface, so it has no implicit index signature). Each
@@ -106,6 +112,50 @@ const CELL_CLASS: Partial<Record<string, string>> = {
   confidence: "tabular-nums",
 }
 
+/**
+ * Browse sends status/kind to the server, so the engine must DISPLAY the funnel
+ * state without re-applying it — and `resultMeta.total` is silently ignored (with a
+ * dev warning) under engine filter authority, so external authority is what makes
+ * the honest total reachable at all.
+ *
+ * Sort is external AND the browse columns are non-sortable: leaving sort on
+ * "engine" would sort a server-selected window locally, which presents the wrong
+ * SAMPLE under a truthful-looking `aria-sort`, while external sort without an
+ * `orderBy` in the request would paint a header arrow that does nothing. Sorting
+ * comes back with server ordering.
+ */
+const SERVER_PROCESSING: PretableProcessingOptions = { filter: "external", sort: "external" }
+
+const BROWSE_COLUMNS: PretableColumn<GridRow>[] = COLUMNS.map((column) => ({
+  ...column,
+  sortable: false,
+}))
+
+/** Enough room for a loading/empty/error block to be legible when the body holds
+ *  no rows to give the viewport its height. */
+const MIN_BODY_STATE_PX = 160
+
+/** Lifecycle copy. `emptyStateMessage` is NOT here — filtered-empty and
+ *  unfiltered-empty are different answers, and only the caller knows which. */
+const BROWSE_MESSAGES: PretableSurfaceMessages = {
+  loadingStateMessage: () => "Loading memories…",
+  dataErrorAnnouncement: ({ message }) =>
+    message === undefined ? "Could not load memories." : `Could not load memories: ${message}`,
+  staleAnnouncement: () => "Updating results…",
+  focusedRowRemovedAnnouncement: () => "The focused memory was removed.",
+  resultsAnnouncement: ({ loaded, total, added, scope }) => {
+    const head =
+      scope === "all" || total.kind !== "exact"
+        ? `${loaded.toLocaleString()} loaded`
+        : `${loaded.toLocaleString()} loaded of ${total.count.toLocaleString()} matching`
+    return added === undefined ? head : `Loaded ${added.toLocaleString()} more. ${head}.`
+  },
+  moreRowsBoundaryAnnouncement: ({ loadedCount, total }) =>
+    total === undefined
+      ? `End of the ${loadedCount.toLocaleString()} loaded memories.`
+      : `End of the ${loadedCount.toLocaleString()} loaded memories, of ${total.toLocaleString()} matching.`,
+}
+
 function statusClass(status: MemoryStatus): string {
   if (status === "candidate") return "bg-amber-50"
   if (status === "superseded") return "text-zinc-400 line-through"
@@ -142,6 +192,10 @@ export function MemoryGrid({
   groupByNamespace = false,
   filters,
   onFiltersChange,
+  dataState,
+  resultMeta,
+  emptyMessage,
+  onRetry,
 }: {
   records: readonly MemoryRecord[]
   onSelect: (id: string) => void
@@ -157,6 +211,20 @@ export function MemoryGrid({
    *  column filtering — the grouped search results filter nothing. */
   filters?: Record<string, ColumnFilter>
   onFiltersChange?: (next: Record<string, ColumnFilter>) => void
+  /** Supply to turn lifecycle presentation ON: body blocks, the phase attribute,
+   *  phase announcements, and external processing authority. Omit it — as the
+   *  search results do — and the grid behaves exactly as it did before. */
+  dataState?: PretableDataState
+  /** The matching population and the dataset identity, always for the FULFILLED
+   *  revision. */
+  resultMeta?: PretableResultMeta
+  /** Body copy for the empty block. "Nothing stored" and "nothing matches what you
+   *  asked for" are different answers; only the caller knows which applies. */
+  emptyMessage?: string
+  /** Retry affordance for the error block. The design routes it through the
+   *  body-state slot rather than a second banner, so exactly one retry control is
+   *  ever on screen. */
+  onRetry?: () => void
 }) {
   const rows = useMemo(() => records.map(toRow), [records])
 
@@ -176,21 +244,69 @@ export function MemoryGrid({
     setContentHeight(telemetry.totalHeight)
   }, [])
   const density = getDensityHeights()
-  const viewportHeight = Math.min(
-    (contentHeight ?? rows.length * density.rowHeight) + density.headerHeight,
-    MAX_VIEWPORT_PX,
+  const viewportHeight = Math.max(
+    Math.min(
+      (contentHeight ?? rows.length * density.rowHeight) + density.headerHeight,
+      MAX_VIEWPORT_PX,
+    ),
+    dataState !== undefined && rows.length === 0 ? MIN_BODY_STATE_PX : 0,
+  )
+
+  const messages = useMemo<PretableSurfaceMessages>(
+    () => ({
+      ...BROWSE_MESSAGES,
+      emptyStateMessage: () => emptyMessage ?? "No memories.",
+    }),
+    [emptyMessage],
   )
 
   return (
     <PretableSurface<GridRow>
       ariaLabel="Memories"
-      columns={COLUMNS}
+      columns={dataState === undefined ? COLUMNS : BROWSE_COLUMNS}
       rows={rows}
       getRowId={rowIdOf}
       viewportHeight={viewportHeight}
       // One controlled `state`: a second `state` prop would clobber the first,
       // silently ungrouping the moment a filter was applied.
       state={surfaceState}
+      // Spread-or-omit rather than `prop={undefined}`: `exactOptionalPropertyTypes`
+      // rejects an explicit undefined, and `dataState` has NO default — omitting it
+      // turns lifecycle presentation entirely off.
+      {...(dataState === undefined ? {} : { dataState, processing: SERVER_PROCESSING, messages })}
+      {...(resultMeta === undefined ? {} : { resultMeta })}
+      {...(dataState === undefined
+        ? {}
+        : {
+            renderBodyState: ({
+              kind,
+              errorMessage,
+            }: {
+              kind: PretableBodyStateKind
+              errorMessage?: string
+            }) =>
+              kind === "loading" ? (
+                <p data-testid="browse-loading" className="p-4 text-sm text-zinc-400">
+                  Loading memories…
+                </p>
+              ) : kind === "empty" ? (
+                <p data-testid="browse-empty" className="p-4 text-sm text-zinc-400">
+                  {emptyMessage ?? "No memories."}
+                </p>
+              ) : (
+                <div
+                  data-testid="browse-error"
+                  className="flex items-center gap-3 rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700"
+                >
+                  <span>{errorMessage ?? "Could not load memories."}</span>
+                  {onRetry ? (
+                    <Button variant="outline" className="h-7 px-2" onClick={onRetry}>
+                      Retry
+                    </Button>
+                  ) : null}
+                </div>
+              ),
+          })}
       {...(onTickedChange
         ? {
             rowSelectionColumn: { enabled: true, headerCheckbox: true } as const,

--- a/packages/inspector/src/components/memory/memory-grid.tsx
+++ b/packages/inspector/src/components/memory/memory-grid.tsx
@@ -2,13 +2,13 @@
 import type { MemoryKind, MemoryRecord, MemoryStatus } from "@dawn-ai/memory"
 import {
   type ColumnFilter,
-  type PretableBodyStateKind,
   type PretableColumn,
   type PretableDataState,
   type PretableProcessingOptions,
   type PretableResultMeta,
   PretableSurface,
   type PretableSurfaceMessages,
+  type PretableSurfaceProps,
   type PretableTelemetry,
 } from "@pretable/react"
 import { getDensityHeights } from "@pretable/ui"
@@ -131,24 +131,35 @@ const BROWSE_COLUMNS: PretableColumn<GridRow>[] = COLUMNS.map((column) => ({
   sortable: false,
 }))
 
-/** Enough room for a loading/empty/error block to be legible when the body holds
- *  no rows to give the viewport its height. */
+/** Room the body-state block itself needs to stay legible when there are no rows
+ *  to give the viewport its height. The block is an overlay inset below the sticky
+ *  header, so the header's height is not part of it. */
 const MIN_BODY_STATE_PX = 160
 
-/** Lifecycle copy. `emptyStateMessage` is NOT here — filtered-empty and
- *  unfiltered-empty are different answers, and only the caller knows which. */
+/** Announcement copy only. The visible loading/empty/error blocks come from
+ *  `renderBodyState`, which pretable prefers over `loadingStateMessage` and
+ *  `emptyStateMessage` whenever it is supplied — and it always is here. */
 const BROWSE_MESSAGES: PretableSurfaceMessages = {
-  loadingStateMessage: () => "Loading memories…",
   dataErrorAnnouncement: ({ message }) =>
     message === undefined ? "Could not load memories." : `Could not load memories: ${message}`,
   staleAnnouncement: () => "Updating results…",
   focusedRowRemovedAnnouncement: () => "The focused memory was removed.",
   resultsAnnouncement: ({ loaded, total, added, scope }) => {
-    const head =
-      scope === "all" || total.kind !== "exact"
-        ? `${loaded.toLocaleString()} loaded`
-        : `${loaded.toLocaleString()} loaded of ${total.count.toLocaleString()} matching`
-    return added === undefined ? head : `Loaded ${added.toLocaleString()} more. ${head}.`
+    // `scope: "all"` means the loaded records ARE the population and `total`
+    // restates them — say one number. Every other case keeps the qualifier the
+    // total carries, so "of about" never hardens into a count nobody promised.
+    const population =
+      scope === "all"
+        ? ""
+        : total.kind === "exact"
+          ? ` of ${total.count.toLocaleString()} matching`
+          : total.kind === "estimate"
+            ? ` of about ${total.count.toLocaleString()} matching`
+            : total.atLeast === undefined
+              ? ""
+              : ` of more than ${total.atLeast.toLocaleString()} matching`
+    const head = `${loaded.toLocaleString()} loaded${population}.`
+    return added === undefined ? head : `Loaded ${added.toLocaleString()} more. ${head}`
   },
   moreRowsBoundaryAnnouncement: ({ loadedCount, total }) =>
     total === undefined
@@ -213,7 +224,12 @@ export function MemoryGrid({
   onFiltersChange?: (next: Record<string, ColumnFilter>) => void
   /** Supply to turn lifecycle presentation ON: body blocks, the phase attribute,
    *  phase announcements, and external processing authority. Omit it — as the
-   *  search results do — and the grid behaves exactly as it did before. */
+   *  search results do — and the grid behaves exactly as it did before.
+   *
+   *  WHETHER it is supplied must be stable for the mount, though its value may
+   *  change freely: presence selects `columns` and `processing`, which pretable
+   *  treats as create-time config and rebuilds the grid around, discarding
+   *  selection, focus, measured heights and column layout. */
   dataState?: PretableDataState
   /** The matching population and the dataset identity, always for the FULFILLED
    *  revision. */
@@ -221,7 +237,7 @@ export function MemoryGrid({
   /** Body copy for the empty block. "Nothing stored" and "nothing matches what you
    *  asked for" are different answers; only the caller knows which applies. */
   emptyMessage?: string
-  /** Retry affordance for the error block. The design routes it through the
+  /** Retry affordance for the error blocks. The design routes it through the
    *  body-state slot rather than a second banner, so exactly one retry control is
    *  ever on screen. */
   onRetry?: () => void
@@ -249,16 +265,59 @@ export function MemoryGrid({
       (contentHeight ?? rows.length * density.rowHeight) + density.headerHeight,
       MAX_VIEWPORT_PX,
     ),
-    dataState !== undefined && rows.length === 0 ? MIN_BODY_STATE_PX : 0,
+    dataState !== undefined && rows.length === 0 ? MIN_BODY_STATE_PX + density.headerHeight : 0,
   )
 
-  const messages = useMemo<PretableSurfaceMessages>(
-    () => ({
-      ...BROWSE_MESSAGES,
-      emptyStateMessage: () => emptyMessage ?? "No memories.",
-    }),
-    [emptyMessage],
-  )
+  // Typed against the prop rather than inline in the JSX spread below: a spread
+  // gets no contextual type, so an inline callback's parameter would have to be
+  // hand-declared, and a hand-declared one silently accepts a shape the library
+  // has since renamed.
+  const renderBodyState: NonNullable<PretableSurfaceProps<GridRow>["renderBodyState"]> = ({
+    kind,
+    errorMessage,
+  }) => {
+    if (kind === "loading") {
+      return (
+        <p data-testid="browse-loading" className="p-4 text-sm text-zinc-400">
+          Loading memories…
+        </p>
+      )
+    }
+    if (kind === "empty") {
+      return (
+        <p data-testid="browse-empty" className="p-4 text-sm text-zinc-400">
+          {emptyMessage ?? "No memories."}
+        </p>
+      )
+    }
+    const message = errorMessage ?? "Could not load memories."
+    const retry = onRetry ? (
+      <Button variant="outline" className="h-7 px-2" onClick={onRetry}>
+        Retry
+      </Button>
+    ) : null
+    // `error-strip` means rows survived the failure and are still on screen
+    // answering the previous question, so the block sits ABOVE them as a band
+    // rather than covering the body — same failure, a different claim about what
+    // is underneath.
+    return kind === "error-strip" ? (
+      <div
+        data-testid="browse-error-strip"
+        className="mb-2 flex items-center gap-3 rounded-md border border-red-200 bg-red-50 px-3 py-1.5 text-sm text-red-700"
+      >
+        <span>{message}</span>
+        {retry}
+      </div>
+    ) : (
+      <div
+        data-testid="browse-error"
+        className="flex items-center gap-3 rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700"
+      >
+        <span>{message}</span>
+        {retry}
+      </div>
+    )
+  }
 
   return (
     <PretableSurface<GridRow>
@@ -270,43 +329,18 @@ export function MemoryGrid({
       // One controlled `state`: a second `state` prop would clobber the first,
       // silently ungrouping the moment a filter was applied.
       state={surfaceState}
-      // Spread-or-omit rather than `prop={undefined}`: `exactOptionalPropertyTypes`
-      // rejects an explicit undefined, and `dataState` has NO default — omitting it
-      // turns lifecycle presentation entirely off.
-      {...(dataState === undefined ? {} : { dataState, processing: SERVER_PROCESSING, messages })}
-      {...(resultMeta === undefined ? {} : { resultMeta })}
+      // All four together or none: `renderBodyState` is what makes the lifecycle
+      // copy in `BROWSE_MESSAGES` reachable, and `SERVER_PROCESSING` is what makes
+      // `resultMeta.total` reachable. Splitting them would leave a half-wired mode.
       {...(dataState === undefined
         ? {}
         : {
-            renderBodyState: ({
-              kind,
-              errorMessage,
-            }: {
-              kind: PretableBodyStateKind
-              errorMessage?: string
-            }) =>
-              kind === "loading" ? (
-                <p data-testid="browse-loading" className="p-4 text-sm text-zinc-400">
-                  Loading memories…
-                </p>
-              ) : kind === "empty" ? (
-                <p data-testid="browse-empty" className="p-4 text-sm text-zinc-400">
-                  {emptyMessage ?? "No memories."}
-                </p>
-              ) : (
-                <div
-                  data-testid="browse-error"
-                  className="flex items-center gap-3 rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700"
-                >
-                  <span>{errorMessage ?? "Could not load memories."}</span>
-                  {onRetry ? (
-                    <Button variant="outline" className="h-7 px-2" onClick={onRetry}>
-                      Retry
-                    </Button>
-                  ) : null}
-                </div>
-              ),
+            dataState,
+            processing: SERVER_PROCESSING,
+            messages: BROWSE_MESSAGES,
+            renderBodyState,
           })}
+      {...(resultMeta === undefined ? {} : { resultMeta })}
       {...(onTickedChange
         ? {
             rowSelectionColumn: { enabled: true, headerCheckbox: true } as const,

--- a/packages/inspector/test/components/browse-chrome.test.tsx
+++ b/packages/inspector/test/components/browse-chrome.test.tsx
@@ -4,6 +4,13 @@ import { BrowseErrorBanners, BrowseStatusBar } from "../../src/components/memory
 
 afterEach(cleanup)
 
+/** Count and time expectations below go through the same Intl call the component
+ *  does. A literal "5,432" or "10:13:20 PM" would pin the RUNNER's locale and
+ *  timezone instead of the component's behavior, failing under any non-en-US shell;
+ *  `test.env` cannot fix that, since ICU resolves the default locale before a test
+ *  can set LC_ALL. */
+const PAUSED_AT = 1_754_000_000_000
+
 describe("BrowseErrorBanners", () => {
   it("renders nothing when no slot is filled", () => {
     const { container } = render(<BrowseErrorBanners errors={[]} />)
@@ -23,6 +30,19 @@ describe("BrowseErrorBanners", () => {
     expect(screen.getByTestId("error-refresh").textContent).toBe("boom")
   })
 
+  it("keys by SOURCE, so reordering moves a line instead of repainting it", () => {
+    const stats = { source: "stats", message: "boom" }
+    const refresh = { source: "refresh", message: "boom" }
+    const { rerender } = render(<BrowseErrorBanners errors={[stats, refresh]} />)
+    const statsLine = screen.getByTestId("error-stats")
+
+    // Two identical messages keyed BY MESSAGE reconcile positionally, so the node
+    // holding stats' line would quietly become refresh's. Node identity is the only
+    // thing that tells the two keyings apart.
+    rerender(<BrowseErrorBanners errors={[refresh, stats]} />)
+    expect(screen.getByTestId("error-stats")).toBe(statsLine)
+  })
+
   it("offers a retry control only when one is supplied", () => {
     const onRetry = vi.fn()
     const { rerender } = render(
@@ -35,13 +55,25 @@ describe("BrowseErrorBanners", () => {
     fireEvent.click(screen.getByRole("button", { name: "Retry" }))
     expect(onRetry).toHaveBeenCalledTimes(1)
   })
+
+  it("keeps the retry control outside the live region", () => {
+    render(
+      <BrowseErrorBanners errors={[{ source: "refresh", message: "boom" }]} onRetry={vi.fn()} />,
+    )
+    // role="alert" is atomic: every string inside is announced as one utterance, so
+    // a control in the region gets its label read out as part of the failure.
+    const region = screen.getByRole("alert")
+    expect(region.textContent).toBe("boom")
+    expect(region.querySelector("button")).toBeNull()
+    expect(screen.getByRole("button", { name: "Retry" })).not.toBeNull()
+  })
 })
 
 describe("BrowseStatusBar", () => {
   it("says loaded-of-matching once a total is known", () => {
     render(<BrowseStatusBar loaded={200} total={5432} phase="idle" asOf={null} />)
     expect(screen.getByTestId("browse-status").textContent).toContain(
-      "200 loaded of 5,432 matching",
+      `200 loaded of ${(5432).toLocaleString()} matching`,
     )
   })
 
@@ -60,7 +92,24 @@ describe("BrowseStatusBar", () => {
     expect(bar.textContent).toContain("Updating results…")
     expect(bar.textContent).not.toContain("Updated ")
 
-    rerender(<BrowseStatusBar loaded={200} total={5432} phase="idle" asOf={1_754_000_000_000} />)
-    expect(screen.getByTestId("browse-status").textContent).toContain("Updated ")
+    rerender(<BrowseStatusBar loaded={200} total={5432} phase="idle" asOf={PAUSED_AT} />)
+    expect(screen.getByTestId("browse-status").textContent).toContain(
+      `Updated ${new Date(PAUSED_AT).toLocaleTimeString()}`,
+    )
+  })
+
+  it("stamps the instant it is handed rather than the wall clock", () => {
+    const anHourLater = PAUSED_AT + 3_600_000
+    const { rerender } = render(
+      <BrowseStatusBar loaded={200} total={5432} phase="idle" asOf={PAUSED_AT} />,
+    )
+    expect(screen.getByTestId("browse-status").textContent).toContain(
+      `Updated ${new Date(PAUSED_AT).toLocaleTimeString()}`,
+    )
+
+    rerender(<BrowseStatusBar loaded={200} total={5432} phase="idle" asOf={anHourLater} />)
+    expect(screen.getByTestId("browse-status").textContent).toContain(
+      `Updated ${new Date(anHourLater).toLocaleTimeString()}`,
+    )
   })
 })

--- a/packages/inspector/test/components/browse-chrome.test.tsx
+++ b/packages/inspector/test/components/browse-chrome.test.tsx
@@ -1,0 +1,66 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react"
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { BrowseErrorBanners, BrowseStatusBar } from "../../src/components/memory/browse-chrome"
+
+afterEach(cleanup)
+
+describe("BrowseErrorBanners", () => {
+  it("renders nothing when no slot is filled", () => {
+    const { container } = render(<BrowseErrorBanners errors={[]} />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it("keys by SOURCE, so two sources with the same message both show", () => {
+    render(
+      <BrowseErrorBanners
+        errors={[
+          { source: "stats", message: "boom" },
+          { source: "refresh", message: "boom" },
+        ]}
+      />,
+    )
+    expect(screen.getByTestId("error-stats").textContent).toBe("boom")
+    expect(screen.getByTestId("error-refresh").textContent).toBe("boom")
+  })
+
+  it("offers a retry control only when one is supplied", () => {
+    const onRetry = vi.fn()
+    const { rerender } = render(
+      <BrowseErrorBanners errors={[{ source: "refresh", message: "boom" }]} />,
+    )
+    expect(screen.queryByRole("button", { name: "Retry" })).toBeNull()
+    rerender(
+      <BrowseErrorBanners errors={[{ source: "refresh", message: "boom" }]} onRetry={onRetry} />,
+    )
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }))
+    expect(onRetry).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe("BrowseStatusBar", () => {
+  it("says loaded-of-matching once a total is known", () => {
+    render(<BrowseStatusBar loaded={200} total={5432} phase="idle" asOf={null} />)
+    expect(screen.getByTestId("browse-status").textContent).toContain(
+      "200 loaded of 5,432 matching",
+    )
+  })
+
+  it("claims only what it knows before the first total lands", () => {
+    render(<BrowseStatusBar loaded={0} total={null} phase="loading" asOf={null} />)
+    expect(screen.getByTestId("browse-status").textContent).toContain("0 loaded")
+    expect(screen.getByTestId("browse-status").textContent).not.toContain("matching")
+  })
+
+  it("marks the stale phase and shows an as-of instant only while paused", () => {
+    const { rerender } = render(
+      <BrowseStatusBar loaded={200} total={5432} phase="stale" asOf={null} />,
+    )
+    const bar = screen.getByTestId("browse-status")
+    expect(bar.getAttribute("data-phase")).toBe("stale")
+    expect(bar.textContent).toContain("Updating results…")
+    expect(bar.textContent).not.toContain("Updated ")
+
+    rerender(<BrowseStatusBar loaded={200} total={5432} phase="idle" asOf={1_754_000_000_000} />)
+    expect(screen.getByTestId("browse-status").textContent).toContain("Updated ")
+  })
+})

--- a/packages/inspector/test/components/browse-lifecycle.test.tsx
+++ b/packages/inspector/test/components/browse-lifecycle.test.tsx
@@ -11,7 +11,7 @@ const stats: MemoryStats = {
   bySourceType: { tool: 2 },
 }
 
-function record(id: string, over: Partial<MemoryRecord> = {}): MemoryRecord {
+function record(id: string): MemoryRecord {
   return {
     id,
     kind: "semantic",
@@ -24,7 +24,6 @@ function record(id: string, over: Partial<MemoryRecord> = {}): MemoryRecord {
     status: "active",
     createdAt: "2026-07-13T00:00:00.000Z",
     updatedAt: "2026-08-01T00:00:00.000Z",
-    ...over,
   }
 }
 
@@ -34,6 +33,11 @@ function jsonResponse(body: unknown, status = 200): Response {
     headers: { "content-type": "application/json" },
   })
 }
+
+/** Counts go through the same Intl call the component does; a literal "5,432"
+ *  would pin the RUNNER's locale, and `test.env` cannot fix that because ICU
+ *  resolves the default locale before a test can set LC_ALL. */
+const TOTAL = 5432
 
 /** A fake server whose /list answer is swappable mid-test. */
 function stubServer(list: () => Response) {
@@ -55,11 +59,13 @@ afterEach(() => {
 
 describe("browse lifecycle", () => {
   it("flow 1: shows a loading block, then rows and the honest total", async () => {
-    stubServer(() => jsonResponse({ records: [record("a")], total: 5432 }))
+    stubServer(() => jsonResponse({ records: [record("a")], total: TOTAL }))
     render(<ListPage />)
-    expect(screen.getByTestId("browse-loading")).toBeDefined()
-    expect(await screen.findByText("content a")).toBeDefined()
-    expect(screen.getByTestId("browse-status").textContent).toContain("1 loaded of 5,432 matching")
+    expect(screen.queryByTestId("browse-loading")).not.toBeNull()
+    await screen.findByText("content a")
+    expect(screen.getByTestId("browse-status").textContent).toContain(
+      `1 loaded of ${TOTAL.toLocaleString()} matching`,
+    )
   })
 
   it("an empty result gets the empty block, with copy that knows about filters", async () => {
@@ -90,7 +96,7 @@ describe("browse lifecycle", () => {
 
     fail = false
     fireEvent.click(within(block).getByRole("button", { name: "Retry" }))
-    expect(await screen.findByText("content a")).toBeDefined()
+    await screen.findByText("content a")
     expect(screen.queryByTestId("browse-error")).toBeNull()
   })
 
@@ -98,17 +104,20 @@ describe("browse lifecycle", () => {
     let release: (() => void) | undefined
     const mock = stubServer(() => jsonResponse({ records: [record("a")], total: 1 }))
     render(<ListPage />)
-    expect(await screen.findByText("content a")).toBeDefined()
+    await screen.findByText("content a")
 
     // Hold the next answer so the stale window is observable.
     mock.mockImplementation(async (url: RequestInfo | URL) => {
       const u = String(url)
       if (u.includes("/api/memory/stats")) return jsonResponse(stats)
       if (u.includes("/api/memory/search")) return jsonResponse({ groups: [] })
-      await new Promise<void>((resolve) => {
-        release = resolve
-      })
-      return jsonResponse({ records: [record("z")], total: 1 })
+      if (u.includes("/api/memory/list")) {
+        await new Promise<void>((resolve) => {
+          release = resolve
+        })
+        return jsonResponse({ records: [record("z")], total: 1 })
+      }
+      return jsonResponse({ error: "not found" }, 404)
     })
 
     const rail = screen.getByRole("navigation")
@@ -117,14 +126,17 @@ describe("browse lifecycle", () => {
       expect(screen.getByTestId("browse-status").getAttribute("data-phase")).toBe("stale"),
     )
     // The OLD rows are still on screen, and marked as answering the old question.
-    expect(screen.getByText("content a")).toBeDefined()
+    expect(screen.queryByText("content a")).not.toBeNull()
 
     release?.()
-    expect(await screen.findByText("content z")).toBeDefined()
-    const listCalls = mock.mock.calls
-      .map((call) => String(call[0]))
-      .filter((u) => u.includes("/api/memory/list"))
-    expect(listCalls.some((u) => u.includes("namespace=route%3D%2Fnotes"))).toBe(true)
+    await screen.findByText("content z")
+    // Parsed, not substring-matched: a request for the sibling `route=/notes2`
+    // also contains the substring `namespace=route%3D%2Fnotes`.
+    const scoped = mock.mock.calls
+      .map((call) => new URL(String(call[0]), "http://localhost"))
+      .filter((u) => u.pathname.endsWith("/api/memory/list"))
+      .filter((u) => u.searchParams.get("namespace") === "route=/notes")
+    expect(scoped.length).toBeGreaterThan(0)
   })
 
   it("flow 8/9: a failing poll tick banners itself without disturbing the rows", async () => {
@@ -137,15 +149,18 @@ describe("browse lifecycle", () => {
           : jsonResponse({ records: [record("a")], total: 1 }),
       )
       render(<ListPage />)
-      await vi.waitFor(() => expect(screen.getByText("content a")).toBeDefined())
+      await vi.waitFor(() => screen.getByText("content a"))
 
       fail = true
       await vi.advanceTimersByTimeAsync(2100)
+      // Sibling banners render their message bare, so this prefix is the only thing
+      // naming a background refresh as the source of the failure.
       await vi.waitFor(() =>
-        expect(screen.getByTestId("error-refresh").textContent).toContain("network down"),
+        expect(screen.getByTestId("error-refresh").textContent).toContain(
+          "Refresh failed: network down",
+        ),
       )
-      // Rows survive a failed refresh, and the failure did NOT become the error block.
-      expect(screen.getByText("content a")).toBeDefined()
+      expect(screen.queryByText("content a")).not.toBeNull()
       expect(screen.queryByTestId("browse-error")).toBeNull()
 
       fail = false
@@ -159,7 +174,7 @@ describe("browse lifecycle", () => {
   it("shows an as-of instant once polling is paused", async () => {
     stubServer(() => jsonResponse({ records: [record("a")], total: 1 }))
     render(<ListPage />)
-    expect(await screen.findByText("content a")).toBeDefined()
+    await screen.findByText("content a")
     expect(screen.getByTestId("browse-status").textContent).not.toContain("Updated ")
 
     fireEvent.click(screen.getByLabelText("live"))

--- a/packages/inspector/test/components/browse-lifecycle.test.tsx
+++ b/packages/inspector/test/components/browse-lifecycle.test.tsx
@@ -1,0 +1,170 @@
+import type { MemoryRecord, MemoryStats } from "@dawn-ai/memory"
+import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react"
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { ListPage } from "../../src/components/memory/list-page"
+
+const stats: MemoryStats = {
+  total: 2,
+  byStatus: { candidate: 1, active: 1 },
+  byKind: { semantic: 2 },
+  byNamespace: { "route=/notes": 2 },
+  bySourceType: { tool: 2 },
+}
+
+function record(id: string, over: Partial<MemoryRecord> = {}): MemoryRecord {
+  return {
+    id,
+    kind: "semantic",
+    namespace: "route=/notes",
+    content: `content ${id}`,
+    data: {},
+    source: { type: "tool", id: "remember" },
+    confidence: 0.5,
+    tags: [],
+    status: "active",
+    createdAt: "2026-07-13T00:00:00.000Z",
+    updatedAt: "2026-08-01T00:00:00.000Z",
+    ...over,
+  }
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  })
+}
+
+/** A fake server whose /list answer is swappable mid-test. */
+function stubServer(list: () => Response) {
+  const mock = vi.fn(async (url: RequestInfo | URL) => {
+    const u = String(url)
+    if (u.includes("/api/memory/stats")) return jsonResponse(stats)
+    if (u.includes("/api/memory/list")) return list()
+    if (u.includes("/api/memory/search")) return jsonResponse({ groups: [] })
+    return jsonResponse({ error: "not found" }, 404)
+  })
+  vi.stubGlobal("fetch", mock)
+  return mock
+}
+
+afterEach(() => {
+  cleanup()
+  vi.unstubAllGlobals()
+})
+
+describe("browse lifecycle", () => {
+  it("flow 1: shows a loading block, then rows and the honest total", async () => {
+    stubServer(() => jsonResponse({ records: [record("a")], total: 5432 }))
+    render(<ListPage />)
+    expect(screen.getByTestId("browse-loading")).toBeDefined()
+    expect(await screen.findByText("content a")).toBeDefined()
+    expect(screen.getByTestId("browse-status").textContent).toContain("1 loaded of 5,432 matching")
+  })
+
+  it("an empty result gets the empty block, with copy that knows about filters", async () => {
+    stubServer(() => jsonResponse({ records: [], total: 0 }))
+    render(<ListPage />)
+    await waitFor(() =>
+      expect(screen.getByTestId("browse-empty").textContent).toContain("No memories yet"),
+    )
+    const rail = screen.getByRole("navigation")
+    fireEvent.click(within(rail).getByRole("button", { name: /route=\/notes/ }))
+    await waitFor(() =>
+      expect(screen.getByTestId("browse-empty").textContent).toContain(
+        "No memories match these filters",
+      ),
+    )
+  })
+
+  it("flow 7: an initial failure renders the error block with a retry that recovers", async () => {
+    let fail = true
+    stubServer(() =>
+      fail
+        ? jsonResponse({ error: "no memory store configured" }, 500)
+        : jsonResponse({ records: [record("a")], total: 1 }),
+    )
+    render(<ListPage />)
+    const block = await screen.findByTestId("browse-error")
+    expect(block.textContent).toContain("no memory store configured")
+
+    fail = false
+    fireEvent.click(within(block).getByRole("button", { name: "Retry" }))
+    expect(await screen.findByText("content a")).toBeDefined()
+    expect(screen.queryByTestId("browse-error")).toBeNull()
+  })
+
+  it("flow 2/4: a facet change marks the visible rows stale and asks for the exact namespace", async () => {
+    let release: (() => void) | undefined
+    const mock = stubServer(() => jsonResponse({ records: [record("a")], total: 1 }))
+    render(<ListPage />)
+    expect(await screen.findByText("content a")).toBeDefined()
+
+    // Hold the next answer so the stale window is observable.
+    mock.mockImplementation(async (url: RequestInfo | URL) => {
+      const u = String(url)
+      if (u.includes("/api/memory/stats")) return jsonResponse(stats)
+      if (u.includes("/api/memory/search")) return jsonResponse({ groups: [] })
+      await new Promise<void>((resolve) => {
+        release = resolve
+      })
+      return jsonResponse({ records: [record("z")], total: 1 })
+    })
+
+    const rail = screen.getByRole("navigation")
+    fireEvent.click(within(rail).getByRole("button", { name: /route=\/notes/ }))
+    await waitFor(() =>
+      expect(screen.getByTestId("browse-status").getAttribute("data-phase")).toBe("stale"),
+    )
+    // The OLD rows are still on screen, and marked as answering the old question.
+    expect(screen.getByText("content a")).toBeDefined()
+
+    release?.()
+    expect(await screen.findByText("content z")).toBeDefined()
+    const listCalls = mock.mock.calls
+      .map((call) => String(call[0]))
+      .filter((u) => u.includes("/api/memory/list"))
+    expect(listCalls.some((u) => u.includes("namespace=route%3D%2Fnotes"))).toBe(true)
+  })
+
+  it("flow 8/9: a failing poll tick banners itself without disturbing the rows", async () => {
+    vi.useFakeTimers()
+    try {
+      let fail = false
+      stubServer(() =>
+        fail
+          ? jsonResponse({ error: "network down" }, 503)
+          : jsonResponse({ records: [record("a")], total: 1 }),
+      )
+      render(<ListPage />)
+      await vi.waitFor(() => expect(screen.getByText("content a")).toBeDefined())
+
+      fail = true
+      await vi.advanceTimersByTimeAsync(2100)
+      await vi.waitFor(() =>
+        expect(screen.getByTestId("error-refresh").textContent).toContain("network down"),
+      )
+      // Rows survive a failed refresh, and the failure did NOT become the error block.
+      expect(screen.getByText("content a")).toBeDefined()
+      expect(screen.queryByTestId("browse-error")).toBeNull()
+
+      fail = false
+      await vi.advanceTimersByTimeAsync(2100)
+      await vi.waitFor(() => expect(screen.queryByTestId("error-refresh")).toBeNull())
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it("shows an as-of instant once polling is paused", async () => {
+    stubServer(() => jsonResponse({ records: [record("a")], total: 1 }))
+    render(<ListPage />)
+    expect(await screen.findByText("content a")).toBeDefined()
+    expect(screen.getByTestId("browse-status").textContent).not.toContain("Updated ")
+
+    fireEvent.click(screen.getByLabelText("live"))
+    await waitFor(() =>
+      expect(screen.getByTestId("browse-status").textContent).toContain("Updated "),
+    )
+  })
+})

--- a/packages/inspector/test/components/browse-machine.test.ts
+++ b/packages/inspector/test/components/browse-machine.test.ts
@@ -1,4 +1,4 @@
-import type { MemoryRecord } from "@dawn-ai/memory/browse"
+import { BROWSE_MAX_LIMIT, type MemoryRecord } from "@dawn-ai/memory/browse"
 import { describe, expect, it } from "vitest"
 import {
   BROWSE_PAGE_SIZE,
@@ -26,6 +26,22 @@ function record(id: string, updatedAt = "2026-08-01T00:00:00.000Z"): MemoryRecor
     createdAt: "2026-07-13T00:00:00.000Z",
     updatedAt,
   }
+}
+
+/** Rows in the default browse order — `updatedAt` DESCENDS as the index rises, so a
+ *  generated window agrees with the order the reconciler compares spans in. */
+function rows(count: number, from = 0): MemoryRecord[] {
+  return Array.from({ length: count }, (_, i) =>
+    record(`r${from + i}`, new Date(Date.UTC(2026, 7, 1) - (from + i) * 60_000).toISOString()),
+  )
+}
+
+/** Rows a day newer than every `rows()` row: a refresh window made entirely of head
+ *  inserts, which is what pushes residents past the span rule 3 retains. */
+function inserted(count: number): MemoryRecord[] {
+  return Array.from({ length: count }, (_, i) =>
+    record(`n${i}`, new Date(Date.UTC(2026, 7, 2) - i * 60_000).toISOString()),
+  )
 }
 
 /** Apply a list of events, returning the final state. Mirrors what the hook does:
@@ -358,6 +374,70 @@ describe("browse machine — single-flight arbitration", () => {
   it("load-more is unavailable once everything matching is loaded", () => {
     const complete: BrowseState = { ...loaded, fulfilled: { ...fulfilled, total: 2 } }
     expect(browseCanLoadMore(complete)).toBe(false)
+  })
+})
+
+describe("browse machine — the resident cap", () => {
+  function loadedWith(records: readonly MemoryRecord[], total = 5432): BrowseState {
+    return apply(
+      INITIAL_BROWSE_STATE,
+      { type: "query-changed", datasetKey: KEY_A },
+      { type: "response", revision: 1, kind: "initial", page: { records, total }, at: 1000 },
+    )
+  }
+
+  it("is the route's own BROWSE_MAX_LIMIT, so one refresh can ask for the whole set", () => {
+    expect(BROWSE_RESIDENT_CAP).toBe(BROWSE_MAX_LIMIT)
+  })
+
+  it("holds the resident set at the cap however the pages land", () => {
+    // A resident count off the 200 boundary is ordinary, not exotic: `dedupeById` drops
+    // a paging duplicate whenever an insert shifts the offsets under a load-more.
+    let state = loadedWith(rows(197))
+    for (let guard = 0; browseCanLoadMore(state) && guard < 20; guard += 1) {
+      const transition = browseReduce(state, { type: "load-more-requested" })
+      const request = transition.start
+      if (request === null) throw new Error("unreachable")
+      expect(request.window.offset + request.window.limit).toBeLessThanOrEqual(BROWSE_RESIDENT_CAP)
+      state = browseReduce(transition.state, {
+        type: "response",
+        revision: 1,
+        kind: "load-more",
+        page: { records: rows(request.window.limit, request.window.offset), total: 5432 },
+        at: 2000,
+      }).state
+    }
+    expect(state.fulfilled?.records).toHaveLength(BROWSE_RESIDENT_CAP)
+    expect(browseCanLoadMore(state)).toBe(false)
+  })
+
+  it("truncates a reconciled refresh, so rule 3's tail stays inside a later window", () => {
+    const state = loadedWith(rows(900))
+    const refreshing = browseReduce(state, { type: "poll-tick" })
+    expect(refreshing.start?.window).toEqual({ limit: 900, offset: 0 })
+    const settled = browseReduce(refreshing.state, {
+      type: "response",
+      revision: 1,
+      kind: "refresh",
+      page: { records: inserted(900), total: 6000 },
+      at: 2000,
+    }).state
+    expect(settled.fulfilled?.records).toHaveLength(BROWSE_RESIDENT_CAP)
+    // Dropped from the FAR end: a row the next window can still reach is worth more
+    // than one parked past the limit, which no refresh can ever re-cover again.
+    expect(settled.fulfilled?.records.at(-1)?.id).toBe("r99")
+    expect(browseReduce(settled, { type: "poll-tick" }).start?.window.limit).toBe(
+      BROWSE_RESIDENT_CAP,
+    )
+  })
+
+  it("retry does not re-issue a load-more the cap has already closed", () => {
+    const atCap: BrowseState = {
+      ...loadedWith(rows(BROWSE_RESIDENT_CAP)),
+      kindErrors: { "load-more": "boom" },
+    }
+    expect(browseCanLoadMore(atCap)).toBe(false)
+    expect(browseReduce(atCap, { type: "retry" }).start?.kind).toBe("refresh")
   })
 })
 

--- a/packages/inspector/test/components/browse-machine.test.ts
+++ b/packages/inspector/test/components/browse-machine.test.ts
@@ -629,8 +629,17 @@ describe("browse machine — flows 7 and 8: failure, slots and retry", () => {
       kind: "load-more",
       window: { limit: BROWSE_PAGE_SIZE, offset: 1 },
     })
+    // Both slots filled is the only arrangement that puts the preference to the test:
+    // refresh is also the fallback for a state carrying no failure at all, so a
+    // refresh-only case cannot tell a preference from a default.
+    const bothFailed: BrowseState = { ...loaded, kindErrors: { refresh: "r", "load-more": "l" } }
+    expect(browseReduce(bothFailed, { type: "retry" }).start?.kind).toBe("load-more")
     const refreshFailed: BrowseState = { ...loaded, kindErrors: { refresh: "boom" } }
-    expect(browseReduce(refreshFailed, { type: "retry" }).start?.kind).toBe("refresh")
+    expect(browseReduce(refreshFailed, { type: "retry" }).start).toEqual({
+      revision: 1,
+      kind: "refresh",
+      window: { limit: BROWSE_PAGE_SIZE, offset: 0 },
+    })
   })
 
   it("retry after the query moved on is simply the new query's initial fetch", () => {

--- a/packages/inspector/test/components/browse-machine.test.ts
+++ b/packages/inspector/test/components/browse-machine.test.ts
@@ -474,6 +474,23 @@ describe("browse machine — flow 9: refresh reconciles, load-more dedupes", () 
     expect(settled.state.fulfilled?.total).toBe(5431)
   })
 
+  it("refuses a refresh response with nothing in flight instead of guessing its span", () => {
+    // The request's limit is the only record of how far this response reached, and
+    // either guess decides rule 3: too high drops a live tail, too low pins a stale one.
+    expect(() =>
+      browseReduce(
+        { ...loaded, inFlight: null },
+        {
+          type: "response",
+          revision: 1,
+          kind: "refresh",
+          page: { records: [record("a")], total: 5432 },
+          at: 2000,
+        },
+      ),
+    ).toThrow(/in flight/)
+  })
+
   it("a load-more response is appended with ids deduped", () => {
     const loading = browseReduce(loaded, { type: "load-more-requested" }).state
     const settled = browseReduce(loading, {

--- a/packages/inspector/test/components/browse-machine.test.ts
+++ b/packages/inspector/test/components/browse-machine.test.ts
@@ -1,0 +1,505 @@
+import type { MemoryRecord } from "@dawn-ai/memory/browse"
+import { describe, expect, it } from "vitest"
+import {
+  BROWSE_PAGE_SIZE,
+  BROWSE_RESIDENT_CAP,
+  type BrowseEvent,
+  type BrowseState,
+  browseCanLoadMore,
+  browseDataState,
+  browsePhase,
+  browseReduce,
+  INITIAL_BROWSE_STATE,
+} from "../../src/browse/browse-machine"
+
+function record(id: string, updatedAt = "2026-08-01T00:00:00.000Z"): MemoryRecord {
+  return {
+    id,
+    kind: "semantic",
+    namespace: "route=/notes",
+    content: `content ${id}`,
+    data: {},
+    source: { type: "tool", id: "remember" },
+    confidence: 0.5,
+    tags: [],
+    status: "active",
+    createdAt: "2026-07-13T00:00:00.000Z",
+    updatedAt,
+  }
+}
+
+/** Apply a list of events, returning the final state. Mirrors what the hook does:
+ *  it feeds the reducer's `state` back in and ignores `start`/`abort`. */
+function apply(state: BrowseState, ...events: BrowseEvent[]): BrowseState {
+  let next = state
+  for (const event of events) next = browseReduce(next, event).state
+  return next
+}
+
+const KEY_A = '["list",null,null,null,null]'
+const KEY_B = '["list","route=/notes",null,null,null]'
+
+describe("browse machine — flow 1: initial load", () => {
+  it("mount bumps the revision to 1 and asks for the first window", () => {
+    const transition = browseReduce(INITIAL_BROWSE_STATE, {
+      type: "query-changed",
+      datasetKey: KEY_A,
+    })
+    expect(transition.state.revision).toBe(1)
+    expect(transition.state.datasetKey).toBe(KEY_A)
+    expect(transition.abort).toBe(false)
+    expect(transition.start).toEqual({
+      revision: 1,
+      kind: "initial",
+      window: { limit: BROWSE_PAGE_SIZE, offset: 0 },
+    })
+    expect(browsePhase(transition.state)).toBe("loading")
+  })
+
+  it("the response stores records, total and key together, tagged with the revision", () => {
+    const state = apply(
+      INITIAL_BROWSE_STATE,
+      { type: "query-changed", datasetKey: KEY_A },
+      {
+        type: "response",
+        revision: 1,
+        kind: "initial",
+        page: { records: [record("a")], total: 5432 },
+        at: 1000,
+      },
+    )
+    expect(state.fulfilled).toEqual({
+      revision: 1,
+      datasetKey: KEY_A,
+      records: [record("a")],
+      total: 5432,
+      at: 1000,
+    })
+    expect(browsePhase(state)).toBe("idle")
+    expect(browseDataState(state)).toEqual({ phase: "idle" })
+  })
+})
+
+describe("browse machine — flows 2 and 4: a new desired query over a fulfilled one", () => {
+  const loaded = apply(
+    INITIAL_BROWSE_STATE,
+    { type: "query-changed", datasetKey: KEY_A },
+    {
+      type: "response",
+      revision: 1,
+      kind: "initial",
+      page: { records: [record("a")], total: 5432 },
+      at: 1000,
+    },
+  )
+
+  it("keeps the old rows visible and marks them stale", () => {
+    const transition = browseReduce(loaded, { type: "query-changed", datasetKey: KEY_B })
+    expect(transition.state.revision).toBe(2)
+    expect(transition.state.fulfilled?.revision).toBe(1)
+    expect(browsePhase(transition.state)).toBe("stale")
+    expect(transition.start?.kind).toBe("initial")
+  })
+
+  it("aborts what was in flight, and drops the queued load-more and every error slot", () => {
+    const busy: BrowseState = {
+      ...loaded,
+      inFlight: { revision: 1, kind: "refresh", window: { limit: 200, offset: 0 } },
+      queuedLoadMore: true,
+      kindErrors: { refresh: "boom" },
+    }
+    const transition = browseReduce(busy, { type: "query-changed", datasetKey: KEY_B })
+    expect(transition.abort).toBe(true)
+    expect(transition.state.queuedLoadMore).toBe(false)
+    expect(transition.state.kindErrors).toEqual({})
+  })
+
+  it("fulfilling the new revision replaces the records and re-tags the key", () => {
+    const state = apply(
+      loaded,
+      { type: "query-changed", datasetKey: KEY_B },
+      {
+        type: "response",
+        revision: 2,
+        kind: "initial",
+        page: { records: [record("z")], total: 7 },
+        at: 2000,
+      },
+    )
+    expect(state.fulfilled).toEqual({
+      revision: 2,
+      datasetKey: KEY_B,
+      records: [record("z")],
+      total: 7,
+      at: 2000,
+    })
+    expect(browsePhase(state)).toBe("idle")
+  })
+})
+
+describe("browse machine — flow 6: a stale response completing after a query change", () => {
+  it("discards the response WHOLE — records, total and the flight slot", () => {
+    const stale = apply(
+      INITIAL_BROWSE_STATE,
+      { type: "query-changed", datasetKey: KEY_A },
+      {
+        type: "query-changed",
+        datasetKey: KEY_B,
+      },
+    )
+    const transition = browseReduce(stale, {
+      type: "response",
+      revision: 1,
+      kind: "initial",
+      page: { records: [record("a")], total: 999 },
+      at: 3000,
+    })
+    expect(transition.state).toBe(stale)
+    expect(transition.start).toBeNull()
+    expect(browsePhase(transition.state)).toBe("loading")
+  })
+
+  it("discards a stale FAILURE too, so it cannot hold the new revision in error", () => {
+    const stale = apply(
+      INITIAL_BROWSE_STATE,
+      { type: "query-changed", datasetKey: KEY_A },
+      {
+        type: "query-changed",
+        datasetKey: KEY_B,
+      },
+    )
+    const transition = browseReduce(stale, {
+      type: "failure",
+      revision: 1,
+      kind: "initial",
+      message: "gone",
+    })
+    expect(transition.state).toBe(stale)
+    expect(browsePhase(transition.state)).toBe("loading")
+  })
+})
+
+describe("browse machine — the phase table", () => {
+  const loaded = apply(
+    INITIAL_BROWSE_STATE,
+    { type: "query-changed", datasetKey: KEY_A },
+    {
+      type: "response",
+      revision: 1,
+      kind: "initial",
+      page: { records: [record("a")], total: 5432 },
+      at: 1000,
+    },
+  )
+
+  it("names the in-flight kind while the desired revision is fulfilled", () => {
+    expect(
+      browsePhase({
+        ...loaded,
+        inFlight: { revision: 1, kind: "refresh", window: { limit: 200, offset: 0 } },
+      }),
+    ).toBe("refreshing")
+    expect(
+      browsePhase({
+        ...loaded,
+        inFlight: { revision: 1, kind: "load-more", window: { limit: 200, offset: 1 } },
+      }),
+    ).toBe("loading-more")
+  })
+
+  it("error means nothing is fulfilled for the DESIRED revision, with or without rows", () => {
+    const failedCold = apply(
+      INITIAL_BROWSE_STATE,
+      { type: "query-changed", datasetKey: KEY_A },
+      {
+        type: "failure",
+        revision: 1,
+        kind: "initial",
+        message: "no memory store configured",
+      },
+    )
+    expect(browsePhase(failedCold)).toBe("error")
+    expect(browseDataState(failedCold)).toEqual({
+      phase: "error",
+      message: "no memory store configured",
+    })
+
+    const failedWarm = apply(
+      loaded,
+      { type: "query-changed", datasetKey: KEY_B },
+      {
+        type: "failure",
+        revision: 2,
+        kind: "initial",
+        message: "boom",
+      },
+    )
+    expect(browsePhase(failedWarm)).toBe("error")
+    expect(failedWarm.fulfilled?.records).toHaveLength(1)
+  })
+
+  it("a retry in flight is a fresh attempt, not the held failure", () => {
+    const failed = apply(
+      INITIAL_BROWSE_STATE,
+      { type: "query-changed", datasetKey: KEY_A },
+      {
+        type: "failure",
+        revision: 1,
+        kind: "initial",
+        message: "boom",
+      },
+    )
+    const retried = browseReduce(failed, { type: "retry" })
+    expect(retried.start).toEqual({
+      revision: 1,
+      kind: "initial",
+      window: { limit: BROWSE_PAGE_SIZE, offset: 0 },
+    })
+    expect(browsePhase(retried.state)).toBe("loading")
+  })
+})
+
+describe("browse machine — single-flight arbitration", () => {
+  const loaded = apply(
+    INITIAL_BROWSE_STATE,
+    { type: "query-changed", datasetKey: KEY_A },
+    {
+      type: "response",
+      revision: 1,
+      kind: "initial",
+      page: { records: [record("a"), record("b")], total: 5432 },
+      at: 1000,
+    },
+  )
+  const fulfilled = loaded.fulfilled
+  if (fulfilled === null) throw new Error("unreachable")
+
+  it("a poll tick asks for offset 0 with limit = resident count, floored at one page", () => {
+    expect(browseReduce(loaded, { type: "poll-tick" }).start).toEqual({
+      revision: 1,
+      kind: "refresh",
+      window: { limit: BROWSE_PAGE_SIZE, offset: 0 },
+    })
+    const big: BrowseState = {
+      ...loaded,
+      fulfilled: { ...fulfilled, records: Array.from({ length: 600 }, (_, i) => record(`r${i}`)) },
+    }
+    expect(browseReduce(big, { type: "poll-tick" }).start?.window).toEqual({
+      limit: 600,
+      offset: 0,
+    })
+  })
+
+  it("a poll tick due while ANYTHING is in flight is skipped", () => {
+    for (const kind of ["initial", "refresh", "load-more"] as const) {
+      const busy: BrowseState = {
+        ...loaded,
+        inFlight: { revision: 1, kind, window: { limit: 200, offset: 0 } },
+      }
+      const transition = browseReduce(busy, { type: "poll-tick" })
+      expect(transition.start).toBeNull()
+      expect(transition.state).toBe(busy)
+    }
+  })
+
+  it("a load-more asked for during a poll tick is QUEUED and runs when the tick settles", () => {
+    const refreshing = browseReduce(loaded, { type: "poll-tick" }).state
+    const queued = browseReduce(refreshing, { type: "load-more-requested" })
+    expect(queued.start).toBeNull()
+    expect(queued.state.queuedLoadMore).toBe(true)
+
+    const settled = browseReduce(queued.state, {
+      type: "response",
+      revision: 1,
+      kind: "refresh",
+      page: { records: [record("a"), record("b")], total: 5432 },
+      at: 2000,
+    })
+    expect(settled.state.queuedLoadMore).toBe(false)
+    expect(settled.start).toEqual({
+      revision: 1,
+      kind: "load-more",
+      window: { limit: BROWSE_PAGE_SIZE, offset: 2 },
+    })
+  })
+
+  it("a queued load-more also runs when the tick it waited on FAILS", () => {
+    const refreshing = browseReduce(loaded, { type: "poll-tick" }).state
+    const queued = browseReduce(refreshing, { type: "load-more-requested" }).state
+    const settled = browseReduce(queued, {
+      type: "failure",
+      revision: 1,
+      kind: "refresh",
+      message: "boom",
+    })
+    expect(settled.start?.kind).toBe("load-more")
+  })
+
+  it("load-more during load-more is a no-op, and stops at the resident cap", () => {
+    const loading: BrowseState = {
+      ...loaded,
+      inFlight: { revision: 1, kind: "load-more", window: { limit: 200, offset: 2 } },
+    }
+    expect(browseReduce(loading, { type: "load-more-requested" }).start).toBeNull()
+    expect(browseReduce(loading, { type: "load-more-requested" }).state.queuedLoadMore).toBe(false)
+
+    const atCap: BrowseState = {
+      ...loaded,
+      fulfilled: {
+        ...fulfilled,
+        records: Array.from({ length: BROWSE_RESIDENT_CAP }, (_, i) => record(`r${i}`)),
+        total: 5432,
+      },
+    }
+    expect(browseCanLoadMore(atCap)).toBe(false)
+    expect(browseReduce(atCap, { type: "load-more-requested" }).start).toBeNull()
+  })
+
+  it("load-more is unavailable once everything matching is loaded", () => {
+    const complete: BrowseState = { ...loaded, fulfilled: { ...fulfilled, total: 2 } }
+    expect(browseCanLoadMore(complete)).toBe(false)
+  })
+})
+
+describe("browse machine — flow 9: refresh reconciles, load-more dedupes", () => {
+  const loaded = apply(
+    INITIAL_BROWSE_STATE,
+    { type: "query-changed", datasetKey: KEY_A },
+    {
+      type: "response",
+      revision: 1,
+      kind: "initial",
+      page: {
+        records: [record("a", "2026-08-03T00:00:00.000Z"), record("b", "2026-08-02T00:00:00.000Z")],
+        total: 5432,
+      },
+      at: 1000,
+    },
+  )
+
+  it("a refresh response is reconciled against the residents, not concatenated", () => {
+    const refreshing = browseReduce(loaded, { type: "poll-tick" }).state
+    // A partial window (2 of a 200 limit) ends the span: `b` is gone.
+    const settled = browseReduce(refreshing, {
+      type: "response",
+      revision: 1,
+      kind: "refresh",
+      page: {
+        records: [record("c", "2026-08-09T00:00:00.000Z"), record("a", "2026-08-03T00:00:00.000Z")],
+        total: 5431,
+      },
+      at: 2000,
+    })
+    expect(settled.state.fulfilled?.records.map((r) => r.id)).toEqual(["c", "a"])
+    expect(settled.state.fulfilled?.total).toBe(5431)
+  })
+
+  it("a load-more response is appended with ids deduped", () => {
+    const loading = browseReduce(loaded, { type: "load-more-requested" }).state
+    const settled = browseReduce(loading, {
+      type: "response",
+      revision: 1,
+      kind: "load-more",
+      page: {
+        records: [record("b", "2026-08-02T00:00:00.000Z"), record("c", "2026-08-01T00:00:00.000Z")],
+        total: 5432,
+      },
+      at: 2000,
+    })
+    expect(settled.state.fulfilled?.records.map((r) => r.id)).toEqual(["a", "b", "c"])
+  })
+})
+
+describe("browse machine — flows 7 and 8: failure, slots and retry", () => {
+  const loaded = apply(
+    INITIAL_BROWSE_STATE,
+    { type: "query-changed", datasetKey: KEY_A },
+    {
+      type: "response",
+      revision: 1,
+      kind: "initial",
+      page: { records: [record("a")], total: 5432 },
+      at: 1000,
+    },
+  )
+
+  it("a refresh failure keeps the rows and the idle phase, and fills only its own slot", () => {
+    const refreshing = browseReduce(loaded, { type: "poll-tick" }).state
+    const failed = browseReduce(refreshing, {
+      type: "failure",
+      revision: 1,
+      kind: "refresh",
+      message: "network down",
+    }).state
+    expect(browsePhase(failed)).toBe("idle")
+    expect(failed.fulfilled?.records).toHaveLength(1)
+    expect(failed.kindErrors).toEqual({ refresh: "network down" })
+  })
+
+  it("one kind's success cannot clear another kind's failure", () => {
+    const withBoth: BrowseState = { ...loaded, kindErrors: { refresh: "r", "load-more": "l" } }
+    const refreshing = browseReduce(withBoth, { type: "poll-tick" }).state
+    const ok = browseReduce(refreshing, {
+      type: "response",
+      revision: 1,
+      kind: "refresh",
+      page: { records: [record("a")], total: 5432 },
+      at: 2000,
+    }).state
+    expect(ok.kindErrors).toEqual({ "load-more": "l" })
+  })
+
+  it("a repeated identical failure keeps the SAME slots object, so a 2 s cadence cannot re-render", () => {
+    const refreshing = browseReduce(loaded, { type: "poll-tick" }).state
+    const once = browseReduce(refreshing, {
+      type: "failure",
+      revision: 1,
+      kind: "refresh",
+      message: "network down",
+    }).state
+    const again = browseReduce(browseReduce(once, { type: "poll-tick" }).state, {
+      type: "failure",
+      revision: 1,
+      kind: "refresh",
+      message: "network down",
+    }).state
+    expect(again.kindErrors).toBe(once.kindErrors)
+  })
+
+  it("retry re-attempts the failed KIND, preferring load-more over refresh", () => {
+    const loadMoreFailed: BrowseState = { ...loaded, kindErrors: { "load-more": "boom" } }
+    expect(browseReduce(loadMoreFailed, { type: "retry" }).start).toEqual({
+      revision: 1,
+      kind: "load-more",
+      window: { limit: BROWSE_PAGE_SIZE, offset: 1 },
+    })
+    const refreshFailed: BrowseState = { ...loaded, kindErrors: { refresh: "boom" } }
+    expect(browseReduce(refreshFailed, { type: "retry" }).start?.kind).toBe("refresh")
+  })
+
+  it("retry after the query moved on is simply the new query's initial fetch", () => {
+    const moved = apply(
+      loaded,
+      { type: "query-changed", datasetKey: KEY_B },
+      {
+        type: "failure",
+        revision: 2,
+        kind: "initial",
+        message: "boom",
+      },
+    )
+    expect(browseReduce(moved, { type: "retry" }).start).toEqual({
+      revision: 2,
+      kind: "initial",
+      window: { limit: BROWSE_PAGE_SIZE, offset: 0 },
+    })
+  })
+
+  it("retry while something is in flight is a no-op", () => {
+    const busy: BrowseState = {
+      ...loaded,
+      inFlight: { revision: 1, kind: "refresh", window: { limit: 200, offset: 0 } },
+    }
+    expect(browseReduce(busy, { type: "retry" }).start).toBeNull()
+  })
+})

--- a/packages/inspector/test/components/browse-machine.test.ts
+++ b/packages/inspector/test/components/browse-machine.test.ts
@@ -377,6 +377,65 @@ describe("browse machine — single-flight arbitration", () => {
   })
 })
 
+describe("browse machine — immutability and identity", () => {
+  const loaded = apply(
+    INITIAL_BROWSE_STATE,
+    { type: "query-changed", datasetKey: KEY_A },
+    {
+      type: "response",
+      revision: 1,
+      kind: "initial",
+      page: { records: [record("a")], total: 5432 },
+      at: 1000,
+    },
+  )
+
+  it("freezes the singletons it hands out, which `readonly` does not survive to runtime", () => {
+    expect(Object.isFrozen(INITIAL_BROWSE_STATE)).toBe(true)
+    expect(Object.isFrozen(INITIAL_BROWSE_STATE.kindErrors)).toBe(true)
+    // The same empty-slots object is installed on EVERY query change, so one widening
+    // cast downstream would edit the slots of every state that ever cleared them.
+    const cleared = browseReduce(
+      { ...loaded, kindErrors: { refresh: "boom" } },
+      { type: "query-changed", datasetKey: KEY_B },
+    ).state
+    expect(Object.isFrozen(cleared.kindErrors)).toBe(true)
+  })
+
+  it("a load-more asked for twice under one tick keeps the SAME state", () => {
+    const refreshing = browseReduce(loaded, { type: "poll-tick" }).state
+    const queued = browseReduce(refreshing, { type: "load-more-requested" }).state
+    expect(queued.queuedLoadMore).toBe(true)
+    expect(browseReduce(queued, { type: "load-more-requested" }).state).toBe(queued)
+  })
+
+  it("hands out one dataState per phase, so a consumer can hold it as a dependency", () => {
+    expect(browseDataState(loaded)).toBe(browseDataState(loaded))
+    // The 2 s cadence walks idle → refreshing → idle forever; coming back to idle is
+    // not a change, and a fresh object each tick says it is.
+    const refreshing = browseReduce(loaded, { type: "poll-tick" }).state
+    const settled = browseReduce(refreshing, {
+      type: "response",
+      revision: 1,
+      kind: "refresh",
+      page: { records: [record("a")], total: 5432 },
+      at: 2000,
+    }).state
+    expect(browseDataState(refreshing)).not.toBe(browseDataState(loaded))
+    expect(browseDataState(settled)).toBe(browseDataState(loaded))
+  })
+
+  it("holds one dataState per failure, message and all", () => {
+    const failed = apply(
+      INITIAL_BROWSE_STATE,
+      { type: "query-changed", datasetKey: KEY_A },
+      { type: "failure", revision: 1, kind: "initial", message: "boom" },
+    )
+    expect(browseDataState(failed)).toEqual({ phase: "error", message: "boom" })
+    expect(browseDataState(failed)).toBe(browseDataState(failed))
+  })
+})
+
 describe("browse machine — the resident cap", () => {
   function loadedWith(records: readonly MemoryRecord[], total = 5432): BrowseState {
     return apply(

--- a/packages/inspector/test/components/browse-query.test.ts
+++ b/packages/inspector/test/components/browse-query.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vitest"
+import {
+  browseMatchesNothing,
+  browseSearchParams,
+  canonicalBrowseQuery,
+  datasetKeyOf,
+} from "../../src/browse/canonical-query"
+
+describe("canonicalBrowseQuery", () => {
+  it("uses null for unfiltered and keeps an empty set as itself", () => {
+    const unfiltered = canonicalBrowseQuery({ view: "list" })
+    expect(unfiltered).toEqual({
+      view: "list",
+      namespace: null,
+      status: null,
+      kind: null,
+      since: null,
+    })
+    const nothing = canonicalBrowseQuery({ view: "list", status: [] })
+    expect(nothing.status).toEqual([])
+  })
+
+  it("sorts and dedupes value sets so tick order cannot fork the dataset", () => {
+    const a = canonicalBrowseQuery({ view: "list", status: ["superseded", "active", "active"] })
+    const b = canonicalBrowseQuery({ view: "list", status: ["active", "superseded"] })
+    expect(a.status).toEqual(["active", "superseded"])
+    expect(datasetKeyOf(a)).toBe(datasetKeyOf(b))
+  })
+
+  it("defaults the timeline view to episodic, and lets the funnel override it", () => {
+    expect(canonicalBrowseQuery({ view: "timeline" }).kind).toEqual(["episodic"])
+    expect(canonicalBrowseQuery({ view: "timeline", kind: ["semantic"] }).kind).toEqual([
+      "semantic",
+    ])
+    // An emptied funnel still means "matches nothing", not "fall back to episodic".
+    expect(canonicalBrowseQuery({ view: "timeline", kind: [] }).kind).toEqual([])
+  })
+
+  it("gives a different key to every identity field", () => {
+    const base = canonicalBrowseQuery({ view: "list" })
+    const variants = [
+      canonicalBrowseQuery({ view: "timeline" }),
+      canonicalBrowseQuery({ view: "list", namespace: "route=/notes" }),
+      canonicalBrowseQuery({ view: "list", status: ["active"] }),
+      canonicalBrowseQuery({ view: "list", kind: ["semantic"] }),
+      canonicalBrowseQuery({ view: "list", since: "2026-08-01T00:00:00.000Z" }),
+    ]
+    for (const variant of variants) {
+      expect(datasetKeyOf(variant)).not.toBe(datasetKeyOf(base))
+    }
+  })
+})
+
+describe("browseMatchesNothing", () => {
+  it("is true only for a set narrowed to nothing", () => {
+    expect(browseMatchesNothing(canonicalBrowseQuery({ view: "list" }))).toBe(false)
+    expect(browseMatchesNothing(canonicalBrowseQuery({ view: "list", status: ["active"] }))).toBe(
+      false,
+    )
+    expect(browseMatchesNothing(canonicalBrowseQuery({ view: "list", status: [] }))).toBe(true)
+    expect(browseMatchesNothing(canonicalBrowseQuery({ view: "list", kind: [] }))).toBe(true)
+  })
+})
+
+describe("browseSearchParams", () => {
+  it("sends the EXACT namespace, repeated enum params, and the window", () => {
+    const params = browseSearchParams(
+      canonicalBrowseQuery({
+        view: "list",
+        namespace: "route=/notes",
+        status: ["active", "candidate"],
+        kind: ["semantic"],
+      }),
+      { limit: 200, offset: 400 },
+    )
+    expect(params.get("namespace")).toBe("route=/notes")
+    expect(params.get("namespacePrefix")).toBeNull()
+    expect(params.getAll("status")).toEqual(["active", "candidate"])
+    expect(params.getAll("kind")).toEqual(["semantic"])
+    expect(params.get("limit")).toBe("200")
+    expect(params.get("offset")).toBe("400")
+  })
+
+  it("omits absent narrowings entirely", () => {
+    const params = browseSearchParams(canonicalBrowseQuery({ view: "list" }), {
+      limit: 200,
+      offset: 0,
+    })
+    expect(params.get("namespace")).toBeNull()
+    expect(params.getAll("status")).toEqual([])
+    expect(params.get("since")).toBeNull()
+  })
+
+  it("threads the pinned timeline window bound", () => {
+    const params = browseSearchParams(
+      canonicalBrowseQuery({ view: "timeline", since: "2026-08-01T00:00:00.000Z" }),
+      { limit: 200, offset: 0 },
+    )
+    expect(params.get("since")).toBe("2026-08-01T00:00:00.000Z")
+    expect(params.getAll("kind")).toEqual(["episodic"])
+  })
+})

--- a/packages/inspector/test/components/browse-query.test.ts
+++ b/packages/inspector/test/components/browse-query.test.ts
@@ -36,6 +36,19 @@ describe("canonicalBrowseQuery", () => {
     expect(canonicalBrowseQuery({ view: "timeline", kind: [] }).kind).toEqual([])
   })
 
+  it("reads an empty namespace as unfiltered, the way the server does", () => {
+    const empty = canonicalBrowseQuery({ view: "list", namespace: "" })
+    expect(empty.namespace).toBeNull()
+    expect(datasetKeyOf(empty)).toBe(datasetKeyOf(canonicalBrowseQuery({ view: "list" })))
+  })
+
+  it("freezes value sets, so the shared timeline default cannot be mutated for the process", () => {
+    expect(Object.isFrozen(canonicalBrowseQuery({ view: "timeline" }).kind)).toBe(true)
+    expect(Object.isFrozen(canonicalBrowseQuery({ view: "list", status: ["active"] }).status)).toBe(
+      true,
+    )
+  })
+
   it("gives a different key to every identity field", () => {
     const base = canonicalBrowseQuery({ view: "list" })
     const variants = [
@@ -89,6 +102,20 @@ describe("browseSearchParams", () => {
     expect(params.get("namespace")).toBeNull()
     expect(params.getAll("status")).toEqual([])
     expect(params.get("since")).toBeNull()
+  })
+
+  it("takes the expiry cutoff out of the answer, so one key means one set", () => {
+    const params = browseSearchParams(canonicalBrowseQuery({ view: "timeline" }), {
+      limit: 200,
+      offset: 400,
+    })
+    expect(params.get("includeExpired")).toBe("1")
+    expect(params.get("now")).toBeNull()
+  })
+
+  it("refuses a matches-nothing query instead of asking for everything", () => {
+    const nothing = canonicalBrowseQuery({ view: "list", status: [] })
+    expect(() => browseSearchParams(nothing, { limit: 200, offset: 0 })).toThrow(/matches nothing/)
   })
 
   it("threads the pinned timeline window bound", () => {

--- a/packages/inspector/test/components/browse-reconcile.test.ts
+++ b/packages/inspector/test/components/browse-reconcile.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  compareDefaultBrowseOrder,
+  dedupeById,
+  reconcileRefreshedWindow,
+} from "../../src/browse/browse-reconcile"
+
+/** A row carrying just the two fields the default order reads, plus a payload
+ *  marker so "took the response's payload" is observable. */
+function row(id: string, updatedAt: string, payload = "old") {
+  return { id, updatedAt, payload }
+}
+
+describe("compareDefaultBrowseOrder", () => {
+  it("orders updatedAt DESC then id ASC", () => {
+    expect(
+      compareDefaultBrowseOrder(
+        row("a", "2026-08-02T00:00:00.000Z"),
+        row("b", "2026-08-01T00:00:00.000Z"),
+      ),
+    ).toBeLessThan(0)
+    expect(
+      compareDefaultBrowseOrder(
+        row("a", "2026-08-01T00:00:00.000Z"),
+        row("b", "2026-08-02T00:00:00.000Z"),
+      ),
+    ).toBeGreaterThan(0)
+    expect(
+      compareDefaultBrowseOrder(
+        row("a", "2026-08-01T00:00:00.000Z"),
+        row("b", "2026-08-01T00:00:00.000Z"),
+      ),
+    ).toBeLessThan(0)
+    expect(
+      compareDefaultBrowseOrder(
+        row("a", "2026-08-01T00:00:00.000Z"),
+        row("a", "2026-08-01T00:00:00.000Z"),
+      ),
+    ).toBe(0)
+  })
+
+  it("breaks id ties on code units, so uppercase sorts before lowercase", () => {
+    expect(compareDefaultBrowseOrder(row("Z", "t"), row("a", "t"))).toBeLessThan(0)
+  })
+})
+
+describe("dedupeById", () => {
+  it("appends only ids the resident set does not hold", () => {
+    const prev = [row("a", "t"), row("b", "t")]
+    expect(dedupeById(prev, [row("b", "t"), row("c", "t")]).map((r) => r.id)).toEqual([
+      "a",
+      "b",
+      "c",
+    ])
+  })
+
+  it("returns the SAME array when nothing was added", () => {
+    const prev = [row("a", "t")]
+    expect(dedupeById(prev, [row("a", "t")])).toBe(prev)
+  })
+})
+
+describe("reconcileRefreshedWindow", () => {
+  it("rule 1: a resident row in the response takes the response payload AND position", () => {
+    const resident = [row("a", "2026-08-03T00:00:00.000Z"), row("b", "2026-08-02T00:00:00.000Z")]
+    // `b` was approved: hoisted above `a`, with a new payload.
+    const refreshed = [
+      row("b", "2026-08-04T00:00:00.000Z", "new"),
+      row("a", "2026-08-03T00:00:00.000Z", "new"),
+    ]
+    const next = reconcileRefreshedWindow(resident, refreshed, 2)
+    expect(next.map((r) => r.id)).toEqual(["b", "a"])
+    expect(next.every((r) => r.payload === "new")).toBe(true)
+  })
+
+  it("rule 2: a resident row inside the refreshed span but absent from it is dropped", () => {
+    const resident = [
+      row("a", "2026-08-03T00:00:00.000Z"),
+      row("b", "2026-08-02T00:00:00.000Z"),
+      row("c", "2026-08-01T00:00:00.000Z"),
+    ]
+    // A full window that no longer contains `b` — deleted, or filtered out.
+    const refreshed = [row("a", "2026-08-03T00:00:00.000Z"), row("c", "2026-08-01T00:00:00.000Z")]
+    expect(reconcileRefreshedWindow(resident, refreshed, 2).map((r) => r.id)).toEqual(["a", "c"])
+  })
+
+  it("rule 3: a resident row BEYOND the refreshed span is retained as a stale tail", () => {
+    const resident = [
+      row("a", "2026-08-03T00:00:00.000Z"),
+      row("b", "2026-08-02T00:00:00.000Z"),
+      row("c", "2026-08-01T00:00:00.000Z"),
+    ]
+    // Two head inserts filled the whole limit, so coverage now ends at `x2`.
+    const refreshed = [row("x1", "2026-08-09T00:00:00.000Z"), row("x2", "2026-08-08T00:00:00.000Z")]
+    const next = reconcileRefreshedWindow(resident, refreshed, 2)
+    expect(next.map((r) => r.id)).toEqual(["x1", "x2", "a", "b", "c"])
+  })
+
+  it("a window that did not FILL its limit has an unbounded span, so nothing is retained", () => {
+    const resident = [row("a", "2026-08-03T00:00:00.000Z"), row("b", "2026-08-02T00:00:00.000Z")]
+    // One row back out of a limit of 200: the matching set really is one row.
+    expect(
+      reconcileRefreshedWindow(resident, [row("a", "2026-08-03T00:00:00.000Z")], 200).map(
+        (r) => r.id,
+      ),
+    ).toEqual(["a"])
+  })
+
+  it("an empty response empties the resident set", () => {
+    expect(reconcileRefreshedWindow([row("a", "t")], [], 200)).toEqual([])
+  })
+})

--- a/packages/inspector/test/components/browse-reconcile.test.ts
+++ b/packages/inspector/test/components/browse-reconcile.test.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_BROWSE_ORDER } from "@dawn-ai/memory/browse"
 import { describe, expect, it } from "vitest"
 
 import {
@@ -43,6 +44,18 @@ describe("compareDefaultBrowseOrder", () => {
   it("breaks id ties on code units, so uppercase sorts before lowercase", () => {
     expect(compareDefaultBrowseOrder(row("Z", "t"), row("a", "t"))).toBeLessThan(0)
   })
+
+  // The premise of the whole module: rules 2 and 3 only decide anything if this
+  // comparator is the ORDER BY the server actually ran. Changing the store default —
+  // or starting to send an explicit `orderBy`, which `src/store/browse-params.ts`
+  // already parses — desynchronizes them silently, so pin the default here. The
+  // trailing `id ASC` is not in this array: both stores append it themselves so every
+  // order is total.
+  it("implements the server's DEFAULT_BROWSE_ORDER", () => {
+    expect(DEFAULT_BROWSE_ORDER.map((entry) => [entry.field, entry.dir])).toEqual([
+      ["updatedAt", "desc"],
+    ])
+  })
 })
 
 describe("dedupeById", () => {
@@ -59,6 +72,11 @@ describe("dedupeById", () => {
     const prev = [row("a", "t")]
     expect(dedupeById(prev, [row("a", "t")])).toBe(prev)
   })
+
+  it("drops a duplicate WITHIN next, not only one against prev", () => {
+    const next = [row("b", "t"), row("b", "t", "again"), row("c", "t")]
+    expect(dedupeById([row("a", "t")], next).map((r) => r.id)).toEqual(["a", "b", "c"])
+  })
 })
 
 describe("reconcileRefreshedWindow", () => {
@@ -69,7 +87,7 @@ describe("reconcileRefreshedWindow", () => {
       row("b", "2026-08-04T00:00:00.000Z", "new"),
       row("a", "2026-08-03T00:00:00.000Z", "new"),
     ]
-    const next = reconcileRefreshedWindow(resident, refreshed, 2)
+    const next = reconcileRefreshedWindow(resident, refreshed, { filled: true })
     expect(next.map((r) => r.id)).toEqual(["b", "a"])
     expect(next.every((r) => r.payload === "new")).toBe(true)
   })
@@ -82,7 +100,9 @@ describe("reconcileRefreshedWindow", () => {
     ]
     // A full window that no longer contains `b` — deleted, or filtered out.
     const refreshed = [row("a", "2026-08-03T00:00:00.000Z"), row("c", "2026-08-01T00:00:00.000Z")]
-    expect(reconcileRefreshedWindow(resident, refreshed, 2).map((r) => r.id)).toEqual(["a", "c"])
+    expect(
+      reconcileRefreshedWindow(resident, refreshed, { filled: true }).map((r) => r.id),
+    ).toEqual(["a", "c"])
   })
 
   it("rule 3: a resident row BEYOND the refreshed span is retained as a stale tail", () => {
@@ -93,21 +113,41 @@ describe("reconcileRefreshedWindow", () => {
     ]
     // Two head inserts filled the whole limit, so coverage now ends at `x2`.
     const refreshed = [row("x1", "2026-08-09T00:00:00.000Z"), row("x2", "2026-08-08T00:00:00.000Z")]
-    const next = reconcileRefreshedWindow(resident, refreshed, 2)
+    const next = reconcileRefreshedWindow(resident, refreshed, { filled: true })
     expect(next.map((r) => r.id)).toEqual(["x1", "x2", "a", "b", "c"])
+  })
+
+  it("an insert and a delete in ONE refresh leave the retained tail contiguous", () => {
+    const resident = [
+      row("a", "2026-08-04T00:00:00.000Z"),
+      row("b", "2026-08-03T00:00:00.000Z"),
+      row("c", "2026-08-02T00:00:00.000Z"),
+      row("d", "2026-08-01T00:00:00.000Z"),
+    ]
+    // `b` deleted and two inserted in the same tick: the window still ends at `c`, so
+    // `d` alone is beyond it. Dropping `b` must not pull `d` inside the span.
+    const refreshed = [
+      row("x1", "2026-08-09T00:00:00.000Z"),
+      row("x2", "2026-08-08T00:00:00.000Z"),
+      row("a", "2026-08-04T00:00:00.000Z"),
+      row("c", "2026-08-02T00:00:00.000Z"),
+    ]
+    expect(
+      reconcileRefreshedWindow(resident, refreshed, { filled: true }).map((r) => r.id),
+    ).toEqual(["x1", "x2", "a", "c", "d"])
   })
 
   it("a window that did not FILL its limit has an unbounded span, so nothing is retained", () => {
     const resident = [row("a", "2026-08-03T00:00:00.000Z"), row("b", "2026-08-02T00:00:00.000Z")]
-    // One row back out of a limit of 200: the matching set really is one row.
+    // The response did not fill: the matching set really is one row.
     expect(
-      reconcileRefreshedWindow(resident, [row("a", "2026-08-03T00:00:00.000Z")], 200).map(
-        (r) => r.id,
-      ),
+      reconcileRefreshedWindow(resident, [row("a", "2026-08-03T00:00:00.000Z")], {
+        filled: false,
+      }).map((r) => r.id),
     ).toEqual(["a"])
   })
 
   it("an empty response empties the resident set", () => {
-    expect(reconcileRefreshedWindow([row("a", "t")], [], 200)).toEqual([])
+    expect(reconcileRefreshedWindow([row("a", "t")], [], { filled: false })).toEqual([])
   })
 })

--- a/packages/inspector/test/components/column-filter-wiring.test.tsx
+++ b/packages/inspector/test/components/column-filter-wiring.test.tsx
@@ -155,11 +155,11 @@ describe("column filters drive the server query", () => {
 
     const before = listUrls(mock).length
     await waitFor(() => {
-      expect(screen.getByTestId("no-matches")).toBeDefined()
+      expect(screen.getByTestId("browse-empty")).toBeDefined()
     })
     // Over HTTP a param that appears zero times is *absent*, so re-asking the
     // server would come back unfiltered — the page must answer it here.
     expect(listUrls(mock).length).toBe(before)
-    expect(screen.getByTestId("no-matches").textContent).toContain("match these filters")
+    expect(screen.getByTestId("browse-empty").textContent).toContain("match these filters")
   })
 })

--- a/packages/inspector/test/components/list.test.tsx
+++ b/packages/inspector/test/components/list.test.tsx
@@ -88,38 +88,41 @@ describe("ListPage", () => {
     fireEvent.click(facet)
     await vi.waitFor(() => {
       const scoped = callsTo(mock, "/api/memory/list").filter(
-        (u) => u.searchParams.get("namespacePrefix") === "route=/notes",
+        (u) => u.searchParams.get("namespace") === "route=/notes",
       )
       expect(scoped.length).toBeGreaterThan(0)
     })
   })
 
-  it("a selected facet filters the page to the exact namespace, not the prefix", async () => {
+  it("a selected facet asks the server for the exact namespace", async () => {
     const sibling: MemoryRecord = {
       ...candidate,
       id: "cand2",
       namespace: "route=/notes2",
       content: "sibling prefix record",
     }
-    vi.stubGlobal(
-      "fetch",
-      vi.fn(async (url: RequestInfo | URL) => {
-        const u = String(url)
-        if (u.includes("/api/memory/stats")) {
-          return jsonResponse({
-            ...stats,
-            total: 2,
-            byNamespace: { "route=/notes": 1, "route=/notes2": 1 },
-          })
-        }
-        if (u.includes("/api/memory/list")) {
-          // The server narrows by PREFIX, so a route=/notes selection still
-          // returns the route=/notes2 sibling — the client must filter exactly.
-          return jsonResponse({ records: [candidate, sibling], total: 2 })
-        }
-        return jsonResponse({ groups: [] })
-      }),
-    )
+    const mock = vi.fn(async (url: RequestInfo | URL) => {
+      const u = String(url)
+      if (u.includes("/api/memory/stats")) {
+        return jsonResponse({
+          ...stats,
+          total: 2,
+          byNamespace: { "route=/notes": 1, "route=/notes2": 1 },
+        })
+      }
+      if (u.includes("/api/memory/list")) {
+        // The request now carries the EXACT namespace, so the server answers with
+        // exactly that namespace's rows — no client-side narrowing left to do.
+        const exact = new URL(u, "http://localhost").searchParams.get("namespace")
+        return jsonResponse(
+          exact === "route=/notes"
+            ? { records: [candidate], total: 1 }
+            : { records: [candidate, sibling], total: 2 },
+        )
+      }
+      return jsonResponse({ groups: [] })
+    })
+    vi.stubGlobal("fetch", mock)
     render(<ListPage />)
     expect(await screen.findByText("acme threshold is 750")).toBeDefined()
     expect(await screen.findByText("sibling prefix record")).toBeDefined()
@@ -134,6 +137,10 @@ describe("ListPage", () => {
       expect(screen.queryByText("sibling prefix record")).toBeNull()
     })
     expect(screen.getByText("acme threshold is 750")).toBeDefined()
+    const exact = callsTo(mock, "/api/memory/list").filter(
+      (u) => u.searchParams.get("namespace") === "route=/notes",
+    )
+    expect(exact.length).toBeGreaterThan(0)
   })
 
   it("typing a query fires a debounced search and renders grouped results", async () => {

--- a/packages/inspector/test/components/list.test.tsx
+++ b/packages/inspector/test/components/list.test.tsx
@@ -55,11 +55,26 @@ function stubApi() {
   return mock
 }
 
-function callsTo(mock: ReturnType<typeof stubApi>, path: string): URL[] {
+/** Structural on purpose: the mutation stubs below take an `init` the read-only
+ *  stub does not, so a `ReturnType<typeof stubApi>` parameter would reject them. */
+function callsTo(mock: { mock: { calls: readonly (readonly unknown[])[] } }, path: string): URL[] {
   return mock.mock.calls
     .map((call) => String(call[0]))
     .filter((u) => u.includes(path))
     .map((u) => new URL(u, "http://localhost"))
+}
+
+function rowCheckbox(container: HTMLElement, rowId: string): HTMLElement {
+  const box = container.querySelector(
+    `[data-pretable-row-id="${rowId}"] button[data-pretable-row-select]`,
+  )
+  if (!box) throw new Error(`no checkbox for ${rowId}`)
+  return box as HTMLElement
+}
+
+function postCount(mock: { mock: { calls: readonly (readonly unknown[])[] } }): number {
+  return mock.mock.calls.filter((call) => (call[1] as RequestInit | undefined)?.method === "POST")
+    .length
 }
 
 describe("ListPage", () => {
@@ -161,5 +176,151 @@ describe("ListPage", () => {
     render(<ListPage />)
     const banner = await screen.findByRole("alert")
     expect(banner.textContent).toContain("no memory store configured")
+  })
+
+  it("surfaces a browse failure in the timeline view, with a way out", async () => {
+    let fail = true
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: RequestInfo | URL) => {
+        const u = String(url)
+        if (u.includes("/api/memory/stats")) return jsonResponse(stats)
+        if (u.includes("/api/memory/list")) {
+          return fail
+            ? jsonResponse({ error: "no memory store configured" }, 500)
+            : jsonResponse({ records: [candidate], total: 1 })
+        }
+        return jsonResponse({ groups: [] })
+      }),
+    )
+    render(<ListPage />)
+    fireEvent.click(screen.getByRole("button", { name: "timeline" }))
+
+    const entry = await screen.findByTestId("error-browse")
+    expect(entry.textContent).toContain("no memory store configured")
+    // The error phase suspends polling, so without a control here the timeline never
+    // asks again and the failure reads as an empty window for the rest of the session.
+    fail = false
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }))
+    expect(await screen.findByText("acme threshold is 750")).toBeDefined()
+    expect(screen.queryByTestId("error-browse")).toBeNull()
+  })
+
+  it("puts exactly one retry on screen for a failed browse", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: RequestInfo | URL) => {
+        const u = String(url)
+        if (u.includes("/api/memory/stats")) return jsonResponse(stats)
+        if (u.includes("/api/memory/list")) {
+          return jsonResponse({ error: "no memory store configured" }, 500)
+        }
+        return jsonResponse({ groups: [] })
+      }),
+    )
+    render(<ListPage />)
+    const block = await screen.findByTestId("browse-error")
+    expect(block.textContent).toContain("no memory store configured")
+    // The grid's body-state block owns the error PHASE wherever the grid is mounted;
+    // a banner for the same failure would put a second retry on screen for one failure.
+    expect(screen.queryByTestId("error-browse")).toBeNull()
+    expect(screen.getAllByRole("button", { name: "Retry" })).toHaveLength(1)
+  })
+
+  it("leaves a failed bulk action to the bar that reports it", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: RequestInfo | URL, init?: RequestInit) => {
+        const u = String(url)
+        if (init?.method === "POST") return jsonResponse({ error: "would supersede" }, 409)
+        if (u.includes("/api/memory/stats")) return jsonResponse(stats)
+        if (u.includes("/api/memory/list")) return jsonResponse({ records: [candidate], total: 1 })
+        return jsonResponse({ groups: [] })
+      }),
+    )
+    const { container } = render(<ListPage />)
+    await screen.findByText("acme threshold is 750")
+    fireEvent.click(rowCheckbox(container, "cand1"))
+    fireEvent.click(await screen.findByRole("button", { name: /approve 1/i }))
+
+    const report = await screen.findByTestId("bulk-error")
+    expect(report.textContent).toContain("1 of 1 failed")
+    // One failure, one channel. A banner repeating it announces the same event a second
+    // time, and — cleared by nothing the bar does — outlives the bar it points at.
+    expect(screen.queryByTestId("error-mutation")).toBeNull()
+    expect(screen.queryByText(/bulk action\(s\) failed/)).toBeNull()
+  })
+
+  it("a mutation still refetches when a request was already in flight", async () => {
+    let release: (() => void) | undefined
+    let hold = false
+    const mock = vi.fn(async (url: RequestInfo | URL, init?: RequestInit) => {
+      const u = String(url)
+      if (init?.method === "POST") return jsonResponse({ ok: true })
+      if (u.includes("/api/memory/stats")) return jsonResponse(stats)
+      if (u.includes("/api/memory/list")) {
+        if (hold) {
+          await new Promise<void>((resolve) => {
+            release = resolve
+          })
+        }
+        return jsonResponse({ records: [candidate], total: 1 })
+      }
+      return jsonResponse({ groups: [] })
+    })
+    vi.stubGlobal("fetch", mock)
+    const { container } = render(<ListPage />)
+    await screen.findByText("acme threshold is 750")
+
+    // Live off: the post-mutation refresh is the only thing that will ever ask again.
+    fireEvent.click(screen.getByLabelText("live"))
+    hold = true
+    const rail = screen.getByRole("navigation")
+    fireEvent.click(within(rail).getByRole("button", { name: /route=\/notes/ }))
+    await vi.waitFor(() => {
+      expect(release).toBeDefined()
+    })
+
+    fireEvent.click(rowCheckbox(container, "cand1"))
+    fireEvent.click(await screen.findByRole("button", { name: /approve 1/i }))
+    await vi.waitFor(() => {
+      expect(postCount(mock)).toBe(1)
+    })
+
+    hold = false
+    const before = callsTo(mock, "/api/memory/list").length
+    release?.()
+    await vi.waitFor(() => {
+      expect(callsTo(mock, "/api/memory/list").length).toBeGreaterThan(before)
+    })
+  })
+
+  it("does not call an unanswered timeline window empty", async () => {
+    let release: (() => void) | undefined
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: RequestInfo | URL) => {
+        const u = String(url)
+        if (u.includes("/api/memory/stats")) return jsonResponse(stats)
+        if (u.includes("/api/memory/list")) {
+          await new Promise<void>((resolve) => {
+            release = resolve
+          })
+          return jsonResponse({ records: [candidate], total: 1 })
+        }
+        return jsonResponse({ groups: [] })
+      }),
+    )
+    render(<ListPage />)
+    fireEvent.click(screen.getByRole("button", { name: "timeline" }))
+
+    expect(await screen.findByTestId("browse-loading")).toBeDefined()
+    // "No episodes in this window." is an ANSWER, and the server has not given one.
+    expect(screen.queryByText("No episodes in this window.")).toBeNull()
+
+    release?.()
+    expect(await screen.findByText("acme threshold is 750")).toBeDefined()
+    // Counts and freshness describe the browse, not the grid — both surfaces get them.
+    expect(screen.getByTestId("browse-status").textContent).toContain("1 loaded of 1 matching")
   })
 })

--- a/packages/inspector/test/components/memory-grid.test.tsx
+++ b/packages/inspector/test/components/memory-grid.test.tsx
@@ -34,6 +34,20 @@ function headerFor(container: HTMLElement, label: string): HTMLElement {
   return header as HTMLElement
 }
 
+/** Leaves the keyboard on one row's cell and returns it. Pointer-down moves the
+ *  grid's focus without activating the row; a click does both, and activation is
+ *  what the callers are testing. Which key walks focus in from outside the grid
+ *  is pretable's contract, not the Inspector's — deliberately not asserted. */
+function focusRow(container: HTMLElement, id: string): HTMLElement {
+  const cell = container.querySelector<HTMLElement>(
+    `[data-pretable-row][data-pretable-row-id="${id}"] [role="gridcell"]`,
+  )
+  if (!cell) throw new Error(`no row for ${id}`)
+  fireEvent.pointerDown(cell, { button: 0, pointerId: 1 })
+  expect(document.activeElement).toBe(cell)
+  return cell
+}
+
 afterEach(cleanup)
 
 describe("MemoryGrid", () => {
@@ -44,7 +58,6 @@ describe("MemoryGrid", () => {
         onSelect={vi.fn()}
       />,
     )
-    expect(screen.getByText("acme threshold is 750")).toBeDefined()
     expect(columnText(container, "content")).toEqual(["acme threshold is 750", "content b"])
     expect(screen.getAllByText("route=/notes")).toHaveLength(2)
   })
@@ -61,16 +74,14 @@ describe("MemoryGrid", () => {
     expect(onSelect.mock.calls).toEqual([["b"]])
   })
 
-  it("a keyboard user can reach a row and activate it with Enter", () => {
+  it("Enter activates the focused row", () => {
     const onSelect = vi.fn()
     const { container } = render(
       <MemoryGrid records={[record({ id: "a" }), record({ id: "b" })]} onSelect={onSelect} />,
     )
-    // Tab lands on the first column header; Down moves into the body.
-    const header = headerFor(container, "status")
-    header.focus()
-    fireEvent.keyDown(header, { key: "ArrowDown" })
-    fireEvent.keyDown(document.activeElement ?? header, { key: "Enter" })
+    const cell = focusRow(container, "a")
+    expect(onSelect.mock.calls).toEqual([])
+    fireEvent.keyDown(cell, { key: "Enter" })
     expect(onSelect.mock.calls).toEqual([["a"]])
   })
 
@@ -79,11 +90,8 @@ describe("MemoryGrid", () => {
     const { container } = render(
       <MemoryGrid records={[record({ id: "a" }), record({ id: "b" })]} onSelect={onSelect} />,
     )
-    const header = headerFor(container, "status")
-    header.focus()
-    fireEvent.keyDown(header, { key: "ArrowDown" })
-    fireEvent.keyDown(document.activeElement ?? header, { key: "ArrowDown" })
-    fireEvent.keyDown(document.activeElement ?? header, { key: " " })
+    const cell = focusRow(container, "b")
+    fireEvent.keyDown(cell, { key: " " })
     expect(onSelect.mock.calls).toEqual([["b"]])
   })
 
@@ -160,7 +168,11 @@ describe("MemoryGrid", () => {
           `[data-pretable-row][data-pretable-row-id="${id}"] [role="gridcell"]`,
         ),
       ].map((cell) => cell.className)
+    // `every`/`some` over an empty list would pass without testing anything, and
+    // the selector hangs off pretable-owned attributes that can be renamed.
     expect(cellClasses("a").length).toBeGreaterThan(0)
+    expect(cellClasses("b").length).toBeGreaterThan(0)
+    expect(cellClasses("c").length).toBeGreaterThan(0)
     expect(cellClasses("a").every((cls) => cls.includes("amber"))).toBe(true)
     expect(cellClasses("b").every((cls) => cls.includes("line-through"))).toBe(true)
     expect(cellClasses("c").some((cls) => cls.includes("line-through"))).toBe(false)

--- a/packages/inspector/test/components/memory-grid.test.tsx
+++ b/packages/inspector/test/components/memory-grid.test.tsx
@@ -1,5 +1,5 @@
 import type { MemoryRecord } from "@dawn-ai/memory"
-import { cleanup, fireEvent, render, screen } from "@testing-library/react"
+import { act, cleanup, fireEvent, render, screen, within } from "@testing-library/react"
 import { afterEach, describe, expect, it, vi } from "vitest"
 import { MemoryGrid } from "../../src/components/memory/memory-grid"
 
@@ -176,5 +176,198 @@ describe("MemoryGrid", () => {
     expect(cellClasses("a").every((cls) => cls.includes("amber"))).toBe(true)
     expect(cellClasses("b").every((cls) => cls.includes("line-through"))).toBe(true)
     expect(cellClasses("c").some((cls) => cls.includes("line-through"))).toBe(false)
+  })
+})
+
+function grid(container: HTMLElement): HTMLElement {
+  const el = container.querySelector<HTMLElement>('[role="grid"]')
+  if (!el) throw new Error("no grid")
+  return el
+}
+
+function bodyState(container: HTMLElement): HTMLElement {
+  const el = container.querySelector<HTMLElement>("[data-pretable-body-state]")
+  if (!el) throw new Error("no body-state block")
+  return el
+}
+
+/** The live region is portaled to `document.body`, and the surface debounces every
+ *  announcement, so a caller must run the timers before reading it. */
+function announcement(): string {
+  return document.querySelector("[data-pretable-live-region]")?.textContent ?? ""
+}
+
+describe("MemoryGrid lifecycle", () => {
+  it("is untouched when dataState is omitted", () => {
+    const { container } = render(
+      <MemoryGrid
+        records={[record({ id: "a", content: "apple" }), record({ id: "b", content: "banana" })]}
+        onSelect={vi.fn()}
+      />,
+    )
+    expect(container.querySelector("[data-pretable-data-phase]")).toBeNull()
+    expect(container.querySelector("[data-pretable-body-state]")).toBeNull()
+    // Loaded rows plus the header row — the grid speaks only for what it holds.
+    expect(grid(container).getAttribute("aria-rowcount")).toBe("3")
+    fireEvent.click(headerFor(container, "content"))
+    expect(columnText(container, "content")).toEqual(["banana", "apple"])
+    expect(headerFor(container, "content").getAttribute("aria-sort")).toBe("descending")
+  })
+
+  it("shows a loading block before the first answer", () => {
+    const { container } = render(
+      <MemoryGrid records={[]} onSelect={vi.fn()} dataState={{ phase: "loading" }} />,
+    )
+    expect(bodyState(container).getAttribute("data-pretable-body-state")).toBe("loading")
+    expect(screen.getByTestId("browse-loading").textContent).toBe("Loading memories…")
+    expect(grid(container).getAttribute("data-pretable-data-phase")).toBe("loading")
+  })
+
+  it("shows the caller's empty copy, exactly once", () => {
+    const { container } = render(
+      <MemoryGrid
+        records={[]}
+        onSelect={vi.fn()}
+        dataState={{ phase: "idle" }}
+        emptyMessage="No memories match these filters."
+      />,
+    )
+    expect(bodyState(container).getAttribute("data-pretable-body-state")).toBe("empty")
+    expect(screen.getByTestId("browse-empty").textContent).toBe("No memories match these filters.")
+    expect(screen.getAllByText("No memories match these filters.")).toHaveLength(1)
+  })
+
+  it("leaves a body block room to be legible when no rows give the grid height", () => {
+    const { container } = render(
+      <MemoryGrid records={[]} onSelect={vi.fn()} dataState={{ phase: "loading" }} />,
+    )
+    // The block is an overlay inset below the sticky header, so the grid's own
+    // height is not what the block gets. jsdom computes no geometry; these are the
+    // inline styles the surface lays itself out with.
+    const available =
+      Number.parseFloat(grid(container).style.height) -
+      Number.parseFloat(bodyState(container).style.top)
+    expect(available).toBeGreaterThanOrEqual(160)
+  })
+
+  it("renders a full-bleed error with a retry when nothing is loaded", () => {
+    const onRetry = vi.fn()
+    const { container } = render(
+      <MemoryGrid
+        records={[]}
+        onSelect={vi.fn()}
+        dataState={{ phase: "error", message: "no memory store configured" }}
+        onRetry={onRetry}
+      />,
+    )
+    expect(bodyState(container).getAttribute("data-pretable-body-state")).toBe("error")
+    const block = screen.getByTestId("browse-error")
+    expect(block.textContent).toContain("no memory store configured")
+    fireEvent.click(within(block).getByRole("button", { name: "Retry" }))
+    expect(onRetry).toHaveBeenCalledTimes(1)
+  })
+
+  it("marks a failure over intact rows as a strip, not a full-bleed error", () => {
+    const onRetry = vi.fn()
+    const { container } = render(
+      <MemoryGrid
+        records={[record({ id: "a", content: "banana" }), record({ id: "b", content: "apple" })]}
+        onSelect={vi.fn()}
+        dataState={{ phase: "error", message: "list failed" }}
+        onRetry={onRetry}
+      />,
+    )
+    // A query change whose initial fetch fails leaves the PREVIOUS question's rows
+    // on screen, so the failure is a strip above them rather than a block instead
+    // of them — and a test that cannot tell the two apart cannot catch the swap.
+    expect(bodyState(container).getAttribute("data-pretable-body-state")).toBe("error-strip")
+    expect(screen.queryByTestId("browse-error")).toBeNull()
+    const strip = screen.getByTestId("browse-error-strip")
+    expect(strip.textContent).toContain("list failed")
+    expect(columnText(container, "content")).toEqual(["banana", "apple"])
+    fireEvent.click(within(strip).getByRole("button", { name: "Retry" }))
+    expect(onRetry).toHaveBeenCalledTimes(1)
+  })
+
+  it("claims the server's population, never the loaded window", () => {
+    const records = [record({ id: "a" }), record({ id: "b" }), record({ id: "c" })]
+    const { container } = render(
+      <MemoryGrid
+        records={records}
+        onSelect={vi.fn()}
+        dataState={{ phase: "idle" }}
+        resultMeta={{ total: { kind: "exact", count: 4322 } }}
+      />,
+    )
+    expect(grid(container).getAttribute("aria-rowcount")).toBe("4323")
+
+    cleanup()
+    const withoutMeta = render(
+      <MemoryGrid records={records} onSelect={vi.fn()} dataState={{ phase: "idle" }} />,
+    )
+    // Unknown, not 4: under server authority the loaded rows are a window, and
+    // reporting them as the population is the lie the whole design exists to stop.
+    expect(grid(withoutMeta.container).getAttribute("aria-rowcount")).toBe("-1")
+  })
+
+  it("browse headers do not sort — the rows are a server-selected sample", () => {
+    const { container } = render(
+      <MemoryGrid
+        records={[
+          record({ id: "a", content: "banana" }),
+          record({ id: "b", content: "apple" }),
+          record({ id: "c", content: "cherry" }),
+        ]}
+        onSelect={vi.fn()}
+        dataState={{ phase: "idle" }}
+        resultMeta={{ total: { kind: "exact", count: 4322 } }}
+      />,
+    )
+    const header = headerFor(container, "content")
+    fireEvent.click(header)
+    expect(columnText(container, "content")).toEqual(["banana", "apple", "cherry"])
+    expect(header.getAttribute("aria-sort")).toBe("none")
+  })
+
+  it("announces the settled result in the app's own words", () => {
+    vi.useFakeTimers()
+    try {
+      const { rerender } = render(
+        <MemoryGrid records={[]} onSelect={vi.fn()} dataState={{ phase: "loading" }} />,
+      )
+      rerender(
+        <MemoryGrid
+          records={[record({ id: "a" })]}
+          onSelect={vi.fn()}
+          dataState={{ phase: "idle" }}
+          resultMeta={{ total: { kind: "exact", count: 4322 } }}
+        />,
+      )
+      act(() => {
+        vi.runAllTimers()
+      })
+      expect(announcement()).toBe("1 loaded of 4,322 matching.")
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it("announces a failure in the app's own words", () => {
+    vi.useFakeTimers()
+    try {
+      render(
+        <MemoryGrid
+          records={[]}
+          onSelect={vi.fn()}
+          dataState={{ phase: "error", message: "list failed" }}
+        />,
+      )
+      act(() => {
+        vi.runAllTimers()
+      })
+      expect(announcement()).toBe("Could not load memories: list failed")
+    } finally {
+      vi.useRealTimers()
+    }
   })
 })

--- a/packages/inspector/test/components/use-memory-browse.test.tsx
+++ b/packages/inspector/test/components/use-memory-browse.test.tsx
@@ -1,0 +1,237 @@
+import type { MemoryRecord } from "@dawn-ai/memory/browse"
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react"
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { canonicalBrowseQuery } from "../../src/browse/canonical-query"
+import { useMemoryBrowse } from "../../src/browse/use-memory-browse"
+
+function record(id: string): MemoryRecord {
+  return {
+    id,
+    kind: "semantic",
+    namespace: "route=/notes",
+    content: `content ${id}`,
+    data: {},
+    source: { type: "tool", id: "remember" },
+    confidence: 0.5,
+    tags: [],
+    status: "active",
+    createdAt: "2026-07-13T00:00:00.000Z",
+    updatedAt: "2026-08-01T00:00:00.000Z",
+  }
+}
+
+/** A fetcher whose every call is resolved by hand, so a response can be made to
+ *  land after the query it belongs to has already been superseded. */
+function deferredFetcher() {
+  const calls: {
+    params: URLSearchParams
+    signal: AbortSignal
+    resolve: (page: { records: readonly MemoryRecord[]; total: number }) => void
+    reject: (error: Error) => void
+  }[] = []
+  const fetchPage = vi.fn(
+    (params: URLSearchParams, signal: AbortSignal) =>
+      new Promise<{ records: readonly MemoryRecord[]; total: number }>((resolve, reject) => {
+        calls.push({ params, signal, resolve, reject })
+      }),
+  )
+  return { calls, fetchPage }
+}
+
+afterEach(cleanup)
+
+describe("useMemoryBrowse", () => {
+  it("fetches the first window on mount and reports loading until it lands", async () => {
+    const { calls, fetchPage } = deferredFetcher()
+    const query = canonicalBrowseQuery({ view: "list" })
+    const { result } = renderHook(() => useMemoryBrowse({ query, live: true, fetchPage }))
+
+    expect(result.current.dataState).toEqual({ phase: "loading" })
+    await waitFor(() => expect(calls).toHaveLength(1))
+    expect(calls[0]?.params.get("limit")).toBe("200")
+    expect(calls[0]?.params.get("offset")).toBe("0")
+
+    await act(async () => {
+      calls[0]?.resolve({ records: [record("a")], total: 5432 })
+    })
+    expect(result.current.dataState).toEqual({ phase: "idle" })
+    expect(result.current.records.map((r) => r.id)).toEqual(["a"])
+    expect(result.current.total).toBe(5432)
+    expect(result.current.resultMeta.total).toEqual({ kind: "exact", count: 5432 })
+    expect(result.current.resultMeta.datasetKey).toBe('["list",null,null,null,null]')
+  })
+
+  it("publishes the FULFILLED dataset key, so the grid pivots when the answer lands", async () => {
+    const { calls, fetchPage } = deferredFetcher()
+    const { result, rerender } = renderHook(
+      ({ namespace }: { namespace?: string }) =>
+        useMemoryBrowse({
+          query: canonicalBrowseQuery({ view: "list", ...(namespace ? { namespace } : {}) }),
+          live: true,
+          fetchPage,
+        }),
+      { initialProps: {} as { namespace?: string } },
+    )
+    await waitFor(() => expect(calls).toHaveLength(1))
+    await act(async () => {
+      calls[0]?.resolve({ records: [record("a")], total: 2 })
+    })
+    const firstKey = result.current.resultMeta.datasetKey
+
+    rerender({ namespace: "route=/notes" })
+    expect(result.current.dataState).toEqual({ phase: "stale" })
+    // Still the OLD key while the old rows are on screen: selection over them is
+    // valid FOR THEM, and is cleared exactly when the new answer lands.
+    expect(result.current.resultMeta.datasetKey).toBe(firstKey)
+
+    await waitFor(() => expect(calls).toHaveLength(2))
+    await act(async () => {
+      calls[1]?.resolve({ records: [record("z")], total: 1 })
+    })
+    expect(result.current.resultMeta.datasetKey).not.toBe(firstKey)
+    expect(result.current.records.map((r) => r.id)).toEqual(["z"])
+  })
+
+  it("aborts the superseded request and discards it even if abort loses the race", async () => {
+    const { calls, fetchPage } = deferredFetcher()
+    const { result, rerender } = renderHook(
+      ({ namespace }: { namespace?: string }) =>
+        useMemoryBrowse({
+          query: canonicalBrowseQuery({ view: "list", ...(namespace ? { namespace } : {}) }),
+          live: true,
+          fetchPage,
+        }),
+      { initialProps: {} as { namespace?: string } },
+    )
+    await waitFor(() => expect(calls).toHaveLength(1))
+    rerender({ namespace: "route=/notes" })
+    expect(calls[0]?.signal.aborted).toBe(true)
+
+    // Abort lost the race: the superseded response resolves anyway.
+    await act(async () => {
+      calls[0]?.resolve({ records: [record("stale")], total: 999 })
+    })
+    expect(result.current.records).toHaveLength(0)
+    expect(result.current.total).toBeNull()
+    expect(result.current.dataState).toEqual({ phase: "loading" })
+  })
+
+  it("answers a set narrowed to nothing locally, without a request", async () => {
+    const { calls, fetchPage } = deferredFetcher()
+    const query = canonicalBrowseQuery({ view: "list", status: [] })
+    const { result } = renderHook(() => useMemoryBrowse({ query, live: true, fetchPage }))
+    await waitFor(() => expect(result.current.dataState).toEqual({ phase: "idle" }))
+    expect(calls).toHaveLength(0)
+    expect(result.current.total).toBe(0)
+  })
+
+  it("polls on the interval, and a failure suspends polling until retry", async () => {
+    vi.useFakeTimers()
+    try {
+      const { calls, fetchPage } = deferredFetcher()
+      const query = canonicalBrowseQuery({ view: "list" })
+      const { result } = renderHook(() =>
+        useMemoryBrowse({ query, live: true, fetchPage, pollIntervalMs: 2000 }),
+      )
+      await act(async () => {
+        calls[0]?.resolve({ records: [record("a")], total: 5432 })
+      })
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(2000)
+      })
+      expect(calls).toHaveLength(2)
+      expect(result.current.dataState).toEqual({ phase: "refreshing" })
+
+      await act(async () => {
+        calls[1]?.reject(new Error("network down"))
+      })
+      // A refresh failure keeps the rows and the idle phase; it fills its own slot.
+      expect(result.current.dataState).toEqual({ phase: "idle" })
+      expect(result.current.errors).toEqual({ refresh: "network down" })
+      expect(result.current.paused).toBe(false)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it("pauses when live goes off and ticks IMMEDIATELY on resume", async () => {
+    vi.useFakeTimers()
+    try {
+      const { calls, fetchPage } = deferredFetcher()
+      const query = canonicalBrowseQuery({ view: "list" })
+      const { result, rerender } = renderHook(
+        ({ live }: { live: boolean }) =>
+          useMemoryBrowse({ query, live, fetchPage, pollIntervalMs: 2000 }),
+        { initialProps: { live: true } },
+      )
+      await act(async () => {
+        calls[0]?.resolve({ records: [record("a")], total: 5432 })
+      })
+
+      rerender({ live: false })
+      expect(result.current.paused).toBe(true)
+      expect(result.current.updatedAt).not.toBeNull()
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(10_000)
+      })
+      expect(calls).toHaveLength(1)
+
+      await act(async () => {
+        rerender({ live: true })
+      })
+      expect(calls).toHaveLength(2)
+      expect(result.current.paused).toBe(false)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it("an initial failure holds the error phase and suspends polling", async () => {
+    vi.useFakeTimers()
+    try {
+      const { calls, fetchPage } = deferredFetcher()
+      const query = canonicalBrowseQuery({ view: "list" })
+      const { result } = renderHook(() =>
+        useMemoryBrowse({ query, live: true, fetchPage, pollIntervalMs: 2000 }),
+      )
+      await act(async () => {
+        calls[0]?.reject(new Error("no memory store configured"))
+      })
+      expect(result.current.dataState).toEqual({
+        phase: "error",
+        message: "no memory store configured",
+      })
+      expect(result.current.paused).toBe(true)
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(10_000)
+      })
+      expect(calls).toHaveLength(1)
+
+      await act(async () => {
+        result.current.retry()
+      })
+      expect(calls).toHaveLength(2)
+      await act(async () => {
+        calls[1]?.resolve({ records: [record("a")], total: 1 })
+      })
+      expect(result.current.dataState).toEqual({ phase: "idle" })
+      expect(result.current.paused).toBe(false)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it("ignores a response that resolves after unmount", async () => {
+    const { calls, fetchPage } = deferredFetcher()
+    const query = canonicalBrowseQuery({ view: "list" })
+    const { unmount } = renderHook(() => useMemoryBrowse({ query, live: true, fetchPage }))
+    await waitFor(() => expect(calls).toHaveLength(1))
+    unmount()
+    expect(calls[0]?.signal.aborted).toBe(true)
+    // Resolving now must not throw, warn, or touch anything.
+    await act(async () => {
+      calls[0]?.resolve({ records: [record("a")], total: 1 })
+    })
+  })
+})

--- a/packages/inspector/test/components/use-memory-browse.test.tsx
+++ b/packages/inspector/test/components/use-memory-browse.test.tsx
@@ -1,8 +1,14 @@
 import type { MemoryRecord } from "@dawn-ai/memory/browse"
 import { act, cleanup, renderHook, waitFor } from "@testing-library/react"
+import { Suspense, startTransition, useState } from "react"
+import { createRoot } from "react-dom/client"
 import { afterEach, describe, expect, it, vi } from "vitest"
-import { canonicalBrowseQuery } from "../../src/browse/canonical-query"
-import { useMemoryBrowse } from "../../src/browse/use-memory-browse"
+import { type CanonicalBrowseQuery, canonicalBrowseQuery } from "../../src/browse/canonical-query"
+import {
+  fetchBrowsePage,
+  type UseMemoryBrowseResult,
+  useMemoryBrowse,
+} from "../../src/browse/use-memory-browse"
 
 function record(id: string): MemoryRecord {
   return {
@@ -20,22 +26,38 @@ function record(id: string): MemoryRecord {
   }
 }
 
+type BrowsePage = { records: readonly MemoryRecord[]; total: number }
+
+interface DeferredCall {
+  params: URLSearchParams
+  signal: AbortSignal
+  resolve: (page: BrowsePage) => void
+  reject: (error: Error) => void
+}
+
 /** A fetcher whose every call is resolved by hand, so a response can be made to
  *  land after the query it belongs to has already been superseded. */
 function deferredFetcher() {
-  const calls: {
-    params: URLSearchParams
-    signal: AbortSignal
-    resolve: (page: { records: readonly MemoryRecord[]; total: number }) => void
-    reject: (error: Error) => void
-  }[] = []
+  const calls: DeferredCall[] = []
   const fetchPage = vi.fn(
     (params: URLSearchParams, signal: AbortSignal) =>
-      new Promise<{ records: readonly MemoryRecord[]; total: number }>((resolve, reject) => {
+      new Promise<BrowsePage>((resolve, reject) => {
         calls.push({ params, signal, resolve, reject })
       }),
   )
   return { calls, fetchPage }
+}
+
+/** Indexing straight into `calls` optional-chains the ACTION as much as the read: a
+ *  request that was never issued would settle nothing, and the miss would surface
+ *  several assertions later as a phase that makes no sense. This throws at the line
+ *  that is actually wrong. */
+function callAt(calls: readonly DeferredCall[], index: number): DeferredCall {
+  const call = calls[index]
+  if (call === undefined) {
+    throw new Error(`no browse request at index ${index}; ${calls.length} were issued`)
+  }
+  return call
 }
 
 afterEach(cleanup)
@@ -48,11 +70,11 @@ describe("useMemoryBrowse", () => {
 
     expect(result.current.dataState).toEqual({ phase: "loading" })
     await waitFor(() => expect(calls).toHaveLength(1))
-    expect(calls[0]?.params.get("limit")).toBe("200")
-    expect(calls[0]?.params.get("offset")).toBe("0")
+    expect(callAt(calls, 0).params.get("limit")).toBe("200")
+    expect(callAt(calls, 0).params.get("offset")).toBe("0")
 
     await act(async () => {
-      calls[0]?.resolve({ records: [record("a")], total: 5432 })
+      callAt(calls, 0).resolve({ records: [record("a")], total: 5432 })
     })
     expect(result.current.dataState).toEqual({ phase: "idle" })
     expect(result.current.records.map((r) => r.id)).toEqual(["a"])
@@ -74,7 +96,7 @@ describe("useMemoryBrowse", () => {
     )
     await waitFor(() => expect(calls).toHaveLength(1))
     await act(async () => {
-      calls[0]?.resolve({ records: [record("a")], total: 2 })
+      callAt(calls, 0).resolve({ records: [record("a")], total: 2 })
     })
     const firstKey = result.current.resultMeta.datasetKey
 
@@ -86,7 +108,7 @@ describe("useMemoryBrowse", () => {
 
     await waitFor(() => expect(calls).toHaveLength(2))
     await act(async () => {
-      calls[1]?.resolve({ records: [record("z")], total: 1 })
+      callAt(calls, 1).resolve({ records: [record("z")], total: 1 })
     })
     expect(result.current.resultMeta.datasetKey).not.toBe(firstKey)
     expect(result.current.records.map((r) => r.id)).toEqual(["z"])
@@ -105,11 +127,11 @@ describe("useMemoryBrowse", () => {
     )
     await waitFor(() => expect(calls).toHaveLength(1))
     rerender({ namespace: "route=/notes" })
-    expect(calls[0]?.signal.aborted).toBe(true)
+    expect(callAt(calls, 0).signal.aborted).toBe(true)
 
     // Abort lost the race: the superseded response resolves anyway.
     await act(async () => {
-      calls[0]?.resolve({ records: [record("stale")], total: 999 })
+      callAt(calls, 0).resolve({ records: [record("stale")], total: 999 })
     })
     expect(result.current.records).toHaveLength(0)
     expect(result.current.total).toBeNull()
@@ -125,7 +147,7 @@ describe("useMemoryBrowse", () => {
     expect(result.current.total).toBe(0)
   })
 
-  it("polls on the interval, and a failure suspends polling until retry", async () => {
+  it("polls on the interval, and a refresh failure banners itself and keeps polling", async () => {
     vi.useFakeTimers()
     try {
       const { calls, fetchPage } = deferredFetcher()
@@ -134,7 +156,7 @@ describe("useMemoryBrowse", () => {
         useMemoryBrowse({ query, live: true, fetchPage, pollIntervalMs: 2000 }),
       )
       await act(async () => {
-        calls[0]?.resolve({ records: [record("a")], total: 5432 })
+        callAt(calls, 0).resolve({ records: [record("a")], total: 5432 })
       })
       await act(async () => {
         await vi.advanceTimersByTimeAsync(2000)
@@ -143,12 +165,90 @@ describe("useMemoryBrowse", () => {
       expect(result.current.dataState).toEqual({ phase: "refreshing" })
 
       await act(async () => {
-        calls[1]?.reject(new Error("network down"))
+        callAt(calls, 1).reject(new Error("network down"))
       })
       // A refresh failure keeps the rows and the idle phase; it fills its own slot.
       expect(result.current.dataState).toEqual({ phase: "idle" })
       expect(result.current.errors).toEqual({ refresh: "network down" })
       expect(result.current.paused).toBe(false)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it("holds the published identities across a refresh that changes neither", async () => {
+    vi.useFakeTimers()
+    try {
+      const { calls, fetchPage } = deferredFetcher()
+      const query = canonicalBrowseQuery({ view: "list" })
+      const { result } = renderHook(() =>
+        useMemoryBrowse({ query, live: true, fetchPage, pollIntervalMs: 2000 }),
+      )
+      await act(async () => {
+        callAt(calls, 0).resolve({ records: [record("a")], total: 5432 })
+      })
+      const meta = result.current.resultMeta
+      const dataState = result.current.dataState
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(2000)
+      })
+      await act(async () => {
+        callAt(calls, 1).resolve({ records: [record("a")], total: 5432 })
+      })
+      // The grid holds both of these as dependencies and the cadence walks
+      // idle → refreshing → idle every 2 s: a fresh object on the way back reports a
+      // change that did not happen.
+      expect(result.current.resultMeta).toBe(meta)
+      expect(result.current.dataState).toBe(dataState)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it("queues a load-more asked for behind a refresh and drains it onto the tail", async () => {
+    vi.useFakeTimers()
+    try {
+      const { calls, fetchPage } = deferredFetcher()
+      const query = canonicalBrowseQuery({ view: "list" })
+      const { result } = renderHook(() =>
+        useMemoryBrowse({ query, live: true, fetchPage, pollIntervalMs: 2000 }),
+      )
+      await act(async () => {
+        callAt(calls, 0).resolve({ records: [record("a"), record("b")], total: 5 })
+      })
+      expect(result.current.canLoadMore).toBe(true)
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(2000)
+      })
+      expect(calls).toHaveLength(2)
+      expect(callAt(calls, 1).params.get("offset")).toBe("0")
+
+      // Asked for while the tick holds the single flight: intent is queued, never
+      // dropped, and no second request goes out yet.
+      act(() => {
+        result.current.loadMore()
+      })
+      expect(calls).toHaveLength(2)
+
+      // Draining happens INSIDE the refresh's own promise handler, so the queued
+      // request re-enters `startRequest` while that handler is still on the stack —
+      // and must not abort or orphan the controller it is unwinding from.
+      await act(async () => {
+        callAt(calls, 1).resolve({ records: [record("a"), record("b")], total: 5 })
+      })
+      expect(calls).toHaveLength(3)
+      expect(callAt(calls, 2).params.get("offset")).toBe("2")
+      expect(callAt(calls, 2).signal.aborted).toBe(false)
+      expect(result.current.dataState).toEqual({ phase: "loading-more" })
+
+      await act(async () => {
+        callAt(calls, 2).resolve({ records: [record("c")], total: 5 })
+      })
+      expect(result.current.records.map((r) => r.id)).toEqual(["a", "b", "c"])
+      expect(result.current.dataState).toEqual({ phase: "idle" })
+      expect(result.current.canLoadMore).toBe(true)
     } finally {
       vi.useRealTimers()
     }
@@ -165,7 +265,7 @@ describe("useMemoryBrowse", () => {
         { initialProps: { live: true } },
       )
       await act(async () => {
-        calls[0]?.resolve({ records: [record("a")], total: 5432 })
+        callAt(calls, 0).resolve({ records: [record("a")], total: 5432 })
       })
 
       rerender({ live: false })
@@ -195,7 +295,7 @@ describe("useMemoryBrowse", () => {
         useMemoryBrowse({ query, live: true, fetchPage, pollIntervalMs: 2000 }),
       )
       await act(async () => {
-        calls[0]?.reject(new Error("no memory store configured"))
+        callAt(calls, 0).reject(new Error("no memory store configured"))
       })
       expect(result.current.dataState).toEqual({
         phase: "error",
@@ -213,7 +313,7 @@ describe("useMemoryBrowse", () => {
       })
       expect(calls).toHaveLength(2)
       await act(async () => {
-        calls[1]?.resolve({ records: [record("a")], total: 1 })
+        callAt(calls, 1).resolve({ records: [record("a")], total: 1 })
       })
       expect(result.current.dataState).toEqual({ phase: "idle" })
       expect(result.current.paused).toBe(false)
@@ -222,16 +322,140 @@ describe("useMemoryBrowse", () => {
     }
   })
 
-  it("ignores a response that resolves after unmount", async () => {
+  it("aborts on unmount, and the abort is what discards a response that lands after", async () => {
     const { calls, fetchPage } = deferredFetcher()
+    const now = vi.fn(() => 1_700_000_000_000)
     const query = canonicalBrowseQuery({ view: "list" })
-    const { unmount } = renderHook(() => useMemoryBrowse({ query, live: true, fetchPage }))
+    const { unmount } = renderHook(() => useMemoryBrowse({ query, live: true, fetchPage, now }))
     await waitFor(() => expect(calls).toHaveLength(1))
     unmount()
-    expect(calls[0]?.signal.aborted).toBe(true)
-    // Resolving now must not throw, warn, or touch anything.
+    expect(callAt(calls, 0).signal.aborted).toBe(true)
+
     await act(async () => {
-      calls[0]?.resolve({ records: [record("a")], total: 1 })
+      callAt(calls, 0).resolve({ records: [record("a")], total: 1 })
     })
+    // Stamping the as-of instant is the FIRST thing applying a response does, so an
+    // unread clock is the observable proof the handler bailed on the aborted signal.
+    expect(now).not.toHaveBeenCalled()
+  })
+
+  it("builds a request from the COMMITTED query, never from a render React threw away", async () => {
+    const container = document.createElement("div")
+    document.body.appendChild(container)
+    const root = createRoot(container)
+    let release = () => {}
+    try {
+      const { calls, fetchPage } = deferredFetcher()
+      const everything = canonicalBrowseQuery({ view: "list" })
+      const narrowed = canonicalBrowseQuery({ view: "list", namespace: "route=/notes" })
+      const held = new Promise<void>((resolve) => {
+        release = resolve
+      })
+      let latest: UseMemoryBrowseResult | undefined
+      let update: (next: { query: CanonicalBrowseQuery; suspend: boolean }) => void = () => {}
+
+      function Probe({ query, suspend }: { query: CanonicalBrowseQuery; suspend: boolean }) {
+        latest = useMemoryBrowse({ query, live: false, fetchPage })
+        if (suspend) throw held
+        return null
+      }
+      function App() {
+        const [props, setProps] = useState({ query: everything, suspend: false })
+        update = setProps
+        return (
+          <Suspense fallback={null}>
+            <Probe {...props} />
+          </Suspense>
+        )
+      }
+
+      await act(async () => {
+        root.render(<App />)
+      })
+      await act(async () => {
+        callAt(calls, 0).resolve({ records: [record("a")], total: 5432 })
+      })
+
+      // A transition keeps the committed tree — and everything it can still dispatch
+      // from — alive while the next one renders. This render reaches the hook, so it
+      // has already written whatever a render writes, and then suspends: React throws
+      // it away and no effect of it ever runs.
+      await act(async () => {
+        startTransition(() => update({ query: narrowed, suspend: true }))
+      })
+
+      // The refresh belongs to the revision the machine still holds, which is the
+      // un-narrowed one. Params from the abandoned render would put one question's
+      // rows and total under the other's dataset key — and `browseReduce` accepts the
+      // response, because the revision it is tagged with is still the desired one.
+      latest?.refresh()
+      expect(calls).toHaveLength(2)
+      expect(callAt(calls, 1).params.get("namespace")).toBeNull()
+    } finally {
+      release()
+      await act(async () => {
+        root.unmount()
+      })
+      container.remove()
+    }
+  })
+
+  it("fails the request when a page cannot be applied, rather than wedging", async () => {
+    const { calls, fetchPage } = deferredFetcher()
+    const query = canonicalBrowseQuery({ view: "list" })
+    const { result } = renderHook(() => useMemoryBrowse({ query, live: true, fetchPage }))
+    await waitFor(() => expect(calls).toHaveLength(1))
+
+    // A fetcher is caller-supplied, so what it resolves with is unchecked: applying
+    // this one throws inside the reducer, on the promise handler's own stack.
+    await act(async () => {
+      callAt(calls, 0).resolve(undefined as unknown as BrowsePage)
+    })
+    expect(result.current.dataState.phase).toBe("error")
+
+    // Nothing is left in flight, so the hook is still reachable afterwards. A throw
+    // that escaped instead would leave `inFlight` populated for good, and single
+    // flight would skip this retry and every tick after it.
+    await act(async () => {
+      result.current.retry()
+    })
+    expect(calls).toHaveLength(2)
+  })
+})
+
+describe("fetchBrowsePage", () => {
+  function stubFetch(response: () => Response) {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => response()),
+    )
+  }
+
+  afterEach(() => vi.unstubAllGlobals())
+
+  it("returns a well-formed page", async () => {
+    stubFetch(() => Response.json({ records: [record("a")], total: 1 }))
+    const page = await fetchBrowsePage(new URLSearchParams(), new AbortController().signal)
+    expect(page.total).toBe(1)
+    expect(page.records.map((r) => r.id)).toEqual(["a"])
+  })
+
+  it("rejects a 200 that is not a page, rather than handing it to the reducer", async () => {
+    stubFetch(() => new Response("<html>gateway</html>", { status: 200 }))
+    await expect(
+      fetchBrowsePage(new URLSearchParams(), new AbortController().signal),
+    ).rejects.toThrow(/not a browse page/)
+
+    stubFetch(() => Response.json({ records: [record("a")] }))
+    await expect(
+      fetchBrowsePage(new URLSearchParams(), new AbortController().signal),
+    ).rejects.toThrow(/not a browse page/)
+  })
+
+  it("surfaces the API's error body on a failed status", async () => {
+    stubFetch(() => Response.json({ error: "no memory store configured" }, { status: 500 }))
+    await expect(
+      fetchBrowsePage(new URLSearchParams(), new AbortController().signal),
+    ).rejects.toThrow("no memory store configured")
   })
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -533,14 +533,14 @@ importers:
         specifier: workspace:*
         version: link:../memory
       '@pretable/core':
-        specifier: 0.0.8
-        version: 0.0.8
+        specifier: 0.3.0
+        version: 0.3.0
       '@pretable/react':
-        specifier: 0.0.8
-        version: 0.0.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        specifier: 0.3.0
+        version: 0.3.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@pretable/ui':
-        specifier: 0.0.8
-        version: 0.0.8
+        specifier: 0.3.0
+        version: 0.3.0
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -3013,17 +3013,17 @@ packages:
   '@preact/signals-core@1.14.4':
     resolution: {integrity: sha512-HNB6HYeYKhQbJ1aKl+YRjrS4+QWHLKX6qKoUsfS/m0vqzsVaEBiZiaKbG/e+NKk2ch5ALQr/ihWaMHxiCuuWHA==}
 
-  '@pretable/core@0.0.8':
-    resolution: {integrity: sha512-9S2E0hW+RncgqMeZpC5tRTfWOy2KZOIcPOP7jfj8EnVPGDL4O28AtRNItgb3+Hu2CnSfMhhuV+v2lUILyFyswA==}
+  '@pretable/core@0.3.0':
+    resolution: {integrity: sha512-zU0b3Xa61V2qqMq49X8e5H73lwXIHvxvJ1ajNTEB3KJ4j3AmuHNyO9sc1RtdIlC1mMbsUhheVU4z431d27tWtQ==}
 
-  '@pretable/react@0.0.8':
-    resolution: {integrity: sha512-Xv+cBnfFKi+Y6BoZWe+cEu4pYCdUzv3TWTpvBFQKPyIyfLdGrlMuwdDSpYVIemrSGNPnKr7ZqH/+IRFsRSTnxQ==}
+  '@pretable/react@0.3.0':
+    resolution: {integrity: sha512-eM7g6f9Nl3SL2SD6O91i1RiXnFr2xC3zO+Js5vL3u3ubwzEIcNAEFxbS6/Chv5DnZkpGg5SP2TJixf0zdfpxiw==}
     peerDependencies:
       react: ^19.0.0
       react-dom: ^19.0.0
 
-  '@pretable/ui@0.0.8':
-    resolution: {integrity: sha512-Zdp48L6htWAR/NjR/jWA618GQVTkbbyWjqkpSz+wpnSZ1S43Wd928gFLr9We4GVSLQXhIryN3wl2/GHOwnMARw==}
+  '@pretable/ui@0.3.0':
+    resolution: {integrity: sha512-EEew07Iy/gQNmUUMD7YZPMBnrV3asTQf8FoaZqIZRSss8cZTJhn5dceAWhKz93t6YuVL56KTm6MjahfjIYKhyw==}
 
   '@protobuf-ts/protoc@2.11.1':
     resolution: {integrity: sha512-mUZJaV0daGO6HUX90o/atzQ6A7bbN2RSuHtdwo8SSF2Qoe3zHwa4IHyCN1evftTeHfLmdz+45qo47sL+5P8nyg==}
@@ -11031,16 +11031,16 @@ snapshots:
 
   '@preact/signals-core@1.14.4': {}
 
-  '@pretable/core@0.0.8': {}
+  '@pretable/core@0.3.0': {}
 
-  '@pretable/react@0.0.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+  '@pretable/react@0.3.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
-      '@pretable/core': 0.0.8
-      '@pretable/ui': 0.0.8
+      '@pretable/core': 0.3.0
+      '@pretable/ui': 0.3.0
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
 
-  '@pretable/ui@0.0.8': {}
+  '@pretable/ui@0.3.0': {}
 
   '@protobuf-ts/protoc@2.11.1': {}
 


### PR DESCRIPTION
## Summary

Replaces the memory browse's `usePolling` list fetch with a `useMemoryBrowse` hook that owns desired-vs-fulfilled query revisions, single-flight arbitration, head-anchored refresh reconciliation and per-kind failure slots, and surfaces all of it through `@pretable/react@0.3.0`'s `dataState` / `resultMeta`.

The request shape is unchanged apart from the namespace facet, which now sends the exact `namespace` parameter instead of narrowing a prefix answer client-side — without that, `total` and the rows on screen describe different sets and "N loaded of M matching" is a lie.

## Three judgment calls worth a reviewer's attention

1. **All three `@pretable/*` packages are pinned to `0.3.0`.** They were on `0.0.8`. `@pretable/react@0.3.0` declares `@pretable/core@0.3.0` and `@pretable/ui@0.3.0` as dependencies, so bumping only `react` and leaving core behind would install two engines.
2. **`processing: { filter: "external", sort: "external" }`.** `setResultMeta` ignores `meta.total` (with a dev warning) under engine filter authority, so external filter authority is required for the honest total. Leaving sort on `"engine"` then trips the partial-window warning, and external sort without `orderBy` paints a header arrow that does nothing — so the browse columns are `sortable: false` until server ordering lands. Search results keep sortable columns.
3. **The exact-namespace request** pulls one line of a later slice forward, for the honesty reason above. It uses only parameters the shipped route already parses; `filters`, `orderBy` and `cursor` are untouched.

## Testing

- `browse-query`, `browse-reconcile`, `browse-machine`, `browse-chrome`, `use-memory-browse`, `browse-lifecycle` — new
- `list`, `memory-grid`, `grouping`, `column-filter-wiring` — pass, two facet assertions updated
- `pnpm turbo run test --filter @dawn-ai/inspector` (both projects), plus `typecheck` and `lint`
- The e2e project is gated behind `DAWN_TEST_INSPECTOR=1` (as in `.github/workflows/ci.yml`); run with the flag it is 18 files / 216 tests, none skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Why the two keyboard tests changed

`@pretable/*` moves `0.0.8` → `0.3.0`, and two Inspector tests asserted
ArrowDown-from-header entry into the grid body. Pretable deliberately changed that
in "Fix row grouping correctness and accessibility" (#259) — body entry is via Tab
now, and the header gate keeps the grid from stealing keys from header controls.
Dawn was pinned *before* that change, so its tests encoded the old contract.

They were rewritten to assert only what they actually exercise — activation from a
focused cell — rather than restate a contract that no longer holds. That narrows
the claim honestly but drops keyboard-reachability coverage here, which is the
right trade: jsdom cannot do native tab traversal, so a Tab test in this layer
would be partly asserting its own emulation. Real traversal is covered by the
Playwright walkthrough in the verification slice, which walks the whole tab order
with no pointer events at all.

## On the disabled sorting

Worth stating plainly because it reads like a regression: sorting a server-selected
window *locally* presents the wrong **sample**, not merely the wrong order. The top
200 by update time, re-ranked by confidence, is not the top 200 by confidence.
Removing a control that lies beats keeping one that looks like it works. Sorting
returns in the next slice, server-side.

## Verification

`@dawn-ai/inspector`: 16 files, 188 passed, 28 skipped (pre-existing
`describe.skipIf` e2e suites that need an env gate). Typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
