### PR TITLE
feat(ag-ui): surface plan and subagent activities

### DIFF
--- a/.changeset/ag-ui-activity-snapshots.md
+++ b/.changeset/ag-ui-activity-snapshots.md
@@ -1,0 +1,12 @@
+---
+"@dawn-ai/ag-ui": patch
+"@dawn-ai/devkit": patch
+"create-dawn-ai-app": patch
+---
+
+Expose Dawn planning and subagent progress as bounded standard AG-UI activity
+snapshots. The research web example renders plan checklists and delegated-work
+status from those snapshots, which exclude child prose, prompts, tool inputs,
+tool outputs, and final child answers. Ordinary root tool events remain a
+separate surface, and the generated research starter now points users to that
+activity-aware web recipe.

--- a/apps/web/content/docs/ag-ui.mdx
+++ b/apps/web/content/docs/ag-ui.mdx
@@ -41,6 +41,11 @@ browser
 CopilotKit's sidebar uses the literal agent id `default` when none is supplied,
 so the example registers the Dawn route under that key. See
 `examples/chat/web/README.md` for the complete setup and smoke checklist.
+That basic client registers no activity renderers. For plan and researcher
+cards, use the [activity-aware research recipe](/docs/recipes/research-web-ui)
+and its
+[`examples/research/web`](https://github.com/cacheplane/dawnai/tree/main/examples/research/web)
+implementation.
 
 ## Adapter API
 
@@ -77,13 +82,44 @@ correlation.
 | `token` | `TEXT_MESSAGE_START` once, then `TEXT_MESSAGE_CONTENT` per delta |
 | `tool_call` | close open text, then `TOOL_CALL_START`, `TOOL_CALL_ARGS`, `TOOL_CALL_END` |
 | `tool_result` | close open text, then `TOOL_CALL_RESULT` |
+| root `plan_update` | replacement `ACTIVITY_SNAPSHOT` with activity type `dawn.plan` |
+| `subagent.start` and matching child plan/tool/result/end chunks | replacement `ACTIVITY_SNAPSHOT` with activity type `dawn.subagent` |
 | `interrupt` | terminal `RUN_FINISHED` with `outcome.type: "interrupt"` |
 | `done` | terminal `RUN_FINISHED` with `outcome.type: "success"` |
 | upstream error | terminal `RUN_ERROR` |
 
-Planning updates, subagent capability events, and unknown chunk types have no v1
-mapping and are ignored. The adapter does not invent application state or
-protocol-specific custom events.
+### Activity snapshots
+
+Activities use standard AG-UI framing and complete replacement snapshots. A
+root plan has stable message id `dawn:plan:${runId}`, activity type `dawn.plan`,
+and content containing only the complete todo list. Todo status is exactly
+`pending`, `in_progress`, or `completed`. Dawn emits no seeded-plan activity at
+run start; the first snapshot follows a valid root `plan_update`.
+
+Each subagent has stable message id `dawn:subagent:${call_id}`, activity type
+`dawn.subagent`, and complete content with its name, positive integer depth,
+`running`/`completed`/`failed` status, an optional current todo list, up to five
+recent child-tool name/status summaries, and the total observed tool count.
+Tool-summary status is exactly `running`, `completed`, or `incomplete`. A failed
+activity can also contain a human-readable error capped at 400 characters.
+Because every event has `replace: true`, later snapshots replace the same
+stable activity message.
+
+The adapter validates the full internal identity
+`{ call_id, subagent, route_id, depth }` on every recognized child event. Only
+an exact match with the original `subagent.start` can update its activity;
+`call_id` is used only to form the stable standard message id, while `route_id`
+and child tool ids remain internal. None is duplicated in public content.
+`subagent.message` is consumed without emission.
+
+This boundary excludes child reasoning and prose, prompts, tool inputs, tool
+outputs, final child answers, route ids, and raw runtime ids. It is an explicit
+allowlist rather than a generic capability mapping: unknown capability chunks
+retain the existing behavior of closing any open text message and then being
+ignored. Dawn emits neither activity deltas nor a raw advanced child stream.
+Activities are informational; standard interrupt UI remains the only place to
+resolve or cancel permission requests. No queued, waiting, cancelled, or
+parent-task correlation state is inferred.
 
 ### Inbound input
 

--- a/apps/web/content/docs/api.mdx
+++ b/apps/web/content/docs/api.mdx
@@ -992,6 +992,8 @@ Pure, transport-agnostic AG-UI translation utilities. The CLI uses the same adap
 
 ```ts
 import {
+  DAWN_PLAN_ACTIVITY_TYPE,
+  DAWN_SUBAGENT_ACTIVITY_TYPE,
   createCounterIdFactory,
   createDefaultIdFactory,
   fromRunAgentInput,
@@ -1000,8 +1002,10 @@ import {
   type DawnAgentStreamChunk,
   type DawnInterruptEnvelope,
   type DawnMessage,
+  type DawnPlanActivityContent,
   type DawnResumeRequest,
   type DawnRunInput,
+  type DawnSubagentActivityContent,
   type IdFactory,
   type RunContext,
   type ToAguiOptions,
@@ -1040,7 +1044,26 @@ export function toAguiEvents(
 
 Maps Dawn `token`, `tool_call`, `tool_result`, `interrupt`, and `done` chunks to canonical AG-UI lifecycle, text, and tool events. Upstream tool invocation ids are preserved. Interrupts produce a standard `RUN_FINISHED` interrupt outcome, successful runs produce a success outcome, and upstream failures produce one `RUN_ERROR`.
 
-Planning updates, subagent capability events, and other unknown chunk types have no v1 mapping and are ignored.
+A valid root `plan_update` produces a complete replacement
+`ACTIVITY_SNAPSHOT` with message id `dawn:plan:${runId}`, activity type
+`DAWN_PLAN_ACTIVITY_TYPE` (`dawn.plan`), and `DawnPlanActivityContent` containing
+only the complete todo list, whose status values are `pending`, `in_progress`,
+or `completed`. A recognized subagent lifecycle produces complete replacement
+snapshots with message id `dawn:subagent:${call_id}`, activity type
+`DAWN_SUBAGENT_ACTIVITY_TYPE` (`dawn.subagent`), and
+`DawnSubagentActivityContent`: name, depth, `running`/`completed`/`failed`
+status, optional todos, at most five child-tool name/status summaries, total
+tool count, and an optional failure string capped at 400 characters. Tool
+summary status is `running`, `completed`, or `incomplete`.
+
+Child updates are accepted only when `{ call_id, subagent, route_id, depth }`
+exactly matches the start identity. `subagent.message` is consumed without
+emission. Child reasoning or prose, prompts, tool inputs, tool outputs, final
+child answers, route ids, and raw runtime ids are never copied into activity
+content. Other unknown chunks retain the existing flush-and-ignore behavior;
+the adapter does not synthesize seeded plans or emit activity deltas. Activity
+messages are informational, while permissions remain on the standard interrupt
+and resume path.
 
 ### `fromRunAgentInput(input)`
 

--- a/apps/web/content/docs/recipes/research-web-ui.mdx
+++ b/apps/web/content/docs/recipes/research-web-ui.mdx
@@ -14,13 +14,18 @@ The demo lives in `examples/research`: a Dawn server (`server/`) and a Next.js
 CopilotKit client (`web/`). The client provides:
 
 - **Chat + report** - streamed output and citations in a `CopilotSidebar`.
+- **Plan cards** - the root checklist updates in place while research runs.
+- **Researcher cards** - delegated-work status, child checklist progress, and a
+  bounded trail of child-tool names and statuses.
+- **Suggestions + tools** - the three discovery prompts and generic root-tool
+  cards remain available.
+- **Permissions** - standard interrupt UI owns approval and denial actions.
 - **Memory candidates** - durable facts proposed by the agent and reviewed from
   the web UI.
 
-The AG-UI v1 adapter does not map planning or subagent capability events, so the
-web client does not present live plan or subagent panels. It also does not add a
-client-specific interrupt compatibility layer; interrupt outcomes and answers
-use the standard AG-UI fields documented on the protocol page.
+The plan and researcher cards are informational. They never resolve or cancel
+an interrupt; interrupt outcomes and answers use the standard AG-UI fields
+documented on the protocol page.
 
 ## Run it
 
@@ -86,11 +91,22 @@ export const POST = async (req: NextRequest): Promise<Response> => {
 ```tsx title="examples/research/web/app/page.tsx"
 "use client"
 import { CopilotKit, CopilotSidebar } from "@copilotkit/react-core/v2"
+import { activityMessageRenderers } from "./components/ActivityRenderers"
+import { DemoSuggestions } from "./components/DemoSuggestions"
 import { MemoryCandidates } from "./components/MemoryCandidates"
+import { PermissionInterrupt } from "./components/PermissionInterrupt"
+import { ToolCallCard } from "./components/ToolCallCard"
 
 export default function Home() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit">
+    <CopilotKit
+      runtimeUrl="/api/copilotkit"
+      defaultThrottleMs={100}
+      renderActivityMessages={activityMessageRenderers}
+    >
+      <DemoSuggestions />
+      <PermissionInterrupt />
+      <ToolCallCard />
       <div style={{ display: "flex", height: "100vh" }}>
         <MemoryCandidates />
         <main style={{ flex: 1 }}>
@@ -111,6 +127,127 @@ export default function Home() {
   CopilotKit's sidebar falls back to the id `default`. Register the Dawn agent
   under that id, or set the same explicit id on every consumer.
 </Callout>
+
+## Render plan and researcher activities
+
+The client validates both public activity content types with strict runtime
+schemas. A payload with unknown or incompatible fields fails closed instead of
+dumping arbitrary JSON into the transcript:
+
+```ts title="examples/research/web/app/components/ActivitySchemas.ts"
+import type {
+  DawnPlanActivityContent,
+  DawnSubagentActivityContent,
+} from "@dawn-ai/ag-ui"
+import { z } from "zod"
+
+const todoSchema = z.strictObject({
+  content: z.string().trim().min(1),
+  status: z.enum(["pending", "in_progress", "completed"]),
+})
+
+export const planActivityContentSchema = z.strictObject({
+  todos: z.array(todoSchema),
+})
+
+function assignPlanOutputToPublicType(
+  content: z.output<typeof planActivityContentSchema>,
+): DawnPlanActivityContent {
+  return content
+}
+void assignPlanOutputToPublicType
+
+const toolSchema = z.strictObject({
+  name: z.string().trim().min(1),
+  status: z.enum(["running", "completed", "incomplete"]),
+})
+
+const subagentFields = {
+  name: z.string().trim().min(1),
+  depth: z.number().int().positive(),
+  todos: z.array(todoSchema).optional(),
+  tools: z.array(toolSchema).max(5),
+  totalToolCount: z.number().int().nonnegative(),
+}
+
+export const subagentActivityContentSchema = z
+  .discriminatedUnion("status", [
+    z.strictObject({ ...subagentFields, status: z.literal("running") }),
+    z.strictObject({ ...subagentFields, status: z.literal("completed") }),
+    z.strictObject({
+      ...subagentFields,
+      status: z.literal("failed"),
+      error: z.string().trim().min(1).max(400),
+    }),
+  ])
+  .refine((content) => content.totalToolCount >= content.tools.length, {
+    message: "totalToolCount must include every displayed tool",
+    path: ["totalToolCount"],
+  })
+
+function assignSubagentOutputToPublicType(
+  content: z.output<typeof subagentActivityContentSchema>,
+): DawnSubagentActivityContent {
+  return content
+}
+void assignSubagentOutputToPublicType
+```
+
+Register the renderers once at module scope. The public constants ensure the
+registry follows the adapter's activity-type contract, and stable array
+identity avoids replacing the registry on every React render:
+
+```tsx title="examples/research/web/app/components/ActivityRenderers.tsx"
+import type { ReactActivityMessageRenderer } from "@copilotkit/react-core/v2"
+import {
+  DAWN_PLAN_ACTIVITY_TYPE,
+  DAWN_SUBAGENT_ACTIVITY_TYPE,
+  type DawnPlanActivityContent,
+  type DawnSubagentActivityContent,
+} from "@dawn-ai/ag-ui"
+import {
+  planActivityContentSchema,
+  subagentActivityContentSchema,
+} from "./ActivitySchemas"
+import { PlanActivityCard } from "./PlanActivityCard"
+import { SubagentActivityCard } from "./SubagentActivityCard"
+
+const planActivityRenderer = {
+  activityType: DAWN_PLAN_ACTIVITY_TYPE,
+  content: planActivityContentSchema,
+  render: ({ content }) => <PlanActivityCard content={content} />,
+} satisfies ReactActivityMessageRenderer<DawnPlanActivityContent>
+
+const subagentActivityRenderer = {
+  activityType: DAWN_SUBAGENT_ACTIVITY_TYPE,
+  content: subagentActivityContentSchema,
+  render: ({ content }) => <SubagentActivityCard content={content} />,
+} satisfies ReactActivityMessageRenderer<DawnSubagentActivityContent>
+
+export const activityMessageRenderers = [
+  planActivityRenderer,
+  subagentActivityRenderer,
+]
+```
+
+Root plan snapshots replace `dawn:plan:${runId}` and carry the complete todo
+list. Subagent snapshots replace `dawn:subagent:${call_id}` and carry the name,
+depth, `running`/`completed`/`failed` status, optional todos, up to five recent
+tool name/status summaries, the total tool count, and an optional 400-character
+failure summary. Both root and child checklist views display at most eight
+todos, while their snapshots retain the complete valid todo lists.
+The `dawn.plan` and `dawn.subagent` activity content supplied to these cards
+excludes child reasoning or prose, prompts, tool inputs, tool outputs, final
+child answers, route ids, and raw runtime ids.
+
+Ordinary root `task` tool call/result events are a separate surface. Root task
+events can carry the coordinator-visible input and result. The current generic
+card reduces task input to the subagent name and may show the result. These
+activity renderers do not suppress or specialize those events.
+
+Choose **Research a topic** on the empty chat to see the root plan and
+researcher progress update before the cited answer. This live flow still uses
+the Dawn server's model key; it is not a browser-automation fixture.
 
 ## Approve memory candidates
 

--- a/docs/superpowers/plans/2026-08-10-ag-ui-plan-subagent-activities.md
+++ b/docs/superpowers/plans/2026-08-10-ag-ui-plan-subagent-activities.md
@@ -1,0 +1,1573 @@
+# AG-UI Plan and Subagent Activities Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Expose Dawn's root-plan and delegated-research progress as bounded standard AG-UI activity snapshots, render those activities inline in the flagship research web client, and prove the complete wire path without exposing child prose or raw payloads.
+
+**Architecture:** Add one request-local, allowlist-only projector inside `@dawn-ai/ag-ui`, then intercept recognized activity chunks after interrupt suppression and before the existing outbound switch. Publish only two stable activity constants and two semantic content contracts; the private research web app validates those contracts again with strict Zod schemas and renders native, accessible checklist cards through CopilotKit's standard `renderActivityMessages` prop. Keep generic root tool cards, permission handling, memory review, suggestions, and the 100 ms render throttle unchanged.
+
+**Tech Stack:** TypeScript 7, Node.js 24, pnpm 10, Vitest 4, `@ag-ui/core`/`@ag-ui/client` 0.0.57, CopilotKit React 1.66.x, React 19 server rendering, Zod 4, Next.js 16, Biome, Changesets, and the existing candidate-registry generated-app harness.
+
+**Approved spec:** `docs/superpowers/specs/2026-08-10-ag-ui-plan-subagent-activities-design.md`
+
+**Execution baseline:** `origin/main` at `e95f4d61` or later. The design commit has been rebased onto that baseline. The user also approved the narrow README-only exception for the generated research starter, so the release changeset includes `@dawn-ai/devkit` and `create-dawn-ai-app` without adding scaffold code or UI.
+
+**Dependency order:** Tasks 1–3 are sequential: the outbound bridge depends on the projector, and the web client imports the public protocol contracts. Task 4 documents the finished behavior. Do not run builds, installs, package checks, or generated harness lanes concurrently in this shared worktree because they mutate `dist/`, the lockfile, packed artifacts, or registry state.
+
+---
+
+### Task 0: Confirm the execution baseline and build inputs
+
+**Files:**
+- Read: `AGENTS.md`
+- Read: `docs/superpowers/specs/2026-08-10-ag-ui-plan-subagent-activities-design.md`
+- Read: `docs/superpowers/plans/2026-08-10-ag-ui-plan-subagent-activities.md`
+- Verify only: repository root
+
+- [ ] **Step 1: Confirm the branch is clean and based on current main**
+
+```bash
+git status --short --branch
+git fetch origin main
+git merge-base --is-ancestor origin/main HEAD
+```
+
+Expected: the worktree is clean and the ancestry command exits `0`. If `origin/main` advanced, rebase before editing and repeat the overlap check below.
+
+- [ ] **Step 2: Recheck overlap if main advanced**
+
+```bash
+git diff --name-status HEAD..origin/main -- \
+  packages/ag-ui \
+  examples/research/web \
+  examples/chat/README.md \
+  examples/chat/web/README.md \
+  packages/devkit/templates/app-research/README.md \
+  test/generated/run-generated-research-activation.test.ts \
+  scripts/lib/pack-check.mjs \
+  scripts/pack-check.test.mjs \
+  scripts/lib/published-artifacts.mjs \
+  scripts/published-artifacts.test.mjs \
+  scripts/published-artifact-smoke.mjs \
+  vitest.workspace.ts \
+  apps/web/content/docs
+```
+
+Expected: no unreviewed overlap. If any target changed, re-read it and update the affected plan step before implementation; do not overwrite upstream work.
+
+- [ ] **Step 3: Select the normative toolchain**
+
+```bash
+node --version
+npm --version
+pnpm --version
+```
+
+Expected: Node `v24.x`, npm `11.x`, and pnpm `10.x`. On the current workstation, prepend `/Users/blove/.nvm/versions/node/v24.18.0/bin` to `PATH` if the shell selects another Node version.
+
+- [ ] **Step 4: Install the locked workspace**
+
+```bash
+pnpm install --frozen-lockfile
+```
+
+Expected: PASS without changing `pnpm-lock.yaml`.
+
+- [ ] **Step 5: Build before any `dist/` consumer runs**
+
+```bash
+pnpm build
+```
+
+Expected: PASS. This is mandatory because the research web package resolves `@dawn-ai/ag-ui` through its built export and the generated activation packs and executes workspace `dist/` output.
+
+### Task 1: Add the bounded activity contracts, projector, and release surface
+
+**Files:**
+- Create: `packages/ag-ui/src/activities.ts`
+- Create: `packages/ag-ui/test/activities.test.ts`
+- Modify: `packages/ag-ui/src/index.ts`
+- Modify: `packages/ag-ui/test/public-api.test.ts`
+- Modify: `packages/ag-ui/test/types.test.ts`
+- Modify: `scripts/lib/pack-check.mjs`
+- Modify: `scripts/pack-check.test.mjs`
+- Modify: `scripts/lib/published-artifacts.mjs`
+- Modify: `scripts/published-artifacts.test.mjs`
+- Modify: `scripts/published-artifact-smoke.mjs`
+
+Use `@superpowers:test-driven-development` for this task. The projector is deliberately internal even though it lives in a packed file: only the two constants and two content types are exported from the package root.
+
+- [ ] **Step 1: Write the recognized-type and root-plan tests**
+
+Create `packages/ag-ui/test/activities.test.ts`. Import `ActivitySnapshotEventSchema` and `EventType` from `@ag-ui/core`, and import the not-yet-created constants, `createDawnActivityProjector`, and `isDawnActivityChunkType` from `../src/activities.ts`.
+
+Use these shared fixtures:
+
+```ts
+const identity = {
+  call_id: "call-research-1",
+  subagent: "researcher",
+  route_id: "/research#researcher",
+  depth: 1,
+} as const
+
+const todos = [
+  { content: "Search the corpus", status: "completed" },
+  { content: "Read the best source", status: "in_progress" },
+] as const
+
+function parseSnapshot(value: unknown) {
+  return ActivitySnapshotEventSchema.parse(value)
+}
+```
+
+Test the exact seven recognized types and reject `token`, `tool_call`, `done`, and `capability.unknown`. Test two valid root plan replacements with one `dawn:plan:run-1` id, `replace: true`, and complete replacement content. Parse both through `parseSnapshot()`.
+
+- [ ] **Step 2: Run the first projector RED**
+
+```bash
+pnpm --filter @dawn-ai/ag-ui exec vitest --run --config vitest.config.ts \
+  test/activities.test.ts
+```
+
+Expected: FAIL because `src/activities.ts` does not exist.
+
+- [ ] **Step 3a: Add the public contracts and recognized-type allowlist**
+
+Create `packages/ag-ui/src/activities.ts` with these public definitions:
+
+```ts
+import { EventType, type ActivitySnapshotEvent } from "@ag-ui/core"
+
+export const DAWN_PLAN_ACTIVITY_TYPE = "dawn.plan"
+export const DAWN_SUBAGENT_ACTIVITY_TYPE = "dawn.subagent"
+
+export interface DawnPlanActivityContent {
+  readonly todos: ReadonlyArray<{
+    readonly content: string
+    readonly status: "pending" | "in_progress" | "completed"
+  }>
+}
+
+export interface DawnSubagentActivityContent {
+  readonly name: string
+  readonly depth: number
+  readonly status: "running" | "completed" | "failed"
+  readonly todos?: DawnPlanActivityContent["todos"]
+  readonly tools: ReadonlyArray<{
+    readonly name: string
+    readonly status: "running" | "completed" | "incomplete"
+  }>
+  readonly totalToolCount: number
+  readonly error?: string
+}
+
+export type DawnActivityChunkType =
+  | "plan_update"
+  | "subagent.start"
+  | "subagent.plan_update"
+  | "subagent.tool_call"
+  | "subagent.tool_result"
+  | "subagent.message"
+  | "subagent.end"
+
+export interface DawnActivityProjector {
+  project(type: DawnActivityChunkType, data: unknown): ActivitySnapshotEvent | null
+}
+```
+
+Implement `isDawnActivityChunkType(value: string)` with an explicit `switch`; do not use prefix matching.
+
+- [ ] **Step 3b: Add strict todo parsing**
+
+Add `isRecord`, `asNonEmptyString`, and `parseTodos`. The todo parser requires a `todos` array, non-empty item content, and one exact status; it returns new allowlisted objects and never spreads input. Wrap property access in `try/catch`.
+
+- [ ] **Step 3c: Add plan-only projection**
+
+Implement the `plan_update` branch of `createDawnActivityProjector(runId)` with `dawn:plan:${runId}`, the exact constant, `replace: true`, and a fresh complete todo snapshot. Return `null` for other recognized types for now.
+
+- [ ] **Step 4: Run the root-plan tests GREEN**
+
+```bash
+pnpm --filter @dawn-ai/ag-ui exec vitest --run --config vitest.config.ts \
+  test/activities.test.ts
+```
+
+Expected: recognized-type and plan replacement tests PASS.
+
+- [ ] **Step 5: Write canonical identity, start, and child-plan tests**
+
+Add tests for a valid start and matching `subagent.plan_update`. Require one stable `dawn:subagent:call-research-1` message id and a complete running snapshot with replaced child todos. Add RED cases for plan-before-start, missing identity fields, and conflicting `subagent`, `route_id`, or `depth` on the same call id.
+
+- [ ] **Step 6: Run the identity/child-plan RED**
+
+```bash
+pnpm --filter @dawn-ai/ag-ui exec vitest --run --config vitest.config.ts \
+  test/activities.test.ts -t "subagent identity|child plan"
+```
+
+Expected: FAIL because subagent state is not implemented.
+
+- [ ] **Step 7a: Add request-local subagent state**
+
+Add one request-local `Map<string, InternalSubagentState>` keyed by `call_id`. Use these private shapes:
+
+The internal state must contain:
+
+```ts
+interface SubagentIdentity {
+  readonly callId: string
+  readonly subagent: string
+  readonly routeId: string
+  readonly depth: number
+}
+
+interface InternalToolState {
+  readonly id: string
+  readonly name: string
+  status: "running" | "completed" | "incomplete"
+}
+
+interface InternalSubagentState {
+  readonly identity: SubagentIdentity
+  status: "running" | "completed" | "failed"
+  todos?: DawnPlanActivityContent["todos"]
+  readonly seenToolIds: Set<string>
+  tools: InternalToolState[]
+  totalToolCount: number
+  error?: string
+  terminal: boolean
+}
+```
+
+- [ ] **Step 7b: Add canonical identity and snapshot helpers**
+
+Add `parseSubagentIdentity(data)` requiring all four fields, `sameIdentity(left, right)`, and `snapshotSubagent(state)`. The snapshot copies only public fields and uses conditional spreads for optional todos so `exactOptionalPropertyTypes` stays satisfied.
+
+- [ ] **Step 7c: Implement start and child-plan transitions**
+
+Implement `subagent.start` and `subagent.plan_update` only. Identical starts may re-emit; conflicting identity and updates before start return `null`. Child plans replace the full stored list.
+
+- [ ] **Step 8: Run identity and child-plan tests GREEN**
+
+```bash
+pnpm --filter @dawn-ai/ag-ui exec vitest --run --config vitest.config.ts \
+  test/activities.test.ts -t "subagent identity|child plan"
+```
+
+Expected: PASS.
+
+- [ ] **Step 9: Write child-tool correlation and five-entry-bound tests**
+
+Add a lifecycle test for call → result and a six-tool test. Require six unique calls to retain tools 2–6 in recency order with `totalToolCount: 6`; result for evicted tool 1 returns `null`; result for retained tool 6 emits completed; repeating an existing id never increments the total. Include sensitive input/output sentinels in payloads and require their absence from serialized snapshots.
+
+- [ ] **Step 10: Run the child-tool RED**
+
+```bash
+pnpm --filter @dawn-ai/ag-ui exec vitest --run --config vitest.config.ts \
+  test/activities.test.ts -t "child tool|five recent"
+```
+
+Expected: FAIL because tool transitions are not implemented.
+
+- [ ] **Step 11a: Implement child tool-call retention**
+
+For matching nonterminal identities, implement `subagent.tool_call` using non-empty raw `id` and `tool`; upsert it as running, count each id once with `seenToolIds`, and retain only the newest five summaries. Reinsert an evicted repeated id without incrementing the total.
+
+- [ ] **Step 11b: Implement child tool-result correlation**
+
+Implement `subagent.tool_result` using only its retained `id`; mark it completed without reading `tool` or `output`. Unknown and evicted ids return `null`.
+
+- [ ] **Step 12: Run child-tool tests GREEN**
+
+```bash
+pnpm --filter @dawn-ai/ag-ui exec vitest --run --config vitest.config.ts \
+  test/activities.test.ts -t "child tool|five recent"
+```
+
+Expected: PASS.
+
+- [ ] **Step 13: Write terminal, idempotency, and parallel-state tests**
+
+Add focused tests for successful end, failed end with a 500-character string capped to 400, running tools normalized to incomplete, terminal freeze, identical repeated start preserving progress, events-before-start ignored, and two interleaved call ids staying isolated. If `error` exists with a non-string value, require the malformed end to return `null`; empty/whitespace error is treated as no error and completes.
+
+- [ ] **Step 14: Run the terminal/state RED**
+
+```bash
+pnpm --filter @dawn-ai/ag-ui exec vitest --run --config vitest.config.ts \
+  test/activities.test.ts -t "terminal|repeated start|parallel"
+```
+
+Expected: FAIL because end/freeze behavior is not implemented.
+
+- [ ] **Step 15a: Implement terminal normalization**
+
+Implement `truncateError(value)` for string errors only. On matching `subagent.end`, turn running tools incomplete, set failed only for a trimmed non-empty string error, otherwise completed, ignore `final_message`, emit once, and freeze the state. Reject a present non-string error as malformed.
+
+- [ ] **Step 15b: Implement idempotent and terminal state guards**
+
+Preserve plan/tools on identical repeated start, ignore conflicting repeated starts, and ignore every mutation after terminal.
+
+- [ ] **Step 16: Run terminal/state tests GREEN**
+
+```bash
+pnpm --filter @dawn-ai/ag-ui exec vitest --run --config vitest.config.ts \
+  test/activities.test.ts -t "terminal|repeated start|parallel"
+```
+
+Expected: PASS.
+
+- [ ] **Step 17: Write privacy, message-ignore, malformed, and hostile-input tests**
+
+Add tests that `subagent.message` emits nothing, and that serialized public content omits child prose, tool inputs/outputs, `final_message`, route ids, call ids, and child tool ids. Add malformed todo/status/id/name/route/depth/tool cases, arrays where records are required, and an object with a throwing getter. Require `null` and no throw. Parse every non-null projection in the whole file with `ActivitySnapshotEventSchema`.
+
+- [ ] **Step 18: Run the hardening RED**
+
+```bash
+pnpm --filter @dawn-ai/ag-ui exec vitest --run --config vitest.config.ts \
+  test/activities.test.ts -t "privacy|malformed|hostile|message"
+```
+
+Expected: FAIL on the still-unhandled malformed/hostile edge cases.
+
+- [ ] **Step 19: Complete allowlist hardening**
+
+Make `isRecord` reject arrays, make every string validator reject whitespace-only values, and keep the entire `project()` parse/mutation path inside `try/catch`. Implement matching `subagent.message` as a consumed `null` without reading message content. Ensure `snapshotSubagent` creates fresh allowlisted arrays and conditionally spreads optional todos/error; never spread a runtime payload.
+
+- [ ] **Step 20: Run the complete projector suite GREEN**
+
+```bash
+pnpm --filter @dawn-ai/ag-ui exec vitest --run --config vitest.config.ts \
+  test/activities.test.ts
+```
+
+Expected: all projector tests PASS and every emitted event parses with AG-UI 0.0.57.
+
+- [ ] **Step 21: Add failing root-surface and type assertions**
+
+Change `packages/ag-ui/test/public-api.test.ts` to require the exact sorted runtime surface:
+
+```ts
+expect(Object.keys(api).sort()).toEqual([
+  "DAWN_PLAN_ACTIVITY_TYPE",
+  "DAWN_SUBAGENT_ACTIVITY_TYPE",
+  "createCounterIdFactory",
+  "createDefaultIdFactory",
+  "fromRunAgentInput",
+  "toAguiEvents",
+])
+
+expect(api.DAWN_PLAN_ACTIVITY_TYPE).toBe("dawn.plan")
+expect(api.DAWN_SUBAGENT_ACTIVITY_TYPE).toBe("dawn.subagent")
+```
+
+Extend `packages/ag-ui/test/types.test.ts` with compile-time `DawnPlanActivityContent` and `DawnSubagentActivityContent` values plus exact constant assertions, importing only from `../src/index.js`.
+
+- [ ] **Step 22: Run the public-surface RED**
+
+```bash
+pnpm --filter @dawn-ai/ag-ui exec vitest --run --config vitest.config.ts \
+  test/public-api.test.ts test/types.test.ts
+```
+
+Expected: FAIL because the root does not export the new contracts yet.
+
+- [ ] **Step 23: Export the public constants and types**
+
+Export only the constants and the two content types from `packages/ag-ui/src/index.ts`:
+
+```ts
+export {
+  DAWN_PLAN_ACTIVITY_TYPE,
+  DAWN_SUBAGENT_ACTIVITY_TYPE,
+  type DawnPlanActivityContent,
+  type DawnSubagentActivityContent,
+} from "./activities.js"
+```
+
+Do not export the projector or chunk-type guard from the root.
+
+- [ ] **Step 24: Run projector, public-surface, and typecheck GREEN**
+
+```bash
+pnpm --filter @dawn-ai/ag-ui exec vitest --run --config vitest.config.ts \
+  test/activities.test.ts test/public-api.test.ts test/types.test.ts
+pnpm --filter @dawn-ai/ag-ui typecheck
+```
+
+Expected: all focused tests and typecheck PASS.
+
+- [ ] **Step 25: Add the two pack-manifest assertions**
+
+In `scripts/pack-check.test.mjs`, require `dist/activities.js` and `dist/activities.d.ts` in the AG-UI manifest test. In `scripts/published-artifacts.test.mjs`, require those same two files from `expectedFilesForPackage("@dawn-ai/ag-ui")`.
+
+- [ ] **Step 26a: Add ESM-probe surface assertions**
+
+In `scripts/published-artifacts.test.mjs`, update the generated ESM-probe assertion to the exact six-name surface while leaving the function loop at four functions.
+
+- [ ] **Step 26b: Add TypeScript-probe and fixture assertions**
+
+Update the type-probe assertion for both constants and both interfaces. Extend `createAgUiProbeFixture()` with the literal constants and interface declarations while preserving all removed-legacy-export negatives.
+
+- [ ] **Step 27: Run the release-guard RED**
+
+Run:
+
+```bash
+node --test --test-name-pattern="checks the AG-UI root and SSE entrypoints" \
+  scripts/pack-check.test.mjs
+node --test \
+  --test-name-pattern="AG-UI installed probes|returns AG-UI entrypoint expectations" \
+  scripts/published-artifacts.test.mjs
+```
+
+Expected: FAIL because the release manifests/probe generators still describe the old four-function surface and omit `dist/activities.*`.
+
+- [ ] **Step 28: Update the two expected-file manifests**
+
+Add `dist/activities.js` and `dist/activities.d.ts` to `scripts/lib/pack-check.mjs`'s AG-UI list and `scripts/lib/published-artifacts.mjs`'s `@dawn-ai/ag-ui` expectations, preserving sorted order.
+
+- [ ] **Step 29: Update the installed-package smoke generator**
+
+In `scripts/published-artifact-smoke.mjs`, make the sorted runtime surface:
+
+  ```ts
+  [
+    "DAWN_PLAN_ACTIVITY_TYPE",
+    "DAWN_SUBAGENT_ACTIVITY_TYPE",
+    "createCounterIdFactory",
+    "createDefaultIdFactory",
+    "fromRunAgentInput",
+    "toAguiEvents",
+  ]
+  ```
+
+Assert the two values equal `dawn.plan` and `dawn.subagent`. Keep only the four functions in the function-type loop. Import the two public content interfaces into the TypeScript probe, place the constants in `RootValueSurface`, and place the interfaces in `RootTypeSurface`.
+
+- [ ] **Step 30: Synchronize published-artifact fixtures**
+
+In `scripts/published-artifacts.test.mjs`, mirror the exact surface in fixture JS/declarations and source-string assertions. Add empty `dist/activities.js` and representative `dist/activities.d.ts` fixture files only where a package-file fixture enumerates physical expected files.
+
+Do not add a package export subpath for `activities`; it is an internal emitted module reachable through the root re-exports only.
+
+- [ ] **Step 31: Run focused release guards GREEN**
+
+```bash
+node --test --test-name-pattern="checks the AG-UI root and SSE entrypoints" \
+  scripts/pack-check.test.mjs
+node --test \
+  --test-name-pattern="AG-UI installed probes|returns AG-UI entrypoint expectations" \
+  scripts/published-artifacts.test.mjs
+```
+
+Expected: PASS.
+
+- [ ] **Step 32a: Build the AG-UI package**
+
+```bash
+pnpm --filter @dawn-ai/ag-ui build
+```
+
+Expected: PASS; `dist/activities.js` and `.d.ts` exist locally but remain gitignored.
+
+- [ ] **Step 32b: Run complete release-guard suites**
+
+```bash
+pnpm test:pack-check
+pnpm test:published-artifacts
+```
+
+Expected: PASS.
+
+- [ ] **Step 32c: Run complete AG-UI package checks**
+
+```bash
+pnpm --filter @dawn-ai/ag-ui test
+pnpm --filter @dawn-ai/ag-ui lint
+pnpm --filter @dawn-ai/ag-ui typecheck
+```
+
+Expected: PASS.
+
+- [ ] **Step 32d: Check the task diff**
+
+```bash
+git diff --check
+```
+
+Expected: PASS.
+
+- [ ] **Step 33: Commit the bounded contract and release surface**
+
+```bash
+git add \
+  packages/ag-ui/src/activities.ts \
+  packages/ag-ui/src/index.ts \
+  packages/ag-ui/test/activities.test.ts \
+  packages/ag-ui/test/public-api.test.ts \
+  packages/ag-ui/test/types.test.ts \
+  scripts/lib/pack-check.mjs \
+  scripts/pack-check.test.mjs \
+  scripts/lib/published-artifacts.mjs \
+  scripts/published-artifacts.test.mjs \
+  scripts/published-artifact-smoke.mjs
+git commit -m "feat(ag-ui): add bounded activity contracts"
+```
+
+Expected: the commit contains only the listed source, tests, and release guards.
+
+### Task 2: Integrate activities into the outbound stream and packaged activation
+
+**Files:**
+- Modify: `packages/ag-ui/src/outbound.ts`
+- Modify: `packages/ag-ui/test/outbound.test.ts`
+- Modify: `packages/ag-ui/test/conformance.test.ts`
+- Modify: `test/generated/run-generated-research-activation.test.ts`
+- Reuse: `packages/ag-ui/src/activities.ts`
+
+Use `@superpowers:test-driven-development`. Write all outbound and generated-journey assertions before wiring the projector so both the cheap unit boundary and the real packaged boundary reach a genuine RED.
+
+- [ ] **Step 1: Replace the old “plan is unknown” fixture with a truly unknown chunk**
+
+In `packages/ag-ui/test/outbound.test.ts`, change the existing test named `unknown non-token chunks flush an open text message before being ignored` to use:
+
+```ts
+{ type: "capability.unknown", data: { arbitrary: true } }
+```
+
+Keep its expected framing unchanged: unknown chunks still close the open text message before the next token.
+
+- [ ] **Step 2: Write the recognized-plan framing tests**
+
+Import `ActivitySnapshotEventSchema` and the two public constants. Add one valid `plan_update` between two token chunks and require a valid plan snapshot without `TEXT_MESSAGE_END` until `done`. Add one malformed recognized plan and require no activity, no flush, and no `RUN_ERROR`.
+
+- [ ] **Step 3: Run the plan-framing RED**
+
+```bash
+pnpm --filter @dawn-ai/ag-ui exec vitest --run --config vitest.config.ts \
+  test/outbound.test.ts -t "plan activity|malformed recognized plan"
+```
+
+Expected: FAIL because `outbound.ts` still sends plans through its default flush-and-ignore branch.
+
+- [ ] **Step 4: Write the complete subagent wire/privacy test**
+
+Use this full identity on every event:
+
+```ts
+const child = {
+  call_id: "call-1",
+  subagent: "researcher",
+  route_id: "/research#researcher",
+  depth: 1,
+}
+```
+
+Send start, child plan, tool call `{ id: "child-tool-1", tool: "readDoc", input: "secret-input" }`, tool result `{ id: "child-tool-1", output: "secret-output" }`, message with `secret-child-prose`, and end with `final_message: "secret-final"`. Require standard snapshots and exact allowlisted contents; none of the four secret sentinels may appear in serialized activity content or root text.
+
+- [ ] **Step 5: Write interrupt-before-start and child-interrupt tests**
+
+Add one scenario where delegation approval interrupts before `subagent.start`; require no activity and preserve the exact interrupt terminal. Add one where a valid start precedes a child-owned interrupt; require one running snapshot, then require post-interrupt child plan/tool/end chunks to remain suppressed.
+
+- [ ] **Step 6: Write the request-local resume replacement test**
+
+Use two separate `collect()` calls. The first starts the child and parks on an interrupt. The second re-emits start and end with the same `call_id`. Require the same `dawn:subagent:${callId}` message id across requests, fresh running state on resume, and terminal completion; do not expect pre-interrupt plan/tools to replay.
+
+- [ ] **Step 7: Make the AG-UI client conformance stream require activities**
+
+Update `packages/ag-ui/test/conformance.test.ts` so `CANNED` contains:
+
+```ts
+const childIdentity = {
+  call_id: "c1",
+  subagent: "researcher",
+  route_id: "/research#researcher",
+  depth: 1,
+} as const
+
+const CANNED: DawnAgentStreamChunk[] = [
+  { type: "token", data: "Researching" },
+  { type: "tool_call", data: { name: "searchCorpus", input: { query: "agents" } } },
+  { type: "tool_result", data: { name: "searchCorpus", output: [{ path: "corpus/a.md" }] } },
+  { type: "plan_update", data: { todos: [{ content: "search", status: "completed" }] } },
+  { type: "subagent.start", data: childIdentity },
+  {
+    type: "subagent.plan_update",
+    data: { ...childIdentity, todos: [{ content: "read", status: "in_progress" }] },
+  },
+  {
+    type: "subagent.tool_call",
+    data: { ...childIdentity, id: "child-tool-1", tool: "readDoc", input: "not public" },
+  },
+  {
+    type: "subagent.tool_result",
+    data: { ...childIdentity, id: "child-tool-1", output: "not public" },
+  },
+  { type: "subagent.message", data: { ...childIdentity, message: "not root text" } },
+  { type: "subagent.end", data: { ...childIdentity, final_message: "not public" } },
+  { type: "token", data: " done. [corpus/a.md]" },
+  { type: "done", data: { messages: [] } },
+]
+```
+
+After `agent.run(input).pipe(verifyEvents(false), toArray())`, require:
+
+- `ACTIVITY_SNAPSHOT` is present and every such event parses through `ActivitySnapshotEventSchema`;
+- the activity types are exactly `dawn.plan` and `dawn.subagent`;
+- the stream still begins with `RUN_STARTED`, still contains the root tool call/result, and ends with `RUN_FINISHED`;
+- it contains no `ACTIVITY_DELTA`, `STATE_SNAPSHOT`, `CUSTOM`, or `RAW`; and
+- serialized activity content omits `not public`, route ids, call ids, and child tool ids.
+
+- [ ] **Step 8: Run all cheap pre-integration tests RED**
+
+```bash
+pnpm --filter @dawn-ai/ag-ui exec vitest --run --config vitest.config.ts \
+  test/outbound.test.ts test/conformance.test.ts
+```
+
+Expected: FAIL only on missing activity snapshots/no-flush semantics. Existing root text/tool/interrupt and terminal tests remain green.
+
+- [ ] **Step 9: Extract the packaged child-reply sentinel**
+
+In `test/generated/run-generated-research-activation.test.ts`, extract the child fixture reply:
+
+```ts
+const CHILD_REPLY =
+  "ReAct and plan-and-execute are common agent architectures. [corpus/agent-architectures.md]"
+```
+
+Use `CHILD_REPLY` in `createSafeResearchFixtures()` without changing fixture order or output.
+
+- [ ] **Step 10: Add no-activity assertions to unaffected journeys**
+
+Add:
+
+```ts
+function expectNoActivitySnapshots(events: readonly AgUiEvent[]): void {
+  expect(events.filter((event) => event.type === "ACTIVITY_SNAPSHOT")).toEqual([])
+}
+```
+
+Call it from `assertGatedResearchInterrupt()`, `assertResumedGatedJourney()`, and `assertBuiltArtifactJourney()`. Those fixtures do not run `writeTodos` or `task`, and this slice must not synthesize a seed-plan activity.
+
+- [ ] **Step 11: Add the exact packaged plan assertion**
+
+Extend `assertSafeResearchJourney()` after the existing successful-terminal and root-tool assertions. Require exactly seven activity snapshots: one plan and six updates of one researcher message.
+
+The plan must equal exactly:
+
+```ts
+{
+  type: "ACTIVITY_SNAPSHOT",
+  messageId: `dawn:plan:${ids.runId}`,
+  activityType: "dawn.plan",
+  replace: true,
+  content: { todos },
+}
+```
+
+- [ ] **Step 12: Add the six packaged researcher states**
+
+The six subagent contents, in exact order, must equal:
+
+```ts
+[
+  {
+    name: "researcher",
+    depth: 1,
+    status: "running",
+    tools: [],
+    totalToolCount: 0,
+  },
+  {
+    name: "researcher",
+    depth: 1,
+    status: "running",
+    tools: [{ name: "searchCorpus", status: "running" }],
+    totalToolCount: 1,
+  },
+  {
+    name: "researcher",
+    depth: 1,
+    status: "running",
+    tools: [{ name: "searchCorpus", status: "completed" }],
+    totalToolCount: 1,
+  },
+  {
+    name: "researcher",
+    depth: 1,
+    status: "running",
+    tools: [
+      { name: "searchCorpus", status: "completed" },
+      { name: "readDoc", status: "running" },
+    ],
+    totalToolCount: 2,
+  },
+  {
+    name: "researcher",
+    depth: 1,
+    status: "running",
+    tools: [
+      { name: "searchCorpus", status: "completed" },
+      { name: "readDoc", status: "completed" },
+    ],
+    totalToolCount: 2,
+  },
+  {
+    name: "researcher",
+    depth: 1,
+    status: "completed",
+    tools: [
+      { name: "searchCorpus", status: "completed" },
+      { name: "readDoc", status: "completed" },
+    ],
+    totalToolCount: 2,
+  },
+]
+```
+
+Every subagent snapshot has `messageId: "dawn:subagent:call_task_0_2"`, `activityType: "dawn.subagent"`, and `replace: true`. None has `todos` or `error` in this fixture.
+
+- [ ] **Step 13: Add packaged activity ordering assertions**
+
+Use the already-correlated root tool ids to assert ordering:
+
+- plan snapshot index is after `writeTodos` `TOOL_CALL_END` and before its `TOOL_CALL_RESULT`;
+- first researcher snapshot is after `task` `TOOL_CALL_END`;
+- terminal researcher snapshot is before `task` `TOOL_CALL_RESULT`; and
+- all seven activity snapshots precede the first final-root `TEXT_MESSAGE_CONTENT`.
+
+- [ ] **Step 14: Add packaged leakage and forbidden-event assertions**
+
+Serialize only the seven activity `content` values and require absence of:
+
+```ts
+[
+  SUBQUESTION,
+  CHILD_REPLY,
+  report,
+  "corpus/agent-architectures.md",
+  "call_task_0_2",
+  "call_searchCorpus_0_0",
+  "call_readDoc_0_1",
+  '"call_id"',
+  '"route_id"',
+  '"id"',
+  '"input"',
+  '"output"',
+  '"final_message"',
+]
+```
+
+Also require `reconstructAssistantText(events)` not to contain the full `CHILD_REPLY`, while preserving the existing citation assertion. Require no `ACTIVITY_DELTA`, `CUSTOM`, `RAW`, or `STATE_SNAPSHOT`. Do not alter scaffold/install/lifecycle, permission/resume, memory, report, sanitizer, server-cleanup, or transcript assertions.
+
+- [ ] **Step 15a: Build the pre-integration source**
+
+```bash
+pnpm build
+```
+
+Expected: PASS; built output still contains the old outbound flush-ignore behavior.
+
+- [ ] **Step 15b: Run the packaged pre-integration RED**
+
+```bash
+pnpm exec vitest --run --config test/generated/vitest.config.ts \
+  test/generated/run-generated-research-activation.test.ts
+```
+
+Expected: FAIL only because the safe exchange has zero activity snapshots; the unchanged scaffold/npm lifecycle and safe AG-UI journey reach that assertion. Let registry/global teardown and server cleanup complete naturally. Preserve the printed temp root on failure until GREEN is accepted.
+
+- [ ] **Step 16: Add the activity event type and request-local projector**
+
+In `packages/ag-ui/src/outbound.ts`:
+
+1. Import `type ActivitySnapshotEvent` from `@ag-ui/core`.
+2. Import `createDawnActivityProjector` and `isDawnActivityChunkType` from `./activities.js`.
+3. Add `ActivitySnapshotEvent` to `AguiOutboundEvent`.
+4. Construct one projector per `toAguiEvents()` call:
+
+   ```ts
+   const activityProjector = createDawnActivityProjector(ctx.runId)
+   ```
+
+- [ ] **Step 17: Intercept recognized activities at the exact outbound seam**
+
+After the existing pending-interrupt suppression block and before the `switch`, add:
+
+   ```ts
+   if (isDawnActivityChunkType(chunk.type)) {
+     const activity = activityProjector.project(chunk.type, chunk.data)
+     if (activity !== null) yield activity
+     continue
+   }
+   ```
+
+This position is load-bearing. Recognized valid or malformed activity chunks must not call `flushText()`. Unknown extensions must still reach the existing default branch and retain flush-then-ignore behavior. Pending interrupts must still suppress later activity chunks before projection.
+
+- [ ] **Step 18: Run the focused outbound/conformance boundary GREEN**
+
+```bash
+pnpm --filter @dawn-ai/ag-ui exec vitest --run --config vitest.config.ts \
+  test/outbound.test.ts test/conformance.test.ts
+```
+
+Expected: PASS, including AG-UI client `verifyEvents(false)`.
+
+- [ ] **Step 19a: Run all focused AG-UI tests GREEN**
+
+```bash
+pnpm --filter @dawn-ai/ag-ui exec vitest --run --config vitest.config.ts \
+  test/activities.test.ts test/outbound.test.ts test/conformance.test.ts \
+  test/public-api.test.ts test/types.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 19b: Run AG-UI static checks and build**
+
+```bash
+pnpm --filter @dawn-ai/ag-ui lint
+pnpm --filter @dawn-ai/ag-ui build
+pnpm --filter @dawn-ai/ag-ui typecheck
+```
+
+Expected: PASS.
+
+- [ ] **Step 19c: Run the complete AG-UI package test script**
+
+```bash
+pnpm --filter @dawn-ai/ag-ui test
+```
+
+Expected: PASS. Check that conformance still uses `verifyEvents(false)` and that no test relaxed existing text/tool/interrupt terminal ordering.
+
+- [ ] **Step 20: Refresh the workspace build**
+
+```bash
+pnpm build
+```
+
+Expected: PASS and all `dist/` consumers reflect the outbound bridge.
+
+- [ ] **Step 21: Run the packaged activation GREEN**
+
+```bash
+pnpm exec vitest --run --config test/generated/vitest.config.ts \
+  test/generated/run-generated-research-activation.test.ts
+```
+
+Expected: one test PASS. The safe journey produces exactly seven snapshots, gated/resume/built journeys produce none, and all existing npm lifecycle, report, transcript, and process cleanup checks remain green. Delete only the Task 2 RED temp root after this accepted run; do not remove unrelated preserved diagnostics.
+
+- [ ] **Step 22: Audit the exact Task 2 diff**
+
+```bash
+git diff --check
+git diff --name-only
+```
+
+Expected: only the four Task 2 files are newly modified since the Task 1 commit.
+
+- [ ] **Step 23: Commit the outbound bridge and real activation proof**
+
+```bash
+git add \
+  packages/ag-ui/src/outbound.ts \
+  packages/ag-ui/test/outbound.test.ts \
+  packages/ag-ui/test/conformance.test.ts \
+  test/generated/run-generated-research-activation.test.ts
+git commit -m "feat(ag-ui): emit plan and subagent activities"
+```
+
+Expected: the commit contains the outbound integration and both fast/packaged behavior proofs, with no fixture behavior change.
+
+### Task 3: Render activities in the flagship research web client
+
+**Files:**
+- Create: `examples/research/web/app/components/ActivitySchemas.ts`
+- Create: `examples/research/web/app/components/ActivityChecklist.tsx`
+- Create: `examples/research/web/app/components/PlanActivityCard.tsx`
+- Create: `examples/research/web/app/components/SubagentActivityCard.tsx`
+- Create: `examples/research/web/app/components/ActivityRenderers.tsx`
+- Create: `examples/research/web/app/components/ActivityRenderers.test.tsx`
+- Create: `examples/research/web/vitest.config.ts`
+- Modify: `examples/research/web/app/page.tsx`
+- Modify: `examples/research/web/package.json`
+- Modify: `pnpm-lock.yaml`
+- Modify: `vitest.workspace.ts`
+
+Do not modify `DemoSuggestions.tsx`, `ToolCallCard.tsx`, `PermissionInterrupt.tsx`, `MemoryCandidates.tsx`, the CopilotKit route, the research server, or any scaffold source. Use `@superpowers:test-driven-development`.
+
+- [ ] **Step 1a: Add research-web test and schema dependencies**
+
+Update `examples/research/web/package.json`:
+
+```json
+{
+  "scripts": {
+    "test": "vitest --run --config vitest.config.ts"
+  },
+  "dependencies": {
+    "@dawn-ai/ag-ui": "workspace:*",
+    "zod": "^4.4.3"
+  },
+  "devDependencies": {
+    "vitest": "^4.1.10"
+  }
+}
+```
+
+Merge those entries into the existing objects; retain every current script and dependency.
+
+```bash
+pnpm install
+```
+
+Expected: PASS and update only the intended research-web importer/lock entries.
+
+- [ ] **Step 1b: Register the research-web Vitest project**
+
+Create `examples/research/web/vitest.config.ts`:
+
+```ts
+import { defineConfig } from "vitest/config"
+
+export default defineConfig({
+  esbuild: { jsx: "automatic" },
+  test: {
+    name: "research-web",
+    environment: "node",
+    include: ["app/**/*.test.{ts,tsx}"],
+  },
+})
+```
+
+Add `./examples/research/web/vitest.config.ts` to `vitest.workspace.ts` immediately after the research-server entry.
+
+- [ ] **Step 1c: Write the first missing-schema test**
+
+Create `ActivityRenderers.test.tsx` importing only the not-yet-created `planActivityContentSchema`. Add one valid plan `safeParse` assertion and one strict-extra-key rejection.
+
+- [ ] **Step 1d: Run the missing-schema RED**
+
+```bash
+pnpm --filter @dawn-example/research-web test
+```
+
+Expected: lockfile/workspace links update, then the test FAILS because `ActivitySchemas.ts` is missing. “No tests found” is not a valid RED.
+
+- [ ] **Step 2: Implement the plan activity schema**
+
+Create `ActivitySchemas.ts` importing both public content types from `@dawn-ai/ag-ui` and `z` from `zod`. Implement:
+
+```ts
+const todoSchema = z
+  .object({
+    content: z.string().min(1),
+    status: z.enum(["pending", "in_progress", "completed"]),
+  })
+  .strict()
+
+export const planActivityContentSchema = z
+  .object({ todos: z.array(todoSchema) })
+  .strict()
+```
+
+Add a compile-time assignment from `z.output<typeof planActivityContentSchema>` to `DawnPlanActivityContent`. Do not export `todoSchema`.
+
+- [ ] **Step 3: Run the plan-schema test GREEN**
+
+```bash
+pnpm --filter @dawn-example/research-web test -t "plan schema"
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Write the subagent-schema RED cases**
+
+Import the not-yet-created `subagentActivityContentSchema` into the same test. Add valid running/completed/failed cases. Add strict failures for extra `call_id`, `route_id`, `id`, `input`, `output`, or `final_message`; six tools; 401-character error; `error` on non-failed status; missing error on failed; non-positive depth; and `totalToolCount < tools.length`.
+
+- [ ] **Step 5: Run the subagent-schema RED**
+
+```bash
+pnpm --filter @dawn-example/research-web test -t "subagent schema"
+```
+
+Expected: FAIL because the subagent schema is not exported.
+
+- [ ] **Step 6: Implement the strict subagent discriminated union**
+
+Add the private strict tool schema:
+
+```ts
+const toolSchema = z
+  .object({
+    name: z.string().min(1),
+    status: z.enum(["running", "completed", "incomplete"]),
+  })
+  .strict()
+```
+
+Build `subagentActivityContentSchema` as a strict discriminated union on `status`. Running/completed accept non-empty name, positive integer depth, optional todo array, at most five tools, and nonnegative integer total; they reject error. Failed requires `error: z.string().min(1).max(400)`. Refine the union so `totalToolCount >= tools.length`. Add a compile-time output assignment to `DawnSubagentActivityContent`.
+
+- [ ] **Step 7: Run both schema groups GREEN**
+
+```bash
+pnpm --filter @dawn-example/research-web test -t "schema"
+```
+
+Expected: PASS, and every `safeParse` call returns synchronously.
+
+- [ ] **Step 8: Write checklist and plan-card SSR tests**
+
+Import `renderToStaticMarkup` plus the not-yet-created checklist and plan card. Require active plan markup to contain `<details open`, `Plan · 1/3 complete`, and visible pending/in-progress/completed labels. Render ten todos and require exactly eight list items plus `+2 more`. Require a plan without `in_progress` to omit the `open` attribute.
+
+- [ ] **Step 9: Run the plan-card RED**
+
+```bash
+pnpm --filter @dawn-example/research-web test -t "plan card|checklist"
+```
+
+Expected: FAIL because the components do not exist.
+
+- [ ] **Step 10: Implement the shared checklist**
+
+Create `ActivityChecklist.tsx` with props:
+
+```ts
+interface ActivityChecklistProps {
+  readonly todos: DawnPlanActivityContent["todos"]
+  readonly limit?: number
+}
+```
+
+Render an ordered list of the first `limit ?? 8` items. Give each status both a glyph and visible label (`pending`, `in progress`, or `completed`) so meaning is not color-only. When truncated, render `+N more` after the list. Do not mutate or sort the input.
+
+- [ ] **Step 11: Implement the plan card**
+
+Create `PlanActivityCard.tsx`. Derive `completedCount`, `totalCount`, and whether any todo is `in_progress`. Render a native `<details open={hasActiveTodo}>` with summary text exactly `Plan · N/M complete`; render `ActivityChecklist` in the body with limit 8. The inactive card has no `open` attribute but remains user-expandable.
+
+- [ ] **Step 12: Run checklist and plan-card tests GREEN**
+
+```bash
+pnpm --filter @dawn-example/research-web test -t "plan card|checklist"
+```
+
+Expected: PASS.
+
+- [ ] **Step 13: Write running/nested subagent-card SSR tests**
+
+Import the not-yet-created subagent card. Require a running card to be expanded and show name, running status, total-tool count, an optional child plan, and five tool names/statuses. Require depth 2 to show `nested` and depth 1 not to.
+
+- [ ] **Step 14: Write terminal/failure subagent-card SSR tests**
+
+Require completed and failed cards to omit `open`; failed markup must contain `role="alert"` and its supplied bounded error. Assert no runtime id/input/output sentinel is present.
+
+- [ ] **Step 15: Run the subagent-card RED**
+
+```bash
+pnpm --filter @dawn-example/research-web test -t "subagent card"
+```
+
+Expected: FAIL because `SubagentActivityCard.tsx` does not exist.
+
+- [ ] **Step 16: Implement the bounded subagent card**
+
+Create `SubagentActivityCard.tsx` using the public subagent content type.
+
+- Render `<details open={content.status === "running"}>`.
+- Summary text contains the human-readable name, lifecycle status, and `${totalToolCount} tools`.
+- Render a visible `nested` badge only when `depth > 1`.
+- Render the optional child plan with `ActivityChecklist` and the same eight-item visual bound.
+- Render only the already-bounded `content.tools` list, with both glyph and visible status text.
+- On failure, render the bounded error in an element with `role="alert"`.
+- Never render message ids, call ids, route ids, tool ids, prompts, arguments, outputs, or raw serialized payloads.
+
+Use the example's existing small inline-style convention; do not add a styling framework or redesign the page.
+
+- [ ] **Step 17: Run subagent-card tests GREEN**
+
+```bash
+pnpm --filter @dawn-example/research-web test -t "subagent card"
+```
+
+Expected: PASS.
+
+- [ ] **Step 18: Write the stable renderer-registry RED**
+
+Import the not-yet-created renderer registry. Require its activity types, in order, to equal the two public constants. Validate a representative payload through each renderer's Standard Schema hook and require synchronous results.
+
+- [ ] **Step 19: Run the renderer-registry RED**
+
+```bash
+pnpm --filter @dawn-example/research-web test -t "renderer registry"
+```
+
+Expected: FAIL because `ActivityRenderers.tsx` does not exist.
+
+- [ ] **Step 20: Register typed activity renderers with stable identity**
+
+Create `ActivityRenderers.tsx`:
+
+```tsx
+import {
+  DAWN_PLAN_ACTIVITY_TYPE,
+  DAWN_SUBAGENT_ACTIVITY_TYPE,
+  type DawnPlanActivityContent,
+  type DawnSubagentActivityContent,
+} from "@dawn-ai/ag-ui"
+import type { ReactActivityMessageRenderer } from "@copilotkit/react-core/v2"
+import { planActivityContentSchema, subagentActivityContentSchema } from "./ActivitySchemas"
+import { PlanActivityCard } from "./PlanActivityCard"
+import { SubagentActivityCard } from "./SubagentActivityCard"
+
+export const planActivityRenderer = {
+  activityType: DAWN_PLAN_ACTIVITY_TYPE,
+  content: planActivityContentSchema,
+  render: ({ content }) => <PlanActivityCard content={content} />,
+} satisfies ReactActivityMessageRenderer<DawnPlanActivityContent>
+
+export const subagentActivityRenderer = {
+  activityType: DAWN_SUBAGENT_ACTIVITY_TYPE,
+  content: subagentActivityContentSchema,
+  render: ({ content }) => <SubagentActivityCard content={content} />,
+} satisfies ReactActivityMessageRenderer<DawnSubagentActivityContent>
+
+export const activityMessageRenderers = [planActivityRenderer, subagentActivityRenderer]
+```
+
+Keep the array at module scope and mutable; do not construct it inline in `Home` and do not add hooks or side effects inside renderer callbacks.
+
+- [ ] **Step 21: Run the complete renderer/schema suite GREEN**
+
+```bash
+pnpm --filter @dawn-example/research-web test
+```
+
+Expected: PASS. Tests use `renderToStaticMarkup`, not jsdom/Playwright/Testing Library, and assert semantics rather than full style-ordered HTML.
+
+- [ ] **Step 22: Wire the stable registry into the existing provider**
+
+Modify only the provider wiring in `examples/research/web/app/page.tsx`:
+
+```tsx
+import { activityMessageRenderers } from "./components/ActivityRenderers"
+
+<CopilotKit
+  runtimeUrl="/api/copilotkit"
+  defaultThrottleMs={100}
+  renderActivityMessages={activityMessageRenderers}
+>
+```
+
+Preserve `DemoSuggestions`, `PermissionInterrupt`, `ToolCallCard`, `MemoryCandidates`, the sidebar, and their order. Update the stale installed-version comment from CopilotKit 1.62.3 to 1.66.4, but do not rewrite the surrounding investigation notes or touch `ToolCallCard.tsx`.
+
+- [ ] **Step 23: Prove root Vitest collection**
+
+```bash
+pnpm --filter @dawn-example/research-web test
+pnpm exec vitest --run --config vitest.workspace.ts --project research-web
+```
+
+Expected: both commands PASS. The second proves the renderer project belongs to the root Vitest configuration.
+
+- [ ] **Step 24: Typecheck and build the research web app**
+
+```bash
+pnpm --filter @dawn-example/research-web typecheck
+pnpm --filter @dawn-example/research-web build
+```
+
+Expected: both commands PASS with the public `@dawn-ai/ag-ui` types and CopilotKit renderer prop.
+
+- [ ] **Step 25: Run scoped style and diff checks**
+
+```bash
+pnpm exec biome check --config-path packages/config-biome/biome.json \
+  examples/research/web/app/components/ActivitySchemas.ts \
+  examples/research/web/app/components/ActivityChecklist.tsx \
+  examples/research/web/app/components/PlanActivityCard.tsx \
+  examples/research/web/app/components/SubagentActivityCard.tsx \
+  examples/research/web/app/components/ActivityRenderers.tsx \
+  examples/research/web/app/components/ActivityRenderers.test.tsx \
+  examples/research/web/app/page.tsx \
+  examples/research/web/package.json \
+  examples/research/web/vitest.config.ts \
+  vitest.workspace.ts
+git diff --check
+```
+
+Expected: PASS with no unrelated formatting.
+
+- [ ] **Step 26: Commit the flagship activity UI**
+
+```bash
+git add \
+  examples/research/web/app/components/ActivitySchemas.ts \
+  examples/research/web/app/components/ActivityChecklist.tsx \
+  examples/research/web/app/components/PlanActivityCard.tsx \
+  examples/research/web/app/components/SubagentActivityCard.tsx \
+  examples/research/web/app/components/ActivityRenderers.tsx \
+  examples/research/web/app/components/ActivityRenderers.test.tsx \
+  examples/research/web/app/page.tsx \
+  examples/research/web/package.json \
+  examples/research/web/vitest.config.ts \
+  pnpm-lock.yaml \
+  vitest.workspace.ts
+git commit -m "feat(research): render AG-UI activities"
+```
+
+Expected: no server, generic-tool, permission, memory, suggestion, route, or scaffold source is staged.
+
+### Task 4: Document the exact activity boundary and release it honestly
+
+**Files:**
+- Modify: `packages/ag-ui/README.md`
+- Modify: `apps/web/content/docs/ag-ui.mdx`
+- Modify: `apps/web/content/docs/dev-server.mdx`
+- Modify: `apps/web/content/docs/api.mdx`
+- Modify: `apps/web/content/docs/recipes/research-web-ui.mdx`
+- Modify: `examples/research/web/README.md`
+- Modify: `examples/chat/README.md`
+- Modify: `examples/chat/web/README.md`
+- Modify: `packages/devkit/templates/app-research/README.md`
+- Create: `.changeset/ag-ui-activity-snapshots.md`
+- Verify only: generated `packages/cli/docs/` output
+
+This task includes the user-approved narrow scope amendment: correct the README shipped by the generated research starter, but do not add a scaffold web client or change starter source, dependencies, scripts, ports, or runtime behavior.
+
+**Required documentation contract:**
+
+Make the documentation agree on this exact mapping:
+
+| Dawn chunk | AG-UI output | Public content |
+|---|---|---|
+| root `plan_update` | replacement `ACTIVITY_SNAPSHOT`, id `dawn:plan:${runId}`, type `dawn.plan` | complete todo list only |
+| `subagent.start`, matching child plan/tool/result/end | replacement `ACTIVITY_SNAPSHOT`, id `dawn:subagent:${call_id}`, type `dawn.subagent` | name, depth, status, optional todos, at most five tool name/status summaries, total count, optional 400-character error |
+| `subagent.message` | consumed without emission | none |
+| unknown capability chunk | existing flush-and-ignore behavior | none |
+
+Every relevant page must say snapshots replace stable messages and must explicitly exclude child reasoning/prose, prompts, tool inputs, tool outputs, final child answers, route ids, and raw runtime ids from content. Do not claim reconnect, replay, generic capability mapping, activity deltas, or durable state.
+
+- [ ] **Step 1: Update the package README**
+
+In `packages/ag-ui/README.md`, add the two constants/content types to the root import example; replace both “planning/subagents are ignored” statements with a snapshot-only activity section; retain unknown-event and no-replay limits.
+
+- [ ] **Step 2: Update the AG-UI protocol guide**
+
+In `apps/web/content/docs/ag-ui.mdx`, add both activity rows to the outbound table; document stable ids, full replacement, exact statuses, five-tool/400-character bounds, identity validation, and excluded data.
+
+- [ ] **Step 3: Update the dev-server AG-UI endpoint**
+
+In `apps/web/content/docs/dev-server.mdx`, update only the AG-UI endpoint section's stale sentence. Preserve the earlier Agent Protocol `/runs/stream` table because it correctly documents raw runtime events.
+
+- [ ] **Step 4: Update the API reference**
+
+In `apps/web/content/docs/api.mdx`, add public constants and content types to the `@dawn-ai/ag-ui` import block and replace the stale mapping paragraph with the exact snapshot contract plus unknown-event behavior.
+
+Do not edit `packages/cli/docs/*.md`; those are generated/ignored build output from website MDX.
+
+- [ ] **Step 5: Update the flagship research-web recipe**
+
+In `apps/web/content/docs/recipes/research-web-ui.mdx`, add plan/researcher cards to “What you'll build”; show a stable module-level `renderActivityMessages` registry using the public constants and strict schemas; keep `defaultThrottleMs={100}`; say cards are informational and permissions remain owned by the separate standard interrupt UI.
+
+- [ ] **Step 6: Update the flagship research-web README**
+
+In `examples/research/web/README.md`, document `ActivitySchemas`, checklist/cards, and registry; state the safe suggestion shows plan and researcher progress before the cited answer; retain generic root-tool, permission, suggestions, memory, and server-held-key behavior. Describe the evidence honestly: SSR tests prove renderer presentation and the packaged activation proves the wire path; neither is a browser/live-model test.
+
+- [ ] **Step 7: Correct the chat example overview**
+
+In `examples/chat/README.md`, say the adapter emits standard planning/subagent activities, while the basic chat web client drives only `/chat` and registers no activity renderers. Do not imply the `/coordinator` UI now exists.
+
+- [ ] **Step 8: Correct the chat-web README**
+
+In `examples/chat/web/README.md`, make the same distinction in one concise paragraph; the basic client still has no plan/subagent presentation.
+
+- [ ] **Step 9: Correct the shipped research-starter README**
+
+In `packages/devkit/templates/app-research/README.md`, say the generated server endpoint emits standard activity messages and point to the separate research-web recipe/example that renders them. State plainly that the generated starter remains server-first and contains no web UI.
+
+- [ ] **Step 10: Add the exact patch changeset**
+
+Create `.changeset/ag-ui-activity-snapshots.md`:
+
+```md
+---
+"@dawn-ai/ag-ui": patch
+"@dawn-ai/devkit": patch
+"create-dawn-ai-app": patch
+---
+
+Expose Dawn planning and subagent progress as bounded standard AG-UI activity
+snapshots. The research web example renders plan checklists and delegated-work
+status without forwarding child prose, prompts, tool inputs, tool outputs, or
+final child answers, and the generated research starter now points users to
+that activity-aware web recipe.
+```
+
+The research web package is private and receives no changeset entry. Use patch because Dawn's fixed 0.x release group would turn a minor entry into 1.0.
+
+- [ ] **Step 11: Prove every stale claim is gone**
+
+First prove the old claims are gone:
+
+```bash
+! rg -n \
+  'AG-UI v1.*ignore|does not map planning|no v1 mapping.*ignored|does not expose live planning|planning capability events.*ignored' \
+  packages/ag-ui/README.md \
+  apps/web/content/docs/ag-ui.mdx \
+  apps/web/content/docs/dev-server.mdx \
+  apps/web/content/docs/api.mdx \
+  apps/web/content/docs/recipes/research-web-ui.mdx \
+  examples/research/web/README.md \
+  examples/chat/README.md \
+  examples/chat/web/README.md \
+  packages/devkit/templates/app-research/README.md
+```
+
+Expected: PASS because the search finds no matches.
+
+- [ ] **Step 12: Rebuild generated CLI docs**
+
+```bash
+pnpm --filter @dawn-ai/cli build
+```
+
+Expected: PASS. Do not stage generated/ignored `packages/cli/docs` output.
+
+- [ ] **Step 13: Run docs and release-inventory checks**
+
+```bash
+node scripts/check-docs.mjs
+pnpm check:release-inventory
+```
+
+Expected: PASS.
+
+- [ ] **Step 14: Run scoped style and diff checks**
+
+```bash
+pnpm exec biome check --config-path packages/config-biome/biome.json \
+  packages/ag-ui/README.md \
+  apps/web/content/docs/ag-ui.mdx \
+  apps/web/content/docs/dev-server.mdx \
+  apps/web/content/docs/api.mdx \
+  apps/web/content/docs/recipes/research-web-ui.mdx \
+  examples/research/web/README.md \
+  examples/chat/README.md \
+  examples/chat/web/README.md \
+  packages/devkit/templates/app-research/README.md \
+  .changeset/ag-ui-activity-snapshots.md
+git diff --check
+```
+
+Expected: PASS. If Biome does not support one of the Markdown files, remove only that unsupported path from the scoped Biome invocation; `check-docs` and `git diff --check` remain mandatory.
+
+- [ ] **Step 15: Commit docs and changeset**
+
+```bash
+git add \
+  packages/ag-ui/README.md \
+  apps/web/content/docs/ag-ui.mdx \
+  apps/web/content/docs/dev-server.mdx \
+  apps/web/content/docs/api.mdx \
+  apps/web/content/docs/recipes/research-web-ui.mdx \
+  examples/research/web/README.md \
+  examples/chat/README.md \
+  examples/chat/web/README.md \
+  packages/devkit/templates/app-research/README.md \
+  .changeset/ag-ui-activity-snapshots.md
+git commit -m "docs: document AG-UI activities"
+```
+
+Expected: the commit contains only the nine docs and one changeset.
+
+- [ ] **Step 16: Run the commit-aware changeset checks**
+
+```bash
+BASE_REF=origin/main node scripts/check-changesets.mjs
+pnpm exec changeset status --since=origin/main
+```
+
+Expected: the changeset checker reports the user-facing AG-UI/devkit/creator changes are covered, and Changesets reports one valid patch file. The checker compares committed history, so running it only before the commit is not sufficient. If either check fails, correct the docs/changeset and amend the docs commit.
+
+### Task 5: Run complete verification and independent review
+
+**Files:**
+- Verify: all files changed by Tasks 1–4
+- Verify: `docs/superpowers/specs/2026-08-10-ag-ui-plan-subagent-activities-design.md`
+- Verify: `docs/superpowers/plans/2026-08-10-ag-ui-plan-subagent-activities.md`
+
+Use `@superpowers:verification-before-completion` before making any completion claim. Use `@superpowers:requesting-code-review` after the full checks are green.
+
+- [ ] **Step 1: Confirm exact scope and current-main ancestry**
+
+```bash
+git status --short --branch
+git fetch origin main
+git merge-base --is-ancestor origin/main HEAD
+git diff --name-status origin/main...HEAD
+git log --oneline --reverse origin/main..HEAD
+```
+
+Expected: clean worktree, current main is an ancestor, and the diff contains only protocol/release guards, research activity UI/tests, the generated activation assertion, the nine approved docs, one changeset, and the design/plan docs. No generic tool-card, permission, memory, runtime, scaffold code, provider, deployment, or browser-E2E file appears.
+
+If main advanced and the ancestry check fails, rebase now, repeat the overlap audit from Task 0, rebuild, and rerun every affected focused test before continuing.
+
+- [ ] **Step 2: Reconfirm the final toolchain**
+
+```bash
+node --version
+npm --version
+pnpm --version
+```
+
+Expected: Node 24, npm 11, pnpm 10.
+
+- [ ] **Step 3: Run the complete AG-UI package checks**
+
+```bash
+pnpm --filter @dawn-ai/ag-ui test
+pnpm --filter @dawn-ai/ag-ui lint
+pnpm --filter @dawn-ai/ag-ui typecheck
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Run the focused release-guard tests**
+
+```bash
+pnpm test:pack-check
+pnpm test:published-artifacts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Run the complete research-web checks**
+
+```bash
+pnpm --filter @dawn-example/research-web test
+pnpm exec vitest --run --config vitest.workspace.ts --project research-web
+pnpm --filter @dawn-example/research-web typecheck
+pnpm --filter @dawn-example/research-web build
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Refresh the final workspace build**
+
+```bash
+pnpm build
+```
+
+Expected: PASS with current source reflected in every `dist/` consumer.
+
+- [ ] **Step 7: Run the final packaged activation**
+
+```bash
+pnpm exec vitest --run --config test/generated/vitest.config.ts \
+  test/generated/run-generated-research-activation.test.ts
+```
+
+Expected: PASS. The activation uses aimock rather than a live model and completes all child-process/global-registry teardown. If it fails, preserve and report its printed diagnostic root; use `@superpowers:systematic-debugging` rather than rerunning blindly.
+
+- [ ] **Step 8: Run committed documentation and changeset checks**
+
+```bash
+node scripts/check-docs.mjs
+BASE_REF=origin/main node scripts/check-changesets.mjs
+pnpm exec changeset status --since=origin/main
+pnpm check:release-inventory
+```
+
+Expected: PASS with exactly the three patch entries.
+
+- [ ] **Step 9: Run complete package and TypeScript tooling checks**
+
+```bash
+pnpm pack:check
+pnpm verify:typescript-tooling-pack
+```
+
+Expected: PASS. `pack:check` must observe `dist/activities.js` and `.d.ts`, while the installed probe must observe the exact two new runtime constants and public types without reintroducing removed legacy exports.
+
+- [ ] **Step 10: Run the repository Definition of Done**
+
+```bash
+pnpm ci:validate
+```
+
+Expected: PASS through lint, build-cache, build, typecheck, root source tests (including the registered research-web project), release checks, docs, pack checks, TypeScript tooling, and all harness lanes. Run this serially and allow every registry/server teardown to finish.
+
+- [ ] **Step 11: Audit protocol privacy**
+
+```bash
+rg -n \
+  'ACTIVITY_DELTA|STATE_SNAPSHOT|CUSTOM|RAW|subagent\.message|final_message|route_id|tool_run_id' \
+  packages/ag-ui/src/activities.ts \
+  packages/ag-ui/src/outbound.ts \
+  examples/research/web/app/components/ActivitySchemas.ts \
+  examples/research/web/app/components/ActivityRenderers.tsx
+```
+
+Expected: matches are limited to allowlist/ignore logic or comments enforcing exclusion—never copied public payload fields.
+
+- [ ] **Step 12: Audit unchanged UX and scaffold boundaries**
+
+```bash
+git diff origin/main...HEAD -- \
+  examples/research/web/app/components/DemoSuggestions.tsx \
+  examples/research/web/app/components/ToolCallCard.tsx \
+  examples/research/web/app/components/PermissionInterrupt.tsx \
+  examples/research/web/app/components/MemoryCandidates.tsx \
+  packages/devkit/templates/app-research/package.json.template \
+  packages/devkit/templates/app-research/src
+```
+
+Expected: empty diff. Confirm separately that `defaultThrottleMs={100}` is unchanged and activity renderers are module-scoped.
+
+- [ ] **Step 13: Request independent spec review**
+
+Dispatch one spec reviewer with the exact `origin/main...HEAD` range. Ask them to check:
+
+- complete canonical identity validation and request-local state;
+- bounded tools/error and no retained child content;
+- recognized-no-flush versus unknown-flush behavior;
+- interrupt-before-start and child-interrupt/resume semantics;
+- AG-UI 0.0.57 conformance and exact public/release surfaces;
+- schema failure-closed behavior, stable renderer identity, accessibility, and root-test collection;
+- packaged seven-snapshot order/privacy without weakening prior activation assertions; and
+- the docs-only starter exception with no scaffold UI/code promotion.
+
+Expected: no spec deviation.
+
+- [ ] **Step 14: Request independent quality review**
+
+Dispatch a separate code-quality reviewer over the same range. Ask it to focus on malformed/hostile input safety, state bounds, exact-optional typing, React/schema behavior, accessibility, release guard completeness, test isolation, and accidental scope creep.
+
+Expected: no Critical or Important finding.
+
+- [ ] **Step 15: Resolve validated review findings**
+
+Use `@superpowers:receiving-code-review`. For a behavior fix, add a regression test first, run the smallest RED/GREEN boundary, then rerun `pnpm ci:validate`. Commit or amend deliberately and redispatch the relevant reviewer. If both reviews are clean, record that no edit was needed.
+
+- [ ] **Step 16: Produce the final evidence summary**
+
+```bash
+git status --short --branch
+git diff --check origin/main...HEAD
+git log --oneline --reverse origin/main..HEAD
+```
+
+Expected: clean worktree, no whitespace errors, and intentional commits equivalent to:
+
+```text
+docs: design AG-UI research activities
+docs: plan AG-UI research activities
+feat(ag-ui): add bounded activity contracts
+feat(ag-ui): emit plan and subagent activities
+feat(research): render AG-UI activities
+docs: document AG-UI activities
+```
+
+Report the exact verification commands/results, generated activation duration and cleanup state, full `ci:validate` result, changeset packages, reviewer verdicts, and any preserved failure artifact path. Do not claim browser E2E, replay, a raw advanced stream, scaffold UI promotion, or generic-tool-card specialization; those remain follow-ups.

--- a/docs/superpowers/specs/2026-08-10-ag-ui-plan-subagent-activities-design.md
+++ b/docs/superpowers/specs/2026-08-10-ag-ui-plan-subagent-activities-design.md
@@ -1,0 +1,636 @@
+# AG-UI Plan and Subagent Activities Design
+
+**Status:** Approved
+**Date:** 2026-08-10
+**Baseline:** `e95f4d61` (`origin/main` after the Vercel deployment slice)
+
+## Summary
+
+Expose Dawn's existing planning and subagent progress as two standard AG-UI
+activity-message types and render them inline in the flagship research web
+example.
+
+The adapter emits authoritative `ACTIVITY_SNAPSHOT` events for a root plan and
+for each subagent dispatch. The snapshots update stable activity messages in
+place. Their content is intentionally semantic and bounded: plan items,
+subagent identity and status, the child plan, and a short child-tool status
+trail. Child reasoning, token streams, prompts, tool inputs, tool outputs, and
+final child answers do not cross this UI boundary.
+
+The research web client registers typed CopilotKit renderers for both activity
+types. Plans appear as checklists; running subagents show bounded progress and
+collapse to a concise summary after completion or failure. Existing suggestion,
+permission, memory, and generic tool-card behavior remains intact.
+
+## Context
+
+Dawn's runtime already emits the information needed for a useful research
+activity experience:
+
+- the planning capability emits a complete `plan_update` after every
+  `writeTodos` replacement;
+- subagent execution emits `subagent.start`, `subagent.message`,
+  `subagent.tool_call`, `subagent.tool_result`, capability events such as
+  `subagent.plan_update`, and `subagent.end`; and
+- every subagent event carries one generated `call_id`, its subagent name,
+  route id, and numeric depth.
+
+The CLI preserves these capability chunks until the final AG-UI translation
+boundary. The current `@dawn-ai/ag-ui` v1 translator deliberately ignores them,
+so CopilotKit users see the root tool calls and final report but not the plan or
+delegated work that produces it.
+
+The default research web UI already provides the surrounding activation path:
+
+- a safe suggestion that drives planning, a researcher subagent, corpus tools,
+  and a cited report;
+- a permission suggestion and standard interrupt/resume UI;
+- generic root-tool cards;
+- memory-candidate review; and
+- a 100 ms CopilotKit render throttle required to keep a full research stream
+  responsive.
+
+The pinned stack needs no protocol or UI-framework upgrade. AG-UI 0.0.57
+supports `ACTIVITY_SNAPSHOT` and `ACTIVITY_DELTA`, and CopilotKit 1.66.x supports
+schema-validated `renderActivityMessages` entries rendered inline by the
+standard chat surface.
+
+## Research evidence
+
+Two local framework audits shaped this boundary.
+
+### Flue
+
+Flue has no first-class plan model. It emits semantic `task_start` and `task`
+boundaries, but also flattens every child message, reasoning delta, tool event,
+and idle event into the parent stream. Its default React reducer ignores the
+task boundaries and does not scope all nested events by child session. That
+creates noisy presentation and concrete parent/child projection hazards.
+
+The useful lesson is to retain stable correlation and rich runtime
+observability without forwarding the raw nested stream into the primary chat
+projection.
+
+### Eve
+
+Eve has a durable, full-replacement todo tool, but it exposes the todo lifecycle
+as ordinary tool JSON rather than a plan activity. Its subagent topology is
+cleaner: the parent stream carries a small control plane and a child-session id,
+while detailed child events live on a separate stream. Eve's terminal client
+follows that stream and deliberately projects only nested reasoning, messages,
+and child-tool status into an expandable subagent region.
+
+The useful lesson is to make the default UI projection explicit, bounded, and
+collapsible. Dawn does not need Eve's additional child-stream transport for this
+slice because Dawn already has correlated child events at its translator
+boundary.
+
+Neither project justifies exposing a new raw client API as part of the primary
+activation path.
+
+## Goals
+
+1. Map root `plan_update` events to one standard `dawn.plan` activity per AG-UI
+   run.
+2. Map each correlated subagent lifecycle to one standard `dawn.subagent`
+   activity per `call_id`.
+3. Update activities in place with complete replacement snapshots.
+4. Expose enough bounded progress to make the research run understandable
+   while it is happening.
+5. Keep child prose, reasoning, prompts, tool inputs, tool outputs, and final
+   child answers out of activity content.
+6. Render both activity types inline in the existing research CopilotSidebar.
+7. Preserve all existing text, root-tool, interrupt/resume, memory, and terminal
+   run behavior.
+8. Prove the public event contract with package tests, AG-UI client conformance,
+   focused renderer tests, and the deterministic generated research activation.
+9. Update directly affected documentation and publish the protocol addition
+   with a patch changeset.
+
+## Non-goals
+
+- Expose a raw or advanced child-event stream API.
+- Emit `CUSTOM`, `RAW`, `STATE_SNAPSHOT`, or activity delta events.
+- Add AG-UI reconnect, replay, or thread-management semantics.
+- Add queued, waiting, cancelled, or paused subagent states that the Dawn stream
+  does not currently support truthfully.
+- Show child reasoning, token streams, prompts, tool inputs, tool outputs, or
+  final child answers.
+- Change planning or subagent runtime semantics.
+- Add a parent call id, preserve `tool_run_id`, or otherwise change the existing
+  subagent correlation envelope.
+- Suppress, specialize, or correlate the existing generic `writeTodos` and
+  `task` tool cards. A separate follow-up investigates that work.
+- Add a persistent activity side rail.
+- Change suggestions, permissions, memory governance, or the 100 ms render
+  throttle.
+- Add browser end-to-end infrastructure.
+- Promote the research web tree into `create-dawn-ai-app` or the default
+  scaffold.
+- Change the generated research starter's runtime, layout, or dependencies. A
+  README-only correction is included because the shipped starter currently
+  says these activity events are ignored.
+- Add a keyless product demo, provider picker, deployment flow, or analytics.
+
+## Selected approach
+
+Use standard, snapshot-only AG-UI activities and inline CopilotKit renderers.
+
+This is preferable to a custom side panel because CopilotKit already treats
+activities as first-class messages, updates them independently by message id,
+and renders them in chronological chat context. A side panel would introduce a
+second client projection, responsive layout work, and run-grouping state while
+competing with the existing memory rail.
+
+It is preferable to specialized `writeTodos` and `task` tool cards because
+those root tools cannot represent child plans or child-tool progress during the
+delegated run, and they would leave Dawn without a reusable AG-UI activity
+contract.
+
+It uses complete snapshots rather than JSON Patch deltas because the source plan
+is already full-replacement state, the subagent projection is deliberately
+small, and a delta is silently unusable before a base snapshot exists.
+
+## Architecture and ownership
+
+The change has two independent layers:
+
+```text
+Dawn runtime chunks
+        |
+        | explicit allowlisted projection
+        v
+@dawn-ai/ag-ui ACTIVITY_SNAPSHOT events
+        |
+        | activityType + schema
+        v
+CopilotKit research activity renderers
+```
+
+### Protocol layer
+
+`@dawn-ai/ag-ui` owns:
+
+- the two public activity-type constants;
+- the two public TypeScript content contracts;
+- strict parsing of recognized Dawn capability payloads;
+- request-local subagent projection state;
+- stable AG-UI activity message ids; and
+- standard snapshot emission.
+
+The translator recognizes only root `plan_update` and the documented
+`subagent.*` variants. Other capability extensions keep the existing
+flush-and-ignore behavior.
+
+Recognized activity chunks do not close an open root text message. They update a
+separate AG-UI activity message without introducing extra assistant text
+messages.
+
+### UI layer
+
+The private research web package owns:
+
+- local runtime schemas for the activity contents;
+- `PlanActivityCard` and `SubagentActivityCard` presentation;
+- the stable renderer registry supplied to `<CopilotKit>`; and
+- focused renderer tests.
+
+It adds a direct Zod dependency for synchronous renderer validation. AG-UI and
+CopilotKit versions remain unchanged.
+
+The generic tool renderer, permission renderer, suggestion registration, memory
+rail, and runtime route remain separate components and are not modified beyond
+the provider accepting the new stable activity-renderer registry.
+
+## Public activity contracts
+
+### Activity type constants
+
+`@dawn-ai/ag-ui` exports stable constants equivalent to:
+
+```ts
+export const DAWN_PLAN_ACTIVITY_TYPE = "dawn.plan"
+export const DAWN_SUBAGENT_ACTIVITY_TYPE = "dawn.subagent"
+```
+
+It also exports TypeScript interfaces for both content shapes. The package does
+not add a runtime-schema dependency solely for these interfaces.
+
+### Plan activity
+
+Every valid root `plan_update` emits:
+
+```ts
+{
+  type: EventType.ACTIVITY_SNAPSHOT,
+  messageId: `dawn:plan:${runId}`,
+  activityType: "dawn.plan",
+  replace: true,
+  content: {
+    todos: Array<{
+      content: string,
+      status: "pending" | "in_progress" | "completed"
+    }>
+  }
+}
+```
+
+The snapshot contains the complete source list. It does not duplicate derived
+counts or invent an overall plan status. The UI derives progress from the item
+statuses.
+
+There is no initial activity for seed `plan.md` content because Dawn currently
+emits a plan event only after `writeTodos`. This slice does not add a synthetic
+run-start snapshot.
+
+### Subagent activity
+
+Every valid subagent lifecycle uses:
+
+```ts
+messageId: `dawn:subagent:${call_id}`
+activityType: "dawn.subagent"
+replace: true
+```
+
+Its complete content is equivalent to:
+
+```ts
+interface DawnSubagentActivityContent {
+  name: string
+  depth: number
+  status: "running" | "completed" | "failed"
+  todos?: Array<{
+    content: string
+    status: "pending" | "in_progress" | "completed"
+  }>
+  tools: Array<{
+    name: string
+    status: "running" | "completed" | "incomplete"
+  }>
+  totalToolCount: number
+  error?: string
+}
+```
+
+`call_id` remains the correlation source and appears in the standard activity
+message id. It is not duplicated inside content. Route id and child tool ids are
+also omitted from content because the primary renderer does not need them.
+
+The projection retains at most the five most recent child tools. It uses child
+tool ids only inside request-local state to correlate calls and results. A tool
+id, input, result, or error object never enters public activity content.
+
+The internal canonical identity for a subagent is the complete
+`{ call_id, subagent, route_id, depth }` tuple already emitted by Dawn. Every
+recognized `subagent.*` payload must contain that tuple, and an event may mutate
+existing state only when all four fields exactly match the start identity.
+`route_id` remains internal to validation and is never copied into public
+activity content.
+
+An exposed error is a human-readable string capped at 400 characters. It never
+contains a raw error object or stack trace produced by this adapter.
+
+## Event projection
+
+### Root plan
+
+For each valid `plan_update`:
+
+1. validate the full todo array and each item;
+2. emit a complete `dawn.plan` replacement snapshot; and
+3. leave root text, tools, interrupts, and terminal state untouched.
+
+A malformed plan update is ignored.
+
+### Subagent start
+
+For `subagent.start`:
+
+1. require a non-empty `call_id`, subagent name, and `route_id` plus a positive
+   integer depth;
+2. create running state when the call is new;
+3. treat an identical repeated start in the same request as an idempotent
+   upsert without discarding accumulated progress;
+4. ignore a conflicting canonical identity that reuses an existing call id;
+   and
+5. emit the complete running snapshot.
+
+Because projection state is request-local, a request resumed from an interrupt
+inside an already-started child begins by re-emitting `subagent.start`. The
+runtime reuses the original `call_id`, so the standard client replaces the
+pre-interrupt activity instead of creating a duplicate. Delegation approval is
+different: it occurs before any start, so resume emits the first activity for
+that call. In both cases the new snapshot is intentionally authoritative; the
+adapter does not claim durable replay.
+
+### Child plan
+
+For `subagent.plan_update`:
+
+1. require an existing subagent whose complete canonical identity matches;
+2. validate the complete todo list;
+3. replace the stored child plan; and
+4. emit the complete subagent snapshot.
+
+An update before start or with malformed content is ignored.
+
+### Child tools
+
+For `subagent.tool_call`:
+
+1. require an existing subagent whose complete canonical identity matches, a
+   non-empty child tool id, and a non-empty tool name;
+2. upsert that tool as running;
+3. increment `totalToolCount` only for a new tool id;
+4. retain only the five newest tool summaries; and
+5. emit the complete subagent snapshot.
+
+For `subagent.tool_result`:
+
+1. require an existing subagent whose complete canonical identity matches and
+   a currently retained matching child tool id;
+2. mark that tool completed; and
+3. emit the complete subagent snapshot.
+
+Tool inputs and outputs are deliberately neither parsed nor copied. A result
+for an unknown or already evicted tool id is ignored.
+
+### Child messages
+
+`subagent.message` is consumed without retaining content or emitting an AG-UI
+event. It never becomes root `TEXT_MESSAGE_CONTENT`.
+
+### Subagent end
+
+For `subagent.end`:
+
+1. require existing subagent state whose complete canonical identity matches;
+2. set running tool summaries without results to `incomplete`;
+3. set the activity to `failed` when a non-empty error is present, otherwise to
+   `completed`;
+4. attach only the bounded error for failure;
+5. ignore `final_message`; and
+6. emit the complete terminal snapshot.
+
+Events received after a terminal end do not mutate that activity. An end before
+start is ignored.
+
+### Interrupts and termination
+
+The standard permission interrupt remains the sole actionable representation of
+a parked run. Delegation approval happens before `subagent.start`, so no
+subagent activity exists while that approval is pending; the first activity is
+emitted only after approval succeeds on resume. If an interrupt instead arises
+inside an already-started child, its existing activity remains running because
+the runtime deliberately emits no terminal `subagent.end`. Resume reuses that
+child's `call_id`, so new running and terminal snapshots replace the same
+activity message.
+
+The adapter does not reinterpret observation disconnects, aborts, or missing
+`subagent.end` events as cancellation or failure. Current runtime behavior does
+not provide enough information to make that claim truthfully.
+
+## Research UI
+
+### Renderer registration
+
+Two schema-validated renderer entries are defined with stable module-level or
+memoized identity and supplied through `<CopilotKit
+renderActivityMessages={...}>`.
+
+An incompatible activity payload fails closed through the renderer schema and
+renders nothing. It does not crash the chat or fall back to dumping JSON.
+
+Activity messages remain in the browser transcript but are filtered from later
+`RunAgentInput.messages` by the standard AG-UI client, so they do not pollute
+model context.
+
+### Plan card
+
+The plan card header shows `Plan · N/M complete`.
+
+- It is expanded when any item is `in_progress`.
+- It is collapsed, but remains user-expandable, when no item is active.
+- It shows at most eight items and a `+N more` indicator.
+- Pending, active, and completed items use both text/icon semantics and visual
+  styling rather than color alone.
+- Repeated snapshots update the same card instead of creating revision history.
+
+### Subagent card
+
+The subagent header shows its human-readable name, lifecycle status, and total
+tool count.
+
+- Running cards are expanded.
+- Completed and failed cards collapse automatically and remain expandable.
+- The body shows the current child checklist when present.
+- The body shows up to five recent child-tool names and statuses.
+- A failed card shows the bounded error summary.
+- Depth greater than one gets a small `nested` label.
+- Cards are not visually attached to a particular parent card because Dawn does
+  not expose an unambiguous parent-call id for parallel nested branches.
+
+The renderer displays neither route ids nor runtime correlation ids.
+
+### Existing UI behavior
+
+The three starter suggestions are unchanged. The safe research suggestion is
+the primary activity demo.
+
+The standard permission UI remains separate and owns every approval action. An
+activity card is informational only and never resolves or cancels an interrupt.
+
+Memory candidates remain in the existing left rail. Generic tool cards remain
+registered and can temporarily duplicate limited `writeTodos` and `task`
+context. That additive behavior is safer than suppressing a tool without a
+proven correlation contract and is owned by the separate follow-up.
+
+The provider retains `defaultThrottleMs={100}`. Token-rate child activity is not
+introduced.
+
+## Error handling and bounds
+
+The activity bridge is an allowlist, not a generic capability passthrough.
+
+- Unknown capability types retain existing ignore behavior.
+- Malformed recognized payloads are ignored without terminating the run.
+- Parallel subagents use independent state keyed by `call_id`.
+- Conflicting reuse of one call id cannot overwrite another identity.
+- Repeated tool calls are deduplicated by child tool id.
+- Only five recent tool summaries are retained and exposed.
+- Only eight plan items are rendered, though the complete valid plan remains in
+  protocol content.
+- Child text and arbitrary tool data are never retained by projection state.
+- Error display is bounded to 400 characters.
+
+No activity failure may suppress or replace root text, tool calls, interrupts,
+`RUN_FINISHED`, or `RUN_ERROR`.
+
+## Verification strategy
+
+### `@dawn-ai/ag-ui` unit tests
+
+Focused tests cover:
+
+1. multiple plan replacements using one run-scoped message id;
+2. exact plan activity content and `replace: true`;
+3. two interleaved subagents with isolated call-scoped message ids;
+4. running, completed, and failed subagent status;
+5. child-plan replacement;
+6. child-tool add, result correlation, five-entry eviction, total count, and
+   incomplete terminal normalization;
+7. idempotent repeated start and conflicting call-id reuse;
+8. rejection of a missing or conflicting `route_id` and any other canonical
+   identity mismatch;
+9. delegation approval before start versus an interrupt inside an
+   already-started child, including stable replacement after resume;
+10. ignored child messages, unknown tools, out-of-order events, and malformed
+   payloads;
+11. absence of child text, final answers, runtime ids, tool inputs, and tool
+   outputs from serialized activity content;
+12. unchanged root text framing, root tool correlation, interrupts, and terminal
+    events; and
+13. absence of activity deltas, custom, raw, and state events.
+
+Each emitted activity must parse with AG-UI's activity snapshot schema.
+
+### AG-UI client conformance
+
+The existing canned conformance stream gains complete plan and subagent
+identities. `@ag-ui/client` and `verifyEvents(false)` must accept the stream and
+observe standard activity snapshots while the existing first/last run framing,
+root tools, and terminal result remain unchanged.
+
+### Renderer tests
+
+Focused research-web tests use synchronous schema parsing and server-side React
+rendering rather than browser automation. The research web package receives a
+Vitest configuration and direct test dependency, and that configuration is
+listed in the root `vitest.workspace.ts`, so the normal root `pnpm test` lane
+executes these tests. They verify:
+
+- plan progress counts, active/collapsed behavior, eight-item display bound, and
+  overflow text;
+- running, completed, and failed subagent presentation;
+- child-plan rendering;
+- five-tool display bound and total count;
+- nested labeling and bounded error display; and
+- failure-closed handling of incompatible content.
+
+### Generated research activation
+
+The existing packaged default-research activation remains the end-to-end
+behavior proof. Its safe deterministic journey already drives `writeTodos`, the
+researcher subagent, `searchCorpus`, `readDoc`, and a cited report.
+
+Extend that journey to require:
+
+1. one `dawn.plan` message identity updated with the expected fixture plan;
+2. one researcher activity identity progressing from running to completed;
+3. child tool summaries in exact `searchCorpus`, then `readDoc` order;
+4. no child prose, tool arguments, tool results, or final child answer in
+   activity content;
+5. activity snapshots before the final cited report; and
+6. the existing exact root tool sequence, report, permission/resume, memory,
+   build, dev, start, cleanup, and sanitized transcript assertions remaining
+   unchanged.
+
+The scenario continues to use aimock only as deterministic test infrastructure.
+It does not create a keyless user demo.
+
+### Repository verification
+
+Implementation verification includes focused package and renderer tests,
+research web typecheck/build, the generated activation, AG-UI conformance, docs
+and changeset checks, and the repository's normal validation lane. A focused
+renderer command is useful while iterating, but root `pnpm test` must also
+collect and execute that project. The existing browser-activation gate remains
+a later slice.
+
+## Documentation and release
+
+Update documentation that currently says planning and subagent chunks are
+ignored:
+
+- `packages/ag-ui/README.md`;
+- `apps/web/content/docs/ag-ui.mdx`;
+- `apps/web/content/docs/dev-server.mdx`;
+- `apps/web/content/docs/api.mdx`;
+- `apps/web/content/docs/recipes/research-web-ui.mdx`; and
+- `examples/research/web/README.md`;
+- `examples/chat/README.md`;
+- `examples/chat/web/README.md`; and
+- `packages/devkit/templates/app-research/README.md`.
+
+The documentation names both activity types, describes full-snapshot
+replacement, lists their bounded public fields, and states the excluded child
+content. It does not claim reconnect/replay or generic capability mapping.
+
+Add one patch changeset for `@dawn-ai/ag-ui`, `@dawn-ai/devkit`, and
+`create-dawn-ai-app`. The latter two entries account only for correcting the
+README shipped by the generated research starter; they do not promote or add a
+web client to that scaffold. The research web package is private and receives
+no changeset entry.
+
+## Expected file ownership
+
+The implementation plan may refine exact test-file placement, but the intended
+ownership is:
+
+- `packages/ag-ui/src/activities.ts` — public constants, types, validation, and
+  bounded projection helpers;
+- `packages/ag-ui/src/outbound.ts` — stream integration and activity emission;
+- `packages/ag-ui/src/index.ts` — public exports;
+- `packages/ag-ui/test/*` — focused mapping, type, and conformance tests;
+- `examples/research/web/app/components/*Activity*.tsx` — typed renderers and
+  cards;
+- `examples/research/web/app/page.tsx` — stable renderer registration;
+- `examples/research/web/package.json` — direct schema/test dependencies and
+  scripts when required;
+- `examples/research/web/vitest.config.ts` and focused research renderer tests;
+- `vitest.workspace.ts` — include the research-web project in the repository
+  test lane;
+- the existing generated activation test;
+- directly affected docs, including the generated research starter README; and
+- one patch changeset.
+
+No core planning, LangChain subagent, creator source, devkit template runtime,
+permission, memory, or deployment source file is expected to change.
+
+## Acceptance criteria
+
+The slice is complete when:
+
+1. A compatible AG-UI client receives valid standard `dawn.plan` and
+   `dawn.subagent` activity snapshots.
+2. Repeated plan and subagent updates replace stable activity messages rather
+   than create duplicates.
+3. A first-click safe research run visibly shows its plan and researcher
+   progress before the cited final report.
+4. The subagent activity shows bounded child-plan and child-tool status without
+   exposing child prose, reasoning, prompts, inputs, outputs, or final answers.
+5. Parallel, malformed, interrupted, resumed, failed, and terminal event paths
+   preserve honest status and existing AG-UI behavior.
+6. The flagship renderer is responsive, accessible, and compatible with the
+   existing suggestions, permissions, memory, and generic tools.
+7. The packaged deterministic activation proves the real protocol path without
+   a live model or product-facing keyless mode.
+8. Public documentation and the patch changeset describe the exact shipped
+   contract.
+9. All focused and repository verification gates pass.
+
+## Follow-up sequence
+
+After this slice:
+
+1. use the separate generic-tool-card investigation to decide whether
+   `writeTodos` and `task` should remain, specialize, or be suppressed when a
+   correlated semantic activity exists;
+2. add the deterministic browser activation gate that clicks the existing
+   suggestions and verifies visible plan, subagent, citation, and permission
+   behavior; and
+3. treat that browser gate as a prerequisite for a later design that promotes a
+   web UI into the default scaffold.
+
+Those are independent specs rather than hidden expansion of this one.

--- a/examples/chat/README.md
+++ b/examples/chat/README.md
@@ -16,22 +16,27 @@
 - `AGENTS.md` memory autoload — Dawn auto-injects `workspace/AGENTS.md` into the system prompt on every turn; the agent updates it via `writeFile`
 - **Planning** — `plan.md` in the route directory opts the agent into the built-in
   `writeTodos` tool, a `todos` state channel, and a `plan_update` Agent Protocol stream
-  event. AG-UI v1 intentionally ignores planning capability events.
+  event. The AG-UI adapter maps valid root updates to standard replacement
+  `dawn.plan` activity snapshots.
 - **Skills** — `src/app/chat/skills/<name>/SKILL.md` files are auto-listed in
   the agent's system prompt (name + description). The agent calls
   `readSkill({ name })` to load a skill's full body on demand. Two example
   skills ship with the demo: `workspace-conventions` and `recover-from-failure`.
 - **Subagents** — `/coordinator` dispatches to specialist subagents (`research`,
   `summarizer`) via an auto-generated `task({ subagent, input })` tool. Subagent runs
-  bubble `subagent.*` Agent Protocol stream events with `call_id` correlation. The basic
-  web client does not expose `/coordinator`; drive it through Agent Protocol instead.
+  bubble `subagent.*` Agent Protocol stream events with `call_id` correlation, and the
+  AG-UI adapter maps matching lifecycles to bounded replacement `dawn.subagent`
+  snapshots. The basic web client drives only `/chat`; it does not expose
+  `/coordinator` or register activity renderers, so drive coordinator runs through
+  Agent Protocol instead.
 - **HITL permissions** — `dawn.config.ts` seeds allow/deny lists for `runBash`. Unknown
   commands in interactive mode emit an interrupt; resume the thread with `once`, `always`,
   or `deny` to continue. See [Permissions](../../apps/web/content/docs/permissions.mdx)
   for the interrupt/resume flow.
 - End-to-end streaming to a [CopilotKit](https://docs.copilotkit.ai) web client over Dawn's
   AG-UI endpoint (`POST /agui/{routeId}`, see `@dawn-ai/ag-ui`) for basic `/chat` messages.
-  The web example deliberately has no planning, subagent, or permission compatibility UI.
+  The web example deliberately has no planning or subagent activity presentation and no
+  permission decision control.
 
 ## Model choice
 
@@ -109,4 +114,5 @@ The remaining limitations are scoped to this example's surface, not missing runt
 capabilities:
 
 - Nested-object tool inputs (e.g., `edit_file({ edits: [{ old, new }] })`) — typegen extension
-- The web client only drives `/chat`; `/coordinator` (subagents) has no web UI yet (fast-follow)
+- The web client only drives `/chat` and registers no activity renderers;
+  `/coordinator` is outside this basic client's UI.

--- a/examples/chat/web/README.md
+++ b/examples/chat/web/README.md
@@ -11,8 +11,11 @@ This app runs **live** against a real model — there is no aimock/demo mode her
 deterministic, no-key proof that the AG-UI wire protocol works is the `/agui` endpoint's
 test suite in `@dawn-ai/cli`.
 
-Scope: basic chat with the `/chat` route. The AG-UI v1 adapter intentionally
-ignores planning and subagent capability events.
+Scope: basic chat with the `/chat` route. Dawn's AG-UI adapter emits standard
+replacement `dawn.plan` and `dawn.subagent` activity snapshots when matching
+runtime chunks occur, but this client drives only `/chat` and registers no
+activity renderers. It therefore remains a transport-wiring example with no
+planning or subagent presentation, not a coordinator UI.
 
 ## Architecture
 

--- a/examples/research/web/README.md
+++ b/examples/research/web/README.md
@@ -4,12 +4,14 @@ A [CopilotKit](https://docs.copilotkit.ai) v2 app (`@copilotkit/react-core/v2` +
 `@copilotkit/runtime`) whose runtime route (`app/api/copilotkit/route.ts`) registers an
 `HttpAgent` pointed at Dawn's encoded `/research#agent` AG-UI endpoint (see
 `@dawn-ai/ag-ui`). It mirrors `examples/chat/web` (the canonical AG-UI wiring
-reference) and adds research suggestions, generic tool cards, standard permission
-handling, and memory-candidate approval.
+reference) and adds research suggestions, plan and researcher activity cards,
+generic tool cards, standard permission handling, and memory-candidate approval.
 
 This app runs **live** against a real model — there is no aimock/demo mode here. The
-deterministic, no-key proof that the research route and its AG-UI wire protocol work is
-the server's own offline test/eval suite (`examples/research/server`).
+focused web tests render the activity components to static markup, proving their
+presentation without a browser or model. The packaged generated-research activation
+drives the deterministic server and AG-UI client path, proving activity snapshots reach
+the client before the final report. Neither test is a browser test or a live-model run.
 
 ## Architecture
 
@@ -25,9 +27,21 @@ browser
   served via `copilotRuntimeNextJSAppRouterEndpoint`. No LLM credentials live here; the
   Dawn server holds `OPENAI_API_KEY`.
 - `app/page.tsx` — `CopilotKit` (`runtimeUrl="/api/copilotkit"`) wrapping a
-  `CopilotSidebar` (streaming chat transcript + cited report), plus suggestion
-  prompts, generic tool cards, standard permission handling, and the memory-review
-  panel.
+  `CopilotSidebar` (streaming chat transcript + cited report), with the stable
+  module-level activity renderer registry, 100 ms render throttle, suggestion prompts,
+  generic root-tool cards, standard permission handling, and the memory-review panel.
+- `app/components/ActivitySchemas.ts` — strict runtime schemas for Dawn's public plan
+  and subagent activity content. Incompatible payloads fail closed.
+- `app/components/ActivityChecklist.tsx` and `PlanActivityCard.tsx` — the checklist
+  shared by root and child cards, plus the root plan card. Each checklist view displays
+  at most eight items plus `+N more`, while its snapshot retains the complete valid
+  todo list. The root card derives its completed count from that full snapshot.
+- `app/components/SubagentActivityCard.tsx` — researcher name, depth, lifecycle status,
+  optional child checklist, at most five recent child-tool name/status summaries, total
+  tool count, and an optional error capped at 400 characters.
+- `app/components/ActivityRenderers.tsx` — the module-level
+  `activityMessageRenderers` registry, keyed by the public
+  `DAWN_PLAN_ACTIVITY_TYPE` and `DAWN_SUBAGENT_ACTIVITY_TYPE` constants.
 - `app/components/MemoryCandidates.tsx` — after a research run proposes durable memory
   via `remember()`, the candidate (`status:"candidate"`) shows up in this panel with
   **Approve**/**Reject** buttons, backed by the dev server's
@@ -39,10 +53,27 @@ Components/hooks that omit `agentId` resolve CopilotKit's default agent id
 (`"default"`), which the runtime route registers as the Dawn `/research` agent — same
 pattern as `examples/chat/web`, no per-component wiring needed.
 
-The AG-UI v1 adapter intentionally ignores planning and subagent capability
-events. Interrupts use the standard AG-UI run outcome and top-level resume
-array; this example does not add a client-specific compatibility component for
-them.
+Root plan snapshots replace the stable `dawn:plan:${runId}` message and carry
+the complete todo list. Each researcher snapshot replaces
+`dawn:subagent:${call_id}` and carries only its name, depth,
+`running`/`completed`/`failed` status, optional todos, bounded tool summaries,
+total tool count, and optional bounded error. Todo status is
+`pending`/`in_progress`/`completed`; tool-summary status is
+`running`/`completed`/`incomplete`. `subagent.message` is consumed without an
+activity emission. The `dawn.plan` and `dawn.subagent` activity content supplied
+to the cards excludes child reasoning or prose, prompts, tool inputs, tool
+outputs, final child answers, route ids, and raw runtime ids.
+
+Ordinary root `task` tool call/result events remain a separate surface. Root task
+events can carry the coordinator-visible input and result. The current generic card
+reduces task input to the subagent name and may show the result. The activity renderers
+neither suppress nor specialize those events.
+
+Choose the safe **Research a topic** suggestion to see plan and researcher
+progress before the cited answer. Activity cards are informational: generic
+root-tool rendering remains registered, while standard interrupt UI exclusively
+owns permission actions. Suggestions, memory review, and the server-held
+`OPENAI_API_KEY` flow are unchanged.
 
 ## Running
 
@@ -58,10 +89,11 @@ pnpm dev                             # server on :3002, web on :3010
 # open http://localhost:3010
 ```
 
-`pnpm --filter @dawn-example/research-web typecheck` / `build` cover this package in CI —
-that verifies the CopilotKit/AG-UI wiring compiles and the Next.js app builds. It does
-**not** exercise a live model; there's no automated substitute for the smoke below
-because this client intentionally has no demo/mock mode.
+`pnpm --filter @dawn-example/research-web test` renders the cards on the server and
+checks their schemas and bounds. `typecheck` / `build` verify the CopilotKit/AG-UI
+wiring compiles and the Next.js app builds. The repository's packaged research
+activation proves the deterministic wire path. These checks do **not** drive a browser
+or exercise a live model; this client intentionally has no demo/mock mode.
 
 ## Live smoke checklist (run manually, with a real `OPENAI_API_KEY`)
 
@@ -70,7 +102,7 @@ because this client intentionally has no demo/mock mode.
    `OPENAI_API_KEY`.
 3. Run `pnpm dev` there (server :3002, web :3010).
 4. Open http://localhost:3010. Send a research question — expect a streamed, cited
-   report in the sidebar.
+   report in the sidebar, with plan and researcher cards updating before the answer.
 5. If the run calls `remember()`, expect the **Memory candidates** panel to populate
    once the run finishes. Click **Approve** on one — expect it to disappear from the
    panel (now `status:"active"` in `.dawn/memory.sqlite`); **Reject** deletes it.

--- a/examples/research/web/app/components/ActivityChecklist.tsx
+++ b/examples/research/web/app/components/ActivityChecklist.tsx
@@ -1,0 +1,45 @@
+import type { DawnPlanActivityContent } from "@dawn-ai/ag-ui"
+
+const statusPresentation = {
+  pending: { glyph: "○", label: "pending" },
+  in_progress: { glyph: "◐", label: "in progress" },
+  completed: { glyph: "✓", label: "completed" },
+} as const
+
+export function ActivityChecklist({
+  todos,
+  limit = 8,
+}: {
+  todos: DawnPlanActivityContent["todos"]
+  limit?: number
+}) {
+  const visibleTodos = todos.slice(0, limit)
+  const overflow = todos.length - visibleTodos.length
+
+  return (
+    <div style={{ marginTop: 8 }}>
+      {/* biome-ignore lint/a11y/noRedundantRoles: Markerless lists need explicit list semantics. */}
+      <ol role="list" style={{ listStyle: "none", margin: 0, padding: 0 }}>
+        {visibleTodos.map((todo, index) => {
+          const presentation = statusPresentation[todo.status]
+          return (
+            <li
+              key={
+                // biome-ignore lint/suspicious/noArrayIndexKey: Activity todos intentionally expose no stable runtime IDs.
+                `${todo.content}:${index}`
+              }
+              style={{ display: "flex", gap: 8, alignItems: "baseline", marginTop: 4 }}
+            >
+              <span aria-hidden="true">{presentation.glyph}</span>
+              <span style={{ flex: 1, minWidth: 0, overflowWrap: "anywhere" }}>{todo.content}</span>
+              <span style={{ color: "#666", fontSize: 11 }}>{presentation.label}</span>
+            </li>
+          )
+        })}
+      </ol>
+      {overflow > 0 ? (
+        <div style={{ color: "#666", fontSize: 12, marginTop: 5 }}>+{overflow} more</div>
+      ) : null}
+    </div>
+  )
+}

--- a/examples/research/web/app/components/ActivityRenderers.test.tsx
+++ b/examples/research/web/app/components/ActivityRenderers.test.tsx
@@ -1,0 +1,413 @@
+import { DAWN_PLAN_ACTIVITY_TYPE, DAWN_SUBAGENT_ACTIVITY_TYPE } from "@dawn-ai/ag-ui"
+import { isValidElement, type ReactElement, type ReactNode } from "react"
+import { renderToStaticMarkup } from "react-dom/server"
+import { describe, expect, it } from "vitest"
+import { ActivityChecklist } from "./ActivityChecklist"
+import { activityMessageRenderers } from "./ActivityRenderers"
+import { planActivityContentSchema, subagentActivityContentSchema } from "./ActivitySchemas"
+import { PlanActivityCard } from "./PlanActivityCard"
+import { SubagentActivityCard } from "./SubagentActivityCard"
+
+describe("plan schema", () => {
+  it("accepts a valid plan activity", () => {
+    expect(
+      planActivityContentSchema.safeParse({
+        todos: [
+          { content: "Search the corpus", status: "in_progress" },
+          { content: "Write the report", status: "pending" },
+        ],
+      }).success,
+    ).toBe(true)
+  })
+
+  it("rejects extra keys", () => {
+    expect(
+      planActivityContentSchema.safeParse({
+        todos: [{ content: "Search the corpus", status: "completed" }],
+        id: "runtime-plan-id",
+      }).success,
+    ).toBe(false)
+  })
+})
+
+const runningSubagent = {
+  name: "researcher",
+  depth: 1,
+  status: "running",
+  tools: [{ name: "searchCorpus", status: "running" }],
+  totalToolCount: 1,
+} as const
+
+describe("subagent schema valid states", () => {
+  it.each([
+    runningSubagent,
+    { ...runningSubagent, status: "completed", tools: [] as const },
+    { ...runningSubagent, status: "failed", error: "Corpus unavailable" },
+  ])("accepts $status content", (content) => {
+    expect(subagentActivityContentSchema.safeParse(content).success).toBe(true)
+  })
+})
+
+describe("subagent schema privacy", () => {
+  it.each(["call_id", "route_id", "id", "input", "output", "final_message"])(
+    "rejects the extra key %s",
+    (key) => {
+      expect(
+        subagentActivityContentSchema.safeParse({ ...runningSubagent, [key]: "private" }).success,
+      ).toBe(false)
+    },
+  )
+})
+
+describe("subagent schema bounds", () => {
+  it("rejects more than five tools", () => {
+    expect(
+      subagentActivityContentSchema.safeParse({
+        ...runningSubagent,
+        tools: Array.from({ length: 6 }, (_, index) => ({
+          name: `tool-${index}`,
+          status: "completed",
+        })),
+        totalToolCount: 6,
+      }).success,
+    ).toBe(false)
+  })
+
+  it("rejects errors longer than 400 characters", () => {
+    expect(
+      subagentActivityContentSchema.safeParse({
+        ...runningSubagent,
+        status: "failed",
+        error: "x".repeat(401),
+      }).success,
+    ).toBe(false)
+  })
+
+  it.each(["running", "completed"] as const)("rejects an error for %s content", (status) => {
+    expect(
+      subagentActivityContentSchema.safeParse({
+        ...runningSubagent,
+        status,
+        error: "not allowed",
+      }).success,
+    ).toBe(false)
+  })
+
+  it("requires an error for failed content", () => {
+    expect(
+      subagentActivityContentSchema.safeParse({ ...runningSubagent, status: "failed" }).success,
+    ).toBe(false)
+  })
+
+  it.each([0, -1, 1.5])("rejects invalid depth %s", (depth) => {
+    expect(subagentActivityContentSchema.safeParse({ ...runningSubagent, depth }).success).toBe(
+      false,
+    )
+  })
+
+  it("rejects a total tool count below the displayed tool count", () => {
+    expect(
+      subagentActivityContentSchema.safeParse({ ...runningSubagent, totalToolCount: 0 }).success,
+    ).toBe(false)
+  })
+})
+
+describe("plan activity card", () => {
+  it("expands an active plan and shows progress with visible status labels", () => {
+    const markup = renderToStaticMarkup(
+      <PlanActivityCard
+        content={{
+          todos: [
+            { content: "Collect sources", status: "pending" },
+            { content: "Analyze evidence", status: "in_progress" },
+            { content: "Write report", status: "completed" },
+          ],
+        }}
+      />,
+    )
+
+    expect(markup).toContain("<details open")
+    expect(markup).toContain("Plan · 1/3 complete")
+    expect(markup).toContain("pending")
+    expect(markup).toContain("in progress")
+    expect(markup).toContain("completed")
+  })
+
+  it("shows at most eight todos and reports the overflow", () => {
+    const markup = renderToStaticMarkup(
+      <PlanActivityCard
+        content={{
+          todos: Array.from({ length: 10 }, (_, index) => ({
+            content: `Step ${index + 1}`,
+            status: "pending" as const,
+          })),
+        }}
+      />,
+    )
+
+    expect(markup.match(/<li/g)).toHaveLength(8)
+    expect(markup).toContain("+2 more")
+  })
+
+  it("collapses a plan with no active todo", () => {
+    const markup = renderToStaticMarkup(
+      <PlanActivityCard
+        content={{ todos: [{ content: "Collect sources", status: "completed" }] }}
+      />,
+    )
+
+    expect(markup).not.toContain("<details open")
+  })
+})
+
+const displayedTools = [
+  { name: "searchCorpus", status: "completed" },
+  { name: "readDoc", status: "completed" },
+  { name: "extractQuotes", status: "completed" },
+  { name: "compareSources", status: "running" },
+  { name: "checkCitation", status: "incomplete" },
+] as const
+
+describe("subagent activity card", () => {
+  it("expands running work with a child plan and five visible tool statuses", () => {
+    const markup = renderToStaticMarkup(
+      <SubagentActivityCard
+        content={{
+          name: "researcher",
+          depth: 2,
+          status: "running",
+          todos: [
+            { content: "Find primary sources", status: "completed" },
+            { content: "Compare the evidence", status: "in_progress" },
+          ],
+          tools: displayedTools,
+          totalToolCount: 12,
+        }}
+      />,
+    )
+
+    expect(markup).toContain("<details open")
+    expect(markup).toContain("researcher")
+    expect(markup).toContain("running")
+    expect(markup).toContain("12 tools")
+    expect(markup).toContain("Find primary sources")
+    for (const tool of displayedTools) {
+      expect(markup).toContain(tool.name)
+      expect(markup).toContain(tool.status)
+    }
+  })
+
+  it("labels only subagents deeper than the first level as nested", () => {
+    const nestedMarkup = renderToStaticMarkup(
+      <SubagentActivityCard
+        content={{
+          name: "fact checker",
+          depth: 2,
+          status: "completed",
+          tools: [],
+          totalToolCount: 0,
+        }}
+      />,
+    )
+    const rootMarkup = renderToStaticMarkup(
+      <SubagentActivityCard
+        content={{
+          name: "researcher",
+          depth: 1,
+          status: "completed",
+          tools: [],
+          totalToolCount: 0,
+        }}
+      />,
+    )
+
+    expect(nestedMarkup).toContain("nested")
+    expect(rootMarkup).not.toContain("nested")
+  })
+
+  it.each([
+    {
+      name: "researcher",
+      depth: 1,
+      status: "completed" as const,
+      tools: [],
+      totalToolCount: 0,
+    },
+    {
+      name: "researcher",
+      depth: 1,
+      status: "failed" as const,
+      tools: [],
+      totalToolCount: 0,
+      error: "The source service returned an error",
+    },
+  ])("collapses $status work", (content) => {
+    const markup = renderToStaticMarkup(<SubagentActivityCard content={content} />)
+    expect(markup).not.toContain("<details open")
+  })
+
+  it("shows the supplied bounded failure as an alert", () => {
+    const boundedError = `Bounded failure: ${"x".repeat(380)}`
+    const markup = renderToStaticMarkup(
+      <SubagentActivityCard
+        content={{
+          name: "researcher",
+          depth: 1,
+          status: "failed",
+          tools: [],
+          totalToolCount: 0,
+          error: boundedError,
+        }}
+      />,
+    )
+
+    expect(markup).toContain('role="alert"')
+    expect(markup).toContain(boundedError)
+  })
+
+  it("does not render runtime identifiers, inputs, or outputs", () => {
+    const privateContent = {
+      name: "researcher",
+      depth: 1,
+      status: "running" as const,
+      tools: [],
+      totalToolCount: 0,
+      call_id: "CALL-ID-SENTINEL",
+      route_id: "ROUTE-ID-SENTINEL",
+      input: "INPUT-SENTINEL",
+      output: "OUTPUT-SENTINEL",
+    }
+    const markup = renderToStaticMarkup(<SubagentActivityCard content={privateContent} />)
+
+    expect(markup).not.toMatch(/CALL-ID-SENTINEL|ROUTE-ID-SENTINEL|INPUT-SENTINEL|OUTPUT-SENTINEL/)
+  })
+})
+
+function descendantElements(element: ReactElement): ReactElement[] {
+  const { children } = element.props as { children?: ReactNode }
+  const childNodes = Array.isArray(children) ? children : [children]
+  return childNodes.flatMap((child) =>
+    isValidElement(child) ? [child, ...descendantElements(child)] : [],
+  )
+}
+
+describe("activity card quality boundaries", () => {
+  it("assigns unique identifier-free keys to duplicate todo content", () => {
+    const checklist = ActivityChecklist({
+      todos: [
+        { content: "Review evidence", status: "pending" },
+        { content: "Review evidence", status: "in_progress" },
+      ],
+    })
+    const itemKeys = descendantElements(checklist)
+      .filter((element) => element.type === "li")
+      .map((element) => element.key)
+
+    expect(new Set(itemKeys).size).toBe(itemKeys.length)
+  })
+
+  it("assigns unique identifier-free keys to duplicate tool names", () => {
+    const card = SubagentActivityCard({
+      content: {
+        name: "researcher",
+        depth: 1,
+        status: "running",
+        tools: [
+          { name: "searchCorpus", status: "completed" },
+          { name: "searchCorpus", status: "running" },
+        ],
+        totalToolCount: 2,
+      },
+    })
+    const itemKeys = descendantElements(card)
+      .filter((element) => element.type === "li")
+      .map((element) => element.key)
+
+    expect(new Set(itemKeys).size).toBe(itemKeys.length)
+  })
+
+  it("protects long unbroken plan content from overflowing", () => {
+    const longContent = "evidence".repeat(60)
+    const markup = renderToStaticMarkup(
+      <PlanActivityCard content={{ todos: [{ content: longContent, status: "in_progress" }] }} />,
+    )
+
+    expect(markup).toContain(longContent)
+    expect(markup).toContain("min-width:0")
+    expect(markup).toContain("overflow-wrap:anywhere")
+  })
+
+  it("protects long unbroken subagent and tool names from overflowing", () => {
+    const longName = "researcher".repeat(50)
+    const longToolName = "searchCorpus".repeat(50)
+    const markup = renderToStaticMarkup(
+      <SubagentActivityCard
+        content={{
+          name: longName,
+          depth: 1,
+          status: "running",
+          tools: [{ name: longToolName, status: "running" }],
+          totalToolCount: 1,
+        }}
+      />,
+    )
+
+    expect(markup).toContain(longName)
+    expect(markup).toContain(longToolName)
+    expect(markup.match(/min-width:0/g)).toHaveLength(2)
+    expect(markup.match(/overflow-wrap:anywhere/g)).toHaveLength(2)
+  })
+
+  it("retains explicit list semantics for the markerless checklist", () => {
+    const markup = renderToStaticMarkup(
+      <PlanActivityCard content={{ todos: [{ content: "Review evidence", status: "pending" }] }} />,
+    )
+
+    expect(markup).toMatch(/<ol[^>]*role="list"/)
+  })
+
+  it("retains explicit list semantics for markerless tools", () => {
+    const markup = renderToStaticMarkup(
+      <SubagentActivityCard
+        content={{
+          name: "researcher",
+          depth: 1,
+          status: "running",
+          tools: [{ name: "searchCorpus", status: "running" }],
+          totalToolCount: 1,
+        }}
+      />,
+    )
+
+    expect(markup).toMatch(/<ul[^>]*role="list"/)
+  })
+})
+
+describe("activity renderer registry", () => {
+  it("registers the public activity types in order", () => {
+    expect(activityMessageRenderers.map((renderer) => renderer.activityType)).toEqual([
+      DAWN_PLAN_ACTIVITY_TYPE,
+      DAWN_SUBAGENT_ACTIVITY_TYPE,
+    ])
+  })
+
+  it("synchronously validates representative content through each renderer", () => {
+    const representativeContent = [
+      { todos: [{ content: "Write the report", status: "pending" }] },
+      {
+        name: "researcher",
+        depth: 1,
+        status: "running",
+        tools: [{ name: "searchCorpus", status: "running" }],
+        totalToolCount: 1,
+      },
+    ] as const
+
+    activityMessageRenderers.forEach((renderer, index) => {
+      const result = renderer.content["~standard"].validate(representativeContent[index])
+      expect(result).not.toBeInstanceOf(Promise)
+      if (result instanceof Promise) throw new Error("activity validation must be synchronous")
+      expect("value" in result).toBe(true)
+    })
+  })
+})

--- a/examples/research/web/app/components/ActivityRenderers.tsx
+++ b/examples/research/web/app/components/ActivityRenderers.tsx
@@ -1,0 +1,24 @@
+import type { ReactActivityMessageRenderer } from "@copilotkit/react-core/v2"
+import {
+  DAWN_PLAN_ACTIVITY_TYPE,
+  DAWN_SUBAGENT_ACTIVITY_TYPE,
+  type DawnPlanActivityContent,
+  type DawnSubagentActivityContent,
+} from "@dawn-ai/ag-ui"
+import { planActivityContentSchema, subagentActivityContentSchema } from "./ActivitySchemas"
+import { PlanActivityCard } from "./PlanActivityCard"
+import { SubagentActivityCard } from "./SubagentActivityCard"
+
+export const planActivityRenderer = {
+  activityType: DAWN_PLAN_ACTIVITY_TYPE,
+  content: planActivityContentSchema,
+  render: ({ content }) => <PlanActivityCard content={content} />,
+} satisfies ReactActivityMessageRenderer<DawnPlanActivityContent>
+
+export const subagentActivityRenderer = {
+  activityType: DAWN_SUBAGENT_ACTIVITY_TYPE,
+  content: subagentActivityContentSchema,
+  render: ({ content }) => <SubagentActivityCard content={content} />,
+} satisfies ReactActivityMessageRenderer<DawnSubagentActivityContent>
+
+export const activityMessageRenderers = [planActivityRenderer, subagentActivityRenderer]

--- a/examples/research/web/app/components/ActivitySchemas.ts
+++ b/examples/research/web/app/components/ActivitySchemas.ts
@@ -1,0 +1,53 @@
+import type { DawnPlanActivityContent, DawnSubagentActivityContent } from "@dawn-ai/ag-ui"
+import { z } from "zod"
+
+const todoSchema = z.strictObject({
+  content: z.string().trim().min(1),
+  status: z.enum(["pending", "in_progress", "completed"]),
+})
+
+export const planActivityContentSchema = z.strictObject({
+  todos: z.array(todoSchema),
+})
+
+function assignPlanOutputToPublicType(
+  content: z.output<typeof planActivityContentSchema>,
+): DawnPlanActivityContent {
+  return content
+}
+void assignPlanOutputToPublicType
+
+const toolSchema = z.strictObject({
+  name: z.string().trim().min(1),
+  status: z.enum(["running", "completed", "incomplete"]),
+})
+
+const subagentFields = {
+  name: z.string().trim().min(1),
+  depth: z.number().int().positive(),
+  todos: z.array(todoSchema).optional(),
+  tools: z.array(toolSchema).max(5),
+  totalToolCount: z.number().int().nonnegative(),
+}
+
+export const subagentActivityContentSchema = z
+  .discriminatedUnion("status", [
+    z.strictObject({ ...subagentFields, status: z.literal("running") }),
+    z.strictObject({ ...subagentFields, status: z.literal("completed") }),
+    z.strictObject({
+      ...subagentFields,
+      status: z.literal("failed"),
+      error: z.string().trim().min(1).max(400),
+    }),
+  ])
+  .refine((content) => content.totalToolCount >= content.tools.length, {
+    message: "totalToolCount must include every displayed tool",
+    path: ["totalToolCount"],
+  })
+
+function assignSubagentOutputToPublicType(
+  content: z.output<typeof subagentActivityContentSchema>,
+): DawnSubagentActivityContent {
+  return content
+}
+void assignSubagentOutputToPublicType

--- a/examples/research/web/app/components/PlanActivityCard.tsx
+++ b/examples/research/web/app/components/PlanActivityCard.tsx
@@ -1,0 +1,25 @@
+import type { DawnPlanActivityContent } from "@dawn-ai/ag-ui"
+import { ActivityChecklist } from "./ActivityChecklist"
+
+export function PlanActivityCard({ content }: { content: DawnPlanActivityContent }) {
+  const completedCount = content.todos.filter((todo) => todo.status === "completed").length
+  const hasActiveTodo = content.todos.some((todo) => todo.status === "in_progress")
+
+  return (
+    <details
+      open={hasActiveTodo}
+      style={{
+        border: "1px solid #e5e5e5",
+        borderRadius: 8,
+        padding: "8px 10px",
+        margin: "6px 0",
+        fontSize: 13,
+      }}
+    >
+      <summary style={{ cursor: "pointer", fontWeight: 600 }}>
+        Plan · {completedCount}/{content.todos.length} complete
+      </summary>
+      <ActivityChecklist todos={content.todos} limit={8} />
+    </details>
+  )
+}

--- a/examples/research/web/app/components/SubagentActivityCard.tsx
+++ b/examples/research/web/app/components/SubagentActivityCard.tsx
@@ -1,0 +1,84 @@
+import type { DawnSubagentActivityContent } from "@dawn-ai/ag-ui"
+import { ActivityChecklist } from "./ActivityChecklist"
+
+const toolStatusPresentation = {
+  running: { glyph: "◐", label: "running" },
+  completed: { glyph: "✓", label: "completed" },
+  incomplete: { glyph: "!", label: "incomplete" },
+} as const
+
+export function SubagentActivityCard({ content }: { content: DawnSubagentActivityContent }) {
+  return (
+    <details
+      open={content.status === "running"}
+      style={{
+        border: "1px solid #e5e5e5",
+        borderRadius: 8,
+        padding: "8px 10px",
+        margin: "6px 0",
+        fontSize: 13,
+      }}
+    >
+      <summary style={{ cursor: "pointer" }}>
+        <span style={{ fontWeight: 600, minWidth: 0, overflowWrap: "anywhere" }}>
+          {content.name}
+        </span>
+        <span style={{ color: "#666" }}> · {content.status}</span>
+        <span style={{ color: "#666" }}> · {content.totalToolCount} tools</span>
+        {content.depth > 1 ? (
+          <span
+            style={{
+              background: "#f2f2f2",
+              borderRadius: 4,
+              fontSize: 11,
+              marginLeft: 6,
+              padding: "1px 5px",
+            }}
+          >
+            nested
+          </span>
+        ) : null}
+      </summary>
+
+      {content.todos !== undefined ? (
+        <section aria-label="Subagent plan" style={{ marginTop: 8 }}>
+          <div style={{ color: "#666", fontSize: 11, fontWeight: 600 }}>Plan</div>
+          <ActivityChecklist todos={content.todos} limit={8} />
+        </section>
+      ) : null}
+
+      {content.tools.length > 0 ? (
+        <section aria-label="Subagent tools" style={{ marginTop: 8 }}>
+          <div style={{ color: "#666", fontSize: 11, fontWeight: 600 }}>Tools</div>
+          {/* biome-ignore lint/a11y/noRedundantRoles: Markerless lists need explicit list semantics. */}
+          <ul role="list" style={{ listStyle: "none", margin: "4px 0 0", padding: 0 }}>
+            {content.tools.map((tool, index) => {
+              const presentation = toolStatusPresentation[tool.status]
+              return (
+                <li
+                  key={
+                    // biome-ignore lint/suspicious/noArrayIndexKey: Activity tools intentionally expose no stable runtime IDs.
+                    `${tool.name}:${index}`
+                  }
+                  style={{ display: "flex", gap: 8, alignItems: "baseline", marginTop: 4 }}
+                >
+                  <span aria-hidden="true">{presentation.glyph}</span>
+                  <span style={{ flex: 1, minWidth: 0, overflowWrap: "anywhere" }}>
+                    {tool.name}
+                  </span>
+                  <span style={{ color: "#666", fontSize: 11 }}>{presentation.label}</span>
+                </li>
+              )
+            })}
+          </ul>
+        </section>
+      ) : null}
+
+      {content.status === "failed" ? (
+        <div role="alert" style={{ color: "#9f1239", marginTop: 8, overflowWrap: "anywhere" }}>
+          {content.error}
+        </div>
+      ) : null}
+    </details>
+  )
+}

--- a/examples/research/web/app/page.tsx
+++ b/examples/research/web/app/page.tsx
@@ -1,11 +1,12 @@
 "use client"
 import { CopilotKit, CopilotSidebar } from "@copilotkit/react-core/v2"
+import { activityMessageRenderers } from "./components/ActivityRenderers"
 import { DemoSuggestions } from "./components/DemoSuggestions"
 import { MemoryCandidates } from "./components/MemoryCandidates"
 import { PermissionInterrupt } from "./components/PermissionInterrupt"
 import { ToolCallCard } from "./components/ToolCallCard"
 
-// Notes (verified against installed @copilotkit/react-core@1.62.3 types — see
+// Notes (verified against installed @copilotkit/react-core@1.66.4 types — see
 // examples/chat/web/app/page.tsx for the original investigation):
 // - Use the `CopilotKit` wrapper (not bare `CopilotKitProvider`) per CopilotKit's own v2
 //   guidance: it adds the error boundary, toasts, and threads provider around the context.
@@ -24,7 +25,11 @@ import { ToolCallCard } from "./components/ToolCallCard"
 //   (the UI froze outright). 100ms keeps it live-feeling while capping re-renders.
 export default function Home() {
   return (
-    <CopilotKit runtimeUrl="/api/copilotkit" defaultThrottleMs={100}>
+    <CopilotKit
+      runtimeUrl="/api/copilotkit"
+      defaultThrottleMs={100}
+      renderActivityMessages={activityMessageRenderers}
+    >
       <DemoSuggestions />
       <PermissionInterrupt />
       <ToolCallCard />

--- a/examples/research/web/package.json
+++ b/examples/research/web/package.json
@@ -7,21 +7,25 @@
     "dev": "next dev -p 3010",
     "build": "next build",
     "start": "next start -p 3010",
+    "test": "vitest --run --config vitest.config.ts",
     "typecheck": "tsc -p . --noEmit"
   },
   "dependencies": {
     "@ag-ui/client": "0.0.57",
     "@copilotkit/react-core": "^1.66.0",
     "@copilotkit/runtime": "^1.66.0",
+    "@dawn-ai/ag-ui": "workspace:*",
     "next": "16.3.0",
     "react": "19.2.8",
-    "react-dom": "19.2.8"
+    "react-dom": "19.2.8",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@dawn-ai/config-typescript": "workspace:*",
     "@types/node": "26.1.2",
     "@types/react": "19.2.18",
     "@types/react-dom": "19.2.4",
-    "typescript": "7.0.2"
+    "typescript": "7.0.2",
+    "vitest": "^4.1.10"
   }
 }

--- a/examples/research/web/vitest.config.ts
+++ b/examples/research/web/vitest.config.ts
@@ -1,0 +1,5 @@
+import { defineConfig } from "vitest/config"
+export default defineConfig({
+  esbuild: { jsx: "automatic" },
+  test: { name: "research-web", environment: "node", include: ["app/**/*.test.{ts,tsx}"] },
+})

--- a/packages/ag-ui/README.md
+++ b/packages/ag-ui/README.md
@@ -37,6 +37,8 @@ POST http://127.0.0.1:3001/agui/%2Fchat%23agent
 
 ```ts
 import {
+  DAWN_PLAN_ACTIVITY_TYPE,
+  DAWN_SUBAGENT_ACTIVITY_TYPE,
   createCounterIdFactory,
   createDefaultIdFactory,
   fromRunAgentInput,
@@ -45,8 +47,10 @@ import {
   type DawnAgentStreamChunk,
   type DawnInterruptEnvelope,
   type DawnMessage,
+  type DawnPlanActivityContent,
   type DawnResumeRequest,
   type DawnRunInput,
+  type DawnSubagentActivityContent,
   type IdFactory,
   type RunContext,
   type ToAguiOptions,
@@ -104,8 +108,10 @@ type DawnAgentStreamChunk =
 `dawnChunks` can be any `AsyncIterable<DawnAgentStreamChunk>`, including the
 LangChain adapter's `AgentStreamChunk` stream. An interrupt maps when its data is
 a `DawnInterruptEnvelope` with a non-empty `interruptId`. Tool call ids from
-Dawn chunks are preserved as AG-UI `toolCallId`. Capability-contributed and
-other unknown chunk types are ignored.
+Dawn chunks are preserved as AG-UI `toolCallId`. Valid root planning and
+correlated subagent chunks map to the activity snapshots described below.
+Other capability-contributed and unknown chunk types retain the existing
+flush-and-ignore behavior.
 
 ### `fromRunAgentInput(input)`
 
@@ -151,8 +157,67 @@ Each interrupt uses the Dawn `interruptId` as its AG-UI `id`, and the complete
 Dawn envelope is retained in `metadata`. Successful runs finish with
 `outcome: { type: "success" }`; upstream failures become one `RUN_ERROR`.
 
-Planning updates, subagent capability events, and other unknown Dawn chunk types
-have no v1 mapping and are ignored.
+## Planning and subagent activities
+
+The adapter projects an explicit allowlist of Dawn capability chunks into
+standard `ACTIVITY_SNAPSHOT` events. Every snapshot has `replace: true`, so a
+compatible client replaces the stable activity message instead of appending a
+revision history.
+
+A valid root `plan_update` uses the `messageId` value
+`dawn:plan:${runId}` and
+`activityType: DAWN_PLAN_ACTIVITY_TYPE` (`"dawn.plan"`). Its
+`DawnPlanActivityContent` contains only the complete source todo list:
+
+```ts
+interface DawnPlanActivityContent {
+  readonly todos: ReadonlyArray<{
+    readonly content: string
+    readonly status: "pending" | "in_progress" | "completed"
+  }>
+}
+```
+
+The adapter does not synthesize an initial activity from a seeded `plan.md`;
+the first plan snapshot follows the first valid `plan_update`.
+
+`subagent.start` and matching `subagent.plan_update`,
+`subagent.tool_call`, `subagent.tool_result`, and `subagent.end` chunks use
+the `messageId` value `dawn:subagent:${call_id}` and
+`activityType: DAWN_SUBAGENT_ACTIVITY_TYPE` (`"dawn.subagent"`). Each complete
+replacement has this bounded public content:
+
+```ts
+interface DawnSubagentActivityContent {
+  readonly name: string
+  readonly depth: number
+  readonly status: "running" | "completed" | "failed"
+  readonly todos?: DawnPlanActivityContent["todos"]
+  readonly tools: ReadonlyArray<{
+    readonly name: string
+    readonly status: "running" | "completed" | "incomplete"
+  }>
+  readonly totalToolCount: number
+  readonly error?: string
+}
+```
+
+Only the five most recent child-tool name/status summaries are retained; the
+total count still covers every observed child tool. A failure may include one
+human-readable error truncated to 400 characters. A lifecycle event can update
+an activity only when its full internal identity
+`{ call_id, subagent, route_id, depth }` matches the original start.
+
+`subagent.message` is consumed without emission. Public activity content never
+contains child reasoning or prose, prompts, tool inputs, tool outputs, final
+child answers, route ids, child tool ids, or raw runtime correlation ids;
+`call_id` is used only to form the stable standard message id. This is not a
+generic capability mapping, activity-delta API, or raw advanced stream. Unknown
+chunks continue to flush any open assistant text message and are then ignored.
+
+Activities are informational. Permission requests and decisions remain on the
+standard interrupt and resume path; activity content does not add queued,
+waiting, cancelled, or parent-task correlation states.
 
 ## SSE Transport
 
@@ -170,9 +235,17 @@ The SSE helper is a focused subpath; it is not exported from the root adapter.
 
 ## CopilotKit
 
-The canonical example is `examples/chat/web`. It registers a CopilotKit
-`HttpAgent` that points at Dawn's AG-UI endpoint. The web app does not need
-model credentials; the Dawn server holds `OPENAI_API_KEY`.
+The canonical basic transport example is
+[`examples/chat/web`](https://github.com/cacheplane/dawnai/tree/main/examples/chat/web).
+It registers a CopilotKit `HttpAgent` that points at Dawn's AG-UI endpoint but
+registers no activity renderers. The web app does not need model credentials;
+the Dawn server holds `OPENAI_API_KEY`.
+
+For an activity-aware client that renders plan and researcher cards, follow the
+[Research assistant web UI recipe](https://dawnai.org/docs/recipes/research-web-ui)
+or browse the
+[`examples/research/web`](https://github.com/cacheplane/dawnai/tree/main/examples/research/web)
+source.
 
 ```text
 browser
@@ -191,6 +264,8 @@ browser
 - Dawn middleware gates Agent Protocol run, wait, and resume execution plus
   AG-UI route execution. It does not gate thread create, read, delete, or state
   endpoints. Allowed middleware context is exposed to tools as `ctx.middleware`.
+- Activity projection is request-local. The adapter does not buffer activity
+  state or provide reconnect, replay, or durable activity history.
 - The package translates protocol events; it does not host a web UI.
 
 ## License

--- a/packages/ag-ui/src/activities.ts
+++ b/packages/ag-ui/src/activities.ts
@@ -1,0 +1,305 @@
+import { type ActivitySnapshotEvent, EventType } from "@ag-ui/core"
+
+export const DAWN_PLAN_ACTIVITY_TYPE = "dawn.plan"
+export const DAWN_SUBAGENT_ACTIVITY_TYPE = "dawn.subagent"
+
+export interface DawnPlanActivityContent {
+  readonly todos: ReadonlyArray<{
+    readonly content: string
+    readonly status: "pending" | "in_progress" | "completed"
+  }>
+}
+
+export interface DawnSubagentActivityContent {
+  readonly name: string
+  readonly depth: number
+  readonly status: "running" | "completed" | "failed"
+  readonly todos?: DawnPlanActivityContent["todos"]
+  readonly tools: ReadonlyArray<{
+    readonly name: string
+    readonly status: "running" | "completed" | "incomplete"
+  }>
+  readonly totalToolCount: number
+  readonly error?: string
+}
+
+export type DawnActivityChunkType =
+  | "plan_update"
+  | "subagent.start"
+  | "subagent.plan_update"
+  | "subagent.tool_call"
+  | "subagent.tool_result"
+  | "subagent.message"
+  | "subagent.end"
+
+export interface DawnActivityProjector {
+  project(type: DawnActivityChunkType, data: unknown): ActivitySnapshotEvent | null
+}
+
+interface SubagentIdentity {
+  readonly callId: string
+  readonly subagent: string
+  readonly routeId: string
+  readonly depth: number
+}
+
+interface InternalToolState {
+  readonly id: string
+  readonly name: string
+  status: "running" | "completed" | "incomplete"
+}
+
+interface InternalSubagentState {
+  readonly identity: SubagentIdentity
+  status: "running" | "completed" | "failed"
+  todos?: DawnPlanActivityContent["todos"]
+  readonly seenToolIds: Set<string>
+  tools: InternalToolState[]
+  totalToolCount: number
+  error?: string
+  terminal: boolean
+}
+
+export function isDawnActivityChunkType(value: string): value is DawnActivityChunkType {
+  switch (value) {
+    case "plan_update":
+    case "subagent.start":
+    case "subagent.plan_update":
+    case "subagent.tool_call":
+    case "subagent.tool_result":
+    case "subagent.message":
+    case "subagent.end":
+      return true
+    default:
+      return false
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+function parseTodos(data: unknown): DawnPlanActivityContent["todos"] | null {
+  try {
+    if (!isRecord(data) || !Array.isArray(data.todos)) return null
+
+    const parsed: Array<DawnPlanActivityContent["todos"][number]> = []
+    for (const todo of data.todos) {
+      if (!isRecord(todo)) return null
+      const content = todo.content
+      const status = todo.status
+      if (typeof content !== "string" || content.trim().length === 0) return null
+      if (status !== "pending" && status !== "in_progress" && status !== "completed") return null
+      parsed.push({ content: content.trim(), status })
+    }
+    return parsed
+  } catch {
+    return null
+  }
+}
+
+function parseSubagentIdentity(data: unknown): SubagentIdentity | null {
+  try {
+    if (!isRecord(data)) return null
+    const callId = data.call_id
+    const subagent = data.subagent
+    const routeId = data.route_id
+    const depth = data.depth
+    if (typeof callId !== "string" || callId.trim().length === 0) return null
+    if (typeof subagent !== "string" || subagent.trim().length === 0) return null
+    if (typeof routeId !== "string" || routeId.trim().length === 0) return null
+    if (!Number.isInteger(depth) || (depth as number) <= 0) return null
+    return {
+      callId,
+      subagent,
+      routeId,
+      depth: depth as number,
+    }
+  } catch {
+    return null
+  }
+}
+
+function identitiesMatch(left: SubagentIdentity, right: SubagentIdentity): boolean {
+  return (
+    left.callId === right.callId &&
+    left.subagent === right.subagent &&
+    left.routeId === right.routeId &&
+    left.depth === right.depth
+  )
+}
+
+function readRawNonemptyString(data: unknown, key: string): string | null {
+  try {
+    if (!isRecord(data)) return null
+    const value = data[key]
+    return typeof value === "string" && value.trim().length > 0 ? value : null
+  } catch {
+    return null
+  }
+}
+
+function readTrimmedNonemptyString(data: unknown, key: string): string | null {
+  try {
+    if (!isRecord(data)) return null
+    const value = data[key]
+    return typeof value === "string" && value.trim().length > 0 ? value.trim() : null
+  } catch {
+    return null
+  }
+}
+
+function parseEndError(
+  data: unknown,
+): { readonly valid: false } | { readonly valid: true; error?: string } {
+  try {
+    if (!isRecord(data)) return { valid: false }
+    if (!Object.hasOwn(data, "error")) return { valid: true }
+    const value = data.error
+    if (typeof value !== "string") return { valid: false }
+    const trimmed = value.trim()
+    return trimmed.length === 0 ? { valid: true } : { valid: true, error: trimmed.slice(0, 400) }
+  } catch {
+    return { valid: false }
+  }
+}
+
+function subagentSnapshot(state: InternalSubagentState): ActivitySnapshotEvent {
+  return {
+    type: EventType.ACTIVITY_SNAPSHOT,
+    messageId: `dawn:subagent:${state.identity.callId}`,
+    activityType: DAWN_SUBAGENT_ACTIVITY_TYPE,
+    replace: true,
+    content: {
+      name: state.identity.subagent,
+      depth: state.identity.depth,
+      status: state.status,
+      ...(state.todos !== undefined
+        ? { todos: state.todos.map((todo) => ({ content: todo.content, status: todo.status })) }
+        : {}),
+      tools: state.tools.map((tool) => ({ name: tool.name, status: tool.status })),
+      totalToolCount: state.totalToolCount,
+      ...(state.error !== undefined ? { error: state.error } : {}),
+    },
+  }
+}
+
+export function createDawnActivityProjector(runId: string): DawnActivityProjector {
+  const subagents = new Map<string, InternalSubagentState>()
+
+  return {
+    project(type, data) {
+      if (type === "plan_update") {
+        const parsedTodos = parseTodos(data)
+        if (parsedTodos === null) return null
+        return {
+          type: EventType.ACTIVITY_SNAPSHOT,
+          messageId: `dawn:plan:${runId}`,
+          activityType: DAWN_PLAN_ACTIVITY_TYPE,
+          replace: true,
+          content: { todos: parsedTodos },
+        }
+      }
+
+      const parsedIdentity = parseSubagentIdentity(data)
+      if (parsedIdentity === null) return null
+      const current = subagents.get(parsedIdentity.callId)
+
+      if (type === "subagent.start") {
+        if (current !== undefined) {
+          return !current.terminal && identitiesMatch(current.identity, parsedIdentity)
+            ? subagentSnapshot(current)
+            : null
+        }
+        const state: InternalSubagentState = {
+          identity: parsedIdentity,
+          status: "running",
+          seenToolIds: new Set(),
+          tools: [],
+          totalToolCount: 0,
+          terminal: false,
+        }
+        subagents.set(parsedIdentity.callId, state)
+        return subagentSnapshot(state)
+      }
+
+      if (type === "subagent.plan_update") {
+        if (
+          current === undefined ||
+          current.terminal ||
+          !identitiesMatch(current.identity, parsedIdentity)
+        ) {
+          return null
+        }
+        const parsedTodos = parseTodos(data)
+        if (parsedTodos === null) return null
+        current.todos = parsedTodos
+        return subagentSnapshot(current)
+      }
+
+      if (type === "subagent.tool_call") {
+        if (
+          current === undefined ||
+          current.terminal ||
+          !identitiesMatch(current.identity, parsedIdentity)
+        ) {
+          return null
+        }
+        const id = readRawNonemptyString(data, "id")
+        const name = readTrimmedNonemptyString(data, "tool")
+        if (id === null || name === null) return null
+
+        const retainedIndex = current.tools.findIndex((tool) => tool.id === id)
+        if (retainedIndex !== -1) current.tools.splice(retainedIndex, 1)
+        if (!current.seenToolIds.has(id)) {
+          current.seenToolIds.add(id)
+          current.totalToolCount += 1
+        }
+        current.tools.push({ id, name, status: "running" })
+        if (current.tools.length > 5) current.tools.shift()
+        return subagentSnapshot(current)
+      }
+
+      if (type === "subagent.tool_result") {
+        if (
+          current === undefined ||
+          current.terminal ||
+          !identitiesMatch(current.identity, parsedIdentity)
+        ) {
+          return null
+        }
+        const id = readRawNonemptyString(data, "id")
+        if (id === null) return null
+        const tool = current.tools.find((candidate) => candidate.id === id)
+        if (tool === undefined) return null
+        tool.status = "completed"
+        return subagentSnapshot(current)
+      }
+
+      if (type === "subagent.end") {
+        if (
+          current === undefined ||
+          current.terminal ||
+          !identitiesMatch(current.identity, parsedIdentity)
+        ) {
+          return null
+        }
+        const parsedError = parseEndError(data)
+        if (!parsedError.valid) return null
+        for (const tool of current.tools) {
+          if (tool.status === "running") tool.status = "incomplete"
+        }
+        if (parsedError.error !== undefined) {
+          current.status = "failed"
+          current.error = parsedError.error
+        } else {
+          current.status = "completed"
+        }
+        current.terminal = true
+        return subagentSnapshot(current)
+      }
+
+      return null
+    },
+  }
+}

--- a/packages/ag-ui/src/index.ts
+++ b/packages/ag-ui/src/index.ts
@@ -1,3 +1,9 @@
+export {
+  DAWN_PLAN_ACTIVITY_TYPE,
+  DAWN_SUBAGENT_ACTIVITY_TYPE,
+  type DawnPlanActivityContent,
+  type DawnSubagentActivityContent,
+} from "./activities.js"
 export { createCounterIdFactory, createDefaultIdFactory, type IdFactory } from "./ids.js"
 export { type DawnMessage, type DawnRunInput, fromRunAgentInput } from "./inbound.js"
 export type { DawnInterruptEnvelope, DawnResumeRequest } from "./interrupts.js"

--- a/packages/ag-ui/src/outbound.ts
+++ b/packages/ag-ui/src/outbound.ts
@@ -1,4 +1,5 @@
 import type {
+  ActivitySnapshotEvent,
   Interrupt,
   RunErrorEvent,
   RunFinishedEvent,
@@ -12,6 +13,7 @@ import type {
   ToolCallStartEvent,
 } from "@ag-ui/core"
 import { EventType } from "@ag-ui/core"
+import { createDawnActivityProjector, isDawnActivityChunkType } from "./activities.js"
 import { createDefaultIdFactory, type IdFactory } from "./ids.js"
 import { toAguiInterrupt } from "./interrupts.js"
 import {
@@ -33,6 +35,7 @@ export type AguiOutboundEvent =
   | ToolCallArgsEvent
   | ToolCallEndEvent
   | ToolCallResultEvent
+  | ActivitySnapshotEvent
 
 export interface ToAguiOptions {
   readonly idFactory?: IdFactory
@@ -59,8 +62,9 @@ function stringifyContent(output: unknown): string {
 
 /**
  * Map a Dawn agent stream (`token | tool_call | tool_result | interrupt |
- * done`) to an AG-UI event stream. Stateful: it frames assistant text and tool
- * calls that Dawn emits implicitly, and it never throws into the consumer - an
+ * done`) to AG-UI events, including snapshots for recognized Dawn plan and
+ * subagent activity chunks. Stateful: it frames assistant text and tool calls
+ * that Dawn emits implicitly, and it never throws into the consumer - an
  * upstream error becomes a `RUN_ERROR` event and a clean return.
  */
 export async function* toAguiEvents(
@@ -69,6 +73,7 @@ export async function* toAguiEvents(
   options: ToAguiOptions = {},
 ): AsyncGenerator<AguiOutboundEvent> {
   const nextId = options.idFactory ?? createDefaultIdFactory()
+  const activityProjector = createDawnActivityProjector(ctx.runId)
   let openMessageId: string | null = null
   const pendingFallbackToolCallIds = new Map<string, string[]>()
   const pendingInterrupts: Interrupt[] = []
@@ -94,6 +99,12 @@ export async function* toAguiEvents(
           }
           return
         }
+        continue
+      }
+
+      if (isDawnActivityChunkType(chunk.type)) {
+        const activity = activityProjector.project(chunk.type, chunk.data)
+        if (activity !== null) yield activity
         continue
       }
 
@@ -174,8 +185,8 @@ export async function* toAguiEvents(
         }
         default:
           yield* flushText()
-          // Unknown/capability chunk types (e.g. plan_update) have no v1
-          // AG-UI mapping - ignore them.
+          // Unknown extension chunks (e.g. capability.unknown) flush open text
+          // and are ignored.
           break
       }
     }

--- a/packages/ag-ui/test/activities.test.ts
+++ b/packages/ag-ui/test/activities.test.ts
@@ -1,0 +1,652 @@
+import { ActivitySnapshotEventSchema, EventType } from "@ag-ui/core"
+import { describe, expect, test } from "vitest"
+import {
+  createDawnActivityProjector as createUncheckedDawnActivityProjector,
+  DAWN_PLAN_ACTIVITY_TYPE,
+  DAWN_SUBAGENT_ACTIVITY_TYPE,
+  isDawnActivityChunkType,
+} from "../src/activities.ts"
+
+const identity = {
+  call_id: "call-research-1",
+  subagent: "researcher",
+  route_id: "/research#researcher",
+  depth: 1,
+} as const
+
+const todos = [
+  { content: "Search the corpus", status: "completed" },
+  { content: "Read the best source", status: "in_progress" },
+] as const
+
+function createDawnActivityProjector(runId: string) {
+  const projector = createUncheckedDawnActivityProjector(runId)
+  return {
+    project(...args: Parameters<typeof projector.project>) {
+      const event = projector.project(...args)
+      if (event !== null) expect(ActivitySnapshotEventSchema.parse(event)).toEqual(event)
+      return event
+    },
+  }
+}
+
+describe("isDawnActivityChunkType", () => {
+  test("recognizes exactly the seven activity chunk types", () => {
+    for (const type of [
+      "plan_update",
+      "subagent.start",
+      "subagent.plan_update",
+      "subagent.tool_call",
+      "subagent.tool_result",
+      "subagent.message",
+      "subagent.end",
+    ]) {
+      expect(isDawnActivityChunkType(type)).toBe(true)
+    }
+
+    for (const type of [
+      "token",
+      "tool_call",
+      "done",
+      "capability.unknown",
+      "subagent.unknown",
+      "subagent.start.extra",
+    ]) {
+      expect(isDawnActivityChunkType(type)).toBe(false)
+    }
+  })
+})
+
+describe("createDawnActivityProjector", () => {
+  test("emits complete plan replacements with one stable run-scoped id", () => {
+    const projector = createDawnActivityProjector("run-1")
+    const first = projector.project("plan_update", { todos: [todos[0]] })
+    const second = projector.project("plan_update", { todos })
+
+    expect(first).toEqual({
+      type: EventType.ACTIVITY_SNAPSHOT,
+      messageId: "dawn:plan:run-1",
+      activityType: DAWN_PLAN_ACTIVITY_TYPE,
+      replace: true,
+      content: { todos: [todos[0]] },
+    })
+    expect(second).toEqual({
+      type: EventType.ACTIVITY_SNAPSHOT,
+      messageId: "dawn:plan:run-1",
+      activityType: DAWN_PLAN_ACTIVITY_TYPE,
+      replace: true,
+      content: { todos },
+    })
+    expect(DAWN_SUBAGENT_ACTIVITY_TYPE).toBe("dawn.subagent")
+    expect(ActivitySnapshotEventSchema.parse(first)).toEqual(first)
+    expect(ActivitySnapshotEventSchema.parse(second)).toEqual(second)
+  })
+
+  test("starts a subagent and replaces its complete child plan", () => {
+    const projector = createDawnActivityProjector("run-1")
+    const start = projector.project("subagent.start", identity)
+    const plan = projector.project("subagent.plan_update", { ...identity, todos })
+
+    expect(start).toEqual({
+      type: EventType.ACTIVITY_SNAPSHOT,
+      messageId: "dawn:subagent:call-research-1",
+      activityType: DAWN_SUBAGENT_ACTIVITY_TYPE,
+      replace: true,
+      content: {
+        name: "researcher",
+        depth: 1,
+        status: "running",
+        tools: [],
+        totalToolCount: 0,
+      },
+    })
+    expect(plan).toEqual({
+      type: EventType.ACTIVITY_SNAPSHOT,
+      messageId: "dawn:subagent:call-research-1",
+      activityType: DAWN_SUBAGENT_ACTIVITY_TYPE,
+      replace: true,
+      content: {
+        name: "researcher",
+        depth: 1,
+        status: "running",
+        todos,
+        tools: [],
+        totalToolCount: 0,
+      },
+    })
+    expect(ActivitySnapshotEventSchema.parse(start)).toEqual(start)
+    expect(ActivitySnapshotEventSchema.parse(plan)).toEqual(plan)
+  })
+
+  test("ignores child plans before start and payloads without canonical identity", () => {
+    const projector = createDawnActivityProjector("run-1")
+
+    expect(projector.project("subagent.plan_update", { ...identity, todos })).toBeNull()
+    expect(
+      projector.project("subagent.start", {
+        call_id: identity.call_id,
+        subagent: identity.subagent,
+        depth: identity.depth,
+      }),
+    ).toBeNull()
+  })
+
+  test("ignores identity conflicts after start", () => {
+    const projector = createDawnActivityProjector("run-1")
+    expect(projector.project("subagent.start", identity)).not.toBeNull()
+
+    expect(
+      projector.project("subagent.start", { ...identity, route_id: "/research#writer" }),
+    ).toBeNull()
+    expect(
+      projector.project("subagent.plan_update", {
+        ...identity,
+        subagent: "writer",
+        todos,
+      }),
+    ).toBeNull()
+  })
+
+  test("requires byte-exact identity fields after start", () => {
+    for (const paddedIdentity of [
+      { ...identity, call_id: `  ${identity.call_id}  ` },
+      { ...identity, subagent: `  ${identity.subagent}  ` },
+      { ...identity, route_id: `  ${identity.route_id}  ` },
+    ]) {
+      const projector = createDawnActivityProjector("run-1")
+      expect(projector.project("subagent.start", identity)).not.toBeNull()
+      expect(projector.project("subagent.plan_update", { ...paddedIdentity, todos })).toBeNull()
+    }
+  })
+
+  test("correlates child tool calls and results without exposing inputs or outputs", () => {
+    const projector = createDawnActivityProjector("run-1")
+    projector.project("subagent.start", identity)
+
+    const call = projector.project("subagent.tool_call", {
+      ...identity,
+      id: "tool-1",
+      tool: "searchCorpus",
+      input: { secret: "private prompt" },
+    })
+    const result = projector.project("subagent.tool_result", {
+      ...identity,
+      id: "tool-1",
+      tool: "wrong-name-must-not-be-read",
+      output: { secret: "private result" },
+    })
+
+    expect(call?.content).toMatchObject({
+      tools: [{ name: "searchCorpus", status: "running" }],
+      totalToolCount: 1,
+    })
+    expect(result?.content).toMatchObject({
+      tools: [{ name: "searchCorpus", status: "completed" }],
+      totalToolCount: 1,
+    })
+    expect(JSON.stringify([call, result])).not.toMatch(/private prompt|private result|wrong-name/)
+    expect(ActivitySnapshotEventSchema.parse(call)).toEqual(call)
+    expect(ActivitySnapshotEventSchema.parse(result)).toEqual(result)
+  })
+
+  test("preserves tool ids for exact correlation while trimming public names", () => {
+    const projector = createDawnActivityProjector("run-1")
+    projector.project("subagent.start", identity)
+
+    const called = projector.project("subagent.tool_call", {
+      ...identity,
+      id: "tool-1",
+      tool: "  searchCorpus  ",
+    })
+    expect(called?.content).toMatchObject({
+      tools: [{ name: "searchCorpus", status: "running" }],
+      totalToolCount: 1,
+    })
+
+    expect(
+      projector.project("subagent.tool_result", {
+        ...identity,
+        id: "  tool-1  ",
+      }),
+    ).toBeNull()
+
+    const completed = projector.project("subagent.tool_result", {
+      ...identity,
+      id: "tool-1",
+    })
+    expect(completed?.content).toMatchObject({
+      tools: [{ name: "searchCorpus", status: "completed" }],
+      totalToolCount: 1,
+    })
+
+    const padded = projector.project("subagent.tool_call", {
+      ...identity,
+      id: "  tool-1  ",
+      tool: "  searchCorpusAgain  ",
+    })
+    expect(padded?.content).toMatchObject({
+      tools: [
+        { name: "searchCorpus", status: "completed" },
+        { name: "searchCorpusAgain", status: "running" },
+      ],
+      totalToolCount: 2,
+    })
+
+    const paddedCompleted = projector.project("subagent.tool_result", {
+      ...identity,
+      id: "  tool-1  ",
+    })
+    expect(paddedCompleted?.content).toMatchObject({
+      tools: [
+        { name: "searchCorpus", status: "completed" },
+        { name: "searchCorpusAgain", status: "completed" },
+      ],
+      totalToolCount: 2,
+    })
+  })
+
+  test("retains only the five newest tool summaries while counting each id once", () => {
+    const projector = createDawnActivityProjector("run-1")
+    projector.project("subagent.start", identity)
+
+    let snapshot = null
+    for (let index = 1; index <= 6; index += 1) {
+      snapshot = projector.project("subagent.tool_call", {
+        ...identity,
+        id: `tool-${index}`,
+        tool: `toolName${index}`,
+      })
+    }
+
+    expect(snapshot?.content).toMatchObject({
+      tools: [
+        { name: "toolName2", status: "running" },
+        { name: "toolName3", status: "running" },
+        { name: "toolName4", status: "running" },
+        { name: "toolName5", status: "running" },
+        { name: "toolName6", status: "running" },
+      ],
+      totalToolCount: 6,
+    })
+    expect(projector.project("subagent.tool_result", { ...identity, id: "tool-1" })).toBeNull()
+
+    const completed = projector.project("subagent.tool_result", {
+      ...identity,
+      id: "tool-6",
+    })
+    expect(completed?.content).toMatchObject({
+      tools: [
+        { name: "toolName2", status: "running" },
+        { name: "toolName3", status: "running" },
+        { name: "toolName4", status: "running" },
+        { name: "toolName5", status: "running" },
+        { name: "toolName6", status: "completed" },
+      ],
+      totalToolCount: 6,
+    })
+
+    const reinserted = projector.project("subagent.tool_call", {
+      ...identity,
+      id: "tool-1",
+      tool: "toolName1",
+    })
+    expect(reinserted?.content).toMatchObject({
+      tools: [
+        { name: "toolName3", status: "running" },
+        { name: "toolName4", status: "running" },
+        { name: "toolName5", status: "running" },
+        { name: "toolName6", status: "completed" },
+        { name: "toolName1", status: "running" },
+      ],
+      totalToolCount: 6,
+    })
+    expect(ActivitySnapshotEventSchema.parse(reinserted)).toEqual(reinserted)
+  })
+
+  test("completes once, marks running tools incomplete, and freezes terminal state", () => {
+    const projector = createDawnActivityProjector("run-1")
+    projector.project("subagent.start", identity)
+    projector.project("subagent.plan_update", { ...identity, todos })
+    projector.project("subagent.tool_call", {
+      ...identity,
+      id: "tool-running",
+      tool: "searchCorpus",
+    })
+    projector.project("subagent.tool_call", {
+      ...identity,
+      id: "tool-completed",
+      tool: "readDoc",
+    })
+    projector.project("subagent.tool_result", { ...identity, id: "tool-completed" })
+
+    const ended = projector.project("subagent.end", {
+      ...identity,
+      final_message: "private child answer",
+    })
+    expect(ended?.content).toEqual({
+      name: "researcher",
+      depth: 1,
+      status: "completed",
+      todos,
+      tools: [
+        { name: "searchCorpus", status: "incomplete" },
+        { name: "readDoc", status: "completed" },
+      ],
+      totalToolCount: 2,
+    })
+    expect(JSON.stringify(ended)).not.toContain("private child answer")
+    expect(ActivitySnapshotEventSchema.parse(ended)).toEqual(ended)
+
+    expect(projector.project("subagent.end", identity)).toBeNull()
+    expect(projector.project("subagent.start", identity)).toBeNull()
+    expect(
+      projector.project("subagent.tool_call", {
+        ...identity,
+        id: "tool-late",
+        tool: "lateTool",
+      }),
+    ).toBeNull()
+    expect(projector.project("subagent.plan_update", { ...identity, todos: [] })).toBeNull()
+  })
+
+  test("caps failure errors at 400 characters", () => {
+    const projector = createDawnActivityProjector("run-1")
+    projector.project("subagent.start", identity)
+
+    const ended = projector.project("subagent.end", {
+      ...identity,
+      error: "x".repeat(500),
+    })
+
+    expect(ended?.content).toMatchObject({
+      status: "failed",
+      error: "x".repeat(400),
+    })
+    expect(ActivitySnapshotEventSchema.parse(ended)).toEqual(ended)
+  })
+
+  test("rejects a present non-string error without ending, while whitespace completes", () => {
+    const projector = createDawnActivityProjector("run-1")
+    projector.project("subagent.start", identity)
+
+    expect(
+      projector.project("subagent.end", { ...identity, error: { message: "private" } }),
+    ).toBeNull()
+    const ended = projector.project("subagent.end", { ...identity, error: "   " })
+    expect(ended?.content).toMatchObject({ status: "completed" })
+    expect(ended?.content).not.toHaveProperty("error")
+    expect(ActivitySnapshotEventSchema.parse(ended)).toEqual(ended)
+  })
+
+  test("re-emits an identical repeated start without discarding progress", () => {
+    const projector = createDawnActivityProjector("run-1")
+    projector.project("subagent.start", identity)
+    projector.project("subagent.plan_update", { ...identity, todos })
+    projector.project("subagent.tool_call", {
+      ...identity,
+      id: "tool-1",
+      tool: "searchCorpus",
+    })
+
+    const repeated = projector.project("subagent.start", identity)
+    expect(repeated?.content).toEqual({
+      name: "researcher",
+      depth: 1,
+      status: "running",
+      todos,
+      tools: [{ name: "searchCorpus", status: "running" }],
+      totalToolCount: 1,
+    })
+    expect(ActivitySnapshotEventSchema.parse(repeated)).toEqual(repeated)
+  })
+
+  test("ignores lifecycle events received before start", () => {
+    const projector = createDawnActivityProjector("run-1")
+
+    expect(
+      projector.project("subagent.tool_call", {
+        ...identity,
+        id: "tool-1",
+        tool: "searchCorpus",
+      }),
+    ).toBeNull()
+    expect(projector.project("subagent.tool_result", { ...identity, id: "tool-1" })).toBeNull()
+    expect(projector.project("subagent.message", { ...identity, content: "private" })).toBeNull()
+    expect(projector.project("subagent.end", identity)).toBeNull()
+  })
+
+  test("keeps interleaved call ids isolated", () => {
+    const projector = createDawnActivityProjector("run-1")
+    const writerIdentity = {
+      call_id: "call-writer-1",
+      subagent: "writer",
+      route_id: "/research#writer",
+      depth: 2,
+    } as const
+    projector.project("subagent.start", identity)
+    projector.project("subagent.start", writerIdentity)
+    projector.project("subagent.tool_call", {
+      ...identity,
+      id: "research-tool",
+      tool: "searchCorpus",
+    })
+    projector.project("subagent.tool_call", {
+      ...writerIdentity,
+      id: "writer-tool",
+      tool: "draftReport",
+    })
+
+    const researchEnded = projector.project("subagent.end", identity)
+    const writerProgress = projector.project("subagent.tool_result", {
+      ...writerIdentity,
+      id: "writer-tool",
+    })
+    expect(researchEnded?.messageId).toBe("dawn:subagent:call-research-1")
+    expect(researchEnded?.content).toMatchObject({
+      name: "researcher",
+      status: "completed",
+      tools: [{ name: "searchCorpus", status: "incomplete" }],
+    })
+    expect(writerProgress?.messageId).toBe("dawn:subagent:call-writer-1")
+    expect(writerProgress?.content).toMatchObject({
+      name: "writer",
+      status: "running",
+      tools: [{ name: "draftReport", status: "completed" }],
+    })
+    expect(ActivitySnapshotEventSchema.parse(researchEnded)).toEqual(researchEnded)
+    expect(ActivitySnapshotEventSchema.parse(writerProgress)).toEqual(writerProgress)
+  })
+
+  test("consumes child messages and exposes only allowlisted public fields", () => {
+    const projector = createDawnActivityProjector("run-1")
+    projector.project("subagent.start", { ...identity, private_start: "secret-start" })
+    expect(
+      projector.project("subagent.message", {
+        ...identity,
+        content: "private child prose",
+        reasoning: "private reasoning",
+      }),
+    ).toBeNull()
+    const call = projector.project("subagent.tool_call", {
+      ...identity,
+      id: "private-tool-id",
+      tool: "searchCorpus",
+      input: { query: "private query" },
+    })
+    projector.project("subagent.tool_result", {
+      ...identity,
+      id: "private-tool-id",
+      tool: "private result tool name",
+      output: "private tool output",
+    })
+    const ended = projector.project("subagent.end", {
+      ...identity,
+      final_message: "private final child answer",
+    })
+
+    expect(Object.keys(call?.content ?? {}).sort()).toEqual([
+      "depth",
+      "name",
+      "status",
+      "tools",
+      "totalToolCount",
+    ])
+    expect(Object.keys(ended?.content ?? {}).sort()).toEqual([
+      "depth",
+      "name",
+      "status",
+      "tools",
+      "totalToolCount",
+    ])
+    const serializedContent = JSON.stringify([call?.content, ended?.content])
+    for (const privateValue of [
+      identity.call_id,
+      identity.route_id,
+      "private-tool-id",
+      "private child prose",
+      "private reasoning",
+      "private query",
+      "private tool output",
+      "private result tool name",
+      "private final child answer",
+      "secret-start",
+    ]) {
+      expect(serializedContent).not.toContain(privateValue)
+    }
+  })
+
+  test("rejects malformed plans and canonical subagent fields", () => {
+    const malformedPlanProjector = createDawnActivityProjector("run-plan")
+    for (const data of [
+      null,
+      [],
+      { todos: {} },
+      { todos: [null] },
+      { todos: [{ content: "", status: "pending" }] },
+      { todos: [{ content: "   ", status: "pending" }] },
+      { todos: [{ content: "valid", status: "unknown" }] },
+    ]) {
+      expect(malformedPlanProjector.project("plan_update", data)).toBeNull()
+    }
+
+    const malformedIdentities = [
+      [],
+      { ...identity, call_id: " " },
+      { ...identity, subagent: " " },
+      { ...identity, route_id: " " },
+      { ...identity, depth: 0 },
+      { ...identity, depth: -1 },
+      { ...identity, depth: 1.5 },
+      { ...identity, depth: "1" },
+    ]
+    for (const data of malformedIdentities) {
+      const projector = createDawnActivityProjector("run-subagent")
+      expect(projector.project("subagent.start", data)).toBeNull()
+    }
+  })
+
+  test("normalizes todo prose but preserves accepted identity strings", () => {
+    const projector = createDawnActivityProjector("run-1")
+    const plan = projector.project("plan_update", {
+      todos: [{ content: "  Search the corpus  ", status: "pending" }],
+    })
+    const paddedIdentity = {
+      call_id: "  call-trimmed  ",
+      subagent: "  researcher  ",
+      route_id: "  /research#researcher  ",
+      depth: 1,
+    } as const
+    const start = projector.project("subagent.start", paddedIdentity)
+
+    expect(plan?.content).toEqual({
+      todos: [{ content: "Search the corpus", status: "pending" }],
+    })
+    expect(start?.messageId).toBe("dawn:subagent:  call-trimmed  ")
+    expect(start?.content).toMatchObject({ name: "  researcher  " })
+    expect(
+      projector.project("subagent.plan_update", {
+        call_id: "call-trimmed",
+        subagent: "researcher",
+        route_id: "/research#researcher",
+        depth: 1,
+        todos,
+      }),
+    ).toBeNull()
+    expect(projector.project("subagent.plan_update", { ...paddedIdentity, todos })).not.toBeNull()
+  })
+
+  test("rejects malformed child plans, tool ids, tool names, and unknown results", () => {
+    const projector = createDawnActivityProjector("run-1")
+    projector.project("subagent.start", identity)
+
+    expect(
+      projector.project("subagent.plan_update", {
+        ...identity,
+        todos: [{ content: "valid", status: "invalid" }],
+      }),
+    ).toBeNull()
+    expect(
+      projector.project("subagent.tool_call", {
+        ...identity,
+        id: " ",
+        tool: "searchCorpus",
+      }),
+    ).toBeNull()
+    expect(
+      projector.project("subagent.tool_call", {
+        ...identity,
+        id: "tool-1",
+        tool: " ",
+      }),
+    ).toBeNull()
+    expect(projector.project("subagent.tool_result", { ...identity, id: "unknown" })).toBeNull()
+  })
+
+  test("returns null without throwing for hostile getters and never reads ignored prose", () => {
+    const throwingIdentity = Object.defineProperty({}, "call_id", {
+      get() {
+        throw new Error("hostile identity")
+      },
+    })
+    const throwingTodos = Object.defineProperty({}, "todos", {
+      get() {
+        throw new Error("hostile todos")
+      },
+    })
+    expect(() =>
+      createDawnActivityProjector("run-1").project("subagent.start", throwingIdentity),
+    ).not.toThrow()
+    expect(
+      createDawnActivityProjector("run-1").project("subagent.start", throwingIdentity),
+    ).toBeNull()
+    expect(() =>
+      createDawnActivityProjector("run-1").project("plan_update", throwingTodos),
+    ).not.toThrow()
+    expect(createDawnActivityProjector("run-1").project("plan_update", throwingTodos)).toBeNull()
+
+    const projector = createDawnActivityProjector("run-1")
+    projector.project("subagent.start", identity)
+    const hostileTool = Object.defineProperty({ ...identity, tool: "searchCorpus" }, "id", {
+      get() {
+        throw new Error("hostile tool id")
+      },
+    })
+    expect(() => projector.project("subagent.tool_call", hostileTool)).not.toThrow()
+    expect(projector.project("subagent.tool_call", hostileTool)).toBeNull()
+
+    const hostileMessage = Object.defineProperty({ ...identity }, "content", {
+      get() {
+        throw new Error("child prose must not be read")
+      },
+    })
+    expect(() => projector.project("subagent.message", hostileMessage)).not.toThrow()
+    expect(projector.project("subagent.message", hostileMessage)).toBeNull()
+
+    const hostileEnd = Object.defineProperty({ ...identity }, "final_message", {
+      get() {
+        throw new Error("final child answer must not be read")
+      },
+    })
+    expect(() => projector.project("subagent.end", hostileEnd)).not.toThrow()
+  })
+})

--- a/packages/ag-ui/test/conformance.test.ts
+++ b/packages/ag-ui/test/conformance.test.ts
@@ -1,8 +1,9 @@
 import { createServer, type Server } from "node:http"
 import { HttpAgent, verifyEvents } from "@ag-ui/client"
-import { EventType, type RunAgentInput } from "@ag-ui/core"
+import { ActivitySnapshotEventSchema, EventType, type RunAgentInput } from "@ag-ui/core"
 import { lastValueFrom, toArray } from "rxjs"
 import { afterEach, expect, it } from "vitest"
+import { DAWN_PLAN_ACTIVITY_TYPE, DAWN_SUBAGENT_ACTIVITY_TYPE } from "../src/activities.ts"
 import { createCounterIdFactory } from "../src/ids.js"
 import { toAguiEvents } from "../src/outbound.js"
 import { encodeAgUiSse } from "../src/sse.js"
@@ -18,15 +19,47 @@ afterEach(async () => {
   })
 })
 
+const childIdentity = {
+  call_id: "c1",
+  subagent: "researcher",
+  route_id: "/research#researcher",
+  depth: 1,
+} as const
+
 const CANNED: DawnAgentStreamChunk[] = [
   { type: "token", data: "Researching" },
-  { type: "tool_call", data: { name: "searchCorpus", input: { query: "agents" } } },
+  {
+    type: "tool_call",
+    data: { id: "root-tool-1", name: "searchCorpus", input: { query: "agents" } },
+  },
   {
     type: "tool_result",
-    data: { name: "searchCorpus", output: [{ path: "corpus/a.md" }] },
+    data: { id: "root-tool-1", name: "searchCorpus", output: [{ path: "corpus/a.md" }] },
   },
   { type: "plan_update", data: { todos: [{ content: "search", status: "completed" }] } },
-  { type: "subagent.start", data: { call_id: "c1", subagent: "researcher" } },
+  { type: "subagent.start", data: childIdentity },
+  {
+    type: "subagent.plan_update",
+    data: {
+      ...childIdentity,
+      todos: [{ content: "read source", status: "in_progress" }],
+    },
+  },
+  {
+    type: "subagent.tool_call",
+    data: {
+      ...childIdentity,
+      id: "child-tool-1",
+      tool: "readDoc",
+      input: "not public input",
+    },
+  },
+  {
+    type: "subagent.tool_result",
+    data: { ...childIdentity, id: "child-tool-1", output: "not public output" },
+  },
+  { type: "subagent.message", data: { ...childIdentity, content: "not public message" } },
+  { type: "subagent.end", data: { ...childIdentity, final_message: "not public final" } },
   { type: "token", data: " done. [corpus/a.md]" },
   { type: "done", data: { messages: [] } },
 ]
@@ -83,7 +116,31 @@ it("produces an AG-UI stream that @ag-ui/client parses and verifyEvents accepts"
   expect(kinds[0]).toBe(EventType.RUN_STARTED)
   expect(kinds).toContain(EventType.TOOL_CALL_START)
   expect(kinds).toContain(EventType.TOOL_CALL_RESULT)
+  const activities = events
+    .filter((event) => event.type === EventType.ACTIVITY_SNAPSHOT)
+    .map((event) => ActivitySnapshotEventSchema.parse(event))
+  expect(activities.length).toBeGreaterThan(0)
+  expect(new Set(activities.map((activity) => activity.activityType))).toEqual(
+    new Set([DAWN_PLAN_ACTIVITY_TYPE, DAWN_SUBAGENT_ACTIVITY_TYPE]),
+  )
+  const serializedActivityContent = JSON.stringify(activities.map((activity) => activity.content))
+  for (const privateValue of [
+    "not public",
+    childIdentity.route_id,
+    childIdentity.call_id,
+    "child-tool-1",
+  ]) {
+    expect(serializedActivityContent).not.toContain(privateValue)
+  }
+  expect(
+    events
+      .filter((event) => event.type === EventType.TEXT_MESSAGE_CONTENT)
+      .map((event) => event.delta)
+      .join(""),
+  ).toBe("Researching done. [corpus/a.md]")
+  expect(kinds).not.toContain(EventType.ACTIVITY_DELTA)
   expect(kinds).not.toContain(EventType.STATE_SNAPSHOT)
   expect(kinds).not.toContain(EventType.CUSTOM)
+  expect(kinds).not.toContain(EventType.RAW)
   expect(kinds[kinds.length - 1]).toBe(EventType.RUN_FINISHED)
 })

--- a/packages/ag-ui/test/outbound.test.ts
+++ b/packages/ag-ui/test/outbound.test.ts
@@ -1,11 +1,18 @@
-import { EventType, ToolCallResultEventSchema } from "@ag-ui/core"
+import { ActivitySnapshotEventSchema, EventType, ToolCallResultEventSchema } from "@ag-ui/core"
 import { describe, expect, test } from "vitest"
+import { DAWN_PLAN_ACTIVITY_TYPE, DAWN_SUBAGENT_ACTIVITY_TYPE } from "../src/activities.ts"
 import { createCounterIdFactory } from "../src/ids.js"
 import { toAguiEvents } from "../src/outbound.js"
 import { encodeAgUiSse } from "../src/sse.js"
 import type { DawnAgentStreamChunk } from "../src/types.js"
 
 const CTX = { threadId: "th-1", runId: "rn-1" }
+const CHILD = {
+  call_id: "call-1",
+  subagent: "researcher",
+  route_id: "/research#researcher",
+  depth: 1,
+} as const
 
 async function collect(chunks: DawnAgentStreamChunk[]) {
   const out = []
@@ -118,7 +125,9 @@ describe("toAguiEvents", () => {
       { type: "tool_call", data: { id: "run-function", name: "echo", input: () => undefined } },
       { type: "done", data: {} },
     ])
-    const args = events.filter((e) => e.type === EventType.TOOL_CALL_ARGS) as Array<{ delta: string }>
+    const args = events.filter((e) => e.type === EventType.TOOL_CALL_ARGS) as Array<{
+      delta: string
+    }>
     expect(args.map((e) => e.delta)).toEqual(["{}", "{}"])
   })
 
