### PR TITLE
test(inspector): stop the focus-continuity poll racing the drawn head

### DIFF
--- a/packages/inspector/e2e/a11y-focus.spec.ts
+++ b/packages/inspector/e2e/a11y-focus.spec.ts
@@ -14,6 +14,7 @@ import {
   focusReport,
   GROUP_ROW_ID_PREFIX,
   grid,
+  headAndFocusReport,
   liveRegionText,
   loadMore,
   MIN_RENDERED_ROWS,
@@ -78,10 +79,32 @@ test.describe("focus continuity", () => {
     await sortByHeader(page, FOCUS_COLUMN)
     await expectPhase(page, "idle")
 
-    const after = await rowIds(page)
-    // The pivot also resets scroll, so the drawn head IS the model head — `after[0]` is
-    // an address, not merely "whatever is on screen".
-    const head = after[0] as string
+    // POLLED, and both halves read in ONE evaluation. `rowIds` is documented one-shot —
+    // the rendered set can still change a frame after the phase reads `idle` — so a head
+    // pinned from it here can name a row the result no longer leads with. That is how
+    // this failed in CI: the head read as `route=/chat` while focus sat, correctly, on
+    // `route=/notes`, and the poll below then waited out its timeout against an address
+    // that had already stopped being the head.
+    //
+    // `headAndFocusReport` closes that by sampling the head and the focus address
+    // together, so no re-render, second fetch or re-group can land between them. The
+    // whole address in one sample, for the reason the old comment here gave: `columnId`
+    // is what says the focused node is a cell rather than the row wrapper or the
+    // row-select control, and a second sample for a second field could straddle a commit.
+    //
+    // The re-seat happens in a layout effect and DOM focus follows it from a second one,
+    // so the phase attribute lands first and this genuinely needs to poll.
+    await expect
+      .poll(() => headAndFocusReport(page))
+      .toMatchObject({
+        focusIsHead: true,
+        columnId: GROUP_COLUMN_ID,
+        inGrid: true,
+        onBody: false,
+      })
+
+    // Settled: re-read for the two claims about WHICH row the head is.
+    const head = (await headAndFocusReport(page)).head
     // The one place this lane pins a divergence from its own design, so the message says
     // what to do about it rather than leaving that in a comment the failure never prints.
     expect(
@@ -97,15 +120,6 @@ test.describe("focus continuity", () => {
     // re-renders the same coordinates over new rows, so "focus is on the head" and "focus
     // did not move" are the same sentence unless the two rows differ.
     expect(head).not.toBe(anchored)
-
-    // POLLED: the re-seat happens in a layout effect and DOM focus follows it from a
-    // second effect, so the phase attribute lands first. The WHOLE address, in ONE sample:
-    // `columnId` is what says the focused node is a cell rather than the row wrapper or
-    // the row-select control, and a second sample of the same helper for a second field
-    // could straddle a commit.
-    await expect
-      .poll(() => focusReport(page))
-      .toEqual({ rowId: head, columnId: GROUP_COLUMN_ID, inGrid: true, onBody: false })
   })
 
   test("an append leaves focus exactly where it was", async ({ page, consoleErrors }) => {

--- a/packages/inspector/e2e/helpers.ts
+++ b/packages/inspector/e2e/helpers.ts
@@ -262,6 +262,46 @@ export interface FocusReport {
  * tell "focus moved to the head of the NEW result" — which is what design §4.2 promises —
  * from focus that was re-asserted at the same coordinates over different rows.
  */
+/**
+ * `focusReport`, plus the drawn head, in the SAME evaluation — and the one derived fact a
+ * caller asking "did the pivot seat focus at the head?" actually wants.
+ *
+ * This exists because pairing `focusReport` with a separately-sampled `rowIds` reopens the
+ * straddle `focusReport` was written to close. `rowIds` is documented one-shot ("the
+ * rendered set can still change a frame after the phase reads `idle`"), so a head pinned
+ * from it right after `expectPhase(page, "idle")` can name a row the result no longer
+ * leads with. A poll written against that stale head then waits out its timeout while
+ * focus sits correctly on the real head — which is exactly how this failed in CI, reading
+ * `route=/chat` as the head while focus was on `route=/notes`.
+ *
+ * Sampling both here means the comparison can never straddle a commit, whatever made the
+ * order move: a late re-render, a second fetch, or a re-group. `focusIsHead` is computed
+ * in-page for the same reason every other field is — a caller recomputing it from two
+ * fields of two samples is the bug again.
+ */
+export async function headAndFocusReport(
+  page: Page,
+): Promise<FocusReport & { readonly head: string; readonly focusIsHead: boolean }> {
+  return browseRegion(page).evaluate((region) => {
+    const active = document.activeElement as HTMLElement | null
+    const viewport = region.querySelector("[data-pretable-scroll-viewport]")
+    const head =
+      viewport?.querySelector("[data-pretable-row-id]")?.getAttribute("data-pretable-row-id") ?? ""
+    const rowId =
+      active?.closest("[data-pretable-row-id]")?.getAttribute("data-pretable-row-id") ?? ""
+    return {
+      head,
+      rowId,
+      columnId: active?.getAttribute("data-pretable-column-id") ?? "",
+      inGrid: viewport?.contains(active ?? null) ?? false,
+      onBody: active === document.body,
+      // `head !== ""` matters: before the first paint both sides are `""` and a bare
+      // equality would report the head as focused when nothing is drawn at all.
+      focusIsHead: head !== "" && rowId === head,
+    }
+  })
+}
+
 export async function focusReport(page: Page): Promise<FocusReport> {
   return browseRegion(page).evaluate((region) => {
     const active = document.activeElement as HTMLElement | null


### PR DESCRIPTION
## What failed

`a11y-focus.spec.ts` › "a query reset re-seats focus at the head of the new result, never on `<body>`" failed on `main` (run 31644774279):

```
-   "rowId": "__group__:namespace=s:route%3D%2Fchat",     ← the head the test pinned
+   "rowId": "__group__:namespace=s:route%3D%2Fnotes",    ← where focus actually was
Timeout 10000ms exceeded while waiting on the predicate
```

**The safety property held.** Focus was `inGrid: true`, `onBody: false` — the thing the test is named for was never in doubt. What broke is how the two halves were sampled.

## Why

`rowIds` carries this in its own doc comment:

> One-shot, and deliberately not retrying: … the rendered set can still change a frame after the phase reads `idle`. Callers assert through `expect.poll`/`toPass` so that settling is retried rather than raced

The spec pinned `head` from exactly such a one-shot read, immediately after `expectPhase(page, "idle")`, then polled `focusReport` against that frozen value. So it spent 10s waiting for focus to arrive at an address that had already stopped being the head.

`focusReport` was written to stop precisely this class of straddle *between its own fields* ("two locator reads would carry a driver round trip between them and could straddle a commit"). Pairing it with a separately-sampled head reopened the same gap one level up.

## Fix

`headAndFocusReport` reads the drawn head and the focus address in **one** page evaluation and derives `focusIsHead` in-page. Nothing — late re-render, second fetch, re-group — can land between the two halves.

This is deliberately agnostic about *what* moved the order, because I could not reproduce the CI condition locally and did not want a fix that only works against my guess at the mechanism.

## What I could and could not verify

**Could not reproduce locally.** 11 runs of the test, including 6 under 6× CPU throttling via CDP, all show a stable head (`route=/notes`) with `headChanged=false`. The trigger is timing this machine does not produce — likely fetch/paging rather than CPU.

**Proved the assertion can fail.** Mutating the helper to report the *second* drawn row as the head reddens the test with `focusIsHead: false`, which is exactly the CI condition:

```
✘ a query reset re-seats focus at the head of the new result, never on <body>
-   "focusIsHead": true,
+   "focusIsHead": false,
```

**Full inspector e2e suite: 44 passed.** Note `--repeat-each` is not usable on this spec — the fixture is seeded once per webServer and the removal test mutates the store, so repeats 2+ fail by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)