### PR TITLE
chore(deps): bump five pinned actions and re-audit every pin site

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
@@ -34,7 +34,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
@@ -42,7 +42,7 @@ jobs:
           version: 10.33.0
 
       - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           # Node 24 — Dawn's floor is the active LTS line (node:sqlite
           # unflagged, npm >= 11 bundled). Matches release.yml and engines.
@@ -116,7 +116,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
@@ -124,7 +124,7 @@ jobs:
           version: 10.33.0
 
       - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24.17.0
           cache: pnpm
@@ -148,7 +148,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
@@ -156,7 +156,7 @@ jobs:
           version: 10.33.0
 
       - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           # Node 24 — Dawn's floor is the active LTS line (node:sqlite
           # unflagged, npm >= 11 bundled). Matches release.yml and engines.
@@ -181,7 +181,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
@@ -189,7 +189,7 @@ jobs:
           version: 10.33.0
 
       - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           # Node 24 — Dawn's floor is the active LTS line (node:sqlite
           # unflagged, npm >= 11 bundled). Matches release.yml and engines.
@@ -218,7 +218,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
@@ -226,7 +226,7 @@ jobs:
           version: 10.33.0
 
       - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           # Node 24 — Dawn's floor is the active LTS line (node:sqlite
           # unflagged, npm >= 11 bundled). Matches release.yml and engines.
@@ -273,7 +273,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
@@ -281,7 +281,7 @@ jobs:
           version: 10.33.0
 
       - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           # Node 24 — Dawn's floor is the active LTS line (node:sqlite
           # unflagged, npm >= 11 bundled). Matches release.yml and engines.
@@ -355,7 +355,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
@@ -363,7 +363,7 @@ jobs:
           version: 10.33.0
 
       - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24.17.0
           cache: pnpm
@@ -436,7 +436,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
@@ -444,7 +444,7 @@ jobs:
           version: 10.33.0
 
       - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           # Node 24 — Dawn's floor is the active LTS line (node:sqlite
           # unflagged, npm >= 11 bundled). Matches release.yml and engines.
@@ -491,7 +491,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Helm
         uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
@@ -552,7 +552,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
@@ -560,7 +560,7 @@ jobs:
           version: 10.33.0
 
       - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           # Node 24 — Dawn's floor is the active LTS line (node:sqlite
           # unflagged, npm >= 11 bundled). Matches release.yml and engines.
@@ -631,7 +631,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
@@ -639,7 +639,7 @@ jobs:
           version: 10.33.0
 
       - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           # Node 24 — Dawn's floor is the active LTS line (node:sqlite
           # unflagged, npm >= 11 bundled). Matches release.yml and engines.
@@ -760,7 +760,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
@@ -768,7 +768,7 @@ jobs:
           version: 10.33.0
 
       - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           # Node 24 — Dawn's floor is the active LTS line (node:sqlite
           # unflagged, npm >= 11 bundled). Matches release.yml and engines.
@@ -833,7 +833,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Helm
         uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -41,7 +41,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 1
 
@@ -100,7 +100,7 @@ jobs:
       - name: Claude review
         id: claude
         if: steps.preflight.outputs.skip != 'true'
-        uses: anthropics/claude-code-action@e90deca47693f9457b72f2b53c17d7c445a87342 # v1
+        uses: anthropics/claude-code-action@1623c36729ac1cd5895198cded705a287de7db79 # v1
         with:
           # Pass GITHUB_TOKEN explicitly (maps to OVERRIDE_GITHUB_TOKEN) so the
           # action skips OIDC token exchange — that path needs `id-token: write`

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -25,15 +25,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4
+        uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4
         with:
           languages: javascript-typescript
           build-mode: none
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4
+        uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4
         with:
           category: "/language:javascript-typescript"

--- a/.github/workflows/publish-chart.yml
+++ b/.github/workflows/publish-chart.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Helm
         uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1

--- a/.github/workflows/published-artifact-verify.yml
+++ b/.github/workflows/published-artifact-verify.yml
@@ -42,7 +42,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
@@ -50,7 +50,7 @@ jobs:
           version: 10.33.0
 
       - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24.17.0
           cache: pnpm

--- a/.github/workflows/release-shadow.yml
+++ b/.github/workflows/release-shadow.yml
@@ -24,7 +24,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           fetch-depth: 0
           ref: main
@@ -36,7 +36,7 @@ jobs:
           version: 10.33.0
 
       - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
         with:
           node-version: "24.17.0"
           cache: pnpm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
