### PR TITLE
test(cli): count the benign Vercel marker per log row, not per row version

### DIFF
--- a/packages/cli/test/helpers/vercel-native-fixture.ts
+++ b/packages/cli/test/helpers/vercel-native-fixture.ts
@@ -4445,6 +4445,12 @@ export async function pollNativeVercelRuntimeLogs(options: {
   const queryStartIso = queryStartDate.toISOString()
   const overallStartMs = nativeClockNow(options.clock, "native Vercel log polling clock")
   const seenVersions = new Set<string>()
+  // Keyed by row id, NOT by row version. Vercel rewrites a request row after the
+  // invocation returns -- responseStatusCode 0 -> 200, cache "" -> "MISS" -- so the
+  // same log event arrives again under a new fingerprint. Summing across versions
+  // counted that one event twice and failed a healthy deployment purely on whether a
+  // poll landed before the row settled.
+  const markerOccurrencesByRow = new Map<string, number>()
   let markerOccurrences = 0
   let quietSinceMs: number | undefined
 
@@ -4491,9 +4497,19 @@ export async function pollNativeVercelRuntimeLogs(options: {
       const identity = `${version.id}\0${version.fingerprint}`
       if (seenVersions.has(identity)) continue
       seenVersions.add(identity)
-      markerOccurrences += version.markerOccurrences
+      // Max, not sum: a later version of the same row reports the same occurrence.
+      // A row that genuinely carries the marker twice still reports 2, and a second
+      // marker-bearing row has its own id, so both real violations still trip below.
+      markerOccurrencesByRow.set(
+        version.id,
+        Math.max(markerOccurrencesByRow.get(version.id) ?? 0, version.markerOccurrences),
+      )
       newVersions += 1
     }
+    markerOccurrences = [...markerOccurrencesByRow.values()].reduce(
+      (total, count) => total + count,
+      0,
+    )
     if (markerOccurrences > 1) {
       throw new Error("native Vercel logs contain more than one benign marker occurrence")
     }

--- a/packages/cli/test/vercel-native-lane.test.ts
+++ b/packages/cli/test/vercel-native-lane.test.ts
@@ -5293,6 +5293,43 @@ describe("runtime log scan", () => {
     })
   })
 
+  // Vercel finalizes a request row AFTER the invocation returns: responseStatusCode
+  // goes 0 -> 200 and cache "" -> "MISS". That rewrite is a new fingerprint for the
+  // SAME row id, and when the row carries the marker it used to be counted twice,
+  // failing a healthy deployment purely on poll timing. The sibling test above
+  // mutates a row too, but only a marker-less one, so it never caught this.
+  test("counts one marker row across the versions Vercel writes as a request settles", async () => {
+    const startMs = 1_800_000_000_000
+    let current = startMs
+    const clock = {
+      now: () => current,
+      sleep: async (milliseconds: number) => {
+        current += milliseconds
+      },
+    }
+    const inFlight = validLogRow({ cache: "", id: "request-marker", responseStatusCode: 0 })
+    const settled = validLogRow({ cache: "MISS", id: "request-marker", responseStatusCode: 200 })
+    const result = await pollNativeVercelRuntimeLogs({
+      clock,
+      deploymentId,
+      logBoundary: {
+        logs: async () => {
+          const elapsed = current - startMs
+          if (elapsed < 4_000) return ""
+          return `${JSON.stringify(elapsed < 10_000 ? inFlight : settled)}\n`
+        },
+      },
+      logMarker,
+      orgId: "team_Test123",
+      projectId,
+      queryStartMs: startMs,
+    })
+    // Both versions are still reported as distinct row versions -- the quiet-interval
+    // logic depends on seeing them -- but they are ONE marker occurrence.
+    expect(result.markerOccurrences).toBe(1)
+    expect(result.uniqueRowVersions).toBe(2)
+  })
+
   test("rejects duplicate marker versions, child failure, and the 180-second deadline", async () => {
     const startMs = 1_800_000_000_000
     const base = {
@@ -5374,10 +5411,18 @@ describe("runtime log scan", () => {
     expect(calls).toBe(2)
   })
 
+  // A later version of one row is the same request re-reported, so a benign rewrite
+  // must NOT count twice (see the settling test above). What must still reject is a
+  // genuine second occurrence: the row's own logs growing to carry the marker twice.
   test("counts a changed version of the same marker row and rejects the second occurrence", async () => {
     const startMs = 1_800_000_000_000
     let current = startMs
     let calls = 0
+    const markerEntry = (version: number) => ({
+      level: "info",
+      message: `dawn-vercel-fixture-log ${logMarker}`,
+      context: { version },
+    })
     await expect(
       pollNativeVercelRuntimeLogs({
         clock: {
@@ -5392,13 +5437,7 @@ describe("runtime log scan", () => {
             calls += 1
             return `${JSON.stringify(
               validLogRow({
-                logs: [
-                  {
-                    level: "info",
-                    message: `dawn-vercel-fixture-log ${logMarker}`,
-                    context: { version: calls },
-                  },
-                ],
+                logs: calls === 1 ? [markerEntry(1)] : [markerEntry(1), markerEntry(2)],
               }),
             )}\n`
           },


### PR DESCRIPTION
## Summary

The `vercel-native` lane fails intermittently with `native Vercel logs contain more than one benign marker occurrence` — on `main` itself (run 31602459050) and on unrelated branches, while passing on others. It was never the branch under test.

**Vercel finalizes a request row after the invocation returns.** Taken from the failing run's own `vercel-native-diagnostics` artifact, the marker-bearing row `nk5jj-…` arrives twice under one id with different content:

| field | first poll | second poll |
|---|---|---|
| `responseStatusCode` | `0` | `200` |
| `cache` | `""` | `"MISS"` |

`pollNativeVercelRuntimeLogs` deduplicated on `id + sha256(canonicalized row)`, so the settled row was a **new version** and its marker was counted again: `1 + 1 = 2`, tripping the `> 1` guard.

Replaying the captured snapshots through the real counting algorithm shows the counter is the only thing wrong:

```
snapshot1 snapshotMarkerOccurrences = 1   (nk5jj, status 0)
snapshot2 snapshotMarkerOccurrences = 1   (nk5jj, status 200)
cumulative                          = 2   -> throws
```

Each snapshot is healthy. A healthy deployment failed purely on whether a poll landed before the row settled — that is the whole flake, and it explains the intermittency exactly.

## The fix

Count marker occurrences **per row id**, taking the max across that row's versions, instead of summing across versions. Both genuine violations still reject:

- a **second marker-bearing row** has its own id, so the total is still 2
- a **row whose own logs carry the marker twice** reports 2 for that id

Max rather than latest, so a later version that dropped the marker could not erase the evidence.

Row versions are still tracked by fingerprint. The quiet-interval logic depends on seeing them — the loop was *already* built to wait out these rewrites via `newVersions === 0`, which is why only the marker counter needed changing. The bug was that the fatal check fired on the very mutation the loop exists to absorb.

## Why the suite missed it

It mutated rows, and it asserted on markers, but never both on the same row. The polling test freezes its marker row at `responseStatusCode: 0` and mutates a marker-less `otherRow` instead, so the gap was invisible.

Two test changes:

- **New:** `counts one marker row across the versions Vercel writes as a request settles` — replays the captured `0 → 200` / `"" → "MISS"` settle. It fails on the pre-fix code with the exact production error.
- **Changed:** `counts a changed version of the same marker row and rejects the second occurrence` asserted that *any* rewrite of the marker row is fatal — the bug stated as a requirement. It now grows the row's own logs to carry the marker twice, so it still guards a real second occurrence rather than a benign metadata rewrite.

## Validation

- New test verified **red before the fix** (exact error: `native Vercel logs contain more than one benign marker occurrence`) and green after — a real red-green cycle, not a test written after the fact.
- `vercel-native-lane.test.ts` — **291 passed, 1 skipped, exit 0** (the skip is the live-deployment test, which needs Vercel credentials).
- `pnpm typecheck` — **26/26 successful, exit 0** after a clean `pnpm install` + `pnpm build`.
- `biome check` on both changed files — exit 0.

Note this change is in the test lane itself, so the honest end-to-end proof is the `vercel-native` job passing here and staying green on subsequent runs.

- [x] `pnpm lint` (biome, changed files)
- [x] `pnpm build`
- [x] `pnpm typecheck`
- [x] `pnpm test` (the affected suite)
- [ ] `node scripts/check-docs.mjs` — not run locally; no docs touched
- [ ] `pnpm pack:check` — not run locally; test-only change ships nothing
- [x] Harness verification — n/a, no runtime behavior changed

## Release Notes

- [x] Not needed. Test-only (`packages/cli/test/`); the changesets gate covers `packages/*/src/` and READMEs.

## Checklist

- [x] I read `CONTRIBUTING.md`.
- [x] I followed `CODE_OF_CONDUCT.md`.
- [x] I did not include secrets, credentials, or private data.
- [x] I am not disclosing a security vulnerability publicly.
