### PR TITLE
test(inspector): verification hardening — the fourteen dogfood scenarios, a11y, and measured budgets

### DIFF
--- a/.changeset/dawn-inspector-verification.md
+++ b/.changeset/dawn-inspector-verification.md
@@ -1,0 +1,7 @@
+---
+"@dawn-ai/inspector": patch
+---
+
+Bulk actions now prune succeeded ids from the selection, so a retry after a partial
+failure re-sends only the failures and can never repeat a completed delete. Polling
+pauses for the duration of a bulk run.

--- a/.changeset/memory-conformance-composed-filter.md
+++ b/.changeset/memory-conformance-composed-filter.md
@@ -1,0 +1,9 @@
+---
+"@dawn-ai/testing": patch
+---
+
+`runMemoryStoreConformance` now asserts that a composed browse filter (exact namespace +
+`status in` + `kind in` + `content contains`, ordered by `updatedAt desc`) returns a
+byte-exact ordered id list on every backend. The case covers rows that share an
+`updatedAt` stamp, so a store whose sort omits the id tie-break now fails conformance
+instead of passing on a window where the ambiguity happens not to surface.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -410,7 +410,8 @@ jobs:
   inspector-e2e:
     runs-on: ubuntu-latest
     # 35, not 20: the browser lane below adds a chromium download, a second
-    # standalone boot and ~20 single-worker specs on top of the vitest lane.
+    # standalone boot and 19 single-worker spec files (44 tests) on top of the
+    # vitest lane.
     timeout-minutes: 35
 
     steps:
@@ -450,9 +451,10 @@ jobs:
         run: pnpm --filter @dawn-ai/inspector exec playwright install --with-deps chromium
 
       - name: Inspector browser verification
-        # Boots the same .next/standalone artifact the step above uses, against a seeded
-        # 1250-record store. `workers: 1` in playwright.config.ts is load-bearing: the
-        # specs share one store and several mutate it.
+        # Boots the same .next/standalone artifact the vitest lane above uses (`Inspector
+        # standalone e2e`, not the browser-install step immediately above), against a
+        # seeded 1250-record store. `workers: 1` in playwright.config.ts is load-bearing:
+        # the specs share one store and several mutate it.
         run: pnpm --filter @dawn-ai/inspector test:e2e
 
       - name: Upload Playwright traces

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -409,7 +409,9 @@ jobs:
 
   inspector-e2e:
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    # 35, not 20: the browser lane below adds a chromium download, a second
+    # standalone boot and ~20 single-worker specs on top of the vitest lane.
+    timeout-minutes: 35
 
     steps:
       - name: Checkout
@@ -440,6 +442,26 @@ jobs:
 
       - name: Inspector standalone e2e
         run: DAWN_TEST_INSPECTOR=1 pnpm --filter @dawn-ai/inspector test
+
+      - name: Install Playwright browsers
+        # `--filter` is required, not stylistic: @playwright/test is a dependency of
+        # packages/inspector only, so a bare root `pnpm exec playwright` fails with
+        # ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL / Command "playwright" not found.
+        run: pnpm --filter @dawn-ai/inspector exec playwright install --with-deps chromium
+
+      - name: Inspector browser verification
+        # Boots the same .next/standalone artifact the step above uses, against a seeded
+        # 1250-record store. `workers: 1` in playwright.config.ts is load-bearing: the
+        # specs share one store and several mutate it.
+        run: pnpm --filter @dawn-ai/inspector test:e2e
+
+      - name: Upload Playwright traces
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: inspector-playwright-traces
+          path: packages/inspector/test-results
+          retention-days: 7
 
   chart-validate:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,8 @@ artifacts/
 .superpowers/
 .vercel
 .knot/
+test-results/
+playwright-report/
 packages/testing/test/fixtures/**/.dawn/
 test/runtime/dawn-testing/**/.dawn/
 test/runtime/dawn-testing/**/workspace/tool-outputs/

--- a/docs/superpowers/notes/2026-08-10-d1-budget-status.md
+++ b/docs/superpowers/notes/2026-08-10-d1-budget-status.md
@@ -1,0 +1,116 @@
+# D1 budget ledger — measured vs proposed
+
+Design: `docs/superpowers/specs/2026-08-09-server-controlled-exploration-design.md` §11.
+Plan: `docs/superpowers/plans/2026-08-10-dawn-inspector-verification.md`, Tasks 18, 21, 22.
+
+This file replaces the plan's "Budget status" table. Every row that entered slice 5 as
+*proposed* or *estimated* now carries either the number a run printed or an explicit
+statement that no run has produced one. A cell that says "estimate" is not a soft pass —
+it means nothing has been measured and the budget is still a proposal.
+
+## Where the numbers came from
+
+| Lane | Command | Run |
+| --- | --- | --- |
+| Server (SQLite) | `pnpm --filter @dawn-ai/memory bench:budgets -- --assert` | 2026-08-12, Apple M1 Max / macOS 26.5 / Node 24.18.0. 100 000 rows, 20 samples, nearest-rank p95 (the 19th observation, never interpolated). Load average at start: 4.66. |
+| Server (Postgres) | — | **Never run.** See the Postgres record below. |
+| Client (pretable) | `PRETABLE_BENCH_SCRIPT=replace pnpm bench:e2e apps/bench/tests/bench.spec.ts`, same for `append`, then `pnpm bench:budgets` | 2026-08-12, same machine, Chromium 151.0.7922.34, `pretable/default/S1/dev`, viewport 1440×900, seed 101, 2 000-row scenario. |
+| Client heap | `pnpm bench:memory` | Same machine and run identity. |
+
+Both client commands live in the pretable worktree
+(`/Users/blove/repos/pretable/.claude/worktrees/hopeful-cray-45f99a`), not in dawn.
+
+## The ledger
+
+| Budget | Ceiling (§11) | Measured | Verdict |
+| --- | --- | --- | --- |
+| Server: windowed fetch, default order, keyset | p95 < 10 ms @100k SQLite | **1.61 ms** p95, whole `store.browse({ limit: 200 })` | **Met.** Supersedes the §5.5 per-statement 0.54 ms — this figure includes decode. |
+| Server: filtered `COUNT(*)` | p95 < 25 ms @100k SQLite | **6.61 ms** p95, rows + COUNT in one `browse()` with a `status in` filter | **Met.** |
+| Server: head refresh (rows+count, resident 1 000) | p95 < 50 ms @100k | **3.65 ms** p95 at `limit = 1000` | **Met — first measurement ever.** See the head-refresh record below. |
+| Server: non-default sort window | p95 < 50 ms @100k | **12.32 ms** p95, `orderBy confidence desc` | **Met.** |
+| Server: content contains | p95 < 150 ms @100k | **45.12 ms** p95, rare-term needle matching exactly one row | **Met.** |
+| Server: any Postgres figure | < 30 ms windowed / < 100 ms filtered count | **No measurement.** | **Estimate only.** See the Postgres record below. |
+| Client: replace (refresh, 200 rows) | < 20 ms grid work, no grid reconstruction | **7.90 ms** `interaction_latency_ms`, `grid_instance_reconstructed` 0, `scroll_position_drift_px` 0 | **Met**, with the frame-quantisation caveat below. |
+| Client: append (200 onto 800, at the cap) | < 30 ms grid work, zero scroll movement | **9.90 ms** `interaction_latency_ms`, `scroll_position_drift_px` 0, `grid_instance_reconstructed` 0, resident 800 → 1 000 | **Met** at the measured shape. §11 words the shape differently — see the append record below. |
+| Client memory at resident cap | ≤ 32 MB grid-attributable heap | **10.90 MB** page-attributable (11.37 MB at cap − 0.47 MB blank baseline) | **Met on a weaker instrument.** The number is the WHOLE bench page, not the grid alone; see the heap record below. |
+| Poll tick, no changes | < 10 ms client CPU, zero announcements | **CPU: no measurement.** Announcements: 0, asserted by `packages/inspector/e2e/a11y-announcements.spec.ts` | **Half met.** The zero-announcement half is pinned by a test; the CPU half is still proposed and no task in this plan measures it. |
+| End-to-end interaction | p95 < 300 ms local server | **No p95.** `01-beyond-window-filter.spec.ts` bounds one filter round trip at < 2 000 ms | **Unverified.** The e2e ceiling is a regression-of-kind guard (a client round-trip storm), deliberately loose, one sample. It is not the §11 p95 and must not be read as one. |
+
+## Records
+
+### head-refresh, measured for the first time
+
+§11 grounds `head-refresh` by extrapolation — "~3–8 ms + decode" — and §5.5 has no row for
+it. Nothing had ever been run at `limit = 1000`, which is the span that matters: the
+resident cap is 1 000, and one head refresh covering the whole resident span is what makes
+convergence arithmetic instead of a merge. The measured p95 is **3.65 ms**, inside the
+extrapolated band and 13× under the 50 ms ceiling. The ceiling was set with decode margin
+that the measurement shows is not needed at this row count; it is left alone rather than
+tightened, because one machine's p95 is not grounds to move an approved number.
+
+### Postgres stays an estimate
+
+Task 18 was planned to add a gated container lane. **It did not.** What shipped is
+`POSTGRES_BROWSE_BUDGETS_MS` in `packages/memory/src/browse-budget.ts` — two constants
+(30 ms windowed, 100 ms filtered count) and a comment saying both are estimates. There is
+no pgvector bench, gated or otherwise, and no container has been run. The three other
+shapes are deliberately absent from that table so the checker reports them as *unbudgeted*
+rather than inventing a ceiling.
+
+So: **no Postgres number in this ledger is measured.** Anyone reading a Postgres figure as
+a verified budget is reading an extrapolation from SQLite. Measuring it is owed work.
+
+### The append shape: §11 contradicts itself, and 800 is the honest reading
+
+§11's client-append row says "200 onto 1 800". The same section caps residency at
+**1 000 rows**. Both cannot be true: appending 200 onto 1 800 lands at 2 000, twice the
+cap, so the row as written describes a state the design forbids elsewhere.
+
+This ledger measures **200 onto 800**, arriving exactly at the 1 000 cap — the largest
+append the design permits, and therefore the worst case that can actually occur. The
+artifact records `resident rows: 800 to 1000 (scenario holds 2000)`.
+
+Owed follow-up (design text, not code): correct §11's append row from "200 onto 1 800" to
+"200 onto 800, arriving at the 1 000 resident cap". One line.
+
+### Both client latencies sit at the one-frame floor
+
+`interaction_latency_ms` is a difference between two `requestAnimationFrame` timestamps, so
+it cannot resolve below one frame. The replace run reports 7.90 ms against a median frame
+interval of 8.40 ms; the append run reports 9.90 ms against a 9.90 ms median. Both are
+**one frame** — the instrument's floor, not a measurement of grid work that happens to be
+small. The correct reading is "the grid finished inside the first frame after the update",
+which clears 20 ms and 30 ms respectively. A regression would have to cost more than a
+frame before this number moves at all, so treat these as *ceiling cleared*, not as a
+baseline to defend to the tenth of a millisecond.
+
+Both runs also report `grid_instance_reconstructed: 0`, which is the clause the replace
+budget actually rests on — §11 asks for "no grid reconstruction", and that is a 0/1 fact
+rather than a timing.
+
+### The heap figure measures the page, not the grid
+
+§11 budgets **grid-attributable** heap. `resident-cap-memory.spec.ts` cannot isolate the
+grid: its baseline is `about:blank`, so the 10.90 MB difference is the whole bench page —
+app bundle, React, the generated 2 000-row scenario dataset, and the grid.
+
+Over-counting is the safe direction (the grid is a subset of the page), so a page under
+32 MB puts the grid under it too, and the verdict above is sound. What the instrument
+**cannot** do is resolve resident row count: the same page holding all 2 000 scenario rows
+measured 10.53 MB, i.e. **0.84 MB below** the 1 000-row cap state — a negative marginal
+cost, which means the grid's per-row footprint is inside `Runtime.getHeapUsage` noise.
+
+Consequence: at ~11 MB against a 32 MB ceiling, this assertion trips only on roughly a 3×
+whole-page regression. Raising `BENCH_RESIDENT_CAP_ROWS` would not move it. It is a page
+ceiling, not a per-row instrument, and it should not be cited as evidence about row cost.
+
+### What is still owed
+
+1. A Postgres/pgvector container bench. Until then both Postgres numbers are estimates.
+2. A poll-tick CPU measurement. No task in this plan produces one.
+3. A real §11 end-to-end p95. The e2e bound is a single sample at a deliberately loose
+   ceiling, and `timeToFulfilled` measures the Playwright driver along with the page.
+4. The §11 append-row correction described above.
+5. The recorded VoiceOver pass (plan Task 14). It needs a human with a screen reader and
+   was deliberately not fabricated; `docs/superpowers/notes/2026-08-10-voiceover-walkthrough.md`
+   holds the protocol, not results.

--- a/docs/superpowers/notes/2026-08-10-d1-budget-status.md
+++ b/docs/superpowers/notes/2026-08-10-d1-budget-status.md
@@ -1,7 +1,15 @@
 # D1 budget ledger — measured vs proposed
 
-Design: `docs/superpowers/specs/2026-08-09-server-controlled-exploration-design.md` §11.
-Plan: `docs/superpowers/plans/2026-08-10-dawn-inspector-verification.md`, Tasks 18, 21, 22.
+Both references below live in the **pretable** repo, not in dawn — `docs/superpowers/specs/`
+here holds ~90 unrelated specs and neither path resolves from this checkout. Read them at
+`/Users/blove/repos/pretable/.claude/worktrees/hopeful-cray-45f99a`:
+
+- Design: `docs/superpowers/specs/2026-08-09-server-controlled-exploration-design.md` §11
+- Plan: `docs/superpowers/plans/2026-08-10-dawn-inspector-verification.md`, Tasks 18, 21, 22
+
+Every "§11" in this file is a reference into that design, whose own MEASURED block
+(§11, immediately under the budget table) is the other half of this record — see the
+frame-quantisation entry below, which reconciles the two.
 
 This file replaces the plan's "Budget status" table. Every row that entered slice 5 as
 *proposed* or *estimated* now carries either the number a run printed or an explicit
@@ -12,7 +20,7 @@ it means nothing has been measured and the budget is still a proposal.
 
 | Lane | Command | Run |
 | --- | --- | --- |
-| Server (SQLite) | `pnpm --filter @dawn-ai/memory bench:budgets -- --assert` | 2026-08-12, Apple M1 Max / macOS 26.5 / Node 24.18.0. 100 000 rows, 20 samples, nearest-rank p95 (the 19th observation, never interpolated). Load average at start: 4.66. |
+| Server (SQLite) | `pnpm --filter @dawn-ai/memory bench:budgets -- --assert` | 2026-08-12, Apple M1 Max / macOS 26.5 / Node 24.18.0. 100 000 rows, 20 samples, nearest-rank p95 (the 19th observation, never interpolated). Load average 4.66 at the start of *measurement* — the bench prints `loadavg()` after `seed()` inserts the 100 000 rows, so that figure includes this process's own seeding and is not ambient machine load. |
 | Server (Postgres) | — | **Never run.** See the Postgres record below. |
 | Client (pretable) | `PRETABLE_BENCH_SCRIPT=replace pnpm bench:e2e apps/bench/tests/bench.spec.ts`, same for `append`, then `pnpm bench:budgets` | 2026-08-12, same machine, Chromium 151.0.7922.34, `pretable/default/S1/dev`, viewport 1440×900, seed 101, 2 000-row scenario. |
 | Client heap | `pnpm bench:memory` | Same machine and run identity. |
@@ -31,10 +39,26 @@ Both client commands live in the pretable worktree
 | Server: content contains | p95 < 150 ms @100k | **45.12 ms** p95, rare-term needle matching exactly one row | **Met.** |
 | Server: any Postgres figure | < 30 ms windowed / < 100 ms filtered count | **No measurement.** | **Estimate only.** See the Postgres record below. |
 | Client: replace (refresh, 200 rows) | < 20 ms grid work, no grid reconstruction | **7.90 ms** `interaction_latency_ms`, `grid_instance_reconstructed` 0, `scroll_position_drift_px` 0 | **Met**, with the frame-quantisation caveat below. |
-| Client: append (200 onto 800, at the cap) | < 30 ms grid work, zero scroll movement | **9.90 ms** `interaction_latency_ms`, `scroll_position_drift_px` 0, `grid_instance_reconstructed` 0, resident 800 → 1 000 | **Met** at the measured shape. §11 words the shape differently — see the append record below. |
+| Client: append (200 onto 800, at the cap) | < 30 ms grid work, zero scroll movement | **9.90 ms** `interaction_latency_ms`, `scroll_position_drift_px` 0, `grid_instance_reconstructed` 0, resident 800 → 1 000 | **Met** at the worst case the design permits — §11 words the shape the same way. See the append record below. |
 | Client memory at resident cap | ≤ 32 MB grid-attributable heap | **10.90 MB** page-attributable (11.37 MB at cap − 0.47 MB blank baseline) | **Met on a weaker instrument.** The number is the WHOLE bench page, not the grid alone; see the heap record below. |
 | Poll tick, no changes | < 10 ms client CPU, zero announcements | **CPU: no measurement.** Announcements: 0, asserted by `packages/inspector/e2e/a11y-announcements.spec.ts` | **Half met.** The zero-announcement half is pinned by a test; the CPU half is still proposed and no task in this plan measures it. |
 | End-to-end interaction | p95 < 300 ms local server | **No p95.** `01-beyond-window-filter.spec.ts` bounds one filter round trip at < 2 000 ms | **Unverified.** The e2e ceiling is a regression-of-kind guard (a client round-trip storm), deliberately loose, one sample. It is not the §11 p95 and must not be read as one. |
+
+## No verdict here is defended by CI
+
+**Every "Met" above is a one-shot measurement on one developer machine, not a regression
+gate.** No workflow in either repo re-checks any of these numbers:
+
+- dawn: `grep -rn bench .github/workflows/` returns nothing. `bench:budgets` exists as a
+  package script and runs only when a human types it.
+- pretable: `bench:budgets`, `bench:e2e` and `bench:memory` appear in no workflow. The root
+  `test` script runs `check-bench-budgets.test.mjs`, which tests *the checker's own logic*
+  against fixtures — it never reads a bench artifact and cannot fail on a slow grid.
+
+So a change that doubles any of these costs merges green. "Met" means "was met once, on
+2026-08-12, on an M1 Max" — read it as a dated observation, not a standing guarantee. Wiring
+any of this into CI was not in scope for the task that produced this file; it is listed as
+owed work below.
 
 ## Records
 
@@ -60,29 +84,46 @@ rather than inventing a ceiling.
 So: **no Postgres number in this ledger is measured.** Anyone reading a Postgres figure as
 a verified budget is reading an extrapolation from SQLite. Measuring it is owed work.
 
-### The append shape: §11 contradicts itself, and 800 is the honest reading
+### The append shape is 200 onto 800, and §11 already says so
 
-§11's client-append row says "200 onto 1 800". The same section caps residency at
-**1 000 rows**. Both cannot be true: appending 200 onto 1 800 lands at 2 000, twice the
-cap, so the row as written describes a state the design forbids elsewhere.
+The measured shape is **200 onto 800**, arriving exactly at the 1 000 resident cap — the
+largest append the design permits, and therefore the worst case that can actually occur.
+The artifact records `resident rows: 800 to 1000 (scenario holds 2000)`.
 
-This ledger measures **200 onto 800**, arriving exactly at the 1 000 cap — the largest
-append the design permits, and therefore the worst case that can actually occur. The
-artifact records `resident rows: 800 to 1000 (scenario holds 2000)`.
+§11 agrees. Its client-append row reads "200 onto 800 — the resident cap is 1 000, so
+1 800 was never reachable", corrected in pretable `adcceccd` (#307). No follow-up is owed
+here. An earlier draft of this ledger filed a §11 correction as outstanding work; that was
+read off the *plan's* stale preamble table, which still carries the pre-`adcceccd` "200
+onto 1 800" wording. The plan preamble is the stale copy — the design is not.
 
-Owed follow-up (design text, not code): correct §11's append row from "200 onto 1 800" to
-"200 onto 800, arriving at the 1 000 resident cap". One line.
-
-### Both client latencies sit at the one-frame floor
+### Both client latencies sit at the one-frame floor — and §11 owns the instrument that resolves it
 
 `interaction_latency_ms` is a difference between two `requestAnimationFrame` timestamps, so
 it cannot resolve below one frame. The replace run reports 7.90 ms against a median frame
-interval of 8.40 ms; the append run reports 9.90 ms against a 9.90 ms median. Both are
-**one frame** — the instrument's floor, not a measurement of grid work that happens to be
-small. The correct reading is "the grid finished inside the first frame after the update",
-which clears 20 ms and 30 ms respectively. A regression would have to cost more than a
-frame before this number moves at all, so treat these as *ceiling cleared*, not as a
-baseline to defend to the tenth of a millisecond.
+interval of 8.40 ms; the append run reports 9.90 ms against a 9.90 ms median. Both report
+`frames to first change: 1`. Both are therefore **one frame** — the instrument's floor, not
+a measurement of grid work that happens to be small. The correct reading is "the grid
+finished inside the first frame after the update", which clears 20 ms and 30 ms
+respectively. A regression would have to cost more than a frame before this number moves at
+all, so treat these as *ceiling cleared*, not as a baseline to defend to the tenth of a
+millisecond.
+
+**This is a re-run, not a second opinion.** §11's MEASURED block records replace 8.6 / 8.3 ms
+and append 8.9 / 8.3 ms from the 2026-08-11 run; the table above records 7.90 and 9.90 ms
+from a 2026-08-12 re-run of the same two scripts at the same run identity. The numbers
+differ by well under one frame interval, which is exactly what "the metric cannot resolve
+below one frame" predicts — neither set is more correct, and a reader should not treat the
+gap as drift. Where the two documents differ in *content*, §11 is the stronger record and
+governs.
+
+**§11's consequence, which this ledger must not be read without.** Because the metric
+quantises to a frame, it **cannot discriminate replace from append** — which is the entire
+point of D1-PERF-04 measuring them separately. The discrimination comes from the sliced
+trace, which shows it plainly: `setRows` self-time is **78 µs for replace against 402 µs for
+append** (1 000 rows vs 200). The standing rule §11 sets, restated here so this file cannot
+be used to dodge it: *any future claim that replace and append have been compared must cite
+the trace, not the latency metric.* A budget an instrument cannot resolve is a budget that
+will be reported as met no matter what happens to the code.
 
 Both runs also report `grid_instance_reconstructed: 0`, which is the clause the replace
 budget actually rests on — §11 asks for "no grid reconstruction", and that is a 0/1 fact
@@ -90,7 +131,8 @@ rather than a timing.
 
 ### The heap figure measures the page, not the grid
 
-§11 budgets **grid-attributable** heap. `resident-cap-memory.spec.ts` cannot isolate the
+§11 budgets **grid-attributable** heap. `apps/bench/tests/resident-cap-memory.spec.ts` (in
+pretable, like the other client lanes) cannot isolate the
 grid: its baseline is `about:blank`, so the 10.90 MB difference is the whole bench page —
 app bundle, React, the generated 2 000-row scenario dataset, and the grid.
 
@@ -110,7 +152,8 @@ ceiling, not a per-row instrument, and it should not be cited as evidence about 
 2. A poll-tick CPU measurement. No task in this plan produces one.
 3. A real §11 end-to-end p95. The e2e bound is a single sample at a deliberately loose
    ceiling, and `timeToFulfilled` measures the Playwright driver along with the page.
-4. The §11 append-row correction described above.
+4. CI wiring for any of it — see "No verdict here is defended by CI" above. Every "Met"
+   in the table is a one-shot local measurement that no workflow re-checks.
 5. The recorded VoiceOver pass (plan Task 14). It needs a human with a screen reader and
    was deliberately not fabricated; `docs/superpowers/notes/2026-08-10-voiceover-walkthrough.md`
    holds the protocol, not results.

--- a/docs/superpowers/notes/2026-08-10-voiceover-walkthrough.md
+++ b/docs/superpowers/notes/2026-08-10-voiceover-walkthrough.md
@@ -1,0 +1,122 @@
+# VoiceOver walkthrough — Inspector browse, D1 lifecycle states
+
+> **STATUS: NOT RUN.** The nine stops below have no verbatim column because no screen
+> reader was driven over them. An agent cannot hear speech, and enabling VoiceOver is a
+> system accessibility setting it must not change. This file is the *prepared protocol*
+> plus a DOM pre-check that corrects two stops of the original script; it is **not**
+> evidence that the pass happened. Do not cite it as the design's "one real screen-reader
+> pass" until the verbatim column is filled in by a human.
+
+## Environment
+
+| Field | Value |
+| --- | --- |
+| macOS | 26.5 (build 25F71) |
+| Safari | 26.5 |
+| Commit under test | `0d4a23331c439aaf56731f01c4a8657c5fbd21c3` |
+| Worktree | `/Users/blove/repos/dawn/.worktrees/inspector-verification` |
+| Fixture | `BROWSE_SEED_COUNT = 1250`, `BROWSE_PAGE_SIZE = 200`, `BROWSE_RESIDENT_CAP = 1000` |
+| Protocol prepared | 2026-08-11 |
+| Pass performed | — |
+
+## Boot (verified)
+
+```
+cd /Users/blove/repos/dawn/.worktrees/inspector-verification
+pnpm turbo run build --filter=@dawn-ai/inspector...
+INSPECTOR_E2E_PORT=3919 node packages/inspector/e2e/serve.ts
+```
+
+Both steps ran clean on the commit above; `/healthz` answered `{"status":"ready"}` within a
+second and `/api/memory/stats` reported `total: 1250`. Open `http://127.0.0.1:3919/memory`
+in Safari.
+
+Keep the Safari window **frontmost** for the whole pass. `usePolling` skips every tick while
+`document.visibilityState === "hidden"`, which is deliberate — but it means a backgrounded
+window leaves the facet rail showing `all —` with no namespaces, and stop 5's silence would
+be vacuous rather than earned.
+
+## The nine stops
+
+| Stop | What VoiceOver said (verbatim) | Verdict | Follow-up |
+| --- | --- | --- | --- |
+| 1. Enter the grid (`VO+Shift+Down`) | | NOT RUN | script corrected — see C1 |
+| 2. `VO+Right` across a row, then `VO+Down` | | NOT RUN | script corrected — see C2 |
+| 3. Tab to the status funnel, open it, check `active` | | NOT RUN | |
+| 4. Utterance while the filter is in flight (throttle the network) | | NOT RUN | |
+| 5. Ten seconds on the settled grid with `live` on | | NOT RUN | |
+| 6. Load-more control: its label, then activate it | | NOT RUN | |
+| 7. Tab past the load-more control | | NOT RUN | |
+| 8. Stop the server, wait for the poll to fail | | NOT RUN | |
+| 9. Restart, find and activate retry by keyboard | | NOT RUN | |
+
+A stop that fails gets an issue reference here, not a softened verdict.
+
+## Script corrections
+
+Two stops of the original script contradict the shipped, test-pinned behavior. A human
+following them as written would record two failures against correct code.
+
+### C1 — stop 1 expects "1251 rows"; the landing view publishes 204
+
+The unscoped landing view is **grouped** (`list-page.tsx`:
+`groupByNamespace={namespace === undefined}`), and design §4.5 downgrades `aria-rowcount`
+to the loaded model whenever grouping is on. Measured on the running fixture:
+`aria-rowcount="204"` — 200 records + 3 namespace group headers + 1 header row. The
+population 1,250 is spoken by the **status bar**, not by the grid.
+
+`1251` corresponds to no reachable state: it would require an unscoped grid that was also
+ungrouped, and unscoped implies grouped here.
+
+Corrected expectation for stop 1: the grid's label ("Memories"), a row count of the loaded
+model (204 on a pristine fixture), and the first cell's position. The 1,250 arrives
+separately, from the polite status region: `200 loaded of 1,250 matching.`
+
+### C2 — stop 2 forbids the very thing §4.5 requires
+
+The script says positions must read "row 3 of 1251" and "never row 3 of 200". On the
+landing view the correct utterance *is* out of the loaded model — "row 3 of 204" — because
+of the same grouping downgrade. As written the stop would flag conformant behavior.
+
+Corrected expectation: on the landing view, positions out of the loaded model. To exercise
+the global-position claim the stop is actually reaching for, first scope to a namespace
+facet (`route=/notes`, 667 records) — ungrouped, so `aria-rowcount` becomes 668 and
+positions are global. `a11y-counts.spec.ts` pins both halves; both were green on this
+commit in this worktree:
+
+```
+  ✓  1 e2e/a11y-counts.spec.ts:194:3 › ARIA counts and positions › an exact total publishes the POPULATION, and positions are global (3.7s)
+  ✓  2 e2e/a11y-counts.spec.ts:234:3 › ARIA counts and positions › GROUPING downgrades the rowcount to the loaded model (409ms)
+  7 passed (14.8s)
+```
+
+## DOM pre-check — what the stops should produce
+
+Read off the running fixture (landing view) or off source. This is what the attributes
+promise; whether they *become a usable sentence* is exactly what the VoiceOver pass decides,
+and this table cannot answer it.
+
+| Stop | Source of the utterance | Value |
+| --- | --- | --- |
+| 1 | grid `aria-label` / `aria-rowcount` / `aria-colcount` | `Memories` / `204` / `7` |
+| 1 | first three rows | row 1 header; row 2 group `▾ route=/chat (53 loaded)` at `aria-level="1"`; row 3 first record at `aria-level="2"` |
+| 3 | funnel buttons | `Filter status`, `Filter content`, `Filter kind`, `Filter confidence`, `Filter updated` |
+| 3, 6 | polite region (`role="status"`, `aria-atomic="true"`) | `200 loaded of 1,250 matching.` |
+| 4 | `memory-grid.tsx` `staleAnnouncement` | `Updating results…` |
+| 5 | — | no periodic writer to the live region; silence is the assertion |
+| 6 | load-more label | `Load more — 200 of 1,250 loaded` |
+| 6 | append announcement | `Loaded 200 more. 400 loaded of 1,250 matching.` |
+| 6 | at the end of the set | `End of the N loaded memories, of 1,250 matching.` |
+| 8, 9 | error banner (`role="alert"`) and its control | banner text, then a `Retry` button *outside* the atomic region |
+| all | grid `aria-busy` | absent in every phase |
+
+`aria-busy`'s absence and the four `aria-rowcount` downgrade branches are covered by
+`a11y-counts.spec.ts`; the single-channel announcement rules by `a11y-announcements.spec.ts`;
+focus continuity by `a11y-focus.spec.ts`. VoiceOver is the only thing that can decide
+whether those attributes read as English, which is why this file exists and why it is
+still empty.
+
+## What remains
+
+Stop 2 of the plan's Task 14 — the pass itself — with the corrected stops 1 and 2. One
+human, one Safari window, `Cmd+F5`, nine stops, verbatim into the table above.

--- a/packages/inspector/e2e/00-smoke.spec.ts
+++ b/packages/inspector/e2e/00-smoke.spec.ts
@@ -6,7 +6,7 @@ import {
   seedIdsInDefaultOrder,
 } from "../test/seed"
 import { expect, test } from "./fixtures"
-import { grid, openBrowse, rowIds } from "./helpers"
+import { grid, openBrowse, rowIds, status } from "./helpers"
 
 /** Pretable's group row id, mirrored: `__group__:<columnId>=s:<value>` with `%`, `/`
  *  and `=` percent-escaped (grid-core `makeGroupId`/`escapeGroupKey`). */
@@ -15,10 +15,21 @@ function groupRowId(namespace: string): string {
   return `__group__:namespace=s:${escaped}`
 }
 
-/** Pretable orders group siblings with an `Intl.Collator`, not by byte — the three
- *  seeded namespaces are lowercase ASCII, where the two agree, but mirroring the real
- *  comparator keeps that a fact about the fixture rather than an assumption. */
-const collator = new Intl.Collator()
+/** Pretable orders group siblings with these exact options (grid-core `sortSiblings`),
+ *  ascending unless the active sort targets the grouped column — which the browse
+ *  default, `updatedAt DESC`, does not. Constructed the same way here so this really is
+ *  the shipped comparator, and not a lookalike that happens to agree on three
+ *  lowercase-ASCII namespaces. */
+const collator = new Intl.Collator(undefined, { numeric: true, sensitivity: "base" })
+
+/** A floor on how much of the window the virtualizer has to actually draw. The grid caps
+ *  its viewport height, so only a fraction of the 200 loaded rows is ever in the
+ *  document — but without a floor, `slice(0, ids.length)` lets the value under test
+ *  choose its own coverage, and a regression that collapsed the grid to a single row
+ *  would still satisfy both `toBeVisible` and the order assertion. Well under the ~19
+ *  the capped viewport currently fits, because that count is a rendering detail and this
+ *  is a floor, not a pin. */
+const MIN_RENDERED_ROWS = 15
 
 /**
  * What the browse grid actually renders for the first server window.
@@ -50,17 +61,32 @@ function groupedFirstWindow(): string[] {
 }
 
 test("the standalone server serves the seeded browse dataset", async ({ page, consoleErrors }) => {
+  // Naming the fixture is what subscribes to it; the console-error gate runs in its
+  // teardown, so the unused-looking parameter IS the subscription.
   void consoleErrors
   await openBrowse(page)
   await expect(grid(page)).toBeVisible()
-  const ids = await rowIds(page)
-  expect(ids.length).toBeGreaterThan(0)
-  expect(ids.length).toBeLessThanOrEqual(BROWSE_PAGE_SIZE)
-  // The head of the documented default order as the grid draws it, not an arbitrary
-  // slice: this one assertion is what makes every later "beyond the window" claim mean
-  // something. The slice is by rendered count because the grid virtualizes — only the
-  // rows that fit the viewport are in the document, so this covers the head of the
-  // window and not all BROWSE_PAGE_SIZE of it.
-  expect(ids).toEqual(groupedFirstWindow().slice(0, ids.length))
-  expect(BROWSE_SEED_COUNT).toBe(1250)
+
+  // The window and the population, both read off the page: `loaded` is the page size the
+  // server actually returned and `total` the count it matched over the whole store. The
+  // only claim here that does not depend on how much of the window the grid draws — the
+  // row assertion below sees 18 records of the 200.
+  await expect(status(page)).toHaveText(
+    `${BROWSE_PAGE_SIZE.toLocaleString("en-US")} loaded of ${BROWSE_SEED_COUNT.toLocaleString("en-US")} matching`,
+  )
+
+  // Re-read inside the retry rather than once before it: the rendered set can still
+  // change a frame after the phase reads `idle` (see `rowIds`), and a floor over a single
+  // snapshot would convert that into a flake.
+  await expect(async () => {
+    const ids = await rowIds(page)
+    expect(ids.length).toBeGreaterThanOrEqual(MIN_RENDERED_ROWS)
+    expect(ids.length).toBeLessThanOrEqual(BROWSE_PAGE_SIZE)
+    // The head of the documented default order as the grid DRAWS it, not an arbitrary
+    // slice: this one assertion is what makes every later "beyond the window" claim mean
+    // something. Sliced by rendered count because the grid virtualizes.
+    expect(ids).toEqual(groupedFirstWindow().slice(0, ids.length))
+    // Bounded well under the test timeout: a genuinely wrong window would otherwise
+    // retry for the full 60 s and report as a timeout rather than as a diff.
+  }).toPass({ timeout: 15_000 })
 })

--- a/packages/inspector/e2e/00-smoke.spec.ts
+++ b/packages/inspector/e2e/00-smoke.spec.ts
@@ -1,0 +1,66 @@
+import type { MemoryRecord } from "@dawn-ai/memory"
+import {
+  BROWSE_PAGE_SIZE,
+  BROWSE_SEED_COUNT,
+  browseSeedRecords,
+  seedIdsInDefaultOrder,
+} from "../test/seed"
+import { expect, test } from "./fixtures"
+import { grid, openBrowse, rowIds } from "./helpers"
+
+/** Pretable's group row id, mirrored: `__group__:<columnId>=s:<value>` with `%`, `/`
+ *  and `=` percent-escaped (grid-core `makeGroupId`/`escapeGroupKey`). */
+function groupRowId(namespace: string): string {
+  const escaped = namespace.replace(/%/g, "%25").replace(/\//g, "%2F").replace(/=/g, "%3D")
+  return `__group__:namespace=s:${escaped}`
+}
+
+/** Pretable orders group siblings with an `Intl.Collator`, not by byte — the three
+ *  seeded namespaces are lowercase ASCII, where the two agree, but mirroring the real
+ *  comparator keeps that a fact about the fixture rather than an assumption. */
+const collator = new Intl.Collator()
+
+/**
+ * What the browse grid actually renders for the first server window.
+ *
+ * NOT the flat default order: `list-page` passes `groupByNamespace={namespace ===
+ * undefined}`, so the unscoped browse — which is what `/memory` opens on — groups the
+ * window by namespace. The engine emits one `__group__:` row per namespace, groups
+ * ascending by key, rows inside a group still in the order the server returned them.
+ * So this projection pins BOTH the server's `updatedAt DESC, id ASC` window and the
+ * grouping applied over it; a server that returned a different window, or an id
+ * tie-break that had drifted, moves rows across and within these buckets.
+ */
+function groupedFirstWindow(): string[] {
+  const records: readonly MemoryRecord[] = browseSeedRecords()
+  const namespaceOf = new Map(records.map((record) => [record.id, record.namespace]))
+  const buckets = new Map<string, string[]>()
+  for (const id of seedIdsInDefaultOrder(records).slice(0, BROWSE_PAGE_SIZE)) {
+    const namespace = namespaceOf.get(id) as string
+    const bucket = buckets.get(namespace)
+    if (bucket) bucket.push(id)
+    else buckets.set(namespace, [id])
+  }
+  const out: string[] = []
+  for (const namespace of [...buckets.keys()].sort(collator.compare)) {
+    out.push(groupRowId(namespace))
+    out.push(...(buckets.get(namespace) as string[]))
+  }
+  return out
+}
+
+test("the standalone server serves the seeded browse dataset", async ({ page, consoleErrors }) => {
+  void consoleErrors
+  await openBrowse(page)
+  await expect(grid(page)).toBeVisible()
+  const ids = await rowIds(page)
+  expect(ids.length).toBeGreaterThan(0)
+  expect(ids.length).toBeLessThanOrEqual(BROWSE_PAGE_SIZE)
+  // The head of the documented default order as the grid draws it, not an arbitrary
+  // slice: this one assertion is what makes every later "beyond the window" claim mean
+  // something. The slice is by rendered count because the grid virtualizes — only the
+  // rows that fit the viewport are in the document, so this covers the head of the
+  // window and not all BROWSE_PAGE_SIZE of it.
+  expect(ids).toEqual(groupedFirstWindow().slice(0, ids.length))
+  expect(BROWSE_SEED_COUNT).toBe(1250)
+})

--- a/packages/inspector/e2e/00-smoke.spec.ts
+++ b/packages/inspector/e2e/00-smoke.spec.ts
@@ -6,7 +6,7 @@ import {
   seedIdsInDefaultOrder,
 } from "../test/seed"
 import { expect, test } from "./fixtures"
-import { grid, openBrowse, rowIds, status } from "./helpers"
+import { grid, openBrowse, rowIds, status, statusText } from "./helpers"
 
 /** Pretable's group row id, mirrored: `__group__:<columnId>=s:<value>` with `%`, `/`
  *  and `=` percent-escaped (grid-core `makeGroupId`/`escapeGroupKey`). */
@@ -71,9 +71,7 @@ test("the standalone server serves the seeded browse dataset", async ({ page, co
   // server actually returned and `total` the count it matched over the whole store. The
   // only claim here that does not depend on how much of the window the grid draws — the
   // row assertion below sees 18 records of the 200.
-  await expect(status(page)).toHaveText(
-    `${BROWSE_PAGE_SIZE.toLocaleString("en-US")} loaded of ${BROWSE_SEED_COUNT.toLocaleString("en-US")} matching`,
-  )
+  await expect(status(page)).toHaveText(statusText(BROWSE_PAGE_SIZE, BROWSE_SEED_COUNT))
 
   // Re-read inside the retry rather than once before it: the rendered set can still
   // change a frame after the phase reads `idle` (see `rowIds`), and a floor over a single

--- a/packages/inspector/e2e/01-beyond-window-filter.spec.ts
+++ b/packages/inspector/e2e/01-beyond-window-filter.spec.ts
@@ -1,0 +1,75 @@
+import {
+  BROWSE_PAGE_SIZE,
+  NEEDLE_ID,
+  NEEDLE_TERM,
+  seedIdsInDefaultOrder,
+  seedRecordsMatching,
+} from "../test/seed"
+import { expect, test } from "./fixtures"
+import {
+  applySetFilter,
+  applyTextFilter,
+  asDrawn,
+  clearFilter,
+  expectDrawnRows,
+  openBrowse,
+  rowIds,
+  status,
+  timeToFulfilled,
+  total,
+} from "./helpers"
+
+// D1-GRID-01, D1-QUERY-01..08. A matching record outside the initial window appears
+// after a server-side filter. If filtering were local, none of these could ever match:
+// the record is not in the loaded window when the filter is applied.
+test.describe("scenario 1 — beyond-window filter", () => {
+  test("a content filter finds a record the first window never loaded", async ({
+    page,
+    consoleErrors,
+  }) => {
+    void consoleErrors
+    await openBrowse(page)
+    const before = await rowIds(page)
+    expect(before).not.toContain(NEEDLE_ID)
+    // The claim the test rests on, and it is about the WINDOW rather than about what
+    // the virtualizer drew: `before` proves the needle is not on screen, this proves
+    // the client never received it, so a local filter had nothing to find.
+    expect(seedIdsInDefaultOrder().indexOf(NEEDLE_ID)).toBeGreaterThan(BROWSE_PAGE_SIZE)
+
+    const elapsed = await timeToFulfilled(
+      page,
+      () => applyTextFilter(page, "content", "contains", NEEDLE_TERM),
+      () => expectDrawnRows(page, asDrawn([NEEDLE_ID])),
+    )
+    // One record matches, so this is the whole answer and not a head of it: the loaded
+    // count, the matching total and the rows all describe the same single record.
+    await expect(status(page)).toHaveText("1 loaded of 1 matching")
+    // Design §11: p95 < 300 ms against a local server. One sample is not a p95 — and
+    // this one includes the gesture itself, the funnel's 200 ms debounce included — so
+    // the ceiling is deliberately loose. It catches a regression of KIND (a client
+    // round-trip storm), not of degree; tasks 18 and 21 are where the budget is
+    // measured.
+    expect(elapsed).toBeLessThan(2_000)
+  })
+
+  test("an enum filter narrows to the server's whole matching set, not the window's", async ({
+    page,
+    consoleErrors,
+  }) => {
+    void consoleErrors
+    await openBrowse(page)
+    await applySetFilter(page, "status", ["superseded"])
+    // The matching set, in the documented default order, truncated to one window —
+    // exactly what a server-authoritative first page should be.
+    const matching = seedRecordsMatching({ status: ["superseded"] })
+    await expectDrawnRows(page, asDrawn(seedIdsInDefaultOrder(matching).slice(0, BROWSE_PAGE_SIZE)))
+    // The count that no local filter could produce: the client holds 200 records and
+    // this names a population of the whole store, for the query the rows answer.
+    expect(matching.length).toBeGreaterThan(BROWSE_PAGE_SIZE)
+    await expect(total(page)).toHaveText(matching.length.toLocaleString("en-US"))
+
+    // Clearing restores the unfiltered head — clearing is a new query, not an undo.
+    await clearFilter(page, "status")
+    await expectDrawnRows(page, asDrawn(seedIdsInDefaultOrder().slice(0, BROWSE_PAGE_SIZE)))
+  })
+})

--- a/packages/inspector/e2e/01-beyond-window-filter.spec.ts
+++ b/packages/inspector/e2e/01-beyond-window-filter.spec.ts
@@ -13,7 +13,6 @@ import {
   clearFilter,
   expectDrawnRows,
   openBrowse,
-  rowIds,
   status,
   timeToFulfilled,
   total,
@@ -29,11 +28,15 @@ test.describe("scenario 1 — beyond-window filter", () => {
   }) => {
     void consoleErrors
     await openBrowse(page)
-    const before = await rowIds(page)
-    expect(before).not.toContain(NEEDLE_ID)
-    // The claim the test rests on, and it is about the WINDOW rather than about what
-    // the virtualizer drew: `before` proves the needle is not on screen, this proves
-    // the client never received it, so a local filter had nothing to find.
+    // The pre-filter state, asserted POSITIVELY. A bare `expect(await rowIds(page)).not
+    // .toContain(NEEDLE_ID)` reads as the stronger claim and is the weaker one: taken
+    // before the first paint it answers `[]` and passes without the grid having drawn
+    // anything. Pinning the whole drawn head instead cannot pass vacuously, and says the
+    // same thing about the needle on the way past.
+    await expectDrawnRows(page, asDrawn(seedIdsInDefaultOrder().slice(0, BROWSE_PAGE_SIZE)))
+    // The claim the test rests on, and it is about the WINDOW rather than about what the
+    // virtualizer drew: the client never RECEIVED the needle, so a local filter would
+    // have had nothing to find.
     expect(seedIdsInDefaultOrder().indexOf(NEEDLE_ID)).toBeGreaterThan(BROWSE_PAGE_SIZE)
 
     const elapsed = await timeToFulfilled(
@@ -44,11 +47,12 @@ test.describe("scenario 1 — beyond-window filter", () => {
     // One record matches, so this is the whole answer and not a head of it: the loaded
     // count, the matching total and the rows all describe the same single record.
     await expect(status(page)).toHaveText("1 loaded of 1 matching")
-    // Design §11: p95 < 300 ms against a local server. One sample is not a p95 — and
-    // this one includes the gesture itself, the funnel's 200 ms debounce included — so
-    // the ceiling is deliberately loose. It catches a regression of KIND (a client
-    // round-trip storm), not of degree; tasks 18 and 21 are where the budget is
-    // measured.
+    // Design §11 proposes p95 < 300 ms against a local server. This is not that: one
+    // sample is not a p95, and `timeToFulfilled` measures the driver as well as the page
+    // (its doc lists what rides along). The 200 ms debounce is NOT among the costs — the
+    // menu's unmount cleanup applies the pending draft, so Escape flushes it rather than
+    // waiting it out. The ceiling is deliberately loose: it catches a regression of KIND
+    // (a client round-trip storm), not of degree. Tasks 18 and 21 measure the budget.
     expect(elapsed).toBeLessThan(2_000)
   })
 

--- a/packages/inspector/e2e/02-global-sort.spec.ts
+++ b/packages/inspector/e2e/02-global-sort.spec.ts
@@ -1,0 +1,99 @@
+import {
+  BROWSE_PAGE_SIZE,
+  browseSeedRecords,
+  seedIdsInDefaultOrder,
+  seedIdsSortedBy,
+} from "../test/seed"
+import { expect, test } from "./fixtures"
+import {
+  asDrawn,
+  expectDrawnRows,
+  openBrowse,
+  rowIds,
+  sortByHeader,
+  sortHeader,
+  timeToFulfilled,
+} from "./helpers"
+
+/** Pretable's group rows share the row-id channel with records; a caller that wants the
+ *  records has to drop them. */
+function recordsOnly(ids: readonly string[]): string[] {
+  return ids.filter((id) => !id.startsWith("__group__:"))
+}
+
+// D1-QUERY-09, D1-QUERY-10. Sorting returns the GLOBALLY correct first window with a
+// deterministic tie-break — not a re-sort of the 200 rows already loaded, which would
+// present a recency-biased sample as a confidence-sorted result.
+test.describe("scenario 2 — global sort", () => {
+  test("confidence DESC returns the global head with an id tie-break", async ({
+    page,
+    consoleErrors,
+  }) => {
+    void consoleErrors
+    await openBrowse(page)
+
+    // The whole store in confidence order, truncated to one window. Computed over all
+    // 1250 records, which is what makes it a claim about the SERVER's answer.
+    const expected = asDrawn(
+      seedIdsSortedBy([{ field: "confidence", dir: "desc" }]).slice(0, BROWSE_PAGE_SIZE),
+    )
+    // What a LOCAL re-sort of the window already on screen would have drawn. Pinned so
+    // the assertion below cannot be satisfied under either authority: if the two agreed
+    // at the top, this scenario would prove nothing, and it would say so here rather
+    // than pass quietly.
+    const firstWindow = new Set(seedIdsInDefaultOrder().slice(0, BROWSE_PAGE_SIZE))
+    const localReSort = asDrawn(
+      seedIdsSortedBy(
+        [{ field: "confidence", dir: "desc" }],
+        browseSeedRecords().filter((record) => firstWindow.has(record.id)),
+      ),
+    )
+    expect(recordsOnly(localReSort)[0]).not.toEqual(recordsOnly(expected)[0])
+
+    // One click, because pretable's cycle is none → desc → asc → none.
+    const elapsed = await timeToFulfilled(
+      page,
+      () => sortByHeader(page, "confidence"),
+      () => expectDrawnRows(page, expected),
+    )
+    // Read back rather than assumed: an assertion about a descending window means
+    // nothing if the click actually produced an ascending one.
+    await expect(sortHeader(page, "confidence")).toHaveAttribute("aria-sort", "descending")
+    expect(elapsed).toBeLessThan(2_000)
+
+    // The proof taken off the PAGE rather than off the fixture: the top record the grid
+    // shows carries the store's maximum confidence, which the window the client held
+    // before the click did not have at that position.
+    const records = new Map(browseSeedRecords().map((record) => [record.id, record]))
+    const topDrawn = recordsOnly(await rowIds(page))[0] as string
+    expect(records.get(topDrawn)?.confidence).toBe(0.98)
+  })
+
+  test("updated ASC returns the global tail, with the id tie-break still ascending", async ({
+    page,
+    consoleErrors,
+  }) => {
+    void consoleErrors
+    await openBrowse(page)
+
+    const ascendingWindow = seedIdsSortedBy([{ field: "updatedAt", dir: "asc" }]).slice(
+      0,
+      BROWSE_PAGE_SIZE,
+    )
+    // Ascending is NOT the default order played backwards, and this pins the
+    // difference: ten records share every `updatedAt`, and the store terminates on
+    // `id ASC` whichever way the key runs. A server that reversed its terminator along
+    // with its key would return the reversed list — same records, different order —
+    // and would satisfy any assertion that only checked WHICH records are in the
+    // window.
+    expect(ascendingWindow).not.toEqual(
+      [...seedIdsInDefaultOrder()].reverse().slice(0, BROWSE_PAGE_SIZE),
+    )
+
+    // Twice: the first click is descending.
+    await sortByHeader(page, "updated")
+    await sortByHeader(page, "updated")
+    await expect(sortHeader(page, "updated")).toHaveAttribute("aria-sort", "ascending")
+    await expectDrawnRows(page, asDrawn(ascendingWindow))
+  })
+})

--- a/packages/inspector/e2e/02-global-sort.spec.ts
+++ b/packages/inspector/e2e/02-global-sort.spec.ts
@@ -9,17 +9,12 @@ import {
   asDrawn,
   expectDrawnRows,
   openBrowse,
-  rowIds,
+  recordCells,
+  recordsOnly,
   sortByHeader,
   sortHeader,
   timeToFulfilled,
 } from "./helpers"
-
-/** Pretable's group rows share the row-id channel with records; a caller that wants the
- *  records has to drop them. */
-function recordsOnly(ids: readonly string[]): string[] {
-  return ids.filter((id) => !id.startsWith("__group__:"))
-}
 
 // D1-QUERY-09, D1-QUERY-10. Sorting returns the GLOBALLY correct first window with a
 // deterministic tie-break — not a re-sort of the 200 rows already loaded, which would
@@ -59,14 +54,25 @@ test.describe("scenario 2 — global sort", () => {
     // Read back rather than assumed: an assertion about a descending window means
     // nothing if the click actually produced an ascending one.
     await expect(sortHeader(page, "confidence")).toHaveAttribute("aria-sort", "descending")
+    // A ceiling of KIND, not of degree — `timeToFulfilled`'s doc lists what the number
+    // carries besides the page, and 01 states the §11 position this shares.
     expect(elapsed).toBeLessThan(2_000)
 
-    // The proof taken off the PAGE rather than off the fixture: the top record the grid
-    // shows carries the store's maximum confidence, which the window the client held
-    // before the click did not have at that position.
-    const records = new Map(browseSeedRecords().map((record) => [record.id, record]))
-    const topDrawn = recordsOnly(await rowIds(page))[0] as string
-    expect(records.get(topDrawn)?.confidence).toBe(0.98)
+    // Computed, never transcribed (`seed.ts`'s convention): `0.98` is the store's
+    // maximum only for as long as the seed says so.
+    const maxConfidence = Math.max(...browseSeedRecords().map((record) => record.confidence))
+    // A guard on the scenario's own premise, not a claim about the product. Under
+    // grouping the TOP DRAWN row is the head of the alphabetically-first namespace
+    // bucket, so its carrying the store's maximum is a property of this seed rather than
+    // of the query — pinned here so a seed change reddens with that sentence instead of
+    // reddening the page assertion below with a bare value diff.
+    const byId = new Map(browseSeedRecords().map((record) => [record.id, record.confidence]))
+    expect(byId.get(recordsOnly(expected)[0] ?? "")).toBe(maxConfidence)
+
+    // Taken off the PAGE, and the one thing the id list above cannot show: the cells the
+    // user actually reads carry the values those ids have, through the column's own
+    // `toFixed(2)` format. Auto-retried by `toHaveText`, so it settles rather than races.
+    await expect(recordCells(page, "confidence").first()).toHaveText(maxConfidence.toFixed(2))
   })
 
   test("updated ASC returns the global tail, with the id tie-break still ascending", async ({
@@ -90,8 +96,15 @@ test.describe("scenario 2 — global sort", () => {
       [...seedIdsInDefaultOrder()].reverse().slice(0, BROWSE_PAGE_SIZE),
     )
 
-    // Twice: the first click is descending.
+    // Twice, with the intermediate state pinned rather than passed through: the first
+    // click is descending. There is nothing in the ROWS to settle on between the two —
+    // `updatedAt DESC` is already the default order, so the descending window is the one
+    // on screen — which means the second click does land while the first sort's request
+    // may still be in flight. That path is real and this test does cover it; the
+    // assertion at the end is on the FULFILLED ascending window, so a stale answer
+    // winning the race fails here rather than passing quietly.
     await sortByHeader(page, "updated")
+    await expect(sortHeader(page, "updated")).toHaveAttribute("aria-sort", "descending")
     await sortByHeader(page, "updated")
     await expect(sortHeader(page, "updated")).toHaveAttribute("aria-sort", "ascending")
     await expectDrawnRows(page, asDrawn(ascendingWindow))

--- a/packages/inspector/e2e/03-multi-filter-parity.spec.ts
+++ b/packages/inspector/e2e/03-multi-filter-parity.spec.ts
@@ -1,0 +1,49 @@
+import { BROWSE_PAGE_SIZE, seedIdsInDefaultOrder, seedRecordsMatching } from "../test/seed"
+import { expect, test } from "./fixtures"
+import {
+  applySetFilter,
+  applyTextFilter,
+  asDrawn,
+  expectDrawnRows,
+  openBrowse,
+  total,
+} from "./helpers"
+
+// D1-QUERY-02..07, D1-QUERY-13. Composed filters return one ordered id list.
+//
+// SCOPE, stated honestly: the Inspector runs SQLite only, so this spec proves the
+// composed query against the fixture's own pure expectation. Cross-backend parity
+// (identical ordered ids on SQLite and Postgres) is proven by the shared conformance
+// suite, not here — Task 9 adds the composed-filter case there.
+test.describe("scenario 3 — multi-filter parity", () => {
+  test("status + kind + content compose into one ordered window", async ({
+    page,
+    consoleErrors,
+  }) => {
+    void consoleErrors
+    await openBrowse(page)
+    await applySetFilter(page, "status", ["candidate", "active"])
+    await applySetFilter(page, "kind", ["semantic"])
+    await applyTextFilter(page, "content", "contains", "threshold 1")
+
+    const matching = seedRecordsMatching({
+      status: ["candidate", "active"],
+      kind: ["semantic"],
+      contentContains: "threshold 1",
+    })
+    // Every clause has to bite, or "composed" would be proven by whichever predicate
+    // happened to be narrowest. Pinned rather than assumed: a seed change that made two
+    // of these redundant would leave the scenario passing while testing one filter.
+    expect(matching.length).toBeGreaterThan(0)
+    for (const looser of [
+      seedRecordsMatching({ status: ["candidate", "active"] }),
+      seedRecordsMatching({ kind: ["semantic"] }),
+      seedRecordsMatching({ contentContains: "threshold 1" }),
+    ]) {
+      expect(matching.length).toBeLessThan(looser.length)
+    }
+
+    await expectDrawnRows(page, asDrawn(seedIdsInDefaultOrder(matching).slice(0, BROWSE_PAGE_SIZE)))
+    await expect(total(page)).toHaveText(matching.length.toLocaleString("en-US"))
+  })
+})

--- a/packages/inspector/e2e/04-exact-namespace.spec.ts
+++ b/packages/inspector/e2e/04-exact-namespace.spec.ts
@@ -1,0 +1,73 @@
+import {
+  BROWSE_PAGE_SIZE,
+  browseSeedRecords,
+  seedIdsInDefaultOrder,
+  seedRecordsMatching,
+} from "../test/seed"
+import { expect, test } from "./fixtures"
+import { expectDrawnRows, grid, openBrowse, rowIds, status } from "./helpers"
+
+/** The facet under test and the prefix sibling it must not sweep in. The seed exists to
+ *  bait exactly this trap (`seed.ts`'s `namespaceFor`). */
+const NAMESPACE = "route=/notes"
+const SIBLING = "route=/notes-archive"
+
+// D1-QUERY-08, D1-COUNT-01. The facet rail sends an EXACT namespace, so prefix
+// siblings are excluded server-side — and the total it displays counts the same set
+// the rows come from.
+test.describe("scenario 4 — exact namespace", () => {
+  test("selecting route=/notes excludes route=/notes-archive and its total matches", async ({
+    page,
+    consoleErrors,
+  }) => {
+    void consoleErrors
+    await openBrowse(page)
+
+    const matching = seedRecordsMatching({ namespace: NAMESPACE })
+    const archiveIds = new Set(seedRecordsMatching({ namespace: SIBLING }).map((r) => r.id))
+    // The trap has to be BAITED, and baited WHERE THE TEST LOOKS. A non-empty archive is
+    // not enough on its own: the assertions below read one window, so a prefix query
+    // whose first window happened to be archive-free would satisfy them. This pins that
+    // the prefix answer differs inside the very window the grid draws.
+    expect(archiveIds.size).toBeGreaterThan(0)
+    const prefixWindow = seedIdsInDefaultOrder(
+      seedRecordsMatching({ namespacePrefix: NAMESPACE }),
+    ).slice(0, BROWSE_PAGE_SIZE)
+    expect(prefixWindow.some((id) => archiveIds.has(id))).toBe(true)
+
+    // The rail labels each facet `<namespace> <count>`, so the accessible name carries
+    // both. The count is COMPUTED here rather than transcribed, which makes this click
+    // also pin the claim the rail's own note makes: `stats.byNamespace` is a bare
+    // `GROUP BY` over the whole table, so the number beside a facet is the global
+    // census and not the current query's.
+    //
+    // `exact`, because `route=/notes` is a PREFIX of the sibling's label: substring
+    // matching resolves to both buttons and fails on strict mode.
+    await page.getByRole("button", { name: `${NAMESPACE} ${matching.length}`, exact: true }).click()
+
+    // FLAT, not `asDrawn`: `list-page` passes `groupByNamespace={namespace === undefined}`,
+    // so selecting a facet turns grouping off — every row would otherwise sit under a
+    // single header restating the facet. An `asDrawn` expectation here would assert a
+    // group row the grid is correct not to draw.
+    await expectDrawnRows(page, seedIdsInDefaultOrder(matching).slice(0, BROWSE_PAGE_SIZE))
+
+    // The exclusion in its own words rather than left implied by the list above. Safe as
+    // a negative only because `expectDrawnRows` has already settled a POSITIVE claim
+    // about this same read — taken alone, before the first paint, it would pass against
+    // an empty grid.
+    expect((await rowIds(page)).filter((id) => archiveIds.has(id))).toEqual([])
+
+    // D1-COUNT-01: the total belongs to the same query as the rows. Both numbers, so a
+    // total quoted for the unfiltered store — or for a prefix match — reddens here.
+    await expect(status(page)).toHaveText(
+      `${Math.min(BROWSE_PAGE_SIZE, matching.length).toLocaleString("en-US")} loaded of ${matching.length.toLocaleString("en-US")} matching`,
+    )
+    expect(matching.length).toBeLessThan(browseSeedRecords().length)
+
+    // Design §4.5: `aria-rowcount = total + 1` holds under full external authority, an
+    // exact total and NO grouping — which is this view and not the unscoped one. It is
+    // the only channel through which a screen-reader user learns the population while
+    // the client holds one window, and scenario 5 pins the grouped downgrade.
+    await expect(grid(page)).toHaveAttribute("aria-rowcount", String(matching.length + 1))
+  })
+})

--- a/packages/inspector/e2e/04-exact-namespace.spec.ts
+++ b/packages/inspector/e2e/04-exact-namespace.spec.ts
@@ -5,7 +5,7 @@ import {
   seedRecordsMatching,
 } from "../test/seed"
 import { expect, test } from "./fixtures"
-import { expectDrawnRows, grid, openBrowse, rowIds, status } from "./helpers"
+import { expectDrawnRows, grid, openBrowse, rowIds, status, statusText } from "./helpers"
 
 /** The facet under test and the prefix sibling it must not sweep in. The seed exists to
  *  bait exactly this trap (`seed.ts`'s `namespaceFor`). */
@@ -60,7 +60,7 @@ test.describe("scenario 4 — exact namespace", () => {
     // D1-COUNT-01: the total belongs to the same query as the rows. Both numbers, so a
     // total quoted for the unfiltered store — or for a prefix match — reddens here.
     await expect(status(page)).toHaveText(
-      `${Math.min(BROWSE_PAGE_SIZE, matching.length).toLocaleString("en-US")} loaded of ${matching.length.toLocaleString("en-US")} matching`,
+      statusText(Math.min(BROWSE_PAGE_SIZE, matching.length), matching.length),
     )
     expect(matching.length).toBeLessThan(browseSeedRecords().length)
 

--- a/packages/inspector/e2e/05-honest-partial-result.spec.ts
+++ b/packages/inspector/e2e/05-honest-partial-result.spec.ts
@@ -13,25 +13,13 @@ import {
   grid,
   liveRegionText,
   loadMore,
+  n,
   openBrowse,
   scrollGridTo,
   scrollTop,
   status,
+  statusText,
 } from "./helpers"
-
-/** The page formats every count through `toLocaleString`/`Intl.NumberFormat`, and
- *  `playwright.config` pins the runner to `en-US` for exactly this reason. Expectations
- *  go through the same formatter rather than through `String(n)`, which would look right
- *  and never match a four-digit count. */
-function n(value: number): string {
-  return value.toLocaleString("en-US")
-}
-
-/** `BrowseStatusBar`'s whole sentence — the two numbers this scenario is about, in the
- *  one place a sighted user reads them. */
-function statusText(loaded: number, matching: number): string {
-  return `${n(loaded)} loaded of ${n(matching)} matching`
-}
 
 // D1-GRID-06, D1-DATA-07, D1-COUNT-01. The UI distinguishes LOADED records from
 // MATCHING records and can retrieve another window without losing what it holds.

--- a/packages/inspector/e2e/05-honest-partial-result.spec.ts
+++ b/packages/inspector/e2e/05-honest-partial-result.spec.ts
@@ -8,11 +8,13 @@ import { expect, test } from "./fixtures"
 import {
   asDrawn,
   expectDrawnRows,
+  expectDrawnRunAround,
   expectPhase,
   grid,
   liveRegionText,
   loadMore,
   openBrowse,
+  scrollGridTo,
   scrollTop,
   status,
 } from "./helpers"
@@ -31,17 +33,9 @@ function statusText(loaded: number, matching: number): string {
   return `${n(loaded)} loaded of ${n(matching)} matching`
 }
 
-async function scrollGridTo(page: Parameters<typeof grid>[0], offset: number): Promise<void> {
-  await grid(page).evaluate((node, top) => {
-    node.scrollTop = top
-  }, offset)
-}
-
 // D1-GRID-06, D1-DATA-07, D1-COUNT-01. The UI distinguishes LOADED records from
 // MATCHING records and can retrieve another window without losing what it holds.
 test.describe("scenario 5 — honest partial result", () => {
-  test.setTimeout(90_000)
-
   test("loaded count and matching total are separately stated, and load-more appends", async ({
     page,
     consoleErrors,
@@ -79,6 +73,11 @@ test.describe("scenario 5 — honest partial result", () => {
     await expect(status(page)).toHaveText(statusText(BROWSE_PAGE_SIZE * 2, BROWSE_SEED_COUNT))
     await expectPhase(page, "idle")
     // Design §11: an append moves nothing, because the rows arrive BELOW the viewport.
+    //
+    // A single unretried snapshot, which the settling note on `rowIds` says is normally
+    // a race. Safe HERE for a reason that does not generalise: an append only grows
+    // `scrollHeight`, and the browser re-clamps `scrollTop` only when it shrinks. A
+    // scenario that asserts this shape after a REPLACE has to poll instead.
     expect(await scrollTop(page)).toBe(offsetBefore)
     // The announcement carries the DELTA and the SCOPE, not a bare number — asserted as
     // the whole sentence, since "400" alone appears in any count-shaped message.
@@ -90,16 +89,51 @@ test.describe("scenario 5 — honest partial result", () => {
         `Loaded ${n(BROWSE_PAGE_SIZE)} more. ${statusText(BROWSE_PAGE_SIZE * 2, BROWSE_SEED_COUNT)}.`,
       )
 
-    // What it HOLDS, not just what it counted: the extended window is the same order
-    // continued, so the head is unchanged and the second page follows the first. Read
-    // back at the top because the grid virtualizes — the rows this compares are only in
-    // the document while the viewport is over them.
+    // What it HOLDS, not just what it counted. Three reads, because the count channels
+    // above are all one channel: a page that incremented its own counter and dropped the
+    // records satisfies every assertion so far.
+    const both = asDrawn(order.slice(0, BROWSE_PAGE_SIZE * 2))
+
+    // The rows reached the GRID's model rather than only the page's chrome. Under
+    // grouping `aria-rowcount` IS the loaded model's size (the downgrade pinned above),
+    // so this is an independent witness to the same append and the only one that is not
+    // a number the status bar computed.
+    await expect(grid(page)).toHaveAttribute("aria-rowcount", String(both.length + 1))
+
+    // The head is UNCHANGED — an append, not a replace. This is all a read at the top
+    // can settle: the viewport draws ~19 rows and the one-window and two-window
+    // projections share a 54-row prefix, so it passes against either.
     await scrollGridTo(page, 0)
-    await expectDrawnRows(page, asDrawn(order.slice(0, BROWSE_PAGE_SIZE * 2)))
+    await expectDrawnRows(page, both)
+
+    // …and the second window CONTINUES the first, which is only testable AT THE SEAM.
+    // The seam is not at row 200: grouping files each arriving record under its own
+    // namespace, so window 2's rows land at the END OF THEIR GROUP and the first of them
+    // sits inside the first group. Taking it as "the first drawn row the append
+    // contributed" finds that position from the projection instead of naming a row.
+    //
+    // What this settles, exactly: the second window's RECORDS are resident, in the
+    // server's order. Residency is attributable to the click — the background refresh
+    // asks for a limit of the RESIDENT COUNT (`refreshWindow`), so a poll can re-anchor
+    // rows it already has but can never fetch a window the client did not page into.
+    // ORDER is attributable only for ~2 s: a refresh places its response wholesale at
+    // the front, so an append that put the right records in the wrong place is corrected
+    // by the next tick and is out of this scenario's reach. Pinning that needs the poll
+    // suppressed, which is scenario 7's apparatus, not this one's.
+    const appended = new Set(order.slice(BROWSE_PAGE_SIZE, BROWSE_PAGE_SIZE * 2))
+    const seam = both.find((id) => appended.has(id))
+    if (seam === undefined) throw new Error("the seed's second window contributes no drawn row")
+    await expectDrawnRunAround(page, both, seam)
   })
 
   test("load-more stops at the resident cap and says why", async ({ page, consoleErrors }) => {
     void consoleErrors
+    // Four sequential round-trips to the store, each gated on its own `expect` — so the
+    // worst case this test can legitimately reach is four times the 10 s expect budget
+    // plus the page load, which is over the file's 60 s default. Raised on THIS test
+    // only: the append test above makes one round-trip and gains nothing from a longer
+    // budget except a slower report when it genuinely hangs.
+    test.setTimeout(90_000)
     await openBrowse(page)
 
     // Progress is measured off the STATUS BAR, never off the DOM: the grid virtualizes,

--- a/packages/inspector/e2e/05-honest-partial-result.spec.ts
+++ b/packages/inspector/e2e/05-honest-partial-result.spec.ts
@@ -1,0 +1,146 @@
+import {
+  BROWSE_PAGE_SIZE,
+  BROWSE_RESIDENT_CAP,
+  BROWSE_SEED_COUNT,
+  seedIdsInDefaultOrder,
+} from "../test/seed"
+import { expect, test } from "./fixtures"
+import {
+  asDrawn,
+  expectDrawnRows,
+  expectPhase,
+  grid,
+  liveRegionText,
+  loadMore,
+  openBrowse,
+  scrollTop,
+  status,
+} from "./helpers"
+
+/** The page formats every count through `toLocaleString`/`Intl.NumberFormat`, and
+ *  `playwright.config` pins the runner to `en-US` for exactly this reason. Expectations
+ *  go through the same formatter rather than through `String(n)`, which would look right
+ *  and never match a four-digit count. */
+function n(value: number): string {
+  return value.toLocaleString("en-US")
+}
+
+/** `BrowseStatusBar`'s whole sentence — the two numbers this scenario is about, in the
+ *  one place a sighted user reads them. */
+function statusText(loaded: number, matching: number): string {
+  return `${n(loaded)} loaded of ${n(matching)} matching`
+}
+
+async function scrollGridTo(page: Parameters<typeof grid>[0], offset: number): Promise<void> {
+  await grid(page).evaluate((node, top) => {
+    node.scrollTop = top
+  }, offset)
+}
+
+// D1-GRID-06, D1-DATA-07, D1-COUNT-01. The UI distinguishes LOADED records from
+// MATCHING records and can retrieve another window without losing what it holds.
+test.describe("scenario 5 — honest partial result", () => {
+  test.setTimeout(90_000)
+
+  test("loaded count and matching total are separately stated, and load-more appends", async ({
+    page,
+    consoleErrors,
+  }) => {
+    void consoleErrors
+    await openBrowse(page)
+
+    const order = seedIdsInDefaultOrder()
+    const firstWindow = asDrawn(order.slice(0, BROWSE_PAGE_SIZE))
+    await expectDrawnRows(page, firstWindow)
+
+    // Both numbers, in one sentence, and demonstrably different: what the client HOLDS
+    // and what the store MATCHES. A UI that quoted only one of them satisfies neither
+    // half of this.
+    expect(BROWSE_PAGE_SIZE).toBeLessThan(BROWSE_SEED_COUNT)
+    await expect(status(page)).toHaveText(statusText(BROWSE_PAGE_SIZE, BROWSE_SEED_COUNT))
+
+    // Design §4.5: grouping destroys the loaded-index → dataset-position mapping, so
+    // `aria-rowcount` REVERTS to the loaded model — group headers included — and the
+    // population honesty moves to the status chrome asserted above. The unscoped browse
+    // groups by namespace, so the downgraded value is the correct one here, and it is
+    // pinned rather than skipped: publishing the population under grouping would be the
+    // dishonest answer. Scenario 4, where the facet turns grouping off, is where
+    // `total + 1` is claimed.
+    await expect(grid(page)).toHaveAttribute("aria-rowcount", String(firstWindow.length + 1))
+
+    // Scrolled off the top BEFORE the append. Taken at rest the offset is 0, and an
+    // append that reset the scroll box to 0 would satisfy a before/after comparison of
+    // two zeroes while having moved the user's place.
+    await scrollGridTo(page, 400)
+    await expect.poll(() => scrollTop(page)).toBeGreaterThan(0)
+    const offsetBefore = await scrollTop(page)
+
+    await loadMore(page).click()
+    await expect(status(page)).toHaveText(statusText(BROWSE_PAGE_SIZE * 2, BROWSE_SEED_COUNT))
+    await expectPhase(page, "idle")
+    // Design §11: an append moves nothing, because the rows arrive BELOW the viewport.
+    expect(await scrollTop(page)).toBe(offsetBefore)
+    // The announcement carries the DELTA and the SCOPE, not a bare number — asserted as
+    // the whole sentence, since "400" alone appears in any count-shaped message.
+    // `toContain` rather than an equality: the region is one permanent node and its
+    // lifecycle slot is not the only thing that can ever be in it.
+    await expect
+      .poll(() => liveRegionText(page))
+      .toContain(
+        `Loaded ${n(BROWSE_PAGE_SIZE)} more. ${statusText(BROWSE_PAGE_SIZE * 2, BROWSE_SEED_COUNT)}.`,
+      )
+
+    // What it HOLDS, not just what it counted: the extended window is the same order
+    // continued, so the head is unchanged and the second page follows the first. Read
+    // back at the top because the grid virtualizes — the rows this compares are only in
+    // the document while the viewport is over them.
+    await scrollGridTo(page, 0)
+    await expectDrawnRows(page, asDrawn(order.slice(0, BROWSE_PAGE_SIZE * 2)))
+  })
+
+  test("load-more stops at the resident cap and says why", async ({ page, consoleErrors }) => {
+    void consoleErrors
+    await openBrowse(page)
+
+    // Progress is measured off the STATUS BAR, never off the DOM: the grid virtualizes,
+    // so at no point are a thousand rows in the document and a row-count assertion would
+    // be counting the viewport. The loaded count is exactly what this chrome states.
+    for (let loaded = BROWSE_PAGE_SIZE; loaded < BROWSE_RESIDENT_CAP; loaded += BROWSE_PAGE_SIZE) {
+      await loadMore(page).click()
+      await expect(status(page)).toHaveText(
+        statusText(loaded + BROWSE_PAGE_SIZE, BROWSE_SEED_COUNT),
+      )
+    }
+    // The cap is a stop, not a slowdown: it lands ON the cap rather than past it, and
+    // the store still has records the client can never hold at once.
+    await expect(status(page)).toHaveText(statusText(BROWSE_RESIDENT_CAP, BROWSE_SEED_COUNT))
+    expect(BROWSE_RESIDENT_CAP).toBeLessThan(BROWSE_SEED_COUNT)
+
+    // The control STAYS MOUNTED at the cap and is inactive. `toBeDisabled` is satisfied
+    // here through `aria-disabled` — the button is deliberately never natively
+    // `disabled`, which is the next assertion's subject.
+    await expect(loadMore(page)).toBeVisible()
+    await expect(loadMore(page)).toBeDisabled()
+    // Design §9.2: a native `disabled` removes the control from the tab order and drops
+    // keyboard focus to `<body>` at the exact moment the user finished paging. Proven
+    // behaviourally rather than by the absence of an attribute — a natively disabled
+    // button cannot take focus, so this fails if the implementation ever swaps them.
+    await loadMore(page).focus()
+    await expect(loadMore(page)).toBeFocused()
+
+    // The label explains the stop with both numbers…
+    await expect(loadMore(page)).toHaveText(
+      `First ${n(BROWSE_RESIDENT_CAP)} of ${n(BROWSE_SEED_COUNT)} loaded`,
+    )
+    // …and the reason it points at says what to do instead. Read through
+    // `aria-describedby` because that association IS the requirement: the sentence is
+    // the only channel a keyboard or AT user has for why the control went quiet.
+    // Matched as an attribute rather than an `#id` selector — React's `useId` emits
+    // characters that are not valid in one.
+    const reasonId = await loadMore(page).getAttribute("aria-describedby")
+    expect(reasonId).not.toBeNull()
+    await expect(page.locator(`[id="${reasonId}"]`)).toHaveText(
+      `The Inspector holds ${n(BROWSE_RESIDENT_CAP)} records at a time — narrow the filters to reach the rest.`,
+    )
+  })
+})

--- a/packages/inspector/e2e/06-desired-fulfilled-mismatch.spec.ts
+++ b/packages/inspector/e2e/06-desired-fulfilled-mismatch.spec.ts
@@ -59,12 +59,22 @@ test.describe("scenario 6 — desired/fulfilled mismatch", () => {
 
     await applySetFilter(page, "status", ["active"])
 
-    // MID-FLIGHT. The reads below are one-shot on purpose: the claim is about a state
-    // the page is passing THROUGH, and an `expect.poll` would be free to satisfy it
-    // after the hold expired — which is the state this scenario exists to distinguish
-    // it from. The phase read above is what places them inside the window.
+    // MID-FLIGHT. The claim is about a state the page is passing THROUGH, so nothing here
+    // may be satisfiable after the hold expires — and nothing here is, because every read
+    // below is written against a value that MOVES when it does: the phase leaves `stale`,
+    // the total becomes B's, the "Updating results…" node unmounts, pretable replaces the
+    // live region's text with the settled results announcement, and the rowcount becomes
+    // B's (a different number — guarded where `bMatching` is computed, since that is what
+    // keeps the rowcount read from being satisfiable on both sides of the hold).
+    //
+    // That is what makes the retries here safe rather than permissive: an auto-retrying
+    // assertion cannot outlast the window, so its retry only ever absorbs a slow read, and
+    // each read below costs a CDP round trip. `HOLD_MS` is sized for the whole block.
     await expectPhase(page, "stale")
-    expect(await rowIds(page)).toEqual(aIds)
+    // Polled for that reason, and no weaker for it: after the hold these rows are B's. A
+    // one-shot read has the failure `rowIds` warns about, in reverse — a read taken
+    // between paints answers `[]` and reddens a page that is entirely correct.
+    await expect.poll(() => rowIds(page)).toEqual(aIds)
     // The total is A's, on its own node, exactly — not "some number". A UI that
     // published B's population beside A's rows would be answering two questions with
     // one picture, and `toContainText` on the sentence would not catch a value that
@@ -86,11 +96,14 @@ test.describe("scenario 6 — desired/fulfilled mismatch", () => {
     // never changed it: B must be a narrowing, and it must be a non-empty one.
     expect(bMatching.length).toBeGreaterThan(0)
     expect(bMatching.length).toBeLessThan(seedIdsInDefaultOrder().length)
+    const bProjection = asDrawn(seedIdsInDefaultOrder(bMatching).slice(0, BROWSE_PAGE_SIZE))
+    // Both windows are a full page, so the projections differ only in how many namespaces
+    // they span — a fixture that ever made those counts agree would leave B's settled
+    // rowcount satisfying the mid-flight assertion above, and that read would quietly stop
+    // distinguishing the two sides of the hold.
+    expect(bProjection.length).not.toBe(aProjection.length)
     await expectPhase(page, "idle")
-    await expectDrawnRows(
-      page,
-      asDrawn(seedIdsInDefaultOrder(bMatching).slice(0, BROWSE_PAGE_SIZE)),
-    )
+    await expectDrawnRows(page, bProjection)
     // Positive first, so this negative one cannot be satisfied by an empty read.
     expect(await rowIds(page)).not.toEqual(aIds)
     await expect(total(page)).toHaveText(bMatching.length.toLocaleString("en-US"))

--- a/packages/inspector/e2e/06-desired-fulfilled-mismatch.spec.ts
+++ b/packages/inspector/e2e/06-desired-fulfilled-mismatch.spec.ts
@@ -1,0 +1,104 @@
+import { BROWSE_PAGE_SIZE, seedIdsInDefaultOrder, seedRecordsMatching } from "../test/seed"
+import { expect, test } from "./fixtures"
+import {
+  applySetFilter,
+  asDrawn,
+  expectDrawnRows,
+  expectPhase,
+  grid,
+  liveRegionText,
+  openBrowse,
+  rowIds,
+  status,
+  total,
+} from "./helpers"
+
+/** How long query B's first response is held open.
+ *
+ *  Generous on purpose. Everything this scenario claims is claimed about the window
+ *  between the gesture and the answer, and each claim inside it costs a CDP round
+ *  trip — on a machine running several suites at once, a 1 s hold is a window the
+ *  assertions can fall out of, and the failure then reads as "B already landed"
+ *  rather than as anything about staleness. Nothing here waits out the whole hold:
+ *  the settle assertions poll. */
+const HOLD_MS = 5_000
+
+// D1-DATA-01, D1-UX-02. The controls show query B while query A's rows are still on
+// screen; A is visibly stale, and every number beside it still belongs to A.
+test.describe("scenario 6 — desired/fulfilled mismatch", () => {
+  test("query A's rows stay visible, marked stale, and are never presented as B's", async ({
+    page,
+    consoleErrors,
+  }) => {
+    void consoleErrors
+    await openBrowse(page)
+
+    // The unscoped browse groups and virtualizes (preamble 9), so `aIds` is what the
+    // viewport DREW — a prefix of the projection, not the 200-row window. That is
+    // exactly what the "A's rows are intact" comparisons below need it to be: a read
+    // of the same channel, taken before and during, with nothing in between that
+    // could move the scroll box.
+    const aProjection = asDrawn(seedIdsInDefaultOrder().slice(0, BROWSE_PAGE_SIZE))
+    await expectDrawnRows(page, aProjection)
+    const aIds = await rowIds(page)
+    const aTotal = await total(page).innerText()
+
+    // Hold the FIRST request that carries a `filters` param — query B's initial fetch.
+    // A latch rather than a predicate on the param alone: the browse re-polls every 2 s
+    // and every one of those ticks carries B's filters too, so holding all of them
+    // would leave the page permanently mid-flight and the settle assertions below
+    // would be timing the fault injection instead of the product.
+    let heldFirstFilteredRequest = false
+    await page.route("**/api/memory/list*", async (route) => {
+      if (!heldFirstFilteredRequest && new URL(route.request().url()).searchParams.has("filters")) {
+        heldFirstFilteredRequest = true
+        await new Promise((resolve) => setTimeout(resolve, HOLD_MS))
+      }
+      await route.continue()
+    })
+
+    await applySetFilter(page, "status", ["active"])
+
+    // MID-FLIGHT. The reads below are one-shot on purpose: the claim is about a state
+    // the page is passing THROUGH, and an `expect.poll` would be free to satisfy it
+    // after the hold expired — which is the state this scenario exists to distinguish
+    // it from. The phase read above is what places them inside the window.
+    await expectPhase(page, "stale")
+    expect(await rowIds(page)).toEqual(aIds)
+    // The total is A's, on its own node, exactly — not "some number". A UI that
+    // published B's population beside A's rows would be answering two questions with
+    // one picture, and `toContainText` on the sentence would not catch a value that
+    // merely contains A's digits.
+    await expect(total(page)).toHaveText(aTotal)
+    // …and the surface SAYS it is out of date, in both channels: the visible chrome
+    // and the single permanent polite region.
+    await expect(status(page)).toContainText("Updating results…")
+    await expect.poll(() => liveRegionText(page)).toContain("Updating results…")
+    // A stale grid still publishes an honest rowcount. This browse is unscoped, so
+    // §4.5 has already downgraded the attribute to the loaded model (preamble 9) and
+    // the population honesty lives on the `total` node asserted above; what this pins
+    // is that the stale tick did not MOVE the number — it is still the one A had.
+    await expect(grid(page)).toHaveAttribute("aria-rowcount", String(aProjection.length + 1))
+
+    // It settles into B, and only then does anything move.
+    const bMatching = seedRecordsMatching({ status: ["active"] })
+    // Both halves have to bite, or "the total moved" would be provable by a UI that
+    // never changed it: B must be a narrowing, and it must be a non-empty one.
+    expect(bMatching.length).toBeGreaterThan(0)
+    expect(bMatching.length).toBeLessThan(seedIdsInDefaultOrder().length)
+    await expectPhase(page, "idle")
+    await expectDrawnRows(
+      page,
+      asDrawn(seedIdsInDefaultOrder(bMatching).slice(0, BROWSE_PAGE_SIZE)),
+    )
+    // Positive first, so this negative one cannot be satisfied by an empty read.
+    expect(await rowIds(page)).not.toEqual(aIds)
+    await expect(total(page)).toHaveText(bMatching.length.toLocaleString("en-US"))
+    await expect(status(page)).not.toContainText("Updating results…")
+
+    // The fault was actually injected. Without this the whole scenario passes on a
+    // page that never asked for B — a filter param this route stopped recognising
+    // would take every mid-flight claim above with it, silently.
+    expect(heldFirstFilteredRequest).toBe(true)
+  })
+})

--- a/packages/inspector/e2e/07-late-response.spec.ts
+++ b/packages/inspector/e2e/07-late-response.spec.ts
@@ -10,39 +10,74 @@ import {
   asDrawn,
   expectDrawnRows,
   expectPhase,
+  loadMore,
   openBrowse,
   rowIds,
+  total,
 } from "./helpers"
 
 /** A row id no window of the fixture can contain, so its presence anywhere in the grid
  *  is unambiguous: query A's answer, and nothing else, put it there. */
 const SENTINEL_ID = "stale-sentinel"
 
+/** A continuation no query of this fixture issues. Present so the injected page differs
+ *  from B's answer in its THIRD field as well: B's own window does not fill, so B's
+ *  continuation is `null`, and a sentinel page that also carried `null` would be
+ *  indistinguishable from B's on that channel — leaving one of the three things "discarded
+ *  whole" names untested. */
+const SENTINEL_CURSOR = "dead-revision-cursor"
+
 /** How long query A's answer is held. Long enough that B is applied, requested and
  *  drawn while A is still outstanding — the whole point being that A lands into a page
  *  that has already moved on. */
 const LATE_MS = 4_000
 
-/** One read per second across a window that outlasts `LATE_MS` by half again, so the
- *  instant A comes back is inside it wherever it falls. */
-const WATCH_TICKS = 6
+/** How far past A's release the watch keeps sampling. A leak would be repaired by the
+ *  next poll, so this only has to outlast the release plus one poll period; the samples
+ *  that matter are the ones immediately after it. */
+const WATCH_TAIL_MS = 3_000
 
-// D1-DATA-02. A response for a dead revision never reaches the grid: not as a
-// replacement, not as an append, and not as a total beside somebody else's rows.
+/** Sampling period. Well under `BROWSE_POLL_INTERVAL_MS` (2 s), which is the interval
+ *  within which a leak would be overwritten by a fresh answer for B — a sampler slower
+ *  than the repair reads the repair. */
+const SAMPLE_MS = 250
+
+/** A floor on how much of the projection each sample must have caught. Without it, a read
+ *  taken between paints answers `[]`, and `[]` satisfies "does not contain the sentinel"
+ *  no matter what the page went on to draw. Set well under whatever the capped viewport
+ *  currently fits, because that count is a rendering detail and this is a floor. */
+const MIN_SAMPLED_ROWS = 15
+
+// D1-DATA-02 for the rows, D1-DATA-01 for the numbers beside them. A response for a dead
+// revision never reaches the grid: not as a replacement, not as an append, and not as a
+// total or a continuation quoted over somebody else's rows.
 //
-// WHICH MECHANISM THIS SEES. The design gives the client two, in order: a new desired
-// revision aborts what is in flight (§6.1 "single flight … a new desired revision
-// aborts and supersedes anything"), and any response that survives to settle is
-// discarded whole unless its revision is still the desired one. Those are not
-// separable from here. `browse-machine`'s `query-changed` returns `abort: inFlight !==
-// null` and `startRequest` opens every settle with `if (controller.signal.aborted)
-// return`, so the abort always fires FIRST at a network seam — there is no fault this
-// spec can inject that lets a superseded response reach the reducer at all. What this
-// proves is therefore the OUTCOME the requirement is about, over both mechanisms
-// together; the revision gate is pinned on its own, without a network, by
-// `test/components/browse-machine.test.ts` "flow 6: a stale response completing after
-// a query change".
+// WHICH MECHANISM THIS SEES. The design gives the client two, in order (§6.1): a new
+// desired revision aborts what is in flight, and any response that survives to settle is
+// discarded whole unless its revision is still the desired one.
+//
+// The abort is NOT the reducer's `abort:` flag, which reads as the obvious candidate and
+// is inert on this path. On a query change React runs the effect cleanup in
+// `use-memory-browse` first — it aborts the controller and nulls it, and it nulls
+// `inFlight` on the state ref too — so by the time that same effect's body dispatches
+// `query-changed`, `browseReduce` computes `abort: state.inFlight !== null` as false and
+// the hook's own `controllerRef.current !== null` guard is false as well. The cleanup is
+// what cancels; the flag covers a `query-changed` arriving by some other route.
+//
+// The consequence for this spec: on shipped code the sentinel below never reaches the
+// page's JavaScript at all, so there is no network fault it can inject that lets a
+// superseded response reach the reducer. What the watch proves is the OUTCOME, over both
+// mechanisms together — remove either one alone and the grid is still never wrong (with
+// no abort the reducer discards it; with no gate the abort means it is never delivered),
+// and only removing BOTH puts the sentinel on screen, for about one poll period. That is
+// why the loop below SAMPLES rather than settles. The revision gate is pinned on its own,
+// without a network, by `test/components/browse-machine.test.ts` "flow 6: a stale response
+// completing after a query change".
 test.describe("scenario 7 — late response", () => {
+  // The fault injection alone costs `LATE_MS + WATCH_TAIL_MS` of wall clock that no
+  // assertion can shorten, on top of the gestures and the settle — so the suite's 60 s
+  // leaves too little headroom on a machine running several suites at once. Nothing here
+  // retries for a duration, so a genuine failure still reports as a diff, not a timeout.
   test.setTimeout(90_000)
 
   test("a response for a superseded query never reaches the grid", async ({
@@ -52,9 +87,9 @@ test.describe("scenario 7 — late response", () => {
     void consoleErrors
     await openBrowse(page)
 
-    // The abort, observed rather than assumed — this is the mechanism the spec's
-    // preamble says fires first, and reading it off the network is what turns that
-    // claim into an observation instead of a comment.
+    // The abort, observed rather than assumed — this is the mechanism the preamble says
+    // fires first, and reading it off the network is what turns that claim into an
+    // observation instead of a comment.
     const abortedForDeadRevision: string[] = []
     page.on("requestfailed", (request) => {
       if (!request.url().includes("/api/memory/list")) return
@@ -64,30 +99,32 @@ test.describe("scenario 7 — late response", () => {
       }
     })
 
-    // Query A (status=superseded) is answered LATE, with an unmistakable sentinel row.
-    //
-    // The predicate has to exclude B as well as select A. Filters COMPOSE: once the
-    // kind funnel is added, B's params — and every 2 s poll B goes on to make — still
-    // carry "superseded", so a predicate keyed on that word alone would hold and
-    // sentinel-answer the very query whose rows this test is watching.
     // A real fixture record wearing the sentinel id, so the body is a page the client
-    // would accept: `fetchBrowsePage` rejects anything that is not one, and a
-    // hand-rolled row shape would have this test proving the response VALIDATOR
-    // instead of the revision it belongs to.
+    // would accept: `fetchBrowsePage` rejects anything that is not one, and a hand-rolled
+    // row shape would have this test proving the response VALIDATOR instead of the
+    // revision it belongs to.
     const [seedTemplate] = browseSeedRecords()
     if (seedTemplate === undefined) throw new Error("the browse fixture is empty")
 
-    let heldForDeadRevision = 0
+    // Query A (status=superseded) is answered LATE, with an unmistakable sentinel page.
+    //
+    // The predicate has to exclude B as well as select A. Filters COMPOSE: once the kind
+    // funnel is added, B's params — and every 2 s poll B goes on to make — still carry
+    // "superseded", so a predicate keyed on that word alone would hold and
+    // sentinel-answer the very query whose rows this test is watching.
+    let heldForDeadRevisionAt: number | null = null
+    let deliveredForDeadRevision = 0
     await page.route("**/api/memory/list*", async (route) => {
       const filters = new URL(route.request().url()).searchParams.get("filters") ?? ""
       if (filters.includes("superseded") && !filters.includes("episodic")) {
-        heldForDeadRevision += 1
+        heldForDeadRevisionAt ??= Date.now()
         await new Promise((resolve) => setTimeout(resolve, LATE_MS))
-        // Not wrapped: the page has cancelled this request by now, and a Playwright
-        // that ever starts rejecting the fulfil of a cancelled one should redden here
-        // rather than be swallowed — the swallow would leave the loop below watching a
-        // page whose fault was never delivered, which is the one way this scenario can
-        // pass while proving nothing.
+        // Not wrapped, and the delivery is COUNTED rather than asserted by a comment: the
+        // page has cancelled this request by now, and a Playwright that ever stopped
+        // fulfilling a cancelled one would leave the loop below watching a page whose
+        // fault was never delivered — the one way this scenario can pass while proving
+        // nothing. A throw here surfaces as an unhandled rejection with no line to blame
+        // (route handlers are invoked unawaited), so the counter is what reddens.
         await route.fulfill({
           status: 200,
           contentType: "application/json",
@@ -96,9 +133,10 @@ test.describe("scenario 7 — late response", () => {
               { ...seedTemplate, id: SENTINEL_ID, content: "this belongs to a dead revision" },
             ],
             total: 1,
-            continuation: null,
+            continuation: SENTINEL_CURSOR,
           }),
         })
+        deliveredForDeadRevision += 1
         return
       }
       await route.continue()
@@ -111,32 +149,73 @@ test.describe("scenario 7 — late response", () => {
     await applySetFilter(page, "kind", ["episodic"])
 
     const matching = seedRecordsMatching({ status: ["superseded"], kind: ["episodic"] })
-    // B has to be a real, non-empty narrowing of A, or "B's rows are still B's" would
-    // be a claim about an empty grid — which the sentinel would visibly break anyway,
-    // but for the wrong reason.
+    // B has to be a real, non-empty narrowing of A, or "B's rows are still B's" would be a
+    // claim about an empty grid — which the sentinel would visibly break anyway, but for
+    // the wrong reason.
     expect(matching.length).toBeGreaterThan(0)
     expect(matching.length).toBeLessThan(seedRecordsMatching({ status: ["superseded"] }).length)
     const projection = asDrawn(seedIdsInDefaultOrder(matching).slice(0, BROWSE_PAGE_SIZE))
+    // B's window does not fill, so its walk is exhausted and its two counts agree. Both
+    // strings are derived here rather than repeated below, because each is a claim about
+    // one of the three fields the sentinel page carries.
+    const population = matching.length.toLocaleString("en-US")
+    const walkLabel = `All ${population} loaded`
     await expectDrawnRows(page, projection)
 
-    // Watch across the whole window in which A could still land.
-    for (let tick = 0; tick < WATCH_TICKS; tick += 1) {
-      await page.waitForTimeout(1_000)
-      // Positive first, and retried: it settles what the grid IS drawing, which also
-      // guarantees the read below is a populated one. Taken the other way round, a
-      // read that caught the grid between paints answers `[]` and satisfies "does not
-      // contain the sentinel" no matter what arrived.
-      await expectDrawnRows(page, projection)
-      expect(await rowIds(page)).not.toContain(SENTINEL_ID)
+    // The fault was injected. Asserted BEFORE the watch, not after: a filter param this
+    // route stopped recognising would leave every sample below watching a page nobody
+    // ever attacked, and the watch's own deadline is anchored on this instant.
+    const heldAt = heldForDeadRevisionAt
+    if (heldAt === null) throw new Error("the route never matched query A: nothing was injected")
+
+    // Watch across the window in which A's answer is released — anchored on when the hold
+    // STARTED, so however long B took to settle, the release is still inside it.
+    //
+    // Every read is ONE-SHOT and every sample is a single observation, because a leak here
+    // is TRANSIENT by construction: the reducer would take the sentinel page whole and the
+    // next poll tick would overwrite it with a fresh answer for B. Anything that waited —
+    // a retrying `expectDrawnRows`, an auto-retrying locator assertion, or
+    // `waitOnePollPeriod`, which returns just as the repair lands — would be reading the
+    // repair and reporting it as the absence of damage. The negative is asserted on the
+    // same read as the positives beside it for the same reason `rowIds` warns about: a
+    // read that caught the grid between paints answers `[]`.
+    const deadline = heldAt + LATE_MS + WATCH_TAIL_MS
+    let lastSampleAt = 0
+    for (let sample = 0; lastSampleAt < deadline; sample += 1) {
+      lastSampleAt = Date.now()
+      const at = `sample ${sample}`
+      const ids = await rowIds(page)
+      const drawnTotal = await total(page).innerText()
+      const drawnWalk = await loadMore(page).innerText()
+
+      expect(ids, at).not.toContain(SENTINEL_ID)
+      expect(ids.length, at).toBeGreaterThanOrEqual(MIN_SAMPLED_ROWS)
+      expect(ids, at).toEqual(projection.slice(0, ids.length))
+      // The records are one third of a page. An APPENDED sentinel is invisible in the rows
+      // — it lands past the ~19 the viewport draws — and a total or a continuation taken
+      // from a dead revision is invisible there by construction. The footer's label
+      // carries both remaining fields: the loaded count, which an append moves, and the
+      // walk, since `All N loaded` is the shape only an exhausted continuation produces.
+      expect(drawnWalk, at).toBe(walkLabel)
+      expect(drawnTotal, at).toBe(population)
+
+      await page.waitForTimeout(SAMPLE_MS)
     }
 
-    // The fault was injected. Without this, a change to how filters are spelled in the
-    // params would silently stop matching, and the loop above would be watching a page
-    // nobody ever attacked.
-    expect(heldForDeadRevision).toBeGreaterThan(0)
-    // …and the client stopped paying for the dead revision rather than merely ignoring
-    // its answer. §6.1 specifies both halves; this is the one that is observable from
-    // outside the page.
-    expect(abortedForDeadRevision.length).toBeGreaterThan(0)
+    // The watch was still running when A came back. A time-bounded loop whose deadline had
+    // already passed — B taking longer to settle than the hold, on a loaded machine —
+    // samples nothing and passes having asserted nothing, which is the one failure a fixed
+    // tick count does not have and this one does.
+    expect(lastSampleAt, "the watch never sampled after A's answer was released").toBeGreaterThan(
+      heldAt + LATE_MS,
+    )
+    // The held response was actually handed back, rather than the fulfil failing silently
+    // on a request the page had already cancelled.
+    expect(deliveredForDeadRevision).toBeGreaterThan(0)
+    // …and the client stopped paying for the dead revision rather than merely ignoring its
+    // answer. §6.1 specifies both halves; this is the one that is observable from outside
+    // the page. Pinned to the abort rather than to "some failure", or a connection reset
+    // would satisfy the only evidence this spec offers for the cancellation.
+    expect(abortedForDeadRevision).toContain("net::ERR_ABORTED")
   })
 })

--- a/packages/inspector/e2e/07-late-response.spec.ts
+++ b/packages/inspector/e2e/07-late-response.spec.ts
@@ -1,0 +1,142 @@
+import {
+  BROWSE_PAGE_SIZE,
+  browseSeedRecords,
+  seedIdsInDefaultOrder,
+  seedRecordsMatching,
+} from "../test/seed"
+import { expect, test } from "./fixtures"
+import {
+  applySetFilter,
+  asDrawn,
+  expectDrawnRows,
+  expectPhase,
+  openBrowse,
+  rowIds,
+} from "./helpers"
+
+/** A row id no window of the fixture can contain, so its presence anywhere in the grid
+ *  is unambiguous: query A's answer, and nothing else, put it there. */
+const SENTINEL_ID = "stale-sentinel"
+
+/** How long query A's answer is held. Long enough that B is applied, requested and
+ *  drawn while A is still outstanding — the whole point being that A lands into a page
+ *  that has already moved on. */
+const LATE_MS = 4_000
+
+/** One read per second across a window that outlasts `LATE_MS` by half again, so the
+ *  instant A comes back is inside it wherever it falls. */
+const WATCH_TICKS = 6
+
+// D1-DATA-02. A response for a dead revision never reaches the grid: not as a
+// replacement, not as an append, and not as a total beside somebody else's rows.
+//
+// WHICH MECHANISM THIS SEES. The design gives the client two, in order: a new desired
+// revision aborts what is in flight (§6.1 "single flight … a new desired revision
+// aborts and supersedes anything"), and any response that survives to settle is
+// discarded whole unless its revision is still the desired one. Those are not
+// separable from here. `browse-machine`'s `query-changed` returns `abort: inFlight !==
+// null` and `startRequest` opens every settle with `if (controller.signal.aborted)
+// return`, so the abort always fires FIRST at a network seam — there is no fault this
+// spec can inject that lets a superseded response reach the reducer at all. What this
+// proves is therefore the OUTCOME the requirement is about, over both mechanisms
+// together; the revision gate is pinned on its own, without a network, by
+// `test/components/browse-machine.test.ts` "flow 6: a stale response completing after
+// a query change".
+test.describe("scenario 7 — late response", () => {
+  test.setTimeout(90_000)
+
+  test("a response for a superseded query never reaches the grid", async ({
+    page,
+    consoleErrors,
+  }) => {
+    void consoleErrors
+    await openBrowse(page)
+
+    // The abort, observed rather than assumed — this is the mechanism the spec's
+    // preamble says fires first, and reading it off the network is what turns that
+    // claim into an observation instead of a comment.
+    const abortedForDeadRevision: string[] = []
+    page.on("requestfailed", (request) => {
+      if (!request.url().includes("/api/memory/list")) return
+      const filters = new URL(request.url()).searchParams.get("filters") ?? ""
+      if (filters.includes("superseded") && !filters.includes("episodic")) {
+        abortedForDeadRevision.push(request.failure()?.errorText ?? "unknown")
+      }
+    })
+
+    // Query A (status=superseded) is answered LATE, with an unmistakable sentinel row.
+    //
+    // The predicate has to exclude B as well as select A. Filters COMPOSE: once the
+    // kind funnel is added, B's params — and every 2 s poll B goes on to make — still
+    // carry "superseded", so a predicate keyed on that word alone would hold and
+    // sentinel-answer the very query whose rows this test is watching.
+    // A real fixture record wearing the sentinel id, so the body is a page the client
+    // would accept: `fetchBrowsePage` rejects anything that is not one, and a
+    // hand-rolled row shape would have this test proving the response VALIDATOR
+    // instead of the revision it belongs to.
+    const [seedTemplate] = browseSeedRecords()
+    if (seedTemplate === undefined) throw new Error("the browse fixture is empty")
+
+    let heldForDeadRevision = 0
+    await page.route("**/api/memory/list*", async (route) => {
+      const filters = new URL(route.request().url()).searchParams.get("filters") ?? ""
+      if (filters.includes("superseded") && !filters.includes("episodic")) {
+        heldForDeadRevision += 1
+        await new Promise((resolve) => setTimeout(resolve, LATE_MS))
+        // Not wrapped: the page has cancelled this request by now, and a Playwright
+        // that ever starts rejecting the fulfil of a cancelled one should redden here
+        // rather than be swallowed — the swallow would leave the loop below watching a
+        // page whose fault was never delivered, which is the one way this scenario can
+        // pass while proving nothing.
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            records: [
+              { ...seedTemplate, id: SENTINEL_ID, content: "this belongs to a dead revision" },
+            ],
+            total: 1,
+            continuation: null,
+          }),
+        })
+        return
+      }
+      await route.continue()
+    })
+
+    await applySetFilter(page, "status", ["superseded"])
+    await expectPhase(page, "stale")
+
+    // Supersede it with query B before A can answer.
+    await applySetFilter(page, "kind", ["episodic"])
+
+    const matching = seedRecordsMatching({ status: ["superseded"], kind: ["episodic"] })
+    // B has to be a real, non-empty narrowing of A, or "B's rows are still B's" would
+    // be a claim about an empty grid — which the sentinel would visibly break anyway,
+    // but for the wrong reason.
+    expect(matching.length).toBeGreaterThan(0)
+    expect(matching.length).toBeLessThan(seedRecordsMatching({ status: ["superseded"] }).length)
+    const projection = asDrawn(seedIdsInDefaultOrder(matching).slice(0, BROWSE_PAGE_SIZE))
+    await expectDrawnRows(page, projection)
+
+    // Watch across the whole window in which A could still land.
+    for (let tick = 0; tick < WATCH_TICKS; tick += 1) {
+      await page.waitForTimeout(1_000)
+      // Positive first, and retried: it settles what the grid IS drawing, which also
+      // guarantees the read below is a populated one. Taken the other way round, a
+      // read that caught the grid between paints answers `[]` and satisfies "does not
+      // contain the sentinel" no matter what arrived.
+      await expectDrawnRows(page, projection)
+      expect(await rowIds(page)).not.toContain(SENTINEL_ID)
+    }
+
+    // The fault was injected. Without this, a change to how filters are spelled in the
+    // params would silently stop matching, and the loop above would be watching a page
+    // nobody ever attacked.
+    expect(heldForDeadRevision).toBeGreaterThan(0)
+    // …and the client stopped paying for the dead revision rather than merely ignoring
+    // its answer. §6.1 specifies both halves; this is the one that is observable from
+    // outside the page.
+    expect(abortedForDeadRevision.length).toBeGreaterThan(0)
+  })
+})

--- a/packages/inspector/e2e/08-refresh-append-failure.spec.ts
+++ b/packages/inspector/e2e/08-refresh-append-failure.spec.ts
@@ -4,6 +4,7 @@ import { expect, test } from "./fixtures"
 import {
   asDrawn,
   browseRegion,
+  DRAWN_FIRST_WINDOW,
   expectDrawnRows,
   expectPhase,
   grid,
@@ -11,27 +12,23 @@ import {
   openBrowse,
   rowIds,
   status,
+  statusText,
   waitOnePollPeriod,
 } from "./helpers"
 
-/** The page formats every count through `toLocaleString`, and `playwright.config` pins
- *  the runner to `en-US` for exactly that reason. `String(n)` would look right and never
- *  match a four-digit count. */
-function n(value: number): string {
-  return value.toLocaleString("en-US")
+/**
+ * What the browser logs for a browse response the page asked for and the server refused.
+ * Every test below injects one deliberately, so this line is the SUBJECT here rather than
+ * the defect the `consoleErrors` fixture exists to catch.
+ *
+ * The ENDPOINT is half the test, not decoration: Chromium's message text names only the
+ * status, so a shape-only match would drain an unrelated 500 from any other route as
+ * readily as the injected one. The `consoleErrors` fixture appends the location URL for
+ * exactly this.
+ */
+function isSeededBrowseFailure(line: string): boolean {
+  return /Failed to load resource: .*status of 500/.test(line) && line.includes("/api/memory/list")
 }
-
-/** `BrowseStatusBar`'s whole sentence — asserted whole rather than by substring, so an
- *  append is pinned on BOTH numbers at once and a loaded count that moved while the
- *  population silently followed it cannot pass. */
-function statusText(loaded: number, matching: number): string {
-  return `${n(loaded)} loaded of ${n(matching)} matching`
-}
-
-/** What Chromium logs for a response the page asked for and the server refused. Every
- *  test below injects one deliberately, so this line is the SUBJECT here rather than the
- *  defect the `consoleErrors` fixture exists to catch. */
-const SEEDED_500 = /Failed to load resource.*500/
 
 /**
  * Account for the console errors this spec CAUSED, and leave everything else for the
@@ -47,8 +44,8 @@ const SEEDED_500 = /Failed to load resource.*500/
  * that pass while proving nothing about the failure path it claims to exercise.
  */
 function drainSeededFetchErrors(consoleErrors: string[], expected: number): void {
-  const seeded = consoleErrors.filter((line) => SEEDED_500.test(line))
-  const unexpected = consoleErrors.filter((line) => !SEEDED_500.test(line))
+  const seeded = consoleErrors.filter(isSeededBrowseFailure)
+  const unexpected = consoleErrors.filter((line) => !isSeededBrowseFailure(line))
   consoleErrors.length = 0
   expect(unexpected, "console errors this spec did not inject").toEqual([])
   expect(seeded.length, "seeded 500s the browser logged").toBeGreaterThanOrEqual(expected)
@@ -67,12 +64,16 @@ test.describe("scenario 8 — refresh/append failure and retry", () => {
     consoleErrors,
   }) => {
     await openBrowse(page)
+    // Settled BEFORE the sample is taken, not after: `rowIds` deliberately does not
+    // retry, and the rendered set can still change a frame after the phase reads `idle`,
+    // so a `before` captured first is a `before` of a page mid-paint — and it is compared
+    // for EXACT equality below.
+    await expectDrawnRows(page, DRAWN_FIRST_WINDOW)
     const before = await rowIds(page)
-    await expectDrawnRows(page, asDrawn(seedIdsInDefaultOrder().slice(0, BROWSE_PAGE_SIZE)))
 
     // The refresh tick is the cursorless request that follows a fulfilled load: the
     // initial one already landed inside `openBrowse`, above this route.
-    let failuresLeft = 1
+    let failing = true
     let cursorlessRequests = 0
     await page.route("**/api/memory/list*", async (route) => {
       const params = new URL(route.request().url()).searchParams
@@ -81,8 +82,7 @@ test.describe("scenario 8 — refresh/append failure and retry", () => {
         return
       }
       cursorlessRequests += 1
-      if (failuresLeft > 0) {
-        failuresLeft -= 1
+      if (failing) {
         await route.fulfill({
           status: 500,
           contentType: "application/json",
@@ -114,10 +114,17 @@ test.describe("scenario 8 — refresh/append failure and retry", () => {
     await expectPhase(page, "idle")
     await expect(browseRegion(page).locator("[data-pretable-body-state]")).toHaveCount(0)
 
+    // The fault is HELD until here rather than lifted after one tick, so every assertion
+    // above ran with no deadline on it. Lifted after the first failure they would instead
+    // share a single 2 s poll period, and an overrun would clear the banner before
+    // `atFailure` was read — reporting as `expect(2).toBeGreaterThan(2)`, which names
+    // neither the banner nor the timing that actually caused it.
+    const atFailure = cursorlessRequests
+    failing = false
+
     // A succeeding tick clears the refresh slot by itself — no user gesture. The
     // requests counter is what makes that "by itself": the banner going away without a
     // further tick would be the reducer forgetting rather than a success clearing.
-    const atFailure = cursorlessRequests
     await expect(page.getByTestId(TEST_IDS.bannerRefresh)).toHaveCount(0, { timeout: 15_000 })
     expect(cursorlessRequests).toBeGreaterThan(atFailure)
     await expect(status(page)).toHaveText(statusText(BROWSE_PAGE_SIZE, BROWSE_SEED_COUNT))
@@ -131,6 +138,9 @@ test.describe("scenario 8 — refresh/append failure and retry", () => {
   }) => {
     await openBrowse(page)
     const order = seedIdsInDefaultOrder()
+    // Settled before sampled, for the same reason as the test above: `before` is compared
+    // for exact equality once the append has failed.
+    await expectDrawnRows(page, DRAWN_FIRST_WINDOW)
     const before = await rowIds(page)
     await expect(status(page)).toHaveText(statusText(BROWSE_PAGE_SIZE, BROWSE_SEED_COUNT))
 
@@ -231,7 +241,7 @@ test.describe("scenario 8 — refresh/append failure and retry", () => {
     failing = false
     await page.getByTestId(TEST_IDS.retryInitial).click()
     await expectPhase(page, "idle")
-    await expectDrawnRows(page, asDrawn(seedIdsInDefaultOrder().slice(0, BROWSE_PAGE_SIZE)))
+    await expectDrawnRows(page, DRAWN_FIRST_WINDOW)
     await expect(status(page)).toHaveText(statusText(BROWSE_PAGE_SIZE, BROWSE_SEED_COUNT))
     // Polling RESUMES: a further request arrives with no second click.
     const afterRetry = requests

--- a/packages/inspector/e2e/08-refresh-append-failure.spec.ts
+++ b/packages/inspector/e2e/08-refresh-append-failure.spec.ts
@@ -5,6 +5,7 @@ import {
   asDrawn,
   browseRegion,
   DRAWN_FIRST_WINDOW,
+  drainSeededFetchErrors,
   expectDrawnRows,
   expectPhase,
   grid,
@@ -16,40 +17,9 @@ import {
   waitOnePollPeriod,
 } from "./helpers"
 
-/**
- * What the browser logs for a browse response the page asked for and the server refused.
- * Every test below injects one deliberately, so this line is the SUBJECT here rather than
- * the defect the `consoleErrors` fixture exists to catch.
- *
- * The ENDPOINT is half the test, not decoration: Chromium's message text names only the
- * status, so a shape-only match would drain an unrelated 500 from any other route as
- * readily as the injected one. The `consoleErrors` fixture appends the location URL for
- * exactly this.
- */
-function isSeededBrowseFailure(line: string): boolean {
-  return /Failed to load resource: .*status of 500/.test(line) && line.includes("/api/memory/list")
-}
-
-/**
- * Account for the console errors this spec CAUSED, and leave everything else for the
- * fixture to fail on.
- *
- * Not a waiver. The gate is the `consoleErrors` fixture's own teardown check, and it
- * reads the same array this drains — so anything not matching the injected shape is
- * re-asserted here (reddening at the drain, with the offending line in the message) and
- * anything logged after the drain still reaches the fixture untouched.
- *
- * `expected` is a floor, not a formality: a spec whose fault injection silently stopped
- * matching would produce NO console error, and a drain that merely filtered would let
- * that pass while proving nothing about the failure path it claims to exercise.
- */
-function drainSeededFetchErrors(consoleErrors: string[], expected: number): void {
-  const seeded = consoleErrors.filter(isSeededBrowseFailure)
-  const unexpected = consoleErrors.filter((line) => !isSeededBrowseFailure(line))
-  consoleErrors.length = 0
-  expect(unexpected, "console errors this spec did not inject").toEqual([])
-  expect(seeded.length, "seeded 500s the browser logged").toBeGreaterThanOrEqual(expected)
-}
+// Every test below injects a browse failure deliberately, so `drainSeededFetchErrors`
+// accounts for the console lines this spec CAUSED — they are its subject rather than the
+// defect the `consoleErrors` fixture exists to catch.
 
 // D1-DATA-06, D1-UX-01, D1-UX-03. A failed refresh or append never discards fulfilled
 // records, the failure is visible in its OWN banner slot, and retry is safe.

--- a/packages/inspector/e2e/08-refresh-append-failure.spec.ts
+++ b/packages/inspector/e2e/08-refresh-append-failure.spec.ts
@@ -1,0 +1,242 @@
+import { TEST_IDS } from "../src/components/memory/test-ids"
+import { BROWSE_PAGE_SIZE, BROWSE_SEED_COUNT, seedIdsInDefaultOrder } from "../test/seed"
+import { expect, test } from "./fixtures"
+import {
+  asDrawn,
+  browseRegion,
+  expectDrawnRows,
+  expectPhase,
+  grid,
+  loadMore,
+  openBrowse,
+  rowIds,
+  status,
+  waitOnePollPeriod,
+} from "./helpers"
+
+/** The page formats every count through `toLocaleString`, and `playwright.config` pins
+ *  the runner to `en-US` for exactly that reason. `String(n)` would look right and never
+ *  match a four-digit count. */
+function n(value: number): string {
+  return value.toLocaleString("en-US")
+}
+
+/** `BrowseStatusBar`'s whole sentence — asserted whole rather than by substring, so an
+ *  append is pinned on BOTH numbers at once and a loaded count that moved while the
+ *  population silently followed it cannot pass. */
+function statusText(loaded: number, matching: number): string {
+  return `${n(loaded)} loaded of ${n(matching)} matching`
+}
+
+/** What Chromium logs for a response the page asked for and the server refused. Every
+ *  test below injects one deliberately, so this line is the SUBJECT here rather than the
+ *  defect the `consoleErrors` fixture exists to catch. */
+const SEEDED_500 = /Failed to load resource.*500/
+
+/**
+ * Account for the console errors this spec CAUSED, and leave everything else for the
+ * fixture to fail on.
+ *
+ * Not a waiver. The gate is the `consoleErrors` fixture's own teardown check, and it
+ * reads the same array this drains — so anything not matching the injected shape is
+ * re-asserted here (reddening at the drain, with the offending line in the message) and
+ * anything logged after the drain still reaches the fixture untouched.
+ *
+ * `expected` is a floor, not a formality: a spec whose fault injection silently stopped
+ * matching would produce NO console error, and a drain that merely filtered would let
+ * that pass while proving nothing about the failure path it claims to exercise.
+ */
+function drainSeededFetchErrors(consoleErrors: string[], expected: number): void {
+  const seeded = consoleErrors.filter((line) => SEEDED_500.test(line))
+  const unexpected = consoleErrors.filter((line) => !SEEDED_500.test(line))
+  consoleErrors.length = 0
+  expect(unexpected, "console errors this spec did not inject").toEqual([])
+  expect(seeded.length, "seeded 500s the browser logged").toBeGreaterThanOrEqual(expected)
+}
+
+// D1-DATA-06, D1-UX-01, D1-UX-03. A failed refresh or append never discards fulfilled
+// records, the failure is visible in its OWN banner slot, and retry is safe.
+test.describe("scenario 8 — refresh/append failure and retry", () => {
+  // Each test waits on at least one 2 s poll cadence and several 10 s `expect` budgets in
+  // sequence, on a machine that runs other suites at the same time. Nothing here retries
+  // for a duration, so a genuine failure still reports as a diff rather than a timeout.
+  test.setTimeout(90_000)
+
+  test("a failed poll tick keeps the rows, banners itself, and clears on the next success", async ({
+    page,
+    consoleErrors,
+  }) => {
+    await openBrowse(page)
+    const before = await rowIds(page)
+    await expectDrawnRows(page, asDrawn(seedIdsInDefaultOrder().slice(0, BROWSE_PAGE_SIZE)))
+
+    // The refresh tick is the cursorless request that follows a fulfilled load: the
+    // initial one already landed inside `openBrowse`, above this route.
+    let failuresLeft = 1
+    let cursorlessRequests = 0
+    await page.route("**/api/memory/list*", async (route) => {
+      const params = new URL(route.request().url()).searchParams
+      if (params.has("cursor")) {
+        await route.continue()
+        return
+      }
+      cursorlessRequests += 1
+      if (failuresLeft > 0) {
+        failuresLeft -= 1
+        await route.fulfill({
+          status: 500,
+          contentType: "application/json",
+          body: JSON.stringify({ error: "seeded refresh failure" }),
+        })
+        return
+      }
+      await route.continue()
+    })
+
+    await expect(page.getByTestId(TEST_IDS.bannerRefresh)).toBeVisible({ timeout: 15_000 })
+    // The slot says WHICH kind failed and quotes the store's own words. A banner that
+    // merely appeared would satisfy a page that puts every failure in one slot, which is
+    // the arrangement D1-UX-03 exists to rule out.
+    await expect(page.getByTestId(TEST_IDS.bannerRefresh)).toHaveText(
+      "Refresh failed: seeded refresh failure",
+    )
+    // …and only that kind's slot: nothing was appended, so the other one must be empty.
+    await expect(page.getByTestId(TEST_IDS.bannerLoadMore)).toHaveCount(0)
+
+    // Rows survive, and the counts beside them still describe the revision that IS
+    // fulfilled — a failed background tick invalidates nothing.
+    expect(await rowIds(page)).toEqual(before)
+    await expect(status(page)).toHaveText(statusText(BROWSE_PAGE_SIZE, BROWSE_SEED_COUNT))
+    // Phase returns to the settled idle: a background failure is not an error PHASE,
+    // because something IS fulfilled for the desired revision. Read through the grid's
+    // own body-state channel too — the error PRESENTATION (the block that replaces the
+    // rows) must not be on screen while there are rows to show.
+    await expectPhase(page, "idle")
+    await expect(browseRegion(page).locator("[data-pretable-body-state]")).toHaveCount(0)
+
+    // A succeeding tick clears the refresh slot by itself — no user gesture. The
+    // requests counter is what makes that "by itself": the banner going away without a
+    // further tick would be the reducer forgetting rather than a success clearing.
+    const atFailure = cursorlessRequests
+    await expect(page.getByTestId(TEST_IDS.bannerRefresh)).toHaveCount(0, { timeout: 15_000 })
+    expect(cursorlessRequests).toBeGreaterThan(atFailure)
+    await expect(status(page)).toHaveText(statusText(BROWSE_PAGE_SIZE, BROWSE_SEED_COUNT))
+
+    drainSeededFetchErrors(consoleErrors, 1)
+  })
+
+  test("a failed append leaves the loaded rows intact and retry appends exactly once", async ({
+    page,
+    consoleErrors,
+  }) => {
+    await openBrowse(page)
+    const order = seedIdsInDefaultOrder()
+    const before = await rowIds(page)
+    await expect(status(page)).toHaveText(statusText(BROWSE_PAGE_SIZE, BROWSE_SEED_COUNT))
+
+    let failAppend = true
+    await page.route("**/api/memory/list*", async (route) => {
+      if (new URL(route.request().url()).searchParams.has("cursor") && failAppend) {
+        failAppend = false
+        await route.fulfill({
+          status: 500,
+          contentType: "application/json",
+          body: JSON.stringify({ error: "seeded append failure" }),
+        })
+        return
+      }
+      await route.continue()
+    })
+
+    await loadMore(page).click()
+    await expect(page.getByTestId(TEST_IDS.bannerLoadMore)).toBeVisible({ timeout: 15_000 })
+    await expect(page.getByTestId(TEST_IDS.bannerLoadMore)).toHaveText(
+      "Loading more failed: seeded append failure",
+    )
+    await expect(page.getByTestId(TEST_IDS.bannerRefresh)).toHaveCount(0)
+
+    // Nothing was discarded and nothing was half-added: the window the client already
+    // held is exactly the window it still holds.
+    expect(await rowIds(page)).toEqual(before)
+    await expect(status(page)).toHaveText(statusText(BROWSE_PAGE_SIZE, BROWSE_SEED_COUNT))
+    await expectPhase(page, "idle")
+
+    // A refresh tick's SUCCESS must not clear the load-more slot — the slots are
+    // per-kind. `waitOnePollPeriod` pins both ends of a real tick (a sleep would report a
+    // response to a question asked before the failure).
+    await waitOnePollPeriod(page)
+    await expect(page.getByTestId(TEST_IDS.bannerLoadMore)).toBeVisible()
+
+    // Clicked immediately after that tick settled, which is the widest quiet window this
+    // cadence offers: `retry` is dropped outright while anything is in flight, and a
+    // dropped click would surface below as a count that never reached 400.
+    await page.getByTestId(TEST_IDS.bannerRetry).click()
+
+    // The loaded count comes off the STATUS BAR, never off a `rowIds` length: the grid
+    // virtualizes, so the DOM holds ~19 rows however much is resident. It is also where a
+    // DOUBLE append would show — as 600.
+    await expect(status(page)).toHaveText(statusText(BROWSE_PAGE_SIZE * 2, BROWSE_SEED_COUNT))
+    await expect(page.getByTestId(TEST_IDS.bannerLoadMore)).toHaveCount(0)
+    await expectPhase(page, "idle")
+    // What it HOLDS, not only what it counted — and held ACROSS a further tick, so an
+    // append that a subsequent refresh then re-appended is caught rather than sampled
+    // before it happened.
+    await expectDrawnRows(page, asDrawn(order.slice(0, BROWSE_PAGE_SIZE * 2)))
+    await waitOnePollPeriod(page)
+    await expect(status(page)).toHaveText(statusText(BROWSE_PAGE_SIZE * 2, BROWSE_SEED_COUNT))
+
+    drainSeededFetchErrors(consoleErrors, 1)
+  })
+
+  test("an initial failure renders the error block, suspends polling, and retry recovers", async ({
+    page,
+    consoleErrors,
+  }) => {
+    let requests = 0
+    let failing = true
+    await page.route("**/api/memory/list*", async (route) => {
+      requests += 1
+      if (failing) {
+        await route.fulfill({
+          status: 500,
+          contentType: "application/json",
+          body: JSON.stringify({ error: "seeded initial failure" }),
+        })
+        return
+      }
+      await route.continue()
+    })
+
+    await page.goto("/memory")
+    // Pretable's hydration signal, before any click: an SSR'd control is painted and
+    // inert, and a retry press that lands before this flips is silently dropped.
+    await expect(grid(page)).toHaveAttribute("data-pretable-hydrated", "true")
+    await expectPhase(page, "error")
+    const errorBlock = browseRegion(page).locator('[data-pretable-body-state="error"]')
+    await expect(errorBlock).toBeVisible()
+    await expect(errorBlock).toContainText("seeded initial failure")
+    // The error block carries NO live-region role — the failure reaches AT through the
+    // surface's single polite region instead (verified in a11y-announcements.spec).
+    await expect(
+      browseRegion(page).locator('[data-pretable-body-state="error"][role]'),
+    ).toHaveCount(0)
+
+    // Polling is suspended while nothing is fulfilled, so the error presentation does not
+    // flicker on a 2 s cadence. Two ticks' worth of wall clock with no request.
+    const atFailure = requests
+    expect(atFailure).toBeGreaterThan(0)
+    await page.waitForTimeout(5_000)
+    expect(requests).toBe(atFailure)
+
+    failing = false
+    await page.getByTestId(TEST_IDS.retryInitial).click()
+    await expectPhase(page, "idle")
+    await expectDrawnRows(page, asDrawn(seedIdsInDefaultOrder().slice(0, BROWSE_PAGE_SIZE)))
+    await expect(status(page)).toHaveText(statusText(BROWSE_PAGE_SIZE, BROWSE_SEED_COUNT))
+    // Polling RESUMES: a further request arrives with no second click.
+    const afterRetry = requests
+    await expect.poll(() => requests, { timeout: 15_000 }).toBeGreaterThan(afterRetry)
+
+    drainSeededFetchErrors(consoleErrors, 1)
+  })
+})

--- a/packages/inspector/e2e/09-concurrent-write.spec.ts
+++ b/packages/inspector/e2e/09-concurrent-write.spec.ts
@@ -1,141 +1,46 @@
-import {
-  BROWSE_PAGE_SIZE,
-  BROWSE_SEED_COUNT,
-  browseSeedRecords,
-  seedIdsInDefaultOrder,
-} from "../test/seed"
+import { BROWSE_PAGE_SIZE, BROWSE_SEED_COUNT } from "../test/seed"
 import { expect, test } from "./fixtures"
 import {
-  asDrawn,
+  DRAWN_FIRST_WINDOW,
+  DRAWN_FIRST_WINDOW_AFTER_FORGET,
+  DRAWN_FIRST_WINDOW_AFTER_SCENARIO_9,
   expectDrawnRows,
+  expectDrawnRun,
   expectPhase,
+  MIN_RENDERED_ROWS,
+  n,
   openBrowse,
   rowIds,
+  rowIdsAndTotal,
+  SCENARIO_9_APPROVED_ID,
+  SCENARIO_9_FORGOTTEN_ID,
+  SCENARIO_9_STABLE_DRAWN_PREFIX,
   scrollGridTo,
   scrollTop,
   status,
+  statusText,
   total,
 } from "./helpers"
-
-/** The page formats every count through `toLocaleString`; `playwright.config` pins the
- *  runner to `en-US`. `String(1250)` would look right and never match "1,250". */
-function n(value: number): string {
-  return value.toLocaleString("en-US")
-}
-
-/** A floor on how much of the projection a sample caught. Without one, a read taken
- *  between paints answers `[]` — and `[]` satisfies every "no longer contains" assertion
- *  no matter what the page went on to draw. */
-const MIN_DRAWN_ROWS = 15
 
 /** Far past any scrollHeight this fixture produces; the browser clamps it to the bottom.
  *  The bottom is where both mutations below are staged (see the file preamble). */
 const SCROLL_TO_BOTTOM_PX = 1_000_000
 
-const order = seedIdsInDefaultOrder()
-const firstWindow = order.slice(0, BROWSE_PAGE_SIZE)
-/** The pristine projection — what the browse draws before this file has written
- *  anything. */
-const projection = asDrawn(firstWindow)
-
-/**
- * The record test 1 deletes: the LAST row the first window draws.
- *
- * Chosen for where its removal is INVISIBLE, not for where it is convenient. The unscoped
- * browse groups by namespace, so the drawn projection is `route=/chat`, then
- * `route=/notes`, then `route=/notes-archive` — and the last row is the tail of the last
- * group. `STABLE_PREFIX` below turns that into a checked fact rather than a claim.
- */
-const DOOMED_ID = projection[projection.length - 1] as string
-
-const windowAfterDelete = order.filter((id) => id !== DOOMED_ID).slice(0, BROWSE_PAGE_SIZE)
-const projectionAfterDelete = asDrawn(windowAfterDelete)
-
-/**
- * The record test 3 approves, which hoists it: `approve` stamps `updatedAt = now`, and the
- * default order is `updatedAt DESC`, so it lands at position 0 of the whole set.
- *
- * EPISODIC AND A CANDIDATE, and both halves are load-bearing rather than descriptive.
- * `approveWithReconcile` takes an append-kind candidate (episodic, reflection) straight to
- * a plain activation with no identity scan. A SEMANTIC candidate instead reaches
- * `classifyWrite`, where this fixture's uniformly empty `data` makes every active record
- * of the same namespace and kind an identity match with identical data — classified
- * `update`, which DELETES the candidate and returns 200. A procedural one throws inside
- * `writePolicyFor` and returns 409. Picking the row off the screen, as the eye would,
- * therefore has a one-in-four chance of silently deleting a record instead of hoisting one
- * and a one-in-four chance of mutating nothing at all — and this spec would pass either
- * way, having tested neither.
- *
- * The LAST such record in the projection, so that hoisting it moves a row from the bottom
- * of the drawn model to the top of its group: a change strictly ABOVE a viewport parked at
- * the bottom, which is what the scenario is about.
- */
-const HOISTED_ID = (() => {
-  const byId = new Map(browseSeedRecords().map((record) => [record.id, record]))
-  const eligible = projectionAfterDelete.filter((id) => {
-    const record = byId.get(id)
-    return record?.kind === "episodic" && record.status === "candidate"
-  })
-  const last = eligible[eligible.length - 1]
-  if (last === undefined) throw new Error("the fixture has no episodic candidate to hoist")
-  return last
-})()
-
-const projectionAfterHoist = asDrawn([
-  HOISTED_ID,
-  ...windowAfterDelete.filter((id) => id !== HOISTED_ID),
-])
-
-/** How much of the drawn projection BOTH mutations in this file leave untouched — derived
- *  from the three projections rather than asserted about them. Everything a spec that only
- *  looks at the head can see lives inside this prefix, which is what makes the shared
- *  fixture survive this file. */
-const STABLE_PREFIX = (() => {
-  let index = 0
-  while (
-    index < projection.length &&
-    projection[index] === projectionAfterDelete[index] &&
-    projection[index] === projectionAfterHoist[index]
-  ) {
-    index += 1
-  }
-  return index
-})()
-
-/**
- * The drawn rows are a contiguous run of `expected`, and returns where the run starts.
- *
- * The grid virtualizes: at most ~19 of a 203-row projection are ever in the document, so
- * every claim about WHICH rows are drawn is a claim about a window into the model, and the
- * window's position is not known ahead of the read.
- */
-function expectDrawnRun(
-  expected: readonly string[],
-  drawn: readonly string[],
-  label: string,
-): number {
-  expect(drawn.length, `${label}: rows drawn`).toBeGreaterThanOrEqual(MIN_DRAWN_ROWS)
-  const head = drawn[0] as string
-  const offset = expected.indexOf(head)
-  expect(
-    offset,
-    `${label}: drawn row "${head}" is not in the expected projection`,
-  ).toBeGreaterThanOrEqual(0)
-  expect(drawn, label).toEqual(expected.slice(offset, offset + drawn.length))
-  return offset
-}
-
 // D1-DATA-04, D1-COUNT-03. Rows and total come from one transaction snapshot, and the
 // head-anchored refresh converges within one poll period.
 //
 // THIS FILE MUTATES THE SHARED FIXTURE STORE, permanently, for every spec that runs after
-// it — `playwright.config` runs one worker over one seeded store and re-seeds only at
-// `serve.ts`. Two writes land: one record is forgotten (so the matching population is
-// `BROWSE_SEED_COUNT - 1` from here on) and one candidate is approved (so it is `active`,
-// and it sorts first). Both are staged at the BOTTOM of the drawn model on purpose, and
-// `STABLE_PREFIX` is where that intent is checked rather than hoped: the assertions in
-// tests 2 and 3 are confined to it, and it covers every row a spec reading the head of the
-// browse can reach.
+// it. Two writes land: `SCENARIO_9_FORGOTTEN_ID` is forgotten and `SCENARIO_9_APPROVED_ID`
+// is approved. Both ids, the store they leave behind and what a later spec has to account
+// for are declared in `helpers.ts`, so that a spec written after this one COMPUTES against
+// the fixture it will meet rather than transcribing corrections out of this comment.
+//
+// Both writes are staged at the BOTTOM of the drawn model on purpose, and
+// `SCENARIO_9_STABLE_DRAWN_PREFIX` is where that intent is checked rather than hoped: it
+// counts the leading drawn rows all three projections agree on, and a viewport at rest
+// draws far fewer than that. Test 2 works at rest and asserts it stays inside the prefix.
+// Test 3 deliberately does NOT — it parks at the bottom, which is the one place the
+// mutations are visible, and seeing them there is the whole point of it.
 //
 // The tests are ORDERED. Test 1 performs the delete and tests 2 and 3 assert against the
 // store it leaves; Playwright runs a file's tests in declaration order in one worker, and
@@ -152,65 +57,74 @@ test.describe("scenario 9 — concurrent write", () => {
   }) => {
     void consoleErrors
     await openBrowse(page)
-    await expectDrawnRows(page, projection)
+    await expectDrawnRows(page, DRAWN_FIRST_WINDOW)
     await expect(total(page)).toHaveText(n(BROWSE_SEED_COUNT))
 
     // The doomed row has to be ON SCREEN before it can be missed from it: "no longer
     // drawn" is satisfied by every read of a row that was never drawn in the first place.
     await scrollGridTo(page, SCROLL_TO_BOTTOM_PX)
-    await expect.poll(() => rowIds(page), { timeout: 15_000 }).toContain(DOOMED_ID)
-    expectDrawnRun(projection, await rowIds(page), "before the delete")
+    await expect.poll(() => rowIds(page), { timeout: 15_000 }).toContain(SCENARIO_9_FORGOTTEN_ID)
+    expectDrawnRun(DRAWN_FIRST_WINDOW, await rowIds(page), "before the delete")
 
     // Convergence is counted in POLL TICKS, not in wall clock: a 15 s deadline on a
     // machine at load says nothing about whether the refresh converged in one period or
-    // in seven. The tick already in flight when the delete lands was snapshotted before
-    // it, so it is allowed to answer the old population — hence two, not one.
-    const browseResponses: number[] = []
+    // in seven. Counted from HERE, one line above the write, so the number below is the
+    // count since the write with no subtraction to get wrong.
+    let ticks = 0
     page.on("response", (response) => {
-      if (response.url().includes("/api/memory/list")) browseResponses.push(Date.now())
+      if (response.url().includes("/api/memory/list")) ticks += 1
     })
-    const ticksAtWrite = browseResponses.length
 
-    const response = await request.post(`/api/memory/${encodeURIComponent(DOOMED_ID)}/forget`)
-    expect(response.ok(), await response.text()).toBe(true)
+    const response = await request.post(
+      `/api/memory/${encodeURIComponent(SCENARIO_9_FORGOTTEN_ID)}/forget`,
+    )
+    // Read on the failure path only. `text()` consumes nothing another line needs here,
+    // but as an unconditional assertion message it runs on the happy path too and reads
+    // as if the body were part of the claim.
+    if (!response.ok()) {
+      throw new Error(
+        `forget ${SCENARIO_9_FORGOTTEN_ID}: ${response.status()} ${await response.text()}`,
+      )
+    }
 
-    // Sampled rather than settled, and the ROW and the TOTAL are read together on every
-    // sample. That pairing is the scenario: a client that took its records from one
-    // snapshot and its count from another would show the row gone beside 1,250, or still
-    // there beside 1,249, for one tick — and any assertion that waited for the end state
-    // would read past it.
+    // Sampled rather than settled, and the ROW and the TOTAL come from ONE evaluation.
+    // That pairing is the scenario: a client that took its records from one snapshot and
+    // its count from another would show the row gone beside 1,250, or still there beside
+    // 1,249, for one tick — and any assertion that waited for the end state would read
+    // past it. Two separate reads would carry a round trip between them and manufacture
+    // exactly the tear this is here to detect.
     const deadline = Date.now() + 15_000
     let converged = false
     let ticksAtConvergence = -1
     while (!converged && Date.now() < deadline) {
-      const ids = await rowIds(page)
-      const ticks = browseResponses.length
-      const matching = await total(page).innerText()
-      if (ids.length >= MIN_DRAWN_ROWS) {
+      const { ids, total: matching } = await rowIdsAndTotal(page)
+      const ticksNow = ticks
+      // A floor on how much of the projection the sample caught: a read taken between
+      // paints answers `[]`, and `[]` satisfies every "no longer contains" claim below no
+      // matter what the page went on to draw.
+      if (ids.length >= MIN_RENDERED_ROWS) {
+        const stillDrawn = ids.includes(SCENARIO_9_FORGOTTEN_ID)
         expect(
           matching,
-          `the row is ${ids.includes(DOOMED_ID) ? "still drawn" : "gone"}, so the total must match`,
-        ).toBe(ids.includes(DOOMED_ID) ? n(BROWSE_SEED_COUNT) : n(BROWSE_SEED_COUNT - 1))
-        if (!ids.includes(DOOMED_ID)) {
+          `the row is ${stillDrawn ? "still drawn" : "gone"}, so the total must match`,
+        ).toBe(stillDrawn ? n(BROWSE_SEED_COUNT) : n(BROWSE_SEED_COUNT - 1))
+        if (!stillDrawn) {
           converged = true
-          ticksAtConvergence = ticks
+          ticksAtConvergence = ticksNow
         }
       }
       if (!converged) await page.waitForTimeout(150)
     }
     expect(converged, "the delete never reached the grid").toBe(true)
-    expect(
-      ticksAtConvergence - ticksAtWrite,
-      "poll ticks the delete took to converge",
-    ).toBeLessThanOrEqual(2)
+    // Two, not one: the tick already in flight when the delete landed was snapshotted
+    // before it, so it is entitled to answer the old population.
+    expect(ticksAtConvergence, "poll ticks the delete took to converge").toBeLessThanOrEqual(2)
 
     // The window BACKFILLED — the client holds a full page again, from the same snapshot
     // that dropped a row. Without this the scenario is satisfied by a client that simply
     // shortened its list.
-    await expect(status(page)).toHaveText(
-      `${n(BROWSE_PAGE_SIZE)} loaded of ${n(BROWSE_SEED_COUNT - 1)} matching`,
-    )
-    expectDrawnRun(projectionAfterDelete, await rowIds(page), "after the delete")
+    await expect(status(page)).toHaveText(statusText(BROWSE_PAGE_SIZE, BROWSE_SEED_COUNT - 1))
+    expectDrawnRun(DRAWN_FIRST_WINDOW_AFTER_FORGET, await rowIds(page), "after the delete")
     await expectPhase(page, "idle")
   })
 
@@ -221,18 +135,20 @@ test.describe("scenario 9 — concurrent write", () => {
     void consoleErrors
     await openBrowse(page)
 
-    // Into the middle of the loaded window, so a reset to the top would be measurable —
-    // at rest the offset is 0, and a before/after comparison of two zeroes moves the
-    // user's place while passing.
+    // A few rows down — NOT the middle: the offset only has to be nonzero, because at
+    // rest it is 0 and a before/after comparison of two zeroes moves the user's place
+    // while passing. Both properties this depth needs are asserted rather than assumed
+    // below: that it moved at all, and that the run it lands on is still inside the
+    // prefix the previous test's delete provably did not touch.
     await scrollGridTo(page, 400)
     await expect.poll(() => scrollTop(page)).toBeGreaterThan(0)
     const offsetBefore = await scrollTop(page)
     const idsBefore = await rowIds(page)
     // The rows are the RIGHT rows, not merely stable ones — a grid stuck showing garbage
-    // is perfectly stable. Asserted against the PRISTINE projection and confined to the
-    // prefix the previous test's delete provably did not touch.
-    const offset = expectDrawnRun(projection, idsBefore, "at rest")
-    expect(offset + idsBefore.length).toBeLessThanOrEqual(STABLE_PREFIX)
+    // is perfectly stable. Asserted against the PRISTINE projection, which only holds
+    // inside the stable prefix.
+    const offset = expectDrawnRun(DRAWN_FIRST_WINDOW, idsBefore, "at rest")
+    expect(offset + idsBefore.length).toBeLessThanOrEqual(SCENARIO_9_STABLE_DRAWN_PREFIX)
 
     // Ticks are COUNTED, not assumed: "a no-change poll tick changes nothing" is
     // vacuously true of a page that stopped polling, which is the one way this test can
@@ -259,14 +175,22 @@ test.describe("scenario 9 — concurrent write", () => {
     // Parked at the bottom, where the row about to be hoisted is drawn and everything it
     // is about to move above is on screen.
     await scrollGridTo(page, SCROLL_TO_BOTTOM_PX)
-    await expect.poll(() => rowIds(page), { timeout: 15_000 }).toContain(HOISTED_ID)
+    await expect.poll(() => rowIds(page), { timeout: 15_000 }).toContain(SCENARIO_9_APPROVED_ID)
     const idsBefore = await rowIds(page)
-    expectDrawnRun(projectionAfterDelete, idsBefore, "before the hoist")
+    expectDrawnRun(DRAWN_FIRST_WINDOW_AFTER_FORGET, idsBefore, "before the hoist")
     const offsetBefore = await scrollTop(page)
     expect(offsetBefore).toBeGreaterThan(0)
 
-    const response = await request.post(`/api/memory/${encodeURIComponent(HOISTED_ID)}/approve`)
-    expect(response.status(), await response.text()).toBe(200)
+    const response = await request.post(
+      `/api/memory/${encodeURIComponent(SCENARIO_9_APPROVED_ID)}/approve`,
+    )
+    // Read on the failure path only, so the body is still unconsumed for the `json()`
+    // below and the happy path is not quietly fetching something it never looks at.
+    if (response.status() !== 200) {
+      throw new Error(
+        `approve ${SCENARIO_9_APPROVED_ID}: ${response.status()} ${await response.text()}`,
+      )
+    }
     // `activated` is the append-kind path: no identity scan, so nothing was deduped (which
     // DELETES the candidate) and nothing was superseded (which demotes a second record).
     // Without this the rest of the test cannot tell a hoist from a deletion.
@@ -277,8 +201,8 @@ test.describe("scenario 9 — concurrent write", () => {
     // is satisfied by a read that landed between paints and answered `[]`.
     await expect(async () => {
       const ids = await rowIds(page)
-      expect(ids.length).toBeGreaterThanOrEqual(MIN_DRAWN_ROWS)
-      expect(ids).not.toContain(HOISTED_ID)
+      expect(ids.length).toBeGreaterThanOrEqual(MIN_RENDERED_ROWS)
+      expect(ids).not.toContain(SCENARIO_9_APPROVED_ID)
     }).toPass({ timeout: 15_000 })
 
     // THE DESIGN'S ACCEPTED BEHAVIOUR (§8.1 decision 8, Flow 9): D1 has no scroll
@@ -290,9 +214,13 @@ test.describe("scenario 9 — concurrent write", () => {
     expect(await scrollTop(page)).toBe(offsetBefore)
     const idsAfter = await rowIds(page)
     expect(idsAfter, "the hoisted row moved out of the viewport it was drawn in").not.toContain(
-      HOISTED_ID,
+      SCENARIO_9_APPROVED_ID,
     )
-    expectDrawnRun(projectionAfterHoist, idsAfter, "after the hoist")
+    // Against the projection `helpers.ts` publishes for every spec that runs after this
+    // file, rather than against a local reconstruction of it: this assertion is therefore
+    // also the proof that the shared post-mutation view models the store the later specs
+    // will meet.
+    expectDrawnRun(DRAWN_FIRST_WINDOW_AFTER_SCENARIO_9, idsAfter, "after the hoist")
     // The population is untouched: an approval moves a record, it does not add or remove
     // one. This is the independent witness that the append path — not the dedupe that
     // deletes — is what ran.

--- a/packages/inspector/e2e/09-concurrent-write.spec.ts
+++ b/packages/inspector/e2e/09-concurrent-write.spec.ts
@@ -1,0 +1,302 @@
+import {
+  BROWSE_PAGE_SIZE,
+  BROWSE_SEED_COUNT,
+  browseSeedRecords,
+  seedIdsInDefaultOrder,
+} from "../test/seed"
+import { expect, test } from "./fixtures"
+import {
+  asDrawn,
+  expectDrawnRows,
+  expectPhase,
+  openBrowse,
+  rowIds,
+  scrollGridTo,
+  scrollTop,
+  status,
+  total,
+} from "./helpers"
+
+/** The page formats every count through `toLocaleString`; `playwright.config` pins the
+ *  runner to `en-US`. `String(1250)` would look right and never match "1,250". */
+function n(value: number): string {
+  return value.toLocaleString("en-US")
+}
+
+/** A floor on how much of the projection a sample caught. Without one, a read taken
+ *  between paints answers `[]` — and `[]` satisfies every "no longer contains" assertion
+ *  no matter what the page went on to draw. */
+const MIN_DRAWN_ROWS = 15
+
+/** Far past any scrollHeight this fixture produces; the browser clamps it to the bottom.
+ *  The bottom is where both mutations below are staged (see the file preamble). */
+const SCROLL_TO_BOTTOM_PX = 1_000_000
+
+const order = seedIdsInDefaultOrder()
+const firstWindow = order.slice(0, BROWSE_PAGE_SIZE)
+/** The pristine projection — what the browse draws before this file has written
+ *  anything. */
+const projection = asDrawn(firstWindow)
+
+/**
+ * The record test 1 deletes: the LAST row the first window draws.
+ *
+ * Chosen for where its removal is INVISIBLE, not for where it is convenient. The unscoped
+ * browse groups by namespace, so the drawn projection is `route=/chat`, then
+ * `route=/notes`, then `route=/notes-archive` — and the last row is the tail of the last
+ * group. `STABLE_PREFIX` below turns that into a checked fact rather than a claim.
+ */
+const DOOMED_ID = projection[projection.length - 1] as string
+
+const windowAfterDelete = order.filter((id) => id !== DOOMED_ID).slice(0, BROWSE_PAGE_SIZE)
+const projectionAfterDelete = asDrawn(windowAfterDelete)
+
+/**
+ * The record test 3 approves, which hoists it: `approve` stamps `updatedAt = now`, and the
+ * default order is `updatedAt DESC`, so it lands at position 0 of the whole set.
+ *
+ * EPISODIC AND A CANDIDATE, and both halves are load-bearing rather than descriptive.
+ * `approveWithReconcile` takes an append-kind candidate (episodic, reflection) straight to
+ * a plain activation with no identity scan. A SEMANTIC candidate instead reaches
+ * `classifyWrite`, where this fixture's uniformly empty `data` makes every active record
+ * of the same namespace and kind an identity match with identical data — classified
+ * `update`, which DELETES the candidate and returns 200. A procedural one throws inside
+ * `writePolicyFor` and returns 409. Picking the row off the screen, as the eye would,
+ * therefore has a one-in-four chance of silently deleting a record instead of hoisting one
+ * and a one-in-four chance of mutating nothing at all — and this spec would pass either
+ * way, having tested neither.
+ *
+ * The LAST such record in the projection, so that hoisting it moves a row from the bottom
+ * of the drawn model to the top of its group: a change strictly ABOVE a viewport parked at
+ * the bottom, which is what the scenario is about.
+ */
+const HOISTED_ID = (() => {
+  const byId = new Map(browseSeedRecords().map((record) => [record.id, record]))
+  const eligible = projectionAfterDelete.filter((id) => {
+    const record = byId.get(id)
+    return record?.kind === "episodic" && record.status === "candidate"
+  })
+  const last = eligible[eligible.length - 1]
+  if (last === undefined) throw new Error("the fixture has no episodic candidate to hoist")
+  return last
+})()
+
+const projectionAfterHoist = asDrawn([
+  HOISTED_ID,
+  ...windowAfterDelete.filter((id) => id !== HOISTED_ID),
+])
+
+/** How much of the drawn projection BOTH mutations in this file leave untouched — derived
+ *  from the three projections rather than asserted about them. Everything a spec that only
+ *  looks at the head can see lives inside this prefix, which is what makes the shared
+ *  fixture survive this file. */
+const STABLE_PREFIX = (() => {
+  let index = 0
+  while (
+    index < projection.length &&
+    projection[index] === projectionAfterDelete[index] &&
+    projection[index] === projectionAfterHoist[index]
+  ) {
+    index += 1
+  }
+  return index
+})()
+
+/**
+ * The drawn rows are a contiguous run of `expected`, and returns where the run starts.
+ *
+ * The grid virtualizes: at most ~19 of a 203-row projection are ever in the document, so
+ * every claim about WHICH rows are drawn is a claim about a window into the model, and the
+ * window's position is not known ahead of the read.
+ */
+function expectDrawnRun(
+  expected: readonly string[],
+  drawn: readonly string[],
+  label: string,
+): number {
+  expect(drawn.length, `${label}: rows drawn`).toBeGreaterThanOrEqual(MIN_DRAWN_ROWS)
+  const head = drawn[0] as string
+  const offset = expected.indexOf(head)
+  expect(
+    offset,
+    `${label}: drawn row "${head}" is not in the expected projection`,
+  ).toBeGreaterThanOrEqual(0)
+  expect(drawn, label).toEqual(expected.slice(offset, offset + drawn.length))
+  return offset
+}
+
+// D1-DATA-04, D1-COUNT-03. Rows and total come from one transaction snapshot, and the
+// head-anchored refresh converges within one poll period.
+//
+// THIS FILE MUTATES THE SHARED FIXTURE STORE, permanently, for every spec that runs after
+// it — `playwright.config` runs one worker over one seeded store and re-seeds only at
+// `serve.ts`. Two writes land: one record is forgotten (so the matching population is
+// `BROWSE_SEED_COUNT - 1` from here on) and one candidate is approved (so it is `active`,
+// and it sorts first). Both are staged at the BOTTOM of the drawn model on purpose, and
+// `STABLE_PREFIX` is where that intent is checked rather than hoped: the assertions in
+// tests 2 and 3 are confined to it, and it covers every row a spec reading the head of the
+// browse can reach.
+//
+// The tests are ORDERED. Test 1 performs the delete and tests 2 and 3 assert against the
+// store it leaves; Playwright runs a file's tests in declaration order in one worker, and
+// running one of them alone with `-g` is not a supported mode.
+test.describe("scenario 9 — concurrent write", () => {
+  // A poll cadence, a mutation round-trip and several 10 s `expect` budgets in sequence,
+  // on a machine running other suites at the same time.
+  test.setTimeout(90_000)
+
+  test("a delete lands in the grid and the total within one poll period", async ({
+    page,
+    request,
+    consoleErrors,
+  }) => {
+    void consoleErrors
+    await openBrowse(page)
+    await expectDrawnRows(page, projection)
+    await expect(total(page)).toHaveText(n(BROWSE_SEED_COUNT))
+
+    // The doomed row has to be ON SCREEN before it can be missed from it: "no longer
+    // drawn" is satisfied by every read of a row that was never drawn in the first place.
+    await scrollGridTo(page, SCROLL_TO_BOTTOM_PX)
+    await expect.poll(() => rowIds(page), { timeout: 15_000 }).toContain(DOOMED_ID)
+    expectDrawnRun(projection, await rowIds(page), "before the delete")
+
+    // Convergence is counted in POLL TICKS, not in wall clock: a 15 s deadline on a
+    // machine at load says nothing about whether the refresh converged in one period or
+    // in seven. The tick already in flight when the delete lands was snapshotted before
+    // it, so it is allowed to answer the old population — hence two, not one.
+    const browseResponses: number[] = []
+    page.on("response", (response) => {
+      if (response.url().includes("/api/memory/list")) browseResponses.push(Date.now())
+    })
+    const ticksAtWrite = browseResponses.length
+
+    const response = await request.post(`/api/memory/${encodeURIComponent(DOOMED_ID)}/forget`)
+    expect(response.ok(), await response.text()).toBe(true)
+
+    // Sampled rather than settled, and the ROW and the TOTAL are read together on every
+    // sample. That pairing is the scenario: a client that took its records from one
+    // snapshot and its count from another would show the row gone beside 1,250, or still
+    // there beside 1,249, for one tick — and any assertion that waited for the end state
+    // would read past it.
+    const deadline = Date.now() + 15_000
+    let converged = false
+    let ticksAtConvergence = -1
+    while (!converged && Date.now() < deadline) {
+      const ids = await rowIds(page)
+      const ticks = browseResponses.length
+      const matching = await total(page).innerText()
+      if (ids.length >= MIN_DRAWN_ROWS) {
+        expect(
+          matching,
+          `the row is ${ids.includes(DOOMED_ID) ? "still drawn" : "gone"}, so the total must match`,
+        ).toBe(ids.includes(DOOMED_ID) ? n(BROWSE_SEED_COUNT) : n(BROWSE_SEED_COUNT - 1))
+        if (!ids.includes(DOOMED_ID)) {
+          converged = true
+          ticksAtConvergence = ticks
+        }
+      }
+      if (!converged) await page.waitForTimeout(150)
+    }
+    expect(converged, "the delete never reached the grid").toBe(true)
+    expect(
+      ticksAtConvergence - ticksAtWrite,
+      "poll ticks the delete took to converge",
+    ).toBeLessThanOrEqual(2)
+
+    // The window BACKFILLED — the client holds a full page again, from the same snapshot
+    // that dropped a row. Without this the scenario is satisfied by a client that simply
+    // shortened its list.
+    await expect(status(page)).toHaveText(
+      `${n(BROWSE_PAGE_SIZE)} loaded of ${n(BROWSE_SEED_COUNT - 1)} matching`,
+    )
+    expectDrawnRun(projectionAfterDelete, await rowIds(page), "after the delete")
+    await expectPhase(page, "idle")
+  })
+
+  test("a no-change poll tick moves no scroll offset and replaces no rows", async ({
+    page,
+    consoleErrors,
+  }) => {
+    void consoleErrors
+    await openBrowse(page)
+
+    // Into the middle of the loaded window, so a reset to the top would be measurable —
+    // at rest the offset is 0, and a before/after comparison of two zeroes moves the
+    // user's place while passing.
+    await scrollGridTo(page, 400)
+    await expect.poll(() => scrollTop(page)).toBeGreaterThan(0)
+    const offsetBefore = await scrollTop(page)
+    const idsBefore = await rowIds(page)
+    // The rows are the RIGHT rows, not merely stable ones — a grid stuck showing garbage
+    // is perfectly stable. Asserted against the PRISTINE projection and confined to the
+    // prefix the previous test's delete provably did not touch.
+    const offset = expectDrawnRun(projection, idsBefore, "at rest")
+    expect(offset + idsBefore.length).toBeLessThanOrEqual(STABLE_PREFIX)
+
+    // Ticks are COUNTED, not assumed: "a no-change poll tick changes nothing" is
+    // vacuously true of a page that stopped polling, which is the one way this test can
+    // pass while the feature is broken.
+    let ticks = 0
+    page.on("response", (response) => {
+      if (response.url().includes("/api/memory/list")) ticks += 1
+    })
+    await page.waitForTimeout(7_000)
+    expect(ticks, "poll ticks observed over three cadences").toBeGreaterThanOrEqual(2)
+
+    expect(await scrollTop(page)).toBe(offsetBefore)
+    expect(await rowIds(page)).toEqual(idsBefore)
+  })
+
+  test("a tick that hoists a row above the viewport shifts content — offset stability only", async ({
+    page,
+    request,
+    consoleErrors,
+  }) => {
+    void consoleErrors
+    await openBrowse(page)
+
+    // Parked at the bottom, where the row about to be hoisted is drawn and everything it
+    // is about to move above is on screen.
+    await scrollGridTo(page, SCROLL_TO_BOTTOM_PX)
+    await expect.poll(() => rowIds(page), { timeout: 15_000 }).toContain(HOISTED_ID)
+    const idsBefore = await rowIds(page)
+    expectDrawnRun(projectionAfterDelete, idsBefore, "before the hoist")
+    const offsetBefore = await scrollTop(page)
+    expect(offsetBefore).toBeGreaterThan(0)
+
+    const response = await request.post(`/api/memory/${encodeURIComponent(HOISTED_ID)}/approve`)
+    expect(response.status(), await response.text()).toBe(200)
+    // `activated` is the append-kind path: no identity scan, so nothing was deduped (which
+    // DELETES the candidate) and nothing was superseded (which demotes a second record).
+    // Without this the rest of the test cannot tell a hoist from a deletion.
+    expect((await response.json()) as { action?: string }).toMatchObject({ action: "activated" })
+
+    // Phrased POSITIVELY — with a floor on how much was caught — because the read that
+    // settles this is the one every later assertion is taken against: `not.toEqual` alone
+    // is satisfied by a read that landed between paints and answered `[]`.
+    await expect(async () => {
+      const ids = await rowIds(page)
+      expect(ids.length).toBeGreaterThanOrEqual(MIN_DRAWN_ROWS)
+      expect(ids).not.toContain(HOISTED_ID)
+    }).toPass({ timeout: 15_000 })
+
+    // THE DESIGN'S ACCEPTED BEHAVIOUR (§8.1 decision 8, Flow 9): D1 has no scroll
+    // anchoring. The offset is untouched; the CONTENT under it has legitimately moved.
+    // Asserting content STABILITY here would be asserting a guarantee the design
+    // explicitly declines to make — so the content is asserted to have moved to the right
+    // place instead, which is what keeps "the offset did not change" from being a claim
+    // about a page where nothing happened.
+    expect(await scrollTop(page)).toBe(offsetBefore)
+    const idsAfter = await rowIds(page)
+    expect(idsAfter, "the hoisted row moved out of the viewport it was drawn in").not.toContain(
+      HOISTED_ID,
+    )
+    expectDrawnRun(projectionAfterHoist, idsAfter, "after the hoist")
+    // The population is untouched: an approval moves a record, it does not add or remove
+    // one. This is the independent witness that the append path — not the dedupe that
+    // deletes — is what ran.
+    await expect(total(page)).toHaveText(n(BROWSE_SEED_COUNT - 1))
+    await expectPhase(page, "idle")
+  })
+})

--- a/packages/inspector/e2e/10-selection-scope.spec.ts
+++ b/packages/inspector/e2e/10-selection-scope.spec.ts
@@ -73,8 +73,14 @@ async function drawnSelection(page: Page): Promise<{ id: string; selected: boole
     )
 }
 
-// D1-SELECT-01..04. The header checkbox says what it covers, an append does not corrupt
-// the selection, and a query change clears it.
+// One criterion per test, in file order: the header checkbox says what it covers
+// (D1-SELECT-01), an append does not corrupt the selection (-03), and a query change
+// clears it (-02).
+//
+// NOT 04. That one is "a retry after a partial failure re-attempts the failures only",
+// and reaching it needs a mutation that fails for one id and succeeds for the others —
+// an outcome this lane cannot stage against a real store. It is covered against a
+// stubbed route in test/components/bulk-safety.test.tsx instead.
 //
 // This file does NOT mutate the store: the three tests select, page and filter, all of
 // which are client state. It runs after scenario 9 in a full suite, so it reads the

--- a/packages/inspector/e2e/10-selection-scope.spec.ts
+++ b/packages/inspector/e2e/10-selection-scope.spec.ts
@@ -1,0 +1,217 @@
+import type { Locator, Page } from "@playwright/test"
+import { TEST_IDS } from "../src/components/memory/test-ids"
+import { BROWSE_PAGE_SIZE, BROWSE_SEED_COUNT } from "../test/seed"
+import { expect, test } from "./fixtures"
+import {
+  applySetFilter,
+  expectPhase,
+  grid,
+  loadMore,
+  MIN_RENDERED_ROWS,
+  n,
+  openBrowse,
+  scrollGridTo,
+  status,
+  statusText,
+  total,
+} from "./helpers"
+
+/** Far past any scrollHeight this fixture produces; the browser clamps it to the bottom.
+ *  The bottom of the two-window model is where the APPENDED records are drawn. */
+const SCROLL_TO_BOTTOM_PX = 1_000_000
+
+/** How long a query-change response is held back, so the mid-flight half of test 3 has a
+ *  window to be read in rather than a race to win. Comfortably longer than a driver round
+ *  trip on a loaded machine and shorter than the file's per-test budget. */
+const HOLD_MS = 4_000
+
+function selectAll(page: Page): Locator {
+  return grid(page).locator("[data-pretable-row-select-all]")
+}
+
+function bulkBar(page: Page): Locator {
+  return page.getByTestId(TEST_IDS.bulkBar)
+}
+
+/**
+ * The matching population, as a number, read from the PAGE rather than from the seed.
+ *
+ * Two fixture states reach this file. A full-suite run arrives after scenario 9's two
+ * writes (one record forgotten); running this file alone re-seeds the store — `serve.ts`
+ * is what seeds it — and meets the pristine fixture. Every claim below is about the
+ * RELATION between what is loaded and what matches, so neither value is transcribed. It
+ * is still held to the two values the fixture can be in, so a page reporting a count from
+ * nowhere fails here rather than silently satisfying the relations.
+ */
+async function matchingPopulation(page: Page): Promise<number> {
+  const rendered = await total(page).innerText()
+  expect([n(BROWSE_SEED_COUNT), n(BROWSE_SEED_COUNT - 1)]).toContain(rendered)
+  return Number(rendered.replaceAll(",", ""))
+}
+
+/**
+ * Every DATA row in the document with its selected flag.
+ *
+ * `data-pretable-selected` is written on every data row as `"true"` or `"false"`, never
+ * omitted — so the attribute-presence selector the eye reaches for
+ * (`[data-pretable-row-id][data-pretable-selected]`) matches every drawn row and any
+ * claim built on it is vacuous. Group rows carry the row-id channel but no selected
+ * flag at all, which is why they are excluded rather than defaulted.
+ */
+async function drawnSelection(page: Page): Promise<{ id: string; selected: boolean }[]> {
+  return grid(page)
+    .locator("[data-pretable-row-id]:not([data-pretable-group-row])")
+    .evaluateAll((nodes) =>
+      nodes.map((node) => {
+        const element = node as HTMLElement
+        const id = element.dataset.pretableRowId
+        if (id === undefined) throw new Error("pretable rendered a row without a row id")
+        const selected = element.getAttribute("data-pretable-selected")
+        if (selected === null) throw new Error(`row "${id}" carries no selected flag`)
+        return { id, selected: selected === "true" }
+      }),
+    )
+}
+
+// D1-SELECT-01..04. The header checkbox says what it covers, an append does not corrupt
+// the selection, and a query change clears it.
+//
+// This file does NOT mutate the store: the three tests select, page and filter, all of
+// which are client state. It runs after scenario 9 in a full suite, so it reads the
+// population off the page (see `matchingPopulation`) instead of naming it.
+test.describe("scenario 10 — selection scope", () => {
+  test.setTimeout(90_000)
+
+  test("select-all names the LOADED scope, never the population", async ({
+    page,
+    consoleErrors,
+  }) => {
+    void consoleErrors
+    await openBrowse(page)
+
+    // The premise: what the client holds is a strict subset of what the store matches.
+    // Without it every assertion below is satisfied by a grid that loaded everything.
+    const matching = await matchingPopulation(page)
+    expect(BROWSE_PAGE_SIZE).toBeLessThan(matching)
+    await expect(status(page)).toHaveText(statusText(BROWSE_PAGE_SIZE, matching))
+
+    await selectAll(page).click()
+
+    // The bar counts the LOADED window …
+    await expect(bulkBar(page)).toContainText(`${BROWSE_PAGE_SIZE} selected`)
+    // … and the destructive verb names that same number, which is the one the user is
+    // actually about to act on. A bar that agreed in its summary and offered "Forget
+    // 1,249" would satisfy the line above on its own.
+    await expect(
+      bulkBar(page).getByRole("button", { name: `Forget ${BROWSE_PAGE_SIZE}`, exact: true }),
+    ).toBeVisible()
+    // Nowhere on the bar does the POPULATION appear. Locale-formatted, because that is
+    // how every count in this chrome is rendered — `String(matching)` would look right
+    // and never match a four-digit number.
+    await expect(bulkBar(page)).not.toContainText(n(matching))
+
+    // D1-SELECT-01: the control SAYS its scope. `resolveDataScope` answers "loaded" only
+    // because the total is exact and exceeds what is loaded — the same fact the status
+    // bar states above — so this label is the accessible half of that sentence, and the
+    // one an AT user has.
+    await expect(selectAll(page)).toHaveAttribute("aria-label", /loaded/i)
+    await expect(selectAll(page)).toHaveAttribute("aria-checked", "true")
+  })
+
+  test("appending a window preserves the selection and adds no selection entries", async ({
+    page,
+    consoleErrors,
+  }) => {
+    void consoleErrors
+    await openBrowse(page)
+    const matching = await matchingPopulation(page)
+
+    await selectAll(page).click()
+    await expect(bulkBar(page)).toContainText(`${BROWSE_PAGE_SIZE} selected`)
+
+    await loadMore(page).click()
+    // The loaded count comes off the STATUS BAR, never off a row count: the grid
+    // virtualizes, so the document holds ~19 rows however many the client is holding.
+    await expect(status(page)).toHaveText(statusText(BROWSE_PAGE_SIZE * 2, matching))
+    await expectPhase(page, "idle")
+
+    // D1-SELECT-03. Still 200 — the append added ROWS, it did not add selection, and it
+    // did not lose any either. Both failure modes land on this one number: an append that
+    // selected what it appended reads 400, and one that replaced the model rather than
+    // extending it reads 0.
+    await expect(bulkBar(page)).toContainText(`${BROWSE_PAGE_SIZE} selected`)
+
+    // The rows at the HEAD are window 1's, and every one of them is still marked …
+    const head = await drawnSelection(page)
+    expect(head.length).toBeGreaterThanOrEqual(MIN_RENDERED_ROWS)
+    expect(head.filter((row) => !row.selected)).toEqual([])
+    expect(new Set(head.map((row) => row.id)).size).toBe(head.length)
+
+    // … and the rows the append CONTRIBUTED are not. Read at the bottom of the model,
+    // which under grouping is the tail of the last namespace: `asDrawn` files each
+    // arriving record at the end of its own group, so every row down there came from
+    // window 2. Without this half, "still 200 selected" is equally satisfied by a client
+    // that selected the appended rows and dropped as many of the originals.
+    await scrollGridTo(page, SCROLL_TO_BOTTOM_PX)
+    await expect(async () => {
+      const tail = await drawnSelection(page)
+      expect(tail.length).toBeGreaterThanOrEqual(MIN_RENDERED_ROWS)
+      expect(new Set(tail.map((row) => row.id)).size).toBe(tail.length)
+      expect(tail.filter((row) => row.selected)).toEqual([])
+      // The tail is genuinely a DIFFERENT part of the model, not the head read twice at
+      // an offset the virtualizer never applied.
+      expect(tail.map((row) => row.id)).not.toEqual(head.map((row) => row.id))
+    }).toPass({ timeout: 15_000 })
+  })
+
+  test("a query change clears the selection at fulfillment, never mid-flight", async ({
+    page,
+    consoleErrors,
+  }) => {
+    void consoleErrors
+    await openBrowse(page)
+    await selectAll(page).click()
+    await expect(bulkBar(page)).toBeVisible()
+
+    // Hold the query-change response so "mid-flight" is a state with duration. Every
+    // later poll for the new revision carries `filters` too and is held the same way,
+    // which is harmless: the revision gate discards all but one of them.
+    await page.route("**/api/memory/list*", async (route) => {
+      if (new URL(route.request().url()).searchParams.has("filters")) {
+        await new Promise((resolve) => setTimeout(resolve, HOLD_MS))
+      }
+      await route.continue()
+    })
+    await applySetFilter(page, "kind", ["procedural"])
+
+    // MID-FLIGHT. The rows on screen still answer query A, and the ENGINE still holds the
+    // selection over them: nothing has been cleared, because nothing has been fulfilled.
+    // A client that cleared on INTENT would blank this the moment the funnel closed.
+    await expectPhase(page, "stale")
+    const held = await drawnSelection(page)
+    expect(held.length).toBeGreaterThanOrEqual(MIN_RENDERED_ROWS)
+    expect(held.filter((row) => !row.selected)).toEqual([])
+
+    // CORRECTION to the plan's snippet, which expected the bulk bar to stay VISIBLE here.
+    // Design §7 Flow 11 says the opposite — "the bulk bar is disabled during `stale`
+    // (acting on rows a new query is about to replace is the ambiguity D1 bans)" — and
+    // `list-page.tsx` gates the bar on `!browse.rowsAreStale`, so it is withheld outright.
+    // The selection surviving mid-flight is asserted above, on the engine's own flags,
+    // which is where that claim belongs; the bar is a claim about what may be ACTED on.
+    await expect(bulkBar(page)).toHaveCount(0)
+
+    // AT FULFILLMENT the datasetKey pivots and the engine drops selection, focus and
+    // group expansion in one emit. Polled rather than read once: the pivot lands with the
+    // response, a frame after the phase attribute settles.
+    await expectPhase(page, "idle")
+    await expect(grid(page).locator('[data-pretable-selected="true"]')).toHaveCount(0)
+    await expect(bulkBar(page)).toHaveCount(0)
+    // The clear is not an artifact of an empty result — there are rows under it, and they
+    // are the NEW query's.
+    await expect(async () => {
+      const after = await drawnSelection(page)
+      expect(after.length).toBeGreaterThanOrEqual(MIN_RENDERED_ROWS)
+      expect(after.filter((row) => row.selected)).toEqual([])
+    }).toPass({ timeout: 15_000 })
+  })
+})

--- a/packages/inspector/e2e/11-partial-grouping-honesty.spec.ts
+++ b/packages/inspector/e2e/11-partial-grouping-honesty.spec.ts
@@ -1,0 +1,135 @@
+import type { Page } from "@playwright/test"
+import { BROWSE_PAGE_SIZE } from "../test/seed"
+import { expect, test } from "./fixtures"
+import {
+  DRAWN_FIRST_WINDOW,
+  DRAWN_FIRST_WINDOW_AFTER_SCENARIO_9,
+  grid,
+  MIN_RENDERED_ROWS,
+  n,
+  openBrowse,
+  status,
+  total,
+} from "./helpers"
+
+/** One `__group__:` header per namespace present in the first window. Derived from the
+ *  projection rather than counted off the seed, and checked below against the projection
+ *  the post-scenario-9 store produces, so the number holds whichever fixture state this
+ *  run met (see `matchingPopulation` in scenario 10 for why there are two). */
+const NAMESPACE_GROUPS = DRAWN_FIRST_WINDOW.length - BROWSE_PAGE_SIZE
+
+/**
+ * Every group heading in the loaded model — label → child-count text — gathered by
+ * sweeping the viewport.
+ *
+ * The grid virtualizes, so exactly one of the headings is in the document at rest: a
+ * claim about "the group counts" cannot be read off one screenful, and a spec that
+ * asserted only what it could see would be asserting one third of the model. The step is
+ * a third of a viewport, so no heading can fall between two samples, and each step
+ * scrolls and reads inside ONE page evaluation — a driver round trip between the two
+ * would let a poll tick re-render the rows in the gap and drop a heading from the sweep.
+ */
+async function sweepGroupHeadings(page: Page): Promise<Map<string, string>> {
+  const headings = new Map<string, string>()
+  const { max, step } = await grid(page).evaluate((node) => ({
+    max: node.scrollHeight - node.clientHeight,
+    step: Math.max(Math.floor(node.clientHeight / 3), 1),
+  }))
+  for (let top = 0; top <= max + step; top += step) {
+    const found = await grid(page).evaluate(
+      async (node, offset) => {
+        node.scrollTop = offset
+        // Three frames: the scroll handler sets React state, the re-render commits, and
+        // the browser paints. A sample taken earlier answers the PREVIOUS window — which
+        // the overlapping step would recover from, but silently and one sample later.
+        for (let frame = 0; frame < 3; frame += 1) {
+          await new Promise(requestAnimationFrame)
+        }
+        return Array.from(node.querySelectorAll("[data-pretable-group-row]")).map((row) => ({
+          label: row.querySelector("[data-pretable-group-label]")?.textContent ?? "",
+          count: row.querySelector("[data-pretable-group-count]")?.textContent ?? "",
+        }))
+      },
+      Math.min(top, max),
+    )
+    for (const { label, count } of found) headings.set(label, count)
+  }
+  return headings
+}
+
+// D1-COUNT-04. Grouping over a partial window is permitted but MARKED: child counts are
+// rendered loaded-scoped and the grid downgrades its ARIA counts to the loaded model.
+// Presenting a loaded-children count as a population count is what this bans.
+//
+// The plan wrote this scenario as a branch — "either the prototype is off for a partial
+// result, or it is loaded-scoped" — because both are conformant. The shipped disposition
+// is known and is not a branch: `list-page.tsx` passes `groupByNamespace={namespace ===
+// undefined}`, so the unscoped browse this opens on is ALWAYS grouped. Pinning that
+// disposition is the stronger claim; a branch would let grouping silently switch off and
+// still report green over an arm that never ran.
+test.describe("scenario 11 — partial grouping honesty", () => {
+  test.setTimeout(90_000)
+
+  test("grouping over a partial window is loaded-scoped, and ARIA downgrades with it", async ({
+    page,
+    consoleErrors,
+  }) => {
+    void consoleErrors
+    await openBrowse(page)
+
+    // The premise: the window IS partial. Read off the page because two fixture states
+    // reach this file (scenario 9 forgets a record when the whole suite runs), and the
+    // claim is the RELATION — a grid holding everything makes every line below vacuous.
+    await expect(status(page)).toContainText(`${n(BROWSE_PAGE_SIZE)} loaded of `)
+    const matching = Number((await total(page).innerText()).replaceAll(",", ""))
+    expect(BROWSE_PAGE_SIZE).toBeLessThan(matching)
+
+    // Grouped, and saying so in the role. `treegrid` is also what makes the ARIA
+    // downgrade below the correct answer rather than a missing feature.
+    await expect(grid(page)).toHaveAttribute("role", "treegrid")
+    const drawn = await grid(page).locator("[data-pretable-row-id]").count()
+    expect(drawn).toBeGreaterThanOrEqual(MIN_RENDERED_ROWS)
+    await expect(
+      grid(page).locator('[data-pretable-group-row][aria-expanded="true"]').first(),
+    ).toBeVisible()
+
+    // The two fixture states agree on how many namespaces the first window covers, which
+    // is what lets the constant be a constant.
+    expect(DRAWN_FIRST_WINDOW_AFTER_SCENARIO_9.length - BROWSE_PAGE_SIZE).toBe(NAMESPACE_GROUPS)
+
+    // Retried as a whole: the sweep drives the scroll box while a 2 s poll re-renders
+    // underneath it, so a heading missed at one step is re-gathered rather than reported.
+    await expect(async () => {
+      const headings = await sweepGroupHeadings(page)
+      expect(headings.size, "group headings found in the loaded model").toBe(NAMESPACE_GROUPS)
+      let children = 0
+      for (const [label, count] of headings) {
+        // The honesty marker itself: `groupChildCountLabel` is called with
+        // `scope: "loaded"`, so every heading reads "(N loaded)". A bare "(N)" is the
+        // shape this scenario exists to reject — it makes a claim about the population.
+        expect(count, `group "${label}"`).toMatch(/^\(\d+ loaded\)$/)
+        const digits = /\d+/.exec(count)
+        if (digits === null) throw new Error(`group "${label}" has no child count: ${count}`)
+        children += Number(digits[0])
+      }
+      // …and the counts add up to what is LOADED, not to what MATCHES. This is the
+      // assertion D1-COUNT-04 reduces to: group counts sourced from the population would
+      // sum to `matching` here, and the word "loaded" above would be a label over the
+      // wrong number.
+      expect(children, "children summed over every group heading").toBe(BROWSE_PAGE_SIZE)
+    }).toPass({ timeout: 30_000 })
+
+    // Design §4.5: grouping destroys the loaded-index → dataset-position mapping, so
+    // `aria-rowcount` REVERTS to the loaded model — the records, one heading each, and
+    // the header row — and the population honesty moves to the status chrome asserted
+    // above. Pinned exactly rather than bounded: `toBeLessThan(matching + 1)` is also
+    // satisfied by a grid that published a single row.
+    await expect(grid(page)).toHaveAttribute(
+      "aria-rowcount",
+      String(BROWSE_PAGE_SIZE + NAMESPACE_GROUPS + 1),
+    )
+    // Stated separately anyway, because it is the prohibition rather than the value: the
+    // population is NOT what a grouped grid publishes as its row count.
+    expect(BROWSE_PAGE_SIZE + NAMESPACE_GROUPS + 1).toBeLessThan(matching + 1)
+  })
+})

--- a/packages/inspector/e2e/12-view-isolation.spec.ts
+++ b/packages/inspector/e2e/12-view-isolation.spec.ts
@@ -4,22 +4,15 @@ import { expect, test } from "./fixtures"
 import {
   browseRegion,
   expectPhase,
+  loadedText,
   loadMore,
   MIN_RENDERED_ROWS,
-  n,
   openBrowse,
   openFilterMenu,
   rowIds,
   status,
   waitOnePollPeriod,
 } from "./helpers"
-
-/** "400 loaded", not "400": the status bar states two numbers in one sentence and
- *  the second one is the population, which differs between a solo run of this file
- *  (a pristine 1,250) and a whole-suite run (scenario 9 has removed one by then). */
-function loadedText(count: number): string {
-  return `${n(count)} loaded`
-}
 
 // View-scope matrix (§8.2) and Flow 10. Browse controls never appear to constrain a
 // view that ignores them, and leaving browse does not destroy the browse dataset.
@@ -42,9 +35,9 @@ test.describe("scenario 12 — view isolation", () => {
     //   2. no funnel is reachable from it (hidden content is out of the tab
     //      order and out of the accessibility tree),
     //   3. the scope note still tells the user why.
-    // If a future slice reverts to in-place disabling, restore the
-    // aria-disabled + focusable + aria-describedby assertions below, which are
-    // the right shape for THAT structure:
+    // Guidance for a future revert, not a record of anything this file ever had:
+    // if a slice goes back to in-place disabling, the assertions below are the
+    // wrong shape for it and these are the right ones.
     //   await expect(funnel).toHaveAttribute("aria-disabled", "true")
     //   await funnel.focus(); await expect(funnel).toBeFocused()
 

--- a/packages/inspector/e2e/12-view-isolation.spec.ts
+++ b/packages/inspector/e2e/12-view-isolation.spec.ts
@@ -1,0 +1,151 @@
+import { TEST_IDS } from "../src/components/memory/test-ids"
+import { BROWSE_PAGE_SIZE } from "../test/seed"
+import { expect, test } from "./fixtures"
+import {
+  browseRegion,
+  expectPhase,
+  loadMore,
+  MIN_RENDERED_ROWS,
+  n,
+  openBrowse,
+  openFilterMenu,
+  rowIds,
+  status,
+  waitOnePollPeriod,
+} from "./helpers"
+
+/** "400 loaded", not "400": the status bar states two numbers in one sentence and
+ *  the second one is the population, which differs between a solo run of this file
+ *  (a pristine 1,250) and a whole-suite run (scenario 9 has removed one by then). */
+function loadedText(count: number): string {
+  return `${n(count)} loaded`
+}
+
+// View-scope matrix (§8.2) and Flow 10. Browse controls never appear to constrain a
+// view that ignores them, and leaving browse does not destroy the browse dataset.
+test.describe("scenario 12 — view isolation", () => {
+  test.setTimeout(90_000)
+
+  test("browse-only controls are unreachable WITH A REASON in the search view", async ({
+    page,
+    consoleErrors,
+  }) => {
+    void consoleErrors
+    await openBrowse(page)
+
+    // NOTE (corrected after slice 4 shipped): slice 4 chose to keep the browse
+    // grid MOUNTED but `hidden` across view switches, rather than disabling its
+    // funnels in place. So during search the funnel is not merely aria-disabled
+    // — it is inside a hidden region and not reachable at all. Assert the
+    // structure that actually ships:
+    //   1. the browse region is hidden while a search is active,
+    //   2. no funnel is reachable from it (hidden content is out of the tab
+    //      order and out of the accessibility tree),
+    //   3. the scope note still tells the user why.
+    // If a future slice reverts to in-place disabling, restore the
+    // aria-disabled + focusable + aria-describedby assertions below, which are
+    // the right shape for THAT structure:
+    //   await expect(funnel).toHaveAttribute("aria-disabled", "true")
+    //   await funnel.focus(); await expect(funnel).toBeFocused()
+
+    // Opened BEFORE the search, and this is the whole point of the popover
+    // assertion below: pretable portals the panel to `<body>`, which is outside
+    // everything `hidden` reaches, so the same assertion taken with no panel open
+    // would hold just as well over a page that never closes one.
+    await openFilterMenu(page, "status")
+    await expect(page.getByRole("dialog", { name: "Filter status", exact: true })).toBeVisible()
+
+    // `fill` focuses and types; it dispatches no pointer event, so pretable's own
+    // dismiss-on-outside-pointerdown never fires and closing the panel is left
+    // entirely to the page. That is the keyboard user's path, and it is the one
+    // the effect under test exists for.
+    await page.getByLabel("Search memories").fill("acme")
+
+    await expect(browseRegion(page)).toBeHidden()
+    await expect(page.getByRole("button", { name: "Filter status", exact: true })).toHaveCount(0)
+    // And no popover survived the hide: pretable portals them to document.body,
+    // so an open funnel would otherwise float over the search results.
+    await expect(page.getByRole("dialog")).toHaveCount(0)
+    await expect(page.getByTestId(TEST_IDS.searchScopeNote)).toBeVisible()
+  })
+
+  test("a search hides the browse dataset without destroying any of it", async ({
+    page,
+    consoleErrors,
+  }) => {
+    void consoleErrors
+    await openBrowse(page)
+    await loadMore(page).click()
+    // CORRECTED (preamble 9): the loaded count comes off the STATUS BAR, never off
+    // `rowIds` — the DOM holds ~19 rows however many the client is holding, so the
+    // rows alone cannot tell one resident window from two.
+    await expect(status(page)).toContainText(loadedText(BROWSE_PAGE_SIZE * 2))
+    await expectPhase(page, "idle")
+    const loaded = await rowIds(page)
+    // A floor, so the comparisons below are between two real windows: `rowIds`
+    // does not retry, and an empty read would make every later `toEqual` agree
+    // with itself about nothing.
+    expect(loaded.length).toBeGreaterThanOrEqual(MIN_RENDERED_ROWS)
+
+    await page.getByLabel("Search memories").fill("acme")
+    await expect(browseRegion(page)).toBeHidden()
+    // The whole status bar goes with it: those two numbers describe the browse
+    // population, and the search is not it.
+    await expect(status(page)).toHaveCount(0)
+
+    await page.getByLabel("Search memories").fill("")
+    await expect(browseRegion(page)).toBeVisible()
+
+    // Flow 10 at full strength. A search does not touch the browse query, so the
+    // dataset identity here is the one both windows were loaded under: BOTH are
+    // still resident, and the head of the model is untouched.
+    await expect(status(page)).toContainText(loadedText(BROWSE_PAGE_SIZE * 2))
+    await expect.poll(() => rowIds(page)).toEqual(loaded)
+    await expectPhase(page, "idle")
+
+    // Polling really did come back, and the refresh it sends re-derives the whole
+    // resident span rather than the first page of it — one real tick, request and
+    // response both, and the client still holds two windows afterwards.
+    await waitOnePollPeriod(page)
+    await expect(status(page)).toContainText(loadedText(BROWSE_PAGE_SIZE * 2))
+    await expect.poll(() => rowIds(page)).toEqual(loaded)
+  })
+
+  test("the timeline is a different dataset, so neither view inherits the other's walk", async ({
+    page,
+    consoleErrors,
+  }) => {
+    void consoleErrors
+    await openBrowse(page)
+    await loadMore(page).click()
+    await expect(status(page)).toContainText(loadedText(BROWSE_PAGE_SIZE * 2))
+    await expectPhase(page, "idle")
+    const loaded = await rowIds(page)
+    expect(loaded.length).toBeGreaterThanOrEqual(MIN_RENDERED_ROWS)
+
+    await page.getByRole("button", { name: "timeline", exact: true }).click()
+    await expect(browseRegion(page)).toBeHidden()
+    await page.getByRole("button", { name: "list", exact: true }).click()
+    await expect(browseRegion(page)).toBeVisible()
+
+    // Flow 10: the grid is hidden, not unmounted. The head of the model comes back
+    // identical and the phase settles without the surface ever having been rebuilt.
+    await expect.poll(() => rowIds(page)).toEqual(loaded)
+    await expectPhase(page, "idle")
+
+    // …and the WALK does not come back, which is the same design decision seen from
+    // the other side: `view` is part of the canonical query, so this round trip is a
+    // dataset pivot and the list view starts its walk again at one window. Stated in
+    // `canonical-query.ts` — "a switch that inherited them would resume another
+    // surface's walk" — and in Flow 10, which says search and timeline never inherit
+    // the browse continuation.
+    //
+    // Pinned HERE because it is invisible everywhere else: the drawn head is
+    // identical at 200 resident and at 400, so nothing above this line can tell the
+    // two apart, and a user who paged to 400, glanced at the timeline and came back
+    // is silently holding half of what they had. A slice that decides to carry the
+    // walk across the toggle must move this expectation deliberately.
+    await expect(status(page)).toContainText(loadedText(BROWSE_PAGE_SIZE))
+    await expect(status(page)).not.toContainText(loadedText(BROWSE_PAGE_SIZE * 2))
+  })
+})

--- a/packages/inspector/e2e/13-accessibility.spec.ts
+++ b/packages/inspector/e2e/13-accessibility.spec.ts
@@ -1,0 +1,157 @@
+import { TEST_IDS } from "../src/components/memory/test-ids"
+import { BROWSE_PAGE_SIZE, seedRecordsMatching } from "../test/seed"
+import { expect, test } from "./fixtures"
+import {
+  browseRegion,
+  expectPhase,
+  grid,
+  liveRegionText,
+  loadMore,
+  openBrowse,
+  sortByHeader,
+} from "./helpers"
+
+/** What the browser logs for the browse response this spec makes the server refuse.
+ *  Mirrors `08-refresh-append-failure.spec.ts`: the ENDPOINT is half the match,
+ *  because Chromium's message text names only the status. */
+function isSeededBrowseFailure(line: string): boolean {
+  return /Failed to load resource: .*status of 500/.test(line) && line.includes("/api/memory/list")
+}
+
+/** Account for the console errors this spec CAUSED and leave everything else for the
+ *  fixture's own teardown gate. `expected` is a floor, not a formality: a fault
+ *  injection that silently stopped matching would log nothing, and a drain that merely
+ *  filtered would let that pass while proving nothing about the path it claims to walk. */
+function drainSeededFetchErrors(consoleErrors: string[], expected: number): void {
+  const seeded = consoleErrors.filter(isSeededBrowseFailure)
+  const unexpected = consoleErrors.filter((line) => !isSeededBrowseFailure(line))
+  consoleErrors.length = 0
+  expect(unexpected, "console errors this spec did not inject").toEqual([])
+  expect(seeded.length, "seeded 500s the browser logged").toBeGreaterThanOrEqual(expected)
+}
+
+/** Where DOM focus is, relative to the browse grid — read in ONE page evaluation so
+ *  the tag and the containment answer for the same instant. */
+async function focusReport(
+  page: import("@playwright/test").Page,
+): Promise<{ tag: string; inGrid: boolean; onDataCell: boolean }> {
+  return browseRegion(page).evaluate((region) => {
+    const active = document.activeElement as HTMLElement | null
+    const viewport = region.querySelector("[data-pretable-scroll-viewport]")
+    return {
+      tag: active?.tagName ?? "",
+      inGrid: viewport?.contains(active ?? null) ?? false,
+      onDataCell: active?.matches("[data-pretable-cell]") ?? false,
+    }
+  })
+}
+
+// D1-A11Y-01..04, as one walkthrough: busy, count, position, stale, error and retry
+// are all identifiable, and focus is never lost across any of them.
+test.describe("scenario 13 — accessibility walkthrough", () => {
+  test.setTimeout(120_000)
+
+  test("every lifecycle state is identifiable and focus never leaves the page", async ({
+    page,
+    consoleErrors,
+  }) => {
+    await openBrowse(page)
+
+    // CORRECTED (preamble 9): the unscoped browse is GROUPED, so the population is not
+    // in `aria-rowcount` there and the first drawn row is a `__group__:` header rather
+    // than a record — which the cell click below would then be focusing. Scope to a
+    // facet FIRST: that is the branch where §4.5 publishes the population, and it is
+    // the branch this walkthrough means. The grouped downgrade is scenario 5's, and
+    // the two branches side by side are Task 10's.
+    //
+    // The PRISTINE seed is the right input for this count even in a whole-suite run:
+    // both of scenario 9's writes land in `route=/notes-archive`, so this namespace
+    // holds the same 667 records before and after it.
+    const scoped = seedRecordsMatching({ namespace: "route=/notes" })
+    await page.getByRole("button", { name: `route=/notes ${scoped.length}`, exact: true }).click()
+    await expectPhase(page, "idle")
+
+    // COUNT + POSITION: the population in aria-rowcount, the position in aria-rowindex.
+    await expect(grid(page)).toHaveAttribute("aria-rowcount", String(scoped.length + 1))
+    const firstRow = grid(page).locator("[data-pretable-row-id]").first()
+    await expect(firstRow).toHaveAttribute("aria-rowindex", "2")
+
+    // BUSY: never as aria-busy. The lifecycle is a data attribute plus prose.
+    await expect(grid(page)).not.toHaveAttribute("aria-busy", /.*/)
+
+    // Focus a DATA cell. Not `[data-pretable-cell]` first — that is the row-select
+    // checkbox cell, whose click focuses a button and ticks a row instead of moving
+    // the grid's own cell focus. A data-cell click is also row ACTIVATION (pretable
+    // routes click and Enter/Space alike to `onRowActivate`, and this page opens the
+    // detail sheet from it), so the sheet is dismissed again before the query change
+    // below, or the rest of this walkthrough would be about the sheet. Escape is the
+    // sheet's own documented dismissal and moves no focus of its own.
+    await firstRow.locator('[data-pretable-cell][data-pretable-column-id="status"]').click()
+    await page.keyboard.press("Escape")
+    await expect(page.getByLabel("Close detail")).toHaveCount(0)
+    // The precondition, asserted rather than assumed. §4.2's DK-change focus rule is
+    // conditional — "if DOM focus was inside the grid at the change" — so a run that
+    // reached the pivot with focus already elsewhere would satisfy the rule vacuously
+    // and prove nothing.
+    expect(await focusReport(page)).toEqual({ tag: "DIV", inGrid: true, onDataCell: true })
+
+    // The query change is a SORT HEADER, and the choice is load-bearing. §4.2's rule
+    // only governs a pivot that starts with focus inside the grid, and a funnel does
+    // not: pretable's `FilterMenu` is portaled to `<body>` and does not restore focus
+    // to its trigger on Escape — recorded in design §1.1 as a pre-existing a11y gap
+    // that is explicitly NOT a D1 obligation. Driving this through the funnel would
+    // therefore be asserting the exempted path and failing on the exemption. A header
+    // click leaves DOM focus on the header cell, which is inside the viewport, which
+    // is the rule's stated precondition.
+    //
+    // `status` rather than `updated`: one click is DESC, and `updated` DESC is already
+    // the default order, so that gesture would canonicalize to the query the page is
+    // on and pivot no dataset at all.
+    await page.route("**/api/memory/list*", async (route) => {
+      if (new URL(route.request().url()).searchParams.has("orderBy")) {
+        await new Promise((resolve) => setTimeout(resolve, 1_500))
+      }
+      await route.continue()
+    })
+    await sortByHeader(page, "status")
+
+    // STALE: announced once, marked on the DOM, rows still readable.
+    await expectPhase(page, "stale")
+    await expect.poll(() => liveRegionText(page)).toContain("Updating")
+    await expectPhase(page, "idle")
+
+    // §4.2, "deterministic, never `<body>`": the pivot cleared the old focus and the
+    // surface put it on the first data cell of the NEW result.
+    await expect
+      .poll(() => focusReport(page))
+      .toEqual({
+        tag: "DIV",
+        inGrid: true,
+        onDataCell: true,
+      })
+
+    // ERROR + RETRY: reachable by keyboard, announced through the polite region.
+    await page.unrouteAll()
+    let failing = true
+    await page.route("**/api/memory/list*", async (route) => {
+      if (failing) {
+        await route.fulfill({ status: 500, contentType: "application/json", body: "{}" })
+        return
+      }
+      await route.continue()
+    })
+    await page.reload()
+    // Pretable's hydration signal before any keystroke: an SSR'd control is painted
+    // and inert, and the Enter press below would be silently dropped.
+    await expect(grid(page)).toHaveAttribute("data-pretable-hydrated", "true")
+    await expect(grid(page)).toHaveAttribute("data-pretable-data-phase", "error")
+    await expect.poll(() => liveRegionText(page)).toMatch(/could not|error|fail/i)
+    failing = false
+    await page.getByTestId(TEST_IDS.retryInitial).focus()
+    await page.keyboard.press("Enter")
+    await expectPhase(page, "idle")
+    await expect(loadMore(page)).toContainText(String(BROWSE_PAGE_SIZE))
+
+    drainSeededFetchErrors(consoleErrors, 1)
+  })
+})

--- a/packages/inspector/e2e/13-accessibility.spec.ts
+++ b/packages/inspector/e2e/13-accessibility.spec.ts
@@ -1,5 +1,10 @@
 import { TEST_IDS } from "../src/components/memory/test-ids"
-import { BROWSE_PAGE_SIZE, seedRecordsMatching } from "../test/seed"
+import {
+  BROWSE_PAGE_SIZE,
+  seedIdsInDefaultOrder,
+  seedIdsSortedBy,
+  seedRecordsMatching,
+} from "../test/seed"
 import { expect, test } from "./fixtures"
 import {
   browseRegion,
@@ -7,9 +12,22 @@ import {
   grid,
   liveRegionText,
   loadMore,
+  n,
   openBrowse,
   sortByHeader,
 } from "./helpers"
+
+/** How long the sort's FIRST response is held open.
+ *
+ *  Sized like `06-desired-fulfilled-mismatch.spec.ts` and `10-selection-scope.spec.ts`
+ *  rather than guessed, and for their reason: everything claimed about `stale` is claimed
+ *  about the window between the gesture and the answer, each claim inside it costs a CDP
+ *  round trip, and on a machine running several suites at once a 1 s hold is a window the
+ *  assertions can fall out of — reported then as "the sort already landed" rather than as
+ *  anything about staleness. A sort is ONE dataset pivot, so `stale` happens exactly once
+ *  and every later poll is `refreshing`: a missed window is a hard failure that no
+ *  auto-retry can absorb, which is what makes the margin worth its seconds. */
+const HOLD_MS = 5_000
 
 /** What the browser logs for the browse response this spec makes the server refuse.
  *  Mirrors `08-refresh-append-failure.spec.ts`: the ENDPOINT is half the match,
@@ -30,18 +48,33 @@ function drainSeededFetchErrors(consoleErrors: string[], expected: number): void
   expect(seeded.length, "seeded 500s the browser logged").toBeGreaterThanOrEqual(expected)
 }
 
-/** Where DOM focus is, relative to the browse grid — read in ONE page evaluation so
- *  the tag and the containment answer for the same instant. */
+/**
+ * WHICH cell DOM focus is on, relative to the browse grid — read in ONE page evaluation
+ * so every field answers for the same instant.
+ *
+ * The address, not merely the shape. A report of tag + containment + "is a cell" is
+ * identical before and after a dataset pivot, so an expectation written against it cannot
+ * tell "focus moved to the first data cell of the NEW result" — which is what §4.2
+ * promises — from focus that was re-asserted at the same coordinates over different rows.
+ * The row id is what distinguishes them, and it is the seed that says which row that
+ * should be.
+ *
+ * `columnId` is read off the active element itself rather than off an ancestor, so a
+ * non-empty value already means the focused node IS the cell. It also excludes the
+ * row-select cell, which carries `data-pretable-cell` too and would otherwise satisfy a
+ * bare "on a data cell" claim.
+ */
 async function focusReport(
   page: import("@playwright/test").Page,
-): Promise<{ tag: string; inGrid: boolean; onDataCell: boolean }> {
+): Promise<{ tag: string; inGrid: boolean; rowId: string; columnId: string }> {
   return browseRegion(page).evaluate((region) => {
     const active = document.activeElement as HTMLElement | null
     const viewport = region.querySelector("[data-pretable-scroll-viewport]")
     return {
       tag: active?.tagName ?? "",
       inGrid: viewport?.contains(active ?? null) ?? false,
-      onDataCell: active?.matches("[data-pretable-cell]") ?? false,
+      rowId: active?.closest("[data-pretable-row-id]")?.getAttribute("data-pretable-row-id") ?? "",
+      columnId: active?.getAttribute("data-pretable-column-id") ?? "",
     }
   })
 }
@@ -65,8 +98,14 @@ test.describe("scenario 13 — accessibility walkthrough", () => {
     // the two branches side by side are Task 10's.
     //
     // The PRISTINE seed is the right input for this count even in a whole-suite run:
-    // both of scenario 9's writes land in `route=/notes-archive`, so this namespace
-    // holds the same 667 records before and after it.
+    // both of scenario 9's writes land in `route=/notes-archive`, so this namespace holds
+    // the same records before and after it. WHY both land there, so the next reader does
+    // not re-derive it: the drawn projection groups ascending by namespace — `route=/chat`,
+    // `route=/notes`, `route=/notes-archive` — and scenario 9 picks the LAST drawn row to
+    // forget (archive, being the last group) and the LAST episodic candidate in that
+    // projection to approve (archive again, since that group has some). And if either ever
+    // moved, this fails loudly rather than silently: the facet button is located by this
+    // very number.
     const scoped = seedRecordsMatching({ namespace: "route=/notes" })
     await page.getByRole("button", { name: `route=/notes ${scoped.length}`, exact: true }).click()
     await expectPhase(page, "idle")
@@ -93,7 +132,14 @@ test.describe("scenario 13 — accessibility walkthrough", () => {
     // conditional — "if DOM focus was inside the grid at the change" — so a run that
     // reached the pivot with focus already elsewhere would satisfy the rule vacuously
     // and prove nothing.
-    expect(await focusReport(page)).toEqual({ tag: "DIV", inGrid: true, onDataCell: true })
+    //
+    // POLLED, and not for symmetry with the read after the pivot: the sheet restores focus
+    // to its opener from an unmount layout effect, and `toHaveCount(0)` above confirms only
+    // that the sheet is gone — a one-shot read landing in the same tick sees `<body>`.
+    const defaultHead = seedIdsInDefaultOrder(scoped)[0] as string
+    await expect
+      .poll(() => focusReport(page))
+      .toEqual({ tag: "DIV", inGrid: true, rowId: defaultHead, columnId: "status" })
 
     // The query change is a SORT HEADER, and the choice is load-bearing. §4.2's rule
     // only governs a pivot that starts with focus inside the grid, and a funnel does
@@ -107,9 +153,17 @@ test.describe("scenario 13 — accessibility walkthrough", () => {
     // `status` rather than `updated`: one click is DESC, and `updated` DESC is already
     // the default order, so that gesture would canonicalize to the query the page is
     // on and pivot no dataset at all.
+    //
+    // A LATCH on the first sorted request, not a predicate on the param. The browse
+    // re-polls every 2 s and every one of those ticks carries `orderBy` too, so holding
+    // all of them would leave the page mid-flight for the rest of the walkthrough — the
+    // error/retry half below would be read through a permanently delayed transport, and a
+    // handler would still be sleeping when `unrouteAll` fires.
+    let heldFirstSortedRequest = false
     await page.route("**/api/memory/list*", async (route) => {
-      if (new URL(route.request().url()).searchParams.has("orderBy")) {
-        await new Promise((resolve) => setTimeout(resolve, 1_500))
+      if (!heldFirstSortedRequest && new URL(route.request().url()).searchParams.has("orderBy")) {
+        heldFirstSortedRequest = true
+        await new Promise((resolve) => setTimeout(resolve, HOLD_MS))
       }
       await route.continue()
     })
@@ -119,16 +173,21 @@ test.describe("scenario 13 — accessibility walkthrough", () => {
     await expectPhase(page, "stale")
     await expect.poll(() => liveRegionText(page)).toContain("Updating")
     await expectPhase(page, "idle")
+    // The fault was actually injected. Without this the stale claims above are made about
+    // a page that was never held, and an `orderBy` this route stopped recognising would
+    // take them with it, silently.
+    expect(heldFirstSortedRequest).toBe(true)
 
     // §4.2, "deterministic, never `<body>`": the pivot cleared the old focus and the
-    // surface put it on the first data cell of the NEW result.
+    // surface put it on the first data cell of the NEW result — the head of the
+    // status-sorted order, which is a DIFFERENT record from the one focus was on. Without
+    // that inequality this read would be satisfied by focus that never moved, since the
+    // grid re-renders the same coordinates over new rows.
+    const sortedHead = seedIdsSortedBy([{ field: "status", dir: "desc" }], scoped)[0] as string
+    expect(sortedHead).not.toBe(defaultHead)
     await expect
       .poll(() => focusReport(page))
-      .toEqual({
-        tag: "DIV",
-        inGrid: true,
-        onDataCell: true,
-      })
+      .toEqual({ tag: "DIV", inGrid: true, rowId: sortedHead, columnId: "status" })
 
     // ERROR + RETRY: reachable by keyboard, announced through the polite region.
     await page.unrouteAll()
@@ -150,7 +209,7 @@ test.describe("scenario 13 — accessibility walkthrough", () => {
     await page.getByTestId(TEST_IDS.retryInitial).focus()
     await page.keyboard.press("Enter")
     await expectPhase(page, "idle")
-    await expect(loadMore(page)).toContainText(String(BROWSE_PAGE_SIZE))
+    await expect(loadMore(page)).toContainText(n(BROWSE_PAGE_SIZE))
 
     drainSeededFetchErrors(consoleErrors, 1)
   })

--- a/packages/inspector/e2e/13-accessibility.spec.ts
+++ b/packages/inspector/e2e/13-accessibility.spec.ts
@@ -7,8 +7,10 @@ import {
 } from "../test/seed"
 import { expect, test } from "./fixtures"
 import {
-  browseRegion,
+  drainSeededFetchErrors,
   expectPhase,
+  focusRecordCell,
+  focusReport,
   grid,
   liveRegionText,
   loadMore,
@@ -28,56 +30,6 @@ import {
  *  and every later poll is `refreshing`: a missed window is a hard failure that no
  *  auto-retry can absorb, which is what makes the margin worth its seconds. */
 const HOLD_MS = 5_000
-
-/** What the browser logs for the browse response this spec makes the server refuse.
- *  Mirrors `08-refresh-append-failure.spec.ts`: the ENDPOINT is half the match,
- *  because Chromium's message text names only the status. */
-function isSeededBrowseFailure(line: string): boolean {
-  return /Failed to load resource: .*status of 500/.test(line) && line.includes("/api/memory/list")
-}
-
-/** Account for the console errors this spec CAUSED and leave everything else for the
- *  fixture's own teardown gate. `expected` is a floor, not a formality: a fault
- *  injection that silently stopped matching would log nothing, and a drain that merely
- *  filtered would let that pass while proving nothing about the path it claims to walk. */
-function drainSeededFetchErrors(consoleErrors: string[], expected: number): void {
-  const seeded = consoleErrors.filter(isSeededBrowseFailure)
-  const unexpected = consoleErrors.filter((line) => !isSeededBrowseFailure(line))
-  consoleErrors.length = 0
-  expect(unexpected, "console errors this spec did not inject").toEqual([])
-  expect(seeded.length, "seeded 500s the browser logged").toBeGreaterThanOrEqual(expected)
-}
-
-/**
- * WHICH cell DOM focus is on, relative to the browse grid — read in ONE page evaluation
- * so every field answers for the same instant.
- *
- * The address, not merely the shape. A report of tag + containment + "is a cell" is
- * identical before and after a dataset pivot, so an expectation written against it cannot
- * tell "focus moved to the first data cell of the NEW result" — which is what §4.2
- * promises — from focus that was re-asserted at the same coordinates over different rows.
- * The row id is what distinguishes them, and it is the seed that says which row that
- * should be.
- *
- * `columnId` is read off the active element itself rather than off an ancestor, so a
- * non-empty value already means the focused node IS the cell. It also excludes the
- * row-select cell, which carries `data-pretable-cell` too and would otherwise satisfy a
- * bare "on a data cell" claim.
- */
-async function focusReport(
-  page: import("@playwright/test").Page,
-): Promise<{ tag: string; inGrid: boolean; rowId: string; columnId: string }> {
-  return browseRegion(page).evaluate((region) => {
-    const active = document.activeElement as HTMLElement | null
-    const viewport = region.querySelector("[data-pretable-scroll-viewport]")
-    return {
-      tag: active?.tagName ?? "",
-      inGrid: viewport?.contains(active ?? null) ?? false,
-      rowId: active?.closest("[data-pretable-row-id]")?.getAttribute("data-pretable-row-id") ?? "",
-      columnId: active?.getAttribute("data-pretable-column-id") ?? "",
-    }
-  })
-}
 
 // D1-A11Y-01..04, as one walkthrough: busy, count, position, stale, error and retry
 // are all identifiable, and focus is never lost across any of them.
@@ -118,28 +70,16 @@ test.describe("scenario 13 — accessibility walkthrough", () => {
     // BUSY: never as aria-busy. The lifecycle is a data attribute plus prose.
     await expect(grid(page)).not.toHaveAttribute("aria-busy", /.*/)
 
-    // Focus a DATA cell. Not `[data-pretable-cell]` first — that is the row-select
-    // checkbox cell, whose click focuses a button and ticks a row instead of moving
-    // the grid's own cell focus. A data-cell click is also row ACTIVATION (pretable
-    // routes click and Enter/Space alike to `onRowActivate`, and this page opens the
-    // detail sheet from it), so the sheet is dismissed again before the query change
-    // below, or the rest of this walkthrough would be about the sheet. Escape is the
-    // sheet's own documented dismissal and moves no focus of its own.
-    await firstRow.locator('[data-pretable-cell][data-pretable-column-id="status"]').click()
-    await page.keyboard.press("Escape")
-    await expect(page.getByLabel("Close detail")).toHaveCount(0)
-    // The precondition, asserted rather than assumed. §4.2's DK-change focus rule is
-    // conditional — "if DOM focus was inside the grid at the change" — so a run that
-    // reached the pivot with focus already elsewhere would satisfy the rule vacuously
-    // and prove nothing.
+    // Focus a DATA cell, by ID rather than through `firstRow`: the head of the default
+    // order is what the seed says it is, so naming it here makes the click's target a
+    // checked fact and not whatever the grid happened to draw first.
     //
-    // POLLED, and not for symmetry with the read after the pivot: the sheet restores focus
-    // to its opener from an unmount layout effect, and `toHaveCount(0)` above confirms only
-    // that the sheet is gone — a one-shot read landing in the same tick sees `<body>`.
+    // The precondition is asserted rather than assumed — `focusRecordCell` ends by
+    // pinning the whole address. §4.2's DK-change focus rule is conditional ("if DOM
+    // focus was inside the grid at the change"), so a run that reached the pivot with
+    // focus already elsewhere would satisfy the rule vacuously and prove nothing.
     const defaultHead = seedIdsInDefaultOrder(scoped)[0] as string
-    await expect
-      .poll(() => focusReport(page))
-      .toEqual({ tag: "DIV", inGrid: true, rowId: defaultHead, columnId: "status" })
+    await focusRecordCell(page, defaultHead, "status")
 
     // The query change is a SORT HEADER, and the choice is load-bearing. §4.2's rule
     // only governs a pivot that starts with focus inside the grid, and a funnel does
@@ -187,7 +127,7 @@ test.describe("scenario 13 — accessibility walkthrough", () => {
     expect(sortedHead).not.toBe(defaultHead)
     await expect
       .poll(() => focusReport(page))
-      .toEqual({ tag: "DIV", inGrid: true, rowId: sortedHead, columnId: "status" })
+      .toEqual({ rowId: sortedHead, columnId: "status", inGrid: true, onBody: false })
 
     // ERROR + RETRY: reachable by keyboard, announced through the polite region.
     await page.unrouteAll()

--- a/packages/inspector/e2e/14-local-regression.spec.ts
+++ b/packages/inspector/e2e/14-local-regression.spec.ts
@@ -19,29 +19,51 @@ test.describe("scenario 14 — local regression", () => {
     // on for the life of a surface that was ever handed a `dataState`. A
     // document-wide query for the ABSENCE of that chrome would therefore answer about
     // the wrong grid and fail for a reason with nothing to do with the local one.
-    // `<section>` is the search results' own element and nothing else on this page
-    // renders one while a search is active (the timeline is not mounted then).
-    const searchSurface = page.locator("main section").first()
-    const searchGrid = gridIn(searchSurface)
-    await expect(searchGrid).toBeVisible()
+    //
+    // `list-page` renders one `<section>` per search GROUP, so this is N elements and
+    // every one of them holds a local grid. Asserted over ALL of them: `.first()` here
+    // would silently narrow the whole test to group one, and the groups are exactly what
+    // varies. `TimelineView` renders `<section>` per day too, but it is unmounted while a
+    // search is active — and the grid-per-section equality below is what holds that
+    // invariant, since a timeline section carries no grid.
+    const searchSections = page.locator("main section")
+    const searchGrids = gridIn(searchSections)
+    // Waited for BEFORE anything is counted: the search input is debounced, so every
+    // count taken ahead of the first result answers zero and each `toHaveCount(0)` below
+    // would then be a claim about an empty document.
+    await expect(searchGrids.first()).toBeVisible()
+    const groupCount = await searchSections.count()
+    expect(groupCount).toBeGreaterThan(0)
+    await expect(searchGrids).toHaveCount(groupCount)
 
-    // No dataState → no phase attribute, no body-state wrapper, no body-state block.
-    await expect(searchGrid).not.toHaveAttribute("data-pretable-data-phase", /.*/)
-    await expect(searchSurface.locator("[data-pretable-data-state-wrapper]")).toHaveCount(0)
-    await expect(searchSurface.locator("[data-pretable-body-state]")).toHaveCount(0)
+    // No dataState → no body-state wrapper and no body-state block, in ANY group.
+    await expect(searchSections.locator("[data-pretable-data-state-wrapper]")).toHaveCount(0)
+    await expect(searchSections.locator("[data-pretable-body-state]")).toHaveCount(0)
 
-    // The control, without which the three assertions above are just a claim about a
+    // The control, without which the two assertions above are just a claim about a
     // selector that matches nothing anywhere: the grid that DID opt in, in the same
     // document at the same moment, carries the wrapper.
     await expect(browseRegion(page).locator("[data-pretable-data-state-wrapper]")).toHaveCount(1)
 
-    // Local ARIA semantics: aria-rowcount is the VISIBLE row count plus the header,
-    // not any remote population. A search group is the store's ranked top-8, so every
-    // row of it is drawn and the DOM count is the model count — the equality this
-    // makes would not hold over a virtualized 200-row window.
-    const visible = await searchGrid.locator("[data-pretable-row-id]").count()
-    expect(visible).toBeGreaterThan(0)
-    await expect(searchGrid).toHaveAttribute("aria-rowcount", String(visible + 1))
-    await expect(searchGrid).not.toHaveAttribute("aria-busy", /.*/)
+    // The per-grid reads, in ONE page evaluation over every group: an absent phase, an
+    // absent aria-busy, and local ARIA counting — aria-rowcount is the VISIBLE row count
+    // plus the header, not any remote population. A search group is the store's ranked
+    // top-8, so every row of it is drawn and the DOM count is the model count; the
+    // equality this makes would not hold over a virtualized 200-row window.
+    const locals = await searchGrids.evaluateAll((nodes) =>
+      nodes.map((node) => ({
+        phase: node.getAttribute("data-pretable-data-phase"),
+        busy: node.getAttribute("aria-busy"),
+        rowCount: node.getAttribute("aria-rowcount"),
+        rows: node.querySelectorAll("[data-pretable-row-id]").length,
+      })),
+    )
+    expect(locals.length).toBe(groupCount)
+    for (const local of locals) {
+      expect(local.phase).toBeNull()
+      expect(local.busy).toBeNull()
+      expect(local.rows).toBeGreaterThan(0)
+      expect(local.rowCount).toBe(String(local.rows + 1))
+    }
   })
 })

--- a/packages/inspector/e2e/14-local-regression.spec.ts
+++ b/packages/inspector/e2e/14-local-regression.spec.ts
@@ -1,0 +1,47 @@
+import { expect, test } from "./fixtures"
+import { browseRegion, gridIn, openBrowse } from "./helpers"
+
+// D1-GRID-04. The search view renders the SAME MemoryGrid component with no
+// `processing`, no `resultMeta` and no `dataState` — an ordinary complete in-memory
+// Pretable consumer. It must behave exactly as it did before slice 1 existed.
+test.describe("scenario 14 — local regression", () => {
+  test("a grid that opted into nothing gets no lifecycle presentation at all", async ({
+    page,
+    consoleErrors,
+  }) => {
+    void consoleErrors
+    await openBrowse(page)
+    await page.getByLabel("Search memories").fill("acme threshold 1")
+
+    // SCOPED to the search surface, and the scope is the test rather than a detail of
+    // it. Slice 4 keeps the browse grid MOUNTED-and-`hidden` beside the results, and
+    // that grid DOES carry lifecycle chrome — pretable latches its body-state wrapper
+    // on for the life of a surface that was ever handed a `dataState`. A
+    // document-wide query for the ABSENCE of that chrome would therefore answer about
+    // the wrong grid and fail for a reason with nothing to do with the local one.
+    // `<section>` is the search results' own element and nothing else on this page
+    // renders one while a search is active (the timeline is not mounted then).
+    const searchSurface = page.locator("main section").first()
+    const searchGrid = gridIn(searchSurface)
+    await expect(searchGrid).toBeVisible()
+
+    // No dataState → no phase attribute, no body-state wrapper, no body-state block.
+    await expect(searchGrid).not.toHaveAttribute("data-pretable-data-phase", /.*/)
+    await expect(searchSurface.locator("[data-pretable-data-state-wrapper]")).toHaveCount(0)
+    await expect(searchSurface.locator("[data-pretable-body-state]")).toHaveCount(0)
+
+    // The control, without which the three assertions above are just a claim about a
+    // selector that matches nothing anywhere: the grid that DID opt in, in the same
+    // document at the same moment, carries the wrapper.
+    await expect(browseRegion(page).locator("[data-pretable-data-state-wrapper]")).toHaveCount(1)
+
+    // Local ARIA semantics: aria-rowcount is the VISIBLE row count plus the header,
+    // not any remote population. A search group is the store's ranked top-8, so every
+    // row of it is drawn and the DOM count is the model count — the equality this
+    // makes would not hold over a virtualized 200-row window.
+    const visible = await searchGrid.locator("[data-pretable-row-id]").count()
+    expect(visible).toBeGreaterThan(0)
+    await expect(searchGrid).toHaveAttribute("aria-rowcount", String(visible + 1))
+    await expect(searchGrid).not.toHaveAttribute("aria-busy", /.*/)
+  })
+})

--- a/packages/inspector/e2e/a11y-announcements.spec.ts
+++ b/packages/inspector/e2e/a11y-announcements.spec.ts
@@ -3,6 +3,7 @@ import { BROWSE_PAGE_SIZE } from "../test/seed"
 import { expect, test } from "./fixtures"
 import {
   applySetFilter,
+  drainSeededFetchErrors,
   expectPhase,
   liveRegionText,
   loadMore,
@@ -25,25 +26,6 @@ import {
  * against ONE sample — two successive polls can each be satisfied by a different sentence
  * and jointly prove nothing about either.
  */
-
-/** What the browser logs for the browse response the first test refuses. Mirrors
- *  `13-accessibility.spec.ts`: the ENDPOINT is half the match, because Chromium's message
- *  text names only the status. */
-function isSeededBrowseFailure(line: string): boolean {
-  return /Failed to load resource: .*status of 500/.test(line) && line.includes("/api/memory/list")
-}
-
-/** Account for the console errors this spec CAUSED and leave everything else for the
- *  fixture's own teardown gate. `expected` is a floor, not a formality: a fault injection
- *  that silently stopped matching would log nothing, and a drain that merely filtered
- *  would let that pass while proving nothing about the path it claims to walk. */
-function drainSeededFetchErrors(consoleErrors: string[], expected: number): void {
-  const seeded = consoleErrors.filter(isSeededBrowseFailure)
-  const unexpected = consoleErrors.filter((line) => !isSeededBrowseFailure(line))
-  consoleErrors.length = 0
-  expect(unexpected, "console errors this spec did not inject").toEqual([])
-  expect(seeded.length, "seeded 500s the browser logged").toBeGreaterThanOrEqual(expected)
-}
 
 /**
  * Every live region in the document, each reduced to WHO owns it.

--- a/packages/inspector/e2e/a11y-announcements.spec.ts
+++ b/packages/inspector/e2e/a11y-announcements.spec.ts
@@ -1,0 +1,226 @@
+import type { Page } from "@playwright/test"
+import { BROWSE_PAGE_SIZE } from "../test/seed"
+import { expect, test } from "./fixtures"
+import {
+  applySetFilter,
+  expectPhase,
+  liveRegionText,
+  loadMore,
+  openBrowse,
+  status,
+} from "./helpers"
+
+/**
+ * D1-A11Y-02, the announcement half. Shipped semantics, read out of `@pretable/react`
+ * 0.3.0 rather than assumed: one permanent polite region (`[data-pretable-live-region]`,
+ * portalled to `document.body`); the body-state block carries no live-region role;
+ * `scheduleAnnouncement` ranks `error` > pending `user` > pending `lifecycle` with
+ * last-wins between equals; and a resolved `refreshing` speaks only when the sentence it
+ * would say has CHANGED — which is what keeps a 2 s poll from becoming a metronome.
+ *
+ * Every announcement here is debounced by `ANNOUNCE_DEBOUNCE_MS` (500 ms in 0.3.0) and
+ * fired from a phase effect, so the region trails every DOM signal a test can settle on:
+ * the status bar, the phase attribute and the drawn rows all land first. Every read of it
+ * below is therefore POLLED, and any claim made of two halves of one sentence is made
+ * against ONE sample — two successive polls can each be satisfied by a different sentence
+ * and jointly prove nothing about either.
+ */
+
+/** What the browser logs for the browse response the first test refuses. Mirrors
+ *  `13-accessibility.spec.ts`: the ENDPOINT is half the match, because Chromium's message
+ *  text names only the status. */
+function isSeededBrowseFailure(line: string): boolean {
+  return /Failed to load resource: .*status of 500/.test(line) && line.includes("/api/memory/list")
+}
+
+/** Account for the console errors this spec CAUSED and leave everything else for the
+ *  fixture's own teardown gate. `expected` is a floor, not a formality: a fault injection
+ *  that silently stopped matching would log nothing, and a drain that merely filtered
+ *  would let that pass while proving nothing about the path it claims to walk. */
+function drainSeededFetchErrors(consoleErrors: string[], expected: number): void {
+  const seeded = consoleErrors.filter(isSeededBrowseFailure)
+  const unexpected = consoleErrors.filter((line) => !isSeededBrowseFailure(line))
+  consoleErrors.length = 0
+  expect(unexpected, "console errors this spec did not inject").toEqual([])
+  expect(seeded.length, "seeded 500s the browser logged").toBeGreaterThanOrEqual(expected)
+}
+
+/**
+ * Every live region in the document, each reduced to WHO owns it.
+ *
+ * The query pierces open shadow roots — Playwright's CSS engine does that by default, and
+ * here it must: the one region this page does not render lives inside one. Owners are
+ * named rather than counted so that the assertion is over the whole population: a bare
+ * count is satisfied by a banner appearing while another disappears, and it cannot say
+ * which of the two survivors is which.
+ *
+ * An owner this function does not recognise is reported as its own selector rather than
+ * dropped, so a new `role="alert"` anywhere in the app fails the comparison BY NAME.
+ */
+async function liveRegionOwners(page: Page): Promise<{ owner: string; text: string }[]> {
+  return page.locator('[aria-live], [role="status"], [role="alert"]').evaluateAll((nodes) =>
+    nodes.map((node) => {
+      const element = node as HTMLElement
+      const root = element.getRootNode()
+      const host = root instanceof ShadowRoot ? root.host.tagName.toLowerCase() : null
+      const text = element.textContent ?? ""
+      if (element.hasAttribute("data-pretable-live-region")) return { owner: "pretable", text }
+      // Next's App Router appends `<next-route-announcer>` to `<body>` and puts an
+      // assertive region in its OPEN shadow root. It is framework-owned, it is not in the
+      // Inspector's tree, and it speaks only on a client-side route change — so on a
+      // document load it is present and empty, which the caller asserts rather than
+      // assumes. There is no product change that removes it; excluding it silently is
+      // what would be dishonest, so it is named.
+      if (host === "next-route-announcer" && element.id === "__next-route-announcer__") {
+        return { owner: "next-route-announcer", text }
+      }
+      const role = element.getAttribute("role") ?? element.getAttribute("aria-live")
+      return {
+        owner: `${host === null ? "" : `${host}::`}${element.tagName.toLowerCase()}[${role}]`,
+        text,
+      }
+    }),
+  )
+}
+
+test.describe("announcement channels", () => {
+  test.setTimeout(120_000)
+
+  test("there is exactly one live region and the body-state block is not one", async ({
+    page,
+    consoleErrors,
+  }) => {
+    let failing = true
+    await page.route("**/api/memory/list*", async (route) => {
+      if (failing) {
+        await route.fulfill({ status: 500, contentType: "application/json", body: "{}" })
+        return
+      }
+      await route.continue()
+    })
+    await page.goto("/memory")
+    await expect(page.locator('[data-pretable-body-state="error"]')).toBeVisible()
+
+    // One region belonging to this page, and it is the surface's own. Compared as the
+    // whole owner list: the framework's announcer is present because Next puts it there,
+    // and it is EMPTY, so the failure below cannot be reaching AT through it.
+    expect(await liveRegionOwners(page)).toEqual(
+      expect.arrayContaining([{ owner: "next-route-announcer", text: "" }]),
+    )
+    expect((await liveRegionOwners(page)).map((region) => region.owner).sort()).toEqual([
+      "next-route-announcer",
+      "pretable",
+    ])
+
+    // The block that RENDERS the failure is not a second channel. It repeats the error
+    // sentence in the grid body, so a live-region role on it would say the same thing
+    // twice; §4.5 keeps it silent and lets the region below be the only speaker.
+    const bodyStateAttributes = await page
+      .locator("[data-pretable-body-state]")
+      .evaluateAll((nodes) => nodes.map((node) => node.getAttributeNames().sort().join(",")))
+    expect(bodyStateAttributes).toEqual(["data-pretable-body-state,style"])
+
+    // …and the failure does reach AT through that one region, so the silence above is a
+    // single channel rather than none.
+    await expect.poll(() => liveRegionText(page)).toMatch(/could not|error|fail/i)
+
+    // Stop the fault and prove the window is SHUT before draining, or a 500 logged
+    // between the drain and teardown fails the gate this spec is otherwise protected by.
+    // A reload rather than a wait: the error phase is terminal — an initial failure stops
+    // the 2 s poll, so `idle` never arrives on its own — and rather than reach for the
+    // retry control (13-accessibility's subject, not this file's), the cheapest proof that
+    // no request can still 500 is one whole successful load after the switch.
+    failing = false
+    await page.reload()
+    await expectPhase(page, "idle")
+    drainSeededFetchErrors(consoleErrors, 1)
+  })
+
+  test("a no-change poll tick is silent", async ({ page, consoleErrors }) => {
+    void consoleErrors
+    await openBrowse(page)
+    await expect.poll(() => liveRegionText(page)).toContain(String(BROWSE_PAGE_SIZE))
+    const settled = await liveRegionText(page)
+
+    // Ticks over an unchanged dataset. Repeating the same sentence IS the metronome the
+    // design forbids.
+    const ticks: string[] = []
+    page.on("response", (response) => {
+      if (response.url().includes("/api/memory/list")) ticks.push(response.url())
+    })
+    const seen: string[] = []
+    const stop = Date.now() + 7_000
+    while (Date.now() < stop) {
+      seen.push(await liveRegionText(page))
+      await page.waitForTimeout(250)
+    }
+    expect(new Set(seen)).toEqual(new Set([settled]))
+
+    // The metronome actually RAN. Without this the silence above is equally the silence of
+    // a page that stopped polling, and a regression that killed the 2 s tick would read as
+    // this test's strongest pass. A floor rather than the cadence: 7 s at 2 s admits three
+    // or four ticks (measured: 4 responses over 28 samples), and a loaded machine delays
+    // the interval it does not skip — so the floor keeps two ticks of headroom.
+    expect(ticks.length, "browse polls during the silent window").toBeGreaterThanOrEqual(2)
+  })
+
+  test("stale is announced once, and its own resolution supersedes it", async ({
+    page,
+    consoleErrors,
+  }) => {
+    void consoleErrors
+    await openBrowse(page)
+    await page.route("**/api/memory/list*", async (route) => {
+      if (new URL(route.request().url()).searchParams.has("filters")) {
+        await new Promise((resolve) => setTimeout(resolve, 1_500))
+      }
+      await route.continue()
+    })
+    await applySetFilter(page, "status", ["active"])
+    await expect.poll(() => liveRegionText(page)).toContain("Updating")
+    await expectPhase(page, "idle")
+    // The results announcement replaced it — the stale sentence does not linger as the
+    // last thing a screen reader said about a settled grid. Phrased POSITIVELY first
+    // (helpers.ts): "does not contain" is satisfied by an empty read, and by a region that
+    // was cleared rather than superseded, which is a different and worse outcome.
+    //
+    // The SHAPE of `memory-grid.tsx`'s `resultsAnnouncement`, anchored at both ends, not
+    // pretable's default sentence — the Inspector replaces that copy so the spoken line
+    // mirrors `BrowseStatusBar`. Neither number is pinned: the loaded half is the page
+    // size and the matching half is the `status=active` population, which scenario 9 moves
+    // by one when the whole suite runs.
+    await expect
+      .poll(() => liveRegionText(page))
+      .toMatch(/^\d[\d,]* loaded of \d[\d,]* matching\.$/)
+    expect(await liveRegionText(page)).not.toContain("Updating")
+  })
+
+  test("an append announces the delta, not just the new population", async ({
+    page,
+    consoleErrors,
+  }) => {
+    void consoleErrors
+    await openBrowse(page)
+    await loadMore(page).click()
+    // CORRECTED (preamble 9): the loaded count comes off the STATUS BAR, never off
+    // `rowIds` — the DOM holds ~19 rows however many the client is holding.
+    await expect(status(page)).toContainText((BROWSE_PAGE_SIZE * 2).toLocaleString("en-US"))
+
+    // Both halves of ONE sentence, sampled together. The status bar above lands inside the
+    // announcement's 500 ms debounce, so the region still holds the previous sentence when
+    // it settles — and two successive polls, one per number, would be satisfiable by two
+    // DIFFERENT sentences: "Showing 200 of 1,250" carries the first and a later "Showing
+    // 400 of 1,250" carries the second, so the pair would pass over a page that never
+    // announced a delta at all. Raw digits rather than `toLocaleString`, because this
+    // sentence is pretable's and it does not format.
+    await expect
+      .poll(() =>
+        liveRegionText(page).then((text) => ({
+          text,
+          delta: text.includes(String(BROWSE_PAGE_SIZE)),
+          loaded: text.includes(String(BROWSE_PAGE_SIZE * 2)),
+        })),
+      )
+      .toMatchObject({ delta: true, loaded: true })
+  })
+})

--- a/packages/inspector/e2e/a11y-counts.spec.ts
+++ b/packages/inspector/e2e/a11y-counts.spec.ts
@@ -1,4 +1,4 @@
-import type { Page } from "@playwright/test"
+import type { Locator, Page } from "@playwright/test"
 import {
   BROWSE_PAGE_SIZE,
   BROWSE_SEED_COUNT,
@@ -8,6 +8,7 @@ import {
 } from "../test/seed"
 import { expect, test } from "./fixtures"
 import {
+  browseSeedRecordsAfterScenario9,
   DRAWN_FIRST_WINDOW,
   DRAWN_FIRST_WINDOW_AFTER_SCENARIO_9,
   expectDrawnRows,
@@ -26,50 +27,105 @@ import {
 /**
  * D1-A11Y-02. Design §4.5 publishes the matching population as `aria-rowcount` only when
  * every condition making loaded index `i` equal dataset position `i` holds; anything short
- * of that downgrades to the loaded-model count.
+ * of that downgrades to the loaded-model count, and a population that cannot be stated as
+ * an integer at all downgrades to `-1` — ARIA's "the count is unknown".
  *
- * The two branches this surface cannot produce are named rather than tested: an
- * `estimate`/`unknown` total (`useMemoryBrowse` builds `{kind:"exact"}` from the response's
- * integer `total` and nothing else, so `-1` is unreachable from here) and a non-integer
- * count (same reason). Both live in `@pretable/react`'s `data-scope` unit tests. The
- * reachable branches — exact-and-ungrouped, grouped, and a total that undercounts what is
- * loaded — are all below, so a reviewer can see the coverage is complete rather than
- * partial.
+ * Pretable resolves those conditions as ORDERED guards (`resolveAriaRowCount`):
+ * engine-side processing, then GROUPING, then a total that is not `exact`, then a
+ * non-integer count, then a count below the loaded rows. The order is why each test below
+ * has to pin which branch it is standing in and not merely which number it wanted — every
+ * earlier guard answers with the same downgraded count for a different reason, so a test
+ * that names only the number passes just as readily on the branch it did not mean.
+ *
+ * The first guard is the only one the browse grid cannot reach: `memory-grid.tsx` passes
+ * `SERVER_PROCESSING` — a module constant — for every browse render. (The search-result
+ * grids omit `processing` entirely and are handed no `resultMeta` to downgrade; a
+ * different surface, and not this file's subject.)
+ *
+ * The other four are all reachable HERE, the two the plan called impossible included:
+ *   - an `unknown` total, because `useMemoryBrowse` publishes `UNKNOWN_TOTAL_META` for as
+ *     long as nothing is fulfilled — every render before the first response lands, and
+ *     every render after an initial one failed;
+ *   - a non-integer count, because `isBrowsePage` admits any `typeof page.total ===
+ *     "number"` and a fraction is one. That boundary gap is a PRODUCT defect rather than
+ *     a fixture convenience: a fractional total from the store reaches ARIA with nothing
+ *     but pretable's own downgrade between it and the user, and the test below pins that
+ *     second line of defence precisely because the first one is missing.
  *
  * GROUPING is one of §4.5's conditions and the unscoped browse is grouped
  * (`list-page.tsx`: `groupByNamespace={namespace === undefined}`), so the population branch
  * is reachable only under a FACET and the unscoped view IS the grouped-downgrade branch.
  * This file is the one place both are asserted side by side.
+ *
+ * §4.5's `aria-busy` prohibition is over PHASES rather than branches, and the last two
+ * tests split `browse-machine.ts`'s six between them — three that need no fault and three
+ * that do.
  */
 
 /** The facet this file scopes to. Chosen because it survives the shared fixture: scenario
  *  9's two writes both land in `route=/notes-archive` (see the derivation block in
  *  `helpers.ts`), so this namespace holds the same 667 records in the same default order
- *  whether this file runs alone against a freshly seeded store or last in a whole-suite
- *  run. Nothing here needs `browseSeedRecordsAfterScenario9()` for that reason. */
+ *  whether this file runs alone against a freshly seeded store or after every mutating
+ *  scenario. Nothing here needs `browseSeedRecordsAfterScenario9()` for that reason, and
+ *  nothing here depends on where this file sorts in a whole-suite run. */
 const SCOPED = seedRecordsMatching({ namespace: "route=/notes" })
 const SCOPED_ORDER = seedIdsInDefaultOrder(SCOPED)
 
-/** The lie test 3 makes the server tell: a full window of records under a total far below
- *  it. 200 loaded records cannot be a contiguous prefix of a 5-row population, which is
- *  the contract `PretableResultMeta` states and §4.5 downgrades on. */
+/** The lie the undercount test makes the server tell: a full window of records under a
+ *  total far below it. 200 loaded records cannot be a contiguous prefix of a 5-row
+ *  population, which is the contract `PretableResultMeta` states and §4.5 downgrades on. */
 const UNDERCOUNTED_TOTAL = 5
+
+/** A total that is a number and is not an integer — and is ABOVE the loaded window, so the
+ *  undercount guard cannot be what moves the count. The Inspector's own boundary lets this
+ *  through (see the header); pretable is what refuses to publish it. */
+const FRACTIONAL_TOTAL = BROWSE_PAGE_SIZE * 2 + 0.5
+
+/** A total the BOUNDARY rejects rather than one pretable downgrades: `isBrowsePage`
+ *  requires `typeof total === "number"`, so the page the store formatted arrives as an
+ *  ordinary request failure and nothing is ever fulfilled. A 500 would put the machine in
+ *  the same state, but it also makes the browser log a failed subresource — and the
+ *  `consoleErrors` fixture is the gate every spec here leans on, so a test that injected
+ *  one would have to drain the gate it depends on. This lie is silent. */
+const REJECTED_TOTAL = n(BROWSE_SEED_COUNT)
+
+/** Serve every browse window from the head of the seed under a `total` of the caller's
+ *  choosing. `continuation: null`, so the client cannot walk past the claim and discover
+ *  it. */
+async function lieAboutTotal(page: Page, claimed: unknown): Promise<void> {
+  await page.route("**/api/memory/list*", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        records: browseSeedRecords().slice(0, BROWSE_PAGE_SIZE),
+        total: claimed,
+        continuation: null,
+      }),
+    })
+  })
+}
+
+/** The facet button, located by the count the rail publishes beside it, so a fixture that
+ *  drifted fails at the click rather than downstream of it. The rail's counts come from
+ *  `/api/memory/stats`, a different endpoint from the one every lie above intercepts —
+ *  so this finds the same button under all of them, and under a browse that never
+ *  answered at all. */
+function facet(page: Page): Locator {
+  return page.getByRole("button", { name: `route=/notes ${SCOPED.length}`, exact: true })
+}
 
 /**
  * Scope to `route=/notes`, and assert the precondition the population branch needs.
  *
  * `role` is the assertion, not decoration: pretable publishes `treegrid` exactly while it
- * is grouping and `grid` otherwise, and grouping is §4.5's FIRST downgrade — it is checked
- * before the total is even read. Without this line a run in which the facet silently failed
- * to turn grouping off would reach the `aria-rowcount` assertions below as a grouped grid,
- * and they would be about the wrong branch.
- *
- * The rail's counts come from `/api/memory/stats`, which is a different endpoint from the
- * one test 3 intercepts — so this locator finds the same button under the lie as without
- * it.
+ * is grouping and `grid` otherwise, and grouping is §4.5's first REACHABLE downgrade — it
+ * is checked before the total is even read. Without this line a run in which the facet
+ * silently failed to turn grouping off would reach the `aria-rowcount` assertions below as
+ * a grouped grid, and they would be about the wrong branch.
  */
 async function scopeToNotes(page: Page): Promise<void> {
-  await page.getByRole("button", { name: `route=/notes ${SCOPED.length}`, exact: true }).click()
+  await facet(page).click()
   await expectPhase(page, "idle")
   await expect(grid(page)).toHaveAttribute("role", "grid")
 }
@@ -110,6 +166,26 @@ async function tailRow(page: Page): Promise<{ id: string; rowIndex: string }> {
 async function expectNoAriaBusy(page: Page): Promise<void> {
   await expect(grid(page)).not.toHaveAttribute("aria-busy", /.*/)
   expect(await page.locator("[aria-busy]").count(), "elements carrying aria-busy").toBe(0)
+}
+
+/**
+ * A response hold: the promise a route handler awaits, and the switch that frees it.
+ *
+ * Both phase tests below hold a response open to make a phase observable and release it
+ * once they have read it, and neither takes a TIMEOUT to release itself with. An assertion
+ * failing between those two lines does leave a handler awaiting forever, but Playwright
+ * tears the context down without waiting on it and reports the assertion — checked by
+ * failing a test on purpose between a hold and its release, which ended the run in the same
+ * few seconds a passing one takes. A ceiling would buy nothing against that and would add
+ * one way to fail: a loaded machine releasing a hold the test still needed, which reads as
+ * the phase never having occurred.
+ */
+function hold(): { held: Promise<void>; release: () => void } {
+  let release = (): void => {}
+  const held = new Promise<void>((resolve) => {
+    release = resolve
+  })
+  return { held, release: () => release() }
 }
 
 test.describe("ARIA counts and positions", () => {
@@ -164,20 +240,24 @@ test.describe("ARIA counts and positions", () => {
     await openBrowse(page)
     await expect(grid(page)).toHaveAttribute("role", "treegrid")
 
-    // Only the prefix the three fixture states agree on (see `helpers.ts`): this file runs
-    // after scenario 9 in a whole-suite run and against the pristine seed on its own, and
-    // the projections diverge far below anything a viewport draws.
+    // The drawn prefix all three fixture states agree on (see `helpers.ts`): this file may
+    // run after the mutating scenarios or against the pristine seed on its own. The slice
+    // is a CEILING rather than the mechanism — `expectDrawnRows` compares only as many rows
+    // as the viewport actually drew, ~19 against a stable prefix of 163, so today it never
+    // binds; it is what keeps this expectation honest if that viewport ever grows past the
+    // prefix.
     await expectDrawnRows(page, DRAWN_FIRST_WINDOW.slice(0, SCENARIO_9_STABLE_DRAWN_PREFIX))
-    // The rowcount is the whole projection, which is deeper than the drawn prefix — so it
-    // is pinned against a length both fixture states share, checked rather than assumed.
+    // The rowcount is the whole projection, which is deeper than any drawn prefix — so what
+    // makes it safe under either fixture state is this checked equality, not the slice
+    // above.
     expect(DRAWN_FIRST_WINDOW_AFTER_SCENARIO_9.length).toBe(DRAWN_FIRST_WINDOW.length)
     await expect(grid(page)).toHaveAttribute("aria-rowcount", String(DRAWN_FIRST_WINDOW.length + 1))
 
     // The population, read off the page — held to the two values the shared fixture can be
-    // in, so a page reporting a count from nowhere fails here rather than being adopted as
-    // the expectation.
+    // in, both DERIVED from the seed module rather than transcribed, so a page reporting a
+    // count from nowhere fails here rather than being adopted as the expectation.
     const rendered = await total(page).innerText()
-    expect([n(BROWSE_SEED_COUNT), n(BROWSE_SEED_COUNT - 1)]).toContain(rendered)
+    expect([n(BROWSE_SEED_COUNT), n(browseSeedRecordsAfterScenario9().length)]).toContain(rendered)
     const matching = Number(rendered.replaceAll(",", ""))
     await expect(status(page)).toHaveText(statusText(BROWSE_PAGE_SIZE, matching))
     // …and the downgraded rowcount is not the population wearing a different name.
@@ -191,17 +271,7 @@ test.describe("ARIA counts and positions", () => {
     void consoleErrors
     // A lying server: a full window of records under a total of 5. Pretable emits a
     // console.warn on this path (not an error), so the fixture's console gate stays green.
-    await page.route("**/api/memory/list*", async (route) => {
-      await route.fulfill({
-        status: 200,
-        contentType: "application/json",
-        body: JSON.stringify({
-          records: browseSeedRecords().slice(0, BROWSE_PAGE_SIZE),
-          total: UNDERCOUNTED_TOTAL,
-          continuation: null,
-        }),
-      })
-    })
+    await lieAboutTotal(page, UNDERCOUNTED_TOTAL)
     await openBrowse(page)
     // SCOPED, and that is what makes this test about the undercount at all: grouping is
     // checked first and would downgrade the rowcount on its own, so the unscoped view
@@ -209,41 +279,90 @@ test.describe("ARIA counts and positions", () => {
     // ungrouped and the total is the only thing left that can move the count.
     await scopeToNotes(page)
 
-    const drawn = await grid(page).locator("[data-pretable-row-id]").count()
-    expect(drawn).toBeGreaterThanOrEqual(MIN_RENDERED_ROWS)
+    // Polled rather than read once: `MemoryGrid` sizes its viewport from an estimate until
+    // the engine's first telemetry lands, so the rendered set can still change a frame
+    // after the phase reads `idle`.
+    await expect
+      .poll(() => grid(page).locator("[data-pretable-row-id]").count())
+      .toBeGreaterThanOrEqual(MIN_RENDERED_ROWS)
     await expect(grid(page)).toHaveAttribute("aria-rowcount", String(BROWSE_PAGE_SIZE + 1))
-    // Stated as the prohibition too: the number the server claimed must not reach ARIA.
-    await expect(grid(page)).not.toHaveAttribute("aria-rowcount", String(UNDERCOUNTED_TOTAL + 1))
   })
 
-  test("no phase anywhere sets aria-busy, on the grid or inside it", async ({
+  test("a NON-INTEGER total downgrades to the loaded-model count", async ({
     page,
     consoleErrors,
   }) => {
     void consoleErrors
+    // The branch the plan called unreachable. It is reachable because the Inspector's own
+    // boundary check admits it (header); this test therefore stands one layer downstream of
+    // where the rejection belongs, and says so.
+    await lieAboutTotal(page, FRACTIONAL_TOTAL)
+    await openBrowse(page)
+    await scopeToNotes(page)
+
+    // Which guard fired, checked rather than asserted by the number: a fractional total
+    // BELOW the loaded window would be downgraded by the undercount guard first, and this
+    // test would then be a duplicate of the one above wearing a decimal point.
+    expect(FRACTIONAL_TOTAL).toBeGreaterThan(BROWSE_PAGE_SIZE)
+    await expect
+      .poll(() => grid(page).locator("[data-pretable-row-id]").count())
+      .toBeGreaterThanOrEqual(MIN_RENDERED_ROWS)
+    await expect(grid(page)).toHaveAttribute("aria-rowcount", String(BROWSE_PAGE_SIZE + 1))
+    // The page still reports the population it was told, in the chrome where an inexact
+    // number is allowed to be prose: the downgrade is about what ARIA may claim as a
+    // POSITION space, not about hiding the server's answer.
+    await expect(total(page)).toHaveText(n(FRACTIONAL_TOTAL))
+  })
+
+  test("an UNKNOWN total publishes -1, not the rows that happen to be loaded", async ({
+    page,
+    consoleErrors,
+  }) => {
+    void consoleErrors
+    // The second branch the plan called unreachable. Every window is refused at the
+    // boundary, so `useMemoryBrowse` never fulfills and its `resultMeta` stays
+    // `{total:{kind:"unknown"}}` for the whole test.
+    await lieAboutTotal(page, REJECTED_TOTAL)
+    await page.goto("/memory")
+    // Pretable's hydration signal before the facet click below: an SSR'd control is painted
+    // and inert, and a click landing before it flips is silently dropped.
+    await expect(grid(page)).toHaveAttribute("data-pretable-hydrated", "true")
+    await expectPhase(page, "error")
+
+    // Unscoped, so GROUPING answers first and the unknown total is never consulted: the
+    // empty loaded model publishes 1. Asserted so the -1 below is attributable to the
+    // scoping and not to the failure.
+    await expect(grid(page)).toHaveAttribute("role", "treegrid")
+    await expect(grid(page)).toHaveAttribute("aria-rowcount", "1")
+
+    // Ungrouped, and now the total is the only thing left to answer with — and there is no
+    // total. `-1` is ARIA's "unknown", which is the honest answer; the loaded-model count
+    // would be a grid claiming to know it has none.
+    await facet(page).click()
+    await expect(grid(page)).toHaveAttribute("role", "grid")
+    await expectPhase(page, "error")
+    await expect(grid(page)).toHaveAttribute("aria-rowcount", "-1")
+  })
+
+  test("no aria-busy while LOADING, idle or appending", async ({ page, consoleErrors }) => {
+    void consoleErrors
     // Hold the initial request open so `loading` is observable, and hold the FIRST cursored
     // request so `loading-more` is too. Both are latches rather than predicates: the browse
-    // re-polls every 2 s, and holding every tick would leave the page permanently mid-flight
-    // with a handler still sleeping at teardown.
-    let releaseInitial: (() => void) | undefined
-    let releaseAppend: (() => void) | undefined
-    const initialHeld = new Promise<void>((resolve) => {
-      releaseInitial = resolve
-    })
-    const appendHeld = new Promise<void>((resolve) => {
-      releaseAppend = resolve
-    })
+    // re-polls every 2 s, and holding every tick would leave the page permanently
+    // mid-flight.
+    const initial = hold()
+    const append = hold()
     let heldInitial = false
     let heldAppend = false
     await page.route("**/api/memory/list*", async (route) => {
       if (new URL(route.request().url()).searchParams.has("cursor")) {
         if (!heldAppend) {
           heldAppend = true
-          await appendHeld
+          await append.held
         }
       } else if (!heldInitial) {
         heldInitial = true
-        await initialHeld
+        await initial.held
       }
       await route.continue()
     })
@@ -251,7 +370,7 @@ test.describe("ARIA counts and positions", () => {
     await page.goto("/memory")
     await expectPhase(page, "loading")
     await expectNoAriaBusy(page)
-    releaseInitial?.()
+    initial.release()
 
     await expectPhase(page, "idle")
     await expectNoAriaBusy(page)
@@ -262,7 +381,7 @@ test.describe("ARIA counts and positions", () => {
     await loadMore(page).click()
     await expectPhase(page, "loading-more")
     await expectNoAriaBusy(page)
-    releaseAppend?.()
+    append.release()
 
     await expect(status(page)).toContainText(`${n(BROWSE_PAGE_SIZE * 2)} loaded`)
     await expectPhase(page, "idle")
@@ -272,5 +391,61 @@ test.describe("ARIA counts and positions", () => {
     // page that was never held, and a param this route stopped recognising would take them
     // with it, silently.
     expect({ heldInitial, heldAppend }).toEqual({ heldInitial: true, heldAppend: true })
+  })
+
+  test("no aria-busy while REFRESHING, stale or failed", async ({ page, consoleErrors }) => {
+    void consoleErrors
+    // The other three of `browse-machine.ts`'s six phases. Each needs a fault the previous
+    // test does not: a tick held open, a query change held open over the rows it is
+    // replacing, and that same request refused.
+    await openBrowse(page)
+
+    const tick = hold()
+    const scoped = hold()
+    let heldTick = false
+    let heldScoped = false
+    await page.route("**/api/memory/list*", async (route) => {
+      if (new URL(route.request().url()).searchParams.has("namespace")) {
+        if (!heldScoped) {
+          heldScoped = true
+          await scoped.held
+        }
+        // Refused at the BOUNDARY rather than with a 500, for the reason `REJECTED_TOTAL`
+        // states: a status the browser logs would make this test drain the console gate it
+        // is otherwise protected by.
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ records: [], total: REJECTED_TOTAL, continuation: null }),
+        })
+        return
+      }
+      if (!heldTick) {
+        heldTick = true
+        await tick.held
+      }
+      await route.continue()
+    })
+
+    // REFRESHING: the desired revision is fulfilled and a poll tick is in flight over it.
+    await expectPhase(page, "refreshing")
+    await expectNoAriaBusy(page)
+    tick.release()
+    await expectPhase(page, "idle")
+
+    // STALE: the facet bumps the desired revision while the previous revision's rows are
+    // still on screen — the one phase in which the grid is showing an answer to a question
+    // the user has already moved on from, and the strongest case for a busy flag.
+    await facet(page).click()
+    await expectPhase(page, "stale")
+    await expectNoAriaBusy(page)
+    scoped.release()
+
+    // ERROR: nothing is fulfilled for the desired revision, so the phase holds rather than
+    // flickering on the poll cadence, and the prohibition has to hold with it.
+    await expectPhase(page, "error")
+    await expectNoAriaBusy(page)
+
+    expect({ heldTick, heldScoped }).toEqual({ heldTick: true, heldScoped: true })
   })
 })

--- a/packages/inspector/e2e/a11y-counts.spec.ts
+++ b/packages/inspector/e2e/a11y-counts.spec.ts
@@ -1,0 +1,276 @@
+import type { Page } from "@playwright/test"
+import {
+  BROWSE_PAGE_SIZE,
+  BROWSE_SEED_COUNT,
+  browseSeedRecords,
+  seedIdsInDefaultOrder,
+  seedRecordsMatching,
+} from "../test/seed"
+import { expect, test } from "./fixtures"
+import {
+  DRAWN_FIRST_WINDOW,
+  DRAWN_FIRST_WINDOW_AFTER_SCENARIO_9,
+  expectDrawnRows,
+  expectPhase,
+  grid,
+  loadMore,
+  MIN_RENDERED_ROWS,
+  n,
+  openBrowse,
+  SCENARIO_9_STABLE_DRAWN_PREFIX,
+  status,
+  statusText,
+  total,
+} from "./helpers"
+
+/**
+ * D1-A11Y-02. Design §4.5 publishes the matching population as `aria-rowcount` only when
+ * every condition making loaded index `i` equal dataset position `i` holds; anything short
+ * of that downgrades to the loaded-model count.
+ *
+ * The two branches this surface cannot produce are named rather than tested: an
+ * `estimate`/`unknown` total (`useMemoryBrowse` builds `{kind:"exact"}` from the response's
+ * integer `total` and nothing else, so `-1` is unreachable from here) and a non-integer
+ * count (same reason). Both live in `@pretable/react`'s `data-scope` unit tests. The
+ * reachable branches — exact-and-ungrouped, grouped, and a total that undercounts what is
+ * loaded — are all below, so a reviewer can see the coverage is complete rather than
+ * partial.
+ *
+ * GROUPING is one of §4.5's conditions and the unscoped browse is grouped
+ * (`list-page.tsx`: `groupByNamespace={namespace === undefined}`), so the population branch
+ * is reachable only under a FACET and the unscoped view IS the grouped-downgrade branch.
+ * This file is the one place both are asserted side by side.
+ */
+
+/** The facet this file scopes to. Chosen because it survives the shared fixture: scenario
+ *  9's two writes both land in `route=/notes-archive` (see the derivation block in
+ *  `helpers.ts`), so this namespace holds the same 667 records in the same default order
+ *  whether this file runs alone against a freshly seeded store or last in a whole-suite
+ *  run. Nothing here needs `browseSeedRecordsAfterScenario9()` for that reason. */
+const SCOPED = seedRecordsMatching({ namespace: "route=/notes" })
+const SCOPED_ORDER = seedIdsInDefaultOrder(SCOPED)
+
+/** The lie test 3 makes the server tell: a full window of records under a total far below
+ *  it. 200 loaded records cannot be a contiguous prefix of a 5-row population, which is
+ *  the contract `PretableResultMeta` states and §4.5 downgrades on. */
+const UNDERCOUNTED_TOTAL = 5
+
+/**
+ * Scope to `route=/notes`, and assert the precondition the population branch needs.
+ *
+ * `role` is the assertion, not decoration: pretable publishes `treegrid` exactly while it
+ * is grouping and `grid` otherwise, and grouping is §4.5's FIRST downgrade — it is checked
+ * before the total is even read. Without this line a run in which the facet silently failed
+ * to turn grouping off would reach the `aria-rowcount` assertions below as a grouped grid,
+ * and they would be about the wrong branch.
+ *
+ * The rail's counts come from `/api/memory/stats`, which is a different endpoint from the
+ * one test 3 intercepts — so this locator finds the same button under the lie as without
+ * it.
+ */
+async function scopeToNotes(page: Page): Promise<void> {
+  await page.getByRole("button", { name: `route=/notes ${SCOPED.length}`, exact: true }).click()
+  await expectPhase(page, "idle")
+  await expect(grid(page)).toHaveAttribute("role", "grid")
+}
+
+/**
+ * The LAST row the grid draws with the box scrolled to the bottom — its id and its
+ * published position, sampled together.
+ *
+ * The grid virtualizes, so `rows.nth(399)` addresses a node that was never rendered and
+ * the deep position has to be scrolled to. The offset is far past any `scrollHeight` this
+ * fixture produces, so the browser CLAMPS it to the end: no row pitch is assumed and no
+ * arithmetic can drift.
+ *
+ * Scroll, settle and read happen inside ONE page evaluation. A driver round trip between
+ * them would let the 2 s poll re-render the rows in the gap, and the id and the index would
+ * then describe different commits. Three frames because the scroll handler sets React
+ * state, the re-render commits, and only then is the tail in the document.
+ */
+async function tailRow(page: Page): Promise<{ id: string; rowIndex: string }> {
+  return grid(page).evaluate(async (node) => {
+    node.scrollTop = 1e7
+    for (let frame = 0; frame < 3; frame += 1) {
+      await new Promise(requestAnimationFrame)
+    }
+    const rows = node.querySelectorAll("[data-pretable-row-id]")
+    const last = rows[rows.length - 1] as HTMLElement | undefined
+    return {
+      id: last?.dataset.pretableRowId ?? "",
+      rowIndex: last?.getAttribute("aria-rowindex") ?? "",
+    }
+  })
+}
+
+/** §4.5's prohibition, checked at the grid and then across the whole document — the rule is
+ *  "not on the grid, the rowgroup, or the rows in any D1 state", and a per-row or
+ *  per-rowgroup `aria-busy` would satisfy a grid-only check while doing the exact damage
+ *  the ruling exists to prevent. */
+async function expectNoAriaBusy(page: Page): Promise<void> {
+  await expect(grid(page)).not.toHaveAttribute("aria-busy", /.*/)
+  expect(await page.locator("[aria-busy]").count(), "elements carrying aria-busy").toBe(0)
+}
+
+test.describe("ARIA counts and positions", () => {
+  test.setTimeout(90_000)
+
+  test("an exact total publishes the POPULATION, and positions are global", async ({
+    page,
+    consoleErrors,
+  }) => {
+    void consoleErrors
+    await openBrowse(page)
+    await scopeToNotes(page)
+    await expectDrawnRows(page, SCOPED_ORDER.slice(0, BROWSE_PAGE_SIZE))
+
+    await expect(grid(page)).toHaveAttribute("aria-rowcount", String(SCOPED.length + 1))
+    await expect(grid(page).locator("[data-pretable-row-id]").first()).toHaveAttribute(
+      "aria-rowindex",
+      "2",
+    )
+
+    // The gap between the last position and the rowcount is the discovery affordance:
+    // "row 401 of 668" is how a screen-reader user learns more exists. Append a second
+    // window and read the deepest drawn row — position 401 under a rowcount still naming
+    // the whole 667, which is the claim. The loaded count comes off the STATUS BAR rather
+    // than off a row count, because the document holds ~19 rows however many the client is
+    // holding.
+    await loadMore(page).click()
+    await expect(status(page)).toHaveText(statusText(BROWSE_PAGE_SIZE * 2, SCOPED.length))
+    await expectPhase(page, "idle")
+
+    await expect(grid(page)).toHaveAttribute("aria-rowcount", String(SCOPED.length + 1))
+    // Both fields together: the position alone is satisfied by a grid that renumbered rows
+    // it had reordered, and the id alone says nothing about the published position.
+    await expect
+      .poll(() => tailRow(page), { timeout: 20_000 })
+      .toEqual({
+        id: SCOPED_ORDER[BROWSE_PAGE_SIZE * 2 - 1],
+        rowIndex: String(BROWSE_PAGE_SIZE * 2 + 1),
+      })
+    // The gap is real rather than incidental — with the whole population loaded, "position
+    // 401 under a rowcount of 668" would be an ordinary complete-model grid saying nothing
+    // about remote populations at all.
+    expect(BROWSE_PAGE_SIZE * 2).toBeLessThan(SCOPED.length)
+  })
+
+  test("GROUPING downgrades the rowcount to the loaded model", async ({ page, consoleErrors }) => {
+    void consoleErrors
+    // The unscoped browse, which groups by namespace. §4.5: grouping destroys the
+    // loaded-index → dataset-position mapping, so the population must NOT be published —
+    // it moves to the status chrome, which is asserted here beside it so the downgrade is
+    // not mistaken for the number going missing.
+    await openBrowse(page)
+    await expect(grid(page)).toHaveAttribute("role", "treegrid")
+
+    // Only the prefix the three fixture states agree on (see `helpers.ts`): this file runs
+    // after scenario 9 in a whole-suite run and against the pristine seed on its own, and
+    // the projections diverge far below anything a viewport draws.
+    await expectDrawnRows(page, DRAWN_FIRST_WINDOW.slice(0, SCENARIO_9_STABLE_DRAWN_PREFIX))
+    // The rowcount is the whole projection, which is deeper than the drawn prefix — so it
+    // is pinned against a length both fixture states share, checked rather than assumed.
+    expect(DRAWN_FIRST_WINDOW_AFTER_SCENARIO_9.length).toBe(DRAWN_FIRST_WINDOW.length)
+    await expect(grid(page)).toHaveAttribute("aria-rowcount", String(DRAWN_FIRST_WINDOW.length + 1))
+
+    // The population, read off the page — held to the two values the shared fixture can be
+    // in, so a page reporting a count from nowhere fails here rather than being adopted as
+    // the expectation.
+    const rendered = await total(page).innerText()
+    expect([n(BROWSE_SEED_COUNT), n(BROWSE_SEED_COUNT - 1)]).toContain(rendered)
+    const matching = Number(rendered.replaceAll(",", ""))
+    await expect(status(page)).toHaveText(statusText(BROWSE_PAGE_SIZE, matching))
+    // …and the downgraded rowcount is not the population wearing a different name.
+    expect(DRAWN_FIRST_WINDOW.length + 1).toBeLessThan(matching)
+  })
+
+  test("a total that UNDERCOUNTS the loaded rows downgrades to the loaded-model count", async ({
+    page,
+    consoleErrors,
+  }) => {
+    void consoleErrors
+    // A lying server: a full window of records under a total of 5. Pretable emits a
+    // console.warn on this path (not an error), so the fixture's console gate stays green.
+    await page.route("**/api/memory/list*", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          records: browseSeedRecords().slice(0, BROWSE_PAGE_SIZE),
+          total: UNDERCOUNTED_TOTAL,
+          continuation: null,
+        }),
+      })
+    })
+    await openBrowse(page)
+    // SCOPED, and that is what makes this test about the undercount at all: grouping is
+    // checked first and would downgrade the rowcount on its own, so the unscoped view
+    // cannot distinguish this branch from the previous test's. Under the facet the grid is
+    // ungrouped and the total is the only thing left that can move the count.
+    await scopeToNotes(page)
+
+    const drawn = await grid(page).locator("[data-pretable-row-id]").count()
+    expect(drawn).toBeGreaterThanOrEqual(MIN_RENDERED_ROWS)
+    await expect(grid(page)).toHaveAttribute("aria-rowcount", String(BROWSE_PAGE_SIZE + 1))
+    // Stated as the prohibition too: the number the server claimed must not reach ARIA.
+    await expect(grid(page)).not.toHaveAttribute("aria-rowcount", String(UNDERCOUNTED_TOTAL + 1))
+  })
+
+  test("no phase anywhere sets aria-busy, on the grid or inside it", async ({
+    page,
+    consoleErrors,
+  }) => {
+    void consoleErrors
+    // Hold the initial request open so `loading` is observable, and hold the FIRST cursored
+    // request so `loading-more` is too. Both are latches rather than predicates: the browse
+    // re-polls every 2 s, and holding every tick would leave the page permanently mid-flight
+    // with a handler still sleeping at teardown.
+    let releaseInitial: (() => void) | undefined
+    let releaseAppend: (() => void) | undefined
+    const initialHeld = new Promise<void>((resolve) => {
+      releaseInitial = resolve
+    })
+    const appendHeld = new Promise<void>((resolve) => {
+      releaseAppend = resolve
+    })
+    let heldInitial = false
+    let heldAppend = false
+    await page.route("**/api/memory/list*", async (route) => {
+      if (new URL(route.request().url()).searchParams.has("cursor")) {
+        if (!heldAppend) {
+          heldAppend = true
+          await appendHeld
+        }
+      } else if (!heldInitial) {
+        heldInitial = true
+        await initialHeld
+      }
+      await route.continue()
+    })
+
+    await page.goto("/memory")
+    await expectPhase(page, "loading")
+    await expectNoAriaBusy(page)
+    releaseInitial?.()
+
+    await expectPhase(page, "idle")
+    await expectNoAriaBusy(page)
+
+    // Pretable's hydration signal before the click: an SSR'd control is painted and inert,
+    // and a click landing before it flips is silently dropped.
+    await expect(grid(page)).toHaveAttribute("data-pretable-hydrated", "true")
+    await loadMore(page).click()
+    await expectPhase(page, "loading-more")
+    await expectNoAriaBusy(page)
+    releaseAppend?.()
+
+    await expect(status(page)).toContainText(`${n(BROWSE_PAGE_SIZE * 2)} loaded`)
+    await expectPhase(page, "idle")
+    await expectNoAriaBusy(page)
+
+    // Both faults were actually injected. Without this the claims above are made about a
+    // page that was never held, and a param this route stopped recognising would take them
+    // with it, silently.
+    expect({ heldInitial, heldAppend }).toEqual({ heldInitial: true, heldAppend: true })
+  })
+})

--- a/packages/inspector/e2e/a11y-focus.spec.ts
+++ b/packages/inspector/e2e/a11y-focus.spec.ts
@@ -1,0 +1,318 @@
+import type { Page } from "@playwright/test"
+import { TEST_IDS } from "../src/components/memory/test-ids"
+import { BROWSE_PAGE_SIZE } from "../test/seed"
+import { expect, test } from "./fixtures"
+import {
+  browseRegion,
+  expectPhase,
+  grid,
+  loadedText,
+  loadMore,
+  MIN_RENDERED_ROWS,
+  openBrowse,
+  recordsOnly,
+  rowIds,
+  scrollGridTo,
+  sortByHeader,
+  status,
+} from "./helpers"
+
+/**
+ * D1-A11Y-03, focus continuity, as four separable claims: a dataset pivot re-seats focus
+ * deterministically, an append leaves it alone, a data-driven removal repairs it and says
+ * so, and a failure the user did not ask for takes nothing.
+ *
+ * Scenario 13 walks all of these once inside one narrative over the FACET-SCOPED (flat)
+ * browse. This spec is the branch that walkthrough cannot reach: the UNSCOPED browse is
+ * grouped, so "the first data cell of the new result" (design §4.2) addresses a row the
+ * flat view has none of — and the removal and initial-failure halves get a whole test each
+ * rather than a line inside a walkthrough that has already spent its store mutations.
+ */
+
+/** What the browser logs for the browse response the last test refuses. Mirrors
+ *  `13-accessibility.spec.ts`: the ENDPOINT is half the match, because Chromium's message
+ *  text names only the status. */
+function isSeededBrowseFailure(line: string): boolean {
+  return /Failed to load resource: .*status of 500/.test(line) && line.includes("/api/memory/list")
+}
+
+/** Account for the console errors this spec CAUSED and leave everything else for the
+ *  fixture's own teardown gate. `expected` is a floor, not a formality: a fault injection
+ *  that silently stopped matching would log nothing, and a drain that merely filtered
+ *  would let that pass while proving nothing about the path it claims to walk. */
+function drainSeededFetchErrors(consoleErrors: string[], expected: number): void {
+  const seeded = consoleErrors.filter(isSeededBrowseFailure)
+  const unexpected = consoleErrors.filter((line) => !isSeededBrowseFailure(line))
+  consoleErrors.length = 0
+  expect(unexpected, "console errors this spec did not inject").toEqual([])
+  expect(seeded.length, "seeded 500s the browser logged").toBeGreaterThanOrEqual(expected)
+}
+
+interface FocusReport {
+  /** `""` when DOM focus is not on a row — on `<body>`, or on the viewport itself. */
+  readonly rowId: string
+  /** Read off the active element ITSELF, so a non-empty value already means the focused
+   *  node IS a cell rather than something inside one. */
+  readonly columnId: string
+  readonly inGrid: boolean
+  readonly onBody: boolean
+}
+
+/** Where DOM focus is, relative to the browse grid — one page evaluation, so every field
+ *  answers for the same instant. Two locator reads would carry a driver round trip between
+ *  them and could straddle a commit. */
+async function focusReport(page: Page): Promise<FocusReport> {
+  return browseRegion(page).evaluate((region) => {
+    const active = document.activeElement as HTMLElement | null
+    const viewport = region.querySelector("[data-pretable-scroll-viewport]")
+    return {
+      rowId: active?.closest("[data-pretable-row-id]")?.getAttribute("data-pretable-row-id") ?? "",
+      columnId: active?.getAttribute("data-pretable-column-id") ?? "",
+      inGrid: viewport?.contains(active ?? null) ?? false,
+      onBody: active === document.body,
+    }
+  })
+}
+
+/**
+ * The address the grid's ROVING TABINDEX names — the engine's focus, whether or not DOM
+ * focus is currently sitting on it.
+ *
+ * Needed because pressing the load-more button is itself a focus move: the footer is
+ * outside the viewport (design §9.2), so after the click `document.activeElement` is the
+ * button, and pretable will not take DOM focus back off a node outside the grid
+ * (`isFocusOursToMove`). "The append left focus where it was" is therefore a claim about
+ * the engine's address, and `tabindex="0"` is where that address is observable.
+ */
+async function rovingCell(page: Page): Promise<{ rowId: string; columnId: string }> {
+  return browseRegion(page).evaluate((region) => {
+    const viewport = region.querySelector("[data-pretable-scroll-viewport]")
+    if (viewport === null) throw new Error("the browse grid is not in the document")
+    const cells = viewport.querySelectorAll('[data-pretable-cell][tabindex="0"]')
+    if (cells.length !== 1) {
+      throw new Error(`the grid has ${cells.length} cells at tabindex 0, not exactly one`)
+    }
+    const cell = cells[0] as HTMLElement
+    return {
+      rowId: cell.closest("[data-pretable-row-id]")?.getAttribute("data-pretable-row-id") ?? "",
+      columnId: cell.getAttribute("data-pretable-column-id") ?? "",
+    }
+  })
+}
+
+/** The drawn RECORD rows with the position each one publishes, sampled together. Group
+ *  headers are excluded: they share the row-id channel, and a cell click on one is not the
+ *  gesture any of these tests mean. */
+async function drawnRecords(page: Page): Promise<{ id: string; rowIndex: number }[]> {
+  return browseRegion(page).evaluate((region) => {
+    const viewport = region.querySelector("[data-pretable-scroll-viewport]")
+    if (viewport === null) throw new Error("the browse grid is not in the document")
+    return Array.from(
+      viewport.querySelectorAll("[data-pretable-row-id]:not([data-pretable-group-row])"),
+    ).map((node) => ({
+      id: (node as HTMLElement).dataset.pretableRowId ?? "",
+      rowIndex: Number(node.getAttribute("aria-rowindex")),
+    }))
+  })
+}
+
+/** The column every cell click below aims at. Not the first `[data-pretable-cell]` in the
+ *  row — that is the row-select checkbox cell, whose click ticks a row and focuses a
+ *  button instead of moving the grid's own cell focus. */
+const FOCUS_COLUMN = "status"
+
+/**
+ * Put DOM focus on one record's `status` cell and confirm it landed.
+ *
+ * The Escape is not incidental. Pretable routes a data-cell click to `onRowActivate` and
+ * this page opens the detail sheet from it, so every cell click here also opens a sheet
+ * that would otherwise own focus for the rest of the test. The sheet restores focus to its
+ * opener from an unmount layout effect, which is why the read after it is POLLED: a
+ * one-shot read in the same tick as `toHaveCount(0)` sees `<body>`.
+ */
+async function focusRecordCell(page: Page, rowId: string): Promise<void> {
+  await grid(page)
+    .locator(`[data-pretable-row-id="${rowId}"]`)
+    .locator(`[data-pretable-cell][data-pretable-column-id="${FOCUS_COLUMN}"]`)
+    .click()
+  await page.keyboard.press("Escape")
+  await expect(page.getByLabel("Close detail")).toHaveCount(0)
+  await expect
+    .poll(() => focusReport(page))
+    .toEqual({ rowId, columnId: FOCUS_COLUMN, inGrid: true, onBody: false })
+}
+
+test.describe("focus continuity", () => {
+  test.setTimeout(120_000)
+
+  test("a query reset re-seats focus at the head of the new result, never on <body>", async ({
+    page,
+    consoleErrors,
+  }) => {
+    void consoleErrors
+    await openBrowse(page)
+    const anchored = recordsOnly(await rowIds(page))[3] as string
+    await focusRecordCell(page, anchored)
+
+    // A SORT HEADER, not a funnel, and the choice is the rule's precondition rather than
+    // taste. §4.2 governs a pivot that begins with DOM focus inside the grid; pretable's
+    // `FilterMenu` is portaled to `<body>` and does not restore focus to its trigger on
+    // Escape (design §1.1, an accepted pre-existing gap that is explicitly not a D1
+    // obligation), so a funnel-driven pivot begins on `<body>` and the rule does not
+    // apply to it at all. A header click leaves focus inside the viewport.
+    //
+    // `status` rather than `updated`: one click is DESC, and `updated` DESC is already the
+    // default order, so that gesture canonicalizes to the query the page is on and pivots
+    // no dataset.
+    await sortByHeader(page, FOCUS_COLUMN)
+    await expectPhase(page, "idle")
+
+    const after = await rowIds(page)
+    // The pivot also resets scroll, so the drawn head IS the model head — `after[0]` is
+    // an address, not merely "whatever is on screen".
+    const head = after[0] as string
+    // Stated rather than incidental: the unscoped browse is GROUPED, so the head of the
+    // new result is a `__group__:` header and not a record. §4.2 says "the first data
+    // cell"; what ships is `visibleRows[0]`, and under grouping those differ. The rule's
+    // actual promise — deterministic, never `<body>` — is kept either way, and this line
+    // is what makes the resolution visible instead of hidden inside `after[0]`.
+    expect(head.startsWith("__group__:"), `the drawn head "${head}" is a group row`).toBe(true)
+    // Without this the read below is satisfied by focus that never moved: the grid
+    // re-renders the same coordinates over new rows, so "focus is on the head" and "focus
+    // did not move" are the same sentence unless the two rows differ.
+    expect(head).not.toBe(anchored)
+
+    // POLLED: the re-seat happens in a layout effect and DOM focus follows it from a
+    // second effect, so the phase attribute lands first.
+    await expect.poll(() => focusReport(page)).toMatchObject({ rowId: head, inGrid: true })
+    expect(await focusReport(page)).toMatchObject({ onBody: false })
+  })
+
+  test("an append leaves focus exactly where it was", async ({ page, consoleErrors }) => {
+    void consoleErrors
+    await openBrowse(page)
+    const anchored = recordsOnly(await rowIds(page))[7] as string
+    await focusRecordCell(page, anchored)
+
+    await loadMore(page).click()
+    // The loaded count comes off the STATUS BAR — the DOM holds ~19 rows. The LOADED half
+    // alone rather than the whole sentence: the matching population differs between a solo
+    // run of this file and a whole-suite run, where scenario 9 has already removed one.
+    await expect(status(page)).toContainText(loadedText(BROWSE_PAGE_SIZE * 2))
+    await expectPhase(page, "idle")
+
+    // Same datasetKey → selection, focus and measured heights are all preserved. The
+    // engine's address is what "preserved" means here; DOM focus is legitimately on the
+    // button the user just pressed, which sits outside the viewport.
+    expect(await rovingCell(page)).toEqual({ rowId: anchored, columnId: FOCUS_COLUMN })
+    expect(await focusReport(page)).toMatchObject({ inGrid: false, onBody: false })
+
+    // NOT asserted here, and deliberately: whether one Shift+Tab out of the footer lands
+    // back ON that cell is design §9.2's "single entry stop" — D1-A11Y-04, the keyboard
+    // TOPOLOGY, which is scenario 13's and Task 13's subject rather than this one's. It
+    // does not, and the reason is upstream: @pretable/react 0.3.0 renders each row-select
+    // control as `<button role="checkbox">` with no `tabIndex`, so every DRAWN row is its
+    // own tab stop. Measured, not inferred — a backward walk from the footer visits
+    // "Select row" on six consecutive rows.
+  })
+
+  test("a refresh that removes the focused row repairs focus and says so", async ({
+    page,
+    request,
+    consoleErrors,
+  }) => {
+    void consoleErrors
+    await openBrowse(page)
+
+    // DEEP in the loaded window, and chosen off the page rather than transcribed. Two
+    // reasons, both structural. (1) This test performs the lane's second permanent write
+    // to the shared store — see helpers' scenario-9 note — so the row it removes must sit
+    // where no other spec's head assertions can see it; the tail of the drawn projection
+    // is exactly that place, and it is the one scenario 9 already chose for the same
+    // reason. (2) The drawn projection differs between a solo run of this file (a pristine
+    // seed) and a whole-suite run (scenario 9 has mutated it), so a transcribed id would
+    // be right in one mode and wrong in the other.
+    //
+    // `1e7` is a number no content height reaches, so the browser CLAMPS to the end and no
+    // row pitch is assumed.
+    await scrollGridTo(page, 1e7)
+    // The floor is INSIDE the retry, so a read taken before the virtualizer settled at
+    // the new offset is re-driven rather than believed.
+    let drawn: { id: string; rowIndex: number }[] = []
+    await expect(async () => {
+      drawn = await drawnRecords(page)
+      expect(drawn.length).toBeGreaterThanOrEqual(MIN_RENDERED_ROWS)
+    }).toPass({ timeout: 15_000 })
+    // Mid-viewport rather than the last row, so the repair has a neighbour on both sides
+    // and "moved to a nearby row" is not satisfied by the only remaining direction.
+    const doomed = drawn[Math.floor(drawn.length / 2)] as { id: string; rowIndex: number }
+    // The floor makes "deep" a checked fact rather than an intention: a viewport that had
+    // failed to scroll would hand back the head of the model and this test would quietly
+    // delete a row four other specs assert on.
+    expect(doomed.rowIndex, "the doomed row's published position").toBeGreaterThan(120)
+
+    await focusRecordCell(page, doomed.id)
+
+    const response = await request.post(`/api/memory/${encodeURIComponent(doomed.id)}/forget`)
+    if (!response.ok()) {
+      throw new Error(`forget ${doomed.id}: ${response.status()} ${await response.text()}`)
+    }
+
+    // Phrased POSITIVELY: a read taken between paints answers `[]`, and `[]` satisfies
+    // every "no longer contains" claim no matter what the page went on to draw.
+    await expect
+      .poll(
+        async () => {
+          const ids = await rowIds(page)
+          return ids.length >= MIN_RENDERED_ROWS && !ids.includes(doomed.id)
+        },
+        { timeout: 20_000 },
+      )
+      .toBe(true)
+
+    const repaired = await focusReport(page)
+    expect(repaired.inGrid).toBe(true)
+    expect(repaired.onBody).toBe(false)
+    expect(repaired.rowId).not.toBe(doomed.id)
+    expect(repaired.rowId).not.toBe("")
+
+    // The inspector's own copy for `focusedRowRemovedAnnouncement`, not pretable's
+    // default — asserted verbatim, because the sentence is the whole point of the
+    // announcement and a substring match would pass against the results sentence the
+    // same refresh also produces.
+    await expect
+      .poll(() => page.locator("[data-pretable-live-region]").innerText(), { timeout: 15_000 })
+      .toContain("The focused memory was removed.")
+  })
+
+  test("an initial failure never steals focus, and the retry control is reachable", async ({
+    page,
+    consoleErrors,
+  }) => {
+    let failing = true
+    await page.route("**/api/memory/list*", async (route) => {
+      if (failing) {
+        await route.fulfill({ status: 500, contentType: "application/json", body: "{}" })
+        return
+      }
+      await route.continue()
+    })
+    await page.goto("/memory")
+    await expect(grid(page)).toHaveAttribute("data-pretable-hydrated", "true")
+    await expect(grid(page)).toHaveAttribute("data-pretable-data-phase", "error")
+
+    // Focus stayed on `<body>` because the failure ANNOUNCED rather than grabbed. That is
+    // the correct behavior for an error the user did not initiate — and `onBody` is
+    // asserted beside `inGrid` so that focus having been thrown at some third element
+    // fails here too.
+    expect(await focusReport(page)).toMatchObject({ inGrid: false, onBody: true })
+
+    failing = false
+    await page.getByTestId(TEST_IDS.retryInitial).focus()
+    await expect(page.getByTestId(TEST_IDS.retryInitial)).toBeFocused()
+    await page.keyboard.press("Enter")
+    await expectPhase(page, "idle")
+
+    drainSeededFetchErrors(consoleErrors, 1)
+  })
+})

--- a/packages/inspector/e2e/a11y-focus.spec.ts
+++ b/packages/inspector/e2e/a11y-focus.spec.ts
@@ -1,20 +1,32 @@
 import type { Page } from "@playwright/test"
 import { TEST_IDS } from "../src/components/memory/test-ids"
-import { BROWSE_PAGE_SIZE } from "../test/seed"
+import { BROWSE_PAGE_SIZE, BROWSE_SEED_COUNT } from "../test/seed"
 import { expect, test } from "./fixtures"
 import {
+  A11Y_FOCUS_DOOMED_DRAWN_INDEX,
+  A11Y_FOCUS_FORGOTTEN_ID,
   browseRegion,
+  browseSeedRecordsAfterA11yFocus,
+  DRAWN_FIRST_WINDOW,
+  DRAWN_FIRST_WINDOW_AFTER_A11Y_FOCUS,
+  drainSeededFetchErrors,
+  expectDrawnRunAround,
   expectPhase,
+  focusRecordCell,
+  focusReport,
+  GROUP_ROW_ID_PREFIX,
   grid,
-  loadedText,
+  liveRegionText,
   loadMore,
   MIN_RENDERED_ROWS,
+  n,
   openBrowse,
   recordsOnly,
   rowIds,
-  scrollGridTo,
   sortByHeader,
   status,
+  statusText,
+  total,
 } from "./helpers"
 
 /**
@@ -29,117 +41,56 @@ import {
  * rather than a line inside a walkthrough that has already spent its store mutations.
  */
 
-/** What the browser logs for the browse response the last test refuses. Mirrors
- *  `13-accessibility.spec.ts`: the ENDPOINT is half the match, because Chromium's message
- *  text names only the status. */
-function isSeededBrowseFailure(line: string): boolean {
-  return /Failed to load resource: .*status of 500/.test(line) && line.includes("/api/memory/list")
-}
+/** The column every cell click below aims at. Not the first `[data-pretable-cell]` in the
+ *  row — that is the row-select checkbox cell, whose click ticks a row and focuses a
+ *  button instead of moving the grid's own cell focus. */
+const FOCUS_COLUMN = "status"
 
-/** Account for the console errors this spec CAUSED and leave everything else for the
- *  fixture's own teardown gate. `expected` is a floor, not a formality: a fault injection
- *  that silently stopped matching would log nothing, and a drain that merely filtered
- *  would let that pass while proving nothing about the path it claims to walk. */
-function drainSeededFetchErrors(consoleErrors: string[], expected: number): void {
-  const seeded = consoleErrors.filter(isSeededBrowseFailure)
-  const unexpected = consoleErrors.filter((line) => !isSeededBrowseFailure(line))
-  consoleErrors.length = 0
-  expect(unexpected, "console errors this spec did not inject").toEqual([])
-  expect(seeded.length, "seeded 500s the browser logged").toBeGreaterThanOrEqual(expected)
-}
-
-interface FocusReport {
-  /** `""` when DOM focus is not on a row — on `<body>`, or on the viewport itself. */
-  readonly rowId: string
-  /** Read off the active element ITSELF, so a non-empty value already means the focused
-   *  node IS a cell rather than something inside one. */
-  readonly columnId: string
-  readonly inGrid: boolean
-  readonly onBody: boolean
-}
-
-/** Where DOM focus is, relative to the browse grid — one page evaluation, so every field
- *  answers for the same instant. Two locator reads would carry a driver round trip between
- *  them and could straddle a commit. */
-async function focusReport(page: Page): Promise<FocusReport> {
-  return browseRegion(page).evaluate((region) => {
-    const active = document.activeElement as HTMLElement | null
-    const viewport = region.querySelector("[data-pretable-scroll-viewport]")
-    return {
-      rowId: active?.closest("[data-pretable-row-id]")?.getAttribute("data-pretable-row-id") ?? "",
-      columnId: active?.getAttribute("data-pretable-column-id") ?? "",
-      inGrid: viewport?.contains(active ?? null) ?? false,
-      onBody: active === document.body,
-    }
-  })
-}
+/** Pretable's derived group column (grid-core `GROUP_COLUMN_ID`), mirrored rather than
+ *  imported for the reason `helpers`' `groupRowId` is: a rename upstream must redden this
+ *  file, not silently retarget it. `resolveEffectiveColumns` puts this column AHEAD of the
+ *  declaration whenever a row grouping is active, so in the unscoped browse it is the
+ *  first column that is not the row-select one — which is the column pretable's own pivot
+ *  branch re-seats focus into. */
+const GROUP_COLUMN_ID = "__pretable_group__"
 
 /**
- * The address the grid's ROVING TABINDEX names — the engine's focus, whether or not DOM
+ * The address the grid's own focus flag names — the engine's focus, whether or not DOM
  * focus is currently sitting on it.
  *
  * Needed because pressing the load-more button is itself a focus move: the footer is
  * outside the viewport (design §9.2), so after the click `document.activeElement` is the
  * button, and pretable will not take DOM focus back off a node outside the grid
  * (`isFocusOursToMove`). "The append left focus where it was" is therefore a claim about
- * the engine's address, and `tabindex="0"` is where that address is observable.
+ * the engine's address.
+ *
+ * Located on `data-pretable-focused`, the PUBLISHED channel, rather than on the roving
+ * `tabindex` — which pretable derives from the same `cellIsFocused` flag. The tabindex is
+ * asserted to be on that same node instead of selected by, so this also states design
+ * §9.2's single entry stop for the body: exactly one cell in it is tabbable, and it is the
+ * focused one.
  */
 async function rovingCell(page: Page): Promise<{ rowId: string; columnId: string }> {
   return browseRegion(page).evaluate((region) => {
     const viewport = region.querySelector("[data-pretable-scroll-viewport]")
     if (viewport === null) throw new Error("the browse grid is not in the document")
-    const cells = viewport.querySelectorAll('[data-pretable-cell][tabindex="0"]')
-    if (cells.length !== 1) {
-      throw new Error(`the grid has ${cells.length} cells at tabindex 0, not exactly one`)
+    const focused = viewport.querySelectorAll('[data-pretable-cell][data-pretable-focused="true"]')
+    if (focused.length !== 1) {
+      throw new Error(`the grid marks ${focused.length} cells focused, not exactly one`)
     }
-    const cell = cells[0] as HTMLElement
+    const tabbable = viewport.querySelectorAll('[data-pretable-cell][tabindex="0"]')
+    if (tabbable.length !== 1 || tabbable[0] !== focused[0]) {
+      throw new Error(
+        `${tabbable.length} body cell(s) are tabbable and the focused one is ` +
+          `${tabbable[0] === focused[0] ? "among" : "not among"} them`,
+      )
+    }
+    const cell = focused[0] as HTMLElement
     return {
       rowId: cell.closest("[data-pretable-row-id]")?.getAttribute("data-pretable-row-id") ?? "",
       columnId: cell.getAttribute("data-pretable-column-id") ?? "",
     }
   })
-}
-
-/** The drawn RECORD rows with the position each one publishes, sampled together. Group
- *  headers are excluded: they share the row-id channel, and a cell click on one is not the
- *  gesture any of these tests mean. */
-async function drawnRecords(page: Page): Promise<{ id: string; rowIndex: number }[]> {
-  return browseRegion(page).evaluate((region) => {
-    const viewport = region.querySelector("[data-pretable-scroll-viewport]")
-    if (viewport === null) throw new Error("the browse grid is not in the document")
-    return Array.from(
-      viewport.querySelectorAll("[data-pretable-row-id]:not([data-pretable-group-row])"),
-    ).map((node) => ({
-      id: (node as HTMLElement).dataset.pretableRowId ?? "",
-      rowIndex: Number(node.getAttribute("aria-rowindex")),
-    }))
-  })
-}
-
-/** The column every cell click below aims at. Not the first `[data-pretable-cell]` in the
- *  row — that is the row-select checkbox cell, whose click ticks a row and focuses a
- *  button instead of moving the grid's own cell focus. */
-const FOCUS_COLUMN = "status"
-
-/**
- * Put DOM focus on one record's `status` cell and confirm it landed.
- *
- * The Escape is not incidental. Pretable routes a data-cell click to `onRowActivate` and
- * this page opens the detail sheet from it, so every cell click here also opens a sheet
- * that would otherwise own focus for the rest of the test. The sheet restores focus to its
- * opener from an unmount layout effect, which is why the read after it is POLLED: a
- * one-shot read in the same tick as `toHaveCount(0)` sees `<body>`.
- */
-async function focusRecordCell(page: Page, rowId: string): Promise<void> {
-  await grid(page)
-    .locator(`[data-pretable-row-id="${rowId}"]`)
-    .locator(`[data-pretable-cell][data-pretable-column-id="${FOCUS_COLUMN}"]`)
-    .click()
-  await page.keyboard.press("Escape")
-  await expect(page.getByLabel("Close detail")).toHaveCount(0)
-  await expect
-    .poll(() => focusReport(page))
-    .toEqual({ rowId, columnId: FOCUS_COLUMN, inGrid: true, onBody: false })
 }
 
 test.describe("focus continuity", () => {
@@ -152,7 +103,7 @@ test.describe("focus continuity", () => {
     void consoleErrors
     await openBrowse(page)
     const anchored = recordsOnly(await rowIds(page))[3] as string
-    await focusRecordCell(page, anchored)
+    await focusRecordCell(page, anchored, FOCUS_COLUMN)
 
     // A SORT HEADER, not a funnel, and the choice is the rule's precondition rather than
     // taste. §4.2 governs a pivot that begins with DOM focus inside the grid; pretable's
@@ -171,49 +122,83 @@ test.describe("focus continuity", () => {
     // The pivot also resets scroll, so the drawn head IS the model head — `after[0]` is
     // an address, not merely "whatever is on screen".
     const head = after[0] as string
-    // Stated rather than incidental: the unscoped browse is GROUPED, so the head of the
-    // new result is a `__group__:` header and not a record. §4.2 says "the first data
-    // cell"; what ships is `visibleRows[0]`, and under grouping those differ. The rule's
-    // actual promise — deterministic, never `<body>` — is kept either way, and this line
-    // is what makes the resolution visible instead of hidden inside `after[0]`.
-    expect(head.startsWith("__group__:"), `the drawn head "${head}" is a group row`).toBe(true)
+    // The one place this lane pins a divergence from its own design, so the message says
+    // what to do about it rather than leaving that in a comment the failure never prints.
+    expect(
+      head.startsWith(GROUP_ROW_ID_PREFIX),
+      `design §4.2 and the D1-A11Y-03 traceability row say a dataset pivot seats focus on ` +
+        `the first DATA cell. What ships re-seats it on \`visibleRows[0]\` and the first ` +
+        `non-row-select column, and the unscoped browse is GROUPED, so both halves resolve ` +
+        `to a group row's group cell. The drawn head is "${head}": if that is a record, ` +
+        `pretable's re-seat has changed and §4.2 can be read literally again — amend the ` +
+        `design and this test together rather than relaxing the address below`,
+    ).toBe(true)
     // Without this the read below is satisfied by focus that never moved: the grid
     // re-renders the same coordinates over new rows, so "focus is on the head" and "focus
     // did not move" are the same sentence unless the two rows differ.
     expect(head).not.toBe(anchored)
 
     // POLLED: the re-seat happens in a layout effect and DOM focus follows it from a
-    // second effect, so the phase attribute lands first.
-    await expect.poll(() => focusReport(page)).toMatchObject({ rowId: head, inGrid: true })
-    expect(await focusReport(page)).toMatchObject({ onBody: false })
+    // second effect, so the phase attribute lands first. The WHOLE address, in ONE sample:
+    // `columnId` is what says the focused node is a cell rather than the row wrapper or
+    // the row-select control, and a second sample of the same helper for a second field
+    // could straddle a commit.
+    await expect
+      .poll(() => focusReport(page))
+      .toEqual({ rowId: head, columnId: GROUP_COLUMN_ID, inGrid: true, onBody: false })
   })
 
   test("an append leaves focus exactly where it was", async ({ page, consoleErrors }) => {
     void consoleErrors
     await openBrowse(page)
     const anchored = recordsOnly(await rowIds(page))[7] as string
-    await focusRecordCell(page, anchored)
+    await focusRecordCell(page, anchored, FOCUS_COLUMN)
+
+    // The population is READ off the page rather than transcribed — two fixture states
+    // reach this file, a solo run against the pristine seed and a whole-suite run after
+    // scenario 9's forget — and it is still held to those two, so a page reporting a count
+    // from nowhere fails here instead of satisfying the relation below. Read BEFORE the
+    // gesture, because the whole sentence is what an append owes: the loaded half advanced
+    // by exactly one window and the matching half did not move at all. Asserting the
+    // loaded half alone leaves a population that drifted with it unexamined.
+    const rendered = await total(page).innerText()
+    expect([n(BROWSE_SEED_COUNT), n(BROWSE_SEED_COUNT - 1)]).toContain(rendered)
+    const matching = Number(rendered.replaceAll(",", ""))
 
     await loadMore(page).click()
-    // The loaded count comes off the STATUS BAR — the DOM holds ~19 rows. The LOADED half
-    // alone rather than the whole sentence: the matching population differs between a solo
-    // run of this file and a whole-suite run, where scenario 9 has already removed one.
-    await expect(status(page)).toContainText(loadedText(BROWSE_PAGE_SIZE * 2))
+    // The loaded count comes off the STATUS BAR — the DOM holds ~19 rows.
+    await expect(status(page)).toHaveText(statusText(BROWSE_PAGE_SIZE * 2, matching))
     await expectPhase(page, "idle")
 
     // Same datasetKey → selection, focus and measured heights are all preserved. The
     // engine's address is what "preserved" means here; DOM focus is legitimately on the
     // button the user just pressed, which sits outside the viewport.
-    expect(await rovingCell(page)).toEqual({ rowId: anchored, columnId: FOCUS_COLUMN })
-    expect(await focusReport(page)).toMatchObject({ inGrid: false, onBody: false })
+    //
+    // RETRIED rather than read once, for the reason `rowIds` gives: the rendered set can
+    // still change a frame after the phase reads `idle`, and `rovingCell` THROWS on a
+    // transient re-measure, which with `retries: 0` would be a hard suite failure rather
+    // than a re-driven read. `toPass` and not `expect.poll`, because only the former
+    // retries a callback that throws.
+    await expect(async () => {
+      expect(await rovingCell(page)).toEqual({ rowId: anchored, columnId: FOCUS_COLUMN })
+    }).toPass({ timeout: 15_000 })
+    await expect(loadMore(page)).toBeFocused()
+    expect(await focusReport(page)).toEqual({
+      rowId: "",
+      columnId: "",
+      inGrid: false,
+      onBody: false,
+    })
 
     // NOT asserted here, and deliberately: whether one Shift+Tab out of the footer lands
     // back ON that cell is design §9.2's "single entry stop" — D1-A11Y-04, the keyboard
     // TOPOLOGY, which is scenario 13's and Task 13's subject rather than this one's. It
-    // does not, and the reason is upstream: @pretable/react 0.3.0 renders each row-select
-    // control as `<button role="checkbox">` with no `tabIndex`, so every DRAWN row is its
-    // own tab stop. Measured, not inferred — a backward walk from the footer visits
-    // "Select row" on six consecutive rows.
+    // does not, and the reason is a defect upstream rather than in this page:
+    // @pretable/react 0.3.0 renders each row-select control as `<button role="checkbox">`
+    // with no `tabIndex`, so every DRAWN row is its own tab stop. Measured, not inferred —
+    // a backward walk from the footer visits "Select row" on six consecutive rows. Pinning
+    // the count here would pin the defect; it is reported instead, and `rovingCell` above
+    // states the half that IS correct today (one tabbable CELL).
   })
 
   test("a refresh that removes the focused row repairs focus and says so", async ({
@@ -224,38 +209,28 @@ test.describe("focus continuity", () => {
     void consoleErrors
     await openBrowse(page)
 
-    // DEEP in the loaded window, and chosen off the page rather than transcribed. Two
-    // reasons, both structural. (1) This test performs the lane's second permanent write
-    // to the shared store — see helpers' scenario-9 note — so the row it removes must sit
-    // where no other spec's head assertions can see it; the tail of the drawn projection
-    // is exactly that place, and it is the one scenario 9 already chose for the same
-    // reason. (2) The drawn projection differs between a solo run of this file (a pristine
-    // seed) and a whole-suite run (scenario 9 has mutated it), so a transcribed id would
-    // be right in one mode and wrong in the other.
+    // DEEP in the loaded window, and DERIVED rather than picked off the page. This test
+    // performs the lane's second permanent write to the shared store, so which row it
+    // removes has to be computable by every spec that runs after it: `helpers` owns that
+    // choice beside scenario 9's, and publishes `DRAWN_FIRST_WINDOW_AFTER_A11Y_FOCUS` so a
+    // later spec reads the store it will meet instead of transcribing a correction out of
+    // this comment.
     //
-    // `1e7` is a number no content height reaches, so the browser CLAMPS to the end and no
-    // row pitch is assumed.
-    await scrollGridTo(page, 1e7)
-    // The floor is INSIDE the retry, so a read taken before the virtualizer settled at
-    // the new offset is re-driven rather than believed.
-    let drawn: { id: string; rowIndex: number }[] = []
-    await expect(async () => {
-      drawn = await drawnRecords(page)
-      expect(drawn.length).toBeGreaterThanOrEqual(MIN_RENDERED_ROWS)
-    }).toPass({ timeout: 15_000 })
-    // Mid-viewport rather than the last row, so the repair has a neighbour on both sides
-    // and "moved to a nearby row" is not satisfied by the only remaining direction.
-    const doomed = drawn[Math.floor(drawn.length / 2)] as { id: string; rowIndex: number }
-    // The floor makes "deep" a checked fact rather than an intention: a viewport that had
-    // failed to scroll would hand back the head of the model and this test would quietly
-    // delete a row four other specs assert on.
-    expect(doomed.rowIndex, "the doomed row's published position").toBeGreaterThan(120)
+    // `DRAWN_FIRST_WINDOW` — the PRISTINE projection — is the right expectation in a
+    // whole-suite run too: the doomed row is the midpoint of the prefix all three
+    // projections agree on, so the drawn window around it is identical before and after
+    // scenario 9. This call is what turns "deep" into a checked fact: it scrolls there and
+    // pins the run of rows around the row it is about to delete, so a viewport that failed
+    // to move draws the head of the model and fails HERE rather than quietly deleting a
+    // row four other specs assert on.
+    const doomed = A11Y_FOCUS_FORGOTTEN_ID
+    await expectDrawnRunAround(page, DRAWN_FIRST_WINDOW, doomed)
 
-    await focusRecordCell(page, doomed.id)
+    await focusRecordCell(page, doomed, FOCUS_COLUMN)
 
-    const response = await request.post(`/api/memory/${encodeURIComponent(doomed.id)}/forget`)
+    const response = await request.post(`/api/memory/${encodeURIComponent(doomed)}/forget`)
     if (!response.ok()) {
-      throw new Error(`forget ${doomed.id}: ${response.status()} ${await response.text()}`)
+      throw new Error(`forget ${doomed}: ${response.status()} ${await response.text()}`)
     }
 
     // Phrased POSITIVELY: a read taken between paints answers `[]`, and `[]` satisfies
@@ -264,24 +239,60 @@ test.describe("focus continuity", () => {
       .poll(
         async () => {
           const ids = await rowIds(page)
-          return ids.length >= MIN_RENDERED_ROWS && !ids.includes(doomed.id)
+          return ids.length >= MIN_RENDERED_ROWS && !ids.includes(doomed)
         },
         { timeout: 20_000 },
       )
       .toBe(true)
 
-    const repaired = await focusReport(page)
-    expect(repaired.inGrid).toBe(true)
-    expect(repaired.onBody).toBe(false)
-    expect(repaired.rowId).not.toBe(doomed.id)
-    expect(repaired.rowId).not.toBe("")
+    // What this write LEAVES BEHIND, checked against the live store rather than exported
+    // on trust. `browseSeedRecordsAfterA11yFocus()` and `DRAWN_FIRST_WINDOW_AFTER_A11Y_FOCUS`
+    // are what the specs sorting after this file compute their expectations from, and
+    // nothing else reads them yet — so an error in either would first surface inside a spec
+    // with no way to know where it came from. Held to the two states the fixture can be in,
+    // for scenario 10's reason: a whole-suite run has lost scenario 9's record and this one,
+    // a solo run re-seeds and has lost only this one. The projection is checked by its
+    // LENGTH, which is the half that does not depend on which state the store is in: the
+    // window backfills to `BROWSE_PAGE_SIZE` and the seed has no fourth namespace, so a
+    // derivation that dropped or invented a group row is what moves this number.
+    const remaining = await total(page).innerText()
+    expect([n(BROWSE_SEED_COUNT - 1), n(browseSeedRecordsAfterA11yFocus().length)]).toContain(
+      remaining,
+    )
+    expect(DRAWN_FIRST_WINDOW_AFTER_A11Y_FOCUS.length).toBe(DRAWN_FIRST_WINDOW.length)
+
+    // Exactly one of TWO rows, and the pair is a complete statement of the rule rather
+    // than a tolerance. Pretable repairs focus by clamping to the same visible INDEX
+    // (grid-core `reconcileFocusAfterVisibleModelChange`: `afterRows[clamp(oldIndex, …)]`),
+    // and the refreshed window backfills one record to stay at `BROWSE_PAGE_SIZE`. If that
+    // record sorts below the removed row, the old index now names its successor; if above,
+    // its predecessor. There is no third case. The COLUMN is not clamped — `status`
+    // survives the refresh, so the repair keeps it, which is the difference between a
+    // repair and the re-seat the first test asserts.
+    //
+    // Normalised inside ONE sample rather than asserted across two reads of a moving page,
+    // and the sentinel is what a failure prints in place of the row it actually found.
+    const neighbours = [
+      DRAWN_FIRST_WINDOW[A11Y_FOCUS_DOOMED_DRAWN_INDEX - 1] as string,
+      DRAWN_FIRST_WINDOW[A11Y_FOCUS_DOOMED_DRAWN_INDEX + 1] as string,
+    ]
+    const ADJACENT = "<a drawn neighbour of the removed row>"
+    await expect
+      .poll(
+        async () => {
+          const report = await focusReport(page)
+          return neighbours.includes(report.rowId) ? { ...report, rowId: ADJACENT } : report
+        },
+        { timeout: 15_000 },
+      )
+      .toEqual({ rowId: ADJACENT, columnId: FOCUS_COLUMN, inGrid: true, onBody: false })
 
     // The inspector's own copy for `focusedRowRemovedAnnouncement`, not pretable's
     // default — asserted verbatim, because the sentence is the whole point of the
     // announcement and a substring match would pass against the results sentence the
     // same refresh also produces.
     await expect
-      .poll(() => page.locator("[data-pretable-live-region]").innerText(), { timeout: 15_000 })
+      .poll(() => liveRegionText(page), { timeout: 15_000 })
       .toContain("The focused memory was removed.")
   })
 
@@ -302,10 +313,15 @@ test.describe("focus continuity", () => {
     await expect(grid(page)).toHaveAttribute("data-pretable-data-phase", "error")
 
     // Focus stayed on `<body>` because the failure ANNOUNCED rather than grabbed. That is
-    // the correct behavior for an error the user did not initiate — and `onBody` is
-    // asserted beside `inGrid` so that focus having been thrown at some third element
-    // fails here too.
-    expect(await focusReport(page)).toMatchObject({ inGrid: false, onBody: true })
+    // the correct behavior for an error the user did not initiate — and the address is
+    // asserted WHOLE so that focus having been thrown at some third element fails here
+    // too, rather than only focus that reached the grid.
+    expect(await focusReport(page)).toEqual({
+      rowId: "",
+      columnId: "",
+      inGrid: false,
+      onBody: true,
+    })
 
     failing = false
     await page.getByTestId(TEST_IDS.retryInitial).focus()

--- a/packages/inspector/e2e/a11y-focus.spec.ts
+++ b/packages/inspector/e2e/a11y-focus.spec.ts
@@ -1,11 +1,9 @@
-import type { Page } from "@playwright/test"
 import { TEST_IDS } from "../src/components/memory/test-ids"
 import { BROWSE_PAGE_SIZE, BROWSE_SEED_COUNT } from "../test/seed"
 import { expect, test } from "./fixtures"
 import {
   A11Y_FOCUS_DOOMED_DRAWN_INDEX,
   A11Y_FOCUS_FORGOTTEN_ID,
-  browseRegion,
   browseSeedRecordsAfterA11yFocus,
   DRAWN_FIRST_WINDOW,
   DRAWN_FIRST_WINDOW_AFTER_A11Y_FOCUS,
@@ -22,6 +20,7 @@ import {
   n,
   openBrowse,
   recordsOnly,
+  rovingCell,
   rowIds,
   sortByHeader,
   status,
@@ -53,45 +52,6 @@ const FOCUS_COLUMN = "status"
  *  first column that is not the row-select one — which is the column pretable's own pivot
  *  branch re-seats focus into. */
 const GROUP_COLUMN_ID = "__pretable_group__"
-
-/**
- * The address the grid's own focus flag names — the engine's focus, whether or not DOM
- * focus is currently sitting on it.
- *
- * Needed because pressing the load-more button is itself a focus move: the footer is
- * outside the viewport (design §9.2), so after the click `document.activeElement` is the
- * button, and pretable will not take DOM focus back off a node outside the grid
- * (`isFocusOursToMove`). "The append left focus where it was" is therefore a claim about
- * the engine's address.
- *
- * Located on `data-pretable-focused`, the PUBLISHED channel, rather than on the roving
- * `tabindex` — which pretable derives from the same `cellIsFocused` flag. The tabindex is
- * asserted to be on that same node instead of selected by, so this also states design
- * §9.2's single entry stop for the body: exactly one cell in it is tabbable, and it is the
- * focused one.
- */
-async function rovingCell(page: Page): Promise<{ rowId: string; columnId: string }> {
-  return browseRegion(page).evaluate((region) => {
-    const viewport = region.querySelector("[data-pretable-scroll-viewport]")
-    if (viewport === null) throw new Error("the browse grid is not in the document")
-    const focused = viewport.querySelectorAll('[data-pretable-cell][data-pretable-focused="true"]')
-    if (focused.length !== 1) {
-      throw new Error(`the grid marks ${focused.length} cells focused, not exactly one`)
-    }
-    const tabbable = viewport.querySelectorAll('[data-pretable-cell][tabindex="0"]')
-    if (tabbable.length !== 1 || tabbable[0] !== focused[0]) {
-      throw new Error(
-        `${tabbable.length} body cell(s) are tabbable and the focused one is ` +
-          `${tabbable[0] === focused[0] ? "among" : "not among"} them`,
-      )
-    }
-    const cell = focused[0] as HTMLElement
-    return {
-      rowId: cell.closest("[data-pretable-row-id]")?.getAttribute("data-pretable-row-id") ?? "",
-      columnId: cell.getAttribute("data-pretable-column-id") ?? "",
-    }
-  })
-}
 
 test.describe("focus continuity", () => {
   test.setTimeout(120_000)

--- a/packages/inspector/e2e/a11y-keyboard.spec.ts
+++ b/packages/inspector/e2e/a11y-keyboard.spec.ts
@@ -317,7 +317,7 @@ test.describe("keyboard-only walkthrough", () => {
     await page.keyboard.press("Enter")
     await expect
       .poll(() => confirmed)
-      .toBe(`confirm|Permanently forget ${BROWSE_PAGE_SIZE} memor(ies)?`)
+      .toBe(`confirm|Permanently forget ${BROWSE_PAGE_SIZE} selected memor(ies)?`)
     // Dismissed means nothing was written: no bulk error, the selection intact, the
     // population untouched — and the control kept focus, so step 5 continues from here.
     await expect(page.getByTestId(TEST_IDS.bulkError)).toHaveCount(0)

--- a/packages/inspector/e2e/a11y-keyboard.spec.ts
+++ b/packages/inspector/e2e/a11y-keyboard.spec.ts
@@ -1,15 +1,22 @@
 import type { Locator, Page } from "@playwright/test"
 import { TEST_IDS } from "../src/components/memory/test-ids"
-import { BROWSE_PAGE_SIZE, browseSeedRecords, seedRecordsMatching } from "../test/seed"
+import {
+  BROWSE_PAGE_SIZE,
+  BROWSE_RESIDENT_CAP,
+  browseSeedRecords,
+  seedRecordsMatching,
+} from "../test/seed"
 import { expect, test } from "./fixtures"
 import {
   browseSeedRecordsAfterA11yFocus,
   drainSeededFetchErrors,
   expectPhase,
+  focusReport,
   grid,
   loadMore,
   n,
   openBrowse,
+  rovingCell,
   sortHeader,
   status,
   statusText,
@@ -36,7 +43,9 @@ import {
  * Restarting a walk by re-focusing `<body>` does not work and silently costs a whole lap:
  * Chromium keeps a sequential-navigation starting point that `body.focus()` does not
  * reset, so the next Tab continues from the last real element and the "restarted" walk
- * has to cross the grid to come round again.
+ * has to cross the grid to come round again. A walk that means to describe the page's
+ * order therefore starts where the load left focus and lets `walkUntil` press first, so
+ * that stop #1 is IN the record rather than consumed ahead of it.
  *
  * TWO of §9.2's claims are false against what ships. Both are pinned INVERTED rather than
  * deleted, so the day either is fixed this file reddens and the design and the test get
@@ -46,7 +55,13 @@ import {
 
 /** A stop on a tab walk, resolved to the §9.2 region that owns it. Structured rather
  *  than a printed string, because the ORDER of the regions is itself one of §9.2's
- *  claims and a string blob can only be eyeballed. */
+ *  claims and a string blob can only be eyeballed.
+ *
+ *  `tag` is `"BODY"` or `"NONE"` for the two focus-less states, which are different page
+ *  states and are kept apart for that reason: `<body>` is where a portaled popover drops
+ *  focus when it closes, while a null active element means the document has no focus owner
+ *  at all. An assertion that meant one of them would be satisfied by the other if this
+ *  collapsed them. */
 interface Stop {
   readonly tag: string
   readonly label: string
@@ -59,7 +74,12 @@ async function activeStop(page: Page): Promise<Stop> {
     ({ loadMoreId, bulkBarId }) => {
       const el = document.activeElement as HTMLElement | null
       if (el === null || el === document.body) {
-        return { tag: "BODY", label: "", region: "elsewhere" as const, rowSelect: false }
+        return {
+          tag: el === null ? "NONE" : "BODY",
+          label: "",
+          region: "elsewhere" as const,
+          rowSelect: false,
+        }
       }
       // The header row lives INSIDE the scroll viewport (it is sticky, not a sibling), so
       // it has to be tested before the viewport or every header control reports as body.
@@ -88,15 +108,24 @@ async function activeStop(page: Page): Promise<Stop> {
  *
  * The budget is a diagnostic ceiling, not a claim: it exists so an unreachable target
  * reports the walk it made instead of running until the test timeout — which is what a
- * budget-free version does, and it reports as a timeout with nothing in it. The default
- * is set well above what the topology costs TODAY (which is `BROWSE_PAGE_SIZE` more than
- * §9.2 describes), so a "never reached" means genuinely unreachable rather than merely
- * expensive; the COST is asserted separately, where it reads as the defect it is.
+ * budget-free version does, and it reports as a timeout with nothing in it.
+ *
+ * DERIVED rather than chosen, because a literal is a silent coupling to the page size.
+ * Today the body costs one stop per LOADED row (see DIVERGENCE 2), so a walk that crosses
+ * it after a single load-more already costs `BROWSE_PAGE_SIZE * 2` — and a ceiling picked
+ * against today's one-window crossing would report a merely EXPENSIVE walk as an
+ * unreachable control, which is the one thing this must never do. `BROWSE_RESIDENT_CAP` is
+ * the most rows the client will ever hold at once, so this bounds the worst crossing the
+ * page can produce, plus room for the chrome on either side of it. The COST is asserted
+ * separately, where it reads as the defect it is.
  */
 async function walkUntil(
   page: Page,
   predicate: () => Promise<boolean>,
-  { key = "Tab", budget = 400 }: { key?: "Tab" | "Shift+Tab"; budget?: number } = {},
+  {
+    key = "Tab",
+    budget = BROWSE_RESIDENT_CAP + 40,
+  }: { key?: "Tab" | "Shift+Tab"; budget?: number } = {},
 ): Promise<Stop[]> {
   const walked: Stop[] = []
   for (let step = 0; step < budget; step += 1) {
@@ -104,9 +133,15 @@ async function walkUntil(
     await page.keyboard.press(key)
     walked.push(await activeStop(page))
   }
+  // SUMMARISED, not dumped: the budget admits ~1,000 stops, and printing each one buries
+  // the two things a reader needs — the shape of the walk, and where it ended up.
   throw new Error(
-    `never reached the target in ${budget} ${key} stops; walked: ` +
-      walked.map((stop) => `${stop.region}:${stop.tag}|${stop.label}`).join(" -> "),
+    `never reached the target in ${budget} ${key} stops; regions: ` +
+      `${regionOrder(walked).join(" -> ")}; last stops: ` +
+      walked
+        .slice(-20)
+        .map((stop) => `${stop.region}:${stop.tag}|${stop.label}`)
+        .join(" -> "),
   )
 }
 
@@ -117,52 +152,6 @@ function regionOrder(walk: readonly Stop[]): string[] {
 
 function hasFocus(locator: Locator): Promise<boolean> {
   return locator.evaluate((node) => node === document.activeElement)
-}
-
-/** Where DOM focus is, as a cell address — the read that answers for a GROUP row too.
- *  `rovingCell` below is the stronger claim and cannot serve here: the group row's cells
- *  are rendered by a component of their own, so a walk that stops on the head of a
- *  grouped model has no `[data-pretable-focused]` cell to find. */
-async function focusedCell(
-  page: Page,
-): Promise<{ isCell: boolean; rowId: string; columnId: string }> {
-  return page.evaluate(() => {
-    const el = document.activeElement as HTMLElement | null
-    return {
-      isCell: el?.hasAttribute("data-pretable-cell") ?? false,
-      rowId: el?.closest("[data-pretable-row-id]")?.getAttribute("data-pretable-row-id") ?? "",
-      columnId: el?.getAttribute("data-pretable-column-id") ?? "",
-    }
-  })
-}
-
-/**
- * The engine's roving cell: the one cell marked focused, and the one cell that is
- * tabbable. Asserting they are the SAME node is what "roving tabindex" means, and it is
- * the half of §9.2's body clause that HOLDS.
- *
- * THROWS rather than returning a sentinel when either count is wrong, so callers wrap it
- * in `toPass` (which retries a throwing callback) rather than `expect.poll` (which does
- * not) — the rendered set can still change a frame after the phase reads `idle`.
- */
-async function rovingCell(page: Page): Promise<{ rowId: string; columnId: string }> {
-  return grid(page).evaluate((viewport) => {
-    const focused = viewport.querySelectorAll('[data-pretable-cell][data-pretable-focused="true"]')
-    if (focused.length !== 1) {
-      throw new Error(`the grid marks ${focused.length} cells focused, not exactly one`)
-    }
-    const tabbable = viewport.querySelectorAll('[data-pretable-cell][tabindex="0"]')
-    if (tabbable.length !== 1 || tabbable[0] !== focused[0]) {
-      throw new Error(
-        `${tabbable.length} body cell(s) are tabbable and they are not the focused one`,
-      )
-    }
-    const cell = focused[0] as HTMLElement
-    return {
-      rowId: cell.closest("[data-pretable-row-id]")?.getAttribute("data-pretable-row-id") ?? "",
-      columnId: cell.getAttribute("data-pretable-column-id") ?? "",
-    }
-  })
 }
 
 /** The `status: active` population, in the two fixture states this file can meet: a solo
@@ -185,8 +174,16 @@ test.describe("keyboard-only walkthrough", () => {
     await openBrowse(page)
 
     // 1. FILTERS. Walk to the funnel, open it, tick a value, commit — all by key.
-    await page.locator("body").press("Tab")
-    const statusFunnel = page.getByRole("button", { name: "Filter status", exact: true })
+    //
+    // The walk starts from where the load left focus and `walkUntil` presses before it
+    // records, so its first entry IS the page's first tab stop.
+    expect((await activeStop(page)).tag).toBe("BODY")
+    // SCOPED to the browse grid, like `openFilterMenu`'s identical query: `list-page`
+    // keeps this subtree mounted across every view switch and a search renders one more
+    // `MemoryGrid` per result group, so an unscoped funnel query resolves to 1 + N — and
+    // `hasFocus` goes through `locator.evaluate`, which is strict, so a later walk over a
+    // search-bearing page would throw rather than quietly miss.
+    const statusFunnel = grid(page).getByRole("button", { name: "Filter status", exact: true })
     await walkUntil(page, () => hasFocus(statusFunnel))
     await page.keyboard.press("Enter")
     const menu = page.locator("[data-pretable-filter-menu]")
@@ -209,11 +206,16 @@ test.describe("keyboard-only walkthrough", () => {
 
     // The gesture reached the SERVER, not merely the funnel's own display state: the
     // matching population is now the active one. Read off the page and held to the two
-    // states the shared fixture can be in.
+    // states the shared fixture can be in, so a page reporting a count from nowhere fails.
+    //
+    // RETRIED, and phrased as the ANSWER rather than as two gates in front of it: both
+    // gates are satisfiable while the unfiltered total is still on screen. Pretable renders
+    // `data-pretable-filter-active` off its own client filter model, and the `idle` above
+    // can be the state the gesture was about to leave — the request it causes is dispatched
+    // from an effect a tick later.
     await expect(statusFunnel).toHaveAttribute("data-pretable-filter-active", "true")
-    const rendered = await total(page).innerText()
-    expect(ACTIVE_POPULATIONS.map(n)).toContain(rendered)
-    const matching = Number(rendered.replaceAll(",", ""))
+    await expect(total(page)).toHaveText(new RegExp(`^(${ACTIVE_POPULATIONS.map(n).join("|")})$`))
+    const matching = Number((await total(page).innerText()).replaceAll(",", ""))
     await expect(status(page)).toHaveText(statusText(BROWSE_PAGE_SIZE, matching))
 
     // DIVERGENCE 1 — design §1.1, which records it as a pre-existing pretable gap and
@@ -224,7 +226,8 @@ test.describe("keyboard-only walkthrough", () => {
     // turn this into `await expect(statusFunnel).toBeFocused()`.
     expect(
       (await activeStop(page)).tag,
-      "design §1.1 records that pretable's FilterMenu does not restore focus on Escape",
+      "design §1.1 records that pretable's FilterMenu does not restore focus on Escape; it " +
+        "drops focus to <body>",
     ).toBe("BODY")
 
     // 2. SORT, from the header cell — which pretable renders as a real <button>, so it is
@@ -246,7 +249,7 @@ test.describe("keyboard-only walkthrough", () => {
     // 3. SELECTION, from the header checkbox — BACKWARDS, because the select-all sits at
     // the head of the header row and the sort left focus in the middle of it. A sort
     // pivots the datasetKey and clears selection (§9.3), so this cannot be done first.
-    const selectAll = page.locator("[data-pretable-row-select-all]")
+    const selectAll = grid(page).locator("[data-pretable-row-select-all]")
     const back = await walkUntil(page, () => hasFocus(selectAll), {
       key: "Shift+Tab",
       budget: 30,
@@ -267,8 +270,7 @@ test.describe("keyboard-only walkthrough", () => {
 
     // The order design §9.2 states, as the walk actually ran it: header controls, then
     // the body, then the load-more footer, then the rest of the page. The bulk bar IS
-    // "content after the grid" — reaching it is D1-A11Y-04's no-keyboard-trap clause, and
-    // BULK ACTIONS are keyboard-operable exactly because this walk ends on one.
+    // "content after the grid" — reaching it is D1-A11Y-04's no-keyboard-trap clause.
     expect(regionOrder(walk)).toEqual(["header", "body", "load-more", "bulk-bar"])
 
     const bodyStops = walk.filter((stop) => stop.region === "body")
@@ -287,16 +289,41 @@ test.describe("keyboard-only walkthrough", () => {
     // screen. Measured as an exact count so a partial fix is visible: one stop per loaded
     // data row (group headers render no select control and cost nothing), plus the entry.
     //
-    // The user cost IS the number: the load-more control is 200 key presses away at the
-    // first window and 1,000 at BROWSE_RESIDENT_CAP. The fix is upstream in pretable, not
-    // in this page — the Inspector cannot decline the row-select column without dropping
-    // the bulk actions D1 requires. When it lands, these two become `toBe(0)`/`toBe(1)`.
+    // The user cost IS the number: the load-more control is `BROWSE_PAGE_SIZE` key presses
+    // away at the first window. By the same mechanism it WOULD be `BROWSE_RESIDENT_CAP`
+    // once the client is holding its cap — an extrapolation from the rule this assertion
+    // pins, not a second measurement; nothing in this file pages past two windows. The fix
+    // is upstream in pretable, not in this page — the Inspector cannot decline the
+    // row-select column without dropping the bulk actions D1 requires. When it lands, these
+    // two become `toBe(0)` / `toBe(1)`.
     expect(
       bodyStops.filter((stop) => stop.rowSelect).length,
       "design §9.2 says the grid body is a single tab stop; @pretable/react 0.3.0 adds " +
         "one native stop per loaded row through the row-select <button>",
     ).toBe(BROWSE_PAGE_SIZE)
     expect(bodyStops.length).toBe(BROWSE_PAGE_SIZE + 1)
+
+    // BULK ACTIONS are OPERABLE by key, not merely reachable — §9.2 asks for both, and a
+    // walk that only lands on the control proves the weaker half. Enter runs the handler,
+    // which asks `window.confirm` BEFORE it writes: the confirm's own text is therefore
+    // proof the handler fired with the whole selection, and dismissing it is what keeps
+    // this walkthrough a pure reader. Activating for real would forget `BROWSE_PAGE_SIZE`
+    // records out of the store every spec in this lane shares.
+    let confirmed = "<no dialog>"
+    page.once("dialog", (dialog) => {
+      confirmed = `${dialog.type()}|${dialog.message()}`
+      void dialog.dismiss()
+    })
+    await page.keyboard.press("Enter")
+    await expect
+      .poll(() => confirmed)
+      .toBe(`confirm|Permanently forget ${BROWSE_PAGE_SIZE} memor(ies)?`)
+    // Dismissed means nothing was written: no bulk error, the selection intact, the
+    // population untouched — and the control kept focus, so step 5 continues from here.
+    await expect(page.getByTestId(TEST_IDS.bulkError)).toHaveCount(0)
+    await expect(page.getByTestId(TEST_IDS.bulkBar)).toContainText(`${BROWSE_PAGE_SIZE} selected`)
+    await expect(status(page)).toHaveText(statusText(BROWSE_PAGE_SIZE, matching))
+    await expect(forget).toBeFocused()
 
     // 5. LOAD-MORE is the stop immediately before the bulk bar, so one Shift+Tab is the
     // whole distance back to it — and it is operable by key.
@@ -324,7 +351,7 @@ test.describe("keyboard-only walkthrough", () => {
     // control before it is. The predicate is the REGION and not "inside the grid": the
     // header row is a descendant of the scroll viewport, so a containment test is
     // satisfied by the first header button and would never reach the body at all.
-    await page.locator("body").press("Tab")
+    expect((await activeStop(page)).tag).toBe("BODY")
     const entry = await walkUntil(page, async () => (await activeStop(page)).region === "body", {
       budget: 120,
     })
@@ -340,29 +367,44 @@ test.describe("keyboard-only walkthrough", () => {
     // this lane — entering straight out of the header row seats the head cell, entering
     // after the longer walk above leaves DOM focus on the scroll-content box — so nothing
     // here is allowed to depend on which happened.
+    //
+    // `focusReport` and not `rovingCell` until the arrows have run: at the entry stop the
+    // grid has marked NO cell, so `rovingCell` throws there by design. A non-empty ROW id
+    // is what says the focused node is a cell in the body — the header row's cells carry
+    // `data-pretable-column-id` too, but no row id — and it answers for the head of this
+    // grouped model, which is a GROUP row, exactly as it does for a record.
     await page.keyboard.press("ArrowDown")
     await expect(async () => {
-      const seated = await focusedCell(page)
-      expect(seated.isCell).toBe(true)
+      const seated = await focusReport(page)
       expect(seated.rowId).not.toBe("")
+      expect(seated.columnId).not.toBe("")
+      expect(seated.inGrid).toBe(true)
     }).toPass({ timeout: 15_000 })
-    const first = await focusedCell(page)
-    expect((await activeStop(page)).region).toBe("body")
+    const first = await focusReport(page)
 
     // Roving: another arrow moves the engine's focus to a different row and DOM focus
     // follows it, without leaving the viewport.
     await page.keyboard.press("ArrowDown")
     await expect(async () => {
-      expect((await focusedCell(page)).rowId).not.toBe(first.rowId)
+      const moved = await focusReport(page)
+      expect(moved.rowId).not.toBe(first.rowId)
+      expect(moved.rowId).not.toBe("")
+      expect(moved.inGrid).toBe(true)
     }).toPass({ timeout: 15_000 })
-    expect((await activeStop(page)).region).toBe("body")
 
-    // Now that the arrows have moved off the head — which in the unscoped browse is a
-    // GROUP row, rendered by a component of its own — the stronger half of §9.2's body
-    // clause is checkable: the roving tabindex. Exactly one cell is marked focused,
-    // exactly one is tabbable, and they are the same node.
+    // Now the stronger half of §9.2's body clause is checkable: the roving tabindex.
+    // Exactly one cell is marked focused, exactly one is tabbable, they are the same node
+    // — AND that node is where DOM focus actually is, which is the half a perfectly
+    // self-consistent engine could satisfy while the browser's focus sat somewhere else.
+    //
+    // Both reads inside ONE retry, so a commit landing between them is re-driven rather
+    // than reported as a mismatch; `rovingCell` throws on a transient re-measure, which
+    // with `retries: 0` would be a hard suite failure rather than a re-driven read.
     await expect(async () => {
-      expect((await rovingCell(page)).rowId).not.toBe("")
+      const roving = await rovingCell(page)
+      expect(roving.rowId).not.toBe("")
+      const dom = await focusReport(page)
+      expect({ rowId: dom.rowId, columnId: dom.columnId }).toEqual(roving)
     }).toPass({ timeout: 15_000 })
 
     // DIVERGENCE 2, at the exact point design §9.2 makes the claim. `tabBehavior="exit"`
@@ -391,9 +433,13 @@ test.describe("keyboard-only walkthrough", () => {
       await route.continue()
     })
     await page.goto("/memory")
+    // Subsumes the `data-pretable-hydrated` gate every sibling spec takes before its first
+    // key press: `useHydrated` is a `useSyncExternalStore` that answers false on the server
+    // and renders on the same node as the phase, so an `error` phase is only producible by
+    // the hydrated client's own failed fetch.
     await expect(grid(page)).toHaveAttribute("data-pretable-data-phase", "error")
 
-    await page.locator("body").press("Tab")
+    expect((await activeStop(page)).tag).toBe("BODY")
     const retry = page.getByTestId(TEST_IDS.retryInitial)
     const walk = await walkUntil(page, () => hasFocus(retry), { budget: 60 })
 

--- a/packages/inspector/e2e/a11y-keyboard.spec.ts
+++ b/packages/inspector/e2e/a11y-keyboard.spec.ts
@@ -1,0 +1,421 @@
+import type { Locator, Page } from "@playwright/test"
+import { TEST_IDS } from "../src/components/memory/test-ids"
+import { BROWSE_PAGE_SIZE, browseSeedRecords, seedRecordsMatching } from "../test/seed"
+import { expect, test } from "./fixtures"
+import {
+  browseSeedRecordsAfterA11yFocus,
+  drainSeededFetchErrors,
+  expectPhase,
+  grid,
+  loadMore,
+  n,
+  openBrowse,
+  sortHeader,
+  status,
+  statusText,
+  total,
+} from "./helpers"
+
+/**
+ * D1-A11Y-04, the keyboard topology, walked with NO pointer events at all — every
+ * gesture below is a key press. The plan's draft reached two controls with `focus()`;
+ * both were replaced with walks, because a programmatic focus proves reachability that a
+ * tab order need not have, which is the one thing this file exists to check.
+ *
+ * Design §9.2's claim, in full: error banner (retry, when present) → header controls
+ * (funnels, column menus, select-all) → grid body (single entry stop, roving tabindex) →
+ * load-more footer control → rest of page; and every D1 operation — filters, sort,
+ * load-more, retry, selection, bulk actions, reaching content after the grid — operable
+ * by keyboard.
+ *
+ * Column menus are ABSENT from this build rather than unreachable: pretable renders one
+ * only when `groupPanel.enabled`, which `MemoryGrid` does not pass. Nothing below looks
+ * for one.
+ *
+ * Every walk moves in ONE direction from wherever focus actually is, forward or back.
+ * Restarting a walk by re-focusing `<body>` does not work and silently costs a whole lap:
+ * Chromium keeps a sequential-navigation starting point that `body.focus()` does not
+ * reset, so the next Tab continues from the last real element and the "restarted" walk
+ * has to cross the grid to come round again.
+ *
+ * TWO of §9.2's claims are false against what ships. Both are pinned INVERTED rather than
+ * deleted, so the day either is fixed this file reddens and the design and the test get
+ * amended together. They are named at their assertions: the body is not one tab stop (it
+ * costs one per LOADED row), and the filter menu drops focus to `<body>` on Escape.
+ */
+
+/** A stop on a tab walk, resolved to the §9.2 region that owns it. Structured rather
+ *  than a printed string, because the ORDER of the regions is itself one of §9.2's
+ *  claims and a string blob can only be eyeballed. */
+interface Stop {
+  readonly tag: string
+  readonly label: string
+  readonly region: "header" | "body" | "load-more" | "bulk-bar" | "elsewhere"
+  readonly rowSelect: boolean
+}
+
+async function activeStop(page: Page): Promise<Stop> {
+  return page.evaluate(
+    ({ loadMoreId, bulkBarId }) => {
+      const el = document.activeElement as HTMLElement | null
+      if (el === null || el === document.body) {
+        return { tag: "BODY", label: "", region: "elsewhere" as const, rowSelect: false }
+      }
+      // The header row lives INSIDE the scroll viewport (it is sticky, not a sibling), so
+      // it has to be tested before the viewport or every header control reports as body.
+      const region = el.closest("[data-pretable-header-row]")
+        ? ("header" as const)
+        : el.closest("[data-pretable-scroll-viewport]")
+          ? ("body" as const)
+          : el.closest(`[data-testid="${loadMoreId}"]`)
+            ? ("load-more" as const)
+            : el.closest(`[data-testid="${bulkBarId}"]`)
+              ? ("bulk-bar" as const)
+              : ("elsewhere" as const)
+      return {
+        tag: el.tagName,
+        label: el.getAttribute("aria-label") ?? el.textContent?.trim().slice(0, 40) ?? "",
+        region,
+        rowSelect: el.hasAttribute("data-pretable-row-select"),
+      }
+    },
+    { loadMoreId: TEST_IDS.loadMore, bulkBarId: TEST_IDS.bulkBar },
+  )
+}
+
+/**
+ * Press `key` until the predicate holds, recording every stop.
+ *
+ * The budget is a diagnostic ceiling, not a claim: it exists so an unreachable target
+ * reports the walk it made instead of running until the test timeout — which is what a
+ * budget-free version does, and it reports as a timeout with nothing in it. The default
+ * is set well above what the topology costs TODAY (which is `BROWSE_PAGE_SIZE` more than
+ * §9.2 describes), so a "never reached" means genuinely unreachable rather than merely
+ * expensive; the COST is asserted separately, where it reads as the defect it is.
+ */
+async function walkUntil(
+  page: Page,
+  predicate: () => Promise<boolean>,
+  { key = "Tab", budget = 400 }: { key?: "Tab" | "Shift+Tab"; budget?: number } = {},
+): Promise<Stop[]> {
+  const walked: Stop[] = []
+  for (let step = 0; step < budget; step += 1) {
+    if (await predicate()) return walked
+    await page.keyboard.press(key)
+    walked.push(await activeStop(page))
+  }
+  throw new Error(
+    `never reached the target in ${budget} ${key} stops; walked: ` +
+      walked.map((stop) => `${stop.region}:${stop.tag}|${stop.label}`).join(" -> "),
+  )
+}
+
+/** Consecutive duplicates collapsed — the walk's shape, which is what §9.2 states. */
+function regionOrder(walk: readonly Stop[]): string[] {
+  return walk.map((stop) => stop.region).filter((region, i, all) => region !== all[i - 1])
+}
+
+function hasFocus(locator: Locator): Promise<boolean> {
+  return locator.evaluate((node) => node === document.activeElement)
+}
+
+/** Where DOM focus is, as a cell address — the read that answers for a GROUP row too.
+ *  `rovingCell` below is the stronger claim and cannot serve here: the group row's cells
+ *  are rendered by a component of their own, so a walk that stops on the head of a
+ *  grouped model has no `[data-pretable-focused]` cell to find. */
+async function focusedCell(
+  page: Page,
+): Promise<{ isCell: boolean; rowId: string; columnId: string }> {
+  return page.evaluate(() => {
+    const el = document.activeElement as HTMLElement | null
+    return {
+      isCell: el?.hasAttribute("data-pretable-cell") ?? false,
+      rowId: el?.closest("[data-pretable-row-id]")?.getAttribute("data-pretable-row-id") ?? "",
+      columnId: el?.getAttribute("data-pretable-column-id") ?? "",
+    }
+  })
+}
+
+/**
+ * The engine's roving cell: the one cell marked focused, and the one cell that is
+ * tabbable. Asserting they are the SAME node is what "roving tabindex" means, and it is
+ * the half of §9.2's body clause that HOLDS.
+ *
+ * THROWS rather than returning a sentinel when either count is wrong, so callers wrap it
+ * in `toPass` (which retries a throwing callback) rather than `expect.poll` (which does
+ * not) — the rendered set can still change a frame after the phase reads `idle`.
+ */
+async function rovingCell(page: Page): Promise<{ rowId: string; columnId: string }> {
+  return grid(page).evaluate((viewport) => {
+    const focused = viewport.querySelectorAll('[data-pretable-cell][data-pretable-focused="true"]')
+    if (focused.length !== 1) {
+      throw new Error(`the grid marks ${focused.length} cells focused, not exactly one`)
+    }
+    const tabbable = viewport.querySelectorAll('[data-pretable-cell][tabindex="0"]')
+    if (tabbable.length !== 1 || tabbable[0] !== focused[0]) {
+      throw new Error(
+        `${tabbable.length} body cell(s) are tabbable and they are not the focused one`,
+      )
+    }
+    const cell = focused[0] as HTMLElement
+    return {
+      rowId: cell.closest("[data-pretable-row-id]")?.getAttribute("data-pretable-row-id") ?? "",
+      columnId: cell.getAttribute("data-pretable-column-id") ?? "",
+    }
+  })
+}
+
+/** The `status: active` population, in the two fixture states this file can meet: a solo
+ *  run re-seeds and meets the pristine store, a whole-suite run arrives after scenario 9's
+ *  two writes and `a11y-focus`'s removal. Derived, not transcribed — the point of holding
+ *  the page to a PAIR is that a page reporting a count from nowhere still fails. */
+const ACTIVE_POPULATIONS = [
+  seedRecordsMatching({ status: ["active"] }, browseSeedRecords()).length,
+  seedRecordsMatching({ status: ["active"] }, browseSeedRecordsAfterA11yFocus()).length,
+]
+
+test.describe("keyboard-only walkthrough", () => {
+  test.setTimeout(150_000)
+
+  test("filter, sort, select-all, bulk, load-more and the page beyond, by key press only", async ({
+    page,
+    consoleErrors,
+  }) => {
+    void consoleErrors
+    await openBrowse(page)
+
+    // 1. FILTERS. Walk to the funnel, open it, tick a value, commit — all by key.
+    await page.locator("body").press("Tab")
+    const statusFunnel = page.getByRole("button", { name: "Filter status", exact: true })
+    await walkUntil(page, () => hasFocus(statusFunnel))
+    await page.keyboard.press("Enter")
+    const menu = page.locator("[data-pretable-filter-menu]")
+    await expect(menu).toBeVisible()
+    // The menu takes focus on open (pretable seats it on the operator control), which is
+    // what makes the set below reachable without a pointer.
+    await expect(menu.locator("[data-pretable-filter-operator]")).toBeFocused()
+    const activeBox = menu
+      .locator("[data-pretable-filter-set]")
+      // `exact`: the accessible name of each box is the option's own value, so substring
+      // matching would turn any value that prefixes another into a strict-mode violation.
+      .getByRole("checkbox", { name: "active", exact: true })
+    await walkUntil(page, () => hasFocus(activeBox), { budget: 20 })
+    await page.keyboard.press("Space")
+    await expect(activeBox).toBeChecked()
+    // Escape COMMITS as well as closes — pretable flushes the pending draft from the
+    // menu's unmount cleanup.
+    await page.keyboard.press("Escape")
+    await expectPhase(page, "idle")
+
+    // The gesture reached the SERVER, not merely the funnel's own display state: the
+    // matching population is now the active one. Read off the page and held to the two
+    // states the shared fixture can be in.
+    await expect(statusFunnel).toHaveAttribute("data-pretable-filter-active", "true")
+    const rendered = await total(page).innerText()
+    expect(ACTIVE_POPULATIONS.map(n)).toContain(rendered)
+    const matching = Number(rendered.replaceAll(",", ""))
+    await expect(status(page)).toHaveText(statusText(BROWSE_PAGE_SIZE, matching))
+
+    // DIVERGENCE 1 — design §1.1, which records it as a pre-existing pretable gap and
+    // explicitly NOT a D1 obligation: `FilterMenu` does not restore focus on Escape (the
+    // column ⋮ menu does). So a keyboard user who applies a filter is returned to
+    // `<body>` and re-enters the page from the top. Pinned rather than asserted away: if
+    // pretable ever restores the trigger this reddens, and the fix is to amend §1.1 and
+    // turn this into `await expect(statusFunnel).toBeFocused()`.
+    expect(
+      (await activeStop(page)).tag,
+      "design §1.1 records that pretable's FilterMenu does not restore focus on Escape",
+    ).toBe("BODY")
+
+    // 2. SORT, from the header cell — which pretable renders as a real <button>, so it is
+    // in the tab order and Enter activates it. One activation is DESCENDING (the cycle is
+    // none → desc → asc → none).
+    //
+    // Located by attribute, through `sortHeader`, and NOT by `getByRole("button")`: the
+    // element is a `<button>` carrying `role="columnheader"`, and the explicit role is
+    // what ARIA queries see. A role query finds nothing here and reports as a timeout
+    // rather than as "this control is not a button".
+    const confidenceHeader = sortHeader(page, "confidence")
+    await walkUntil(page, () => hasFocus(confidenceHeader))
+    await page.keyboard.press("Enter")
+    await expectPhase(page, "idle")
+    await expect(confidenceHeader).toHaveAttribute("aria-sort", "descending")
+    // Still the same population — a sort re-ranks, it does not re-select.
+    await expect(status(page)).toHaveText(statusText(BROWSE_PAGE_SIZE, matching))
+
+    // 3. SELECTION, from the header checkbox — BACKWARDS, because the select-all sits at
+    // the head of the header row and the sort left focus in the middle of it. A sort
+    // pivots the datasetKey and clears selection (§9.3), so this cannot be done first.
+    const selectAll = page.locator("[data-pretable-row-select-all]")
+    const back = await walkUntil(page, () => hasFocus(selectAll), {
+      key: "Shift+Tab",
+      budget: 30,
+    })
+    // Backwards out of the header reaches the select-all without dropping into the body
+    // or off the grid — the header is a contiguous run in both directions.
+    expect(regionOrder(back)).toEqual(["header"])
+    await page.keyboard.press("Space")
+    await expect(page.getByTestId(TEST_IDS.bulkBar)).toContainText(`${BROWSE_PAGE_SIZE} selected`)
+
+    // 4. ONE forward walk, from the header to the far side of the page, and every §9.2
+    // claim about the ORDER read off it. Walked once rather than once per target because
+    // each crossing of the body costs `BROWSE_PAGE_SIZE` key presses (see below).
+    const forget = page
+      .getByTestId(TEST_IDS.bulkBar)
+      .getByRole("button", { name: `Forget ${BROWSE_PAGE_SIZE}`, exact: true })
+    const walk = await walkUntil(page, () => hasFocus(forget))
+
+    // The order design §9.2 states, as the walk actually ran it: header controls, then
+    // the body, then the load-more footer, then the rest of the page. The bulk bar IS
+    // "content after the grid" — reaching it is D1-A11Y-04's no-keyboard-trap clause, and
+    // BULK ACTIONS are keyboard-operable exactly because this walk ends on one.
+    expect(regionOrder(walk)).toEqual(["header", "body", "load-more", "bulk-bar"])
+
+    const bodyStops = walk.filter((stop) => stop.region === "body")
+    // The body is ENTERED at its entry, not at a row control. Phrased as "not a row
+    // select" rather than as an identity because pretable's auto-seat is racy (see the
+    // second test): the entry stop is the scroll-content box when the seat loses and the
+    // head cell when it wins, and this claim is the one that holds either way. The roving
+    // tabindex itself is the second test's subject.
+    expect(bodyStops[0]?.rowSelect).toBe(false)
+
+    // DIVERGENCE 2 — design §9.2 / D1-A11Y-04: "grid body (single entry stop, roving
+    // tabindex)". It is not one stop. @pretable/react 0.3.0 renders every row's select
+    // control as `<button aria-label="Select row">` with no `tabIndex`, so each is its own
+    // native stop; tabbing to a row below the fold scrolls it in and the virtualizer draws
+    // the next, so the walk crosses the whole LOADED window rather than the ~19 rows on
+    // screen. Measured as an exact count so a partial fix is visible: one stop per loaded
+    // data row (group headers render no select control and cost nothing), plus the entry.
+    //
+    // The user cost IS the number: the load-more control is 200 key presses away at the
+    // first window and 1,000 at BROWSE_RESIDENT_CAP. The fix is upstream in pretable, not
+    // in this page — the Inspector cannot decline the row-select column without dropping
+    // the bulk actions D1 requires. When it lands, these two become `toBe(0)`/`toBe(1)`.
+    expect(
+      bodyStops.filter((stop) => stop.rowSelect).length,
+      "design §9.2 says the grid body is a single tab stop; @pretable/react 0.3.0 adds " +
+        "one native stop per loaded row through the row-select <button>",
+    ).toBe(BROWSE_PAGE_SIZE)
+    expect(bodyStops.length).toBe(BROWSE_PAGE_SIZE + 1)
+
+    // 5. LOAD-MORE is the stop immediately before the bulk bar, so one Shift+Tab is the
+    // whole distance back to it — and it is operable by key.
+    await page.keyboard.press("Shift+Tab")
+    await expect(loadMore(page)).toBeFocused()
+    await page.keyboard.press("Enter")
+    // The loaded count comes off the STATUS BAR — the DOM holds ~19 rows however many the
+    // client is holding — and the WHOLE sentence is asserted, so a loaded count that
+    // advanced while the population silently followed it still fails.
+    await expect(status(page)).toHaveText(statusText(BROWSE_PAGE_SIZE * 2, matching))
+    await expectPhase(page, "idle")
+    // It stays mounted and focused across the append, so focus never drops to `<body>` at
+    // the moment the user finished paging (design §9.2).
+    await expect(loadMore(page)).toBeFocused()
+  })
+
+  test("the grid body is entered once and roves, and a Tab out of it does not leave", async ({
+    page,
+    consoleErrors,
+  }) => {
+    void consoleErrors
+    await openBrowse(page)
+
+    // Entered by KEY from the top of the page — the entry stop is only reachable if every
+    // control before it is. The predicate is the REGION and not "inside the grid": the
+    // header row is a descendant of the scroll viewport, so a containment test is
+    // satisfied by the first header button and would never reach the body at all.
+    await page.locator("body").press("Tab")
+    const entry = await walkUntil(page, async () => (await activeStop(page)).region === "body", {
+      budget: 120,
+    })
+    // Nothing in the body precedes it — the entry is the FIRST thing the body offers.
+    expect(entry.filter((stop) => stop.region === "body")).toHaveLength(1)
+    expect(entry[entry.length - 1]?.rowSelect).toBe(false)
+
+    // Arrows drive the roving focus from the entry stop — the path that is always there.
+    // Pretable ALSO tries to seat focus on the head cell when the Tab came from a header
+    // control, and that attempt is RACY: it records the origin in the viewport's Tab
+    // keydown and clears it from a `queueMicrotask`, a checkpoint that can run before the
+    // browser has performed the focus move the seat is waiting for. Measured both ways in
+    // this lane — entering straight out of the header row seats the head cell, entering
+    // after the longer walk above leaves DOM focus on the scroll-content box — so nothing
+    // here is allowed to depend on which happened.
+    await page.keyboard.press("ArrowDown")
+    await expect(async () => {
+      const seated = await focusedCell(page)
+      expect(seated.isCell).toBe(true)
+      expect(seated.rowId).not.toBe("")
+    }).toPass({ timeout: 15_000 })
+    const first = await focusedCell(page)
+    expect((await activeStop(page)).region).toBe("body")
+
+    // Roving: another arrow moves the engine's focus to a different row and DOM focus
+    // follows it, without leaving the viewport.
+    await page.keyboard.press("ArrowDown")
+    await expect(async () => {
+      expect((await focusedCell(page)).rowId).not.toBe(first.rowId)
+    }).toPass({ timeout: 15_000 })
+    expect((await activeStop(page)).region).toBe("body")
+
+    // Now that the arrows have moved off the head — which in the unscoped browse is a
+    // GROUP row, rendered by a component of its own — the stronger half of §9.2's body
+    // clause is checkable: the roving tabindex. Exactly one cell is marked focused,
+    // exactly one is tabbable, and they are the same node.
+    await expect(async () => {
+      expect((await rovingCell(page)).rowId).not.toBe("")
+    }).toPass({ timeout: 15_000 })
+
+    // DIVERGENCE 2, at the exact point design §9.2 makes the claim. `tabBehavior="exit"`
+    // hands Tab back to the browser rather than wrapping it inside the grid — which is
+    // the right half — and the browser then finds the next row's select <button>, still
+    // inside the viewport. A body that were one tab stop would put focus outside it here.
+    await page.keyboard.press("Tab")
+    const afterTab = await activeStop(page)
+    expect(
+      { region: afterTab.region, rowSelect: afterTab.rowSelect },
+      "design §9.2 says one further Tab leaves the grid body; @pretable/react 0.3.0 lands " +
+        "on the next row's row-select button instead",
+    ).toEqual({ region: "body", rowSelect: true })
+  })
+
+  test("the initial failure's retry is reachable and operable by key, and costs one stop", async ({
+    page,
+    consoleErrors,
+  }) => {
+    let failing = true
+    await page.route("**/api/memory/list*", async (route) => {
+      if (failing) {
+        await route.fulfill({ status: 500, contentType: "application/json", body: "{}" })
+        return
+      }
+      await route.continue()
+    })
+    await page.goto("/memory")
+    await expect(grid(page)).toHaveAttribute("data-pretable-data-phase", "error")
+
+    await page.locator("body").press("Tab")
+    const retry = page.getByTestId(TEST_IDS.retryInitial)
+    const walk = await walkUntil(page, () => hasFocus(retry), { budget: 60 })
+
+    // NOT "before anything else": §9.2 orders the error banner's retry ahead of the header
+    // controls, and the control this scenario reaches is not that one. §6.4 supplies the
+    // INITIAL failure's retry "through the body-state slot, not a second banner" so that
+    // exactly one retry is ever on screen — and the measured order below is what that
+    // decision costs: page chrome, then the grid's header controls, then the body's entry
+    // stop, then the retry, which pretable renders OUTSIDE the scroll viewport. (§9.2's
+    // ordering and Flow 7's "retry button above the grid" both describe a placement §6.4
+    // rejects; the shipped code follows §6.4. The banner retry, `TEST_IDS.bannerRetry`, is
+    // the control §9.2 means, and it appears only for a refresh or load-more failure.)
+    //
+    // The body clause §9.2 does govern holds here exactly, and for the reason that makes
+    // it worth stating: with no rows to walk, the grid body costs ONE tab stop.
+    expect(regionOrder(walk)).toEqual(["elsewhere", "header", "body", "elsewhere"])
+    expect(walk.filter((stop) => stop.region === "body")).toHaveLength(1)
+
+    failing = false
+    await page.keyboard.press("Enter")
+    await expectPhase(page, "idle")
+
+    drainSeededFetchErrors(consoleErrors, 1)
+  })
+})

--- a/packages/inspector/e2e/fixtures.ts
+++ b/packages/inspector/e2e/fixtures.ts
@@ -1,0 +1,22 @@
+import { test as base, expect } from "@playwright/test"
+
+/**
+ * Every spec fails on a console error or an uncaught page exception. The design's
+ * verification requirement names a "console-error gate"; making it a fixture means no
+ * spec can forget it, and the failure names the spec that produced it.
+ */
+export const test = base.extend<{ consoleErrors: string[] }>({
+  consoleErrors: async ({ page }, use, testInfo) => {
+    const errors: string[] = []
+    page.on("console", (message) => {
+      if (message.type() === "error") errors.push(message.text())
+    })
+    page.on("pageerror", (error) => errors.push(`pageerror: ${error.message}`))
+    await use(errors)
+    if (testInfo.status === testInfo.expectedStatus) {
+      expect(errors, `console errors during "${testInfo.title}"`).toEqual([])
+    }
+  },
+})
+
+export { expect }

--- a/packages/inspector/e2e/fixtures.ts
+++ b/packages/inspector/e2e/fixtures.ts
@@ -9,7 +9,15 @@ export const test = base.extend<{ consoleErrors: string[] }>({
   consoleErrors: async ({ page }, use, testInfo) => {
     const errors: string[] = []
     page.on("console", (message) => {
-      if (message.type() === "error") errors.push(message.text())
+      if (message.type() !== "error") return
+      // The URL is appended because Chromium leaves it OUT of `text()` for a failed
+      // subresource — that message is "Failed to load resource: … 500" with nothing
+      // saying which resource — and carries it in the location instead. Without it a
+      // spec accounting for a failure it INJECTED cannot distinguish that one from an
+      // unrelated failure at the same status, and the gate's own output cannot name what
+      // broke.
+      const { url } = message.location()
+      errors.push(url === "" ? message.text() : `${message.text()} [${url}]`)
     })
     page.on("pageerror", (error) => errors.push(`pageerror: ${error.message}`))
     await use(errors)

--- a/packages/inspector/e2e/helpers.ts
+++ b/packages/inspector/e2e/helpers.ts
@@ -2,10 +2,32 @@ import type { Locator, Page } from "@playwright/test"
 import { expect } from "@playwright/test"
 import { TEST_IDS } from "../src/components/memory/test-ids"
 
-/** The browse grid. Pretable puts role + aria-label + the phase attribute on the
- *  scroll viewport itself, so this one locator is also the ARIA subject. */
+/** The browse endpoint, mirrored from `use-memory-browse`'s fetch rather than imported:
+ *  that module is `"use client"` and pulls React, so it cannot load in the runner. A
+ *  rename makes the waits below time out, never pass early. */
+const BROWSE_ENDPOINT = "/api/memory/list"
+
+/** The browse surface. `list-page` keeps this subtree MOUNTED and only `hidden` across
+ *  every view switch, and a search renders one more `MemoryGrid` per result group beside
+ *  it — every one of them carrying the same `aria-label="Memories"`. An unscoped grid
+ *  locator therefore resolves to 1 + N elements the moment a search is active: the
+ *  assertions below would throw on strict mode, and `rowIds`' `evaluateAll` — which is
+ *  NOT strict — would silently concatenate the hidden browse rows with the search rows
+ *  and answer in DOM order. */
+export function browseRegion(page: Page): Locator {
+  return page.getByTestId(TEST_IDS.browseRegion)
+}
+
+/** The grid inside `scope`. Pretable puts role + aria-label + the phase attribute on the
+ *  scroll viewport itself, so this one locator is also the ARIA subject. Take the search
+ *  results' own section as `scope` to assert on those instead. */
+export function gridIn(scope: Locator): Locator {
+  return scope.locator('[data-pretable-scroll-viewport][aria-label="Memories"]')
+}
+
+/** The browse grid — the surface every helper and spec below means. */
 export function grid(page: Page): Locator {
-  return page.locator('[data-pretable-scroll-viewport][aria-label="Memories"]')
+  return gridIn(browseRegion(page))
 }
 
 /** Pretable's own hydration signal. Clicking before it flips is silently dropped —
@@ -23,17 +45,28 @@ export async function expectPhase(
   await expect(grid(page)).toHaveAttribute("data-pretable-data-phase", phase)
 }
 
-/** Every row id the grid has in the DOM, in DOM order. Two things this cannot show:
- *  the grid VIRTUALIZES, so this is the rows that fit the viewport and not the whole
- *  loaded window; and the unscoped browse is GROUPED (`list-page` passes
+/** Every row id the browse grid has in the DOM, in DOM order. Two things this cannot
+ *  show: the grid VIRTUALIZES, so this is the rows that fit the viewport and not the
+ *  whole loaded window; and the unscoped browse is GROUPED (`list-page` passes
  *  `groupByNamespace` whenever no namespace facet is selected), so the list is
  *  interleaved with pretable's `__group__:` header ids. A caller that wants records
  *  has to drop those, and one that wants the server's flat order has to scope to a
- *  namespace first. */
+ *  namespace first.
+ *
+ *  One-shot, and deliberately not retrying: `MemoryGrid` sizes its viewport from a
+ *  row-count estimate until the engine's first telemetry callback lands, so the rendered
+ *  set can still change a frame after the phase reads `idle`. Callers assert through
+ *  `expect.poll`/`toPass` so that settling is retried rather than raced. */
 export async function rowIds(page: Page): Promise<string[]> {
   return grid(page)
     .locator("[data-pretable-row-id]")
-    .evaluateAll((nodes) => nodes.map((node) => (node as HTMLElement).dataset.pretableRowId ?? ""))
+    .evaluateAll((nodes) =>
+      nodes.map((node) => {
+        const id = (node as HTMLElement).dataset.pretableRowId
+        if (id === undefined) throw new Error("pretable rendered a row without a row id")
+        return id
+      }),
+    )
 }
 
 export async function scrollTop(page: Page): Promise<number> {
@@ -53,7 +86,18 @@ export function status(page: Page): Locator {
   return page.getByTestId(TEST_IDS.status)
 }
 
-/** Wait out one full poll period plus response latency. The cadence is 2 s. */
+/** Wait out one poll: block until a browse request that STARTED after this call has
+ *  fully responded.
+ *
+ *  Not a sleep. A sleep has to add an invented latency margin to the 2 s cadence and
+ *  hope, and a poll already in flight when the caller returns answers a question asked
+ *  before whatever the caller just did — so a sleep long enough to catch that stale
+ *  response reports the tick as observed. Waiting for the request first pins both ends. */
 export async function waitOnePollPeriod(page: Page): Promise<void> {
-  await page.waitForTimeout(2_600)
+  const request = await page.waitForRequest((candidate) =>
+    candidate.url().includes(BROWSE_ENDPOINT),
+  )
+  const response = await request.response()
+  if (response === null) throw new Error(`browse poll ${request.url()} produced no response`)
+  await response.finished()
 }

--- a/packages/inspector/e2e/helpers.ts
+++ b/packages/inspector/e2e/helpers.ts
@@ -1,10 +1,11 @@
+import type { MemoryRecord } from "@dawn-ai/memory"
 import type { Locator, Page } from "@playwright/test"
 import { expect } from "@playwright/test"
 import { TEST_IDS } from "../src/components/memory/test-ids"
 // Types only from `@dawn-ai/memory`, so nothing here pulls `node:sqlite` into the
 // Playwright process — `seed.ts` is pure data and computation, and `seed-store.ts` is
 // the half that writes it.
-import { browseSeedRecords } from "../test/seed"
+import { BROWSE_PAGE_SIZE, browseSeedRecords, seedIdsInDefaultOrder } from "../test/seed"
 
 /** The browse endpoint, mirrored from `use-memory-browse`'s fetch rather than imported:
  *  that module is `"use client"` and pulls React, so it cannot load in the runner. A
@@ -22,11 +23,15 @@ export function browseRegion(page: Page): Locator {
   return page.getByTestId(TEST_IDS.browseRegion)
 }
 
-/** The grid inside `scope`. Pretable puts role + aria-label + the phase attribute on the
- *  scroll viewport itself, so this one locator is also the ARIA subject. Take the search
- *  results' own section as `scope` to assert on those instead. */
+/** Pretable puts role + aria-label + the phase attribute on the scroll viewport itself,
+ *  so this one selector is also the ARIA subject. Shared with `rowIdsAndTotal`, which
+ *  runs it inside the page rather than through a locator. */
+const GRID_SELECTOR = '[data-pretable-scroll-viewport][aria-label="Memories"]'
+
+/** The grid inside `scope`. Take the search results' own section as `scope` to assert on
+ *  those instead. */
 export function gridIn(scope: Locator): Locator {
-  return scope.locator('[data-pretable-scroll-viewport][aria-label="Memories"]')
+  return scope.locator(GRID_SELECTOR)
 }
 
 /** The browse grid — the surface every helper and spec below means. */
@@ -102,6 +107,54 @@ export function status(page: Page): Locator {
  *  parsing the sentence around it. Still locale-formatted — the runner pins `en-US`. */
 export function total(page: Page): Locator {
   return page.getByTestId(TEST_IDS.total)
+}
+
+/** The page renders every count through `toLocaleString`, and `playwright.config` pins
+ *  the runner to `en-US` for exactly that reason. Expectations go through the same
+ *  formatter rather than through `String(n)`, which would look right and never match a
+ *  four-digit count. */
+export function n(value: number): string {
+  return value.toLocaleString("en-US")
+}
+
+/** `BrowseStatusBar`'s whole sentence. Asserted whole rather than by substring so that
+ *  BOTH numbers are pinned at once: a loaded count that moved while the population
+ *  silently followed it satisfies either half on its own. */
+export function statusText(loaded: number, matching: number): string {
+  return `${n(loaded)} loaded of ${n(matching)} matching`
+}
+
+/**
+ * The drawn row ids and the matching total, sampled in ONE page evaluation.
+ *
+ * For the claim that the two come from a single transaction snapshot, and only for that:
+ * reading them through two locators is two driver round trips with a poll commit's worth
+ * of room between them, so a tick landing in the gap yields rows from one revision beside
+ * a count from the next — a torn pair the HARNESS produced, reported as the page's. One
+ * evaluation removes the gap; it cannot straddle a commit, because the page is
+ * single-threaded and no paint runs inside it.
+ *
+ * The status bar is a SIBLING of the browse region rather than a descendant, so the two
+ * halves are located from the document and from the region respectively.
+ */
+export async function rowIdsAndTotal(page: Page): Promise<{ ids: string[]; total: string }> {
+  return page.evaluate(
+    ({ regionId, totalId, gridSelector }) => {
+      const region = document.querySelector(`[data-testid="${regionId}"]`)
+      if (region === null) throw new Error("the browse region is not in the document")
+      const viewport = region.querySelector(gridSelector)
+      if (viewport === null) throw new Error("the browse grid is not in the document")
+      const ids = Array.from(viewport.querySelectorAll("[data-pretable-row-id]")).map((node) => {
+        const id = (node as HTMLElement).dataset.pretableRowId
+        if (id === undefined) throw new Error("pretable rendered a row without a row id")
+        return id
+      })
+      const totalNode = document.querySelector(`[data-testid="${totalId}"]`)
+      if (totalNode === null) throw new Error("the matching total is not on screen")
+      return { ids, total: (totalNode as HTMLElement).innerText }
+    },
+    { regionId: TEST_IDS.browseRegion, totalId: TEST_IDS.total, gridSelector: GRID_SELECTOR },
+  )
 }
 
 const GROUP_ROW_ID_PREFIX = "__group__:"
@@ -181,7 +234,7 @@ export function recordCells(page: Page, columnId: string): Locator {
  *  regression that collapsed the grid to a single row would satisfy any prefix. Set well
  *  under whatever the capped viewport currently fits, because that count is a rendering
  *  detail and this is a floor, not a pin. */
-const MIN_RENDERED_ROWS = 15
+export const MIN_RENDERED_ROWS = 15
 
 /**
  * The browse grid draws exactly the head of `expected`.
@@ -267,6 +320,34 @@ export async function expectDrawnRunAround(
     expect(offset).toBeLessThan(index)
     expect(offset + ids.length).toBeGreaterThan(index + 1)
   }).toPass({ timeout: 15_000 })
+}
+
+/**
+ * The already-sampled `drawn` rows are a contiguous run of `expected`; returns where the
+ * run starts.
+ *
+ * The unanchored complement of `expectDrawnRunAround`: takes a read the caller has
+ * already settled instead of driving one, so several claims can be made about that ONE
+ * sample rather than about several successive samples of a moving page.
+ *
+ * The grid virtualizes — at most ~25 of a 203-row projection are ever in the document —
+ * so every claim about WHICH rows are drawn is a claim about a window into the model, and
+ * the window's position is not known ahead of the read.
+ */
+export function expectDrawnRun(
+  expected: readonly string[],
+  drawn: readonly string[],
+  label: string,
+): number {
+  expect(drawn.length, `${label}: rows drawn`).toBeGreaterThanOrEqual(MIN_RENDERED_ROWS)
+  const head = drawn[0] as string
+  const offset = expected.indexOf(head)
+  expect(
+    offset,
+    `${label}: drawn row "${head}" is not in the expected projection`,
+  ).toBeGreaterThanOrEqual(0)
+  expect(drawn, label).toEqual(expected.slice(offset, offset + drawn.length))
+  return offset
 }
 
 /** Open a column's funnel. Pretable labels both the funnel button and the popover
@@ -386,3 +467,123 @@ export async function waitOnePollPeriod(page: Page): Promise<void> {
   if (response === null) throw new Error(`browse poll ${request.url()} produced no response`)
   await response.finished()
 }
+
+/** The drawn projection of the first server window over the PRISTINE seed — what the
+ *  unscoped browse shows at rest, up to and including scenario 8. Scenario 9 writes to
+ *  the shared store, and everything below says what it leaves behind. */
+export const DRAWN_FIRST_WINDOW: readonly string[] = asDrawn(
+  seedIdsInDefaultOrder().slice(0, BROWSE_PAGE_SIZE),
+)
+
+// SCENARIO 9'S PERMANENT MUTATION OF THE SHARED FIXTURE.
+//
+// `playwright.config` runs one worker over one seeded store and re-seeds only in
+// `serve.ts`, so the two writes `09-concurrent-write.spec.ts` performs are visible to
+// every spec that runs after it. They are DERIVED here, beside `asDrawn` — which is what
+// chooses them — rather than left as module-local constants of that spec, so a later spec
+// computes its expectation from the store it will actually meet instead of transcribing a
+// correction out of a comment. `seed.ts` states that discipline for the whole lane; this
+// is the one piece of it the seed module cannot own, because both ids are chosen by where
+// the GRID draws them.
+//
+// What a spec that runs after scenario 9 is looking at:
+//   - the matching population is `browseSeedRecordsAfterScenario9().length` — one fewer
+//     than `BROWSE_SEED_COUNT`;
+//   - `route=/notes-archive` holds 249 records, not 250, and BOTH writes land in it;
+//   - one record moved `candidate` → `active`, so those two facet counts moved with it;
+//   - the FLAT default order now begins with `SCENARIO_9_APPROVED_ID`. Only the DRAWN
+//     order is unchanged at the head, and only because the approved record's namespace
+//     group sorts last — a view that drops grouping, or scopes to that namespace, sees it
+//     first.
+
+/**
+ * The record scenario 9 forgets: the LAST row the first window DRAWS.
+ *
+ * Chosen for where its removal is INVISIBLE, not for where it is convenient. The unscoped
+ * browse groups by namespace, so the drawn projection is `route=/chat`, then
+ * `route=/notes`, then `route=/notes-archive` — and the last drawn row is the tail of the
+ * last group. `SCENARIO_9_STABLE_DRAWN_PREFIX` turns that into a checked fact.
+ *
+ * NOT the tail of the whole 1,250 (which the plan asked for): a record ranked ~1,249th is
+ * never inside the requested window at all, so no viewport can draw it and "the row went
+ * away" would be vacuously true of a row that was never there.
+ */
+export const SCENARIO_9_FORGOTTEN_ID = DRAWN_FIRST_WINDOW[DRAWN_FIRST_WINDOW.length - 1] as string
+
+const windowAfterForget = seedIdsInDefaultOrder()
+  .filter((id) => id !== SCENARIO_9_FORGOTTEN_ID)
+  .slice(0, BROWSE_PAGE_SIZE)
+
+/** The drawn projection between scenario 9's two writes. */
+export const DRAWN_FIRST_WINDOW_AFTER_FORGET: readonly string[] = asDrawn(windowAfterForget)
+
+/**
+ * The record scenario 9 approves, which HOISTS it: `approve` stamps `updatedAt = now`,
+ * and the default order is `updatedAt DESC`, so it lands at position 0 of the whole set.
+ *
+ * EPISODIC AND A CANDIDATE, and both halves are load-bearing rather than descriptive.
+ * `approveWithReconcile` takes an append-kind candidate (episodic, reflection) straight to
+ * a plain activation with no identity scan. A SEMANTIC candidate instead reaches
+ * `classifyWrite`, where this fixture's uniformly empty `data` makes every active record
+ * of the same namespace and kind an identity match with identical data — classified
+ * `update`, which DELETES the candidate and returns 200. A procedural one throws inside
+ * `writePolicyFor` and returns 409. Picking the row off the screen, as the eye would,
+ * therefore has a one-in-four chance of silently deleting a record instead of hoisting one
+ * and a one-in-four chance of mutating nothing at all — and the spec would pass either
+ * way, having tested neither.
+ *
+ * The LAST such record in the projection, so that hoisting it moves a row from the bottom
+ * of the drawn model to the top of its group: a change strictly ABOVE a viewport parked at
+ * the bottom, which is what the scenario is about.
+ */
+export const SCENARIO_9_APPROVED_ID = (() => {
+  const byId = new Map(browseSeedRecords().map((record) => [record.id, record]))
+  const eligible = DRAWN_FIRST_WINDOW_AFTER_FORGET.filter((id) => {
+    const record = byId.get(id)
+    return record?.kind === "episodic" && record.status === "candidate"
+  })
+  const last = eligible[eligible.length - 1]
+  if (last === undefined) throw new Error("the fixture has no episodic candidate to hoist")
+  return last
+})()
+
+/**
+ * The fixture as scenario 9 leaves it, as data — the post-mutation counterpart of
+ * `browseSeedRecords()`, and the input every later spec's `seedIdsInDefaultOrder` /
+ * `seedRecordsMatching` call should take.
+ *
+ * `updatedAt` is a SENTINEL, not a prediction: the server stamps its own `Date.now()` and
+ * this only has to sort first, which any timestamp past the seed's 2026-01-01 band does.
+ * So the ORDER this view produces is real and the approved record's rendered `updated`
+ * cell is not — nothing may assert that one cell against this.
+ */
+export function browseSeedRecordsAfterScenario9(): readonly MemoryRecord[] {
+  return browseSeedRecords()
+    .filter((record) => record.id !== SCENARIO_9_FORGOTTEN_ID)
+    .map((record) =>
+      record.id === SCENARIO_9_APPROVED_ID
+        ? { ...record, status: "active" as const, updatedAt: "9999-01-01T00:00:00.000Z" }
+        : record,
+    )
+}
+
+/** The drawn projection once BOTH of scenario 9's writes have landed. */
+export const DRAWN_FIRST_WINDOW_AFTER_SCENARIO_9: readonly string[] = asDrawn(
+  seedIdsInDefaultOrder(browseSeedRecordsAfterScenario9()).slice(0, BROWSE_PAGE_SIZE),
+)
+
+/** How many leading drawn rows all three projections agree on — derived from them rather
+ *  than asserted about them. A viewport at rest draws ~25 rows, so everything a spec that
+ *  only looks at the head of the unscoped browse can see lives inside this prefix, which
+ *  is what makes the shared fixture survive scenario 9. */
+export const SCENARIO_9_STABLE_DRAWN_PREFIX = (() => {
+  let index = 0
+  while (
+    index < DRAWN_FIRST_WINDOW.length &&
+    DRAWN_FIRST_WINDOW[index] === DRAWN_FIRST_WINDOW_AFTER_FORGET[index] &&
+    DRAWN_FIRST_WINDOW[index] === DRAWN_FIRST_WINDOW_AFTER_SCENARIO_9[index]
+  ) {
+    index += 1
+  }
+  return index
+})()

--- a/packages/inspector/e2e/helpers.ts
+++ b/packages/inspector/e2e/helpers.ts
@@ -124,6 +124,17 @@ export function statusText(loaded: number, matching: number): string {
   return `${n(loaded)} loaded of ${n(matching)} matching`
 }
 
+/** The LOADED half of that sentence alone, and weaker for it in exactly the way the note
+ *  above describes: a loaded count that moved while the population silently followed it
+ *  satisfies this. Available for the one case `statusText` cannot serve — a spec whose
+ *  claim is about the loaded window while the POPULATION differs between a solo run of it
+ *  (a pristine `BROWSE_SEED_COUNT`) and a whole-suite run (scenario 9 has removed one by
+ *  then). Anything that can name both numbers — by transcribing the population or, like
+ *  scenario 10, by reading it off the page — owes the whole sentence instead. */
+export function loadedText(loaded: number): string {
+  return `${n(loaded)} loaded`
+}
+
 /**
  * The drawn row ids and the matching total, sampled in ONE page evaluation.
  *

--- a/packages/inspector/e2e/helpers.ts
+++ b/packages/inspector/e2e/helpers.ts
@@ -76,6 +76,15 @@ export async function scrollTop(page: Page): Promise<number> {
   return grid(page).evaluate((node) => node.scrollTop)
 }
 
+/** The setter beside that getter. Kept together deliberately: the grid virtualizes, so
+ *  every claim about a row below the fold has to move the box first, and a private copy
+ *  of this in one spec is a copy the next scenario writes again. */
+export async function scrollGridTo(page: Page, offset: number): Promise<void> {
+  await grid(page).evaluate((node, top) => {
+    node.scrollTop = top
+  }, offset)
+}
+
 /** The single permanent polite region, portalled to document.body. */
 export async function liveRegionText(page: Page): Promise<string> {
   return page.locator("[data-pretable-live-region]").innerText()
@@ -195,6 +204,68 @@ export async function expectDrawnRows(page: Page, expected: readonly string[]): 
     expect(ids).toEqual(expected.slice(0, ids.length))
     // Bounded well under the test timeout: a genuinely wrong window would otherwise
     // retry for the full 60 s and report as a timeout rather than as a diff.
+  }).toPass({ timeout: 15_000 })
+}
+
+/** The vertical distance from one drawn row to the next, MEASURED rather than assumed.
+ *  Pretable takes its row height from the theme's density and applies the same one to
+ *  group headers, so a single pitch describes the whole model — but the number itself is
+ *  a rendering detail, and a literal here would silently aim at the wrong row the first
+ *  time that density changed. */
+async function rowPitchPx(page: Page): Promise<number> {
+  const tops = await grid(page)
+    .locator("[data-pretable-row-id]")
+    .evaluateAll((nodes) => nodes.map((node) => (node as HTMLElement).getBoundingClientRect().top))
+  const [first, second] = tops
+  if (first === undefined || second === undefined) {
+    throw new Error(`cannot measure a row pitch from ${tops.length} drawn row(s)`)
+  }
+  const pitch = second - first
+  if (pitch <= 0) throw new Error(`measured a non-positive row pitch (${pitch}px)`)
+  return pitch
+}
+
+/**
+ * The browse grid draws a contiguous run of `expected` with `anchorId` INSIDE it.
+ *
+ * The complement of `expectDrawnRows`, which compares against the HEAD of `expected` and
+ * so can only ever settle claims about the top of the model. Anything about a JOIN —
+ * that a second server window continues the first rather than replacing it — is
+ * invisible there: the viewport draws ~19 rows, and two projections that differ deep in
+ * the model still share a long prefix, so the head read passes against either one.
+ *
+ * Three separable claims, and the scenario needs all three: the drawn ids are a run of
+ * `expected` (so the ORDER is the expected one), the run reaches `anchorId` (so the rows
+ * under test are genuinely in the model — an anchor the model lacks cannot be drawn),
+ * and the run extends on BOTH sides of it (so a seam is bracketed rather than merely
+ * touched, which is what "around" is claiming). `anchorId` must therefore be an interior
+ * row; the head and the tail are `expectDrawnRows`' and a scroll-to-bottom's business.
+ *
+ * The scroll sits INSIDE the retry so a read taken before the virtualizer settled is
+ * re-driven rather than re-read at a position it has already left.
+ */
+export async function expectDrawnRunAround(
+  page: Page,
+  expected: readonly string[],
+  anchorId: string,
+): Promise<void> {
+  const index = expected.indexOf(anchorId)
+  expect(index, `"${anchorId}" is not in the expected projection`).toBeGreaterThan(0)
+  expect(index, `"${anchorId}" is the last expected row, so nothing follows it`).toBeLessThan(
+    expected.length - 1,
+  )
+  await expect(async () => {
+    await scrollGridTo(page, index * (await rowPitchPx(page)))
+    const ids = await rowIds(page)
+    expect(ids.length).toBeGreaterThanOrEqual(MIN_RENDERED_ROWS)
+    const head = ids[0]
+    const offset = head === undefined ? -1 : expected.indexOf(head)
+    expect(offset, `drawn row "${head}" is not in the expected projection`).toBeGreaterThanOrEqual(
+      0,
+    )
+    expect(ids).toEqual(expected.slice(offset, offset + ids.length))
+    expect(offset).toBeLessThan(index)
+    expect(offset + ids.length).toBeGreaterThan(index + 1)
   }).toPass({ timeout: 15_000 })
 }
 

--- a/packages/inspector/e2e/helpers.ts
+++ b/packages/inspector/e2e/helpers.ts
@@ -168,7 +168,7 @@ export async function rowIdsAndTotal(page: Page): Promise<{ ids: string[]; total
   )
 }
 
-const GROUP_ROW_ID_PREFIX = "__group__:"
+export const GROUP_ROW_ID_PREFIX = "__group__:"
 
 /** Pretable's group row id, mirrored: `__group__:<columnId>=s:<value>` with `%`, `/`
  *  and `=` percent-escaped (grid-core `makeGroupId`/`escapeGroupKey`). */
@@ -238,6 +238,100 @@ export function recordCells(page: Page, columnId: string): Locator {
   return grid(page)
     .locator("[data-pretable-row-id]:not([data-pretable-group-row])")
     .locator(`[data-pretable-cell][data-pretable-column-id="${columnId}"]`)
+}
+
+export interface FocusReport {
+  /** `""` when DOM focus is not on a row — on `<body>`, or on the viewport itself. */
+  readonly rowId: string
+  /** Read off the active element ITSELF, so a non-empty value already means the focused
+   *  node IS a cell rather than something inside one. It also excludes the row-select
+   *  cell, which carries `data-pretable-cell` too and would otherwise satisfy a bare "on
+   *  a data cell" claim. */
+  readonly columnId: string
+  readonly inGrid: boolean
+  readonly onBody: boolean
+}
+
+/**
+ * Where DOM focus is, relative to the browse grid — one page evaluation, so every field
+ * answers for the same instant. Two locator reads would carry a driver round trip between
+ * them and could straddle a commit.
+ *
+ * The ADDRESS, not merely the shape. A report of containment plus "is a cell" is
+ * identical before and after a dataset pivot, so an expectation written against it cannot
+ * tell "focus moved to the head of the NEW result" — which is what design §4.2 promises —
+ * from focus that was re-asserted at the same coordinates over different rows.
+ */
+export async function focusReport(page: Page): Promise<FocusReport> {
+  return browseRegion(page).evaluate((region) => {
+    const active = document.activeElement as HTMLElement | null
+    const viewport = region.querySelector("[data-pretable-scroll-viewport]")
+    return {
+      rowId: active?.closest("[data-pretable-row-id]")?.getAttribute("data-pretable-row-id") ?? "",
+      columnId: active?.getAttribute("data-pretable-column-id") ?? "",
+      inGrid: viewport?.contains(active ?? null) ?? false,
+      onBody: active === document.body,
+    }
+  })
+}
+
+/**
+ * Put DOM focus on one record's cell in `columnId` and confirm it landed there.
+ *
+ * The column is a parameter with no default because the row-select column is the trap:
+ * it carries `data-pretable-cell` too, and clicking it ticks a row and focuses a button
+ * instead of moving the grid's own cell focus. Naming the column makes every caller say
+ * which one it meant.
+ *
+ * The Escape is not incidental. Pretable routes a data-cell click to `onRowActivate` and
+ * this page opens the detail sheet from it, so every cell click here also opens a sheet
+ * that would otherwise own focus for the rest of the test. The sheet restores focus to
+ * its opener from an unmount layout effect, which is why the read after it is POLLED: a
+ * one-shot read in the same tick as `toHaveCount(0)` sees `<body>`.
+ */
+export async function focusRecordCell(page: Page, rowId: string, columnId: string): Promise<void> {
+  await grid(page)
+    .locator(`[data-pretable-row-id="${rowId}"]`)
+    .locator(`[data-pretable-cell][data-pretable-column-id="${columnId}"]`)
+    .click()
+  await page.keyboard.press("Escape")
+  await expect(page.getByLabel("Close detail")).toHaveCount(0)
+  await expect
+    .poll(() => focusReport(page))
+    .toEqual({ rowId, columnId, inGrid: true, onBody: false })
+}
+
+/**
+ * What the browser logs for a browse response a spec made the server refuse.
+ *
+ * The ENDPOINT is half the match, not decoration: Chromium's message text names only the
+ * status, so a shape-only match would drain an unrelated 500 from any other route as
+ * readily as the injected one. The `consoleErrors` fixture appends the location URL for
+ * exactly this.
+ */
+export function isSeededBrowseFailure(line: string): boolean {
+  return /Failed to load resource: .*status of 500/.test(line) && line.includes(BROWSE_ENDPOINT)
+}
+
+/**
+ * Account for the console errors a spec CAUSED, and leave everything else for the
+ * `consoleErrors` fixture to fail on.
+ *
+ * Not a waiver. The gate is that fixture's own teardown check, and it reads the same
+ * array this drains — so anything not matching the injected shape is re-asserted here
+ * (reddening at the drain, with the offending line in the message) and anything logged
+ * after the drain still reaches the fixture untouched.
+ *
+ * `expected` is a floor, not a formality: a spec whose fault injection silently stopped
+ * matching would produce NO console error, and a drain that merely filtered would let
+ * that pass while proving nothing about the failure path it claims to exercise.
+ */
+export function drainSeededFetchErrors(consoleErrors: string[], expected: number): void {
+  const seeded = consoleErrors.filter(isSeededBrowseFailure)
+  const unexpected = consoleErrors.filter((line) => !isSeededBrowseFailure(line))
+  consoleErrors.length = 0
+  expect(unexpected, "console errors this spec did not inject").toEqual([])
+  expect(seeded.length, "seeded 500s the browser logged").toBeGreaterThanOrEqual(expected)
 }
 
 /** A floor on how much of the window the virtualizer has to actually draw. Without one,
@@ -598,3 +692,75 @@ export const SCENARIO_9_STABLE_DRAWN_PREFIX = (() => {
   }
   return index
 })()
+
+// `a11y-focus.spec.ts`'S PERMANENT MUTATION OF THE SHARED FIXTURE.
+//
+// The lane's second data-driven removal, derived here for scenario 9's reason and by its
+// discipline: `playwright.config` runs one worker in file-path order, so every spec whose
+// filename sorts after `a11y-focus.spec.ts` inherits this write, and the only way such a
+// spec can compute the store it will actually meet is if the choice is made HERE rather
+// than picked off the page inside that spec and left in a comment.
+
+/**
+ * Where in the drawn projection that spec removes a row: the midpoint of the region every
+ * projection of this fixture agrees on.
+ *
+ * DEEP and MODE-INDEPENDENT, and the derivation is chosen for both at once. Deep, because
+ * the claim being settled is that a repair moved focus to a NEIGHBOUR rather than to the
+ * head of the model, and those two are only distinguishable well below what a viewport at
+ * rest draws. Mode-independent, because two fixture states reach that spec — a whole-suite
+ * run arrives after scenario 9's two writes, a solo run re-seeds and meets the pristine
+ * store — and inside `SCENARIO_9_STABLE_DRAWN_PREFIX` both name the same rows, so one
+ * constant addresses both. The MIDPOINT rather than an offset from either end because a
+ * drawn WINDOW around this row then lies inside the agreed region too, which is what lets
+ * that spec pin the rows around it and not merely the row itself.
+ */
+export const A11Y_FOCUS_DOOMED_DRAWN_INDEX = Math.floor(SCENARIO_9_STABLE_DRAWN_PREFIX / 2)
+
+/**
+ * The record `a11y-focus.spec.ts` forgets.
+ *
+ * Its two drawn NEIGHBOURS have to be records as well, not just this row: pretable repairs
+ * focus by clamping to the same visible index, so the row the repair lands on is one of
+ * the two, and a group header there would make that spec's expectation a claim about a
+ * header it never focused. A seed change that moved a group boundary onto this position
+ * fails here, at module load, rather than as an unreadable row diff.
+ */
+export const A11Y_FOCUS_FORGOTTEN_ID = (() => {
+  const around = DRAWN_FIRST_WINDOW.slice(
+    A11Y_FOCUS_DOOMED_DRAWN_INDEX - 1,
+    A11Y_FOCUS_DOOMED_DRAWN_INDEX + 2,
+  )
+  if (around.length !== 3 || around.some((id) => id.startsWith(GROUP_ROW_ID_PREFIX))) {
+    throw new Error(
+      `drawn rows ${A11Y_FOCUS_DOOMED_DRAWN_INDEX - 1}..${A11Y_FOCUS_DOOMED_DRAWN_INDEX + 1} are ` +
+        `not three records: ${around.join(", ")}`,
+    )
+  }
+  return around[1] as string
+})()
+
+/**
+ * The fixture as `a11y-focus.spec.ts` leaves it, as data — the input a later spec's
+ * `seedIdsInDefaultOrder` / `seedRecordsMatching` call should take.
+ *
+ * Composed on top of `browseSeedRecordsAfterScenario9()`, so its `updatedAt` sentinel
+ * carries the same caveat: the ORDER this view produces is real and the approved record's
+ * rendered `updated` cell is not.
+ */
+export function browseSeedRecordsAfterA11yFocus(): readonly MemoryRecord[] {
+  return browseSeedRecordsAfterScenario9().filter((record) => record.id !== A11Y_FOCUS_FORGOTTEN_ID)
+}
+
+/**
+ * The drawn projection once that spec's write has landed.
+ *
+ * NOT `DRAWN_FIRST_WINDOW_AFTER_A11Y_FOCUS[i] === DRAWN_FIRST_WINDOW_AFTER_SCENARIO_9[i+1]`
+ * past the removal: the refreshed window backfills one record to stay at
+ * `BROWSE_PAGE_SIZE`, and grouping files that record under its own namespace rather than
+ * at the end, so rows both above and below the removal can move. Recomputed rather than
+ * spliced for exactly that reason.
+ */
+export const DRAWN_FIRST_WINDOW_AFTER_A11Y_FOCUS: readonly string[] = asDrawn(
+  seedIdsInDefaultOrder(browseSeedRecordsAfterA11yFocus()).slice(0, BROWSE_PAGE_SIZE),
+)

--- a/packages/inspector/e2e/helpers.ts
+++ b/packages/inspector/e2e/helpers.ts
@@ -1,0 +1,59 @@
+import type { Locator, Page } from "@playwright/test"
+import { expect } from "@playwright/test"
+import { TEST_IDS } from "../src/components/memory/test-ids"
+
+/** The browse grid. Pretable puts role + aria-label + the phase attribute on the
+ *  scroll viewport itself, so this one locator is also the ARIA subject. */
+export function grid(page: Page): Locator {
+  return page.locator('[data-pretable-scroll-viewport][aria-label="Memories"]')
+}
+
+/** Pretable's own hydration signal. Clicking before it flips is silently dropped —
+ *  the single largest source of flaky "clicked it, nothing happened" e2e failures. */
+export async function openBrowse(page: Page): Promise<void> {
+  await page.goto("/memory")
+  await expect(grid(page)).toHaveAttribute("data-pretable-hydrated", "true")
+  await expectPhase(page, "idle")
+}
+
+export async function expectPhase(
+  page: Page,
+  phase: "idle" | "loading" | "stale" | "refreshing" | "loading-more" | "error",
+): Promise<void> {
+  await expect(grid(page)).toHaveAttribute("data-pretable-data-phase", phase)
+}
+
+/** Every row id the grid has in the DOM, in DOM order. Two things this cannot show:
+ *  the grid VIRTUALIZES, so this is the rows that fit the viewport and not the whole
+ *  loaded window; and the unscoped browse is GROUPED (`list-page` passes
+ *  `groupByNamespace` whenever no namespace facet is selected), so the list is
+ *  interleaved with pretable's `__group__:` header ids. A caller that wants records
+ *  has to drop those, and one that wants the server's flat order has to scope to a
+ *  namespace first. */
+export async function rowIds(page: Page): Promise<string[]> {
+  return grid(page)
+    .locator("[data-pretable-row-id]")
+    .evaluateAll((nodes) => nodes.map((node) => (node as HTMLElement).dataset.pretableRowId ?? ""))
+}
+
+export async function scrollTop(page: Page): Promise<number> {
+  return grid(page).evaluate((node) => node.scrollTop)
+}
+
+/** The single permanent polite region, portalled to document.body. */
+export async function liveRegionText(page: Page): Promise<string> {
+  return page.locator("[data-pretable-live-region]").innerText()
+}
+
+export function loadMore(page: Page): Locator {
+  return page.getByTestId(TEST_IDS.loadMore)
+}
+
+export function status(page: Page): Locator {
+  return page.getByTestId(TEST_IDS.status)
+}
+
+/** Wait out one full poll period plus response latency. The cadence is 2 s. */
+export async function waitOnePollPeriod(page: Page): Promise<void> {
+  await page.waitForTimeout(2_600)
+}

--- a/packages/inspector/e2e/helpers.ts
+++ b/packages/inspector/e2e/helpers.ts
@@ -49,18 +49,17 @@ export async function expectPhase(
   await expect(grid(page)).toHaveAttribute("data-pretable-data-phase", phase)
 }
 
-/** Every row id the browse grid has in the DOM, in DOM order. Two things this cannot
- *  show: the grid VIRTUALIZES, so this is the rows that fit the viewport and not the
- *  whole loaded window; and the unscoped browse is GROUPED (`list-page` passes
- *  `groupByNamespace` whenever no namespace facet is selected), so the list is
- *  interleaved with pretable's `__group__:` header ids. A caller that wants records
- *  has to drop those, and one that wants the server's flat order has to scope to a
- *  namespace first.
+/** Every row id the browse grid has in the DOM, in DOM order — group header ids
+ *  included, and only as many rows as the viewport fits. `asDrawn` and `expectDrawnRows`
+ *  below are where those two facts are written down; this is the raw read.
  *
  *  One-shot, and deliberately not retrying: `MemoryGrid` sizes its viewport from a
  *  row-count estimate until the engine's first telemetry callback lands, so the rendered
  *  set can still change a frame after the phase reads `idle`. Callers assert through
- *  `expect.poll`/`toPass` so that settling is retried rather than raced. */
+ *  `expect.poll`/`toPass` so that settling is retried rather than raced — and phrase the
+ *  claim POSITIVELY, because a read taken before the first paint answers `[]`, which
+ *  satisfies every assertion of the form "does not contain" no matter what the page
+ *  went on to draw. */
 export async function rowIds(page: Page): Promise<string[]> {
   return grid(page)
     .locator("[data-pretable-row-id]")
@@ -96,19 +95,30 @@ export function total(page: Page): Locator {
   return page.getByTestId(TEST_IDS.total)
 }
 
+const GROUP_ROW_ID_PREFIX = "__group__:"
+
 /** Pretable's group row id, mirrored: `__group__:<columnId>=s:<value>` with `%`, `/`
  *  and `=` percent-escaped (grid-core `makeGroupId`/`escapeGroupKey`). */
 function groupRowId(namespace: string): string {
   const escaped = namespace.replace(/%/g, "%25").replace(/\//g, "%2F").replace(/=/g, "%3D")
-  return `__group__:namespace=s:${escaped}`
+  return `${GROUP_ROW_ID_PREFIX}namespace=s:${escaped}`
 }
 
-/** Pretable orders group siblings with these exact options (grid-core `sortSiblings`),
- *  ascending unless the active sort targets the grouped column — which nothing in this
- *  lane sorts by. Constructed the same way here so this really is the shipped
- *  comparator and not a lookalike that happens to agree on three lowercase-ASCII
- *  namespaces. */
-const groupCollator = new Intl.Collator(undefined, { numeric: true, sensitivity: "base" })
+/** Group rows share the row-id channel with records, so a caller that wants the records
+ *  has to drop them. Keyed off the same prefix `groupRowId` builds with, so the two
+ *  cannot drift into disagreeing about what a group row looks like. */
+export function recordsOnly(ids: readonly string[]): string[] {
+  return ids.filter((id) => !id.startsWith(GROUP_ROW_ID_PREFIX))
+}
+
+/** Pretable orders group siblings with `Intl.Collator(undefined, { numeric: true,
+ *  sensitivity: "base" })` (grid-core `sortSiblings`), ascending unless the active sort
+ *  targets the grouped column — which nothing in this lane sorts by. The OPTIONS are the
+ *  shipped ones. The locale is pinned rather than left to resolve, which is the one
+ *  deliberate difference: the shipped comparator resolves in the PAGE, and
+ *  `playwright.config` pins that to `en-US`, while a copy left `undefined` here would
+ *  resolve in whatever locale the runner's machine happens to have. */
+const groupCollator = new Intl.Collator("en-US", { numeric: true, sensitivity: "base" })
 
 /**
  * A server window, projected into what the UNSCOPED browse DRAWS.
@@ -127,34 +137,52 @@ export function asDrawn(windowIds: readonly string[]): string[] {
   const namespaceOf = new Map(browseSeedRecords().map((record) => [record.id, record.namespace]))
   const buckets = new Map<string, string[]>()
   for (const id of windowIds) {
-    const namespace = namespaceOf.get(id) as string
+    const namespace = namespaceOf.get(id)
+    // A record the fixture does not describe has no namespace to bucket it under, and
+    // filing it under `undefined` would emit a `__group__:namespace=s:undefined` header
+    // and surface as an unreadable row diff. Scenarios that CREATE records reach here
+    // with ids the seed never had, so this is a scheduled arrival, not a hypothetical.
+    if (namespace === undefined) throw new Error(`asDrawn: "${id}" is not a seeded record`)
     const bucket = buckets.get(namespace)
     if (bucket) bucket.push(id)
     else buckets.set(namespace, [id])
   }
   const out: string[] = []
-  for (const namespace of [...buckets.keys()].sort(groupCollator.compare)) {
+  for (const [namespace, ids] of [...buckets].sort(([left], [right]) =>
+    groupCollator.compare(left, right),
+  )) {
     out.push(groupRowId(namespace))
-    out.push(...(buckets.get(namespace) as string[]))
+    out.push(...ids)
   }
   return out
 }
 
-/** A floor on how much of the window the virtualizer has to actually draw. The grid
- *  caps its viewport height, so only ~19 of a 200-row window is ever in the document —
- *  but without a floor, `slice(0, ids.length)` lets the value under test choose its own
- *  coverage, and a regression that collapsed the grid to a single row would satisfy any
- *  prefix. Well under the ~19 the capped viewport currently fits, because that count is
- *  a rendering detail and this is a floor, not a pin. */
+/** A column's cells over RECORD rows only, in DOM order. Group rows carry cells on the
+ *  same `data-pretable-cell` channel — pretable marks the row itself
+ *  `data-pretable-group-row`, which is what this excludes, so an assertion about a
+ *  column's values is not interleaved with group headers' aggregate slots. */
+export function recordCells(page: Page, columnId: string): Locator {
+  return grid(page)
+    .locator("[data-pretable-row-id]:not([data-pretable-group-row])")
+    .locator(`[data-pretable-cell][data-pretable-column-id="${columnId}"]`)
+}
+
+/** A floor on how much of the window the virtualizer has to actually draw. Without one,
+ *  `slice(0, ids.length)` lets the value under test choose its own coverage, and a
+ *  regression that collapsed the grid to a single row would satisfy any prefix. Set well
+ *  under whatever the capped viewport currently fits, because that count is a rendering
+ *  detail and this is a floor, not a pin. */
 const MIN_RENDERED_ROWS = 15
 
 /**
  * The browse grid draws exactly the head of `expected`.
  *
- * Two facts force "head" rather than "all". The grid VIRTUALIZES, so a 200-row window
- * is never wholly in the document; and the rendered set can still change a frame after
- * the phase reads `idle` (see `rowIds`), so the read is retried rather than raced —
- * inside the retry, so a floor over a single snapshot does not become a flake.
+ * "Head" rather than "all" because the grid VIRTUALIZES: it caps its viewport height, so
+ * a 200-row window is never wholly in the document and rows past the fold are never
+ * asserted here. A scenario that needs the deep window has to scroll it into view first.
+ *
+ * The read is retried rather than raced (see `rowIds`), with the floor INSIDE the retry
+ * so that a short first snapshot settles instead of failing.
  *
  * When `expected` is shorter than the floor it is asserted WHOLE, which is the stronger
  * claim and the one a narrow filter earns.
@@ -204,7 +232,14 @@ export async function applySetFilter(
 ): Promise<void> {
   const menu = await openFilterMenu(page, header)
   for (const value of values) {
-    await menu.locator("[data-pretable-filter-set]").getByRole("checkbox", { name: value }).check()
+    // `exact`, matching the sibling lookup in `openFilterMenu`: the accessible name of
+    // each box is the option's own value (`opt.label ?? opt.value`, and the browse
+    // columns declare no labels), so substring matching would turn any value that
+    // prefixes another into a strict-mode violation rather than a miss.
+    await menu
+      .locator("[data-pretable-filter-set]")
+      .getByRole("checkbox", { name: value, exact: true })
+      .check()
   }
   await page.keyboard.press("Escape")
 }
@@ -229,15 +264,28 @@ export async function sortByHeader(page: Page, header: string): Promise<void> {
 }
 
 /**
- * Time a user action from the gesture to the moment the grid ANSWERS it. This is design
- * §11's "end-to-end interaction" budget, measured rather than asserted by construction.
+ * Wall-clock time, on the RUNNER's clock, from the first step of a gesture to the moment
+ * the grid has drawn the answer to it.
+ *
+ * What this is NOT: design §11's "end-to-end interaction" instrument. Three costs the
+ * user never pays sit inside the number. `act` is driven over CDP, so a multi-step
+ * gesture pays a round-trip per step — `applyTextFilter` is four. `settled` is a
+ * Playwright retry, so any duration is rounded up to its polling grid. And the clock runs
+ * outside the page, so it also carries the driver's own latency. It is a loose upper
+ * bound: enough to catch a regression of KIND — a client round-trip storm — and not
+ * enough to state a p95 with. Tasks 18 and 21 have to measure the budget from inside the
+ * page; reusing this helper there would report the harness.
  *
  * `settled` is the caller's own check that the new answer is on screen, and it is a
  * parameter rather than a phase read for a reason: the grid is already `idle` when the
  * gesture lands, and the request that gesture causes is dispatched from an effect a
  * tick later — so waiting for `idle` alone can be satisfied by the state the gesture
- * was about to leave, and report a duration that timed nothing. The phase is asserted
- * after `settled` anyway, so a number is only ever returned for a fulfilled revision.
+ * was about to leave, and report a duration that timed nothing.
+ *
+ * The phase is asserted only AFTER the clock stops, so a number is still only ever
+ * returned for a fulfilled revision, without charging the gesture for a background poll
+ * (`BROWSE_POLL_INTERVAL_MS`, unconditional at 2 s while live and visible) that happened
+ * to be in flight when the rows settled.
  */
 export async function timeToFulfilled(
   page: Page,
@@ -247,8 +295,9 @@ export async function timeToFulfilled(
   const started = Date.now()
   await act()
   await settled()
+  const elapsed = Date.now() - started
   await expectPhase(page, "idle")
-  return Date.now() - started
+  return elapsed
 }
 
 /** Wait out one poll: block until a browse request that STARTED after this call has

--- a/packages/inspector/e2e/helpers.ts
+++ b/packages/inspector/e2e/helpers.ts
@@ -1,6 +1,10 @@
 import type { Locator, Page } from "@playwright/test"
 import { expect } from "@playwright/test"
 import { TEST_IDS } from "../src/components/memory/test-ids"
+// Types only from `@dawn-ai/memory`, so nothing here pulls `node:sqlite` into the
+// Playwright process — `seed.ts` is pure data and computation, and `seed-store.ts` is
+// the half that writes it.
+import { browseSeedRecords } from "../test/seed"
 
 /** The browse endpoint, mirrored from `use-memory-browse`'s fetch rather than imported:
  *  that module is `"use client"` and pulls React, so it cannot load in the runner. A
@@ -84,6 +88,167 @@ export function loadMore(page: Page): Locator {
 
 export function status(page: Page): Locator {
   return page.getByTestId(TEST_IDS.status)
+}
+
+/** The matching population on its own node, so a reader takes the number without
+ *  parsing the sentence around it. Still locale-formatted — the runner pins `en-US`. */
+export function total(page: Page): Locator {
+  return page.getByTestId(TEST_IDS.total)
+}
+
+/** Pretable's group row id, mirrored: `__group__:<columnId>=s:<value>` with `%`, `/`
+ *  and `=` percent-escaped (grid-core `makeGroupId`/`escapeGroupKey`). */
+function groupRowId(namespace: string): string {
+  const escaped = namespace.replace(/%/g, "%25").replace(/\//g, "%2F").replace(/=/g, "%3D")
+  return `__group__:namespace=s:${escaped}`
+}
+
+/** Pretable orders group siblings with these exact options (grid-core `sortSiblings`),
+ *  ascending unless the active sort targets the grouped column — which nothing in this
+ *  lane sorts by. Constructed the same way here so this really is the shipped
+ *  comparator and not a lookalike that happens to agree on three lowercase-ASCII
+ *  namespaces. */
+const groupCollator = new Intl.Collator(undefined, { numeric: true, sensitivity: "base" })
+
+/**
+ * A server window, projected into what the UNSCOPED browse DRAWS.
+ *
+ * `list-page` passes `groupByNamespace={namespace === undefined}`, so `/memory` — which
+ * every scenario here opens on — groups whatever window the server returned: one
+ * `__group__:` row per namespace, groups ascending by key, rows inside a group still in
+ * the order the server sent them. An expectation that skipped this would be comparing
+ * the server's flat order against a list the grid never renders.
+ *
+ * Every scenario's expectation goes through here, so each one pins BOTH the server's
+ * ordered window and the grouping laid over it: a window the server chose differently,
+ * or an id tie-break that had drifted, moves rows across and within these buckets.
+ */
+export function asDrawn(windowIds: readonly string[]): string[] {
+  const namespaceOf = new Map(browseSeedRecords().map((record) => [record.id, record.namespace]))
+  const buckets = new Map<string, string[]>()
+  for (const id of windowIds) {
+    const namespace = namespaceOf.get(id) as string
+    const bucket = buckets.get(namespace)
+    if (bucket) bucket.push(id)
+    else buckets.set(namespace, [id])
+  }
+  const out: string[] = []
+  for (const namespace of [...buckets.keys()].sort(groupCollator.compare)) {
+    out.push(groupRowId(namespace))
+    out.push(...(buckets.get(namespace) as string[]))
+  }
+  return out
+}
+
+/** A floor on how much of the window the virtualizer has to actually draw. The grid
+ *  caps its viewport height, so only ~19 of a 200-row window is ever in the document —
+ *  but without a floor, `slice(0, ids.length)` lets the value under test choose its own
+ *  coverage, and a regression that collapsed the grid to a single row would satisfy any
+ *  prefix. Well under the ~19 the capped viewport currently fits, because that count is
+ *  a rendering detail and this is a floor, not a pin. */
+const MIN_RENDERED_ROWS = 15
+
+/**
+ * The browse grid draws exactly the head of `expected`.
+ *
+ * Two facts force "head" rather than "all". The grid VIRTUALIZES, so a 200-row window
+ * is never wholly in the document; and the rendered set can still change a frame after
+ * the phase reads `idle` (see `rowIds`), so the read is retried rather than raced —
+ * inside the retry, so a floor over a single snapshot does not become a flake.
+ *
+ * When `expected` is shorter than the floor it is asserted WHOLE, which is the stronger
+ * claim and the one a narrow filter earns.
+ */
+export async function expectDrawnRows(page: Page, expected: readonly string[]): Promise<void> {
+  await expect(async () => {
+    const ids = await rowIds(page)
+    expect(ids.length).toBeGreaterThanOrEqual(Math.min(MIN_RENDERED_ROWS, expected.length))
+    expect(ids.length).toBeLessThanOrEqual(expected.length)
+    expect(ids).toEqual(expected.slice(0, ids.length))
+    // Bounded well under the test timeout: a genuinely wrong window would otherwise
+    // retry for the full 60 s and report as a timeout rather than as a diff.
+  }).toPass({ timeout: 15_000 })
+}
+
+/** Open a column's funnel. Pretable labels both the funnel button and the popover
+ *  `Filter <header>`, and renders the popover through OverlayPortal — outside the
+ *  grid, so it is located from the page while its trigger is located from the grid. */
+export async function openFilterMenu(page: Page, header: string): Promise<Locator> {
+  await grid(page)
+    .getByRole("button", { name: `Filter ${header}`, exact: true })
+    .click()
+  const menu = page.locator("[data-pretable-filter-menu]")
+  await expect(menu).toBeVisible()
+  return menu
+}
+
+/** Escape is what COMMITS a typed value, not merely what closes the panel: pretable
+ *  debounces the text input by 200 ms and flushes the pending draft from the menu's
+ *  unmount cleanup. A helper that closed by clicking elsewhere would race that flush. */
+export async function applyTextFilter(
+  page: Page,
+  header: string,
+  operator: string,
+  value: string,
+): Promise<void> {
+  const menu = await openFilterMenu(page, header)
+  await menu.locator("[data-pretable-filter-operator]").selectOption(operator)
+  await menu.locator("[data-pretable-filter-value]").fill(value)
+  await page.keyboard.press("Escape")
+}
+
+export async function applySetFilter(
+  page: Page,
+  header: string,
+  values: readonly string[],
+): Promise<void> {
+  const menu = await openFilterMenu(page, header)
+  for (const value of values) {
+    await menu.locator("[data-pretable-filter-set]").getByRole("checkbox", { name: value }).check()
+  }
+  await page.keyboard.press("Escape")
+}
+
+export async function clearFilter(page: Page, header: string): Promise<void> {
+  const menu = await openFilterMenu(page, header)
+  await menu.locator("[data-pretable-filter-clear]").click()
+  await page.keyboard.press("Escape")
+}
+
+/** A column's header cell — the sort control, and the element carrying `aria-sort`.
+ *  Located by the accessible name pretable gives it, the same channel
+ *  `openFilterMenu` uses for the funnel beside it. */
+export function sortHeader(page: Page, header: string): Locator {
+  return grid(page).locator(`[data-pretable-header-cell][aria-label="Sort ${header}"]`)
+}
+
+/** Click a header cell to advance its sort. Pretable's cycle is none → desc → asc →
+ *  none, so ONE click is descending and two are ascending. */
+export async function sortByHeader(page: Page, header: string): Promise<void> {
+  await sortHeader(page, header).click()
+}
+
+/**
+ * Time a user action from the gesture to the moment the grid ANSWERS it. This is design
+ * §11's "end-to-end interaction" budget, measured rather than asserted by construction.
+ *
+ * `settled` is the caller's own check that the new answer is on screen, and it is a
+ * parameter rather than a phase read for a reason: the grid is already `idle` when the
+ * gesture lands, and the request that gesture causes is dispatched from an effect a
+ * tick later — so waiting for `idle` alone can be satisfied by the state the gesture
+ * was about to leave, and report a duration that timed nothing. The phase is asserted
+ * after `settled` anyway, so a number is only ever returned for a fulfilled revision.
+ */
+export async function timeToFulfilled(
+  page: Page,
+  act: () => Promise<void>,
+  settled: () => Promise<void>,
+): Promise<number> {
+  const started = Date.now()
+  await act()
+  await settled()
+  await expectPhase(page, "idle")
+  return Date.now() - started
 }
 
 /** Wait out one poll: block until a browse request that STARTED after this call has

--- a/packages/inspector/e2e/helpers.ts
+++ b/packages/inspector/e2e/helpers.ts
@@ -276,6 +276,53 @@ export async function focusReport(page: Page): Promise<FocusReport> {
 }
 
 /**
+ * The engine's roving cell: the one cell the grid MARKS focused, and the one cell in the
+ * body that is tabbable. Asserting they are the SAME node is what "roving tabindex" means
+ * — design §9.2's body clause — and it is the half of that clause which holds today. Note
+ * the claim is about CELLS: every row's select `<button>` is separately tabbable, which is
+ * the half that does not hold and is `a11y-keyboard.spec.ts`' subject.
+ *
+ * The address the grid BELIEVES IN, whether or not DOM focus is currently sitting on it —
+ * the complement of `focusReport` above, and not interchangeable with it. Pressing
+ * load-more is itself a focus move: the footer is outside the viewport (design §9.2) and
+ * pretable will not take DOM focus back off a node outside the grid (`isFocusOursToMove`),
+ * so "the append left focus where it was" is a claim about THIS address, while "DOM focus
+ * followed the arrow key" is a claim about that one. A spec that means both owes both.
+ *
+ * Located on `data-pretable-focused`, the PUBLISHED channel, rather than on the roving
+ * `tabindex` — which pretable derives from the same `cellIsFocused` flag. The tabindex is
+ * asserted to be on that same node instead of selected by.
+ *
+ * There is no roving cell at the body's ENTRY tab stop: DOM focus is on the scroll-content
+ * box and the grid has marked nothing, so this throws until an arrow key has seated one.
+ * Group rows DO have one — their cells carry the same flag and tabindex a record's do.
+ *
+ * THROWS rather than returning a sentinel when either count is wrong, so callers wrap it
+ * in `toPass` (which retries a throwing callback) rather than `expect.poll` (which does
+ * not) — the rendered set can still change a frame after the phase reads `idle`.
+ */
+export async function rovingCell(page: Page): Promise<{ rowId: string; columnId: string }> {
+  return grid(page).evaluate((viewport) => {
+    const focused = viewport.querySelectorAll('[data-pretable-cell][data-pretable-focused="true"]')
+    if (focused.length !== 1) {
+      throw new Error(`the grid marks ${focused.length} cells focused, not exactly one`)
+    }
+    const tabbable = viewport.querySelectorAll('[data-pretable-cell][tabindex="0"]')
+    if (tabbable.length !== 1 || tabbable[0] !== focused[0]) {
+      throw new Error(
+        `${tabbable.length} body cell(s) are tabbable and the focused one is ` +
+          `${tabbable[0] === focused[0] ? "among" : "not among"} them`,
+      )
+    }
+    const cell = focused[0] as HTMLElement
+    return {
+      rowId: cell.closest("[data-pretable-row-id]")?.getAttribute("data-pretable-row-id") ?? "",
+      columnId: cell.getAttribute("data-pretable-column-id") ?? "",
+    }
+  })
+}
+
+/**
  * Put DOM focus on one record's cell in `columnId` and confirm it landed there.
  *
  * The column is a parameter with no default because the row-select column is the trap:

--- a/packages/inspector/e2e/serve.ts
+++ b/packages/inspector/e2e/serve.ts
@@ -3,7 +3,7 @@
 // only thing worth asserting against. Run under Node 24: this file is TypeScript and
 // relies on native type stripping.
 import { spawn } from "node:child_process"
-import { mkdirSync, rmSync } from "node:fs"
+import { existsSync, mkdirSync, rmSync } from "node:fs"
 import { join } from "node:path"
 import { fileURLToPath } from "node:url"
 // `writeBrowseSeed` lives in `seed-store.ts`, not `seed.ts`: it value-imports the
@@ -15,6 +15,20 @@ const pkgRoot = fileURLToPath(new URL("..", import.meta.url))
 const appRoot = join(pkgRoot, "test/fixtures/browse-app")
 const serverJs = join(pkgRoot, ".next/standalone/packages/inspector/server.js")
 const port = process.env.INSPECTOR_E2E_PORT ?? "3919"
+
+// Playwright's `webServer` inherits whatever `node` is on PATH — the package's
+// `engines` floor does not reach it — and both of these otherwise surface as its
+// generic "webServer exited early". A Node too old for type stripping never reaches the
+// version check at all: that one fails at parse, which is its own clear message.
+const nodeMajor = Number(process.versions.node.split(".")[0])
+if (nodeMajor < 24) {
+  throw new Error(`the inspector e2e lane requires Node >= 24; running ${process.versions.node}`)
+}
+if (!existsSync(serverJs)) {
+  throw new Error(
+    `no built standalone server at ${serverJs} — run \`pnpm turbo run build --filter=@dawn-ai/inspector...\` first`,
+  )
+}
 
 rmSync(join(appRoot, ".dawn"), { recursive: true, force: true })
 mkdirSync(join(appRoot, ".dawn"), { recursive: true })

--- a/packages/inspector/e2e/serve.ts
+++ b/packages/inspector/e2e/serve.ts
@@ -1,0 +1,30 @@
+// Playwright's `webServer` command. Wipes and re-seeds the browse fixture, then execs
+// the BUILT standalone server — the same artifact `dawn inspect` ships, which is the
+// only thing worth asserting against. Run under Node 24: this file is TypeScript and
+// relies on native type stripping.
+import { spawn } from "node:child_process"
+import { mkdirSync, rmSync } from "node:fs"
+import { join } from "node:path"
+import { fileURLToPath } from "node:url"
+// `writeBrowseSeed` lives in `seed-store.ts`, not `seed.ts`: it value-imports the
+// `@dawn-ai/memory` barrel (and through it `node:sqlite`), which the jsdom component
+// project that imports `seed.ts` cannot bundle.
+import { writeBrowseSeed } from "../test/seed-store.ts"
+
+const pkgRoot = fileURLToPath(new URL("..", import.meta.url))
+const appRoot = join(pkgRoot, "test/fixtures/browse-app")
+const serverJs = join(pkgRoot, ".next/standalone/packages/inspector/server.js")
+const port = process.env.INSPECTOR_E2E_PORT ?? "3919"
+
+rmSync(join(appRoot, ".dawn"), { recursive: true, force: true })
+mkdirSync(join(appRoot, ".dawn"), { recursive: true })
+await writeBrowseSeed(appRoot)
+
+const child = spawn(process.execPath, [serverJs], {
+  env: { ...process.env, DAWN_APP_ROOT: appRoot, PORT: port, HOSTNAME: "127.0.0.1" },
+  stdio: "inherit",
+})
+child.on("exit", (code) => process.exit(code ?? 1))
+for (const signal of ["SIGINT", "SIGTERM"] as const) {
+  process.on(signal, () => child.kill(signal))
+}

--- a/packages/inspector/e2e/serve.ts
+++ b/packages/inspector/e2e/serve.ts
@@ -1,3 +1,9 @@
+/**
+ * This file and the `test/seed-store.ts` it pulls are loaded under bare `node`,
+ * whose ESM resolver does no extension inference — so their relative imports
+ * must carry `.ts`, which is why the package enables
+ * `allowImportingTsExtensions`.
+ */
 // Playwright's `webServer` command. Wipes and re-seeds the browse fixture, then execs
 // the BUILT standalone server — the same artifact `dawn inspect` ships, which is the
 // only thing worth asserting against. Run under Node 24: this file is TypeScript and

--- a/packages/inspector/package.json
+++ b/packages/inspector/package.json
@@ -30,8 +30,9 @@
   "scripts": {
     "build": "next build && node scripts/post-build.mjs",
     "dev": "next dev",
-    "lint": "biome check --config-path ../config-biome/biome.json package.json next.config.ts postcss.config.mjs vitest.config.ts vitest.components.config.ts vitest.e2e.config.ts src app scripts test",
+    "lint": "biome check --config-path ../config-biome/biome.json package.json next.config.ts postcss.config.mjs vitest.config.ts vitest.components.config.ts vitest.e2e.config.ts src app scripts test e2e playwright.config.ts",
     "test": "vitest --run --config vitest.config.ts --passWithNoTests",
+    "test:e2e": "playwright test --config playwright.config.ts",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
@@ -48,6 +49,7 @@
   },
   "devDependencies": {
     "@dawn-ai/config-typescript": "workspace:*",
+    "@playwright/test": "1.62.1",
     "@tailwindcss/postcss": "^4.3.3",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/react": "^16.3.2",

--- a/packages/inspector/package.json
+++ b/packages/inspector/package.json
@@ -33,7 +33,7 @@
     "lint": "biome check --config-path ../config-biome/biome.json package.json next.config.ts postcss.config.mjs vitest.config.ts vitest.components.config.ts vitest.e2e.config.ts src app scripts test e2e playwright.config.ts",
     "test": "vitest --run --config vitest.config.ts --passWithNoTests",
     "test:e2e": "playwright test --config playwright.config.ts",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit && tsc --noEmit -p tsconfig.e2e.json"
   },
   "dependencies": {
     "@dawn-ai/core": "workspace:*",

--- a/packages/inspector/playwright.config.ts
+++ b/packages/inspector/playwright.config.ts
@@ -10,6 +10,21 @@ export default defineConfig({
   workers: 1,
   fullyParallel: false,
   forbidOnly: !!process.env.CI,
+  // 0 on CI too, deliberately — a retry here would report a FALSE failure, not paper over
+  // a real one. The fixture is seeded exactly once, by `serve.ts` at webServer start, and
+  // Playwright does not restart the webServer between retries; no spec re-seeds. So a
+  // retry re-runs a mutating spec against the store that spec already mutated. Concretely:
+  // 09-concurrent-write asserts `total == BROWSE_SEED_COUNT` at its top, then forgets a
+  // row, then asserts `BROWSE_SEED_COUNT - 1`. A failure after the forget would retry into
+  // the first assertion against a store now holding one row fewer — failing at a different
+  // line, for a reason that is an artifact of the retry. That trades one honest red for a
+  // misleading one.
+  //
+  // The cost is understood: these specs carry ~19 s of wall-clock sampling tuned on an
+  // M1 Max and have never run on a 2-vCPU runner. `trace: "retain-on-failure"` below is
+  // what pays for that instead — the first red ships a trace and gets diagnosed. If this
+  // lane proves flaky on CI hardware, the fix is a per-spec fixture reset (or dynamic
+  // count expectations), not a retry budget.
   retries: 0,
   timeout: 60_000,
   expect: { timeout: 10_000 },

--- a/packages/inspector/playwright.config.ts
+++ b/packages/inspector/playwright.config.ts
@@ -16,12 +16,22 @@ export default defineConfig({
   reporter: process.env.CI ? [["github"], ["list"]] : [["list"]],
   use: {
     baseURL: `http://127.0.0.1:${port}`,
+    // Pinned because the page FORMATS: the status bar renders its counts through
+    // `toLocaleString` and the grid renders `updatedAt` through the browser's zone, so
+    // an unpinned runner asserts against whichever machine it happened to run on.
+    locale: "en-US",
+    timezoneId: "UTC",
     trace: "retain-on-failure",
   },
   webServer: {
     command: `node e2e/serve.ts`,
     url: `http://127.0.0.1:${port}/healthz`,
-    reuseExistingServer: !process.env.CI,
+    // Opt-in rather than "anywhere but CI". Reusing a server skips `serve.ts` entirely,
+    // and `serve.ts` is the only thing that wipes and re-seeds the store — so a reused
+    // server hands the suite whatever the previous run's mutating scenarios left behind,
+    // and the run passes over a fixture nobody described. Set this only to iterate on a
+    // spec that does not mutate.
+    reuseExistingServer: process.env.INSPECTOR_E2E_REUSE_SERVER === "1",
     timeout: 180_000,
     stdout: "pipe",
     stderr: "pipe",

--- a/packages/inspector/playwright.config.ts
+++ b/packages/inspector/playwright.config.ts
@@ -1,0 +1,29 @@
+import { defineConfig } from "@playwright/test"
+
+const port = process.env.INSPECTOR_E2E_PORT ?? "3919"
+
+export default defineConfig({
+  testDir: "./e2e",
+  // One worker, always: every spec drives the SAME seeded store and several of them
+  // mutate it. Parallel workers would make scenario 9 (concurrent write) delete a row
+  // scenario 5 is counting.
+  workers: 1,
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: 0,
+  timeout: 60_000,
+  expect: { timeout: 10_000 },
+  reporter: process.env.CI ? [["github"], ["list"]] : [["list"]],
+  use: {
+    baseURL: `http://127.0.0.1:${port}`,
+    trace: "retain-on-failure",
+  },
+  webServer: {
+    command: `node e2e/serve.ts`,
+    url: `http://127.0.0.1:${port}/healthz`,
+    reuseExistingServer: !process.env.CI,
+    timeout: 180_000,
+    stdout: "pipe",
+    stderr: "pipe",
+  },
+})

--- a/packages/inspector/playwright.config.ts
+++ b/packages/inspector/playwright.config.ts
@@ -1,3 +1,19 @@
+/**
+ * Type-checking for this lane lives in `tsconfig.e2e.json`, a separate project
+ * rather than more entries in `tsconfig.json`'s `include`. Two reasons it cannot
+ * just live there: `next build` type-checks whatever that file includes and this
+ * package ships `.next/standalone` to npm, so a type error in a spec would fail
+ * the published build; and the lane imports `src/components/memory/test-ids`, a
+ * test-only contract module the product build has no business resolving.
+ *
+ * Without that project nothing checks these files at all — Playwright STRIPS
+ * types, it does not check them, so a spec's type error reaches the runner as a
+ * collection failure with no line number.
+ *
+ * The config itself carries no comments: `scripts/check-build-cache-config.mjs`
+ * reads every `tsconfig*.json` with a strict `JSON.parse`, and no other tsconfig
+ * in this repo uses JSONC.
+ */
 import { defineConfig } from "@playwright/test"
 
 const port = process.env.INSPECTOR_E2E_PORT ?? "3919"

--- a/packages/inspector/src/components/memory/browse-chrome.tsx
+++ b/packages/inspector/src/components/memory/browse-chrome.tsx
@@ -1,7 +1,7 @@
 "use client"
 import type { PretableDataState } from "@pretable/react"
 import { Button } from "../ui/button"
-import { TEST_IDS } from "./test-ids"
+import { errorBannerId, TEST_IDS } from "./test-ids"
 
 export interface BrowseErrorEntry {
   /** The slot this failure belongs to. Independent per source, so one source's
@@ -38,13 +38,18 @@ export function BrowseErrorBanners({
     <div className="mb-3 rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
       <div role="alert" className="space-y-1">
         {errors.map((entry) => (
-          <div key={entry.source} data-testid={`error-${entry.source}`}>
+          <div key={entry.source} data-testid={errorBannerId(entry.source)}>
             {entry.message}
           </div>
         ))}
       </div>
       {onRetry ? (
-        <Button variant="outline" className="mt-1 h-7 px-2" onClick={onRetry}>
+        <Button
+          variant="outline"
+          className="mt-1 h-7 px-2"
+          data-testid={TEST_IDS.bannerRetry}
+          onClick={onRetry}
+        >
           Retry
         </Button>
       ) : null}
@@ -73,7 +78,7 @@ export function BrowseStatusBar({
 }) {
   return (
     <p
-      data-testid="browse-status"
+      data-testid={TEST_IDS.status}
       data-phase={phase}
       className="mb-2 flex items-center gap-3 text-xs text-zinc-500"
     >

--- a/packages/inspector/src/components/memory/browse-chrome.tsx
+++ b/packages/inspector/src/components/memory/browse-chrome.tsx
@@ -1,6 +1,7 @@
 "use client"
 import type { PretableDataState } from "@pretable/react"
 import { Button } from "../ui/button"
+import { TEST_IDS } from "./test-ids"
 
 export interface BrowseErrorEntry {
   /** The slot this failure belongs to. Independent per source, so one source's
@@ -77,12 +78,25 @@ export function BrowseStatusBar({
       className="mb-2 flex items-center gap-3 text-xs text-zinc-500"
     >
       <span>
-        {total === null
-          ? `${loaded.toLocaleString()} loaded`
-          : `${loaded.toLocaleString()} loaded of ${total.toLocaleString()} matching`}
+        {total === null ? (
+          `${loaded.toLocaleString()} loaded`
+        ) : (
+          // The total gets its own node so a reader can take the number without
+          // parsing the sentence around it — and without a locale-dependent regex,
+          // since the separators come from `toLocaleString`. Split with no JSX
+          // whitespace between the pieces, so this element's `textContent` is
+          // character-for-character what the single string used to be.
+          <>
+            {`${loaded.toLocaleString()} loaded of `}
+            <span data-testid={TEST_IDS.total}>{total.toLocaleString()}</span>
+            {" matching"}
+          </>
+        )}
       </span>
       {phase === "stale" ? <span>Updating results…</span> : null}
-      {asOf === null ? null : <span>{`Updated ${new Date(asOf).toLocaleTimeString()}`}</span>}
+      {asOf === null ? null : (
+        <span data-testid={TEST_IDS.asOf}>{`Updated ${new Date(asOf).toLocaleTimeString()}`}</span>
+      )}
     </p>
   )
 }

--- a/packages/inspector/src/components/memory/bulk-bar.tsx
+++ b/packages/inspector/src/components/memory/bulk-bar.tsx
@@ -5,6 +5,13 @@ import { Button } from "../ui/button"
 import { type MemoryVerb, mutateMemories } from "./actions"
 import { TEST_IDS } from "./test-ids"
 
+/** What a finished run reports. The ids that SUCCEEDED are deliberately not among it:
+ *  the caller narrows the selection to exactly `failed`, so naming the other half would
+ *  be a second way to say the same thing, free to drift from the first. */
+export interface BulkOutcome {
+  readonly failed: readonly string[]
+}
+
 /**
  * Acts on the rows ticked in the grid. Approve is offered only for the
  * candidates in the selection — approving anything else is not a thing the
@@ -20,12 +27,12 @@ export function BulkBar({
   ticked: readonly string[]
   /** The rows currently on screen, to tell candidates from the rest. */
   records: readonly MemoryRecord[]
-  /** The ids that SUCCEEDED and the ids that FAILED, separately. The caller prunes the
-   *  succeeded ones from the selection so a re-run retries failures only — a retry can
-   *  never repeat a completed destructive action (D1-SELECT-04). */
-  onDone: (outcome: { succeeded: string[]; failed: string[] }) => void
-  /** Fired before the first per-id POST. The caller suspends polling for the duration
-   *  of the run so a refresh cannot land between two writes of the same batch. */
+  /** The caller narrows the selection to exactly these, so a re-run retries the
+   *  failures and can never repeat a completed destructive action (D1-SELECT-04). */
+  onDone: (outcome: BulkOutcome) => void
+  /** Fired before the first per-id POST. The caller suspends browse polling until
+   *  `onDone`, so this bar is not unmounted out from under a run in flight: `failures`
+   *  below is component state, and it is the only record of which ids errored. */
   onStart: () => void
   onClear: () => void
 }) {
@@ -37,22 +44,26 @@ export function BulkBar({
   )
 
   const run = async (ids: readonly string[], verb: MemoryVerb) => {
-    // Snapshot AT CONFIRMATION. `ids` is a fresh array on every render, so freezing it
-    // here is what makes the run proceed against exactly the confirmed set even as the
-    // grid updates beneath it.
+    // A copy for hygiene, not a guarantee: the closure already holds the array the
+    // confirmation was asked about, and callers only ever REPLACE `ticked`, never
+    // mutate it in place, so nothing here could observe a later change either way.
     const targets = [...ids]
     setBusy(true)
     setFailures(undefined)
     onStart()
     const results = await mutateMemories(targets, verb)
     setBusy(false)
-    const failed = results.flatMap((r) => (r.error ? [r.id] : []))
-    const succeeded = results.flatMap((r) => (r.error ? [] : [r.id]))
-    const errors = results.flatMap((r) => (r.error ? [`${r.id}: ${r.error}`] : []))
+    // One derivation of "which ones failed", read twice: the ids go back to the caller
+    // to become the selection, the messages stay here to be shown.
+    const errored = results.flatMap((r) => (r.error ? [r] : []))
     // Some may still have succeeded, so refresh either way — but say plainly
     // how many did not, rather than reporting a clean sweep.
-    if (errors.length > 0) setFailures({ attempted: targets.length, errors })
-    onDone({ succeeded, failed })
+    if (errored.length > 0)
+      setFailures({
+        attempted: targets.length,
+        errors: errored.map((r) => `${r.id}: ${r.error}`),
+      })
+    onDone({ failed: errored.map((r) => r.id) })
   }
 
   return (

--- a/packages/inspector/src/components/memory/bulk-bar.tsx
+++ b/packages/inspector/src/components/memory/bulk-bar.tsx
@@ -14,14 +14,19 @@ export function BulkBar({
   ticked,
   records,
   onDone,
+  onStart,
   onClear,
 }: {
   ticked: readonly string[]
   /** The rows currently on screen, to tell candidates from the rest. */
   records: readonly MemoryRecord[]
-  /** `failed` is how many of the attempted ids errored — the selection is kept
-   *  when any did, so the failures stay on screen to be read and retried. */
-  onDone: (outcome: { failed: number }) => void
+  /** The ids that SUCCEEDED and the ids that FAILED, separately. The caller prunes the
+   *  succeeded ones from the selection so a re-run retries failures only — a retry can
+   *  never repeat a completed destructive action (D1-SELECT-04). */
+  onDone: (outcome: { succeeded: string[]; failed: string[] }) => void
+  /** Fired before the first per-id POST. The caller suspends polling for the duration
+   *  of the run so a refresh cannot land between two writes of the same batch. */
+  onStart: () => void
   onClear: () => void
 }) {
   const [busy, setBusy] = useState(false)
@@ -32,15 +37,22 @@ export function BulkBar({
   )
 
   const run = async (ids: readonly string[], verb: MemoryVerb) => {
+    // Snapshot AT CONFIRMATION. `ids` is a fresh array on every render, so freezing it
+    // here is what makes the run proceed against exactly the confirmed set even as the
+    // grid updates beneath it.
+    const targets = [...ids]
     setBusy(true)
     setFailures(undefined)
-    const results = await mutateMemories(ids, verb)
+    onStart()
+    const results = await mutateMemories(targets, verb)
     setBusy(false)
+    const failed = results.flatMap((r) => (r.error ? [r.id] : []))
+    const succeeded = results.flatMap((r) => (r.error ? [] : [r.id]))
     const errors = results.flatMap((r) => (r.error ? [`${r.id}: ${r.error}`] : []))
     // Some may still have succeeded, so refresh either way — but say plainly
     // how many did not, rather than reporting a clean sweep.
-    if (errors.length > 0) setFailures({ attempted: ids.length, errors })
-    onDone({ failed: errors.length })
+    if (errors.length > 0) setFailures({ attempted: targets.length, errors })
+    onDone({ succeeded, failed })
   }
 
   return (
@@ -76,7 +88,7 @@ export function BulkBar({
           variant="destructive"
           disabled={busy}
           onClick={() => {
-            if (window.confirm(`Permanently forget ${ticked.length} memor(ies)?`)) {
+            if (window.confirm(`Permanently forget ${ticked.length} selected memor(ies)?`)) {
               void run(ticked, "forget")
             }
           }}

--- a/packages/inspector/src/components/memory/bulk-bar.tsx
+++ b/packages/inspector/src/components/memory/bulk-bar.tsx
@@ -3,6 +3,7 @@ import type { MemoryRecord } from "@dawn-ai/memory"
 import { useState } from "react"
 import { Button } from "../ui/button"
 import { type MemoryVerb, mutateMemories } from "./actions"
+import { TEST_IDS } from "./test-ids"
 
 /**
  * Acts on the rows ticked in the grid. Approve is offered only for the
@@ -47,7 +48,7 @@ export function BulkBar({
     // first tick would otherwise push every row down, and the next click would
     // land on the row above the one aimed at.
     <div
-      data-testid="bulk-bar"
+      data-testid={TEST_IDS.bulkBar}
       className="fixed bottom-6 left-1/2 z-10 -translate-x-1/2 rounded-md border border-zinc-300 bg-white px-3 py-2 shadow-lg"
     >
       <div className="flex flex-wrap items-center gap-2 text-sm">
@@ -87,7 +88,7 @@ export function BulkBar({
         </Button>
       </div>
       {failures ? (
-        <div data-testid="bulk-error" role="alert" className="mt-2 text-xs text-red-700">
+        <div data-testid={TEST_IDS.bulkError} role="alert" className="mt-2 text-xs text-red-700">
           <p className="font-medium">
             {`${failures.errors.length} of ${failures.attempted} failed`}
           </p>

--- a/packages/inspector/src/components/memory/list-page.tsx
+++ b/packages/inspector/src/components/memory/list-page.tsx
@@ -293,7 +293,12 @@ export function ListPage() {
     refreshBrowse()
   }, [refreshRequested, browsePhase, refreshBrowse])
 
-  const stats = usePolling(statsFn, 2000, live)
+  // Suspended for the run on the same flag as the browse above, so the two cadences stay
+  // in step: the counts and the rows are two readings of one store, and a stats tick
+  // landing between two per-id writes would quote a half-applied batch beside a grid that
+  // is deliberately holding still. `usePolling` runs one immediate tick whenever `enabled`
+  // changes, so this costs one extra stats read at each edge of the run and none inside it.
+  const stats = usePolling(statsFn, 2000, live && !bulkRunning)
 
   // Search is fetched once per (debounced) query change, never polled — a
   // hybrid store would call the embedder on every search request.

--- a/packages/inspector/src/components/memory/list-page.tsx
+++ b/packages/inspector/src/components/memory/list-page.tsx
@@ -9,7 +9,7 @@ import { Input } from "../ui/input"
 import { usePolling } from "../use-polling"
 import { BrowseErrorBanners, type BrowseErrorEntry, BrowseStatusBar } from "./browse-chrome"
 import { loadMoreState } from "./browse-window"
-import { BulkBar } from "./bulk-bar"
+import { BulkBar, type BulkOutcome } from "./bulk-bar"
 import { DetailSheet } from "./detail-sheet"
 import { FacetRail } from "./facet-rail"
 import { LoadMoreFooter } from "./load-more-footer"
@@ -257,9 +257,13 @@ export function ListPage() {
   }, [filters, sort, namespace, view, timelineSince])
 
   // Search replaces the browse view entirely, so browse stops polling behind it. A bulk
-  // run suspends it too: the writes go one at a time, and a tick landing between two of
-  // them would swap the rows the run is still working through — and with them the
-  // `records` the bar reads to decide which ids are candidates.
+  // run suspends it too, for a narrower reason than "the rows must hold still": the bar
+  // below is unmounted at `ticked.length === 0`, and the per-id failure list lives in
+  // ITS state. A tick landing between two of the run's writes can drop every ticked row
+  // from the answer — forgetting the whole loaded page does exactly that — which empties
+  // `ticked` through `onTickedChange` and destroys the only channel that would have said
+  // what failed. This does NOT make the run atomic: a request already in flight when the
+  // run starts still lands. It bounds the window to one that is already open.
   const browse = useMemoryBrowse({ query: browseQuery, live: live && !query && !bulkRunning })
   const { refresh: refreshBrowse, retry: retryBrowse } = browse
   const browsePhase = browse.dataState.phase
@@ -344,7 +348,7 @@ export function ListPage() {
   }, [])
   const handleBulkStart = useCallback(() => setBulkRunning(true), [])
   const handleBulkDone = useCallback(
-    ({ failed }: { succeeded: string[]; failed: string[] }) => {
+    ({ failed }: BulkOutcome) => {
       // Succeeded ids leave the selection; failures stay, with their per-id errors, so
       // the obvious next action retries exactly what did not happen.
       // The DRAWN columns, read at completion: grouping and the checkbox column both
@@ -356,11 +360,20 @@ export function ListPage() {
           grid.getColumns().map((column) => column.id),
         ),
       )
+      // Both writers, on purpose. The line above already reaches `ticked` the long way
+      // round — the engine emits its new row selection and `onTickedChange` mirrors it
+      // back — so this one is normally redundant, and no test can tell it apart. It is
+      // here so the prune does not RIDE on that emit: this is the one write that says
+      // what the RUN concluded rather than what the grid happens to be drawing.
       setTicked(failed)
       setBulkRunning(false)
-      // One refresh on completion reconciles the grid: deleted rows leave, approved
-      // rows change status in place. The datasetKey is unchanged, so the surviving
-      // selection is preserved deliberately.
+      // Reconcile the grid: deleted rows leave, approved rows change status in place.
+      // The datasetKey is unchanged, so the surviving selection is preserved
+      // deliberately. This exists for the LIVE-OFF case, which `setBulkRunning(false)`
+      // cannot cover: clearing that flag only resumes polling when `live` is also on,
+      // and with it off nothing else would ever fetch the post-write answer. With live
+      // on the resume tick beats this call and single flight drops it — the refresh
+      // still happens, just not because of this line.
       requestRefresh()
     },
     [requestRefresh],

--- a/packages/inspector/src/components/memory/list-page.tsx
+++ b/packages/inspector/src/components/memory/list-page.tsx
@@ -14,7 +14,7 @@ import { DetailSheet } from "./detail-sheet"
 import { FacetRail } from "./facet-rail"
 import { LoadMoreFooter } from "./load-more-footer"
 import { STATUSES } from "./memory-domain"
-import { type GridRow, MemoryGrid } from "./memory-grid"
+import { buildRowSelection, type GridRow, MemoryGrid } from "./memory-grid"
 import { TEST_IDS } from "./test-ids"
 import { TimelineView } from "./timeline-view"
 import {
@@ -110,6 +110,8 @@ export function ListPage() {
   const [live, setLive] = useState(true)
   const [selectedId, setSelectedId] = useState<string>()
   const [ticked, setTicked] = useState<readonly string[]>([])
+  /** A bulk run is between its first and last per-id POST. */
+  const [bulkRunning, setBulkRunning] = useState(false)
   const [errors, setErrors] = useState<Partial<Record<ErrorSource, string>>>({})
   const [search, setSearch] = useState<SearchResponse>()
 
@@ -254,8 +256,11 @@ export function ListPage() {
     })
   }, [filters, sort, namespace, view, timelineSince])
 
-  // Search replaces the browse view entirely, so browse stops polling behind it.
-  const browse = useMemoryBrowse({ query: browseQuery, live: live && !query })
+  // Search replaces the browse view entirely, so browse stops polling behind it. A bulk
+  // run suspends it too: the writes go one at a time, and a tick landing between two of
+  // them would swap the rows the run is still working through — and with them the
+  // `records` the bar reads to decide which ids are candidates.
+  const browse = useMemoryBrowse({ query: browseQuery, live: live && !query && !bulkRunning })
   const { refresh: refreshBrowse, retry: retryBrowse } = browse
   const browsePhase = browse.dataState.phase
   // The hook's own `total`, not a second derivation out of `resultMeta` — both gate
@@ -337,14 +342,28 @@ export function ListPage() {
     gridRef.current?.setSelection({ ranges: [], anchor: null })
     setTicked([])
   }, [])
+  const handleBulkStart = useCallback(() => setBulkRunning(true), [])
   const handleBulkDone = useCallback(
-    ({ failed }: { failed: number }) => {
-      // Keep the selection when anything failed: clearing it unmounts the bar, and the
-      // bar is the only channel carrying WHICH ids failed and why.
-      if (failed === 0) clearTicked()
+    ({ failed }: { succeeded: string[]; failed: string[] }) => {
+      // Succeeded ids leave the selection; failures stay, with their per-id errors, so
+      // the obvious next action retries exactly what did not happen.
+      // The DRAWN columns, read at completion: grouping and the checkbox column both
+      // change what a whole-row range has to span.
+      const grid = gridRef.current
+      grid?.setSelection(
+        buildRowSelection(
+          failed,
+          grid.getColumns().map((column) => column.id),
+        ),
+      )
+      setTicked(failed)
+      setBulkRunning(false)
+      // One refresh on completion reconciles the grid: deleted rows leave, approved
+      // rows change status in place. The datasetKey is unchanged, so the surviving
+      // selection is preserved deliberately.
       requestRefresh()
     },
-    [clearTicked, requestRefresh],
+    [requestRefresh],
   )
 
   const byStatus = stats?.byStatus ?? {}
@@ -693,6 +712,7 @@ export function ListPage() {
           ticked={ticked}
           records={browse.rows}
           onDone={handleBulkDone}
+          onStart={handleBulkStart}
           onClear={clearTicked}
         />
       ) : null}

--- a/packages/inspector/src/components/memory/list-page.tsx
+++ b/packages/inspector/src/components/memory/list-page.tsx
@@ -15,6 +15,7 @@ import { FacetRail } from "./facet-rail"
 import { LoadMoreFooter } from "./load-more-footer"
 import { STATUSES } from "./memory-domain"
 import { type GridRow, MemoryGrid } from "./memory-grid"
+import { TEST_IDS } from "./test-ids"
 import { TimelineView } from "./timeline-view"
 import {
   capSortEntries,
@@ -519,7 +520,12 @@ export function ListPage() {
             className="w-64"
           />
           <label className="flex items-center gap-1.5 text-sm text-zinc-600">
-            <input type="checkbox" checked={live} onChange={(e) => setLive(e.target.checked)} />
+            <input
+              type="checkbox"
+              data-testid={TEST_IDS.liveToggle}
+              checked={live}
+              onChange={(e) => setLive(e.target.checked)}
+            />
             live
           </label>
         </div>
@@ -556,7 +562,7 @@ export function ListPage() {
             id="browse-scope-note"
             hidden={!searching}
             className="mb-2 text-xs text-zinc-500"
-            data-testid="browse-scope-note"
+            data-testid={TEST_IDS.searchScopeNote}
           >
             Search ranks active memories, and the namespace facet applies to it. Column filters, the
             view toggle
@@ -613,7 +619,11 @@ export function ListPage() {
               construction. Invisible and outside the a11y tree, but NOT outside a
               document-wide text query: anything asserting on row text has to scope
               itself to the surface it means, or the hidden copy will answer. */}
-          <div data-testid="browse-region" hidden={browseSurfaceHidden} ref={browseRegionRef}>
+          <div
+            data-testid={TEST_IDS.browseRegion}
+            hidden={browseSurfaceHidden}
+            ref={browseRegionRef}
+          >
             {sortCapped ? (
               <p role="status" className="mb-2 text-xs text-zinc-500" data-testid="sort-cap-notice">
                 {`Sorting is limited to ${MAX_BROWSE_SORT_ENTRIES} columns. The extra column was not added.`}

--- a/packages/inspector/src/components/memory/list-page.tsx
+++ b/packages/inspector/src/components/memory/list-page.tsx
@@ -38,6 +38,11 @@ interface SearchResponse {
  *  that lists which ids failed and why. */
 type ErrorSource = "stats" | "search"
 
+/** The counts' cadence. Exported because the suspension around a bulk run is timed
+ *  against it: a test that bounds a run's window has to outlast this to mean anything,
+ *  and a poll that merely had no time to tick reads exactly like a suspended one. */
+export const STATS_POLL_INTERVAL_MS = 2000
+
 /** Timeline window presets → milliseconds back from now ("all" = unbounded). */
 const WINDOWS = {
   "24h": 24 * 60 * 60 * 1000,
@@ -293,12 +298,15 @@ export function ListPage() {
     refreshBrowse()
   }, [refreshRequested, browsePhase, refreshBrowse])
 
-  // Suspended for the run on the same flag as the browse above, so the two cadences stay
-  // in step: the counts and the rows are two readings of one store, and a stats tick
-  // landing between two per-id writes would quote a half-applied batch beside a grid that
-  // is deliberately holding still. `usePolling` runs one immediate tick whenever `enabled`
-  // changes, so this costs one extra stats read at each edge of the run and none inside it.
-  const stats = usePolling(statsFn, 2000, live && !bulkRunning)
+  // Suspended for the run on the same flag as the browse above: the counts and the rows
+  // are two readings of one store, and a stats tick landing between two per-id writes
+  // would quote a half-applied batch beside a grid that is deliberately holding still.
+  // The flag is raised from the same event that issues the first write, so this only
+  // holds because `usePolling` suspends SILENTLY — a hook that took a parting tick on the
+  // way down would take it concurrently with that write, which is the reading this is
+  // here to prevent. Resuming ticks at once, so the run costs one stats read at its
+  // trailing edge and none inside it.
+  const stats = usePolling(statsFn, STATS_POLL_INTERVAL_MS, live && !bulkRunning)
 
   // Search is fetched once per (debounced) query change, never polled — a
   // hybrid store would call the embedder on every search request.

--- a/packages/inspector/src/components/memory/load-more-footer.tsx
+++ b/packages/inspector/src/components/memory/load-more-footer.tsx
@@ -3,6 +3,7 @@ import { useId } from "react"
 import { BROWSE_RESIDENT_CAP } from "../../browse/browse-machine"
 import { Button } from "../ui/button"
 import type { LoadMoreState } from "./browse-window"
+import { TEST_IDS } from "./test-ids"
 
 const NUMBER = new Intl.NumberFormat()
 
@@ -94,6 +95,10 @@ export function LoadMoreFooter({
       <Button
         type="button"
         variant="outline"
+        // On the control, not on the wrapper: the wrapper is also on screen in the
+        // states where the button is inactive, and a reader that clicked the wrapper
+        // would see nothing happen for a reason the DOM never stated.
+        data-testid={TEST_IDS.loadMore}
         // `Button`'s base class dims and blocks pointer events on `disabled:` only.
         // This control is deliberately never natively `disabled`, so without an
         // `aria-disabled`-keyed rule every inactive state renders identically to the

--- a/packages/inspector/src/components/memory/memory-grid.tsx
+++ b/packages/inspector/src/components/memory/memory-grid.tsx
@@ -11,6 +11,7 @@ import {
   PretableSurface,
   type PretableSurfaceMessages,
   type PretableSurfaceProps,
+  type PretableSurfaceState,
   type PretableTelemetry,
 } from "@pretable/react"
 import { getDensityHeights } from "@pretable/ui"
@@ -232,6 +233,39 @@ function toRow(record: MemoryRecord): GridRow {
     kind: record.kind,
     confidence: record.confidence,
     updatedAt: record.updatedAt,
+  }
+}
+
+/**
+ * Row ids → the engine's cell-range selection. Used to PRUNE a selection after a bulk
+ * run. Applied imperatively through `grid.setSelection` rather than through controlled
+ * `state.selection` on purpose: `usePretable` latches a controlled selection across a
+ * `datasetKey` pivot, and the prune has to land whether or not the dataset moved.
+ *
+ * A TICKED row is a range spanning the first and last DRAWN columns — `getColumns()`,
+ * which is what `toggleRowSelection` and the header checkbox both span, and the only
+ * span the surface counts as a whole row. Hard-coding the first and last columns of
+ * `COLUMNS` instead produces an INDETERMINATE row: the drawn set is not that list.
+ * The checkbox column is prepended to it, the derived group column joins it whenever
+ * the page groups by namespace, and `hideGroupedColumns` takes `namespace` back out
+ * again — so a short span leaves the box `mixed`, the row absent from
+ * `onRowSelectionChange`, and the bulk bar gone with it.
+ */
+export function buildRowSelection(
+  rowIds: readonly string[],
+  drawnColumnIds: readonly string[],
+): NonNullable<PretableSurfaceState["selection"]> {
+  const first = drawnColumnIds[0]
+  const last = drawnColumnIds[drawnColumnIds.length - 1]
+  if (first === undefined || last === undefined) return { ranges: [], anchor: null }
+  return {
+    ranges: rowIds.map((rowId) => ({
+      startRowId: rowId,
+      endRowId: rowId,
+      startColumnId: first,
+      endColumnId: last,
+    })),
+    anchor: rowIds.length > 0 ? { rowId: rowIds[0] as string, columnId: first } : null,
   }
 }
 

--- a/packages/inspector/src/components/memory/memory-grid.tsx
+++ b/packages/inspector/src/components/memory/memory-grid.tsx
@@ -250,6 +250,12 @@ function toRow(record: MemoryRecord): GridRow {
  * the page groups by namespace, and `hideGroupedColumns` takes `namespace` back out
  * again — so a short span leaves the box `mixed`, the row absent from
  * `onRowSelectionChange`, and the bulk bar gone with it.
+ *
+ * Which makes `first` the whole of the correctness here, and `last` inert: the surface
+ * widens a range to every data column as soon as EITHER end is the checkbox column, and
+ * the checkbox column always leads `getColumns()`. A wrong `last` therefore cannot be
+ * caught by any test. Read it from the same list anyway — the day the checkbox column
+ * stops leading, `last` is what has to be right.
  */
 export function buildRowSelection(
   rowIds: readonly string[],

--- a/packages/inspector/src/components/memory/memory-grid.tsx
+++ b/packages/inspector/src/components/memory/memory-grid.tsx
@@ -18,6 +18,7 @@ import { useCallback, useMemo, useState } from "react"
 import { Badge } from "../ui/badge"
 import { Button } from "../ui/button"
 import { KINDS, STATUSES } from "./memory-domain"
+import { TEST_IDS } from "./test-ids"
 
 /** Row projection handed to pretable — a plain bag so it satisfies `PretableRow`
  *  (MemoryRecord is an interface, so it has no implicit index signature). Each
@@ -348,8 +349,15 @@ export function MemoryGrid({
       )
     }
     const message = errorMessage ?? "Could not load memories."
+    // One node, reused by both blocks below — they are mutually exclusive kinds, so
+    // the id is never ambiguous in a rendered tree.
     const retry = onRetry ? (
-      <Button variant="outline" className="h-7 px-2" onClick={onRetry}>
+      <Button
+        variant="outline"
+        className="h-7 px-2"
+        data-testid={TEST_IDS.retryInitial}
+        onClick={onRetry}
+      >
         Retry
       </Button>
     ) : null

--- a/packages/inspector/src/components/memory/test-ids.ts
+++ b/packages/inspector/src/components/memory/test-ids.ts
@@ -1,12 +1,29 @@
 /**
  * The DOM hooks the verification lane depends on. One module so a rename is one edit
- * and a missing hook is one red test rather than fourteen mysterious spec failures.
+ * in `src` and a missing hook is one red test rather than fourteen mysterious spec
+ * failures.
+ *
+ * Every entry has an owner that renders it. A key with no owner is worse than no key
+ * at all: the lane believes it, and the failure arrives as a locator timeout in a
+ * scenario written days later. `test-id-contract.test.tsx` holds each entry to that —
+ * either it is asserted against a rendered `ListPage`, or the condition that renders
+ * it is named there — and its coverage map is keyed on this object, so a key added
+ * here without a decision fails typecheck.
  *
  * Pretable's own hooks (`data-pretable-data-phase`, `data-pretable-row-id`,
  * `data-pretable-live-region`, `data-pretable-body-state`,
  * `data-pretable-scroll-viewport`, `data-pretable-hydrated`) are NOT listed here:
  * they are public API of @pretable/react and are pinned by that package's tests.
  */
+
+/** The banner line for one failing source. `BrowseErrorBanners` keys its lines by
+ *  source and the set of sources is open — `stats`, `search`, `browse` and the two
+ *  browse REQUEST kinds today — so the DERIVATION lives here rather than a constant
+ *  per source, and the two the lane targets are spelled out below through it. */
+export function errorBannerId<S extends string>(source: S): `error-${S}` {
+  return `error-${source}`
+}
+
 export const TEST_IDS = {
   /** The browse subtree. Load-bearing as a SCOPE, not just a hook: the subtree stays
    *  mounted-and-`hidden` across view switches and a search renders more grids beside
@@ -23,15 +40,18 @@ export const TEST_IDS = {
   loadMore: "load-more",
   /** Retry inside the error body block, supplied through `renderBodyState`. */
   retryInitial: "browse-retry-initial",
-  /** Per-kind banner slots — one kind's success can never clear another's failure. */
-  bannerRefresh: "browse-banner-refresh",
-  bannerLoadMore: "browse-banner-load-more",
-  bannerMutation: "browse-banner-mutation",
-  retryRefresh: "browse-retry-refresh",
-  retryLoadMore: "browse-retry-load-more",
+  /** Per-kind banner slots for the two browse REQUEST kinds — one kind's success can
+   *  never clear another's failure. A MUTATION's failures are not banners: they stay
+   *  in the bulk bar beside the ids that failed (`bulkError`). */
+  bannerRefresh: errorBannerId("refresh"),
+  bannerLoadMore: errorBannerId("load-more"),
+  /** ONE retry for the banners, not one per kind. `retry()` is a single intent and the
+   *  reducer chooses which kind to re-attempt (a load-more failure before a refresh
+   *  one), so per-kind controls would be two buttons dispatching the same action. */
+  bannerRetry: "browse-banner-retry",
   /** The live/paused polling toggle. */
   liveToggle: "live-toggle",
-  /** Bulk chrome (pre-existing ids, restated here so the lane has one import). */
+  /** The bulk bar, and the per-id failures it holds on screen. */
   bulkBar: "bulk-bar",
   bulkError: "bulk-error",
   /** Search-view controls that are disabled-with-reason (design §8.2). */

--- a/packages/inspector/src/components/memory/test-ids.ts
+++ b/packages/inspector/src/components/memory/test-ids.ts
@@ -1,0 +1,39 @@
+/**
+ * The DOM hooks the verification lane depends on. One module so a rename is one edit
+ * and a missing hook is one red test rather than fourteen mysterious spec failures.
+ *
+ * Pretable's own hooks (`data-pretable-data-phase`, `data-pretable-row-id`,
+ * `data-pretable-live-region`, `data-pretable-body-state`,
+ * `data-pretable-scroll-viewport`, `data-pretable-hydrated`) are NOT listed here:
+ * they are public API of @pretable/react and are pinned by that package's tests.
+ */
+export const TEST_IDS = {
+  /** The browse subtree. Load-bearing as a SCOPE, not just a hook: the subtree stays
+   *  mounted-and-`hidden` across view switches and a search renders more grids beside
+   *  it, all carrying `aria-label="Memories"` — so an unscoped grid locator resolves to
+   *  more than one element whenever a search is active. */
+  browseRegion: "browse-region",
+  /** Wraps the count/total/as-of chrome that sits above the grid. */
+  status: "browse-status",
+  /** The exact matching total, rendered as text. */
+  total: "browse-total",
+  /** "updated 14:32:07" — shown only while polling is paused or suspended. */
+  asOf: "browse-as-of",
+  /** The footer control, OUTSIDE the grid viewport (design §9.2). */
+  loadMore: "load-more",
+  /** Retry inside the error body block, supplied through `renderBodyState`. */
+  retryInitial: "browse-retry-initial",
+  /** Per-kind banner slots — one kind's success can never clear another's failure. */
+  bannerRefresh: "browse-banner-refresh",
+  bannerLoadMore: "browse-banner-load-more",
+  bannerMutation: "browse-banner-mutation",
+  retryRefresh: "browse-retry-refresh",
+  retryLoadMore: "browse-retry-load-more",
+  /** The live/paused polling toggle. */
+  liveToggle: "live-toggle",
+  /** Bulk chrome (pre-existing ids, restated here so the lane has one import). */
+  bulkBar: "bulk-bar",
+  bulkError: "bulk-error",
+  /** Search-view controls that are disabled-with-reason (design §8.2). */
+  searchScopeNote: "search-scope-note",
+} as const

--- a/packages/inspector/src/components/use-polling.ts
+++ b/packages/inspector/src/components/use-polling.ts
@@ -1,10 +1,17 @@
 "use client"
-import { useEffect, useState } from "react"
+import { useEffect, useRef, useState } from "react"
 
 /**
- * Poll `fn` every `intervalMs` while `enabled` and the tab is visible. Always
- * runs one immediate tick on mount and whenever `fn` changes, even when
- * polling is disabled — so filter changes refetch with live mode off.
+ * Poll `fn` every `intervalMs` while `enabled` and the tab is visible. Runs one
+ * immediate tick on mount, whenever `fn` changes, and on resume — including
+ * while polling is disabled, so filter changes refetch with live mode off.
+ *
+ * The one re-run that does NOT tick is the suspension itself, `enabled` going
+ * true → false. A caller disables polling to hold a reading STILL, and a final
+ * read taken on the way down is taken at the worst instant there is: the caller
+ * flips the flag from the same event that starts the writes it wants hidden, so
+ * that read lands beside a half-applied change. Suspending silently is what
+ * makes the suspension mean what its callers read it to mean.
  *
  * The effect deliberately depends on `fn` identity: callers pass useCallback'd
  * fetchers whose identity changes when filters change, so a filter change
@@ -24,7 +31,14 @@ export function usePolling<T>(
   enabled: boolean,
 ): T | undefined {
   const [value, setValue] = useState<T>()
+  /** Whether the previous run of the effect below was polling, to tell a suspension
+   *  apart from every other reason the effect re-runs. Seeded with `enabled` so a
+   *  StrictMode remount — which re-runs the effect against hook state it did not
+   *  reset — reads as "unchanged" and still takes its mount tick. */
+  const wasEnabled = useRef(enabled)
   useEffect(() => {
+    const suspending = wasEnabled.current && !enabled
+    wasEnabled.current = enabled
     let alive = true
     const tick = async () => {
       if (document.visibilityState === "hidden") return
@@ -36,7 +50,10 @@ export function usePolling<T>(
         // must not kill the polling loop.
       }
     }
-    void tick()
+    // An `fn` change that arrives ON the suspension is swallowed with it. No caller can
+    // reach that today — the only `fn` here is stable for the component's life — and a
+    // suspension is the one moment where not fetching is the whole point.
+    if (!suspending) void tick()
     if (!enabled) {
       return () => {
         alive = false

--- a/packages/inspector/test/components/bulk-safety.test.tsx
+++ b/packages/inspector/test/components/bulk-safety.test.tsx
@@ -199,3 +199,104 @@ describe("bulk partial failure", () => {
     await waitFor(() => expect(listed).toBeGreaterThan(listedWhilePaused))
   })
 })
+
+describe("bulk run isolation", () => {
+  /**
+   * The suspension above is read through the status bar; this reads it through the WIRE.
+   * The stub serves its own `order` log rather than the shared one because the property
+   * is an ORDERING — where the browse requests sit relative to the run's writes — and
+   * the shared stub counts them without recording when they happened.
+   */
+  it("issues no browse request between the first and last per-id write", async () => {
+    const order: string[] = []
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input)
+        if (init?.method === "POST") {
+          order.push(`POST ${url}`)
+          // Long enough that a 2 s poll tick would certainly land inside the run if
+          // polling were still armed.
+          await new Promise((resolve) => setTimeout(resolve, 900))
+          return Response.json({ ok: true })
+        }
+        if (url.includes("/api/memory/list")) {
+          order.push("LIST")
+          return Response.json({ records: RECORDS, total: RECORDS.length, continuation: null })
+        }
+        if (url.includes("/api/memory/stats"))
+          return Response.json({
+            total: RECORDS.length,
+            byStatus: {},
+            byKind: {},
+            byNamespace: {},
+            bySourceType: {},
+          })
+        return Response.json({})
+      }),
+    )
+
+    render(<ListPage />)
+    // The shared helper, not a wait on `order`: "LIST" is logged when the request is
+    // ISSUED, and select-all spans the rows the engine can see — ticking on the request
+    // rather than on the answer would tick nothing and raise no bar.
+    await tickEveryLoadedRow()
+    await screen.findByTestId(TEST_IDS.bulkBar)
+    fireEvent.click(screen.getByRole("button", { name: /^Forget/ }))
+
+    await waitFor(
+      () => expect(order.filter((entry) => entry.startsWith("POST"))).toHaveLength(RECORDS.length),
+      { timeout: 20_000 },
+    )
+    const firstPost = order.findIndex((entry) => entry.startsWith("POST"))
+    const lastPost = order.length - 1 - [...order].reverse().findIndex((e) => e.startsWith("POST"))
+    expect(order.slice(firstPost, lastPost)).not.toContain("LIST")
+  }, 30_000)
+
+  /**
+   * Driven through `BulkBar` directly: the property is that the run holds the ids the
+   * CONFIRMATION named, and only a caller that can swap `ticked` mid-flight can tell that
+   * apart from re-reading the prop. `ListPage` cannot be made to do that on demand.
+   */
+  it("runs against the ids confirmed, not the ids currently ticked", async () => {
+    const { BulkBar } = await import("../../src/components/memory/bulk-bar")
+    const posted: string[] = []
+    let release: (() => void) | undefined
+    const gate = new Promise<void>((resolve) => {
+      release = resolve
+    })
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL) => {
+        posted.push(String(input))
+        if (posted.length === 1) await gate
+        return Response.json({ ok: true })
+      }),
+    )
+    const ids = RECORDS.map((record) => record.id)
+    const { rerender } = render(
+      <BulkBar
+        ticked={ids}
+        records={RECORDS}
+        onDone={() => {}}
+        onStart={() => {}}
+        onClear={() => {}}
+      />,
+    )
+    fireEvent.click(screen.getByRole("button", { name: /^Forget/ }))
+    // The grid changes underneath, mid-run: only one row is ticked now.
+    rerender(
+      <BulkBar
+        ticked={[ids[0] as string]}
+        records={RECORDS}
+        onDone={() => {}}
+        onStart={() => {}}
+        onClear={() => {}}
+      />,
+    )
+    release?.()
+    // The run still targets the CONFIRMED four.
+    await waitFor(() => expect(posted).toHaveLength(ids.length), { timeout: 20_000 })
+    for (const id of ids) expect(posted.some((url) => url.includes(id))).toBe(true)
+  }, 30_000)
+})

--- a/packages/inspector/test/components/bulk-safety.test.tsx
+++ b/packages/inspector/test/components/bulk-safety.test.tsx
@@ -1,0 +1,110 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { ListPage } from "../../src/components/memory/list-page"
+import { TEST_IDS } from "../../src/components/memory/test-ids"
+import { browseSeedRecords } from "../seed"
+
+const RECORDS = browseSeedRecords().slice(0, 4)
+const FAILING_ID = RECORDS[1]?.id as string
+
+let posted: string[] = []
+
+function stubFetch(): void {
+  posted = []
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+      if (init?.method === "POST") {
+        posted.push(url)
+        if (url.includes(FAILING_ID))
+          return Response.json({ error: "not a candidate" }, { status: 409 })
+        return Response.json({ ok: true })
+      }
+      if (url.includes("/api/memory/stats"))
+        return Response.json({
+          total: RECORDS.length,
+          byStatus: {},
+          byKind: {},
+          byNamespace: {},
+          bySourceType: {},
+        })
+      if (url.includes("/api/memory/list"))
+        return Response.json({ records: RECORDS, total: RECORDS.length, continuation: null })
+      return Response.json({})
+    }),
+  )
+}
+
+/**
+ * Tick every loaded row through the header checkbox.
+ *
+ * The wait is load-bearing twice over. The header checkbox is in the document from the
+ * first paint, and select-all spans the rows the engine can SEE — clicked before the
+ * first page lands it ticks nothing and no bar ever appears. And these assertions read
+ * the document, not a render result, so a leftover tree from the previous test would
+ * answer them: `cleanup()` below is what keeps each `render` alone in the document.
+ */
+async function tickEveryLoadedRow(): Promise<void> {
+  await waitFor(() =>
+    expect(document.querySelector(`[data-pretable-row-id="${FAILING_ID}"]`)).not.toBeNull(),
+  )
+  const header = document.querySelector("[data-pretable-row-select-all]")
+  expect(header).not.toBeNull()
+  fireEvent.click(header as Element)
+}
+
+beforeEach(() => {
+  stubFetch()
+  vi.spyOn(window, "confirm").mockReturnValue(true)
+})
+
+afterEach(() => {
+  cleanup()
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+})
+
+describe("bulk partial failure", () => {
+  it("keeps ONLY the failures selected, so a retry cannot repeat a completed delete", async () => {
+    render(<ListPage />)
+    await tickEveryLoadedRow()
+
+    const bar = await screen.findByTestId(TEST_IDS.bulkBar)
+    expect(bar.textContent).toContain(String(RECORDS.length))
+
+    fireEvent.click(screen.getByRole("button", { name: /^Forget/ }))
+    await waitFor(() => expect(posted).toHaveLength(RECORDS.length))
+
+    // The three that succeeded are gone from the selection; the one 409 remains.
+    await waitFor(() =>
+      expect(screen.getByTestId(TEST_IDS.bulkBar).textContent).toContain("1 selected"),
+    )
+    expect(screen.getByTestId(TEST_IDS.bulkError).textContent).toContain(FAILING_ID)
+    // The engine agrees with the bar: the surviving tick is a whole row, not the
+    // indeterminate box a short cell range leaves behind.
+    expect(
+      document
+        .querySelector(`[data-pretable-row-id="${FAILING_ID}"] [data-pretable-row-select]`)
+        ?.getAttribute("aria-checked"),
+    ).toBe("true")
+
+    // Retry: exactly one further POST, and it is the failure.
+    posted = []
+    fireEvent.click(screen.getByRole("button", { name: /^Forget/ }))
+    await waitFor(() => expect(posted).toHaveLength(1))
+    expect(posted[0]).toContain(FAILING_ID)
+  })
+
+  it("names the count and the scope in the confirmation", async () => {
+    render(<ListPage />)
+    await tickEveryLoadedRow()
+    await screen.findByTestId(TEST_IDS.bulkBar)
+    fireEvent.click(screen.getByRole("button", { name: /^Forget/ }))
+    const confirmMock = vi.mocked(window.confirm)
+    expect(confirmMock).toHaveBeenCalledTimes(1)
+    const message = String(confirmMock.mock.calls[0]?.[0] ?? "")
+    expect(message).toContain(String(RECORDS.length))
+    expect(message).toMatch(/selected|loaded/i)
+  })
+})

--- a/packages/inspector/test/components/bulk-safety.test.tsx
+++ b/packages/inspector/test/components/bulk-safety.test.tsx
@@ -18,7 +18,9 @@ const WRITE_LATENCY_MS = 900
 const RUN_WINDOW_MS = (RECORDS.length - 1) * WRITE_LATENCY_MS
 
 let posted: string[] = []
-/** Browse responses served, to wait for the reconciling refresh rather than guess at it. */
+/** Browse answers the caller has READ, counted as the body is parsed rather than as the
+ *  request goes out. The waits below stand in for "a reconciling answer has landed", and
+ *  a request-time count opens that gate a whole round trip early — on the asking. */
 let listed = 0
 /** Set to hold every POST mid-flight, so a run can be observed while it is running. */
 let postGate: Promise<void> | undefined
@@ -54,8 +56,22 @@ function stubFetch(): void {
           bySourceType: {},
         })
       if (url.includes("/api/memory/list")) {
-        listed += 1
-        return Response.json({ records: RECORDS, total: RECORDS.length, continuation: null })
+        // The count moves as the caller PARSES the body, not as the request arrives here:
+        // the browse fetcher awaits `response.json()` before it has any records to hand
+        // back, so a count taken at the top of this branch would say "landed" while the
+        // grid still held the pre-run answer.
+        const answer = Response.json({
+          records: RECORDS,
+          total: RECORDS.length,
+          continuation: null,
+        })
+        const readBody = answer.json.bind(answer)
+        answer.json = async (): Promise<unknown> => {
+          const body: unknown = await readBody()
+          listed += 1
+          return body
+        }
+        return answer
       }
       return Response.json({})
     }),
@@ -123,9 +139,17 @@ describe("bulk partial failure", () => {
         ?.getAttribute("aria-checked"),
     ).toBe("false")
 
-    // And it HOLDS through the reconciling refresh. `onTickedChange` mirrors the grid's
-    // selection back into the bar's count, so an unpruned engine would re-arm the bar at
-    // four the moment the next answer landed — after the assertions above had passed.
+    // And it HOLDS through the reconciling refresh — the point at which the two sides
+    // could come apart with nothing on screen saying so. The refresh does NOT re-arm the
+    // bar: `onTickedChange` hears from the engine only when the engine's selection
+    // CHANGES, and an answer at an unchanged `datasetKey` re-emits nothing, so an
+    // unpruned engine never hands its four ids back. The bar reads "1 selected"
+    // permanently while the grid paints three already-forgotten rows as ticked. That
+    // silent DIVERGENCE is the hazard, the count below passes under it either way, and
+    // the checkbox is the only side that reports it — which is why it is re-read here,
+    // once the answer that repaints the rows has landed. It is not cosmetic: those
+    // checkboxes are what a user reads before deciding what to retry, and under an
+    // unpruned engine they show three rows this run already forgot.
     await waitFor(() => expect(listed).toBeGreaterThan(listedBeforeRun))
     expect(screen.getByTestId(TEST_IDS.bulkBar).textContent).toContain("1 selected")
     expect(

--- a/packages/inspector/test/components/bulk-safety.test.tsx
+++ b/packages/inspector/test/components/bulk-safety.test.tsx
@@ -6,17 +6,33 @@ import { browseSeedRecords } from "../seed"
 
 const RECORDS = browseSeedRecords().slice(0, 4)
 const FAILING_ID = RECORDS[1]?.id as string
+/** A row the forget SUCCEEDS on — the only kind that can tell a prune from a no-op. */
+const SUCCEEDED_ID = RECORDS[0]?.id as string
 
 let posted: string[] = []
+/** Browse responses served, to wait for the reconciling refresh rather than guess at it. */
+let listed = 0
+/** Set to hold every POST mid-flight, so a run can be observed while it is running. */
+let postGate: Promise<void> | undefined
 
+/**
+ * The list route answers with all four records for the whole test, INCLUDING the three
+ * the forget succeeds on. A faithful store would drop them, and dropping them would take
+ * the evidence with it: a row absent from the grid paints no checkbox, so a selection
+ * the code failed to prune would be invisible rather than wrong. Keeping the rows is
+ * what makes `aria-checked` on a succeeded row a real reading of the engine's state.
+ */
 function stubFetch(): void {
   posted = []
+  listed = 0
+  postGate = undefined
   vi.stubGlobal(
     "fetch",
     vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input)
       if (init?.method === "POST") {
         posted.push(url)
+        if (postGate !== undefined) await postGate
         if (url.includes(FAILING_ID))
           return Response.json({ error: "not a candidate" }, { status: 409 })
         return Response.json({ ok: true })
@@ -29,8 +45,10 @@ function stubFetch(): void {
           byNamespace: {},
           bySourceType: {},
         })
-      if (url.includes("/api/memory/list"))
+      if (url.includes("/api/memory/list")) {
+        listed += 1
         return Response.json({ records: RECORDS, total: RECORDS.length, continuation: null })
+      }
       return Response.json({})
     }),
   )
@@ -73,6 +91,7 @@ describe("bulk partial failure", () => {
     const bar = await screen.findByTestId(TEST_IDS.bulkBar)
     expect(bar.textContent).toContain(String(RECORDS.length))
 
+    const listedBeforeRun = listed
     fireEvent.click(screen.getByRole("button", { name: /^Forget/ }))
     await waitFor(() => expect(posted).toHaveLength(RECORDS.length))
 
@@ -81,13 +100,31 @@ describe("bulk partial failure", () => {
       expect(screen.getByTestId(TEST_IDS.bulkBar).textContent).toContain("1 selected"),
     )
     expect(screen.getByTestId(TEST_IDS.bulkError).textContent).toContain(FAILING_ID)
-    // The engine agrees with the bar: the surviving tick is a whole row, not the
-    // indeterminate box a short cell range leaves behind.
+    // The engine agrees with the bar, read on BOTH sides. The failure's box is a whole
+    // row, not the indeterminate box a short cell range leaves behind — and a succeeded
+    // row is unticked, which is the reading that distinguishes a prune from a no-op:
+    // select-all had already ticked the failure, so its box alone proves nothing.
     expect(
       document
         .querySelector(`[data-pretable-row-id="${FAILING_ID}"] [data-pretable-row-select]`)
         ?.getAttribute("aria-checked"),
     ).toBe("true")
+    expect(
+      document
+        .querySelector(`[data-pretable-row-id="${SUCCEEDED_ID}"] [data-pretable-row-select]`)
+        ?.getAttribute("aria-checked"),
+    ).toBe("false")
+
+    // And it HOLDS through the reconciling refresh. `onTickedChange` mirrors the grid's
+    // selection back into the bar's count, so an unpruned engine would re-arm the bar at
+    // four the moment the next answer landed — after the assertions above had passed.
+    await waitFor(() => expect(listed).toBeGreaterThan(listedBeforeRun))
+    expect(screen.getByTestId(TEST_IDS.bulkBar).textContent).toContain("1 selected")
+    expect(
+      document
+        .querySelector(`[data-pretable-row-id="${SUCCEEDED_ID}"] [data-pretable-row-select]`)
+        ?.getAttribute("aria-checked"),
+    ).toBe("false")
 
     // Retry: exactly one further POST, and it is the failure.
     posted = []
@@ -100,11 +137,65 @@ describe("bulk partial failure", () => {
     render(<ListPage />)
     await tickEveryLoadedRow()
     await screen.findByTestId(TEST_IDS.bulkBar)
-    fireEvent.click(screen.getByRole("button", { name: /^Forget/ }))
+    // DISMISS. This test wants the question, not the answer: confirming would launch
+    // four real POSTs whose completion handler fires a refresh, and those land after
+    // the assertions — against a `fetch` that `afterEach` has already unstubbed.
     const confirmMock = vi.mocked(window.confirm)
+    confirmMock.mockReturnValue(false)
+    fireEvent.click(screen.getByRole("button", { name: /^Forget/ }))
     expect(confirmMock).toHaveBeenCalledTimes(1)
     const message = String(confirmMock.mock.calls[0]?.[0] ?? "")
     expect(message).toContain(String(RECORDS.length))
     expect(message).toMatch(/selected|loaded/i)
+    expect(posted).toHaveLength(0)
+  })
+
+  /**
+   * Read through the status bar because that is where `paused` reaches the DOM: the bar
+   * quotes an "Updated <time>" instant only while polling is suspended, and shows
+   * nothing while it is live. The property under test is that the suspension covers the
+   * whole run — the bar's failure list is component state, and a tick that empties
+   * `ticked` mid-run unmounts the bar and takes that list with it.
+   */
+  it("suspends browse polling from the first POST until the run completes", async () => {
+    let release = (): void => {}
+    postGate = new Promise<void>((resolve) => {
+      release = resolve
+    })
+    render(<ListPage />)
+    await tickEveryLoadedRow()
+    await screen.findByTestId(TEST_IDS.bulkBar)
+    expect(screen.queryByTestId(TEST_IDS.asOf)).toBeNull()
+
+    fireEvent.click(screen.getByRole("button", { name: /^Forget/ }))
+    await screen.findByTestId(TEST_IDS.asOf)
+
+    postGate = undefined
+    release()
+    await waitFor(() => expect(posted).toHaveLength(RECORDS.length))
+    // And it is a suspension, not a stop: polling resumes on completion.
+    await waitFor(() => expect(screen.queryByTestId(TEST_IDS.asOf)).toBeNull())
+  })
+
+  /**
+   * The completion refresh is redundant while polling is live — resuming from the
+   * suspension above already ticks. Turning polling OFF is what makes it the only thing
+   * that would ever fetch the post-write answer, so it is the only setting in which the
+   * call can be observed at all.
+   */
+  it("reconciles the grid after a run with live polling off", async () => {
+    render(<ListPage />)
+    await tickEveryLoadedRow()
+    await screen.findByTestId(TEST_IDS.bulkBar)
+
+    fireEvent.click(screen.getByTestId(TEST_IDS.liveToggle))
+    // Paused, and settled: the stamp appears once `live` is off, and any tick that was
+    // already in flight has landed by then — so `listed` stops moving on its own here.
+    await screen.findByTestId(TEST_IDS.asOf)
+    const listedWhilePaused = listed
+
+    fireEvent.click(screen.getByRole("button", { name: /^Forget/ }))
+    await waitFor(() => expect(posted).toHaveLength(RECORDS.length))
+    await waitFor(() => expect(listed).toBeGreaterThan(listedWhilePaused))
   })
 })

--- a/packages/inspector/test/components/bulk-safety.test.tsx
+++ b/packages/inspector/test/components/bulk-safety.test.tsx
@@ -1,6 +1,8 @@
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
-import { ListPage } from "../../src/components/memory/list-page"
+import { BROWSE_POLL_INTERVAL_MS } from "../../src/browse/use-memory-browse"
+import { BulkBar } from "../../src/components/memory/bulk-bar"
+import { ListPage, STATS_POLL_INTERVAL_MS } from "../../src/components/memory/list-page"
 import { TEST_IDS } from "../../src/components/memory/test-ids"
 import { browseSeedRecords } from "../seed"
 
@@ -8,6 +10,12 @@ const RECORDS = browseSeedRecords().slice(0, 4)
 const FAILING_ID = RECORDS[1]?.id as string
 /** A row the forget SUCCEEDS on — the only kind that can tell a prune from a no-op. */
 const SUCCEEDED_ID = RECORDS[0]?.id as string
+
+/** How long the isolation test below holds each write. The writes are sequential, so a
+ *  run spans this once per id — but the window an ordering can be read across runs from
+ *  the FIRST write being issued to the LAST, which is one gap shorter. */
+const WRITE_LATENCY_MS = 900
+const RUN_WINDOW_MS = (RECORDS.length - 1) * WRITE_LATENCY_MS
 
 let posted: string[] = []
 /** Browse responses served, to wait for the reconciling refresh rather than guess at it. */
@@ -202,12 +210,18 @@ describe("bulk partial failure", () => {
 
 describe("bulk run isolation", () => {
   /**
-   * The suspension above is read through the status bar; this reads it through the WIRE.
-   * The stub serves its own `order` log rather than the shared one because the property
-   * is an ORDERING — where the browse requests sit relative to the run's writes — and
-   * the shared stub counts them without recording when they happened.
+   * The suspension above is read through the status bar; this reads it through the WIRE,
+   * for BOTH polls — the rows and the counts are two readings of one store, and a run
+   * that stills only the rows still paints a half-applied number beside them. The stub
+   * serves its own `order` log rather than the shared one because the property is an
+   * ORDERING — where the reads sit relative to the run's writes — and the shared stub
+   * counts them without recording when they happened.
    */
-  it("issues no browse request between the first and last per-id write", async () => {
+  it("issues no browse or stats request between the first and last per-id write", async () => {
+    // The window has to outlast the slower poll or neither assertion below proves
+    // anything: a poll still armed but with no time to tick reads exactly like a
+    // suspended one, and the test would pass on a reverted suspension.
+    expect(RUN_WINDOW_MS).toBeGreaterThan(Math.max(BROWSE_POLL_INTERVAL_MS, STATS_POLL_INTERVAL_MS))
     const order: string[] = []
     vi.stubGlobal(
       "fetch",
@@ -215,16 +229,15 @@ describe("bulk run isolation", () => {
         const url = String(input)
         if (init?.method === "POST") {
           order.push(`POST ${url}`)
-          // Long enough that a 2 s poll tick would certainly land inside the run if
-          // polling were still armed.
-          await new Promise((resolve) => setTimeout(resolve, 900))
+          await new Promise((resolve) => setTimeout(resolve, WRITE_LATENCY_MS))
           return Response.json({ ok: true })
         }
         if (url.includes("/api/memory/list")) {
           order.push("LIST")
           return Response.json({ records: RECORDS, total: RECORDS.length, continuation: null })
         }
-        if (url.includes("/api/memory/stats"))
+        if (url.includes("/api/memory/stats")) {
+          order.push("STATS")
           return Response.json({
             total: RECORDS.length,
             byStatus: {},
@@ -232,6 +245,7 @@ describe("bulk run isolation", () => {
             byNamespace: {},
             bySourceType: {},
           })
+        }
         return Response.json({})
       }),
     )
@@ -251,16 +265,24 @@ describe("bulk run isolation", () => {
     const firstPost = order.findIndex((entry) => entry.startsWith("POST"))
     const lastPost = order.length - 1 - [...order].reverse().findIndex((e) => e.startsWith("POST"))
     expect(order.slice(firstPost, lastPost)).not.toContain("LIST")
+    expect(order.slice(firstPost, lastPost)).not.toContain("STATS")
   }, 30_000)
 
   /**
    * Driven through `BulkBar` directly: the property is that the run holds the ids the
    * CONFIRMATION named, and only a caller that can swap `ticked` mid-flight can tell that
    * apart from re-reading the prop. `ListPage` cannot be made to do that on demand.
+   *
+   * What carries the property is the CLOSURE — the click handler captured `ticked` from
+   * the render it fired on, and every later render is a different array the run cannot
+   * see. The defensive copy inside `run` is not it: deleting the copy leaves this test
+   * green. The failure mode this rules out is a loop that re-reads the live selection per
+   * iteration, which is why the swap happens between two writes rather than before them.
    */
   it("runs against the ids confirmed, not the ids currently ticked", async () => {
-    const { BulkBar } = await import("../../src/components/memory/bulk-bar")
-    const posted: string[] = []
+    // Named apart from the file-level `posted`: this test drives the bar alone, and the
+    // shared stub that fills the other one is not installed over this render.
+    const written: string[] = []
     let release: (() => void) | undefined
     const gate = new Promise<void>((resolve) => {
       release = resolve
@@ -268,8 +290,8 @@ describe("bulk run isolation", () => {
     vi.stubGlobal(
       "fetch",
       vi.fn(async (input: RequestInfo | URL) => {
-        posted.push(String(input))
-        if (posted.length === 1) await gate
+        written.push(String(input))
+        if (written.length === 1) await gate
         return Response.json({ ok: true })
       }),
     )
@@ -296,7 +318,7 @@ describe("bulk run isolation", () => {
     )
     release?.()
     // The run still targets the CONFIRMED four.
-    await waitFor(() => expect(posted).toHaveLength(ids.length), { timeout: 20_000 })
-    for (const id of ids) expect(posted.some((url) => url.includes(id))).toBe(true)
+    await waitFor(() => expect(written).toHaveLength(ids.length), { timeout: 20_000 })
+    for (const id of ids) expect(written.some((url) => url.includes(id))).toBe(true)
   }, 30_000)
 })

--- a/packages/inspector/test/components/polling-identity.test.tsx
+++ b/packages/inspector/test/components/polling-identity.test.tsx
@@ -1,0 +1,139 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { BROWSE_POLL_INTERVAL_MS } from "../../src/browse/use-memory-browse"
+import { ListPage } from "../../src/components/memory/list-page"
+import { TEST_IDS } from "../../src/components/memory/test-ids"
+import { browseSeedRecords } from "../seed"
+
+/**
+ * Written over `ListPage` with a stubbed `fetch` rather than over `useMemoryBrowse`,
+ * deliberately: the claim is about what goes on the wire and what reaches the grid, and
+ * that phrasing survives any refactor of the hook's internals — including which of the
+ * two gates (the abort at the boundary, or `browseReduce`'s revision check, pinned in
+ * `browse-machine.test.ts` flow 6) actually performs the discard.
+ */
+
+const ALL = browseSeedRecords().slice(0, 6)
+const ACTIVE = ALL.filter((record) => record.status === "active")
+
+let listUrls: string[] = []
+let deferred: { url: string; resolve: (body: unknown) => void }[] = []
+
+function recordsFor(url: string) {
+  return url.includes("active") ? ACTIVE : ALL
+}
+
+beforeEach(() => {
+  listUrls = []
+  deferred = []
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url.includes("/api/memory/stats"))
+        return Response.json({
+          total: ALL.length,
+          byStatus: {},
+          byKind: {},
+          byNamespace: {},
+          bySourceType: {},
+        })
+      if (!url.includes("/api/memory/list")) return Response.json({})
+      listUrls.push(url)
+      // Every list response is held open so a test can decide the ORDER in which
+      // revisions land — which is the whole subject here.
+      return new Promise((resolve) => {
+        deferred.push({
+          url,
+          resolve: (body) => resolve(Response.json(body)),
+        })
+      })
+    }),
+  )
+})
+
+afterEach(() => {
+  // This project runs vitest without `globals`, so RTL registers no auto-cleanup: the
+  // previous test's page stays mounted, still polling, and every `screen` query below
+  // matches twice. Unmount first, then drop the stub the unmount's last effects read.
+  cleanup()
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+})
+
+/** Settle the oldest held request that matches `match`. */
+function settle(match: (url: string) => boolean): void {
+  const index = deferred.findIndex((entry) => match(entry.url))
+  expect(index, `no held request matched`).toBeGreaterThanOrEqual(0)
+  const [entry] = deferred.splice(index, 1)
+  const records = recordsFor(entry?.url ?? "")
+  entry?.resolve({ records, total: records.length, continuation: null })
+}
+
+describe("polling identity", () => {
+  it("polls with the ACTIVE query's parameters, not the one the page mounted with", async () => {
+    render(<ListPage />)
+    await waitFor(() => expect(listUrls).toHaveLength(1))
+    settle(() => true)
+    await screen.findByText(ALL[0]?.content as string)
+
+    // Move the query.
+    const funnel = await screen.findByRole("button", { name: "Filter status" })
+    fireEvent.click(funnel)
+    fireEvent.click(await screen.findByRole("checkbox", { name: "active" }))
+    fireEvent.keyDown(document.activeElement ?? document.body, { key: "Escape" })
+
+    await waitFor(() => expect(listUrls.length).toBeGreaterThan(1))
+    settle((url) => url.includes("active"))
+
+    // Every subsequent request — poll ticks included — carries the new identity.
+    const before = listUrls.length
+    await waitFor(() => expect(listUrls.length).toBeGreaterThan(before), { timeout: 15_000 })
+    for (const url of listUrls.slice(before)) {
+      expect(url).toContain("active")
+    }
+  }, 30_000)
+
+  it("discards a poll response whose revision is no longer desired", async () => {
+    render(<ListPage />)
+    await waitFor(() => expect(listUrls).toHaveLength(1))
+    settle(() => true)
+    await screen.findByText(ALL[0]?.content as string)
+
+    // WAIT FOR A REAL POLL TICK before moving the query. Settling the mount request and
+    // clicking straight through leaves nothing in flight to be superseded — the held
+    // set is empty at the end and the discard below is never performed. Measured: the
+    // plan's ordering reached the last step with `deferred` at length 0.
+    await waitFor(() => expect(listUrls.length).toBeGreaterThan(1), {
+      timeout: BROWSE_POLL_INTERVAL_MS * 5,
+    })
+    const stalePoll = deferred.find((entry) => !entry.url.includes("active"))
+    // A throw, not an `expect`: the whole point below is to answer THIS request late,
+    // and an assertion that only reports would leave the test passing over a discard it
+    // never performed.
+    if (stalePoll === undefined) throw new Error("no poll request is held in flight")
+
+    // Change the query while that request is still in flight, then land the OLD one last.
+    const funnel = await screen.findByRole("button", { name: "Filter status" })
+    fireEvent.click(funnel)
+    fireEvent.click(await screen.findByRole("checkbox", { name: "active" }))
+    fireEvent.keyDown(document.activeElement ?? document.body, { key: "Escape" })
+    await waitFor(() => expect(deferred.some((d) => d.url.includes("active"))).toBe(true))
+
+    settle((url) => url.includes("active"))
+    await waitFor(() => expect(screen.queryByText(ALL[0]?.content as string)).toBeNull())
+    await screen.findByText(ACTIVE[0]?.content as string)
+    expect(screen.getByTestId(TEST_IDS.total).textContent).toBe(String(ACTIVE.length))
+
+    // Now answer the stale request. Nothing may change — and the total is asserted
+    // beside the rows because a response is discarded WHOLE or not at all.
+    const staleIndex = deferred.indexOf(stalePoll)
+    expect(staleIndex).toBeGreaterThanOrEqual(0)
+    const [stale] = deferred.splice(staleIndex, 1)
+    stale?.resolve({ records: ALL, total: ALL.length, continuation: null })
+
+    await new Promise((resolve) => setTimeout(resolve, 500))
+    expect(screen.queryByText(ALL[0]?.content as string)).toBeNull()
+    expect(screen.getByTestId(TEST_IDS.total).textContent).toBe(String(ACTIVE.length))
+  }, 30_000)
+})

--- a/packages/inspector/test/components/seed.test.ts
+++ b/packages/inspector/test/components/seed.test.ts
@@ -1,3 +1,4 @@
+import type { BrowseSortEntry } from "@dawn-ai/memory/browse"
 import { describe, expect, it } from "vitest"
 import {
   BROWSE_PAGE_SIZE,
@@ -11,6 +12,79 @@ import {
   seedRecordsMatching,
 } from "../seed"
 
+/** The head and tail of every order the lane sorts by, derived from the generator's rules
+ *  by hand rather than from its output — this file is the ONE place the fixture's shape is
+ *  transcribed, so that everything downstream can compute instead of transcribe. A change
+ *  to the fixture is meant to redden this file and nothing else. */
+const SORTS: readonly {
+  readonly name: string
+  readonly entries: readonly BrowseSortEntry[]
+  readonly head: string
+  readonly tail: string
+}[] = [
+  // Newest minute (124) first, id ASC inside it; oldest minute (0) last, id ASC inside it.
+  {
+    name: "updatedAt desc",
+    entries: [{ field: "updatedAt", dir: "desc" }],
+    head: "mem-1240",
+    tail: "mem-0009",
+  },
+  {
+    name: "updatedAt asc",
+    entries: [{ field: "updatedAt", dir: "asc" }],
+    head: "mem-0000",
+    tail: "mem-1249",
+  },
+  // createdAt = minute − (index % 7) − 1, so its extremes fall on neither end of the id
+  // range: proof that the two timestamps really are different orders.
+  {
+    name: "createdAt desc",
+    entries: [{ field: "createdAt", dir: "desc" }],
+    head: "mem-1246",
+    tail: "mem-0006",
+  },
+  // 0.98 is index % 50 === 49, 0 is index % 50 === 0.
+  {
+    name: "confidence desc",
+    entries: [{ field: "confidence", dir: "desc" }],
+    head: "mem-0049",
+    tail: "mem-1200",
+  },
+  {
+    name: "confidence asc",
+    entries: [{ field: "confidence", dir: "asc" }],
+    head: "mem-0000",
+    tail: "mem-1249",
+  },
+  // BINARY order: "route=/chat" < "route=/notes" < "route=/notes-archive" (prefix first).
+  {
+    name: "namespace asc",
+    entries: [{ field: "namespace", dir: "asc" }],
+    head: "mem-0003",
+    tail: "mem-1245",
+  },
+  // "episodic" < "procedural" < "reflection" < "semantic".
+  {
+    name: "kind asc",
+    entries: [{ field: "kind", dir: "asc" }],
+    head: "mem-0001",
+    tail: "mem-1248",
+  },
+  // "active" < "candidate" < "superseded".
+  {
+    name: "status asc",
+    entries: [{ field: "status", dir: "asc" }],
+    head: "mem-0001",
+    tail: "mem-1247",
+  },
+]
+
+function countBy<T>(values: readonly T[]): Map<T, number> {
+  const counts = new Map<T, number>()
+  for (const value of values) counts.set(value, (counts.get(value) ?? 0) + 1)
+  return counts
+}
+
 describe("browse seed fixture", () => {
   it("is larger than one window and larger than the resident cap", () => {
     expect(BROWSE_PAGE_SIZE).toBe(200)
@@ -23,6 +97,76 @@ describe("browse seed fixture", () => {
     expect(browseSeedRecords()).toEqual(browseSeedRecords())
   })
 
+  it("emits every id exactly once, and NOT in id order", () => {
+    const ids = browseSeedRecords().map((record) => record.id)
+    const everyId = Array.from(
+      { length: BROWSE_SEED_COUNT },
+      (_, index) => `mem-${String(index).padStart(4, "0")}`,
+    )
+    expect([...ids].sort()).toEqual(everyId)
+    // The property the id tie-break needs in order to be observable: were the fixture
+    // emitted in id order, a stable sort would return id-ordered ties from a comparator
+    // that had no tie-break at all.
+    expect(ids).not.toEqual(everyId)
+  })
+
+  it("orders every sort by id inside a tie, whatever order the records arrive in", () => {
+    const records = browseSeedRecords()
+    const reversed = [...records].reverse()
+    for (const { name, entries } of SORTS) {
+      expect(seedIdsSortedBy(entries, reversed), name).toEqual(seedIdsSortedBy(entries, records))
+    }
+  })
+
+  it("pins the head and tail of every order the lane sorts by", () => {
+    for (const { name, entries, head, tail } of SORTS) {
+      const ids = seedIdsSortedBy(entries)
+      expect(ids, name).toHaveLength(BROWSE_SEED_COUNT)
+      expect(ids[0], name).toBe(head)
+      expect(ids.at(-1), name).toBe(tail)
+    }
+  })
+
+  it("compares numbers as numbers, not as text", () => {
+    // Out of the [0, 1] confidence domain on purpose: inside it decimal strings sort
+    // exactly like their values, so no record of this fixture can tell a numeric compare
+    // from a lexicographic one.
+    const [template] = browseSeedRecords()
+    if (!template) throw new Error("fixture is empty")
+    const ids = seedIdsSortedBy(
+      [{ field: "confidence", dir: "asc" }],
+      [
+        { ...template, id: "mem-9999", confidence: 10 },
+        { ...template, id: "mem-9998", confidence: 2 },
+      ],
+    )
+    expect(ids).toEqual(["mem-9998", "mem-9999"])
+  })
+
+  it("orders text by bytes and folds case ASCII-only, as SQLite does", () => {
+    // Both properties are invisible in the fixture itself — every value in it is
+    // lowercase ASCII, where ICU collation and BINARY agree and both `lower()`
+    // implementations agree. They are pinned on synthetic records because the day a
+    // namespace carries an upper-case letter, or a needle a non-ASCII one, the model has
+    // to move WITH the store rather than with the JS defaults: `localeCompare` sorts "a"
+    // before "A" where the store sorts "A" first, and JS `toLowerCase()` folds "É" where
+    // SQLite's `lower()` leaves it alone.
+    const [template] = browseSeedRecords()
+    if (!template) throw new Error("fixture is empty")
+    const mixedCase = [
+      { ...template, id: "mem-9998", namespace: "route=/Notes" },
+      { ...template, id: "mem-9999", namespace: "route=/notes" },
+    ]
+    expect(seedIdsSortedBy([{ field: "namespace", dir: "asc" }], mixedCase)).toEqual([
+      "mem-9998",
+      "mem-9999",
+    ])
+    const accented = [{ ...template, id: "mem-9997", content: "CAFÉ threshold" }]
+    expect(seedRecordsMatching({ contentContains: "café" }, accented)).toEqual([])
+    expect(seedRecordsMatching({ contentContains: "CAFÉ" }, accented)).toHaveLength(1)
+    expect(seedRecordsMatching({ contentContains: "cafÉ" }, accented)).toHaveLength(1)
+  })
+
   it("puts ten records on every updatedAt so the id tie-break is exercised in every window", () => {
     const byStamp = new Map<string, string[]>()
     for (const record of browseSeedRecords()) {
@@ -32,26 +176,76 @@ describe("browse seed fixture", () => {
     for (const ids of byStamp.values()) expect(ids).toHaveLength(10)
   })
 
-  it("hides the content needle beyond the first default window", () => {
-    const order = seedIdsInDefaultOrder()
-    expect(order.indexOf(NEEDLE_ID)).toBeGreaterThan(BROWSE_PAGE_SIZE)
+  it("staggers createdAt off updatedAt so one sort cannot pass for the other", () => {
+    for (const record of browseSeedRecords()) {
+      expect(record.createdAt < record.updatedAt, record.id).toBe(true)
+    }
+    expect(seedIdsSortedBy([{ field: "createdAt", dir: "desc" }])).not.toEqual(
+      seedIdsInDefaultOrder(),
+    )
+  })
+
+  it("hides the content needle at a known index beyond the first default window", () => {
+    // 34 whole minutes (124 down to 91) precede the needle's minute, and it is first
+    // inside its own — so the first window can only reach it server-side.
+    const index = seedIdsInDefaultOrder().indexOf(NEEDLE_ID)
+    expect(index).toBe(340)
+    expect(index).toBeGreaterThan(BROWSE_PAGE_SIZE)
     expect(seedRecordsMatching({ contentContains: NEEDLE_TERM }).map((r) => r.id)).toEqual([
       NEEDLE_ID,
     ])
+    expect(
+      seedRecordsMatching({ contentContains: NEEDLE_TERM.toUpperCase() }).map((r) => r.id),
+    ).toEqual([NEEDLE_ID])
   })
 
   it("carries a namespace that is a strict prefix of another namespace", () => {
-    const exact = seedRecordsMatching({ namespace: "route=/notes" })
-    const prefixed = seedRecordsMatching({ namespacePrefix: "route=/notes" })
-    expect(exact.length).toBeGreaterThan(0)
-    expect(prefixed.length).toBeGreaterThan(exact.length)
-    expect(exact.every((r) => r.namespace === "route=/notes")).toBe(true)
+    const counts = countBy(browseSeedRecords().map((record) => record.namespace))
+    // index % 5 === 0 → archive (250); index % 3 === 0 otherwise → chat (417 − 84);
+    // everything else → notes.
+    expect(Object.fromEntries(counts)).toEqual({
+      "route=/notes": 667,
+      "route=/chat": 333,
+      "route=/notes-archive": 250,
+    })
+    expect(seedRecordsMatching({ namespace: "route=/notes" })).toHaveLength(667)
+    expect(seedRecordsMatching({ namespacePrefix: "route=/notes" })).toHaveLength(917)
+    expect(
+      seedRecordsMatching({ namespace: "route=/notes" }).every(
+        (r) => r.namespace === "route=/notes",
+      ),
+    ).toBe(true)
   })
 
   it("ties confidence 25 ways so a sort window is only deterministic with the id tie-break", () => {
-    const top = seedIdsSortedBy([{ field: "confidence", dir: "desc" }]).slice(0, 25)
-    const records = new Map(browseSeedRecords().map((r) => [r.id, r]))
-    expect(new Set(top.map((id) => records.get(id)?.confidence)).size).toBe(1)
-    expect(top).toEqual([...top].sort())
+    const byConfidence = countBy(browseSeedRecords().map((record) => record.confidence))
+    expect(byConfidence.size).toBe(50)
+    for (const [value, count] of byConfidence) expect(count, String(value)).toBe(25)
+    // The 25 ids holding the maximum confidence, in the id order the terminator imposes.
+    expect(seedIdsSortedBy([{ field: "confidence", dir: "desc" }]).slice(0, 25)).toEqual(
+      Array.from({ length: 25 }, (_, k) => `mem-${String(k * 50 + 49).padStart(4, "0")}`),
+    )
+  })
+
+  it("spreads kind, status and source so every facet has something to count", () => {
+    const records = browseSeedRecords()
+    expect(Object.fromEntries(countBy(records.map((r) => r.kind)))).toEqual({
+      semantic: 313,
+      episodic: 313,
+      procedural: 312,
+      reflection: 312,
+    })
+    expect(Object.fromEntries(countBy(records.map((r) => r.status)))).toEqual({
+      candidate: 417,
+      active: 417,
+      superseded: 416,
+    })
+    // One source type across the fixture: the sourceType facet is a single bar, which is
+    // what the "narrowing by it changes nothing" scenarios rely on.
+    for (const record of records) {
+      expect(record.source, record.id).toEqual({ type: "eval", id: "seed" })
+      expect(record.tags, record.id).toEqual([])
+      expect(record.data, record.id).toEqual({})
+    }
   })
 })

--- a/packages/inspector/test/components/seed.test.ts
+++ b/packages/inspector/test/components/seed.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest"
+import {
+  BROWSE_PAGE_SIZE,
+  BROWSE_RESIDENT_CAP,
+  BROWSE_SEED_COUNT,
+  browseSeedRecords,
+  NEEDLE_ID,
+  NEEDLE_TERM,
+  seedIdsInDefaultOrder,
+  seedIdsSortedBy,
+  seedRecordsMatching,
+} from "../seed"
+
+describe("browse seed fixture", () => {
+  it("is larger than one window and larger than the resident cap", () => {
+    expect(BROWSE_PAGE_SIZE).toBe(200)
+    expect(BROWSE_RESIDENT_CAP).toBe(1000)
+    expect(BROWSE_SEED_COUNT).toBe(1250)
+    expect(browseSeedRecords()).toHaveLength(1250)
+  })
+
+  it("is pure — two calls produce equal records", () => {
+    expect(browseSeedRecords()).toEqual(browseSeedRecords())
+  })
+
+  it("puts ten records on every updatedAt so the id tie-break is exercised in every window", () => {
+    const byStamp = new Map<string, string[]>()
+    for (const record of browseSeedRecords()) {
+      byStamp.set(record.updatedAt, [...(byStamp.get(record.updatedAt) ?? []), record.id])
+    }
+    expect(byStamp.size).toBe(125)
+    for (const ids of byStamp.values()) expect(ids).toHaveLength(10)
+  })
+
+  it("hides the content needle beyond the first default window", () => {
+    const order = seedIdsInDefaultOrder()
+    expect(order.indexOf(NEEDLE_ID)).toBeGreaterThan(BROWSE_PAGE_SIZE)
+    expect(seedRecordsMatching({ contentContains: NEEDLE_TERM }).map((r) => r.id)).toEqual([
+      NEEDLE_ID,
+    ])
+  })
+
+  it("carries a namespace that is a strict prefix of another namespace", () => {
+    const exact = seedRecordsMatching({ namespace: "route=/notes" })
+    const prefixed = seedRecordsMatching({ namespacePrefix: "route=/notes" })
+    expect(exact.length).toBeGreaterThan(0)
+    expect(prefixed.length).toBeGreaterThan(exact.length)
+    expect(exact.every((r) => r.namespace === "route=/notes")).toBe(true)
+  })
+
+  it("ties confidence 25 ways so a sort window is only deterministic with the id tie-break", () => {
+    const top = seedIdsSortedBy([{ field: "confidence", dir: "desc" }]).slice(0, 25)
+    const records = new Map(browseSeedRecords().map((r) => [r.id, r]))
+    expect(new Set(top.map((id) => records.get(id)?.confidence)).size).toBe(1)
+    expect(top).toEqual([...top].sort())
+  })
+})

--- a/packages/inspector/test/components/test-id-contract.test.tsx
+++ b/packages/inspector/test/components/test-id-contract.test.tsx
@@ -1,0 +1,57 @@
+import { cleanup, render, screen, waitFor } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { ListPage } from "../../src/components/memory/list-page"
+import { TEST_IDS } from "../../src/components/memory/test-ids"
+import { BROWSE_PAGE_SIZE, BROWSE_SEED_COUNT, browseSeedRecords } from "../seed"
+
+/** One page of the fixture plus the honest total — enough for the chrome to render
+ *  every state the lane targets. */
+function browsePage(offset = 0) {
+  const records = browseSeedRecords().slice(offset, offset + BROWSE_PAGE_SIZE)
+  return { records, total: BROWSE_SEED_COUNT, continuation: "cursor-1" }
+}
+
+beforeEach(() => {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url.includes("/api/memory/stats"))
+        return Response.json({
+          total: BROWSE_SEED_COUNT,
+          byStatus: {},
+          byKind: {},
+          byNamespace: {},
+          bySourceType: {},
+        })
+      if (url.includes("/api/memory/list")) return Response.json(browsePage())
+      return Response.json({})
+    }),
+  )
+})
+
+/** Explicit: this project does not set `globals`, so RTL never registers its own
+ *  auto-cleanup. Without this the second `render` stacks on the first, and the
+ *  containment check below reads a viewport from one tree and a control from the
+ *  other — which passes, while proving nothing. */
+afterEach(() => {
+  cleanup()
+  vi.unstubAllGlobals()
+})
+
+describe("verification DOM contract", () => {
+  it("renders every hook the Playwright lane locates by", async () => {
+    render(<ListPage />)
+    for (const id of [TEST_IDS.status, TEST_IDS.total, TEST_IDS.loadMore, TEST_IDS.liveToggle]) {
+      await waitFor(() => expect(screen.getByTestId(id)).toBeTruthy())
+    }
+  })
+
+  it("puts the load-more control OUTSIDE the grid viewport", async () => {
+    render(<ListPage />)
+    const control = await screen.findByTestId(TEST_IDS.loadMore)
+    const viewport = document.querySelector("[data-pretable-scroll-viewport]")
+    expect(viewport).not.toBeNull()
+    expect(viewport?.contains(control)).toBe(false)
+  })
+})

--- a/packages/inspector/test/components/test-id-contract.test.tsx
+++ b/packages/inspector/test/components/test-id-contract.test.tsx
@@ -6,9 +6,19 @@ import { BROWSE_PAGE_SIZE, BROWSE_SEED_COUNT, browseSeedRecords } from "../seed"
 
 /** One page of the fixture plus the honest total — enough for the chrome to render
  *  every state the lane targets. */
-function browsePage(offset = 0) {
-  const records = browseSeedRecords().slice(offset, offset + BROWSE_PAGE_SIZE)
-  return { records, total: BROWSE_SEED_COUNT, continuation: "cursor-1" }
+function browsePage() {
+  return {
+    records: browseSeedRecords().slice(0, BROWSE_PAGE_SIZE),
+    total: BROWSE_SEED_COUNT,
+    continuation: "cursor-1",
+  }
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  })
 }
 
 beforeEach(() => {
@@ -17,15 +27,18 @@ beforeEach(() => {
     vi.fn(async (input: RequestInfo | URL) => {
       const url = String(input)
       if (url.includes("/api/memory/stats"))
-        return Response.json({
+        return jsonResponse({
           total: BROWSE_SEED_COUNT,
           byStatus: {},
           byKind: {},
           byNamespace: {},
           bySourceType: {},
         })
-      if (url.includes("/api/memory/list")) return Response.json(browsePage())
-      return Response.json({})
+      if (url.includes("/api/memory/list")) return jsonResponse(browsePage())
+      // 404 rather than an empty 200: an endpoint this file has not stubbed must fail
+      // where it is called. A `{}` body is a shape every reader here parses into "no
+      // rows, no total", which reads as a missing HOOK several assertions later.
+      return jsonResponse({ error: "unstubbed endpoint" }, 404)
     }),
   )
 })
@@ -39,19 +52,68 @@ afterEach(() => {
   vi.unstubAllGlobals()
 })
 
+/**
+ * Every id in the module, decided.
+ *
+ * `"mounted"` means the hook is in the DOM of a `ListPage` whose first responses
+ * succeeded, which is what the first test renders. Every other entry names the
+ * condition that produces the hook — each needs a failure, a selection or a paused
+ * poll this file does not stage, and they are reached by the component suites and by
+ * the Playwright scenarios instead.
+ *
+ * Typed on `keyof typeof TEST_IDS`, so an id added to the module without a decision
+ * fails `pnpm typecheck`; the parity test below catches the same thing under the
+ * runner. An id nobody decided is the failure mode this module exists to prevent:
+ * the lane trusts it and finds out fifteen scenarios later, as a locator timeout.
+ */
+const COVERAGE: Record<keyof typeof TEST_IDS, "mounted" | string> = {
+  browseRegion: "mounted",
+  status: "mounted",
+  total: "mounted",
+  loadMore: "mounted",
+  liveToggle: "mounted",
+  // In the document from the first paint and `hidden` until a search runs. Presence
+  // is what a rename breaks; `view-scope.test.tsx` reads what it says.
+  searchScopeNote: "mounted",
+  asOf: "only while polling is paused",
+  retryInitial: "only in the error phase, and only while the grid is visible",
+  bannerRefresh: "only once a poll tick has failed",
+  bannerLoadMore: "only once an append has failed",
+  bannerRetry: "only while a browse request's failure is banner-borne",
+  bulkBar: "only while rows are ticked",
+  bulkError: "only once a bulk mutation has partly failed",
+}
+
+const MOUNTED_IDS = Object.entries(COVERAGE).flatMap(([key, when]) =>
+  when === "mounted" ? [TEST_IDS[key as keyof typeof TEST_IDS]] : [],
+)
+
 describe("verification DOM contract", () => {
   it("renders every hook the Playwright lane locates by", async () => {
+    // A loop over an empty list passes: this test's subject is the LIST as much as
+    // the assertions, and the list is derived.
+    expect(MOUNTED_IDS.length).toBeGreaterThan(0)
     render(<ListPage />)
-    for (const id of [TEST_IDS.status, TEST_IDS.total, TEST_IDS.loadMore, TEST_IDS.liveToggle]) {
+    for (const id of MOUNTED_IDS) {
       await waitFor(() => expect(screen.getByTestId(id)).toBeTruthy())
     }
+  })
+
+  it("leaves no id in the module undecided", () => {
+    expect(Object.keys(COVERAGE).sort()).toEqual(Object.keys(TEST_IDS).sort())
   })
 
   it("puts the load-more control OUTSIDE the grid viewport", async () => {
     render(<ListPage />)
     const control = await screen.findByTestId(TEST_IDS.loadMore)
-    const viewport = document.querySelector("[data-pretable-scroll-viewport]")
-    expect(viewport).not.toBeNull()
-    expect(viewport?.contains(control)).toBe(false)
+    // Scoped to the browse region and pinned to exactly one. A search renders a grid
+    // — so a second viewport — beside this one, and a document-wide first match could
+    // read the viewport this control was never in danger of being inside, passing for
+    // a reason that has nothing to do with the placement §9.2 asks for.
+    const viewports = screen
+      .getByTestId(TEST_IDS.browseRegion)
+      .querySelectorAll("[data-pretable-scroll-viewport]")
+    expect(viewports).toHaveLength(1)
+    expect(viewports[0]?.contains(control)).toBe(false)
   })
 })

--- a/packages/inspector/test/components/use-polling.test.tsx
+++ b/packages/inspector/test/components/use-polling.test.tsx
@@ -1,0 +1,84 @@
+import { cleanup, renderHook, waitFor } from "@testing-library/react"
+import { StrictMode } from "react"
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { usePolling } from "../../src/components/use-polling"
+
+/** Long enough that no interval fires inside a test that is counting IMMEDIATE ticks —
+ *  those tests are about the edges, and a cadence landing mid-assertion would read as
+ *  one. The one test that wants the cadence names its own. */
+const NEVER_MS = 60_000
+
+afterEach(() => {
+  cleanup()
+  vi.restoreAllMocks()
+})
+
+describe("usePolling immediate ticks", () => {
+  it("ticks once on mount even with polling disabled", async () => {
+    const fn = vi.fn(async () => "a")
+    renderHook(() => usePolling(fn, NEVER_MS, false))
+    await waitFor(() => expect(fn).toHaveBeenCalledTimes(1))
+  })
+
+  /**
+   * The reason the effect depends on `fn` identity at all: callers pass a useCallback'd
+   * fetcher whose identity moves when the filters do, and with live mode off this tick
+   * is the ONLY thing that would ever fetch the new question's answer.
+   */
+  it("ticks on an fn change while polling stays disabled", async () => {
+    const first = vi.fn(async () => "a")
+    const second = vi.fn(async () => "b")
+    const { rerender } = renderHook(({ fn }) => usePolling(fn, NEVER_MS, false), {
+      initialProps: { fn: first },
+    })
+    await waitFor(() => expect(first).toHaveBeenCalledTimes(1))
+    rerender({ fn: second })
+    await waitFor(() => expect(second).toHaveBeenCalledTimes(1))
+  })
+
+  /**
+   * The suspension is silent, and that is the whole point of it. Callers disable polling
+   * to hold a reading still across a change they are making themselves — a bulk run's
+   * per-id writes — and they flip the flag from the same event that issues the first
+   * write. A parting tick on the way down would therefore be taken CONCURRENTLY with
+   * that write and publish exactly the half-applied reading the suspension exists to
+   * keep off screen. Resuming ticks at once, so the cost of the suspension is one read
+   * at its trailing edge and none inside it.
+   */
+  it("does not tick when polling is suspended, and ticks again on resume", async () => {
+    const fn = vi.fn(async () => "a")
+    const { rerender } = renderHook(({ enabled }) => usePolling(fn, NEVER_MS, enabled), {
+      initialProps: { enabled: true },
+    })
+    await waitFor(() => expect(fn).toHaveBeenCalledTimes(1))
+
+    rerender({ enabled: false })
+    // Settled, not merely un-awaited: a tick would be issued synchronously by the
+    // effect, so one flushed microtask queue is enough to have seen it.
+    await Promise.resolve()
+    expect(fn).toHaveBeenCalledTimes(1)
+
+    rerender({ enabled: true })
+    await waitFor(() => expect(fn).toHaveBeenCalledTimes(2))
+  })
+
+  /**
+   * The app runs `reactStrictMode`, whose remount re-runs this effect against hook state
+   * it did NOT reset — so the ref telling a suspension from a mount is already written
+   * by the time the second run reads it. Read through the published value rather than a
+   * call count, because that is where the failure would show: the first run's cleanup
+   * marks its tick dead, so a second run that declines to tick leaves the value undefined
+   * forever. Disabled on mount is the arm that can fail; enabled would tick regardless.
+   */
+  it("publishes a mount tick under StrictMode with polling disabled", async () => {
+    const fn = vi.fn(async () => "a")
+    const { result } = renderHook(() => usePolling(fn, NEVER_MS, false), { wrapper: StrictMode })
+    await waitFor(() => expect(result.current).toBe("a"))
+  })
+
+  it("polls on the interval while enabled", async () => {
+    const fn = vi.fn(async () => "a")
+    renderHook(() => usePolling(fn, 20, true))
+    await waitFor(() => expect(fn.mock.calls.length).toBeGreaterThanOrEqual(3))
+  })
+})

--- a/packages/inspector/test/components/view-scope.test.tsx
+++ b/packages/inspector/test/components/view-scope.test.tsx
@@ -2,7 +2,7 @@ import type { MemoryRecord } from "@dawn-ai/memory"
 import { cleanup, fireEvent, render, screen, within } from "@testing-library/react"
 import { afterEach, describe, expect, it, vi } from "vitest"
 import { ListPage } from "../../src/components/memory/list-page"
-import { TEST_IDS } from "../../src/components/memory/test-ids"
+import { errorBannerId, TEST_IDS } from "../../src/components/memory/test-ids"
 
 function record(over: Partial<MemoryRecord> & Pick<MemoryRecord, "id">): MemoryRecord {
   return {
@@ -86,7 +86,7 @@ async function typeSearch(value: string) {
 async function startSearch() {
   await typeSearch("acme")
   await vi.waitFor(() =>
-    expect(screen.getByTestId("browse-region").hasAttribute("hidden")).toBe(true),
+    expect(screen.getByTestId(TEST_IDS.browseRegion).hasAttribute("hidden")).toBe(true),
   )
 }
 
@@ -97,7 +97,7 @@ function facet(): HTMLElement {
 /** Both roles: the surface is a `treegrid` while grouped and a `grid` when flat,
  *  and the namespace grouping this page asks for makes that depend on the facet. */
 function browseGrid(): Element | null {
-  return screen.getByTestId("browse-region").querySelector('[role="grid"],[role="treegrid"]')
+  return screen.getByTestId(TEST_IDS.browseRegion).querySelector('[role="grid"],[role="treegrid"]')
 }
 
 function scopeNote(): string {
@@ -146,7 +146,7 @@ describe("view scope", () => {
     expect(grid).not.toBeNull()
     fireEvent.click(screen.getByRole("button", { name: "timeline" }))
     await screen.findByTestId("timeline-region")
-    expect(screen.getByTestId("browse-region").hasAttribute("hidden")).toBe(true)
+    expect(screen.getByTestId(TEST_IDS.browseRegion).hasAttribute("hidden")).toBe(true)
     expect(browseGrid()).toBe(grid)
   })
 
@@ -197,7 +197,7 @@ describe("view scope", () => {
     await startSearch()
     await typeSearch("")
     await vi.waitFor(() =>
-      expect(screen.getByTestId("browse-region").hasAttribute("hidden")).toBe(false),
+      expect(screen.getByTestId(TEST_IDS.browseRegion).hasAttribute("hidden")).toBe(false),
     )
     expect(popovers()).toHaveLength(0)
   })
@@ -212,7 +212,7 @@ describe("view scope", () => {
     render(<ListPage />)
     await screen.findByText("content a")
     const viewport = screen
-      .getByTestId("browse-region")
+      .getByTestId(TEST_IDS.browseRegion)
       .querySelector<HTMLElement>("[data-pretable-scroll-viewport]")
     if (!viewport) throw new Error("no scroll viewport")
     viewport.scrollTop = 20
@@ -221,7 +221,7 @@ describe("view scope", () => {
     viewport.scrollTop = 0
     await typeSearch("")
     await vi.waitFor(() =>
-      expect(screen.getByTestId("browse-region").hasAttribute("hidden")).toBe(false),
+      expect(screen.getByTestId(TEST_IDS.browseRegion).hasAttribute("hidden")).toBe(false),
     )
     expect(viewport.scrollTop).toBe(20)
   })
@@ -407,12 +407,12 @@ describe("view scope", () => {
     )
     render(<ListPage />)
     await screen.findByTestId("browse-error")
-    expect(screen.queryByTestId("error-browse")).toBeNull()
+    expect(screen.queryByTestId(errorBannerId("browse"))).toBeNull()
     await startSearch()
-    const entry = await screen.findByTestId("error-browse")
+    const entry = await screen.findByTestId(errorBannerId("browse"))
     expect(entry.textContent).toContain("no memory store configured")
     fail = false
     fireEvent.click(screen.getByRole("button", { name: "Retry" }))
-    await vi.waitFor(() => expect(screen.queryByTestId("error-browse")).toBeNull())
+    await vi.waitFor(() => expect(screen.queryByTestId(errorBannerId("browse"))).toBeNull())
   })
 })

--- a/packages/inspector/test/components/view-scope.test.tsx
+++ b/packages/inspector/test/components/view-scope.test.tsx
@@ -2,6 +2,7 @@ import type { MemoryRecord } from "@dawn-ai/memory"
 import { cleanup, fireEvent, render, screen, within } from "@testing-library/react"
 import { afterEach, describe, expect, it, vi } from "vitest"
 import { ListPage } from "../../src/components/memory/list-page"
+import { TEST_IDS } from "../../src/components/memory/test-ids"
 
 function record(over: Partial<MemoryRecord> & Pick<MemoryRecord, "id">): MemoryRecord {
   return {
@@ -100,7 +101,7 @@ function browseGrid(): Element | null {
 }
 
 function scopeNote(): string {
-  return screen.getByTestId("browse-scope-note").textContent ?? ""
+  return screen.getByTestId(TEST_IDS.searchScopeNote).textContent ?? ""
 }
 
 /** Open the status funnel WITHOUT a pointerdown anywhere else first. Pretable's own

--- a/packages/inspector/test/fixtures/browse-app/dawn.config.ts
+++ b/packages/inspector/test/fixtures/browse-app/dawn.config.ts
@@ -1,0 +1,12 @@
+// A dedicated app root so the verification lane's 1250-record store never collides
+// with the small `test/fixtures/app` store the JSON-API e2e tests seed and wipe.
+import { join } from "node:path"
+import { sqliteMemoryStore } from "@dawn-ai/memory"
+
+export default {
+  appDir: "src/app",
+  memory: {
+    writes: "candidate",
+    store: sqliteMemoryStore({ path: join(import.meta.dirname, ".dawn", "memory.sqlite") }),
+  },
+}

--- a/packages/inspector/test/fixtures/browse-app/package.json
+++ b/packages/inspector/test/fixtures/browse-app/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "browse-fixture-app",
+  "private": true,
+  "type": "module"
+}

--- a/packages/inspector/test/fixtures/browse-app/src/app/notes/index.ts
+++ b/packages/inspector/test/fixtures/browse-app/src/app/notes/index.ts
@@ -1,0 +1,1 @@
+export default {}

--- a/packages/inspector/test/fixtures/browse-app/src/app/notes/memory.ts
+++ b/packages/inspector/test/fixtures/browse-app/src/app/notes/memory.ts
@@ -1,0 +1,7 @@
+import { z } from "zod"
+
+export default {
+  kind: "semantic",
+  scope: ["route"],
+  schema: z.object({ subject: z.string(), predicate: z.string(), value: z.string() }),
+}

--- a/packages/inspector/test/seed-store.ts
+++ b/packages/inspector/test/seed-store.ts
@@ -1,6 +1,9 @@
 import { join } from "node:path"
 import { sqliteMemoryStore } from "@dawn-ai/memory"
-import { browseSeedRecords } from "./seed"
+// Explicit `.ts`: `e2e/serve.ts` imports this module under bare `node`, whose ESM
+// resolver does no extension inference — an extensionless specifier here is an
+// ERR_MODULE_NOT_FOUND the moment the Playwright lane boots its web server.
+import { browseSeedRecords } from "./seed.ts"
 
 /**
  * Write the fixture into `<appRoot>/.dawn/memory.sqlite`. Node-only.

--- a/packages/inspector/test/seed-store.ts
+++ b/packages/inspector/test/seed-store.ts
@@ -1,0 +1,22 @@
+import { join } from "node:path"
+import { sqliteMemoryStore } from "@dawn-ai/memory"
+import { browseSeedRecords } from "./seed"
+
+/**
+ * Write the fixture into `<appRoot>/.dawn/memory.sqlite`. Node-only.
+ *
+ * Deliberately NOT in `seed.ts`: this is a value import of the `@dawn-ai/memory` barrel,
+ * which pulls `node:sqlite`, and `seed.ts` is imported by the jsdom components project —
+ * which cannot bundle a builtin and would need `packages/memory/dist` built to try.
+ * Keeping the two apart is what lets the component tests run with neither.
+ *
+ * Records are put in emission order, which is not id order (see `EMIT_STRIDE`), so
+ * SQLite's rowid order cannot stand in for the `id ASC` terminator a browse window is
+ * supposed to be made deterministic by.
+ */
+export async function writeBrowseSeed(appRoot: string): Promise<void> {
+  const store = sqliteMemoryStore({ path: join(appRoot, ".dawn", "memory.sqlite") })
+  for (const record of browseSeedRecords()) {
+    await store.put(record)
+  }
+}

--- a/packages/inspector/test/seed.e2e.test.ts
+++ b/packages/inspector/test/seed.e2e.test.ts
@@ -1,0 +1,144 @@
+import { mkdtempSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import type { BrowseQuery, BrowseSortEntry, MemoryStore } from "@dawn-ai/memory"
+import { sqliteMemoryStore } from "@dawn-ai/memory"
+import { afterAll, beforeAll, describe, expect, it } from "vitest"
+import {
+  BROWSE_SEED_COUNT,
+  browseSeedRecords,
+  NEEDLE_ID,
+  NEEDLE_TERM,
+  seedIdsInDefaultOrder,
+  seedIdsSortedBy,
+  seedRecordsMatching,
+} from "./seed"
+import { writeBrowseSeed } from "./seed-store"
+
+/**
+ * `seed.ts` models the store's ordering and filtering in TypeScript, and every
+ * expectation in the verification lane is read out of that model. This file is the only
+ * place the model is held against the thing it models: without it, a model that is wrong
+ * in the same direction as a downstream assertion is green all the way down.
+ *
+ * It talks to the store directly rather than through the Inspector's HTTP layer — a
+ * server would only add a way for the comparison to fail for reasons that are not about
+ * the fixture.
+ */
+
+let appRoot: string
+let store: MemoryStore
+
+beforeAll(async () => {
+  appRoot = mkdtempSync(join(tmpdir(), "dawn-browse-seed-"))
+  await writeBrowseSeed(appRoot)
+  store = sqliteMemoryStore({ path: join(appRoot, ".dawn", "memory.sqlite") })
+})
+
+afterAll(() => {
+  rmSync(appRoot, { recursive: true, force: true })
+})
+
+/** Walk every page of a query, so an assertion covers the whole order and not just the
+ *  head of it — the id tie-break decides seams as well as windows. */
+async function browseAllIds(query: BrowseQuery = {}): Promise<string[]> {
+  const ids: string[] = []
+  let cursor: string | null = null
+  for (;;) {
+    const page = await store.browse(
+      cursor === null ? { ...query, limit: 500 } : { ...query, limit: 500, cursor },
+    )
+    ids.push(...page.records.map((record) => record.id))
+    if (!page.continuation) return ids
+    cursor = page.continuation
+  }
+}
+
+const SORTS: readonly (readonly BrowseSortEntry[])[] = [
+  [{ field: "updatedAt", dir: "desc" }],
+  [{ field: "updatedAt", dir: "asc" }],
+  [{ field: "createdAt", dir: "desc" }],
+  [{ field: "createdAt", dir: "asc" }],
+  [{ field: "confidence", dir: "desc" }],
+  [{ field: "confidence", dir: "asc" }],
+  [{ field: "namespace", dir: "asc" }],
+  [{ field: "namespace", dir: "desc" }],
+  [{ field: "kind", dir: "asc" }],
+  [{ field: "status", dir: "desc" }],
+  [
+    { field: "namespace", dir: "asc" },
+    { field: "confidence", dir: "desc" },
+  ],
+]
+
+describe("browse seed fixture against the real store", () => {
+  it("writes every record verbatim", async () => {
+    const page = await store.browse({ limit: 1 })
+    expect(page.total).toBe(BROWSE_SEED_COUNT)
+    const model = new Map(browseSeedRecords().map((record) => [record.id, record]))
+    for (const id of [NEEDLE_ID, "mem-0000", "mem-1249"]) {
+      expect(await store.get(id), id).toEqual(model.get(id))
+    }
+  })
+
+  it("returns the model's default order when asked for no order at all", async () => {
+    expect(await browseAllIds()).toEqual(seedIdsInDefaultOrder())
+  })
+
+  it("agrees with the model on every order the lane sorts by", async () => {
+    for (const orderBy of SORTS) {
+      const name = orderBy.map((entry) => `${entry.field} ${entry.dir}`).join(", ")
+      expect(await browseAllIds({ orderBy }), name).toEqual(seedIdsSortedBy(orderBy))
+    }
+  })
+
+  it("agrees with the model on every predicate the lane filters by", async () => {
+    const cases: readonly {
+      readonly name: string
+      readonly query: BrowseQuery
+      readonly expected: readonly string[]
+    }[] = [
+      {
+        name: "status in [superseded]",
+        query: { filters: [{ field: "status", op: "in", values: ["superseded"] }] },
+        expected: seedIdsInDefaultOrder(seedRecordsMatching({ status: ["superseded"] })),
+      },
+      {
+        name: "kind in [episodic]",
+        query: { filters: [{ field: "kind", op: "in", values: ["episodic"] }] },
+        expected: seedIdsInDefaultOrder(seedRecordsMatching({ kind: ["episodic"] })),
+      },
+      {
+        name: "namespace equals route=/notes",
+        query: { namespace: "route=/notes" },
+        expected: seedIdsInDefaultOrder(seedRecordsMatching({ namespace: "route=/notes" })),
+      },
+      {
+        name: "namespace prefix route=/notes",
+        query: { namespacePrefix: "route=/notes" },
+        expected: seedIdsInDefaultOrder(seedRecordsMatching({ namespacePrefix: "route=/notes" })),
+      },
+      {
+        name: "content contains the needle",
+        query: { filters: [{ field: "content", op: "contains", value: NEEDLE_TERM }] },
+        expected: [NEEDLE_ID],
+      },
+      {
+        name: "content contains the needle, upper-cased",
+        query: {
+          filters: [{ field: "content", op: "contains", value: NEEDLE_TERM.toUpperCase() }],
+        },
+        expected: [NEEDLE_ID],
+      },
+      {
+        name: "confidence >= 0.5",
+        query: { filters: [{ field: "confidence", op: "gte", value: 0.5 }] },
+        expected: seedIdsInDefaultOrder(seedRecordsMatching({ confidenceGte: 0.5 })),
+      },
+    ]
+    for (const { name, query, expected } of cases) {
+      expect(await browseAllIds(query), name).toEqual(expected)
+      expect((await store.browse({ ...query, limit: 1 })).total, name).toBe(expected.length)
+    }
+  })
+})

--- a/packages/inspector/test/seed.ts
+++ b/packages/inspector/test/seed.ts
@@ -1,0 +1,128 @@
+import { join } from "node:path"
+import type { MemoryKind, MemoryRecord, MemoryStatus } from "@dawn-ai/memory"
+import { sqliteMemoryStore } from "@dawn-ai/memory"
+import type { BrowseSortEntry } from "@dawn-ai/memory/browse"
+
+/** The Inspector's request window (design §11 "default window / page size"). */
+export const BROWSE_PAGE_SIZE = 200
+/** The client-side resident cap (design §11), deliberately equal to BROWSE_MAX_LIMIT. */
+export const BROWSE_RESIDENT_CAP = 1000
+/** Six-and-a-quarter windows: proves paging, proves the cap, and leaves 250 records
+ *  the client can never hold at once. */
+export const BROWSE_SEED_COUNT = 1250
+
+/** The one record whose content is unique, placed beyond the first default window so a
+ *  content filter that finds it can only have been applied server-side. */
+export const NEEDLE_ID = "mem-0900"
+export const NEEDLE_TERM = "zephyr-needle"
+
+const KINDS: readonly MemoryKind[] = ["semantic", "episodic", "procedural", "reflection"]
+const STATUSES: readonly MemoryStatus[] = ["candidate", "active", "superseded"]
+const BASE_MS = Date.UTC(2026, 0, 1, 0, 0, 0)
+
+/** `route=/notes-archive` exists ONLY so an exact `route=/notes` can prove it excludes
+ *  prefix siblings (dogfood scenario 4). */
+function namespaceFor(index: number): string {
+  if (index % 5 === 0) return "route=/notes-archive"
+  if (index % 3 === 0) return "route=/chat"
+  return "route=/notes"
+}
+
+/**
+ * The fixture, as data. Pure and stable: every expectation in the verification lane is
+ * computed from this array rather than transcribed, so a seed change moves the
+ * expectations with it instead of reddening forty assertions at once.
+ */
+export function browseSeedRecords(): MemoryRecord[] {
+  const records: MemoryRecord[] = []
+  for (let index = 0; index < BROWSE_SEED_COUNT; index += 1) {
+    // Ten records share each timestamp: the id tie-break then decides order INSIDE
+    // every window, not only at a page seam that a single walk might never hit.
+    const stamp = new Date(BASE_MS + Math.floor(index / 10) * 60_000).toISOString()
+    records.push({
+      id: `mem-${String(index).padStart(4, "0")}`,
+      kind: KINDS[index % KINDS.length] as MemoryKind,
+      namespace: namespaceFor(index),
+      content: index === 900 ? `${NEEDLE_TERM} beyond the first window` : `acme threshold ${index}`,
+      data: {},
+      source: { type: "eval", id: "seed" },
+      // 25 records per distinct value: a confidence window is deterministic only
+      // because the store terminates every sort with `id ASC`.
+      confidence: (index % 50) / 50,
+      tags: [],
+      status: STATUSES[index % STATUSES.length] as MemoryStatus,
+      createdAt: stamp,
+      updatedAt: stamp,
+    })
+  }
+  return records
+}
+
+function compareBy(entries: readonly BrowseSortEntry[]) {
+  return (a: MemoryRecord, b: MemoryRecord): number => {
+    for (const entry of entries) {
+      const left = a[entry.field]
+      const right = b[entry.field]
+      let delta = 0
+      if (typeof left === "number" && typeof right === "number") delta = left - right
+      else delta = String(left).localeCompare(String(right))
+      if (delta !== 0) return entry.dir === "desc" ? -delta : delta
+    }
+    // The store's terminator, mirrored: id ASC, always, whatever the sort.
+    return a.id.localeCompare(b.id)
+  }
+}
+
+/** The documented default order: `updatedAt DESC, id ASC`. */
+export function seedIdsInDefaultOrder(records = browseSeedRecords()): string[] {
+  return seedIdsSortedBy([{ field: "updatedAt", dir: "desc" }], records)
+}
+
+export function seedIdsSortedBy(
+  entries: readonly BrowseSortEntry[],
+  records = browseSeedRecords(),
+): string[] {
+  return [...records].sort(compareBy(entries)).map((record) => record.id)
+}
+
+export interface SeedPredicate {
+  readonly namespace?: string
+  readonly namespacePrefix?: string
+  readonly status?: readonly MemoryStatus[]
+  readonly kind?: readonly MemoryKind[]
+  readonly contentContains?: string
+  readonly confidenceGte?: number
+}
+
+/** The predicate semantics of `BrowseQuery`, as a pure filter over the fixture. */
+export function seedRecordsMatching(
+  predicate: SeedPredicate,
+  records = browseSeedRecords(),
+): MemoryRecord[] {
+  return records.filter((record) => {
+    if (predicate.namespace !== undefined && record.namespace !== predicate.namespace) return false
+    if (
+      predicate.namespacePrefix !== undefined &&
+      !record.namespace.startsWith(predicate.namespacePrefix)
+    )
+      return false
+    if (predicate.status !== undefined && !predicate.status.includes(record.status)) return false
+    if (predicate.kind !== undefined && !predicate.kind.includes(record.kind)) return false
+    if (
+      predicate.contentContains !== undefined &&
+      !record.content.toLowerCase().includes(predicate.contentContains.toLowerCase())
+    )
+      return false
+    if (predicate.confidenceGte !== undefined && record.confidence < predicate.confidenceGte)
+      return false
+    return true
+  })
+}
+
+/** Write the fixture into `<appRoot>/.dawn/memory.sqlite`. Node-only. */
+export async function writeBrowseSeed(appRoot: string): Promise<void> {
+  const store = sqliteMemoryStore({ path: join(appRoot, ".dawn", "memory.sqlite") })
+  for (const record of browseSeedRecords()) {
+    await store.put(record)
+  }
+}

--- a/packages/inspector/test/seed.ts
+++ b/packages/inspector/test/seed.ts
@@ -1,11 +1,12 @@
-import { join } from "node:path"
 import type { MemoryKind, MemoryRecord, MemoryStatus } from "@dawn-ai/memory"
-import { sqliteMemoryStore } from "@dawn-ai/memory"
 import type { BrowseSortEntry } from "@dawn-ai/memory/browse"
 
-/** The Inspector's request window (design §11 "default window / page size"). */
+/** The Inspector's request window (design §11 "default window / page size"). A PROPOSAL
+ *  until tasks 18 and 21 measure it; pinned here so a change to it is a deliberate edit
+ *  rather than a drift. */
 export const BROWSE_PAGE_SIZE = 200
-/** The client-side resident cap (design §11), deliberately equal to BROWSE_MAX_LIMIT. */
+/** The client-side resident cap (design §11, likewise proposed), deliberately equal to
+ *  BROWSE_MAX_LIMIT. */
 export const BROWSE_RESIDENT_CAP = 1000
 /** Six-and-a-quarter windows: proves paging, proves the cap, and leaves 250 records
  *  the client can never hold at once. */
@@ -19,6 +20,13 @@ export const NEEDLE_TERM = "zephyr-needle"
 const KINDS: readonly MemoryKind[] = ["semantic", "episodic", "procedural", "reflection"]
 const STATUSES: readonly MemoryStatus[] = ["candidate", "active", "superseded"]
 const BASE_MS = Date.UTC(2026, 0, 1, 0, 0, 0)
+/** Coprime with BROWSE_SEED_COUNT (= 2·5⁴), so `step * EMIT_STRIDE % COUNT` visits every
+ *  index exactly once. Emitting out of id order is load-bearing, not cosmetic: sorts are
+ *  stable and rows reach the store in emission order, so an id-ordered fixture hands back
+ *  id-ordered ties from a comparator — or a store — that has no `id ASC` terminator at
+ *  all, and the determinism this whole fixture exists to prove would be an artifact of
+ *  the input rather than a property of the query. */
+const EMIT_STRIDE = 617
 
 /** `route=/notes-archive` exists ONLY so an exact `route=/notes` can prove it excludes
  *  prefix siblings (dogfood scenario 4). */
@@ -28,34 +36,53 @@ function namespaceFor(index: number): string {
   return "route=/notes"
 }
 
+function seedRecord(index: number): MemoryRecord {
+  const id = `mem-${String(index).padStart(4, "0")}`
+  // Ten records share each updatedAt: the id tie-break then decides order INSIDE
+  // every window, not only at a page seam that a single walk might never hit.
+  const minute = Math.floor(index / 10)
+  return {
+    id,
+    kind: KINDS[index % KINDS.length] as MemoryKind,
+    namespace: namespaceFor(index),
+    content:
+      id === NEEDLE_ID ? `${NEEDLE_TERM} beyond the first window` : `acme threshold ${index}`,
+    data: {},
+    source: { type: "eval", id: "seed" },
+    // 25 records per distinct value: a confidence window is far narrower than the tie it
+    // sits inside, so its contents are decided by the id terminator and not by the key.
+    confidence: (index % 50) / 50,
+    tags: [],
+    status: STATUSES[index % STATUSES.length] as MemoryStatus,
+    // Always before updatedAt — nothing is updated before it exists — but on a different
+    // cycle, so `createdAt` order is NOT `updatedAt` order. With the two equal, every
+    // downstream "this is the documented `updatedAt DESC` default" assertion would hold
+    // just as well against a server that had sorted by createdAt.
+    createdAt: new Date(BASE_MS + (minute - (index % 7) - 1) * 60_000).toISOString(),
+    updatedAt: new Date(BASE_MS + minute * 60_000).toISOString(),
+  }
+}
+
 /**
  * The fixture, as data. Pure and stable: every expectation in the verification lane is
  * computed from this array rather than transcribed, so a seed change moves the
  * expectations with it instead of reddening forty assertions at once.
  */
-export function browseSeedRecords(): MemoryRecord[] {
+export function browseSeedRecords(): readonly MemoryRecord[] {
   const records: MemoryRecord[] = []
-  for (let index = 0; index < BROWSE_SEED_COUNT; index += 1) {
-    // Ten records share each timestamp: the id tie-break then decides order INSIDE
-    // every window, not only at a page seam that a single walk might never hit.
-    const stamp = new Date(BASE_MS + Math.floor(index / 10) * 60_000).toISOString()
-    records.push({
-      id: `mem-${String(index).padStart(4, "0")}`,
-      kind: KINDS[index % KINDS.length] as MemoryKind,
-      namespace: namespaceFor(index),
-      content: index === 900 ? `${NEEDLE_TERM} beyond the first window` : `acme threshold ${index}`,
-      data: {},
-      source: { type: "eval", id: "seed" },
-      // 25 records per distinct value: a confidence window is deterministic only
-      // because the store terminates every sort with `id ASC`.
-      confidence: (index % 50) / 50,
-      tags: [],
-      status: STATUSES[index % STATUSES.length] as MemoryStatus,
-      createdAt: stamp,
-      updatedAt: stamp,
-    })
+  for (let step = 0; step < BROWSE_SEED_COUNT; step += 1) {
+    records.push(seedRecord((step * EMIT_STRIDE) % BROWSE_SEED_COUNT))
   }
   return records
+}
+
+/** SQLite's BINARY collation, which is the order both stores sort text in —
+ *  `browse-order.ts` marks `namespace` `collateC` precisely to hold Postgres to it.
+ *  `localeCompare` is ICU order instead, which puts "A" before "a" where BINARY puts it
+ *  after. JS compares UTF-16 code units and SQLite compares UTF-8 bytes; those agree on
+ *  everything below U+E000, which is every character this fixture uses. */
+function compareBinary(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0
 }
 
 function compareBy(entries: readonly BrowseSortEntry[]) {
@@ -63,24 +90,31 @@ function compareBy(entries: readonly BrowseSortEntry[]) {
     for (const entry of entries) {
       const left = a[entry.field]
       const right = b[entry.field]
-      let delta = 0
-      if (typeof left === "number" && typeof right === "number") delta = left - right
-      else delta = String(left).localeCompare(String(right))
+      // Numbers compare as numbers. No confidence in [0, 1] can demonstrate that —
+      // decimal strings there happen to sort exactly like their values — so
+      // seed.test.ts pins this branch with out-of-domain values instead.
+      const delta =
+        typeof left === "number" && typeof right === "number"
+          ? left - right
+          : compareBinary(String(left), String(right))
       if (delta !== 0) return entry.dir === "desc" ? -delta : delta
     }
-    // The store's terminator, mirrored: id ASC, always, whatever the sort.
-    return a.id.localeCompare(b.id)
+    // The store's terminator, mirrored: id ASC, always, whatever the sort. Because the
+    // fixture arrives out of id order, removing this line changes the answer.
+    return compareBinary(a.id, b.id)
   }
 }
 
 /** The documented default order: `updatedAt DESC, id ASC`. */
-export function seedIdsInDefaultOrder(records = browseSeedRecords()): string[] {
+export function seedIdsInDefaultOrder(
+  records: readonly MemoryRecord[] = browseSeedRecords(),
+): string[] {
   return seedIdsSortedBy([{ field: "updatedAt", dir: "desc" }], records)
 }
 
 export function seedIdsSortedBy(
   entries: readonly BrowseSortEntry[],
-  records = browseSeedRecords(),
+  records: readonly MemoryRecord[] = browseSeedRecords(),
 ): string[] {
   return [...records].sort(compareBy(entries)).map((record) => record.id)
 }
@@ -94,11 +128,19 @@ export interface SeedPredicate {
   readonly confidenceGte?: number
 }
 
+/** SQLite's `lower()` without ICU folds ASCII and nothing else — `sqlite-browse-sql.ts`
+ *  documents it: `lower('CAFÉ')` is `'cafÉ'` there and `'café'` in Postgres. JS
+ *  `toLowerCase()` is full-Unicode and so models neither store; this models the one the
+ *  verification lane actually queries. */
+function asciiLower(value: string): string {
+  return value.replace(/[A-Z]/g, (char) => char.toLowerCase())
+}
+
 /** The predicate semantics of `BrowseQuery`, as a pure filter over the fixture. */
 export function seedRecordsMatching(
   predicate: SeedPredicate,
-  records = browseSeedRecords(),
-): MemoryRecord[] {
+  records: readonly MemoryRecord[] = browseSeedRecords(),
+): readonly MemoryRecord[] {
   return records.filter((record) => {
     if (predicate.namespace !== undefined && record.namespace !== predicate.namespace) return false
     if (
@@ -110,19 +152,11 @@ export function seedRecordsMatching(
     if (predicate.kind !== undefined && !predicate.kind.includes(record.kind)) return false
     if (
       predicate.contentContains !== undefined &&
-      !record.content.toLowerCase().includes(predicate.contentContains.toLowerCase())
+      !asciiLower(record.content).includes(asciiLower(predicate.contentContains))
     )
       return false
     if (predicate.confidenceGte !== undefined && record.confidence < predicate.confidenceGte)
       return false
     return true
   })
-}
-
-/** Write the fixture into `<appRoot>/.dawn/memory.sqlite`. Node-only. */
-export async function writeBrowseSeed(appRoot: string): Promise<void> {
-  const store = sqliteMemoryStore({ path: join(appRoot, ".dawn", "memory.sqlite") })
-  for (const record of browseSeedRecords()) {
-    await store.put(record)
-  }
 }

--- a/packages/inspector/tsconfig.e2e.json
+++ b/packages/inspector/tsconfig.e2e.json
@@ -1,22 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
-  // The Playwright lane, type-checked as its OWN project rather than as more entries in
-  // `tsconfig.json`'s `include`.
-  //
-  // Two reasons it cannot just live there. `next build` type-checks whatever that file
-  // includes, and this package ships `.next/standalone` to npm — so a type error in a
-  // spec would fail the published build. And the lane imports `src/components/memory/
-  // test-ids`, which is a test-only contract module; the product build has no business
-  // resolving it.
-  //
-  // Without this project nothing checks these files at all: Playwright STRIPS types, it
-  // does not check them, so a spec's type error reaches the runner as a collection
-  // failure with no line number. `lint` already covers the same paths.
   "extends": "./tsconfig.json",
-  "compilerOptions": {
-    // The default `.tsbuildinfo` path is derived from this file's name, so the two
-    // projects do not clobber each other's cache.
-    "incremental": true
-  },
+  "compilerOptions": { "incremental": true },
   "include": ["e2e/**/*.ts", "playwright.config.ts"]
 }

--- a/packages/inspector/tsconfig.e2e.json
+++ b/packages/inspector/tsconfig.e2e.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  // The Playwright lane, type-checked as its OWN project rather than as more entries in
+  // `tsconfig.json`'s `include`.
+  //
+  // Two reasons it cannot just live there. `next build` type-checks whatever that file
+  // includes, and this package ships `.next/standalone` to npm — so a type error in a
+  // spec would fail the published build. And the lane imports `src/components/memory/
+  // test-ids`, which is a test-only contract module; the product build has no business
+  // resolving it.
+  //
+  // Without this project nothing checks these files at all: Playwright STRIPS types, it
+  // does not check them, so a spec's type error reaches the runner as a collection
+  // failure with no line number. `lint` already covers the same paths.
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    // The default `.tsbuildinfo` path is derived from this file's name, so the two
+    // projects do not clobber each other's cache.
+    "incremental": true
+  },
+  "include": ["e2e/**/*.ts", "playwright.config.ts"]
+}

--- a/packages/inspector/tsconfig.json
+++ b/packages/inspector/tsconfig.json
@@ -3,6 +3,9 @@
   "extends": "../config-typescript/nextjs.json",
   "compilerOptions": {
     "incremental": true,
+    // `test/seed-store.ts` is loaded by `e2e/serve.ts` under bare `node`, whose ESM
+    // resolver does no extension inference, so its relative import must carry `.ts`.
+    "allowImportingTsExtensions": true,
     "paths": { "@/*": ["./*"] }
   },
   "include": [

--- a/packages/inspector/tsconfig.json
+++ b/packages/inspector/tsconfig.json
@@ -3,8 +3,9 @@
   "extends": "../config-typescript/nextjs.json",
   "compilerOptions": {
     "incremental": true,
-    // `test/seed-store.ts` is loaded by `e2e/serve.ts` under bare `node`, whose ESM
-    // resolver does no extension inference, so its relative import must carry `.ts`.
+    // `e2e/serve.ts` and the `test/seed-store.ts` it pulls are loaded under bare `node`,
+    // whose ESM resolver does no extension inference, so their relative imports must
+    // carry `.ts`.
     "allowImportingTsExtensions": true,
     "paths": { "@/*": ["./*"] }
   },

--- a/packages/inspector/tsconfig.json
+++ b/packages/inspector/tsconfig.json
@@ -3,9 +3,6 @@
   "extends": "../config-typescript/nextjs.json",
   "compilerOptions": {
     "incremental": true,
-    // `e2e/serve.ts` and the `test/seed-store.ts` it pulls are loaded under bare `node`,
-    // whose ESM resolver does no extension inference, so their relative imports must
-    // carry `.ts`.
     "allowImportingTsExtensions": true,
     "paths": { "@/*": ["./*"] }
   },

--- a/packages/memory/bench/browse-budgets.mts
+++ b/packages/memory/bench/browse-budgets.mts
@@ -1,0 +1,114 @@
+// Measures the five §11 SERVER budgets against a seeded store and reports pass/fail.
+//
+//   pnpm --filter @dawn-ai/memory build
+//   node packages/memory/bench/browse-budgets.mts [rowCount] [--assert]
+//
+// Companion to browse-plans.mts, which prints QUERY PLANS. This one prints TIMINGS
+// against approved ceilings, and with --assert exits non-zero on a miss. Timings move
+// with machine load; a miss on a loaded machine is a re-run, not a finding.
+import { mkdtempSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { DatabaseSync } from "node:sqlite"
+import {
+  type BrowseBudgetId,
+  checkBrowseBudgets,
+  formatBrowseBudgetReport,
+  SQLITE_BROWSE_BUDGETS_MS,
+} from "../dist/browse-budget.js"
+import { sqliteMemoryStore } from "../dist/index.js"
+
+const args = process.argv.slice(2)
+const assertBudgets = args.includes("--assert")
+const rowCount = Number(args.find((arg) => !arg.startsWith("--")) ?? 100_000)
+if (!Number.isInteger(rowCount) || rowCount < 1) {
+  throw new Error(`rowCount must be a positive integer, got ${JSON.stringify(args[0])}`)
+}
+/** 20 samples so nearest-rank p95 is the 19th — a real observation, not an interpolation. */
+const SAMPLES = 20
+/** The design's resident cap, which is also the maximum request limit: one head refresh
+ *  covers the whole resident span, which is what makes convergence arithmetic. */
+const RESIDENT_CAP = 1_000
+
+const dir = mkdtempSync(join(tmpdir(), "dawn-budget-"))
+const path = join(dir, "bench.sqlite")
+
+function seed(): void {
+  const db = new DatabaseSync(path)
+  const insert = db.prepare(
+    `INSERT INTO memories
+       (id,kind,namespace,content,data,source,confidence,tags,status,supersedes,created_at,updated_at,effective_at,expires_at)
+     VALUES (?,?,?,?,?,?,?,?,?,NULL,?,?,NULL,NULL)`,
+  )
+  const kinds = ["semantic", "episodic", "procedural", "reflection"]
+  const statuses = ["candidate", "active", "superseded"]
+  db.exec("BEGIN")
+  for (let i = 0; i < rowCount; i += 1) {
+    const stamp = new Date(Date.UTC(2026, 0, 1) + i * 1000).toISOString()
+    insert.run(
+      `r${String(i).padStart(9, "0")}`,
+      kinds[i % kinds.length] as string,
+      `route=/ns${i % 500}`,
+      i % 9973 === 0 ? `rare needle ${i}` : `common filler content ${i}`,
+      "{}",
+      '{"type":"eval","id":"bench"}',
+      (i % 100) / 100,
+      "[]",
+      statuses[i % statuses.length] as string,
+      stamp,
+      stamp,
+    )
+  }
+  db.exec("COMMIT")
+  db.close()
+}
+
+async function sample(run: () => Promise<unknown>): Promise<number[]> {
+  await run() // warm: the first call pays for statement preparation
+  const timings: number[] = []
+  for (let i = 0; i < SAMPLES; i += 1) {
+    const started = performance.now()
+    await run()
+    timings.push(performance.now() - started)
+  }
+  return timings
+}
+
+try {
+  const store = sqliteMemoryStore({ path })
+  seed()
+  console.log(`rows: ${rowCount}, samples: ${SAMPLES}\n`)
+
+  const measurements: Partial<Record<BrowseBudgetId, number[]>> = {}
+  measurements["windowed-fetch"] = await sample(() => store.browse({ limit: 200 }))
+  // A filtered window is rows + COUNT in one transaction; the COUNT is the shape §11
+  // budgets separately, and this is the only way to exercise it through the store.
+  measurements["filtered-count"] = await sample(() =>
+    store.browse({ limit: 200, filters: [{ field: "status", op: "in", values: ["active"] }] }),
+  )
+  measurements["head-refresh"] = await sample(() => store.browse({ limit: RESIDENT_CAP }))
+  measurements["non-default-sort"] = await sample(() =>
+    store.browse({ limit: 200, orderBy: [{ field: "confidence", dir: "desc" }] }),
+  )
+  measurements["content-contains"] = await sample(() =>
+    store.browse({
+      limit: 200,
+      filters: [{ field: "content", op: "contains", value: "rare needle 9973" }],
+    }),
+  )
+
+  const report = checkBrowseBudgets(measurements, SQLITE_BROWSE_BUDGETS_MS)
+  console.log(formatBrowseBudgetReport(report))
+  if (assertBudgets && !report.ok) {
+    console.error("\nAt least one shape missed its approved ceiling.")
+    process.exitCode = 1
+  }
+} finally {
+  // MemoryStore exposes no close(), so the connection is still open here. POSIX unlinks
+  // open files; Windows refuses, and that must not throw over the results.
+  try {
+    rmSync(dir, { recursive: true, force: true })
+  } catch (err) {
+    console.log(`\ncould not remove ${dir}: ${(err as Error).message}`)
+  }
+}

--- a/packages/memory/bench/browse-budgets.mts
+++ b/packages/memory/bench/browse-budgets.mts
@@ -1,13 +1,18 @@
 // Measures the five §11 SERVER budgets against a seeded store and reports pass/fail.
 //
-//   pnpm --filter @dawn-ai/memory build
-//   node packages/memory/bench/browse-budgets.mts [rowCount] [--assert]
+//   pnpm --filter @dawn-ai/memory bench:budgets -- [rowCount] [--assert]
+//
+// It reads the COMPILED ceilings, so it must be built first — that is why the package
+// script builds and this file is not meant to be run bare. Node 24+ only (native .mts);
+// older Node dies at load with ERR_UNKNOWN_FILE_EXTENSION and exit 1, the same code
+// --assert uses for a real miss.
 //
 // Companion to browse-plans.mts, which prints QUERY PLANS. This one prints TIMINGS
 // against approved ceilings, and with --assert exits non-zero on a miss. Timings move
-// with machine load; a miss on a loaded machine is a re-run, not a finding.
+// with machine load; a miss on a loaded machine is a re-run, not a finding, which is why
+// the header line records the load the run happened under.
 import { mkdtempSync, rmSync } from "node:fs"
-import { tmpdir } from "node:os"
+import { loadavg, tmpdir } from "node:os"
 import { join } from "node:path"
 import { DatabaseSync } from "node:sqlite"
 import {
@@ -20,14 +25,17 @@ import { sqliteMemoryStore } from "../dist/index.js"
 
 const args = process.argv.slice(2)
 const assertBudgets = args.includes("--assert")
-const rowCount = Number(args.find((arg) => !arg.startsWith("--")) ?? 100_000)
+const rowCountArg = args.find((arg) => !arg.startsWith("--"))
+const rowCount = Number(rowCountArg ?? 100_000)
 if (!Number.isInteger(rowCount) || rowCount < 1) {
-  throw new Error(`rowCount must be a positive integer, got ${JSON.stringify(args[0])}`)
+  throw new Error(`rowCount must be a positive integer, got ${JSON.stringify(rowCountArg)}`)
 }
 /** 20 samples so nearest-rank p95 is the 19th — a real observation, not an interpolation. */
 const SAMPLES = 20
 /** The design's resident cap, which is also the maximum request limit: one head refresh
- *  covers the whole resident span, which is what makes convergence arithmetic. */
+ *  covers the whole resident span, which is what makes convergence arithmetic. Duplicated
+ *  from BROWSE_RESIDENT_CAP in @dawn-ai/inspector (browse/browse-machine.ts), which this
+ *  package cannot import; if that moves, this bench certifies a span that no longer exists. */
 const RESIDENT_CAP = 1_000
 
 const dir = mkdtempSync(join(tmpdir(), "dawn-budget-"))
@@ -63,39 +71,69 @@ function seed(): void {
   db.close()
 }
 
-async function sample(run: () => Promise<unknown>): Promise<number[]> {
-  await run() // warm: the first call pays for statement preparation
-  const timings: number[] = []
+interface Shape {
+  readonly id: BrowseBudgetId
+  readonly run: () => Promise<unknown>
+}
+
+/**
+ * Round-robin, one sample of every shape per iteration, rather than 20 back-to-back per
+ * shape. Nearest-rank p95 over 20 samples discards only the single worst, so a stall that
+ * spans two consecutive samples blows that shape's p95 outright. Interleaved, the same
+ * stall costs each shape one sample instead of charging all of it to whichever shape held
+ * the CPU — and if it is long enough to matter, every row moves together, which reads as
+ * the machine load it is.
+ */
+async function measure(
+  shapes: readonly Shape[],
+): Promise<Partial<Record<BrowseBudgetId, number[]>>> {
+  const timings: Partial<Record<BrowseBudgetId, number[]>> = {}
+  for (const shape of shapes) {
+    timings[shape.id] = []
+    await shape.run() // warm: the first call pays for statement preparation
+  }
   for (let i = 0; i < SAMPLES; i += 1) {
-    const started = performance.now()
-    await run()
-    timings.push(performance.now() - started)
+    for (const shape of shapes) {
+      const started = performance.now()
+      await shape.run()
+      timings[shape.id]?.push(performance.now() - started)
+    }
   }
   return timings
 }
 
 try {
+  // Constructing the store runs the migrations, so it must precede seed(): the INSERT
+  // below prepares against a table that does not exist yet otherwise.
   const store = sqliteMemoryStore({ path })
   seed()
-  console.log(`rows: ${rowCount}, samples: ${SAMPLES}\n`)
+  console.log(`rows: ${rowCount}, samples: ${SAMPLES}, load: ${(loadavg()[0] ?? 0).toFixed(2)}\n`)
 
-  const measurements: Partial<Record<BrowseBudgetId, number[]>> = {}
-  measurements["windowed-fetch"] = await sample(() => store.browse({ limit: 200 }))
-  // A filtered window is rows + COUNT in one transaction; the COUNT is the shape §11
-  // budgets separately, and this is the only way to exercise it through the store.
-  measurements["filtered-count"] = await sample(() =>
-    store.browse({ limit: 200, filters: [{ field: "status", op: "in", values: ["active"] }] }),
-  )
-  measurements["head-refresh"] = await sample(() => store.browse({ limit: RESIDENT_CAP }))
-  measurements["non-default-sort"] = await sample(() =>
-    store.browse({ limit: 200, orderBy: [{ field: "confidence", dir: "desc" }] }),
-  )
-  measurements["content-contains"] = await sample(() =>
-    store.browse({
-      limit: 200,
-      filters: [{ field: "content", op: "contains", value: "rare needle 9973" }],
-    }),
-  )
+  const measurements = await measure([
+    { id: "windowed-fetch", run: () => store.browse({ limit: 200 }) },
+    // A filtered window is rows + COUNT in one transaction; the COUNT is the shape §11
+    // budgets separately, and this is the only way to exercise it through the store.
+    {
+      id: "filtered-count",
+      run: () =>
+        store.browse({ limit: 200, filters: [{ field: "status", op: "in", values: ["active"] }] }),
+    },
+    { id: "head-refresh", run: () => store.browse({ limit: RESIDENT_CAP }) },
+    {
+      id: "non-default-sort",
+      run: () => store.browse({ limit: 200, orderBy: [{ field: "confidence", dir: "desc" }] }),
+    },
+    {
+      // 49865 is a multiple of the seed's 9973 whose decimal is a prefix of no other row's
+      // (498650 is past 100k), so the needle really does match one row.
+      id: "content-contains",
+      run: () =>
+        store.browse({
+          limit: 200,
+          filters: [{ field: "content", op: "contains", value: "rare needle 49865" }],
+        }),
+    },
+  ])
 
   const report = checkBrowseBudgets(measurements, SQLITE_BROWSE_BUDGETS_MS)
   console.log(formatBrowseBudgetReport(report))

--- a/packages/memory/package.json
+++ b/packages/memory/package.json
@@ -42,7 +42,7 @@
     "access": "public"
   },
   "scripts": {
-    "bench:budgets": "node bench/browse-budgets.mts",
+    "bench:budgets": "pnpm build && node bench/browse-budgets.mts",
     "build": "tsc -b tsconfig.json",
     "lint": "biome check --config-path ../config-biome/biome.json package.json bench src test tsconfig.json tsconfig.test.json vitest.config.ts",
     "test": "vitest --run --config vitest.config.ts --passWithNoTests",

--- a/packages/memory/package.json
+++ b/packages/memory/package.json
@@ -42,6 +42,7 @@
     "access": "public"
   },
   "scripts": {
+    "bench:budgets": "node bench/browse-budgets.mts",
     "build": "tsc -b tsconfig.json",
     "lint": "biome check --config-path ../config-biome/biome.json package.json bench src test tsconfig.json tsconfig.test.json vitest.config.ts",
     "test": "vitest --run --config vitest.config.ts --passWithNoTests",

--- a/packages/memory/src/browse-budget.ts
+++ b/packages/memory/src/browse-budget.ts
@@ -1,0 +1,81 @@
+/**
+ * The §11 server budgets of the server-controlled-exploration design, as data, plus the
+ * comparison the bench and its test share. Deliberately NOT exported from `index.ts` or
+ * `browse.ts`: this is bench vocabulary, not part of the package's public surface.
+ */
+export type BrowseBudgetId =
+  | "windowed-fetch"
+  | "filtered-count"
+  | "head-refresh"
+  | "non-default-sort"
+  | "content-contains"
+
+/** Ceilings approved for SQLite at 100 000 rows. Every one is grounded in a §5.5
+ *  measurement; the margin covers real payload decode. */
+export const SQLITE_BROWSE_BUDGETS_MS: Readonly<Partial<Record<BrowseBudgetId, number>>> = {
+  "windowed-fetch": 10,
+  "filtered-count": 25,
+  "head-refresh": 50,
+  "non-default-sort": 50,
+  "content-contains": 150,
+}
+
+/** Postgres. §11 approves only two numbers, and BOTH are estimates — no container bench
+ *  has ever run. The other three shapes stay deliberately absent so the checker reports
+ *  them as unbudgeted rather than inventing a ceiling. */
+export const POSTGRES_BROWSE_BUDGETS_MS: Readonly<Partial<Record<BrowseBudgetId, number>>> = {
+  "windowed-fetch": 30,
+  "filtered-count": 100,
+}
+
+/** Nearest-rank p95. With 20 samples that is the 19th — no interpolation, so the number
+ *  reported is a measurement that actually happened. */
+export function percentileMs(samples: readonly number[], fraction: number): number {
+  if (samples.length === 0) return Number.NaN
+  const sorted = [...samples].sort((a, b) => a - b)
+  const rank = Math.max(1, Math.ceil(fraction * sorted.length))
+  return sorted[rank - 1] as number
+}
+
+export interface BrowseBudgetRow {
+  readonly id: BrowseBudgetId
+  readonly p95Ms: number
+  readonly budgetMs: number | null
+  readonly status: "pass" | "fail" | "unbudgeted"
+}
+
+export interface BrowseBudgetReport {
+  readonly rows: readonly BrowseBudgetRow[]
+  readonly ok: boolean
+}
+
+export function checkBrowseBudgets(
+  measurements: Readonly<Partial<Record<BrowseBudgetId, readonly number[]>>>,
+  budgets: Readonly<Partial<Record<BrowseBudgetId, number>>>,
+): BrowseBudgetReport {
+  const rows: BrowseBudgetRow[] = []
+  for (const [id, samples] of Object.entries(measurements) as [
+    BrowseBudgetId,
+    readonly number[],
+  ][]) {
+    const p95Ms = percentileMs(samples, 0.95)
+    const budgetMs = budgets[id] ?? null
+    rows.push({
+      id,
+      p95Ms,
+      budgetMs,
+      status: budgetMs === null ? "unbudgeted" : p95Ms <= budgetMs ? "pass" : "fail",
+    })
+  }
+  return { rows, ok: rows.every((row) => row.status !== "fail") }
+}
+
+export function formatBrowseBudgetReport(report: BrowseBudgetReport): string {
+  return report.rows
+    .map(
+      (row) =>
+        `${row.id.padEnd(20)} p95 ${row.p95Ms.toFixed(2).padStart(8)} ms  ` +
+        `budget ${(row.budgetMs === null ? "—" : `${row.budgetMs} ms`).padStart(8)}  ${row.status}`,
+    )
+    .join("\n")
+}

--- a/packages/memory/src/browse-budget.ts
+++ b/packages/memory/src/browse-budget.ts
@@ -10,8 +10,10 @@ export type BrowseBudgetId =
   | "non-default-sort"
   | "content-contains"
 
-/** Ceilings approved for SQLite at 100 000 rows. Every one is grounded in a §5.5
- *  measurement; the margin covers real payload decode. */
+/** Ceilings approved for SQLite at 100 000 rows; the margin covers real payload decode.
+ *  Four are grounded in a §5.5 measurement. `head-refresh` is NOT — §5.5 has no row for
+ *  it, and §11 grounds it by extrapolation ("~3-8 ms + decode"), so this bench is the
+ *  first measurement it has ever had. */
 export const SQLITE_BROWSE_BUDGETS_MS: Readonly<Partial<Record<BrowseBudgetId, number>>> = {
   "windowed-fetch": 10,
   "filtered-count": 25,
@@ -39,9 +41,10 @@ export function percentileMs(samples: readonly number[], fraction: number): numb
 
 export interface BrowseBudgetRow {
   readonly id: BrowseBudgetId
-  readonly p95Ms: number
+  /** null only when the shape was never measured. */
+  readonly p95Ms: number | null
   readonly budgetMs: number | null
-  readonly status: "pass" | "fail" | "unbudgeted"
+  readonly status: "pass" | "fail" | "unbudgeted" | "unmeasured"
 }
 
 export interface BrowseBudgetReport {
@@ -49,6 +52,14 @@ export interface BrowseBudgetReport {
   readonly ok: boolean
 }
 
+/**
+ * A row per measured shape, plus a row per approved ceiling nobody measured. Both holes
+ * are reported rather than skipped, for opposite reasons: a measurement with no ceiling
+ * must not be counted as approval nobody gave, and a ceiling with no measurement must not
+ * let a partial run exit clean — a `--assert` that checked one of five and returned 0
+ * would certify four budgets it never looked at. A zero-sample array is a broken run, not
+ * an absent one, so it fails.
+ */
 export function checkBrowseBudgets(
   measurements: Readonly<Partial<Record<BrowseBudgetId, readonly number[]>>>,
   budgets: Readonly<Partial<Record<BrowseBudgetId, number>>>,
@@ -60,21 +71,22 @@ export function checkBrowseBudgets(
   ][]) {
     const p95Ms = percentileMs(samples, 0.95)
     const budgetMs = budgets[id] ?? null
-    rows.push({
-      id,
-      p95Ms,
-      budgetMs,
-      status: budgetMs === null ? "unbudgeted" : p95Ms <= budgetMs ? "pass" : "fail",
-    })
+    // A zero-sample p95 is NaN, and NaN loses every comparison, so the row falls to "fail".
+    const status = budgetMs === null ? "unbudgeted" : p95Ms <= budgetMs ? "pass" : "fail"
+    rows.push({ id, p95Ms, budgetMs, status })
   }
-  return { rows, ok: rows.every((row) => row.status !== "fail") }
+  for (const [id, budgetMs] of Object.entries(budgets) as [BrowseBudgetId, number][]) {
+    if (id in measurements) continue
+    rows.push({ id, p95Ms: null, budgetMs, status: "unmeasured" })
+  }
+  return { rows, ok: rows.every((row) => row.status === "pass" || row.status === "unbudgeted") }
 }
 
 export function formatBrowseBudgetReport(report: BrowseBudgetReport): string {
   return report.rows
     .map(
       (row) =>
-        `${row.id.padEnd(20)} p95 ${row.p95Ms.toFixed(2).padStart(8)} ms  ` +
+        `${row.id.padEnd(20)} p95 ${(row.p95Ms === null ? "—" : row.p95Ms.toFixed(2)).padStart(8)} ms  ` +
         `budget ${(row.budgetMs === null ? "—" : `${row.budgetMs} ms`).padStart(8)}  ${row.status}`,
     )
     .join("\n")

--- a/packages/memory/test/browse-budget.test.ts
+++ b/packages/memory/test/browse-budget.test.ts
@@ -14,6 +14,24 @@ describe("browse budget checker", () => {
     expect(percentileMs([5], 0.95)).toBe(5)
   })
 
+  it("ranks by value, not by arrival", () => {
+    // The bench hands over timings in the order they happened. Unsorted, rank 5 of these
+    // would be the fifth CALL (4) rather than the fifth slowest (50).
+    expect(percentileMs([50, 1, 2, 3, 4], 0.95)).toBe(50)
+  })
+
+  it("rounds the rank up, and never below the first sample", () => {
+    // 0.95 * 10 = 9.5: rounding down would report the 9th and quietly discard two samples
+    // instead of one. The clamp covers fraction <= 0, where the rank would be index -1.
+    expect(
+      percentileMs(
+        Array.from({ length: 10 }, (_, index) => index + 1),
+        0.95,
+      ),
+    ).toBe(10)
+    expect(percentileMs([7, 8], 0)).toBe(7)
+  })
+
   it("passes when every measured p95 is under its ceiling", () => {
     const report = checkBrowseBudgets(
       {
@@ -29,6 +47,12 @@ describe("browse budget checker", () => {
     expect(report.rows.every((row) => row.status === "pass")).toBe(true)
   })
 
+  it("counts a p95 landing exactly on the ceiling as a pass", () => {
+    const report = checkBrowseBudgets({ "windowed-fetch": [1, 1, 10] }, SQLITE_BROWSE_BUDGETS_MS)
+    expect(report.rows[0]?.p95Ms).toBe(10)
+    expect(report.rows[0]?.status).toBe("pass")
+  })
+
   it("fails the whole report when one shape is over", () => {
     const report = checkBrowseBudgets({ "windowed-fetch": [50, 60, 70] }, SQLITE_BROWSE_BUDGETS_MS)
     expect(report.ok).toBe(false)
@@ -39,8 +63,32 @@ describe("browse budget checker", () => {
   it("marks a shape with no approved ceiling UNBUDGETED rather than passing it", () => {
     // Design §11 approves only two Postgres numbers. Reporting the other three as
     // "pass" would manufacture approval nobody gave.
-    const report = checkBrowseBudgets({ "content-contains": [900] }, POSTGRES_BROWSE_BUDGETS_MS)
-    expect(report.rows[0]?.status).toBe("unbudgeted")
+    const report = checkBrowseBudgets(
+      { "windowed-fetch": [1], "filtered-count": [2], "content-contains": [900] },
+      POSTGRES_BROWSE_BUDGETS_MS,
+    )
+    expect(report.rows.find((row) => row.id === "content-contains")?.status).toBe("unbudgeted")
     expect(report.ok).toBe(true)
+  })
+
+  it("reports an approved ceiling nobody measured, and refuses to call the run ok", () => {
+    // The mirror of UNBUDGETED: a partial run must not certify the four shapes it skipped.
+    const report = checkBrowseBudgets({ "windowed-fetch": [1, 1, 2] }, SQLITE_BROWSE_BUDGETS_MS)
+    expect(report.rows.map((row) => row.status)).toEqual([
+      "pass",
+      "unmeasured",
+      "unmeasured",
+      "unmeasured",
+      "unmeasured",
+    ])
+    expect(report.rows[1]?.p95Ms).toBe(null)
+    expect(report.ok).toBe(false)
+  })
+
+  it("fails a measured shape that produced no samples", () => {
+    // A shape present with zero timings is a broken run, not an absent one.
+    const report = checkBrowseBudgets({ "content-contains": [] }, SQLITE_BROWSE_BUDGETS_MS)
+    expect(report.rows[0]?.status).toBe("fail")
+    expect(report.ok).toBe(false)
   })
 })

--- a/packages/memory/test/browse-budget.test.ts
+++ b/packages/memory/test/browse-budget.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest"
+import {
+  checkBrowseBudgets,
+  POSTGRES_BROWSE_BUDGETS_MS,
+  percentileMs,
+  SQLITE_BROWSE_BUDGETS_MS,
+} from "../src/browse-budget.js"
+
+describe("browse budget checker", () => {
+  it("takes the p95 by nearest-rank, so a 20-sample run reports the 19th", () => {
+    const samples = Array.from({ length: 20 }, (_, index) => index + 1)
+    expect(percentileMs(samples, 0.95)).toBe(19)
+    expect(percentileMs([], 0.95)).toBe(Number.NaN)
+    expect(percentileMs([5], 0.95)).toBe(5)
+  })
+
+  it("passes when every measured p95 is under its ceiling", () => {
+    const report = checkBrowseBudgets(
+      {
+        "windowed-fetch": [1, 1, 2],
+        "filtered-count": [4, 5, 6],
+        "head-refresh": [10, 11, 12],
+        "non-default-sort": [12, 13, 14],
+        "content-contains": [40, 44, 46],
+      },
+      SQLITE_BROWSE_BUDGETS_MS,
+    )
+    expect(report.ok).toBe(true)
+    expect(report.rows.every((row) => row.status === "pass")).toBe(true)
+  })
+
+  it("fails the whole report when one shape is over", () => {
+    const report = checkBrowseBudgets({ "windowed-fetch": [50, 60, 70] }, SQLITE_BROWSE_BUDGETS_MS)
+    expect(report.ok).toBe(false)
+    expect(report.rows[0]?.status).toBe("fail")
+    expect(report.rows[0]?.budgetMs).toBe(10)
+  })
+
+  it("marks a shape with no approved ceiling UNBUDGETED rather than passing it", () => {
+    // Design §11 approves only two Postgres numbers. Reporting the other three as
+    // "pass" would manufacture approval nobody gave.
+    const report = checkBrowseBudgets({ "content-contains": [900] }, POSTGRES_BROWSE_BUDGETS_MS)
+    expect(report.rows[0]?.status).toBe("unbudgeted")
+    expect(report.ok).toBe(true)
+  })
+})

--- a/packages/testing/src/memory-conformance.ts
+++ b/packages/testing/src/memory-conformance.ts
@@ -508,6 +508,58 @@ export function runMemoryStoreConformance(opts: {
         await close?.(s)
       }
     })
+    test("browse returns identical ordered ids for a composed filter on every backend", async () => {
+      const s = await makeStore()
+      try {
+        for (let index = 0; index < 40; index += 1) {
+          await s.put(
+            rec({
+              id: `cmp-${String(index).padStart(3, "0")}`,
+              kind: index % 2 === 0 ? "semantic" : "episodic",
+              namespace: index % 5 === 0 ? "route=/a-archive" : "route=/a",
+              content: index % 3 === 0 ? "needle body" : "filler body",
+              confidence: (index % 4) / 4,
+              status: index % 3 === 0 ? "active" : "candidate",
+              // Ten records per stamp so the id tie-break decides order INSIDE the
+              // window, not only at a page seam this single window never reaches.
+              updatedAt: new Date(
+                Date.UTC(2026, 0, 1) + Math.floor(index / 10) * 60_000,
+              ).toISOString(),
+            }),
+          )
+        }
+        const page = await s.browse({
+          namespace: "route=/a",
+          limit: 10,
+          filters: [
+            { field: "status", op: "in", values: ["active"] },
+            { field: "kind", op: "in", values: ["semantic"] },
+            { field: "content", op: "contains", value: "needle" },
+          ],
+          orderBy: [{ field: "updatedAt", dir: "desc" }],
+        })
+        // Byte-exact expectation, computed the way both stores must compute it: no
+        // archive rows, active ∧ semantic ∧ needle, updatedAt DESC then id ASC.
+        //
+        // The survivors are the indices divisible by 6 — `% 2` picks semantic and
+        // `% 3` picks active-and-needle together — minus those divisible by 5, which
+        // the exact `namespace` puts in the archive: 6, 12, 18, 24, 36. Two of them
+        // (12 and 18) share a minute stamp, so their relative order is decided by the
+        // id terminator rather than by the sort key — which is the half of this a
+        // backend can silently get wrong while looking right.
+        expect(page.records.map((record) => record.id)).toEqual([
+          "cmp-036",
+          "cmp-024",
+          "cmp-012",
+          "cmp-018",
+          "cmp-006",
+        ])
+        expect(page.total).toBe(5)
+        expect(page.continuation).toBeNull()
+      } finally {
+        await close?.(s)
+      }
+    })
     test("browse content filters are case-insensitive substring matches, not LIKE patterns", async () => {
       const s = await makeStore()
       try {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,7 +78,7 @@ importers:
         version: 4.0.3
       next:
         specifier: 16.3.0
-        version: 16.3.0(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        version: 16.3.0(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.1.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       react:
         specifier: 19.2.8
         version: 19.2.8
@@ -185,7 +185,7 @@ importers:
         version: 1.66.4(@anthropic-ai/sdk@0.115.0(zod@4.4.3))(@cfworker/json-schema@4.1.1)(@langchain/core@1.2.5(@opentelemetry/api@1.9.1)(openai@6.45.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0))(@langchain/langgraph-sdk@1.9.28(@langchain/core@1.2.5(@opentelemetry/api@1.9.1)(openai@6.45.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@langchain/openai@1.5.6(@langchain/core@1.2.5(@opentelemetry/api@1.9.1)(openai@6.45.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0))(ws@8.21.0))(@opentelemetry/api@1.9.1)(@types/express@5.0.6)(langchain@1.5.2(@langchain/core@1.2.5(@opentelemetry/api@1.9.1)(openai@6.45.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0))(@opentelemetry/api@1.9.1)(openai@6.45.0(ws@8.21.0)(zod@4.4.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(ws@8.21.0))(openai@6.45.0(ws@8.21.0)(zod@4.4.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10)
       next:
         specifier: 16.3.0
-        version: 16.3.0(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        version: 16.3.0(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.1.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       react:
         specifier: 19.2.8
         version: 19.2.8
@@ -305,7 +305,7 @@ importers:
         version: link:../../../packages/ag-ui
       next:
         specifier: 16.3.0
-        version: 16.3.0(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        version: 16.3.0(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.1.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       react:
         specifier: 19.2.8
         version: 19.2.8
@@ -555,7 +555,7 @@ importers:
         version: 0.7.1
       next:
         specifier: 16.3.0
-        version: 16.3.0(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        version: 16.3.0(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.1.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       react:
         specifier: 19.2.8
         version: 19.2.8
@@ -569,6 +569,9 @@ importers:
       '@dawn-ai/config-typescript':
         specifier: workspace:*
         version: link:../config-typescript
+      '@playwright/test':
+        specifier: 1.62.1
+        version: 1.62.1
       '@tailwindcss/postcss':
         specifier: ^4.3.3
         version: 4.3.3
@@ -3006,6 +3009,11 @@ packages:
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
+
+  '@playwright/test@1.62.1':
+    resolution: {integrity: sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
@@ -5794,6 +5802,11 @@ packages:
     resolution: {integrity: sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==}
     engines: {node: '>=6 <7 || >=8'}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -7476,6 +7489,16 @@ packages:
   pkce-challenge@5.0.1:
     resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
     engines: {node: '>=16.20.0'}
+
+  playwright-core@1.62.1:
+    resolution: {integrity: sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==}
+    engines: {node: '>=20'}
+    hasBin: true
+
+  playwright@1.62.1:
+    resolution: {integrity: sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   points-on-curve@0.2.0:
     resolution: {integrity: sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A==}
@@ -11024,6 +11047,10 @@ snapshots:
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
+  '@playwright/test@1.62.1':
+    dependencies:
+      playwright: 1.62.1
+
   '@polka/url@1.0.0-next.29': {}
 
   '@poppinss/colors@4.1.6':
@@ -14158,6 +14185,9 @@ snapshots:
       jsonfile: 4.0.0
       universalify: 0.1.2
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -15885,7 +15915,7 @@ snapshots:
 
   neo-async@2.6.2: {}
 
-  next@16.3.0(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
+  next@16.3.0(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@26.1.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
     dependencies:
       '@next/env': 16.3.0
       '@swc/helpers': 0.5.15
@@ -15905,6 +15935,7 @@ snapshots:
       '@next/swc-win32-arm64-msvc': 16.3.0
       '@next/swc-win32-x64-msvc': 16.3.0
       '@opentelemetry/api': 1.9.1
+      '@playwright/test': 1.62.1
       sharp: 0.35.3(@types/node@26.1.2)
     transitivePeerDependencies:
       - '@babel/core'
@@ -16252,6 +16283,14 @@ snapshots:
       thread-stream: 3.2.0
 
   pkce-challenge@5.0.1: {}
+
+  playwright-core@1.62.1: {}
+
+  playwright@1.62.1:
+    dependencies:
+      playwright-core: 1.62.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   points-on-curve@0.2.0: {}
 

--- a/scripts/release/test/fixtures/workflow-entrypoints.json
+++ b/scripts/release/test/fixtures/workflow-entrypoints.json
@@ -297,7 +297,7 @@
           "id": "inspector-e2e",
           "descriptor": {
             "runs-on": "ubuntu-latest",
-            "timeout-minutes": 20
+            "timeout-minutes": 35
           },
           "steps": [
             {
@@ -347,6 +347,33 @@
               "descriptor": {
                 "name": "Inspector standalone e2e",
                 "run": "DAWN_TEST_INSPECTOR=1 pnpm --filter @dawn-ai/inspector test"
+              }
+            },
+            {
+              "classification": "safe",
+              "descriptor": {
+                "name": "Install Playwright browsers",
+                "run": "pnpm --filter @dawn-ai/inspector exec playwright install --with-deps chromium"
+              }
+            },
+            {
+              "classification": "safe",
+              "descriptor": {
+                "name": "Inspector browser verification",
+                "run": "pnpm --filter @dawn-ai/inspector test:e2e"
+              }
+            },
+            {
+              "classification": "safe",
+              "descriptor": {
+                "name": "Upload Playwright traces",
+                "if": "failure()",
+                "uses": "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a",
+                "with": {
+                  "name": "inspector-playwright-traces",
+                  "path": "packages/inspector/test-results",
+                  "retention-days": 7
+                }
               }
             }
           ]

--- a/scripts/release/test/fixtures/workflow-safe-executables.json
+++ b/scripts/release/test/fixtures/workflow-safe-executables.json
@@ -574,6 +574,30 @@
       },
       {
         "classification": "safe",
+        "job": "inspector-e2e",
+        "stepIndex": 6,
+        "step": "Install Playwright browsers",
+        "kind": "run",
+        "value": "pnpm --filter @dawn-ai/inspector exec playwright install --with-deps chromium"
+      },
+      {
+        "classification": "safe",
+        "job": "inspector-e2e",
+        "stepIndex": 7,
+        "step": "Inspector browser verification",
+        "kind": "run",
+        "value": "pnpm --filter @dawn-ai/inspector test:e2e"
+      },
+      {
+        "classification": "safe",
+        "job": "inspector-e2e",
+        "stepIndex": 8,
+        "step": "Upload Playwright traces",
+        "kind": "step-uses",
+        "value": "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a"
+      },
+      {
+        "classification": "safe",
         "job": "chart-validate",
         "stepIndex": 0,
         "step": "Checkout",


### PR DESCRIPTION
## Verification hardening — prove the design's claims, or find out they are wrong

Slice 5, the last one. Slices 1–4 built the behavior; this proves it, and the
proving found real defects.

### What it adds

A deterministic 1 250-record fixture with computed expectations, a Playwright
lane, a pinned DOM contract, the **fourteen dogfood acceptance scenarios** from
the design as named specs, four accessibility suites (counts and positions, the
announcement single-channel rules, focus continuity, and a keyboard-only
walkthrough with no pointer events at all), bulk-safety and polling-identity
coverage, and measured server budgets with a `--assert` mode.

### Measured, not assumed

Server budgets ran against the real store. The first ten runs showed a **21×
swing on identical SQL** with the failing shape migrating randomly between four
queries — preemption on a loaded box, not a plan regression — so rather than
record a pass or a fail from noise, the measurement polled for a quiet window
and took three consecutive runs there. Numbers and method are in the budget
ledger.

### Defects this slice found in its own work

- **A fixture assertion that could not fail.** The seed's `id` tie-break was
  unobservable: `browseSeedRecords()` emits ids ascending and V8's sort is
  stable, so ties kept insertion order — which *is* id-ascending — whether or
  not the terminator existed. Proven by mutation and a seven-sort probe. Every
  downstream expectation inherited an ordering that was correct by accident.
- **A test passing on leaked DOM.** This project has no RTL auto-cleanup
  (`globals` is off), so a test without `cleanup()` read the previous test's
  tree. In isolation it failed outright.
- **A bulk-safety property that was not actually pinned.** Deleting the engine
  prune left the suite green while the grid would paint three already-forgotten
  rows as ticked and the bar read "1 selected". The existing assertion could not
  see it — only a *succeeded* row's checkbox discriminates. Now pinned, and the
  mutation reddens.
- **A comment describing a mechanism that does not occur.** It claimed an
  unpruned engine would "re-arm the bar" on the next answer. It does not:
  `onRowSelectionChange` fires only when the selection changes, and a refresh at
  an unchanged `datasetKey` never re-emits — verified across five landed
  responses. The hazard is a silent divergence, which is what the new assertion
  catches.
- **A wait that gated on the wrong event** — counted requests issued, not
  answers landed.

### Owed by a human

**Task 14, the recorded VoiceOver pass, is not done and was not faked.** It needs
someone who can enable VoiceOver and hear speech. The agent assigned it refused
to manufacture utterances and audited the script instead — finding that its first
two stops expected `row 3 of 1251` and forbade `row 3 of 200`, when the unscoped
landing view is *grouped* and therefore correctly publishes ~204 (design §4.5
downgrades the rowcount under grouping). Anyone running it as written would have
logged two failures against correct code. Script corrected in pretable#323.

### Verification

`@dawn-ai/inspector`: 26 files, 345 passed, 29 skipped (pre-existing gated e2e).
Playwright lane green. Typecheck and biome clean. Rebased onto current main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