@@ -144,7 +153,7 @@ describe("toAguiEvents", () => {
   test("unknown non-token chunks flush an open text message before being ignored", async () => {
     const events = await collect([
       { type: "token", data: "hi" },
-      { type: "plan_update", data: {} },
+      { type: "capability.unknown", data: { arbitrary: true } },
       { type: "token", data: "again" },
       { type: "done", data: {} },
     ])
@@ -158,6 +167,178 @@ describe("toAguiEvents", () => {
       EventType.TEXT_MESSAGE_END,
       EventType.RUN_FINISHED,
     ])
+  })
+
+  test("plan activity does not flush an open text message", async () => {
+    const todos = [{ content: "Search the corpus", status: "in_progress" }] as const
+    const events = await collect([
+      { type: "token", data: "before" },
+      { type: "plan_update", data: { todos } },
+      { type: "token", data: "after" },
+      { type: "done", data: {} },
+    ])
+
+    expect(events.map((event) => event.type)).toEqual([
+      EventType.RUN_STARTED,
+      EventType.TEXT_MESSAGE_START,
+      EventType.TEXT_MESSAGE_CONTENT,
+      EventType.ACTIVITY_SNAPSHOT,
+      EventType.TEXT_MESSAGE_CONTENT,
+      EventType.TEXT_MESSAGE_END,
+      EventType.RUN_FINISHED,
+    ])
+    const activity = events.find((event) => event.type === EventType.ACTIVITY_SNAPSHOT)
+    expect(ActivitySnapshotEventSchema.parse(activity)).toEqual({
+      type: EventType.ACTIVITY_SNAPSHOT,
+      messageId: "dawn:plan:rn-1",
+      activityType: DAWN_PLAN_ACTIVITY_TYPE,
+      replace: true,
+      content: { todos },
+    })
+    expect(events.filter((event) => event.type === EventType.TEXT_MESSAGE_CONTENT)).toMatchObject([
+      { messageId: "msg-1", delta: "before" },
+      { messageId: "msg-1", delta: "after" },
+    ])
+  })
+
+  test("malformed recognized plan emits no activity, text flush, or run error", async () => {
+    const events = await collect([
+      { type: "token", data: "before" },
+      { type: "plan_update", data: { todos: [{ content: "invalid", status: "unknown" }] } },
+      { type: "token", data: "after" },
+      { type: "done", data: {} },
+    ])
+
+    expect(events.map((event) => event.type)).toEqual([
+      EventType.RUN_STARTED,
+      EventType.TEXT_MESSAGE_START,
+      EventType.TEXT_MESSAGE_CONTENT,
+      EventType.TEXT_MESSAGE_CONTENT,
+      EventType.TEXT_MESSAGE_END,
+      EventType.RUN_FINISHED,
+    ])
+    expect(events.filter((event) => event.type === EventType.ACTIVITY_SNAPSHOT)).toEqual([])
+    expect(events.filter((event) => event.type === EventType.RUN_ERROR)).toEqual([])
+  })
+
+  test("subagent activity exposes only allowlisted progress and never child content", async () => {
+    const childTodos = [{ content: "Read the source", status: "in_progress" }] as const
+    const events = await collect([
+      { type: "token", data: "root-before" },
+      { type: "subagent.start", data: CHILD },
+      { type: "subagent.plan_update", data: { ...CHILD, todos: childTodos } },
+      {
+        type: "subagent.tool_call",
+        data: {
+          ...CHILD,
+          id: "child-tool-1",
+          tool: "readDoc",
+          input: "secret-input",
+        },
+      },
+      {
+        type: "subagent.tool_result",
+        data: { ...CHILD, id: "child-tool-1", output: "secret-output" },
+      },
+      { type: "subagent.message", data: { ...CHILD, content: "secret-child-prose" } },
+      { type: "subagent.end", data: { ...CHILD, final_message: "secret-final" } },
+      { type: "token", data: "root-after" },
+      { type: "done" },
+    ])
+
+    const activities = events
+      .filter((event) => event.type === EventType.ACTIVITY_SNAPSHOT)
+      .map((event) => ActivitySnapshotEventSchema.parse(event))
+    expect(activities).toEqual([
+      {
+        type: EventType.ACTIVITY_SNAPSHOT,
+        messageId: "dawn:subagent:call-1",
+        activityType: DAWN_SUBAGENT_ACTIVITY_TYPE,
+        replace: true,
+        content: {
+          name: "researcher",
+          depth: 1,
+          status: "running",
+          tools: [],
+          totalToolCount: 0,
+        },
+      },
+      {
+        type: EventType.ACTIVITY_SNAPSHOT,
+        messageId: "dawn:subagent:call-1",
+        activityType: DAWN_SUBAGENT_ACTIVITY_TYPE,
+        replace: true,
+        content: {
+          name: "researcher",
+          depth: 1,
+          status: "running",
+          todos: childTodos,
+          tools: [],
+          totalToolCount: 0,
+        },
+      },
+      {
+        type: EventType.ACTIVITY_SNAPSHOT,
+        messageId: "dawn:subagent:call-1",
+        activityType: DAWN_SUBAGENT_ACTIVITY_TYPE,
+        replace: true,
+        content: {
+          name: "researcher",
+          depth: 1,
+          status: "running",
+          todos: childTodos,
+          tools: [{ name: "readDoc", status: "running" }],
+          totalToolCount: 1,
+        },
+      },
+      {
+        type: EventType.ACTIVITY_SNAPSHOT,
+        messageId: "dawn:subagent:call-1",
+        activityType: DAWN_SUBAGENT_ACTIVITY_TYPE,
+        replace: true,
+        content: {
+          name: "researcher",
+          depth: 1,
+          status: "running",
+          todos: childTodos,
+          tools: [{ name: "readDoc", status: "completed" }],
+          totalToolCount: 1,
+        },
+      },
+      {
+        type: EventType.ACTIVITY_SNAPSHOT,
+        messageId: "dawn:subagent:call-1",
+        activityType: DAWN_SUBAGENT_ACTIVITY_TYPE,
+        replace: true,
+        content: {
+          name: "researcher",
+          depth: 1,
+          status: "completed",
+          todos: childTodos,
+          tools: [{ name: "readDoc", status: "completed" }],
+          totalToolCount: 1,
+        },
+      },
+    ])
+
+    const serializedContent = JSON.stringify(activities.map((activity) => activity.content))
+    for (const secret of [
+      "secret-input",
+      "secret-output",
+      "secret-child-prose",
+      "secret-final",
+      CHILD.call_id,
+      CHILD.route_id,
+      "child-tool-1",
+    ]) {
+      expect(serializedContent).not.toContain(secret)
+    }
+    const rootText = events
+      .filter((event) => event.type === EventType.TEXT_MESSAGE_CONTENT)
+      .map((event) => event.delta)
+      .join("")
+    expect(rootText).toBe("root-beforeroot-after")
+    expect(rootText).not.toMatch(/secret-input|secret-output|secret-child-prose|secret-final/)
   })
 
   test("repeated calls to the same tool get distinct toolCallIds from their upstream ids", async () => {
@@ -178,7 +359,9 @@ describe("toAguiEvents", () => {
       { type: "tool_result", data: { name: "greet", output: "again" } },
       { type: "done", data: {} },
     ])
-    const starts = events.filter((e) => e.type === EventType.TOOL_CALL_START) as Array<{ toolCallId: string }>
+    const starts = events.filter((e) => e.type === EventType.TOOL_CALL_START) as Array<{
+      toolCallId: string
+    }>
     const results = events.filter((e) => e.type === EventType.TOOL_CALL_RESULT) as Array<{
       toolCallId: string
       messageId: string
@@ -198,10 +381,149 @@ describe("toAguiEvents", () => {
       type: EventType.RUN_FINISHED,
       threadId: "th-1",
       runId: "rn-1",
-      outcome: { type: "interrupt", interrupts: [{ id: "perm-1", reason: "command", metadata: { interruptId: "perm-1", kind: "command" } }] },
+      outcome: {
+        type: "interrupt",
+        interrupts: [
+          { id: "perm-1", reason: "command", metadata: { interruptId: "perm-1", kind: "command" } },
+        ],
+      },
     })
     // exactly one RUN_FINISHED (done after interrupt was ignored)
     expect(events.filter((e) => e.type === EventType.RUN_FINISHED)).toHaveLength(1)
+  })
+
+  test("delegation approval interrupt before subagent start emits no activity", async () => {
+    const events = await collect([
+      { type: "interrupt", data: { interruptId: "delegate-1", kind: "tool" } },
+      { type: "subagent.start", data: CHILD },
+      { type: "done" },
+    ])
+
+    expect(events).toEqual([
+      { type: EventType.RUN_STARTED, threadId: "th-1", runId: "rn-1" },
+      {
+        type: EventType.RUN_FINISHED,
+        threadId: "th-1",
+        runId: "rn-1",
+        outcome: {
+          type: "interrupt",
+          interrupts: [
+            {
+              id: "delegate-1",
+              reason: "tool",
+              metadata: { interruptId: "delegate-1", kind: "tool" },
+            },
+          ],
+        },
+      },
+    ])
+  })
+
+  test("child-owned interrupt preserves one running activity and suppresses later child events", async () => {
+    const events = await collect([
+      { type: "subagent.start", data: CHILD },
+      { type: "interrupt", data: { interruptId: "child-approval", kind: "command" } },
+      {
+        type: "subagent.plan_update",
+        data: { ...CHILD, todos: [{ content: "private-late-plan", status: "pending" }] },
+      },
+      {
+        type: "subagent.tool_call",
+        data: { ...CHILD, id: "late-tool", tool: "lateTool", input: "private-late-input" },
+      },
+      { type: "subagent.end", data: { ...CHILD, final_message: "private-late-final" } },
+      { type: "done" },
+    ])
+
+    const activities = events.filter((event) => event.type === EventType.ACTIVITY_SNAPSHOT)
+    expect(activities).toHaveLength(1)
+    expect(ActivitySnapshotEventSchema.parse(activities[0])).toEqual({
+      type: EventType.ACTIVITY_SNAPSHOT,
+      messageId: "dawn:subagent:call-1",
+      activityType: DAWN_SUBAGENT_ACTIVITY_TYPE,
+      replace: true,
+      content: {
+        name: "researcher",
+        depth: 1,
+        status: "running",
+        tools: [],
+        totalToolCount: 0,
+      },
+    })
+    expect(events.at(-1)).toEqual({
+      type: EventType.RUN_FINISHED,
+      threadId: "th-1",
+      runId: "rn-1",
+      outcome: {
+        type: "interrupt",
+        interrupts: [
+          {
+            id: "child-approval",
+            reason: "command",
+            metadata: { interruptId: "child-approval", kind: "command" },
+          },
+        ],
+      },
+    })
+    expect(JSON.stringify(events)).not.toMatch(
+      /private-late-plan|private-late-input|private-late-final/,
+    )
+  })
+
+  test("resume replaces a subagent activity with fresh request-local state", async () => {
+    const firstRequest = await collect([
+      { type: "subagent.start", data: CHILD },
+      {
+        type: "subagent.plan_update",
+        data: { ...CHILD, todos: [{ content: "Old plan", status: "in_progress" }] },
+      },
+      {
+        type: "subagent.tool_call",
+        data: { ...CHILD, id: "old-tool", tool: "oldTool", input: "old-input" },
+      },
+      { type: "interrupt", data: { interruptId: "parked-child", kind: "command" } },
+      { type: "done" },
+    ])
+    const secondRequest = await collect([
+      { type: "subagent.start", data: CHILD },
+      { type: "subagent.end", data: { ...CHILD, final_message: "private-final" } },
+      { type: "done" },
+    ])
+
+    const firstActivities = firstRequest
+      .filter((event) => event.type === EventType.ACTIVITY_SNAPSHOT)
+      .map((event) => ActivitySnapshotEventSchema.parse(event))
+    const secondActivities = secondRequest
+      .filter((event) => event.type === EventType.ACTIVITY_SNAPSHOT)
+      .map((event) => ActivitySnapshotEventSchema.parse(event))
+    expect(firstActivities).toHaveLength(3)
+    expect(secondActivities).toHaveLength(2)
+    expect([...firstActivities, ...secondActivities].map((event) => event.messageId)).toEqual([
+      "dawn:subagent:call-1",
+      "dawn:subagent:call-1",
+      "dawn:subagent:call-1",
+      "dawn:subagent:call-1",
+      "dawn:subagent:call-1",
+    ])
+    expect(secondActivities.map((event) => event.content)).toEqual([
+      {
+        name: "researcher",
+        depth: 1,
+        status: "running",
+        tools: [],
+        totalToolCount: 0,
+      },
+      {
+        name: "researcher",
+        depth: 1,
+        status: "completed",
+        tools: [],
+        totalToolCount: 0,
+      },
+    ])
+    expect(JSON.stringify(secondActivities.map((event) => event.content))).not.toMatch(
+      /Old plan|oldTool|old-input|private-final/,
+    )
   })
 
   test("consecutive interrupts are accumulated in order before done", async () => {
@@ -335,7 +657,12 @@ describe("toAguiEvents", () => {
     const events = await collect([{ type: "done" }])
     expect(events).toEqual([
       { type: EventType.RUN_STARTED, threadId: "th-1", runId: "rn-1" },
-      { type: EventType.RUN_FINISHED, threadId: "th-1", runId: "rn-1", outcome: { type: "success" } },
+      {
+        type: EventType.RUN_FINISHED,
+        threadId: "th-1",
+        runId: "rn-1",
+        outcome: { type: "success" },
+      },
     ])
   })
 

--- a/packages/ag-ui/test/public-api.test.ts
+++ b/packages/ag-ui/test/public-api.test.ts
@@ -3,9 +3,16 @@ import * as api from "../src/index.js"
 
 it("exports only the canonical runtime adapter surface from the package root", () => {
   expect(Object.keys(api).sort()).toEqual([
+    "DAWN_PLAN_ACTIVITY_TYPE",
+    "DAWN_SUBAGENT_ACTIVITY_TYPE",
     "createCounterIdFactory",
     "createDefaultIdFactory",
     "fromRunAgentInput",
     "toAguiEvents",
   ])
+})
+
+it("exports stable activity type literals", () => {
+  expect(api.DAWN_PLAN_ACTIVITY_TYPE).toBe("dawn.plan")
+  expect(api.DAWN_SUBAGENT_ACTIVITY_TYPE).toBe("dawn.subagent")
 })

--- a/packages/ag-ui/test/types.test.ts
+++ b/packages/ag-ui/test/types.test.ts
@@ -1,5 +1,41 @@
 import { describe, expect, test } from "vitest"
+import {
+  DAWN_PLAN_ACTIVITY_TYPE,
+  DAWN_SUBAGENT_ACTIVITY_TYPE,
+  type DawnPlanActivityContent,
+  type DawnSubagentActivityContent,
+} from "../src/index.js"
 import { asToolCallData, asToolResultData, type DawnAgentStreamChunk } from "../src/types.js"
+
+const planActivityContent = {
+  todos: [
+    { content: "Search the corpus", status: "completed" },
+    { content: "Read the best source", status: "in_progress" },
+  ],
+} satisfies DawnPlanActivityContent
+
+const subagentActivityContent = {
+  name: "researcher",
+  depth: 1,
+  status: "failed",
+  todos: planActivityContent.todos,
+  tools: [
+    { name: "searchCorpus", status: "completed" },
+    { name: "readDoc", status: "incomplete" },
+  ],
+  totalToolCount: 2,
+  error: "Source unavailable",
+} satisfies DawnSubagentActivityContent
+
+const planActivityType: "dawn.plan" = DAWN_PLAN_ACTIVITY_TYPE
+const subagentActivityType: "dawn.subagent" = DAWN_SUBAGENT_ACTIVITY_TYPE
+
+test("exposes the activity content and literal constant types", () => {
+  expect(planActivityContent.todos).toHaveLength(2)
+  expect(subagentActivityContent.tools).toHaveLength(2)
+  expect(planActivityType).toBe("dawn.plan")
+  expect(subagentActivityType).toBe("dawn.subagent")
+})
 
 describe("DawnAgentStreamChunk", () => {
   test("accepts canonical chunks and open extension chunks", () => {

--- a/packages/cli/test/docs-bundle.test.ts
+++ b/packages/cli/test/docs-bundle.test.ts
@@ -208,15 +208,17 @@ describe("current AG-UI documentation", () => {
     // are deliberately NOT listed: the canonicalized adapter still surfaces
     // permission gates as AG-UI standard interrupts, and the example UIs render
     // them with CopilotKit's current `useInterrupt` hook (see each example's
-    // PermissionInterrupt.tsx). What must stay gone is the *legacy* vocabulary
-    // below — the custom-event interrupt and the `forwardedProps` resume path.
+    // PermissionInterrupt.tsx). Exact `dawn.subagent` is now a valid standard
+    // activity type. What must stay gone is the *legacy* vocabulary below — the
+    // dotted custom-event family, custom-event interrupt, and `forwardedProps`
+    // resume path.
     const removed = [
       "createAgUiTranslator",
       "mapRunInput",
       'CUSTOM{name:"on_interrupt"}',
       "forwardedProps.command.resume",
       "STATE_SNAPSHOT",
-      "dawn.subagent",
+      "dawn.subagent.",
       "TodosPanel",
     ]
     const roots = [

--- a/packages/devkit/templates/app-research/README.md
+++ b/packages/devkit/templates/app-research/README.md
@@ -28,11 +28,17 @@ curl -N "http://127.0.0.1:3000/agui/%2Fresearch%23agent" \
 ```
 
 That's the [AG-UI](https://github.com/ag-ui-protocol/ag-ui) endpoint (`/agui/<route>`).
-For a **web UI**, follow the *Research assistant web UI* recipe in the Dawn
-docs. Its CopilotKit client adds streaming chat and cited reports, generic tool
-cards, suggestion prompts, standard permission handling, and memory-candidate
-review. The current AG-UI adapter does not expose live planning or subagent
-activity panels.
+Alongside text, root tools, and interrupts, it emits standard replacement
+`dawn.plan` and `dawn.subagent` activity messages for valid planning and matched
+delegated-work progress. For a **web UI**, follow the
+[Research assistant web UI](https://dawnai.org/docs/recipes/research-web-ui)
+recipe or the separate
+[`examples/research/web`](https://github.com/cacheplane/dawnai/tree/main/examples/research/web)
+client. That CopilotKit example renders the activity messages as plan and
+researcher cards and also provides cited reports, generic tool cards, suggestion
+prompts, standard permission handling, and memory-candidate review. This
+generated starter remains server-first and contains no web UI, client
+dependencies, or activity renderers.
 
 ## Check it offline
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -300,6 +300,9 @@ importers:
       '@copilotkit/runtime':
         specifier: ^1.66.0
         version: 1.66.4(@anthropic-ai/sdk@0.115.0(zod@4.4.3))(@cfworker/json-schema@4.1.1)(@langchain/core@1.2.5(@opentelemetry/api@1.9.1)(openai@6.45.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0))(@langchain/langgraph-sdk@1.9.28(@langchain/core@1.2.5(@opentelemetry/api@1.9.1)(openai@6.45.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@langchain/openai@1.5.6(@langchain/core@1.2.5(@opentelemetry/api@1.9.1)(openai@6.45.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0))(ws@8.21.0))(@opentelemetry/api@1.9.1)(@types/express@5.0.6)(langchain@1.5.2(@langchain/core@1.2.5(@opentelemetry/api@1.9.1)(openai@6.45.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0))(@opentelemetry/api@1.9.1)(openai@6.45.0(ws@8.21.0)(zod@4.4.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(ws@8.21.0))(openai@6.45.0(ws@8.21.0)(zod@4.4.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10)
+      '@dawn-ai/ag-ui':
+        specifier: workspace:*
+        version: link:../../../packages/ag-ui
       next:
         specifier: 16.3.0
         version: 16.3.0(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -309,6 +312,9 @@ importers:
       react-dom:
         specifier: 19.2.8
         version: 19.2.8(react@19.2.8)
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
     devDependencies:
       '@dawn-ai/config-typescript':
         specifier: workspace:*
@@ -325,6 +331,9 @@ importers:
       typescript:
         specifier: 7.0.2
         version: 7.0.2
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(@vitest/ui@4.1.10)(jsdom@30.0.1)(vite@6.4.3(@types/node@26.1.2)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.10)(yaml@2.9.0))
 
   packages/ag-ui:
     dependencies:

--- a/scripts/lib/pack-check.mjs
+++ b/scripts/lib/pack-check.mjs
@@ -155,6 +155,8 @@ export const packages = [
   {
     dir: "packages/ag-ui",
     expectedFiles: [
+      "dist/activities.js",
+      "dist/activities.d.ts",
       "dist/ids.js",
       "dist/ids.d.ts",
       "dist/inbound.js",

--- a/scripts/lib/published-artifacts.mjs
+++ b/scripts/lib/published-artifacts.mjs
@@ -44,6 +44,8 @@ const FATAL_NPM_VIEW_CODES = new Set([
 
 const packageFileExpectations = {
   "@dawn-ai/ag-ui": [
+    "dist/activities.js",
+    "dist/activities.d.ts",
     "dist/index.js",
     "dist/index.d.ts",
     "dist/sse.js",

--- a/scripts/pack-check.test.mjs
+++ b/scripts/pack-check.test.mjs
@@ -62,7 +62,12 @@ describe("pack manifest validation", () => {
     const agUiPackage = packages.find(({ dir }) => dir === "packages/ag-ui")
 
     assert.ok(agUiPackage, "Pack manifest is missing packages/ag-ui")
-    for (const expectedFile of ["dist/sse.js", "dist/sse.d.ts"]) {
+    for (const expectedFile of [
+      "dist/activities.js",
+      "dist/activities.d.ts",
+      "dist/sse.js",
+      "dist/sse.d.ts",
+    ]) {
       assert.ok(
         agUiPackage.expectedFiles.includes(expectedFile),
         `AG-UI must expect ${expectedFile}`,

--- a/scripts/published-artifact-smoke.mjs
+++ b/scripts/published-artifact-smoke.mjs
@@ -325,11 +325,16 @@ import * as root from "@dawn-ai/ag-ui"
 import { encodeAgUiSse } from "@dawn-ai/ag-ui/sse"
 
 assert.deepEqual(Object.keys(root).sort(), [
+  "DAWN_PLAN_ACTIVITY_TYPE",
+  "DAWN_SUBAGENT_ACTIVITY_TYPE",
   "createCounterIdFactory",
   "createDefaultIdFactory",
   "fromRunAgentInput",
   "toAguiEvents",
 ])
+
+assert.equal(root.DAWN_PLAN_ACTIVITY_TYPE, "dawn.plan")
+assert.equal(root.DAWN_SUBAGENT_ACTIVITY_TYPE, "dawn.subagent")
 
 for (const exportName of [
   "createCounterIdFactory",
@@ -353,6 +358,8 @@ assert.equal(payload.runId, "published-smoke")
 
 export function agUiTypeProbeSource() {
   return `import {
+  DAWN_PLAN_ACTIVITY_TYPE,
+  DAWN_SUBAGENT_ACTIVITY_TYPE,
   createCounterIdFactory,
   createDefaultIdFactory,
   fromRunAgentInput,
@@ -361,8 +368,10 @@ export function agUiTypeProbeSource() {
   type DawnAgentStreamChunk,
   type DawnInterruptEnvelope,
   type DawnMessage,
+  type DawnPlanActivityContent,
   type DawnResumeRequest,
   type DawnRunInput,
+  type DawnSubagentActivityContent,
   type IdFactory,
   type RunContext,
   type ToAguiOptions,
@@ -404,6 +413,8 @@ import { asToolCallData } from "@dawn-ai/ag-ui"
 import { asToolResultData } from "@dawn-ai/ag-ui"
 
 type RootValueSurface = readonly [
+  typeof DAWN_PLAN_ACTIVITY_TYPE,
+  typeof DAWN_SUBAGENT_ACTIVITY_TYPE,
   typeof createCounterIdFactory,
   typeof createDefaultIdFactory,
   typeof fromRunAgentInput,
@@ -420,6 +431,8 @@ type RootTypeSurface = readonly [
   ToAguiOptions,
   DawnAgentStreamChunk,
   RunContext,
+  DawnPlanActivityContent,
+  DawnSubagentActivityContent,
 ]
 
 declare const rootTypeSurface: RootTypeSurface
@@ -429,8 +442,32 @@ const chunk: DawnAgentStreamChunk = { type: "token", data: "hello" }
 const context: RunContext = { threadId: "published-smoke", runId: "published-smoke" }
 const options: ToAguiOptions = { idFactory }
 const encoder: typeof encodeAgUiSseFromSubpath = encodeAgUiSseFromSubpath
+const planActivity: DawnPlanActivityContent = {
+  todos: [{ content: "Search the corpus", status: "in_progress" }],
+}
+const subagentActivity: DawnSubagentActivityContent = {
+  name: "researcher",
+  depth: 1,
+  status: "running",
+  todos: planActivity.todos,
+  tools: [{ name: "searchCorpus", status: "completed" }],
+  totalToolCount: 1,
+}
+const planActivityType: "dawn.plan" = DAWN_PLAN_ACTIVITY_TYPE
+const subagentActivityType: "dawn.subagent" = DAWN_SUBAGENT_ACTIVITY_TYPE
 
-void [rootValueSurface, rootTypeSurface, chunk, context, options, encoder]
+void [
+  rootValueSurface,
+  rootTypeSurface,
+  chunk,
+  context,
+  options,
+  encoder,
+  planActivity,
+  subagentActivity,
+  planActivityType,
+  subagentActivityType,
+]
 `
 }
 

--- a/scripts/published-artifacts.test.mjs
+++ b/scripts/published-artifacts.test.mjs
@@ -920,6 +920,8 @@ describe("release workflow published TypeScript tooling verification", () => {
 describe("expectedFilesForPackage", () => {
   it("returns AG-UI entrypoint expectations", () => {
     assert.deepEqual(expectedFilesForPackage("@dawn-ai/ag-ui"), [
+      "dist/activities.js",
+      "dist/activities.d.ts",
       "dist/index.js",
       "dist/index.d.ts",
       "dist/sse.js",
@@ -977,6 +979,8 @@ describe("AG-UI installed probes", () => {
     assert.match(source, /import \{ encodeAgUiSse \} from "@dawn-ai\/ag-ui\/sse"/)
     assert.ok(
       source.includes(`assert.deepEqual(Object.keys(root).sort(), [
+  "DAWN_PLAN_ACTIVITY_TYPE",
+  "DAWN_SUBAGENT_ACTIVITY_TYPE",
   "createCounterIdFactory",
   "createDefaultIdFactory",
   "fromRunAgentInput",
@@ -984,6 +988,8 @@ describe("AG-UI installed probes", () => {
 ])`),
       "ESM probe must compare the complete sorted root export surface",
     )
+    assert.match(source, /assert\.equal\(root\.DAWN_PLAN_ACTIVITY_TYPE, "dawn\.plan"\)/)
+    assert.match(source, /assert\.equal\(root\.DAWN_SUBAGENT_ACTIVITY_TYPE, "dawn\.subagent"\)/)
     assert.ok(
       source.includes(`for (const exportName of [
   "createCounterIdFactory",
@@ -1018,6 +1024,8 @@ describe("AG-UI installed probes", () => {
     }
     assert.ok(
       source.includes(`type RootValueSurface = readonly [
+  typeof DAWN_PLAN_ACTIVITY_TYPE,
+  typeof DAWN_SUBAGENT_ACTIVITY_TYPE,
   typeof createCounterIdFactory,
   typeof createDefaultIdFactory,
   typeof fromRunAgentInput,
@@ -1035,6 +1043,8 @@ describe("AG-UI installed probes", () => {
       "ToAguiOptions",
       "DawnAgentStreamChunk",
       "RunContext",
+      "DawnPlanActivityContent",
+      "DawnSubagentActivityContent",
     ]) {
       assert.match(source, new RegExp(`type ${typeName}`))
     }
@@ -1049,6 +1059,8 @@ describe("AG-UI installed probes", () => {
   ToAguiOptions,
   DawnAgentStreamChunk,
   RunContext,
+  DawnPlanActivityContent,
+  DawnSubagentActivityContent,
 ]`),
       "type probe must exercise every canonical root type",
     )
@@ -2292,6 +2304,7 @@ async function createAgUiProbeFixture(options = {}) {
 export function createDefaultIdFactory() {}
 export function fromRunAgentInput(input) { return input }
 export function toAguiEvents(events) { return events }
+export { DAWN_PLAN_ACTIVITY_TYPE, DAWN_SUBAGENT_ACTIVITY_TYPE } from "./activities.js"
 `
   const canonicalFunctionDeclarations = {
     createCounterIdFactory: "export declare function createCounterIdFactory(): IdFactory",
@@ -2316,8 +2329,38 @@ export interface AguiOutboundEvent { readonly type: string }
 export interface ToAguiOptions { readonly idFactory?: IdFactory }
 export type DawnAgentStreamChunk = { readonly type: string; readonly data?: unknown }
 export interface RunContext { readonly threadId: string; readonly runId: string }
+export {
+  DAWN_PLAN_ACTIVITY_TYPE,
+  DAWN_SUBAGENT_ACTIVITY_TYPE,
+  type DawnPlanActivityContent,
+  type DawnSubagentActivityContent,
+} from "./activities.js"
 ${includedFunctionDeclarations}
 ${options.extraRootDeclarations ?? ""}`
+  const activitiesJavaScript = `export const DAWN_PLAN_ACTIVITY_TYPE = "dawn.plan"
+export const DAWN_SUBAGENT_ACTIVITY_TYPE = "dawn.subagent"
+`
+  const activitiesDeclarations = `export declare const DAWN_PLAN_ACTIVITY_TYPE: "dawn.plan"
+export declare const DAWN_SUBAGENT_ACTIVITY_TYPE: "dawn.subagent"
+export interface DawnPlanActivityContent {
+  readonly todos: ReadonlyArray<{
+    readonly content: string
+    readonly status: "pending" | "in_progress" | "completed"
+  }>
+}
+export interface DawnSubagentActivityContent {
+  readonly name: string
+  readonly depth: number
+  readonly status: "running" | "completed" | "failed"
+  readonly todos?: DawnPlanActivityContent["todos"]
+  readonly tools: ReadonlyArray<{
+    readonly name: string
+    readonly status: "running" | "completed" | "incomplete"
+  }>
+  readonly totalToolCount: number
+  readonly error?: string
+}
+`
   const sseJavaScript =
     options.sseSource ??
     `export function encodeAgUiSse(event) {
@@ -2337,6 +2380,8 @@ ${options.extraRootDeclarations ?? ""}`
     writeFile(join(root, "smoke-ag-ui.ts"), agUiTypeProbeSource(), "utf8"),
     writeFile(join(root, "tsconfig.ag-ui.json"), JSON.stringify(agUiTypeScriptConfig()), "utf8"),
     writeFile(join(packageRoot, "package.json"), JSON.stringify(packageJson), "utf8"),
+    writeFile(join(distRoot, "activities.js"), activitiesJavaScript, "utf8"),
+    writeFile(join(distRoot, "activities.d.ts"), activitiesDeclarations, "utf8"),
     writeFile(join(distRoot, "index.js"), rootJavaScript, "utf8"),
     writeFile(join(distRoot, "index.d.ts"), rootDeclarations, "utf8"),
     writeFile(join(distRoot, "sse.js"), sseJavaScript, "utf8"),

--- a/test/generated/run-generated-research-activation.test.ts
+++ b/test/generated/run-generated-research-activation.test.ts
@@ -26,6 +26,8 @@ const ACTIVATION_TIMEOUT_MS = 600_000
 const ACTIVATION_CLEANUP_RESERVE_MS = 30_000
 const SAFE_PROMPT = "What are common agent architectures? Write a short cited report."
 const SUBQUESTION = "Identify common agent architectures and cite the corpus."
+const CHILD_REPLY =
+  "ReAct and plan-and-execute are common agent architectures. [corpus/agent-architectures.md]"
 const GATED_PROMPT =
   "The corpus has nothing on quantum computing — run the external fetch script for it with runBash."
 const FETCH_COMMAND = "node scripts/fetch-source.mjs quantum computing"
@@ -79,9 +81,7 @@ function createSafeResearchFixtures() {
     .user(SUBQUESTION)
     .callsTool("searchCorpus", { query: "agent architectures" })
     .callsTool("readDoc", { path: "corpus/agent-architectures.md" })
-    .replies(
-      "ReAct and plan-and-execute are common agent architectures. [corpus/agent-architectures.md]",
-    )
+    .replies(CHILD_REPLY)
     .build()
   return [...root, ...child]
 }
@@ -172,6 +172,10 @@ function reconstructAssistantText(events: readonly AgUiEvent[]): string {
       return event.delta
     })
     .join("")
+}
+
+function expectNoActivitySnapshots(events: readonly AgUiEvent[]): void {
+  expect(events.filter((event) => event.type === "ACTIVITY_SNAPSHOT")).toEqual([])
 }
 
 function parseAgUiSse(rawSse: string): AgUiEvent[] {
@@ -455,7 +459,161 @@ function assertSafeResearchJourney(
     subagent: "researcher",
     input: SUBQUESTION,
   })
-  expect(reconstructAssistantText(events)).toContain("[corpus/agent-architectures.md]")
+  const assistantText = reconstructAssistantText(events)
+  expect(assistantText).toContain("[corpus/agent-architectures.md]")
+  expect(assistantText).not.toContain(CHILD_REPLY)
+
+  const activities = events.filter((event) => event.type === "ACTIVITY_SNAPSHOT")
+  expect(activities).toEqual([
+    {
+      type: "ACTIVITY_SNAPSHOT",
+      messageId: `dawn:plan:${ids.runId}`,
+      activityType: "dawn.plan",
+      replace: true,
+      content: { todos },
+    },
+    {
+      type: "ACTIVITY_SNAPSHOT",
+      messageId: "dawn:subagent:call_task_0_2",
+      activityType: "dawn.subagent",
+      replace: true,
+      content: {
+        name: "researcher",
+        depth: 1,
+        status: "running",
+        tools: [],
+        totalToolCount: 0,
+      },
+    },
+    {
+      type: "ACTIVITY_SNAPSHOT",
+      messageId: "dawn:subagent:call_task_0_2",
+      activityType: "dawn.subagent",
+      replace: true,
+      content: {
+        name: "researcher",
+        depth: 1,
+        status: "running",
+        tools: [{ name: "searchCorpus", status: "running" }],
+        totalToolCount: 1,
+      },
+    },
+    {
+      type: "ACTIVITY_SNAPSHOT",
+      messageId: "dawn:subagent:call_task_0_2",
+      activityType: "dawn.subagent",
+      replace: true,
+      content: {
+        name: "researcher",
+        depth: 1,
+        status: "running",
+        tools: [{ name: "searchCorpus", status: "completed" }],
+        totalToolCount: 1,
+      },
+    },
+    {
+      type: "ACTIVITY_SNAPSHOT",
+      messageId: "dawn:subagent:call_task_0_2",
+      activityType: "dawn.subagent",
+      replace: true,
+      content: {
+        name: "researcher",
+        depth: 1,
+        status: "running",
+        tools: [
+          { name: "searchCorpus", status: "completed" },
+          { name: "readDoc", status: "running" },
+        ],
+        totalToolCount: 2,
+      },
+    },
+    {
+      type: "ACTIVITY_SNAPSHOT",
+      messageId: "dawn:subagent:call_task_0_2",
+      activityType: "dawn.subagent",
+      replace: true,
+      content: {
+        name: "researcher",
+        depth: 1,
+        status: "running",
+        tools: [
+          { name: "searchCorpus", status: "completed" },
+          { name: "readDoc", status: "completed" },
+        ],
+        totalToolCount: 2,
+      },
+    },
+    {
+      type: "ACTIVITY_SNAPSHOT",
+      messageId: "dawn:subagent:call_task_0_2",
+      activityType: "dawn.subagent",
+      replace: true,
+      content: {
+        name: "researcher",
+        depth: 1,
+        status: "completed",
+        tools: [
+          { name: "searchCorpus", status: "completed" },
+          { name: "readDoc", status: "completed" },
+        ],
+        totalToolCount: 2,
+      },
+    },
+  ])
+
+  const startByName = new Map(
+    events
+      .filter((event) => event.type === "TOOL_CALL_START")
+      .map((event) => [event.toolCallName, event.toolCallId]),
+  )
+  const writeTodosId = startByName.get("writeTodos")
+  const taskId = startByName.get("task")
+  expect(typeof writeTodosId).toBe("string")
+  expect(typeof taskId).toBe("string")
+  const writeTodosEndIndex = events.findIndex(
+    (event) => event.type === "TOOL_CALL_END" && event.toolCallId === writeTodosId,
+  )
+  const writeTodosResultIndex = events.findIndex(
+    (event) => event.type === "TOOL_CALL_RESULT" && event.toolCallId === writeTodosId,
+  )
+  const taskEndIndex = events.findIndex(
+    (event) => event.type === "TOOL_CALL_END" && event.toolCallId === taskId,
+  )
+  const taskResultIndex = events.findIndex(
+    (event) => event.type === "TOOL_CALL_RESULT" && event.toolCallId === taskId,
+  )
+  const activityIndices = activities.map((activity) => events.indexOf(activity))
+  const firstFinalTextIndex = events.findIndex((event) => event.type === "TEXT_MESSAGE_CONTENT")
+  expect(activityIndices[0]).toBeGreaterThan(writeTodosEndIndex)
+  expect(activityIndices[0]).toBeLessThan(writeTodosResultIndex)
+  expect(activityIndices[1]).toBeGreaterThan(taskEndIndex)
+  expect(activityIndices[6]).toBeLessThan(taskResultIndex)
+  expect(firstFinalTextIndex).toBeGreaterThanOrEqual(0)
+  expect(activityIndices.every((index) => index < firstFinalTextIndex)).toBe(true)
+
+  const serializedActivityContent = JSON.stringify(activities.map((activity) => activity.content))
+  for (const privateValue of [
+    SUBQUESTION,
+    CHILD_REPLY,
+    report,
+    "corpus/agent-architectures.md",
+    "call_task_0_2",
+    "call_searchCorpus_0_0",
+    "call_readDoc_0_1",
+    '"call_id"',
+    '"route_id"',
+    '"id"',
+    '"input"',
+    '"output"',
+    '"final_message"',
+  ]) {
+    expect(serializedActivityContent).not.toContain(privateValue)
+  }
+  const kinds = events.map((event) => event.type)
+  expect(kinds).not.toContain("ACTIVITY_DELTA")
+  expect(kinds).not.toContain("CUSTOM")
+  expect(kinds).not.toContain("RAW")
+  expect(kinds).not.toContain("STATE_SNAPSHOT")
 }
 
 function assertGatedResearchInterrupt(
@@ -539,6 +697,7 @@ function assertGatedResearchInterrupt(
     ),
   ).toEqual([])
   expect(events.filter((event) => event.type === "TEXT_MESSAGE_CONTENT")).toEqual([])
+  expectNoActivitySnapshots(events)
 
   return { interruptId }
 }
@@ -612,6 +771,7 @@ function assertResumedGatedJourney(
   expect(resultIndex).toBeGreaterThanOrEqual(0)
   expect(firstTextIndex).toBeGreaterThan(resultIndex)
   expect(reconstructAssistantText(events)).toBe(GATED_REPLY)
+  expectNoActivitySnapshots(events)
 }
 
 function assertBuiltArtifactJourney(
@@ -621,6 +781,7 @@ function assertBuiltArtifactJourney(
   assertSuccessfulTerminal(events, ids)
   expect(events.filter((event) => event.type === "TOOL_CALL_START")).toEqual([])
   expect(reconstructAssistantText(events)).toBe(BUILT_REPLY)
+  expectNoActivitySnapshots(events)
 }
 
 function assertRecordedServerExit(

--- a/vitest.workspace.ts
+++ b/vitest.workspace.ts
@@ -26,6 +26,7 @@ export default defineConfig({
       "./packages/workspace/vitest.config.ts",
       "./examples/chat/server/vitest.config.ts",
       "./examples/research/server/vitest.config.ts",
+      "./examples/research/web/vitest.config.ts",
     ],
   },
 })


### PR DESCRIPTION
## Summary

- project root plans and correlated subagent lifecycles into bounded standard AG-UI activity snapshots
- render typed plan and researcher activity cards in the flagship research web example
- verify the real packaged research wire path and update public docs, release surfaces, and scaffold guidance

## Why

The research starter already emitted structured planning and delegated-work progress, but the AG-UI adapter discarded it. Developers could see root tools and the final report, not the execution progress that makes the first run understandable.

## Developer impact

Clients can render `dawn.plan` and `dawn.subagent` replacement snapshots through standard AG-UI activity renderers. Activity content is allowlisted and bounded; child prose, prompts, tool inputs/outputs, final child answers, and raw runtime IDs remain excluded. Existing interrupts, generic root tool cards, memory review, suggestions, and the server-first generated starter remain unchanged.

## Validation

- Node 24.18.0 / npm 11.19.0 / pnpm 10.33.0
- `pnpm ci:validate`
- 3,560 source tests passed; 211 skipped
- generated framework, runtime, and smoke harnesses passed 3/3
- package/release guards, real pack, TypeScript tooling smoke, docs, and changesets passed
- final independent spec and quality reviews: clean