@@ -37,7 +37,7 @@ jobs:
       # active LTS line (node:sqlite unflagged, npm >= 11 bundled). Publishing
       # uses the same major below.
       - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24.17.0
           cache: pnpm
@@ -53,7 +53,7 @@ jobs:
       # removes the one unpinnable npmCommand and keeps OSSF Pinned-Dependencies
       # clean. registry-url here writes the publish .npmrc for trusted publishing.
       - name: Setup Node.js for publishing
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24.17.0
           registry-url: https://registry.npmjs.org

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -23,18 +23,18 @@ jobs:
       security-events: write
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
       - name: Run Scorecard
-        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        uses: ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc # v2.4.4
         with:
           results_file: scorecard.sarif
           results_format: sarif
           publish_results: true
 
       - name: Upload SARIF
-        uses: github/codeql-action/upload-sarif@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4
+        uses: github/codeql-action/upload-sarif@5595ccaf912efad79be6eef63a5619ff05969be3 # v4
         with:
           sarif_file: scorecard.sarif

--- a/packages/sandbox/test/ci-workflow-pins.test.ts
+++ b/packages/sandbox/test/ci-workflow-pins.test.ts
@@ -7,9 +7,9 @@ const approvedKindNodeImage =
   "kindest/node:v1.35.0@sha256:4613778f3cfcd10e615029370f5786704559103cf27bef934597ba562b269661"
 const approvedReaperImage =
   "docker.io/alpine/k8s:1.35.6@sha256:b7a12c5ddf261994c33d2eaaa06fd69a0803ff6b38683bfa3d30a76dcdf92807"
-const checkoutAction = "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"
+const checkoutAction = "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1"
 const pnpmSetupAction = "pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271"
-const nodeSetupAction = "actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e"
+const nodeSetupAction = "actions/setup-node@820762786026740c76f36085b0efc47a31fe5020"
 const uploadArtifactAction = "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a"
 
 function githubExpression(expression: string): string {

--- a/scripts/release/preflight.mjs
+++ b/scripts/release/preflight.mjs
@@ -42,7 +42,7 @@ const EXPECTED_RELEASE_WORKFLOW = {
       steps: [
         {
           name: "Checkout",
-          uses: "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0",
+          uses: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1",
           with: { "fetch-depth": 0 },
         },
         {
@@ -52,14 +52,14 @@ const EXPECTED_RELEASE_WORKFLOW = {
         },
         {
           name: "Setup Node.js",
-          uses: "actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e",
+          uses: "actions/setup-node@820762786026740c76f36085b0efc47a31fe5020",
           with: { "node-version": "24.17.0", cache: "pnpm" },
         },
         { name: "Install", run: "pnpm install --frozen-lockfile" },
         { name: "Validate Release Candidate", run: "pnpm ci:validate" },
         {
           name: "Setup Node.js for publishing",
-          uses: "actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e",
+          uses: "actions/setup-node@820762786026740c76f36085b0efc47a31fe5020",
           with: {
             "node-version": "24.17.0",
             "registry-url": "https://registry.npmjs.org",

--- a/scripts/release/test/fixtures/workflow-entrypoints.json
+++ b/scripts/release/test/fixtures/workflow-entrypoints.json
@@ -71,7 +71,7 @@
               "classification": "safe",
               "descriptor": {
                 "name": "Checkout",
-                "uses": "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0",
+                "uses": "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1",
                 "with": {
                   "fetch-depth": 0
                 }
@@ -103,7 +103,7 @@
               "classification": "safe",
               "descriptor": {
                 "name": "Checkout",
-                "uses": "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"
+                "uses": "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1"
               }
             },
             {
@@ -144,7 +144,7 @@
               "classification": "safe",
               "descriptor": {
                 "name": "Checkout",
-                "uses": "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"
+                "uses": "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1"
               }
             },
             {
@@ -238,7 +238,7 @@
               "classification": "safe",
               "descriptor": {
                 "name": "Checkout",
-                "uses": "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"
+                "uses": "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1"
               }
             },
             {
@@ -255,7 +255,7 @@
               "classification": "safe",
               "descriptor": {
                 "name": "Setup Node.js",
-                "uses": "actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e",
+                "uses": "actions/setup-node@820762786026740c76f36085b0efc47a31fe5020",
                 "with": {
                   "node-version": "24.17.0",
                   "cache": "pnpm"
@@ -304,7 +304,7 @@
               "classification": "safe",
               "descriptor": {
                 "name": "Checkout",
-                "uses": "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"
+                "uses": "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1"
               }
             },
             {
@@ -321,7 +321,7 @@
               "classification": "safe",
               "descriptor": {
                 "name": "Setup Node.js",
-                "uses": "actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e",
+                "uses": "actions/setup-node@820762786026740c76f36085b0efc47a31fe5020",
                 "with": {
                   "node-version": "24.17.0",
                   "cache": "pnpm"
@@ -390,7 +390,7 @@
               "classification": "safe",
               "descriptor": {
                 "name": "Checkout",
-                "uses": "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"
+                "uses": "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1"
               }
             },
             {
@@ -407,7 +407,7 @@
               "classification": "safe",
               "descriptor": {
                 "name": "Setup Node.js",
-                "uses": "actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e",
+                "uses": "actions/setup-node@820762786026740c76f36085b0efc47a31fe5020",
                 "with": {
                   "node-version": "24.17.0",
                   "cache": "pnpm"
@@ -449,7 +449,7 @@
               "classification": "safe",
               "descriptor": {
                 "name": "Checkout",
-                "uses": "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"
+                "uses": "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1"
               }
             },
             {
@@ -466,7 +466,7 @@
               "classification": "safe",
               "descriptor": {
                 "name": "Setup Node.js",
-                "uses": "actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e",
+                "uses": "actions/setup-node@820762786026740c76f36085b0efc47a31fe5020",
                 "with": {
                   "node-version": "24.17.0",
                   "cache": "pnpm"
@@ -515,7 +515,7 @@
               "classification": "safe",
               "descriptor": {
                 "name": "Checkout",
-                "uses": "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"
+                "uses": "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1"
               }
             },
             {
@@ -532,7 +532,7 @@
               "classification": "safe",
               "descriptor": {
                 "name": "Setup Node.js",
-                "uses": "actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e",
+                "uses": "actions/setup-node@820762786026740c76f36085b0efc47a31fe5020",
                 "with": {
                   "node-version": "24.17.0",
                   "cache": "pnpm"
@@ -584,7 +584,7 @@
               "classification": "safe",
               "descriptor": {
                 "name": "Checkout",
-                "uses": "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"
+                "uses": "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1"
               }
             },
             {
@@ -601,7 +601,7 @@
               "classification": "safe",
               "descriptor": {
                 "name": "Setup Node.js",
-                "uses": "actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e",
+                "uses": "actions/setup-node@820762786026740c76f36085b0efc47a31fe5020",
                 "with": {
                   "node-version": "24.17.0",
                   "cache": "pnpm"
@@ -665,7 +665,7 @@
               "classification": "safe",
               "descriptor": {
                 "name": "Checkout",
-                "uses": "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"
+                "uses": "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1"
               }
             },
             {
@@ -682,7 +682,7 @@
               "classification": "safe",
               "descriptor": {
                 "name": "Setup Node.js",
-                "uses": "actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e",
+                "uses": "actions/setup-node@820762786026740c76f36085b0efc47a31fe5020",
                 "with": {
                   "node-version": "24.17.0",
                   "cache": "pnpm"
@@ -784,7 +784,7 @@
               "classification": "safe",
               "descriptor": {
                 "name": "Checkout",
-                "uses": "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"
+                "uses": "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1"
               }
             },
             {
@@ -801,7 +801,7 @@
               "classification": "safe",
               "descriptor": {
                 "name": "Setup Node.js",
-                "uses": "actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e",
+                "uses": "actions/setup-node@820762786026740c76f36085b0efc47a31fe5020",
                 "with": {
                   "node-version": "24.17.0",
                   "cache": "pnpm"
@@ -926,7 +926,7 @@
               "classification": "safe",
               "descriptor": {
                 "name": "Checkout",
-                "uses": "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"
+                "uses": "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1"
               }
             },
             {
@@ -943,7 +943,7 @@
               "classification": "safe",
               "descriptor": {
                 "name": "Setup Node.js",
-                "uses": "actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e",
+                "uses": "actions/setup-node@820762786026740c76f36085b0efc47a31fe5020",
                 "with": {
                   "node-version": "24.17.0",
                   "cache": "pnpm"
@@ -985,7 +985,7 @@
               "classification": "safe",
               "descriptor": {
                 "name": "Checkout",
-                "uses": "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"
+                "uses": "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1"
               }
             },
             {
@@ -1002,7 +1002,7 @@
               "classification": "safe",
               "descriptor": {
                 "name": "Setup Node.js",
-                "uses": "actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e",
+                "uses": "actions/setup-node@820762786026740c76f36085b0efc47a31fe5020",
                 "with": {
                   "node-version": "24.17.0",
                   "cache": "pnpm"
@@ -1146,7 +1146,7 @@
               "classification": "safe",
               "descriptor": {
                 "name": "Checkout",
-                "uses": "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"
+                "uses": "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1"
               }
             },
             {
@@ -1163,7 +1163,7 @@
               "classification": "safe",
               "descriptor": {
                 "name": "Setup Node.js",
-                "uses": "actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e",
+                "uses": "actions/setup-node@820762786026740c76f36085b0efc47a31fe5020",
                 "with": {
                   "node-version": "24.17.0",
                   "cache": "pnpm"
@@ -1298,7 +1298,7 @@
               "classification": "safe",
               "descriptor": {
                 "name": "Checkout",
-                "uses": "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0",
+                "uses": "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1",
                 "with": {
                   "fetch-depth": 1
                 }
@@ -1322,7 +1322,7 @@
                 "name": "Claude review",
                 "id": "claude",
                 "if": "steps.preflight.outputs.skip != 'true'",
-                "uses": "anthropics/claude-code-action@e90deca47693f9457b72f2b53c17d7c445a87342",
+                "uses": "anthropics/claude-code-action@1623c36729ac1cd5895198cded705a287de7db79",
                 "with": {
                   "github_token": "${{ secrets.GITHUB_TOKEN }}",
                   "anthropic_api_key": "${{ secrets.ANTHROPIC_API_KEY }}",
@@ -1387,14 +1387,14 @@
               "classification": "safe",
               "descriptor": {
                 "name": "Checkout",
-                "uses": "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"
+                "uses": "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1"
               }
             },
             {
               "classification": "safe",
               "descriptor": {
                 "name": "Initialize CodeQL",
-                "uses": "github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9",
+                "uses": "github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3",
                 "with": {
                   "languages": "javascript-typescript",
                   "build-mode": "none"
@@ -1405,7 +1405,7 @@
               "classification": "safe",
               "descriptor": {
                 "name": "Perform CodeQL Analysis",
-                "uses": "github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9",
+                "uses": "github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3",
                 "with": {
                   "category": "/language:javascript-typescript"
                 }
@@ -1448,7 +1448,7 @@
               "classification": "safe",
               "descriptor": {
                 "name": "Checkout",
-                "uses": "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"
+                "uses": "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1"
               }
             },
             {
@@ -1537,7 +1537,7 @@
               "classification": "safe",
               "descriptor": {
                 "name": "Checkout",
-                "uses": "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"
+                "uses": "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1"
               }
             },
             {
@@ -1554,7 +1554,7 @@
               "classification": "safe",
               "descriptor": {
                 "name": "Setup Node.js",
-                "uses": "actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e",
+                "uses": "actions/setup-node@820762786026740c76f36085b0efc47a31fe5020",
                 "with": {
                   "node-version": "24.17.0",
                   "cache": "pnpm"
@@ -1643,7 +1643,7 @@
               "classification": "safe",
               "descriptor": {
                 "name": "Checkout",
-                "uses": "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0",
+                "uses": "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1",
                 "with": {
                   "fetch-depth": 0,
                   "ref": "main",
@@ -1665,7 +1665,7 @@
               "classification": "safe",
               "descriptor": {
                 "name": "Setup Node.js",
-                "uses": "actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e",
+                "uses": "actions/setup-node@820762786026740c76f36085b0efc47a31fe5020",
                 "with": {
                   "node-version": "24.17.0",
                   "cache": "pnpm"
@@ -1749,7 +1749,7 @@
               "classification": "safe",
               "descriptor": {
                 "name": "Checkout",
-                "uses": "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0",
+                "uses": "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1",
                 "with": {
                   "fetch-depth": 0
                 }
@@ -1769,7 +1769,7 @@
               "classification": "safe",
               "descriptor": {
                 "name": "Setup Node.js",
-                "uses": "actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e",
+                "uses": "actions/setup-node@820762786026740c76f36085b0efc47a31fe5020",
                 "with": {
                   "node-version": "24.17.0",
                   "cache": "pnpm"
@@ -1794,7 +1794,7 @@
               "classification": "safe",
               "descriptor": {
                 "name": "Setup Node.js for publishing",
-                "uses": "actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e",
+                "uses": "actions/setup-node@820762786026740c76f36085b0efc47a31fe5020",
                 "with": {
                   "node-version": "24.17.0",
                   "registry-url": "https://registry.npmjs.org"
@@ -1937,7 +1937,7 @@
               "classification": "safe",
               "descriptor": {
                 "name": "Checkout",
-                "uses": "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0",
+                "uses": "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1",
                 "with": {
                   "persist-credentials": false
                 }
@@ -1947,7 +1947,7 @@
               "classification": "safe",
               "descriptor": {
                 "name": "Run Scorecard",
-                "uses": "ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a",
+                "uses": "ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc",
                 "with": {
                   "results_file": "scorecard.sarif",
                   "results_format": "sarif",
@@ -1959,7 +1959,7 @@
               "classification": "safe",
               "descriptor": {
                 "name": "Upload SARIF",
-                "uses": "github/codeql-action/upload-sarif@99df26d4f13ea111d4ec1a7dddef6063f76b97e9",
+                "uses": "github/codeql-action/upload-sarif@5595ccaf912efad79be6eef63a5619ff05969be3",
                 "with": {
                   "sarif_file": "scorecard.sarif"
                 }

--- a/scripts/release/test/fixtures/workflow-safe-executables.json
+++ b/scripts/release/test/fixtures/workflow-safe-executables.json
@@ -18,7 +18,7 @@
         "stepIndex": 0,
         "step": "Checkout",
         "kind": "step-uses",
-        "value": "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"
+        "value": "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1"
       },
       {
         "classification": "safe",
@@ -34,7 +34,7 @@
         "stepIndex": 0,
         "step": "Checkout",
         "kind": "step-uses",
-        "value": "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"
+        "value": "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1"
       },
       {
         "classification": "safe",
@@ -50,7 +50,7 @@
         "stepIndex": 2,
         "step": "Setup Node.js",
         "kind": "step-uses",
-        "value": "actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e"
+        "value": "actions/setup-node@820762786026740c76f36085b0efc47a31fe5020"
       },
       {
         "classification": "safe",
@@ -186,7 +186,7 @@
         "stepIndex": 0,
         "step": "Checkout",
         "kind": "step-uses",
-        "value": "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"
+        "value": "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1"
       },
       {
         "classification": "safe",
@@ -202,7 +202,7 @@
         "stepIndex": 2,
         "step": "Setup Node.js",
         "kind": "step-uses",
-        "value": "actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e"
+        "value": "actions/setup-node@820762786026740c76f36085b0efc47a31fe5020"
       },
       {
         "classification": "safe",
@@ -234,7 +234,7 @@
         "stepIndex": 0,
         "step": "Checkout",
         "kind": "step-uses",
-        "value": "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"
+        "value": "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1"
       },
       {
         "classification": "safe",
@@ -250,7 +250,7 @@
         "stepIndex": 2,
         "step": "Setup Node.js",
         "kind": "step-uses",
-        "value": "actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e"
+        "value": "actions/setup-node@820762786026740c76f36085b0efc47a31fe5020"
       },
       {
         "classification": "safe",
@@ -290,7 +290,7 @@
         "stepIndex": 0,
         "step": "Checkout",
         "kind": "step-uses",
-        "value": "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"
+        "value": "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1"
       },
       {
         "classification": "safe",
@@ -306,7 +306,7 @@
         "stepIndex": 2,
         "step": "Setup Node.js",
         "kind": "step-uses",
-        "value": "actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e"
+        "value": "actions/setup-node@820762786026740c76f36085b0efc47a31fe5020"
       },
       {
         "classification": "safe",
@@ -338,7 +338,7 @@
         "stepIndex": 0,
         "step": "Checkout",
         "kind": "step-uses",
-        "value": "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"
+        "value": "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1"
       },
       {
         "classification": "safe",
@@ -354,7 +354,7 @@
         "stepIndex": 2,
         "step": "Setup Node.js",
         "kind": "step-uses",
-        "value": "actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e"
+        "value": "actions/setup-node@820762786026740c76f36085b0efc47a31fe5020"
       },
       {
         "classification": "safe",
@@ -394,7 +394,7 @@
         "stepIndex": 0,
         "step": "Checkout",
         "kind": "step-uses",
-        "value": "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"
+        "value": "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1"
       },
       {
         "classification": "safe",
@@ -410,7 +410,7 @@
         "stepIndex": 2,
         "step": "Setup Node.js",
         "kind": "step-uses",
-        "value": "actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e"
+        "value": "actions/setup-node@820762786026740c76f36085b0efc47a31fe5020"
       },
       {
         "classification": "safe",
@@ -450,7 +450,7 @@
         "stepIndex": 0,
         "step": "Checkout",
         "kind": "step-uses",
-        "value": "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"
+        "value": "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1"
       },
       {
         "classification": "safe",
@@ -466,7 +466,7 @@
         "stepIndex": 2,
         "step": "Setup Node.js",
         "kind": "step-uses",
-        "value": "actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e"
+        "value": "actions/setup-node@820762786026740c76f36085b0efc47a31fe5020"
       },
       {
         "classification": "safe",
@@ -538,7 +538,7 @@
         "stepIndex": 0,
         "step": "Checkout",
         "kind": "step-uses",
-        "value": "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"
+        "value": "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1"
       },
       {
         "classification": "safe",
@@ -554,7 +554,7 @@
         "stepIndex": 2,
         "step": "Setup Node.js",
         "kind": "step-uses",
-        "value": "actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e"
+        "value": "actions/setup-node@820762786026740c76f36085b0efc47a31fe5020"
       },
       {
         "classification": "safe",
@@ -610,7 +610,7 @@
         "stepIndex": 0,
         "step": "Checkout",
         "kind": "step-uses",
-        "value": "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"
+        "value": "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1"
       },
       {
         "classification": "safe",
@@ -706,7 +706,7 @@
         "stepIndex": 0,
         "step": "Checkout",
         "kind": "step-uses",
-        "value": "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"
+        "value": "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1"
       },
       {
         "classification": "safe",
@@ -722,7 +722,7 @@
         "stepIndex": 2,
         "step": "Setup Node.js",
         "kind": "step-uses",
-        "value": "actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e"
+        "value": "actions/setup-node@820762786026740c76f36085b0efc47a31fe5020"
       },
       {
         "classification": "safe",
@@ -810,7 +810,7 @@
         "stepIndex": 0,
         "step": "Checkout",
         "kind": "step-uses",
-        "value": "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"
+        "value": "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1"
       },
       {
         "classification": "safe",
@@ -826,7 +826,7 @@
         "stepIndex": 2,
         "step": "Setup Node.js",
         "kind": "step-uses",
-        "value": "actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e"
+        "value": "actions/setup-node@820762786026740c76f36085b0efc47a31fe5020"
       },
       {
         "classification": "safe",
@@ -946,7 +946,7 @@
         "stepIndex": 0,
         "step": "Checkout",
         "kind": "step-uses",
-        "value": "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"
+        "value": "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1"
       },
       {
         "classification": "safe",
@@ -962,7 +962,7 @@
         "stepIndex": 2,
         "step": "Setup Node.js",
         "kind": "step-uses",
-        "value": "actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e"
+        "value": "actions/setup-node@820762786026740c76f36085b0efc47a31fe5020"
       },
       {
         "classification": "safe",
@@ -1018,7 +1018,7 @@
         "stepIndex": 0,
         "step": "Checkout",
         "kind": "step-uses",
-        "value": "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"
+        "value": "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1"
       },
       {
         "classification": "safe",
@@ -1052,7 +1052,7 @@
         "stepIndex": 0,
         "step": "Checkout",
         "kind": "step-uses",
-        "value": "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"
+        "value": "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1"
       },
       {
         "classification": "safe",
@@ -1068,7 +1068,7 @@
         "stepIndex": 2,
         "step": "Claude review",
         "kind": "step-uses",
-        "value": "anthropics/claude-code-action@e90deca47693f9457b72f2b53c17d7c445a87342"
+        "value": "anthropics/claude-code-action@1623c36729ac1cd5895198cded705a287de7db79"
       },
       {
         "classification": "safe",
@@ -1086,7 +1086,7 @@
         "stepIndex": 0,
         "step": "Checkout",
         "kind": "step-uses",
-        "value": "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"
+        "value": "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1"
       },
       {
         "classification": "safe",
@@ -1094,7 +1094,7 @@
         "stepIndex": 1,
         "step": "Initialize CodeQL",
         "kind": "step-uses",
-        "value": "github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9"
+        "value": "github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3"
       },
       {
         "classification": "safe",
@@ -1102,7 +1102,7 @@
         "stepIndex": 2,
         "step": "Perform CodeQL Analysis",
         "kind": "step-uses",
-        "value": "github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9"
+        "value": "github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3"
       }
     ],
     "publish-chart.yml": [
@@ -1112,7 +1112,7 @@
         "stepIndex": 0,
         "step": "Checkout",
         "kind": "step-uses",
-        "value": "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"
+        "value": "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1"
       },
       {
         "classification": "safe",
@@ -1146,7 +1146,7 @@
         "stepIndex": 0,
         "step": "Checkout",
         "kind": "step-uses",
-        "value": "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"
+        "value": "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1"
       },
       {
         "classification": "safe",
@@ -1162,7 +1162,7 @@
         "stepIndex": 2,
         "step": "Setup Node.js",
         "kind": "step-uses",
-        "value": "actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e"
+        "value": "actions/setup-node@820762786026740c76f36085b0efc47a31fe5020"
       },
       {
         "classification": "safe",
@@ -1204,7 +1204,7 @@
         "stepIndex": 0,
         "step": "Checkout",
         "kind": "step-uses",
-        "value": "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"
+        "value": "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1"
       },
       {
         "classification": "safe",
@@ -1220,7 +1220,7 @@
         "stepIndex": 2,
         "step": "Setup Node.js",
         "kind": "step-uses",
-        "value": "actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e"
+        "value": "actions/setup-node@820762786026740c76f36085b0efc47a31fe5020"
       },
       {
         "classification": "safe",
@@ -1262,7 +1262,7 @@
         "stepIndex": 0,
         "step": "Checkout",
         "kind": "step-uses",
-        "value": "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"
+        "value": "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1"
       },
       {
         "classification": "safe",
@@ -1278,7 +1278,7 @@
         "stepIndex": 2,
         "step": "Setup Node.js",
         "kind": "step-uses",
-        "value": "actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e"
+        "value": "actions/setup-node@820762786026740c76f36085b0efc47a31fe5020"
       },
       {
         "classification": "safe",
@@ -1302,7 +1302,7 @@
         "stepIndex": 5,
         "step": "Setup Node.js for publishing",
         "kind": "step-uses",
-        "value": "actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e"
+        "value": "actions/setup-node@820762786026740c76f36085b0efc47a31fe5020"
       },
       {
         "classification": "publication",
@@ -1384,7 +1384,7 @@
         "stepIndex": 0,
         "step": "Checkout",
         "kind": "step-uses",
-        "value": "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0"
+        "value": "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1"
       },
       {
         "classification": "safe",
@@ -1392,7 +1392,7 @@
         "stepIndex": 1,
         "step": "Run Scorecard",
         "kind": "step-uses",
-        "value": "ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a"
+        "value": "ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc"
       },
       {
         "classification": "safe",
@@ -1400,7 +1400,7 @@
         "stepIndex": 2,
         "step": "Upload SARIF",
         "kind": "step-uses",
-        "value": "github/codeql-action/upload-sarif@99df26d4f13ea111d4ec1a7dddef6063f76b97e9"
+        "value": "github/codeql-action/upload-sarif@5595ccaf912efad79be6eef63a5619ff05969be3"
       }
     ]
   }

--- a/scripts/release/test/preflight.test.mjs
+++ b/scripts/release/test/preflight.test.mjs
@@ -35,7 +35,7 @@ jobs:
       NPM_CONFIG_PROVENANCE: "true"
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           fetch-depth: 0
       - name: Setup pnpm
@@ -43,7 +43,7 @@ jobs:
         with:
           version: 10.33.0
       - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
         with:
           node-version: 24.17.0
           cache: pnpm
@@ -52,7 +52,7 @@ jobs:
       - name: Validate Release Candidate
         run: pnpm ci:validate
       - name: Setup Node.js for publishing
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
         with:
           node-version: 24.17.0
           registry-url: https://registry.npmjs.org

--- a/scripts/release/test/workflow-contracts.test.mjs
+++ b/scripts/release/test/workflow-contracts.test.mjs
@@ -34,8 +34,8 @@ const EXECUTABLE_ALLOWLIST = JSON.parse(
   await readBoundedFixture(EXECUTABLE_ALLOWLIST_PATH, { root: ROOT }),
 )
 const LEGACY_SAFE_ENTRYPOINTS = new Set([
-  "step-uses:actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0",
-  "step-uses:actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e",
+  "step-uses:actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1",
+  "step-uses:actions/setup-node@820762786026740c76f36085b0efc47a31fe5020",
   "step-uses:pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271",
   "run:pnpm install --frozen-lockfile",
   "run:pnpm ci:validate",
@@ -295,7 +295,7 @@ test("testing-windows has one exact safe descriptor and executable classificatio
         classification: "safe",
         descriptor: {
           name: "Checkout",
-          uses: "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0",
+          uses: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1",
         },
       },
       {
@@ -310,7 +310,7 @@ test("testing-windows has one exact safe descriptor and executable classificatio
         classification: "safe",
         descriptor: {
           name: "Setup Node.js",
-          uses: "actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e",
+          uses: "actions/setup-node@820762786026740c76f36085b0efc47a31fe5020",
           with: { "node-version": "24.17.0", cache: "pnpm" },
         },
       },


### PR DESCRIPTION
## Summary

All five open dependabot PRs — #447, #448, #449, #450, #451 — fail the required `validate` check. It isn't flake, and it isn't dependabot being wrong: each bump changes a pinned action SHA, and that SHA is mirrored in **six places dependabot cannot update**.

| site | what it holds |
|---|---|
| `.github/workflows/*.yml` | the pins themselves |
| `scripts/release/preflight.mjs` | `EXPECTED_RELEASE_WORKFLOW` — **release-controller source, not a test** |
| `scripts/release/test/preflight.test.mjs` | its fixture |
| `scripts/release/test/fixtures/workflow-entrypoints.json` | entrypoint allowlist |
| `scripts/release/test/fixtures/workflow-safe-executables.json` | executable allowlist |
| `scripts/release/test/workflow-contracts.test.mjs` | `LEGACY_SAFE_ENTRYPOINTS` + the `testing-windows` expectation |
| `packages/sandbox/test/ci-workflow-pins.test.ts` | CI pin assertions |

This supersedes all five. One PR, one CI cycle, one coherent audit — which is also the safer shape, for a reason worth stating plainly.

### Why these could not land separately

`preflight.mjs` holds a byte-exact `EXPECTED_RELEASE_WORKFLOW` that the release controller checks **before publishing**. Bumping the workflows without updating it would pass CI and then **fail the next release at preflight**. Merging the five dependabot PRs as-is would have done exactly that — the failure would have surfaced at release time, not at review time.

`LEGACY_SAFE_ENTRYPOINTS` is not dead history despite the name: it is a tighter allowlist applied specifically to `release.yml`, so the publishing workflow's executables must be listed there explicitly.

### Every SHA verified against its tag

Resolved through the GitHub API rather than trusting the bump — this is a supply-chain control, so the SHAs went in verified, not copied:

| action | version | SHA | verified |
|---|---|---|---|
| `github/codeql-action` | v4.37.6 | `5595ccaf912e` | ✅ |
| `actions/checkout` | v7.0.1 | `3d3c42e5aac5` | ✅ |
| `actions/setup-node` | **v7.0.0** | `820762786026` | ✅ |
| `ossf/scorecard-action` | v2.4.4 | `2d1146689b8c` | ✅ |
| `anthropics/claude-code-action` | v1.0.187 | `1623c36729ac` | ✅ |

### A defect in #449 worth knowing about

`actions/setup-node` is a **major** bump, v6 → v7, and dependabot changed the SHA while leaving the inline comment reading `# v6`. A stale version comment beside a pinned SHA is precisely what misleads whoever audits these next, so it now reads `# v7.0.0`.

This is also the only bump carrying real behavioral risk — every job in every workflow uses `setup-node`. CI on this PR is the test of it.

`docs/superpowers/plans/*.md` still reference the old SHAs. That is deliberate: those record what was pinned when each plan was written, and rewriting them would falsify history.

## Validation

- `pnpm test:release-controller` — **525 passed, 0 failed, exit 0**, including the two audits that were failing: `workflow entrypoints fail closed unless their exact normalized form is explicitly audited` and `testing-windows has one exact safe descriptor and executable classification`.
- `ci-workflow-pins.test.ts` — **16 passed, exit 0**.
- `biome check` over `scripts` and the changed test — exit 0.
- Verified zero occurrences of any of the five old SHAs remain outside `docs/`.

- [x] `pnpm lint`
- [ ] `pnpm build` — unchanged by this PR; no source touched
- [ ] `pnpm typecheck` — unchanged by this PR
- [x] `pnpm test` (the affected suites)
- [ ] `node scripts/check-docs.mjs` — not run locally; no docs touched
- [ ] `pnpm pack:check` — not run locally; ships nothing
- [x] Harness verification — n/a

## Release Notes

- [x] Not needed. Workflow and test files only; the changesets gate covers `packages/*/src/` and READMEs.

## Checklist

- [x] I read `CONTRIBUTING.md`.
- [x] I followed `CODE_OF_CONDUCT.md`.
- [x] I did not include secrets, credentials, or private data.
- [x] I am not disclosing a security vulnerability publicly.
