### PR TITLE
feat(cli): authorize the run surface and pending-interrupt reads

### DIFF
--- a/.changeset/thread-access-hook.md
+++ b/.changeset/thread-access-hook.md
@@ -22,9 +22,10 @@ fails the boot with `DAWN_E3003` rather than degrading to "no gate". An app with
 no policy file behaves exactly as before, and every boot logs which layer the
 policy came from, or that there is none.
 
-`dawn build` now fails with `DAWN_E1005` for the `hono` and `langsmith` targets
-while a policy file exists, because neither runtime can carry the hook yet. The
-`node` target is unaffected: its emitted server probes the policy at boot.
+`dawn build` now fails with `DAWN_E1005` for the `langsmith` target while a
+policy file exists, because that runtime cannot carry the hook. The `node`,
+`hono` and `vercel` targets are unaffected: `node`'s emitted server probes the
+policy at boot, and the bundled web targets carry it in their static manifest.
 
 One behavior change applies with or without a policy: `POST /threads` drops the
 reserved `dawn:access` key from client-supplied `metadata`. That key holds the
@@ -40,5 +41,7 @@ the observed run has already finished it answers the existing
 without booting a server, and `createAgentProtocolInjector` accepts a
 `threadAccess` policy.
 
-The run endpoints — `/runs/stream`, `/runs/wait`, `/resume` and `/agui` — are
-not on this policy yet and remain gated by route middleware only.
+The run endpoints — `/runs/stream`, `/runs/wait`, `/resume` and `/agui` — plus
+`GET /threads/:thread_id/pending_interrupts` are gated on this policy too; see
+the entry covering them for the ordering consequences and the `ThreadOperation`
+addition.

--- a/.changeset/thread-access-run-endpoints.md
+++ b/.changeset/thread-access-run-endpoints.md
@@ -1,0 +1,62 @@
+---
+"@dawn-ai/sdk": patch
+"@dawn-ai/cli": patch
+"@dawn-ai/testing": patch
+---
+
+Thread access now authorizes the run endpoints and the pending-interrupts read.
+
+Two things to check before upgrading.
+
+**`ThreadOperation` gains a tenth member, `"thread.pending_interrupts"`.** The
+addition is source-compatible everywhere except an exhaustive `switch` or
+mapped type over the union, which stops compiling until it handles the new
+member. It arrives under `action: "read"`.
+
+**A policy written against the five endpoints of the previous release will now
+be invoked on five more.** `POST /threads/:id/runs/stream`, `/runs/wait`,
+`/resume`, `POST /agui/:routeId` and `GET /threads/:id/pending_interrupts` are
+gated on the thread-access axis. The migration hazard is a policy whose
+`fallback` returns a bare `{ allow: false }`, or denies any operation it does
+not recognize: it will start denying traffic it permitted before, on endpoints
+that previously answered to route middleware alone. Read your `fallback` before
+upgrading. Every `run.*` operation arrives under `action: "update"` — including
+on a thread id with no row yet, which those endpoints create — so a policy that
+permits `update` for the thread's owner needs no change.
+
+These gates compose with route middleware as AND rather than replacing it;
+middleware still answers "may this caller run this route" and keeps doing the
+per-caller work it does today. An app with no policy file is unaffected.
+
+`POST /threads/:id/resume` and `GET /threads/:id/pending_interrupts` gate
+**before** middleware rather than after it, so on those two a caller who would
+have received a middleware `401` now receives a thread-access deny — a `403` on
+`/resume`, a `404` on `/pending_interrupts`. That is forced: both resolve the
+route identity middleware would authorize against out of the thread's own
+metadata, so gating after middleware would mean reading a thread the caller is
+not yet authorized to read. On `/resume` it also stops a denied caller taking
+the thread's resume claim, which was a denial of service against a parked turn
+that needed no credential, and reading the `400`/`409` codes as an oracle on a
+guessed `interruptId`/`resumeKey`. A `/pending_interrupts` deny returns the
+handler's own `404 thread_not_found`, indistinguishable from a genuine miss.
+
+`dawn build --target hono` and `--target vercel` now build an app that has a
+policy file, instead of refusing with `DAWN_E1005`. The policy is bundled into
+the static module manifest and runs on those runtimes exactly as it does under
+`dawn dev`. To close the gap that made the refusal necessary, a build that saw a
+policy file stamps that fact into its entry point, and the boot now fails when
+such an entry point is paired with a manifest carrying no thread-access entry —
+a stale manifest would otherwise come up with every thread endpoint open and
+nothing to say so. `--target langsmith` still refuses, permanently: it
+materializes per-route graphs with no Dawn HTTP layer to run a policy in.
+
+`create-dawn-app` templates now carry a deny-by-default `src/thread-access.ts`
+and the shared `src/auth.ts` it imports, both as `.example` files that a rename
+activates. They ship inert because a deny-by-default policy denies every request
+from a caller the app cannot yet authenticate.
+
+`@dawn-ai/testing`'s `runThreadsStoreConformance` gains two cases, both
+properties the access stamp depends on: a `createThread` on an id that already
+exists never applies the caller's metadata, and `updateMetadata` leaves a
+top-level key its patch does not name intact. Custom `ThreadsStore`
+implementations should re-run the kit.

--- a/.changeset/thread-access-run-endpoints.md
+++ b/.changeset/thread-access-run-endpoints.md
@@ -21,8 +21,16 @@ gated on the thread-access axis. The migration hazard is a policy whose
 not recognize: it will start denying traffic it permitted before, on endpoints
 that previously answered to route middleware alone. Read your `fallback` before
 upgrading. Every `run.*` operation arrives under `action: "update"` — including
-on a thread id with no row yet, which those endpoints create — so a policy that
-permits `update` for the thread's owner needs no change.
+on a thread id with no row yet, which those endpoints create, and which reaches
+the policy as `thread: undefined`. A policy that permits `update` for the
+thread's owner therefore needs one more decision than it did before: what to
+answer when there is no row to own yet. A policy that denies a missing row —
+correct for `delete` and `read`, and what closes the existence oracle there —
+now refuses every AG-UI turn, because `POST /agui/{routeId}` runs on a thread id
+the client picked and never created. Only `POST /threads` writes an access
+stamp, so relaxing `update` for a missing row authorizes the first turn and
+denies the second; mint the id through `POST /threads` instead, or keep your own
+id-to-owner record.
 
 These gates compose with route middleware as AND rather than replacing it;
 middleware still answers "may this caller run this route" and keeps doing the

--- a/apps/web/content/docs/api/cli.mdx
+++ b/apps/web/content/docs/api/cli.mdx
@@ -70,6 +70,7 @@ import { createRuntimeFetchHandler } from "@dawn-ai/cli/fetch"
 | `buildStaticRouteModule` | Build one route module without filesystem discovery. |
 | `createRuntimeFetchHandler` | Assemble a web-standard request handler. |
 | `normalizeMiddlewareModule` | Normalize generated middleware exports. |
+| `normalizeThreadAccessModule` | Normalize generated thread-access policy exports. |
 | `readRuntimeEnv` | Re-export [`@dawn-ai/core` environment lookup](/docs/api/core#dawn-aicore). |
 | `seedDawnConfig` | Re-export [`@dawn-ai/core` static configuration seeding](/docs/api/core#dawn-aicore). |
 | `seedModelImporter` | Re-export the `@dawn-ai/langchain` static importer seam; its deep reference is deferred. |
@@ -110,6 +111,7 @@ import { createRuntimeFetchHandler } from "@dawn-ai/cli/fetch"
 | `loadStaticModules` | Load generated route modules. |
 | `materializeResolvedRouteGraph` | Materialize a resolved graph. |
 | `normalizeMiddlewareModule` | Normalize middleware exports. |
+| `normalizeThreadAccessModule` | Normalize thread-access policy exports. |
 | `readPendingInterrupts` | Read pending human decisions. |
 | `resolveCheckpointer` | Resolve the configured checkpointer. |
 | `resolvePendingResume` | Resolve submitted interrupt decisions. |

--- a/apps/web/content/docs/deployment/edge.mdx
+++ b/apps/web/content/docs/deployment/edge.mdx
@@ -145,6 +145,8 @@ Sharing a database is supported only with hand-composed request stores that pass
 
 Filesystem marker capabilities such as route `memory.md` and `plan.md` do not activate without a marker filesystem. The explicit build gates above cover surfaces that would otherwise be silently replaced, dropped, or fail only on first use.
 
+A [thread-access policy](/docs/thread-access) is not one of these gates: `src/thread-access.ts` is bundled into the manifest as a static import and runs on the edge like it does under `dawn dev`. Nothing in it is filesystem-dependent — the disk probe happens at build time, not at request time. If a manifest built before the app grew a policy is deployed beside a newer entry point, the boot fails rather than serving every thread endpoint ungated, because a bundled runtime has no disk to fall back to. The `langsmith` target still refuses to build while a policy file exists; it materializes graphs with no Dawn HTTP layer to run the policy in.
+
 ## Configuration is in the artifact
 
 The Hono emitter serializes the JSON-representable portion of `dawn.config.ts` into `.dawn/build/app.mjs`. Functions, class instances, and store handles are stripped; ordinary strings remain. Do not put secret literals in build-time config fields, because those values can become readable bundle content. Use host environment variables, Wrangler secrets, or provider bindings instead.

--- a/apps/web/content/docs/dev-server.mdx
+++ b/apps/web/content/docs/dev-server.mdx
@@ -100,6 +100,11 @@ See [Middleware](/docs/middleware) for execution-route behavior and
 [Security Architecture](/docs/security-architecture) for the management routes
 that require service-wide outer authentication.
 
+Middleware is not the only in-runtime gate. [Thread access](/docs/thread-access)
+is a second one on a different axis — the thread rather than the route — and it
+covers every thread endpoint, including the ones middleware never sees. Where
+both apply they compose as AND.
+
 ## Related
 
 <RelatedCards items={[

--- a/apps/web/content/docs/dev-server/agent-protocol.mdx
+++ b/apps/web/content/docs/dev-server/agent-protocol.mdx
@@ -23,6 +23,11 @@ such as `/research#agent`.
   memory-candidate management, and health routes bypass it. Put outer authentication and network
   restrictions around the entire service for any non-local exposure; exempt
   only the health probe you intend to expose.
+
+  An app that adds a [thread-access policy](/docs/thread-access) authorizes
+  every thread endpoint in the table below on a second, independent axis — the
+  thread rather than the route — and the two gates compose as AND. That still
+  leaves the memory-candidate and health routes covered by neither.
 </Callout>
 
 ## Agent Protocol endpoints

--- a/apps/web/content/docs/middleware.mdx
+++ b/apps/web/content/docs/middleware.mdx
@@ -118,7 +118,25 @@ Middleware runs in every Dawn HTTP runtime: `dawn dev`, the Node runtime served 
 | `/threads/:id/pending_interrupts` | `"GET"` | Always `{}` — a `GET` has no body to read them from. |
 | `/agui/:routeId` | `"POST"` | Dynamic segments read from the AG-UI run input. |
 
-Every other endpoint the runtime serves is ungated: `/healthz` (a liveness probe), thread create, read and delete, `GET /threads/:id/state`, `POST /threads/:id/cancel`, and the memory-candidate endpoints.
+Middleware is not the only gate on those five. An app that has a
+[thread-access policy](/docs/thread-access) also authorizes each of them against
+the thread they name, and the two compose as AND: middleware answers "may this
+caller run this route", the policy answers "may this caller touch this thread",
+and a request needs both to pass. An app with no policy file is gated by
+middleware alone, exactly as before.
+
+The endpoints middleware does **not** see are `/healthz` (a liveness probe),
+thread create, read and delete, `GET /threads/:id/state`,
+`POST /threads/:id/cancel`, and the memory-candidate endpoints. Of those, every
+thread endpoint is on the thread-access policy — so "no middleware" no longer
+means "ungated". `/healthz` and the memory-candidate endpoints have no gate of
+either kind; put an outer boundary around them.
+
+Two of the five resolve their route identity from the thread itself, so their
+thread-access check runs **before** middleware and answers first: `/resume` and
+`/pending_interrupts`. On those, a caller middleware would have refused with a
+`401` receives the policy's deny instead. See
+[the run endpoints and middleware](/docs/thread-access#the-run-endpoints-and-middleware).
 
 <Callout type="warn" title="Middleware can now see a GET">
 `GET /threads/:id/pending_interrupts` hands back the human-in-the-loop prompts parked on a thread, so it is gated like a run — and it is the first gated endpoint whose `req.method` is not `"POST"`. Middleware that branches on `req.method === "POST"`, or that reads `req.params` to decide access, falls through on it. See [the endpoint reference](/docs/dev-server/agent-protocol#recovering-prompts-without-a-live-stream) for how its route identity is resolved.
@@ -133,7 +151,7 @@ start gating requests.
 The `langsmith` build target is different: its generated graph entries do not include Dawn HTTP middleware. Put equivalent authentication at the LangSmith/platform boundary when you deploy those entries.
 
 <Callout type="warn" title="Middleware is execution-only">
-  Do not use this hook as blanket service authentication. Create/read/delete, state, cancellation, health, and memory-candidate routes bypass it. Put an outer boundary around the complete runtime surface as described in [Security Architecture](/docs/security-architecture).
+  Do not use this hook as blanket service authentication. Create/read/delete, state, cancellation, health, and memory-candidate routes bypass it. Thread authorization is a [separate file on a separate axis](/docs/thread-access) and covers the thread endpoints; health and memory-candidate routes are covered by neither. Put an outer boundary around the complete runtime surface as described in [Security Architecture](/docs/security-architecture).
 </Callout>
 
 ## When middleware fails to load

--- a/apps/web/content/docs/security-architecture.mdx
+++ b/apps/web/content/docs/security-architecture.mdx
@@ -24,6 +24,8 @@ Dawn middleware runs only when a request is about to execute a route. Management
 
 Apply authorization before dispatch so create, read, delete, state, cancel, memory candidates, and health cannot reach their narrower Dawn handlers unauthenticated.
 
+The "Dawn middleware" column is about route execution only. Every thread row above — management, state, cancellation, Agent Protocol execution and AG-UI execution — is additionally covered in-runtime by a [thread-access policy](/docs/thread-access) when the app has one, on the per-thread ownership axis this table asks the outer boundary to supply. It is a second gate, not a replacement for the outer one, and health and memory-candidate routes are outside it.
+
 ## Authorize the tenant, not the identifier
 
 Verified claims answer *who the caller is*. Route parameters, `thread_id`, AG-UI `threadId`, tenant strings in route input, and memory namespaces answer *which resource was requested*. Compare the two using application-owned records.

--- a/apps/web/content/docs/thread-access.mdx
+++ b/apps/web/content/docs/thread-access.mdx
@@ -42,6 +42,8 @@ export default defineThreadAccess({
 
 Dawn probes four paths, in order: `src/thread-access.ts`, `src/thread-access.js`, `thread-access.ts`, `thread-access.js`. The `default` export wins; a named `threadAccess` export is the fallback.
 
+`create-dawn-app` scaffolds this file, and the `src/auth.ts` it imports, as `src/thread-access.ts.example` and `src/auth.ts.example`. Drop both `.example` suffixes to activate them — Dawn probes for the exact names above, so an unrenamed scaffold changes nothing. They ship inert because a deny-by-default policy denies every request from a caller the app cannot yet authenticate, and a generated app has no identity provider on its first run.
+
 `fallback` is required. "I forgot to handle delete" is a compile error rather than a silent allow — or a silent deny — on every request of that action.
 
 ## What the policy receives
@@ -75,6 +77,11 @@ Repeated headers arrive joined. `X-User-Id: victim` plus `X-User-Id: attacker` i
 | `GET /threads/:thread_id/state` | 404, the same body a missing checkpoint returns |
 | `DELETE /threads/:thread_id` | 403 `thread_access_denied` |
 | `POST /threads/:thread_id/cancel` | 403 `thread_access_denied` |
+| `GET /threads/:thread_id/pending_interrupts` | 404 `thread_not_found`, the same body a genuine miss returns |
+| `POST /threads/:thread_id/runs/stream` | 403 `thread_access_denied` |
+| `POST /threads/:thread_id/runs/wait` | 403 `thread_access_denied` |
+| `POST /threads/:thread_id/resume` | 403 `thread_access_denied` |
+| `POST /agui/:routeId` | 403 `thread_access_denied` |
 
 The read default is 404 so a denial cannot be told apart from a miss, which is what stops anyone enumerating thread ids. The 403s sit on endpoints where the caller has already named a specific thread and asked to change it.
 
@@ -119,7 +126,11 @@ Dawn: no thread access policy (all thread endpoints are open)
 
 ## Build targets
 
-`dawn build --target hono` and `--target langsmith` **fail** with `DAWN_E1005` while a policy file exists. Neither runtime can carry the hook today, and a build that silently dropped it would deploy every thread endpoint ungated. The `node` target needs nothing special — its emitted server reaches the same disk probe `dawn dev` does. An app with no policy file builds for every target exactly as before. See [Deployment](/docs/deployment).
+`dawn build --target langsmith` **fails** with `DAWN_E1005` while a policy file exists, and always will: that target materializes per-route graphs and no Dawn HTTP layer, so there is nowhere for the hook to run, and a build that silently dropped it would deploy every thread endpoint ungated. Put equivalent authorization at the LangSmith platform boundary instead.
+
+`hono` and `vercel` carry the policy. They share one emitter, and the built manifest has a slot for it: the policy rides in as a static import, and the generated entry point records that the build saw one. If a manifest generated before the app grew a policy is later deployed beside a newer entry point, the boot **fails** rather than coming up silently ungated — there is no disk to probe on a bundled runtime, so nothing else would notice.
+
+The `node` target needs nothing special; its emitted server reaches the same disk probe `dawn dev` does. An app with no policy file builds for every target exactly as before. See [Deployment](/docs/deployment) and [Edge and Hono](/docs/deployment/edge).
 
 ## Adopting a policy on an existing app
 
@@ -146,6 +157,16 @@ This is in the same class as `dawn inspect` and `dawn memory`: a local operator 
 
 `GET /threads/:thread_id` returns the raw thread, reserved key included. That is deliberate — hiding it would break round-tripping and make the stamp undebuggable, and that endpoint is gated by the very policy the stamp feeds. Put identifiers in a stamp. Do not put anything in it whose disclosure to a caller your `read` policy admits would matter.
 
-## What this does not cover yet
+## The run endpoints and middleware
 
-The run endpoints — `POST /threads/:thread_id/runs/stream`, `/runs/wait`, `/resume` and `POST /agui/{routeId}` — are gated by [route middleware](/docs/middleware) only. They are not yet on this policy, and a caller who can run a route on a thread can still create the row for an id of their choosing. Keep middleware doing real per-caller authorization until they are.
+The run endpoints — `POST /threads/:thread_id/runs/stream`, `/runs/wait`, `/resume` and `POST /agui/{routeId}` — plus `GET /threads/:thread_id/pending_interrupts` are on this policy **as well as** [route middleware](/docs/middleware). The two compose as AND: middleware answers "may this caller run this route", the policy answers "may this caller touch this thread", and a request needs both. Neither replaces the other, so keep middleware doing the per-caller work it does today.
+
+All four `run.*` operations arrive under `action: "update"` — including on an id with no row yet, which those endpoints create. Starting a turn on a thread mutates it; none of them is a `create`.
+
+`GET /threads/:thread_id/pending_interrupts` composes both checks as AND — the route that parked the interrupts must admit the caller *and* this policy must permit the read — and which one refused is deliberately not visible in the response: a thread-access deny returns the handler's own `404 thread_not_found`, the same bytes a genuine miss returns, while a route-identity refusal returns whatever your middleware returns. Dawn logs neither, so log the denial inside your own policy if you need to tell them apart.
+
+<Callout type="warn" title="On /resume, a thread-access deny replaces a middleware 401">
+`POST /threads/:thread_id/resume` and `GET /threads/:thread_id/pending_interrupts` are the two endpoints whose thread-access gate runs **before** middleware, so on them a caller middleware would have refused with a `401` receives this policy's deny instead — a `403` on `/resume`, a `404` on `/pending_interrupts`.
+
+That ordering is forced, not preferred. Middleware needs the route key, and on both endpoints the route key is read from the thread's own metadata — so resolving the identity middleware would authorize against means reading a thread the caller is not yet authorized to read. On `/resume`, gating later also let a denied caller take the thread's resume claim (a denial of service against a parked turn, needing no credential at all) and read the `400`/`409` codes as an oracle on a guessed `interruptId`/`resumeKey`. Both checks still apply on both endpoints; only which one answers first is decided here.
+</Callout>

--- a/apps/web/content/docs/thread-access.mdx
+++ b/apps/web/content/docs/thread-access.mdx
@@ -163,6 +163,14 @@ The run endpoints — `POST /threads/:thread_id/runs/stream`, `/runs/wait`, `/re
 
 All four `run.*` operations arrive under `action: "update"` — including on an id with no row yet, which those endpoints create. Starting a turn on a thread mutates it; none of them is a `create`.
 
+<Callout type="warn" title="A policy that denies a missing row denies every AG-UI turn">
+The scaffolded `src/thread-access.ts` denies when `req.thread === undefined`, which is correct for `delete` and `read` and is what keeps the existence oracle shut. It also refuses every `run.*` operation on a thread id that has no row yet — and `POST /agui/{routeId}` is exactly that case, because CopilotKit picks its `threadId` in the browser and never calls `POST /threads`. An app that activates the scaffold unchanged answers `403` to every AG-UI turn.
+
+**Relaxing that line for `update` is not the fix.** The implicit create the run endpoints do writes the row with **no access stamp** — only `POST /threads` stamps — so the next turn on the same thread reaches the `access === undefined` branch and is denied anyway. A relaxed policy authorizes the first turn and refuses the second.
+
+Mint the thread with `POST /threads` and pass the returned `thread_id` to the client as its thread id. That is the path that records an owner, so every later turn matches it. If client-chosen ids are non-negotiable, record the id-to-owner mapping yourself, from inside the policy, and consult it on `update`. Do not relax `delete` or `read` to get there.
+</Callout>
+
 `GET /threads/:thread_id/pending_interrupts` composes both checks as AND — the route that parked the interrupts must admit the caller *and* this policy must permit the read — and which one refused is deliberately not visible in the response: a thread-access deny returns the handler's own `404 thread_not_found`, the same bytes a genuine miss returns, while a route-identity refusal returns whatever your middleware returns. Dawn logs neither, so log the denial inside your own policy if you need to tell them apart.
 
 <Callout type="warn" title="On /resume, a thread-access deny replaces a middleware 401">

--- a/docs/superpowers/plans/2026-08-13-thread-access-pr-b.md
+++ b/docs/superpowers/plans/2026-08-13-thread-access-pr-b.md
@@ -1,0 +1,753 @@
+# Thread Access PR B Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close the rest of the thread authorization surface — gate the four run endpoints and `GET /pending_interrupts` on `defineThreadAccess`, lift PR A's `hono` build failure by teaching the static-module pipeline about the policy, and ship the scaffold, conformance and docs that make the hook usable.
+
+**Architecture:** PR A built the seam (`makeThreadGate`, the reserved metadata namespace, the loader, the enumeration test) and gated the five endpoints that ran no middleware at all. PR B reuses that seam unchanged: every task below is a gate call placed at a specific point in an existing handler, plus the build-target work that lets a policy survive `dawn build`. No new authorization concepts.
+
+**Tech Stack:** TypeScript, Node 24 (`engines` requires it — 20 CLI tests fail under Node 22 on `main` too), vitest, pnpm workspaces, turbo, changesets, biome.
+
+---
+
+## Scope
+
+The six items in the spec's **"PR B — the run surface, edge, and defaults"** slice, plus the resolved open question.
+
+**The open question is decided: Option A.** `GET /threads/:id/pending_interrupts` moves onto the thread-access axis, *in addition to* #443's route-identity check, composing as AND. Decided by the repo owner on 2026-08-13, after PR A merged.
+
+**That decision costs one thing the spec hoped to avoid.** The spec assumed the answer would land *before* PR A so the tenth `ThreadOperation` member would ship inside PR A's union and PR B would carry no published type change. PR A merged with **nine** members (`packages/sdk/src/thread-access.ts:38-47`), so Task 2 widens a published union. It is additive, but a consumer with an exhaustive `switch` over `ThreadOperation` will fail to compile. Call it out in the changeset.
+
+## Base-branch reality — read this before Task 1
+
+- Base is `origin/main` at or after `b3f44df0`. PR A (#460), the AG-UI parked-status fix (#462), the episode-park fix (#463), the middleware loader (#464), the vercel-native flake fix (#465) and the action-pin bump (#466) are all in.
+- `main` moves fast — six merges on 2026-08-12 alone. Re-merge `origin/main` before pushing and expect conflicts in `runtime-fetch-core.ts`, which is the busiest file in the repo.
+- Only `validate` is a required check. `review` fails repo-wide on an Anthropic credit balance; `vercel-native`, `chart-apply-smoke`, `chart-validate` and `sandbox-k8s` all flake intermittently on `main` itself. Do not treat those as your regression without checking the step list first.
+
+## Repo gotchas baked into every task
+
+- **Node 24 or the suite lies.** `export PATH="$HOME/.nvm/versions/node/v24.19.0/bin:$PATH"` before any test command.
+- **Capture exit codes explicitly.** `cmd > /tmp/x.log 2>&1; echo "EXIT=$?"` — piping to `grep`/`tail` reports the *pipe's* status and has already produced a false green in this repo's history.
+- **Strip ANSI before grepping CI logs.** `perl -pe 's/\e\[[0-9;]*[a-zA-Z]//g'` — `grep -c "FAIL"` silently returns 0 against coloured output.
+- **Changesets gate:** a changeset is required because `packages/*/src/` changes. `@dawn-ai/sdk`, `@dawn-ai/cli` and `@dawn-ai/testing` all move.
+- **Patch versions only.** Never bump a minor.
+- **`git worktree` + `perl -pi` with a glob:** quote or expand carefully. A collapsed glob has already produced a half-applied edit in this repo — always `git status` after a bulk rewrite.
+
+## File Structure
+
+**Modified — the gates:**
+- `packages/cli/src/lib/dev/runtime-fetch-core.ts` — gates in `handleApStreamRequest` (:1669), `handleApWaitRequest` (:1953), `handleResumeRequest` (:2469), and the `/pending_interrupts` route handler (:1587-1603).
+- `packages/cli/src/lib/dev/agui-handler.ts` — gate in the `POST /agui/:routeId` flow, after `runMiddleware` (:229) and before `tryClaim` (:235).
+
+**Modified — the published surface:**
+- `packages/sdk/src/thread-access.ts` — tenth `ThreadOperation` member.
+
+**Modified — the build pipeline:**
+- `packages/cli/src/lib/runtime/static-modules-core.ts` — `normalizeThreadAccessModule`.
+- `packages/cli/src/runtime-exports.ts`, `packages/cli/src/fetch-exports.ts` — re-export it from **both** barrels; the generated manifest imports by literal specifier per target, so missing either breaks linking.
+- `packages/cli/src/lib/build/modules-emitter.ts` — named-import line composed from a list, not the two-branch ternary at `:346-348`.
+- `packages/cli/src/lib/build/targets/*` — node + hono probes; delete the `DAWN_E1005` hono refusal PR A added.
+
+**Modified — templates, conformance, docs:**
+- scaffold templates: new `src/thread-access.ts` + shared `src/auth.ts`.
+- `runThreadsStoreConformance` — two cases from spec §4.
+- `apps/web/content/docs/thread-access.mdx`, `middleware.mdx` (the "Where middleware runs" table + the ungated-endpoint sentence after it), `dev-server.mdx`.
+
+**Tests (all new unless noted):**
+- `packages/cli/test/thread-access-run-endpoints.test.ts` — the four run gates + ordering.
+- `packages/cli/test/thread-access-pending-interrupts.test.ts` — the Option A gate.
+- `packages/cli/test/thread-access-coverage.test.ts` — MODIFY: move five patterns to `GATED`.
+- `packages/cli/test/pending-interrupts-endpoint.test.ts` — MODIFY: third premise rewrite.
+- `packages/cli/test/static-middleware.test.ts`, `edge-modules-emitter.test.ts` — MODIFY: thread-access twins.
+
+---
+
+## Task 1: Prepare the worktree
+
+**Files:** none (environment only)
+
+- [ ] **Step 1: Confirm the worktree and base**
+
+```bash
+cd /Users/blove/repos/dawn/.claude/worktrees/thread-access-pr-b
+git log --oneline -1
+git status --short
+```
+
+Expected: on `blove/thread-access-pr-b`, clean, at `b3f44df0` or later.
+
+- [ ] **Step 2: Install and build**
+
+```bash
+export PATH="$HOME/.nvm/versions/node/v24.19.0/bin:$PATH"
+pnpm install --frozen-lockfile > /tmp/inst.log 2>&1; echo "EXIT=$?"
+pnpm build > /tmp/build.log 2>&1; echo "EXIT=$?"
+```
+
+Expected: `EXIT=0` both. A stale `dist` produces phantom `TS2305` errors on `@dawn-ai/sdk` exports that do not exist — build before believing any typecheck failure.
+
+- [ ] **Step 3: Establish the green baseline**
+
+```bash
+pnpm --filter @dawn-ai/cli exec vitest --run --config vitest.config.ts thread-access > /tmp/base.log 2>&1; echo "EXIT=$?"
+grep -E "Test Files|Tests " /tmp/base.log
+```
+
+Expected: `EXIT=0`. Record the counts — every later task compares against them.
+
+---
+
+## Task 2: The tenth `ThreadOperation` member
+
+**Files:**
+- Modify: `packages/sdk/src/thread-access.ts:38-47`
+- Test: `packages/sdk/test/thread-access.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `packages/sdk/test/thread-access.test.ts`:
+
+```ts
+it("carries a pending-interrupts operation, so the read gate has a name", () => {
+  // Option A: /pending_interrupts is authorized on the thread-access axis in
+  // addition to the parking route's middleware. Without this member the gate in
+  // runtime-fetch-core has no operation to declare.
+  const operations: ThreadOperation[] = [
+    "thread.create",
+    "thread.get",
+    "thread.state",
+    "thread.delete",
+    "thread.cancel",
+    "thread.pending_interrupts",
+    "run.stream",
+    "run.wait",
+    "run.resume",
+    "run.agui",
+  ]
+  expect(new Set(operations).size).toBe(10)
+})
+```
+
+- [ ] **Step 2: Run it and watch it fail**
+
+```bash
+export PATH="$HOME/.nvm/versions/node/v24.19.0/bin:$PATH"
+pnpm --filter @dawn-ai/sdk exec vitest --run thread-access.test.ts > /tmp/t2.log 2>&1; echo "EXIT=$?"
+```
+
+Expected: `EXIT=1`, a TypeScript error that `"thread.pending_interrupts"` is not assignable to `ThreadOperation`.
+
+- [ ] **Step 3: Add the member**
+
+In `packages/sdk/src/thread-access.ts`, between `"thread.cancel"` and `"run.stream"`:
+
+```ts
+export type ThreadOperation =
+  | "thread.create"
+  | "thread.get"
+  | "thread.state"
+  | "thread.delete"
+  | "thread.cancel"
+  /**
+   * `GET /threads/:id/pending_interrupts`. Gated on this axis IN ADDITION to
+   * the route that parked the interrupts — the two compose as AND. The parked
+   * prompt's `interruptId`/`resumeKey` pair is the credential an attacker needs
+   * to resume someone else's turn, so it answers to the same policy as every
+   * other read of the thread.
+   */
+  | "thread.pending_interrupts"
+  | "run.stream"
+  | "run.wait"
+  | "run.resume"
+  | "run.agui"
+```
+
+- [ ] **Step 4: Verify green**
+
+```bash
+pnpm --filter @dawn-ai/sdk exec vitest --run thread-access.test.ts > /tmp/t2b.log 2>&1; echo "EXIT=$?"
+```
+
+Expected: `EXIT=0`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/sdk/src/thread-access.ts packages/sdk/test/thread-access.test.ts
+git commit -m "feat(sdk): name the pending-interrupts thread operation"
+```
+
+---
+
+## Task 3: Gate `POST /threads/:id/runs/stream`
+
+**Files:**
+- Modify: `packages/cli/src/lib/dev/runtime-fetch-core.ts` — `handleApStreamRequest` (:1669)
+- Test: `packages/cli/test/thread-access-run-endpoints.test.ts` (create)
+
+**Placement:** after `runMiddleware`, before `createThread` (:1749) and before `runRegistry.begin` (:1761). The default ordering — an existing 401 from a missing API key must not silently become a 403, and nothing observable happens in between.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/cli/test/thread-access-run-endpoints.test.ts`.
+
+**Use PR A's own endpoint-test pattern, not `createThreadAccessHarness`.** That harness is a *pure policy unit-tester* — its only method is `check(spec)`, it boots no server and has no `fetch`. Copy the `setup()` / `post()` / `get()` helpers from `packages/cli/test/thread-access-endpoints.test.ts:31-75`: a temp fixture app on disk, then `createRuntimeFetchHandler({ appRoot, threadAccess, threadsStore })` directly. The **injectable `threadsStore`** is how you assert no row was created — the HTTP response cannot answer that on its own.
+
+```ts
+import { describe, expect, it } from "vitest"
+// setup(), post() and a recording in-memory ThreadsStore: copy from
+// thread-access-endpoints.test.ts:31-75 and :77+ rather than re-inventing them.
+
+describe("POST /threads/:id/runs/stream", () => {
+  it("denies an unauthorized run without creating the row or taking a run slot", async () => {
+    const seen: string[] = []
+    const created: string[] = []
+    const threadsStore = recordingStore({ onCreate: (id) => created.push(id) })
+    const { handler } = await setup({
+      threadsStore,
+      threadAccess: {
+        update: (request) => {
+          seen.push(request.operation)
+          return { allow: false }
+        },
+      },
+    })
+
+    const response = await handler.fetch(
+      post("/threads/t-victim/runs/stream", { input: {}, route: "/hello" }),
+    )
+
+    expect(response.status).toBe(403)
+    expect(seen).toEqual(["run.stream"])
+    // The side effects that must NOT have happened on a deny.
+    expect(created).toEqual([])
+    expect(await threadsStore.getThread("t-victim")).toBeUndefined()
+  })
+
+  it("allows an authorized run", async () => {
+    const { handler } = await setup({ threadAccess: { update: () => ({ allow: true }) } })
+    const response = await handler.fetch(
+      post("/threads/t-mine/runs/stream", { input: {}, route: "/hello" }),
+    )
+    expect(response.status).toBe(200)
+  })
+})
+```
+
+**The run-slot assertion needs a second request, not a registry accessor** — nothing exposes `RunRegistry` to a test. Assert it by issuing a second run on the same thread and expecting it to succeed rather than `409 run_in_flight`: if the denied request had taken the slot, the second would conflict.
+
+- [ ] **Step 2: Run it and watch it fail**
+
+```bash
+export PATH="$HOME/.nvm/versions/node/v24.19.0/bin:$PATH"
+pnpm --filter @dawn-ai/cli exec vitest --run --config vitest.config.ts thread-access-run-endpoints > /tmp/t3.log 2>&1; echo "EXIT=$?"
+```
+
+Expected: `EXIT=1` — the deny case returns 200 because no gate exists yet.
+
+- [ ] **Step 3: Insert the gate**
+
+In `handleApStreamRequest`, immediately after the `runMiddleware` result is handled and **before** the `createThread` at `:1749`:
+
+```ts
+if (threadAccess) {
+  const existing = await threadsStore.getThread(threadId)
+  const gate = makeThreadGate(threadAccess, request)
+  const g = gate({
+    action: existing ? "update" : "create",
+    operation: "run.stream",
+    threadId,
+    ...(existing ? { thread: existing } : {}),
+  })
+  const settled = isThenable(g) ? await g : g
+  if (!settled.ok) return settled.response
+}
+```
+
+`threadAccess` must be threaded into this function's options exactly as `middleware` already is — add `readonly threadAccess: ThreadAccessPolicy | undefined` to the options interface at `:1669` and destructure it, then pass it from the route handler's `ctx`.
+
+- [ ] **Step 4: Verify green**
+
+```bash
+pnpm --filter @dawn-ai/cli exec vitest --run --config vitest.config.ts thread-access-run-endpoints > /tmp/t3b.log 2>&1; echo "EXIT=$?"
+```
+
+Expected: `EXIT=0`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/cli/src/lib/dev/runtime-fetch-core.ts packages/cli/test/thread-access-run-endpoints.test.ts
+git commit -m "feat(cli): gate the AP stream endpoint on thread access"
+```
+
+---
+
+## Task 4: Gate `POST /threads/:id/runs/wait`
+
+**Files:**
+- Modify: `packages/cli/src/lib/dev/runtime-fetch-core.ts` — `handleApWaitRequest` (:1953)
+- Test: `packages/cli/test/thread-access-run-endpoints.test.ts`
+
+**Placement:** identical shape to Task 3 — after `runMiddleware`, before `createThread` (:2031) and `runRegistry.begin` (:2038).
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the same file, mirroring Task 3's pair but asserting `operation` is `"run.wait"` and driving `/threads/t-victim/runs/wait`. Repeat the assertions rather than looping — an engineer reading this task alone needs the whole case.
+
+```ts
+describe("POST /threads/:id/runs/wait", () => {
+  it("denies an unauthorized run without creating the row or taking a run slot", async () => {
+    const seen: string[] = []
+    const created: string[] = []
+    const threadsStore = recordingStore({ onCreate: (id) => created.push(id) })
+    const { handler } = await setup({
+      threadsStore,
+      threadAccess: {
+        update: (request) => {
+          seen.push(request.operation)
+          return { allow: false }
+        },
+      },
+    })
+
+    const response = await handler.fetch(
+      post("/threads/t-victim/runs/wait", { input: {}, route: "/hello" }),
+    )
+
+    expect(response.status).toBe(403)
+    expect(seen).toEqual(["run.wait"])
+    expect(created).toEqual([])
+    expect(await threadsStore.getThread("t-victim")).toBeUndefined()
+  })
+})
+```
+
+- [ ] **Step 2: Run it and watch it fail** — same command as Task 3, `EXIT=1`.
+
+- [ ] **Step 3: Insert the gate** — the Task 3 block verbatim, with `operation: "run.wait"`.
+
+- [ ] **Step 4: Verify green** — `EXIT=0`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/cli/src/lib/dev/runtime-fetch-core.ts packages/cli/test/thread-access-run-endpoints.test.ts
+git commit -m "feat(cli): gate the AP wait endpoint on thread access"
+```
+
+---
+
+## Task 5: Gate `POST /threads/:id/resume` — the ordering exception
+
+**Files:**
+- Modify: `packages/cli/src/lib/dev/runtime-fetch-core.ts` — `handleResumeRequest` (:2469)
+- Test: `packages/cli/test/thread-access-run-endpoints.test.ts`
+
+**This one is not a preference and must not be "tidied" to match the others.** The handler order is `tryClaim` (:2521) → `readPendingInterrupts` → `resolvePendingResume` (:2543) → `getThread` for the route key → `runMiddleware`. Gating after middleware would let a caller the policy denies still:
+
+1. take and hold the victim's resume claim, so a concurrent legitimate resume gets `409 resume_in_progress` — a targeted DoS on a parked turn; and
+2. learn from the pre-gate error codes whether the thread has pending interrupts and whether a guessed `interruptId`/`resumeKey` is valid — the exact pair Task 7 gates `/pending_interrupts` to protect.
+
+So the gate goes **immediately after body parse and before `tryClaim` at :2521**, which is *before* `runMiddleware`.
+
+**State the consequence plainly in a comment and in the docs (Task 13):** on `/resume`, and only there, a caller who would have received a middleware 401 receives a thread-access deny instead. Both rules cannot hold at once — `runMiddleware` needs `routeKey`, and `routeKey` is read from thread metadata, so "after middleware" and "before any side effect" are contradictory on this endpoint. The route identity middleware would authorize against is itself derived from the thread the caller has not yet been authorized to read.
+
+- [ ] **Step 1: Write the failing test**
+
+**A parked thread has to be produced, not stubbed.** Reuse the helpers already in `packages/cli/test/pending-interrupts-endpoint.test.ts`: `fixtureApp()` (:109), `withAimock()` (:131), `createHandler(appRoot, checkpointer)` (:151) and `waitForParkedWrite()` (:281), which blocks until the checkpoint durably holds the interrupt. Put this describe block in that file, or export those helpers to a shared test helper — do not re-implement parking.
+
+**aimock fixture-ordering trap:** the `hasToolResult: true` entry MUST precede the plain `userMessage` entry, or the continuation re-matches the tool call and loops forever without finalizing.
+
+```ts
+describe("POST /threads/:id/resume — gated before it claims", () => {
+  it("denies before taking the resume claim, so a legitimate resume is not DoSed", async () => {
+    const appRoot = await fixtureApp()
+    const handler = await createHandler(appRoot, checkpointer)  // deny-everything policy
+    await driveUntilParked(handler, "t-victim")                 // per waitForParkedWrite
+    const parked = await readPendingInterruptsBody(handler, "t-victim")
+
+    const denied = await handler.fetch(
+      post("/threads/t-victim/resume", { resume: { interruptId: "guess", resumeKey: "guess" } }),
+    )
+    expect(denied.status).toBe(403)
+
+    // The claim must still be FREE. Asserted through the only observable there
+    // is: a legitimate resume must now succeed rather than 409 resume_in_progress.
+    const allowed = await allowingHandler.fetch(post("/threads/t-victim/resume", { resume: parked }))
+    expect(allowed.status).not.toBe(409)
+  })
+
+  it("does not leak whether a guessed interruptId is valid", async () => {
+    // Both requests are denied by the policy, so the 400/409 codes
+    // resolvePendingResume derives from the victim's parked interrupts must
+    // never be reachable — the two answers must be byte-identical.
+    const wrong = await handler.fetch(
+      post("/threads/t-victim/resume", { resume: { interruptId: "wrong", resumeKey: "wrong" } }),
+    )
+    const right = await handler.fetch(post("/threads/t-victim/resume", { resume: parked }))
+    expect(wrong.status).toBe(right.status)
+    expect(await wrong.text()).toBe(await right.text())
+  })
+})
+```
+
+- [ ] **Step 2: Run it and watch it fail** — expect `EXIT=1`, and specifically expect the second test to fail by returning *different* bodies, which is the leak.
+
+- [ ] **Step 3: Insert the gate**
+
+In `handleResumeRequest`, immediately after the body parse and **before** `const releaseResumeClaim = resumeClaims.tryClaim(threadId)` at `:2521`:
+
+```ts
+if (threadAccess) {
+  // BEFORE tryClaim, and therefore before runMiddleware — deliberate, and not
+  // the default ordering the other three use. Gating after middleware would let
+  // a denied caller hold the victim's resume claim (a targeted DoS on a parked
+  // turn) and read the 400/409 codes resolvePendingResume derives from the
+  // victim's parked interrupts, which is the interruptId/resumeKey oracle
+  // /pending_interrupts is gated to protect.
+  //
+  // The cost, stated rather than hidden: on this endpoint alone a caller who
+  // would have received a middleware 401 receives a thread-access deny. Both
+  // orders cannot hold — runMiddleware needs routeKey, and routeKey is read
+  // from the thread metadata this caller is not yet authorized to read.
+  const existing = await threadsStore.getThread(threadId)
+  const gate = makeThreadGate(threadAccess, request)
+  const g = gate({
+    action: "update",
+    operation: "run.resume",
+    threadId,
+    ...(existing ? { thread: existing } : {}),
+  })
+  const settled = isThenable(g) ? await g : g
+  if (!settled.ok) return settled.response
+}
+```
+
+- [ ] **Step 4: Verify green** — `EXIT=0`, both tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/cli/src/lib/dev/runtime-fetch-core.ts packages/cli/test/thread-access-run-endpoints.test.ts packages/testing/src
+git commit -m "feat(cli): gate resume before it claims or answers about a parked turn"
+```
+
+---
+
+## Task 6: Gate `POST /agui/:routeId`
+
+**Files:**
+- Modify: `packages/cli/src/lib/dev/agui-handler.ts` — after `runMiddleware` (:229), before `tryClaim` (:235)
+- Test: `packages/cli/test/thread-access-run-endpoints.test.ts`
+
+**Placement:** middleware already runs first here, so the default costs nothing. The gate goes before `resumeClaims.tryClaim` (:235), `readPendingInterrupts` (:249), `runRegistry.begin` (:264) and `createThread` (:280).
+
+**This route's pattern contains no `threads` segment**, which is exactly why the coverage test lists it — it still resolves a client-supplied thread id, creates the row and writes its metadata.
+
+- [ ] **Step 1: Write the failing test** — the Task 3 shape, driving `POST /agui/echo` with a client-supplied `threadId` of `t-victim`, asserting `operation` is `"run.agui"`, status 403, no row created, no run slot taken, and the resume claim still free.
+
+- [ ] **Step 2: Run it and watch it fail** — `EXIT=1`.
+
+- [ ] **Step 3: Insert the gate**
+
+```ts
+if (threadAccess) {
+  const existing = await threadsStore.getThread(input.threadId)
+  const gate = makeThreadGate(threadAccess, request)
+  const g = gate({
+    action: existing ? "update" : "create",
+    operation: "run.agui",
+    threadId: input.threadId,
+    ...(existing ? { thread: existing } : {}),
+  })
+  const settled = isThenable(g) ? await g : g
+  if (!settled.ok) return settled.response
+}
+```
+
+`makeThreadGate`, `isThenable` and `GateSpec` live in `runtime-fetch-core.ts` and are not exported today. Export them from there and import here rather than duplicating — a second copy of the gate is exactly the drift the shared `terminal-status.ts` extraction removed from this same file pair in #462.
+
+- [ ] **Step 4: Verify green** — `EXIT=0`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/cli/src/lib/dev/agui-handler.ts packages/cli/src/lib/dev/runtime-fetch-core.ts packages/cli/test/thread-access-run-endpoints.test.ts
+git commit -m "feat(cli): gate the AG-UI route on thread access"
+```
+
+---
+
+## Task 7: Gate `GET /pending_interrupts` — Option A
+
+**Files:**
+- Modify: `packages/cli/src/lib/dev/runtime-fetch-core.ts` — the route handler at `:1587-1603`
+- Test: `packages/cli/test/thread-access-pending-interrupts.test.ts` (create)
+- Modify: `packages/cli/test/pending-interrupts-endpoint.test.ts` — third premise rewrite
+
+**The two checks compose as AND**, and #443's route-identity check stays. A denied read must route through **this handler's own `404 thread_not_found` literal** so it stays byte-identical to a genuine miss — do not introduce a second 404 shape.
+
+- [ ] **Step 1: Write the failing test**
+
+Same helpers as Task 5 — a real parked thread via `fixtureApp` / `createHandler` / `waitForParkedWrite`.
+
+```ts
+it("denies a read the policy rejects, byte-identically to a genuine miss", async () => {
+  const handler = await createHandler(appRoot, checkpointer)  // read: deny
+  await driveUntilParked(handler, "t-victim")
+
+  const denied = await handler.fetch(get("/threads/t-victim/pending_interrupts"))
+  const missing = await handler.fetch(get("/threads/t-never-existed/pending_interrupts"))
+
+  expect(denied.status).toBe(missing.status)
+  expect(await denied.text()).toBe(await missing.text())
+})
+
+it("still enforces the parking route's middleware — the checks compose as AND", async () => {
+  // A policy that allows everything must not make #443's route-identity check
+  // vanish. This one should pass BEFORE the gate is added: it is a regression
+  // guard on #443, not new behavior.
+  const appRoot = await fixtureApp({
+    "src/middleware.ts": "export default () => new Response(null, { status: 401 })\n",
+  })
+  const handler = await createHandler(appRoot, checkpointer)  // read: allow
+  const response = await handler.fetch(get("/threads/t-mine/pending_interrupts"))
+  expect(response.status).toBe(401)
+})
+```
+
+- [ ] **Step 2: Run it and watch it fail** — `EXIT=1` on the first test; the second should already pass, which is the point (it is a regression guard on #443, not new behavior).
+
+- [ ] **Step 3: Insert the gate**
+
+In the `/pending_interrupts` handler, after the thread is loaded and before the parked-route identity resolution, reusing the handler's existing not-found literal:
+
+```ts
+if (threadAccess) {
+  const gate = makeThreadGate(threadAccess, request)
+  const g = gate({
+    action: "read",
+    notFound,                       // the handler's OWN literal — see above
+    operation: "thread.pending_interrupts",
+    threadId,
+    ...(thread ? { thread } : {}),
+  })
+  const settled = isThenable(g) ? await g : g
+  if (!settled.ok) return settled.response
+}
+```
+
+- [ ] **Step 4: Rewrite the premise in `pending-interrupts-endpoint.test.ts`**
+
+That file asserts this endpoint is gated on route identity *alone*. Find every comment and assertion stating so and correct it to "route identity AND thread access". Do not delete the route-identity coverage — Option A adds a check, it does not replace one.
+
+- [ ] **Step 5: Verify green**
+
+```bash
+pnpm --filter @dawn-ai/cli exec vitest --run --config vitest.config.ts pending-interrupts thread-access > /tmp/t7.log 2>&1; echo "EXIT=$?"
+```
+
+Expected: `EXIT=0`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/cli/src/lib/dev/runtime-fetch-core.ts packages/cli/test/thread-access-pending-interrupts.test.ts packages/cli/test/pending-interrupts-endpoint.test.ts
+git commit -m "feat(cli): authorize pending-interrupt reads on the thread-access axis"
+```
+
+---
+
+## Task 8: Move five patterns from deferred to gated
+
+**Files:**
+- Modify: `packages/cli/test/thread-access-coverage.test.ts`
+
+This test is the reason PR B cannot quietly forget an endpoint. All five patterns currently on `DEFERRED` move to `GATED`, leaving `DEFERRED` empty.
+
+- [ ] **Step 1: Move the entries**
+
+Move all five `routeKey(...)` lines from `DEFERRED` into `GATED`, and replace the `DEFERRED` doc comment with:
+
+```ts
+/**
+ * Empty since PR B. Every thread-scoped route is now gated on the thread-access
+ * axis. A new thread endpoint belongs on GATED; putting it here again needs a
+ * reason written down, because "deferred" was a slice boundary, not a category.
+ */
+const DEFERRED: readonly string[] = []
+```
+
+Update the `GATED` comment from "Gated in PR A: the five endpoints that ran no middleware at all" to name both slices.
+
+- [ ] **Step 2: Verify green**
+
+```bash
+pnpm --filter @dawn-ai/cli exec vitest --run --config vitest.config.ts thread-access-coverage > /tmp/t8.log 2>&1; echo "EXIT=$?"
+```
+
+Expected: `EXIT=0`, still asserting 14 entries.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/cli/test/thread-access-coverage.test.ts
+git commit -m "test(cli): every thread route is gated, so the deferred list is empty"
+```
+
+---
+
+## Task 9: `normalizeThreadAccessModule` and the static-module pipeline
+
+**Files:**
+- Modify: `packages/cli/src/lib/runtime/static-modules-core.ts`
+- Modify: `packages/cli/src/runtime-exports.ts` **and** `packages/cli/src/fetch-exports.ts`
+- Modify: `packages/cli/src/lib/build/modules-emitter.ts:346-348`
+- Test: `packages/cli/test/static-middleware.test.ts`, `packages/cli/test/edge-modules-emitter.test.ts`
+
+**Both barrels or the manifest fails to link** — the generated manifest imports by literal specifier on each target.
+
+**The emitter must compose its named-import line from a list**, not the current two-branch ternary, so a middleware-only app still emits the byte-identical string asserted at `static-middleware.test.ts:108-109` and `edge-modules-emitter.test.ts:248-249`. Place `threadAccess:` **after** `middleware:` and **before** `routes:` so the position assertions at `static-middleware.test.ts:112-116` stay green.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add the thread-access twin of the existing no-middleware guard. `static-middleware.test.ts:141` and `:426` assert `not.toContain("normalizeMiddlewareModule")` for an app with no middleware file; add the same for `normalizeThreadAccessModule` and an app with no policy file — without it a no-policy app could start emitting a hook entry and nothing would notice.
+
+- [ ] **Step 2: Run and watch fail** — `EXIT=1`.
+
+- [ ] **Step 3: Implement** `normalizeThreadAccessModule` alongside `normalizeMiddlewareModule`, export from both barrels, and rewrite the emitter's import line as a list join.
+
+- [ ] **Step 4: Verify green** — run both test files; `EXIT=0`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/cli/src packages/cli/test
+git commit -m "feat(cli): carry a thread-access policy through the static module manifest"
+```
+
+---
+
+## Task 10: The manifest-staleness guard
+
+**Files:**
+- Modify: the build target that records what the build saw + the boot path that checks it
+- Test: `packages/cli/test/thread-access-build-targets.test.ts`
+
+**The failure this closes actually happens:** a manifest generated before the app grew a policy, deployed to edge, silently ungated.
+
+Record that the build saw a policy file, then fail the boot when that record is present and the manifest carries no `threadAccess` **key** — distinguished with `in`, so a bound-nothing entry and an absent entry are different things.
+
+- [ ] **Step 1: Write the failing test** — a manifest with the record set and no `threadAccess` key must fail the boot with a named error; a manifest with `threadAccess: undefined` present must **not**.
+- [ ] **Step 2: Run and watch fail** — `EXIT=1`.
+- [ ] **Step 3: Implement**, using `"threadAccess" in manifest` rather than a truthiness check.
+- [ ] **Step 4: Verify green** — `EXIT=0`.
+- [ ] **Step 5: Commit**
+
+```bash
+git commit -am "fix(cli): fail the boot when a policy-built app deploys a policy-less manifest"
+```
+
+---
+
+## Task 11: Lift PR A's `hono` build refusal
+
+**Files:**
+- Modify: `packages/cli/src/lib/build/targets/*` — remove the `DAWN_E1005` refusal for `hono`
+- Test: `packages/cli/test/thread-access-build-targets.test.ts`
+
+PR A made `dawn build --target hono|langsmith` fail with `DAWN_E1005` while a policy file exists, because the web runtime could not carry one. Task 9 removes that limitation for `hono`.
+
+- [ ] **Step 1:** Flip the existing `hono` refusal test to assert a **successful** build that emits a `threadAccess` entry. Leave `langsmith` refusing and keep its test.
+- [ ] **Step 2:** Run and watch fail — `EXIT=1`.
+- [ ] **Step 3:** Remove the `hono` branch of the refusal.
+- [ ] **Step 4:** Verify green — `EXIT=0`.
+- [ ] **Step 5:** Commit.
+
+```bash
+git commit -am "feat(cli): hono builds carry a thread-access policy"
+```
+
+---
+
+## Task 12: Scaffold and conformance
+
+**Files:**
+- Create: scaffold templates `src/thread-access.ts` (deny-by-default) and a shared `src/auth.ts`
+- Modify: `runThreadsStoreConformance`
+
+- [ ] **Step 1:** Add the two template files. The policy must be **deny-by-default** and must read its subject from the server stamp (`request.thread?.access`), never from `metadata`.
+- [ ] **Step 2:** Add the two conformance cases spec §4 names.
+- [ ] **Step 3:** Run the scaffold + conformance suites; `EXIT=0`.
+- [ ] **Step 4:** Commit.
+
+```bash
+git commit -am "feat(cli): scaffold a deny-by-default thread-access policy"
+```
+
+---
+
+## Task 13: Docs
+
+**Files:**
+- Modify: `apps/web/content/docs/thread-access.mdx` — the recipe, and the `/resume` ordering consequence from Task 5
+- Modify: `apps/web/content/docs/middleware.mdx` — the "Where middleware runs" table and the ungated-endpoint sentence after it, both wrong the moment PR A shipped
+- Modify: `apps/web/content/docs/dev-server.mdx`
+
+- [ ] **Step 1:** Rewrite the middleware "Where middleware runs" table and the sentence after it. The claim that the run endpoints are gated by middleware alone is now false.
+- [ ] **Step 2:** Document, in one clear sentence each: that `/pending_interrupts` composes both checks as AND and which one produced a given denial; and that `/resume` alone answers a thread-access deny where a middleware 401 would otherwise have been returned, with the reason.
+- [ ] **Step 3:** Run the docs guards.
+
+```bash
+node scripts/check-docs.mjs > /tmp/docs.log 2>&1; echo "EXIT=$?"
+```
+
+Expected: `EXIT=0`. If it fails with "did you run pnpm build?", that is a stale `dist`, not a docs error.
+
+- [ ] **Step 4:** Commit.
+
+```bash
+git commit -am "docs: reconcile middleware and thread-access after PR B"
+```
+
+---
+
+## Task 14: Changeset and full validation
+
+- [ ] **Step 1: Write the changeset**
+
+`@dawn-ai/sdk` patch, `@dawn-ai/cli` patch, `@dawn-ai/testing` patch. It must lead with the two consequences a reader needs:
+
+1. `ThreadOperation` gains a tenth member — additive, but an exhaustive `switch` over it will stop compiling.
+2. An app with a policy now has its run endpoints and `/pending_interrupts` authorized. Apps whose policy was written against PR A's five endpoints will see it invoked on five more.
+
+- [ ] **Step 2: Full local validation**
+
+```bash
+export PATH="$HOME/.nvm/versions/node/v24.19.0/bin:$PATH"
+pnpm ci:validate > /tmp/validate.log 2>&1; echo "EXIT=$?"
+```
+
+Expected: `EXIT=0`. This is long; do not interrupt it and do not read a truncated tail as success.
+
+- [ ] **Step 3: Merge `origin/main` and re-validate**
+
+`runtime-fetch-core.ts` is the busiest file in the repo; expect conflicts.
+
+- [ ] **Step 4: Push and open the PR**
+
+The body must state the Option A decision, the `/resume` ordering exception and its cost, and that `DEFERRED` is now empty.
+
+---
+
+## Self-review notes
+
+**Spec coverage.** PR B item 1 → Tasks 3-8. Item 2 → Task 9. Item 3 → Task 10. Item 4 → Task 12. Item 5 → Task 12. Item 6 → Task 13. The resolved open question → Tasks 2 and 7. Item 2's hono lift → Task 11.
+
+**Known thin spots**, flagged rather than papered over:
+
+- Tasks 9-12 carry less literal code than Tasks 3-7. That is deliberate — the gates are the security-critical core and are specified to the line; the build-pipeline tasks depend on the exact shape of `normalizeMiddlewareModule`, which the implementer must read first and mirror. If that reading turns up a surprise, stop and re-plan rather than improvising a second pattern.
+- **A first draft of this plan tested Tasks 3-7 through `createThreadAccessHarness`. That was wrong and is corrected above.** That harness is a pure policy unit-tester — one `check(spec)` method, no server, no `fetch`, no store — and its own doc comment says so. Endpoint tests use the `setup()` / `createRuntimeFetchHandler` pattern at `thread-access-endpoints.test.ts:31-75`, with an injected `threadsStore` for the "no row created" assertion. It is recorded here because the mistake is easy to repeat: the harness has the most inviting name in the package and is the wrong tool for every task in this plan.
+- **There is no `RunRegistry` accessor for tests.** The "no run slot taken" assertion is made through a second request that must not receive `409 run_in_flight`, not through a registry read.
+- Tasks 5 and 7 need a genuinely parked thread, which means driving a real turn through aimock until `waitForParkedWrite` returns. That is slower and fussier than the other tasks — budget for it, and mind the fixture-ordering trap noted in Task 5.

--- a/docs/superpowers/plans/2026-08-13-thread-access-pr-b.md
+++ b/docs/superpowers/plans/2026-08-13-thread-access-pr-b.md
@@ -29,6 +29,7 @@ The six items in the spec's **"PR B — the run surface, edge, and defaults"** s
 - **Node 24 or the suite lies.** `export PATH="$HOME/.nvm/versions/node/v24.19.0/bin:$PATH"` before any test command.
 - **Capture exit codes explicitly.** `cmd > /tmp/x.log 2>&1; echo "EXIT=$?"` — piping to `grep`/`tail` reports the *pipe's* status and has already produced a false green in this repo's history.
 - **Strip ANSI before grepping CI logs.** `perl -pe 's/\e\[[0-9;]*[a-zA-Z]//g'` — `grep -c "FAIL"` silently returns 0 against coloured output.
+- **`pnpm typecheck` on `@dawn-ai/sdk` is meaningless until you `pnpm build` first.** Found the hard way in Task 2. `packages/sdk/test/thread-access.contract.ts` imports from `"@dawn-ai/sdk"` — the package name — which resolves through `package.json`'s `types` to `dist/*.d.ts`, not `src/`. Edit a type in `src/`, run `typecheck` without rebuilding, and it silently checks the **old** types and reports success. It does not error; it lies. Build after every source edit, before every typecheck, or your green is stale. This is a different trap from the plan's other stale-`dist` warning: that one is about an unbuilt tree, this one is about ordering within an edit-test loop.
 - **Changesets gate:** a changeset is required because `packages/*/src/` changes. `@dawn-ai/sdk`, `@dawn-ai/cli` and `@dawn-ai/testing` all move.
 - **Patch versions only.** Never bump a minor.
 - **`git worktree` + `perl -pi` with a glob:** quote or expand carefully. A collapsed glob has already produced a half-applied edit in this repo — always `git status` after a bulk rewrite.
@@ -102,6 +103,12 @@ Expected: `EXIT=0`. Record the counts — every later task compares against them
 **Files:**
 - Modify: `packages/sdk/src/thread-access.ts:38-47`
 - Test: `packages/sdk/test/thread-access.test.ts`
+
+> **Corrected during execution.** The steps below originally put the guard in `packages/sdk/test/thread-access.test.ts` and expected `vitest` to report the type error. It does not: vitest transforms with esbuild and never type-checks, and `packages/sdk/tsconfig.json` includes only `src/**/*.ts`, so that file is type-checked by **nothing**. A `ThreadOperation[]` literal there is just strings at runtime — the test would keep passing if the union member were deleted, which makes it a guard that cannot fail.
+>
+> **The guard belongs in `packages/sdk/test/thread-access.contract.ts`**, which `tsconfig.contracts.json` does include and `pnpm --filter @dawn-ai/sdk run typecheck` does run. Follow that file's existing idiom. Prove it by deleting the member and watching `typecheck` fail.
+>
+> **This applies only to Task 2.** Tasks 3-7 assert HTTP status codes, which vitest checks at runtime — "run it and watch it fail" is a real red step there.
 
 - [ ] **Step 1: Write the failing test**
 

--- a/docs/superpowers/plans/2026-08-13-thread-access-pr-b.md
+++ b/docs/superpowers/plans/2026-08-13-thread-access-pr-b.md
@@ -473,7 +473,11 @@ if (threadAccess) {
 }
 ```
 
-`makeThreadGate`, `isThenable` and `GateSpec` live in `runtime-fetch-core.ts` and are not exported today. Export them from there and import here rather than duplicating — a second copy of the gate is exactly the drift the shared `terminal-status.ts` extraction removed from this same file pair in #462.
+`makeThreadGate`, `isThenable` and `GateSpec` live in `runtime-fetch-core.ts` and are not exported today.
+
+> **Corrected during execution.** This step originally said to export them from `runtime-fetch-core.ts` and import them here. That creates a genuine module cycle — `runtime-fetch-core.ts` already imports `handleAgUiFetchRequest` from `agui-handler.ts`. It is safe at runtime (both symbols are referenced only inside function bodies) but it is the wrong shape, and it contradicts the very precedent the step cites: `terminal-status.ts` exists because #462 extracted a helper shared by **this exact file pair** rather than having one file import the other.
+>
+> **Extract to `packages/cli/src/lib/dev/thread-gate.ts`** and have both files import from it, leaving `runtime-fetch-core.ts`'s public surface unchanged. Move the gate's private helpers (`denyResponse`, `toThreadSubject`, `GATE_OK`, `warnedIgnoredStamp`) only if nothing else in `runtime-fetch-core.ts` uses them — check first. Model the new file on `terminal-status.ts`, and say in its module doc why it is separate.
 
 - [ ] **Step 4: Verify green** — `EXIT=0`.
 

--- a/docs/superpowers/plans/2026-08-13-thread-access-pr-b.md
+++ b/docs/superpowers/plans/2026-08-13-thread-access-pr-b.md
@@ -261,7 +261,7 @@ if (threadAccess) {
   const existing = await threadsStore.getThread(threadId)
   const gate = makeThreadGate(threadAccess, request)
   const g = gate({
-    action: existing ? "update" : "create",
+    action: "update",  // fixed, per the SDK contract — see note below
     operation: "run.stream",
     threadId,
     ...(existing ? { thread: existing } : {}),
@@ -463,7 +463,7 @@ if (threadAccess) {
   const existing = await threadsStore.getThread(input.threadId)
   const gate = makeThreadGate(threadAccess, request)
   const g = gate({
-    action: existing ? "update" : "create",
+    action: "update",  // fixed, per the SDK contract — see note below
     operation: "run.agui",
     threadId: input.threadId,
     ...(existing ? { thread: existing } : {}),
@@ -701,6 +701,8 @@ git commit -am "feat(cli): scaffold a deny-by-default thread-access policy"
 - Modify: `apps/web/content/docs/thread-access.mdx` — the recipe, and the `/resume` ordering consequence from Task 5
 - Modify: `apps/web/content/docs/middleware.mdx` — the "Where middleware runs" table and the ungated-endpoint sentence after it, both wrong the moment PR A shipped
 - Modify: `apps/web/content/docs/dev-server.mdx`
+
+- [ ] **Step 0: Fix the SDK doc comment PR B makes false.** `packages/sdk/src/thread-access.ts:16-37` documents each operation and the action it arrives under, then closes with: *"the four `run.*` members are not gated yet: a policy may match them today and simply will not be invoked for them until the run endpoints are wired."* PR B **is** that wiring. Delete that paragraph and add `thread.pending_interrupts` — `GET /threads/:id/pending_interrupts` — `read` to the list. That comment is also the authoritative statement that all four `run.*` operations arrive under **`update`**, which is what corrected this plan's own gate snippets mid-execution — do not weaken it.
 
 - [ ] **Step 1:** Rewrite the middleware "Where middleware runs" table and the sentence after it. The claim that the run endpoints are gated by middleware alone is now false.
 - [ ] **Step 2:** Document, in one clear sentence each: that `/pending_interrupts` composes both checks as AND and which one produced a given denial; and that `/resume` alone answers a thread-access deny where a middleware 401 would otherwise have been returned, with the reason.

--- a/examples/research/server/src/auth.ts.example
+++ b/examples/research/server/src/auth.ts.example
@@ -1,0 +1,49 @@
+/**
+ * The one place this app turns a request into a principal.
+ *
+ * Rename to `src/auth.ts` — drop the `.example` — to activate it, together with
+ * `src/thread-access.ts.example`.
+ *
+ * Dawn has two authorization files with two different jobs. `src/middleware.ts`
+ * answers "may this caller run this route"; `src/thread-access.ts` answers "may
+ * this caller create, read, mutate or destroy this thread". Nothing makes them
+ * agree, and two independent header parsers is a confused deputy waiting to
+ * happen — middleware admits the caller as org A while the policy derives org
+ * B. So both import this module, and neither parses a header of its own.
+ *
+ * Replace the body. A trusted header is only as trustworthy as the proxy in
+ * front of it; verify a signed token wherever the deployment allows one.
+ */
+
+export interface Principal {
+  readonly id: string
+  readonly isAdmin: boolean
+  readonly org: string
+}
+
+/**
+ * Resolve the caller, or `undefined` when there is no principal.
+ *
+ * `undefined` means "no principal", and every caller must read it as a denial —
+ * never as an anonymous allow. Returning a principal here is the only thing
+ * that opens any thread endpoint.
+ *
+ * `headers` arrives with lowercase keys and repeated headers joined with ", ",
+ * so `X-User-Id: victim` plus `X-User-Id: attacker` is the single string
+ * `"victim, attacker"`. That is safe under `===` and quietly wrong under
+ * `includes`, `startsWith` or `split(",")`. Compare with strict equality.
+ *
+ * It is `async` because a real implementation calls out to verify a token; a
+ * synchronous implementation is equally fine, and Dawn awaits either.
+ */
+export async function principalOf(
+  headers: Readonly<Record<string, string>>,
+): Promise<Principal | undefined> {
+  // REPLACE THIS. It trusts two raw headers, which is only correct behind a
+  // proxy that strips and re-sets them on every inbound request.
+  const id = headers["x-user-id"]
+  const org = headers["x-user-org"]
+  if (id === undefined || org === undefined) return undefined
+
+  return await Promise.resolve({ id, isAdmin: false, org })
+}

--- a/examples/research/server/src/thread-access.ts.example
+++ b/examples/research/server/src/thread-access.ts.example
@@ -1,0 +1,66 @@
+/**
+ * Thread authorization: may this caller create, read, mutate or destroy this
+ * thread?
+ *
+ * Rename to `src/thread-access.ts` — drop the `.example` — to activate it,
+ * together with `src/auth.ts.example`. Until you do, every thread endpoint is
+ * open to anyone who can name a thread id, and ids are neither secret nor
+ * collision-proof (`t-` plus four random bytes). Activating it before you have
+ * an authenticated caller will deny every request, which is the point: this
+ * policy is deny-by-default and only `principalOf` can open it.
+ *
+ * This is NOT route middleware. Middleware is keyed on route identity, and a
+ * thread has no owning route — every endpoint that starts a turn overwrites the
+ * thread's `route` metadata, so anyone allowed to run any route on a thread can
+ * move that identity onto a route of their choosing. Two concepts, two files.
+ *
+ * Run `dawn docs thread-access` for the full reference.
+ */
+
+import { defineThreadAccess, deny, permit, type ThreadAccessRequest } from "@dawn-ai/sdk"
+
+import { principalOf } from "./auth.js"
+
+const owned = async (req: ThreadAccessRequest) => {
+  const user = await principalOf(req.headers)
+  if (!user) return deny()
+
+  // `thread: undefined` reaches `delete`, `update` and `read` alike — Dawn
+  // invokes the policy on every gated request rather than short-circuiting to
+  // the endpoint's natural 404 or 204. Denying it FIRST, ahead of any admin
+  // branch, is what keeps "not yours" and "never existed" the same answer. An
+  // admin allowed to delete a row that never existed reopens the existence
+  // oracle this default closes.
+  if (req.thread === undefined) return deny()
+
+  // `req.thread.access`, never `req.thread.metadata`. Metadata is
+  // client-supplied and untrusted — anyone who can create a thread can write
+  // anything into it. `access` is the stamp this policy's own `create` decision
+  // returned, stored under a reserved key Dawn strips from client input on
+  // every create path, so a client cannot forge one.
+  const owner = req.thread.access?.ownerId
+
+  // `undefined` means a thread created before this app had a policy. Dawn does
+  // not guess what that should mean. Admin-only is the conservative answer; a
+  // one-time backfill is the other one. Do not permit it outright.
+  if (owner === undefined) return user.isAdmin ? permit() : deny()
+
+  if (owner === user.id) return permit()
+  if (req.action === "read" && user.isAdmin) return permit()
+  return deny()
+}
+
+export default defineThreadAccess({
+  create: async (req) => {
+    const user = await principalOf(req.headers)
+    return user ? permit({ ownerId: user.id, org: user.org }) : deny()
+  },
+  // `fallback` is required, and it is the deny-by-default floor: an action with
+  // no handler of its own lands here rather than falling through to an allow.
+  //
+  // It also handles the `update` recheck Dawn runs after every create. The row
+  // just stamped has `ownerId === user.id`, so `owned` permits it; a row the
+  // store handed back on an id collision carries someone else's, so `owned`
+  // denies and the caller never receives a thread they do not own.
+  fallback: owned,
+})

--- a/examples/research/server/src/thread-access.ts.example
+++ b/examples/research/server/src/thread-access.ts.example
@@ -31,6 +31,29 @@ const owned = async (req: ThreadAccessRequest) => {
   // branch, is what keeps "not yours" and "never existed" the same answer. An
   // admin allowed to delete a row that never existed reopens the existence
   // oracle this default closes.
+  //
+  // READ THIS BEFORE YOU SHIP AN AG-UI APP. This line also refuses every
+  // `run.*` operation on a thread id whose row does not exist yet, and those
+  // endpoints are the ones that would have created it: `POST /agui/{routeId}`,
+  // `/runs/stream`, `/runs/wait` and `/resume` all arrive here under
+  // `action: "update"` with `req.thread === undefined`. CopilotKit picks its
+  // `threadId` in the browser and never calls `POST /threads`, so under this
+  // policy every AG-UI turn on a fresh id is denied with a 403.
+  //
+  // Relaxing this line for `update` is NOT the fix, however obvious it looks.
+  // The implicit create those endpoints do writes the row with no access stamp,
+  // so the next turn on the same thread reaches the `owner === undefined`
+  // branch below and is denied anyway: you would authorize turn one and refuse
+  // turn two, which is worse than refusing honestly.
+  //
+  // Mint the thread with `POST /threads` and hand the returned `thread_id` to
+  // the client as its thread id. That is the only path that stamps an owner, so
+  // every later turn matches `owner === user.id` and is served. If you must
+  // authorize client-chosen ids instead, record the id-to-owner mapping
+  // yourself — in your own store, from this policy — and consult it here.
+  // Whatever you do, do not relax `delete` or `read`: those endpoints answer
+  // 204/404 for a row that never existed, and permitting them on a missing row
+  // is exactly what reopens the existence oracle.
   if (req.thread === undefined) return deny()
 
   // `req.thread.access`, never `req.thread.metadata`. Metadata is

--- a/packages/cli/src/fetch-exports.ts
+++ b/packages/cli/src/fetch-exports.ts
@@ -53,6 +53,7 @@ export {
   buildStaticRouteModule,
   type DawnStaticModules,
   normalizeMiddlewareModule,
+  normalizeThreadAccessModule,
   type StaticRouteModule,
   type StaticRouteModuleInput,
   type StaticToolModuleInput,

--- a/packages/cli/src/lib/build/targets/modules-emitter.ts
+++ b/packages/cli/src/lib/build/targets/modules-emitter.ts
@@ -363,7 +363,7 @@ export function emitModulesFileWithFlavor(
   const runtimeSpecifier = JSON.stringify(flavor.runtimeSpecifier)
   // Composed from a list rather than branched per combination: with two
   // optional helpers a ternary tree has four arms, and the arm a middleware-only
-  // app takes must stay byte-identical to what it emitted before thread access
+  // app takes must emit exactly the same bytes it emitted before thread access
   // existed. The order is fixed here — `buildStaticRouteModule` first, then the
   // normalizers in the order their entries appear in the default export below.
   const runtimeImports = [

--- a/packages/cli/src/lib/build/targets/modules-emitter.ts
+++ b/packages/cli/src/lib/build/targets/modules-emitter.ts
@@ -138,6 +138,14 @@ export interface ModulesEmitOptions {
   readonly discoveries: readonly RouteStaticDiscovery[]
   /** App middleware file (absolute), when the build probe found one. */
   readonly middlewareFile?: string
+  /**
+   * App thread-access policy file (absolute), when the build probe found one.
+   *
+   * Carried the same way middleware is — a namespace import plus a runtime
+   * normalization call — so a bundled target, which has no filesystem to probe
+   * at boot, still binds the app's policy instead of booting ungated.
+   */
+  readonly threadAccessFile?: string
 }
 
 /**
@@ -160,7 +168,11 @@ export interface ModulesEmitFlavor {
   readonly appRootSection: (appRoot: string) => readonly string[]
   /** Imports emitted above the runtime-helper import (none on edge). */
   readonly preludeImports: readonly string[]
-  /** Where `buildStaticRouteModule`/`normalizeMiddlewareModule` come from. */
+  /**
+   * Where `buildStaticRouteModule` / `normalizeMiddlewareModule` /
+   * `normalizeThreadAccessModule` come from. Every one of them must be exported
+   * from BOTH barrels, since this specifier is the only thing that differs.
+   */
   readonly runtimeSpecifier: string
 }
 
@@ -239,6 +251,16 @@ export function emitModulesFileWithFlavor(
     // silently miss the named form.
     moduleImports.push(
       `import * as middlewareModule from ${JSON.stringify(importSpecifier(buildDir, options.middlewareFile))}`,
+    )
+  }
+
+  if (options.threadAccessFile) {
+    // Namespace import for the same reason middleware uses one: the dynamic
+    // probe accepts a default OR a named `threadAccess` export, and the shared
+    // selection rule runs at runtime so the built app can never bind a
+    // different export than dev would.
+    moduleImports.push(
+      `import * as threadAccessModule from ${JSON.stringify(importSpecifier(buildDir, options.threadAccessFile))}`,
     )
   }
 
@@ -339,13 +361,21 @@ export function emitModulesFileWithFlavor(
   })
 
   const runtimeSpecifier = JSON.stringify(flavor.runtimeSpecifier)
+  // Composed from a list rather than branched per combination: with two
+  // optional helpers a ternary tree has four arms, and the arm a middleware-only
+  // app takes must stay byte-identical to what it emitted before thread access
+  // existed. The order is fixed here — `buildStaticRouteModule` first, then the
+  // normalizers in the order their entries appear in the default export below.
+  const runtimeImports = [
+    `buildStaticRouteModule`,
+    ...(options.middlewareFile ? [`normalizeMiddlewareModule`] : []),
+    ...(options.threadAccessFile ? [`normalizeThreadAccessModule`] : []),
+  ]
   return [
     ...flavor.header,
     ...flavor.preludeImports,
     ``,
-    options.middlewareFile
-      ? `import { buildStaticRouteModule, normalizeMiddlewareModule } from ${runtimeSpecifier}`
-      : `import { buildStaticRouteModule } from ${runtimeSpecifier}`,
+    `import { ${runtimeImports.join(", ")} } from ${runtimeSpecifier}`,
     ``,
     ...moduleImports,
     ``,
@@ -354,6 +384,12 @@ export function emitModulesFileWithFlavor(
     `export default {`,
     ...(options.middlewareFile
       ? [`  middleware: normalizeMiddlewareModule(middlewareModule),`]
+      : []),
+    // AFTER middleware and BEFORE routes: `middleware` keeps the position the
+    // manifest assertions pin it to, and both hooks stay above the payload they
+    // gate.
+    ...(options.threadAccessFile
+      ? [`  threadAccess: normalizeThreadAccessModule(threadAccessModule),`]
       : []),
     `  routes: [`,
     ...routeCalls,

--- a/packages/cli/src/lib/build/targets/thread-access-probe.ts
+++ b/packages/cli/src/lib/build/targets/thread-access-probe.ts
@@ -1,6 +1,4 @@
-import { existsSync } from "node:fs"
-
-import { threadAccessCandidatePaths } from "../../dev/thread-access.js"
+import { findThreadAccessFile } from "../../dev/thread-access-node.js"
 import { CliError } from "../../output.js"
 
 /**
@@ -10,11 +8,20 @@ import { CliError } from "../../output.js"
  * authorization policy failing open is a breach, so the build refuses rather
  * than emitting artifacts that would deploy every thread endpoint ungated.
  *
- * Same candidate list as the dynamic probe, so the build can never disagree
- * with dev about whether a policy exists.
+ * `langsmith` is the only remaining caller, and permanently so: it materializes
+ * per-route graphs and no app middleware, so there is nowhere for the hook to
+ * run. The web targets used to share this refusal; they now carry the policy in
+ * their static module manifest (`normalizeThreadAccessModule`), resolved
+ * through the same `findThreadAccessFile` this uses.
+ *
+ * That shared resolution is the point: it is the dynamic loader's candidate
+ * list AND its `lstat` hardening, so the build can never disagree with dev
+ * about whether a policy exists — and a policy file that is present but
+ * unprobeable raises rather than reading as "no policy" and letting this
+ * refusal quietly not fire.
  */
 export function assertNoThreadAccessPolicy(appRoot: string, target: string): void {
-  const found = threadAccessCandidatePaths(appRoot).find((candidate) => existsSync(candidate))
+  const found = findThreadAccessFile(appRoot)
   if (!found) return
   throw new CliError(
     `The "${target}" build target cannot carry a thread access policy, and ${found} exists. ` +

--- a/packages/cli/src/lib/build/targets/web-runtime.ts
+++ b/packages/cli/src/lib/build/targets/web-runtime.ts
@@ -6,6 +6,7 @@ import { providerPackages } from "@dawn-ai/langchain"
 import { type BuiltInModelProviderId, inferProvider } from "@dawn-ai/sdk"
 
 import { findMiddlewareFile } from "../../dev/middleware-node.js"
+import { findThreadAccessFile } from "../../dev/thread-access-node.js"
 import { loadDawnConfig } from "../../node-config.js"
 import { CliError, writeLine } from "../../output.js"
 import { scanRouteProviders } from "../../runtime/collect-route-providers.js"
@@ -13,7 +14,6 @@ import { assertEdgeCapabilities, collectEdgeDependencyNotice } from "./edge-capa
 import { edgeAppNamespace, emitEdgeModulesFile } from "./edge-modules-emitter.js"
 import type { BuildEmitContext } from "./index.js"
 import { collectRouteStaticDiscovery, type RouteStaticDiscovery } from "./modules-emitter.js"
-import { assertNoThreadAccessPolicy } from "./thread-access-probe.js"
 
 export interface WebRuntimeEmitOptions {
   readonly outputDir: string
@@ -43,18 +43,26 @@ export async function emitWebRuntimeArtifacts(
   // the target directory. A failed staged build must leave no deployable-looking
   // partial output behind.
   //
-  // The thread-access probe sits HERE, not at each target's `emit`, because
-  // every target routed through this emitter is bundled: none of them can
-  // perform the boot-time filesystem probe the policy loader needs. Enumerating
-  // the call sites is how `vercel` shipped able to emit a policy-carrying app
-  // with every thread endpoint ungated — the guard belongs on the shared path
-  // so a future web target inherits it instead of having to remember it.
-  assertNoThreadAccessPolicy(appRoot, targetName)
+  // The policy probe runs HERE, before anything is written, for the same reason
+  // the refusal it replaces did: every target routed through this emitter is
+  // bundled and can perform no boot-time filesystem probe, so whatever this
+  // resolves is the ONLY thing the deployed app will ever see. It throws rather
+  // than shrugging when a candidate cannot be probed — see `findThreadAccessFile`.
+  const threadAccessFile = findThreadAccessFile(appRoot)
   const config = await loadBuildConfig(appRoot)
   assertEdgeCapabilities({ appRoot, config, manifest }, targetName)
   const providerImports = await resolveProviderImports(manifest, config, targetName)
   const storesEntry = STORES_ENTRY(targetName)
-  const appEntry = emitAppEntry({ appRoot, config, providerImports, targetName })
+  // The entry point records WHAT THE BUILD SAW; the manifest carries the policy
+  // itself. Two artifacts, on purpose: a manifest older than the policy pairs a
+  // set record with a missing entry, which is what the boot guard reads.
+  const appEntry = emitAppEntry({
+    appRoot,
+    config,
+    providerImports,
+    targetName,
+    threadAccessExpected: threadAccessFile !== undefined,
+  })
 
   // The runtime's own discovery functions, run once here at build time —
   // identical to what the node target does, so the two manifests can only
@@ -78,6 +86,7 @@ export async function emitWebRuntimeArtifacts(
       buildDir: outputDir,
       discoveries,
       ...(middlewareFile ? { middlewareFile } : {}),
+      ...(threadAccessFile ? { threadAccessFile } : {}),
     },
     targetName,
   )
@@ -372,6 +381,8 @@ function emitAppEntry(options: {
   readonly config: DawnConfig
   readonly providerImports: readonly string[]
   readonly targetName: WebRuntimeEmitOptions["targetName"]
+  /** Did this build find a thread-access policy file? See `threadAccessRecord`. */
+  readonly threadAccessExpected: boolean
 }): string {
   const namespace = edgeAppNamespace(options.appRoot)
   const serializable = toSerializableConfig(options.config)
@@ -533,7 +544,7 @@ app.all("*", async (c) => {
     appRoot: APP_ROOT,
     config,
     modules,
-    requestStores,
+    requestStores,${threadAccessRecord(options.threadAccessExpected)}
   }).catch((error) => {
     handlerPromise = undefined
     throw error
@@ -544,6 +555,25 @@ app.all("*", async (c) => {
 
 export default app
 `
+}
+
+/**
+ * The build's record of having seen a policy file, emitted into the ENTRY
+ * POINT — which is a different artifact from the manifest that carries the
+ * policy itself, and that separation is the whole mechanism.
+ *
+ * A manifest generated before the app grew a policy, shipped beside a newer
+ * entry, otherwise boots with every thread endpoint open and logs that the app
+ * has no policy: there is no filesystem here to notice the difference. With
+ * this flag set, a manifest carrying no thread-access entry fails the boot
+ * instead (see `StaleThreadAccessManifestError`).
+ *
+ * Emitted only when true, so a policy-less app's entry is unchanged by this
+ * existing — and so the flag can never read as "expected: false" for an app
+ * whose build did find one.
+ */
+function threadAccessRecord(expected: boolean): string {
+  return expected ? `\n    threadAccessExpected: true,` : ""
 }
 
 /**

--- a/packages/cli/src/lib/dev/agui-handler.ts
+++ b/packages/cli/src/lib/dev/agui-handler.ts
@@ -4,7 +4,7 @@ import { type DawnAgentStreamChunk, fromRunAgentInput, toAguiEvents } from "@daw
 import { encodeAgUiSse } from "@dawn-ai/ag-ui/sse"
 import type { MemoryStoreLike } from "@dawn-ai/core"
 import type { PermissionsStore } from "@dawn-ai/permissions"
-import type { DawnMiddleware, MiddlewareRequest } from "@dawn-ai/sdk"
+import type { DawnMiddleware, MiddlewareRequest, ThreadAccessPolicy } from "@dawn-ai/sdk"
 import type { ThreadsStore } from "@dawn-ai/sqlite-storage"
 import type { BaseCheckpointSaver } from "@langchain/langgraph-checkpoint"
 import { type BootResolvedInstances, streamResolvedRoute } from "../runtime/execute-route-core.js"
@@ -26,6 +26,7 @@ import type { RuntimeRegistry } from "./runtime-registry-core.js"
 import { createRequestErrorBody } from "./server-errors.js"
 import { statusResponse } from "./status-response.js"
 import { terminalStatus } from "./terminal-status.js"
+import { isThenable, makeThreadGate } from "./thread-gate.js"
 import { assertNoReservedKey } from "./thread-metadata.js"
 
 export interface AgUiFetchRequestOptions {
@@ -50,6 +51,11 @@ export interface AgUiFetchRequestOptions {
   readonly registry: RuntimeRegistry
   readonly resumeClaims: PendingResumeClaims
   readonly runRegistry: RunRegistry
+  /**
+   * The boot-resolved policy. `undefined` means the app has no policy — the
+   * gate below is then a no-op, exactly like every other gated endpoint.
+   */
+  readonly threadAccess: ThreadAccessPolicy | undefined
   readonly threadsStore: ThreadsStore
   readonly sandboxManager?: SandboxManager
   readonly signal: AbortSignal
@@ -152,6 +158,7 @@ export async function handleAgUiFetchRequest(options: AgUiFetchRequestOptions): 
     registry,
     resumeClaims,
     runRegistry,
+    threadAccess,
     threadsStore,
     sandboxManager,
     signal: shutdownSignal,
@@ -229,6 +236,26 @@ export async function handleAgUiFetchRequest(options: AgUiFetchRequestOptions): 
     const middlewareResult = await runMiddleware(middleware, middlewareRequest)
     if (middlewareResult.action === "reject") {
       return statusResponse(middlewareResult.status, middlewareResult.body)
+    }
+
+    // Unconditionally `update`, like every other `run.*` operation — see
+    // ThreadOperation. AFTER the middleware reject above and BEFORE every
+    // side effect below (`resumeClaims.tryClaim`, `runRegistry.begin`,
+    // `threadsStore.createThread`): a denial must take no claim, no run
+    // slot, and create no row. This route has no `threads` segment — the
+    // client-supplied `input.threadId` is the only thread identity a caller
+    // controls here, and it names any thread id it likes.
+    if (threadAccess) {
+      const existing = await threadsStore.getThread(input.threadId)
+      const gate = makeThreadGate(threadAccess, request)
+      const g = gate({
+        action: "update",
+        operation: "run.agui",
+        threadId: input.threadId,
+        ...(existing ? { thread: existing } : {}),
+      })
+      const settled = isThenable(g) ? await g : g
+      if (!settled.ok) return settled.response
     }
 
     if (dawnInput.resume !== undefined) {

--- a/packages/cli/src/lib/dev/runtime-fetch-core.ts
+++ b/packages/cli/src/lib/dev/runtime-fetch-core.ts
@@ -1424,6 +1424,7 @@ export function buildRouteTable(ctx: {
           middleware,
           registry,
           request,
+          threadAccess,
           threadId: params.thread_id ?? "",
           threadRouteMap,
           threadsStore: getThreadsStore(request),
@@ -2168,12 +2169,21 @@ async function handleApPendingInterruptsRequest(options: {
   readonly middleware: DawnMiddleware | undefined
   readonly registry: RuntimeRegistry
   readonly request: Request
+  readonly threadAccess: ThreadAccessPolicy | undefined
   readonly threadId: string
   readonly threadRouteMap: Map<string, string>
   readonly threadsStore: ThreadsStore
 }): Promise<Response> {
-  const { checkpointer, middleware, registry, request, threadId, threadRouteMap, threadsStore } =
-    options
+  const {
+    checkpointer,
+    middleware,
+    registry,
+    request,
+    threadAccess,
+    threadId,
+    threadRouteMap,
+    threadsStore,
+  } = options
 
   // Thread first, with the same code POST /cancel and POST /resume use for an
   // unknown thread, so a client branches on one code across the AP surface.
@@ -2181,11 +2191,52 @@ async function handleApPendingInterruptsRequest(options: {
   // same as POST /resume, which answers 404 long before it calls
   // runMiddleware. Deliberate, and mandated by §1 of the spec; the interrupt
   // payloads themselves stay behind the middleware gate below.
-  const thread = await threadsStore.getThread(threadId)
-  if (!thread) {
-    return Response.json(createRequestErrorBody("Thread not found", { code: "thread_not_found" }), {
+  const notFound = () =>
+    Response.json(createRequestErrorBody("Thread not found", { code: "thread_not_found" }), {
       status: 404,
     })
+  const thread = await threadsStore.getThread(threadId)
+  if (!thread) return notFound()
+
+  // Thread access, IN ADDITION to the route identity resolved below — the two
+  // compose as AND, and neither replaces the other.
+  //
+  // Route identity alone is not enough here, and the reason is what middleware
+  // usually IS in practice: it AUTHENTICATES rather than authorizes per user. A
+  // shared API key, or any-valid-user, satisfies the parking route's middleware
+  // for every caller alike — so under the common shape, route identity admits
+  // anyone holding the app's key to the parked prompt's `interruptId`/
+  // `resumeKey` pair. That pair is the credential POST /resume takes, and
+  // /resume is now gated on this axis; leaving the read on capability-only
+  // gating would put the weaker gate in front of the more sensitive thing.
+  //
+  // `read`, not `update` — unlike the four run.* operations, this endpoint
+  // changes nothing. So a deny defaults to 404 rather than 403, and it is
+  // `notFound` above, the handler's OWN literal, that it must be
+  // indistinguishable from: a distinct 404 shape here would itself be the
+  // enumeration oracle the shared response exists to close.
+  //
+  // BEFORE the route identity below, not after it — the same ordering exception
+  // POST /resume makes, for the same reason and at the same stated cost. The
+  // route the middleware would authorize against is read off this thread's own
+  // metadata, so "after middleware" would mean resolving an identity from a
+  // thread the caller has not been authorized to read, and it would hand a
+  // denied caller the 409 thread_route_unknown branch — which answers whether
+  // the thread has ever run. The cost: on an app carrying BOTH a policy and
+  // authenticating middleware, a caller who would have received a middleware
+  // 401 receives the 404 instead. The two checks still compose as AND; only
+  // which one answers first is decided here.
+  if (threadAccess) {
+    const gate = makeThreadGate(threadAccess, request)
+    const g = gate({
+      action: "read",
+      notFound,
+      operation: "thread.pending_interrupts",
+      threadId,
+      thread,
+    })
+    const settled = isThenable(g) ? await g : g
+    if (!settled.ok) return settled.response
   }
 
   // Route identity for middleware. The PARKING route wins — the route whose own

--- a/packages/cli/src/lib/dev/runtime-fetch-core.ts
+++ b/packages/cli/src/lib/dev/runtime-fetch-core.ts
@@ -134,6 +134,31 @@ class ThreadAccessPolicyError extends Error {
   }
 }
 
+/**
+ * The entry point says this build saw a policy file; the manifest beside it
+ * carries no thread-access entry at all. Those two artifacts did not come from
+ * the same build, and on a runtime with no filesystem the difference is not
+ * recoverable — so this fails the boot rather than serving every thread
+ * endpoint open while logging that the app has no policy.
+ *
+ * A local class for the same reason `ThreadAccessPolicyError` is one:
+ * `../output.js` is node-only and this module is in the `@dawn-ai/cli/fetch`
+ * graph. Same registry code, because from an operator's seat this IS the policy
+ * failing to load — it just failed at the build boundary rather than at import.
+ */
+class StaleThreadAccessManifestError extends Error {
+  readonly code = "DAWN_E3003"
+  constructor() {
+    super(
+      "This app was built with a thread access policy, but the static module manifest it " +
+        "booted with carries no thread access entry — the manifest is older than the build " +
+        "that stamped the policy. Dawn will not boot with every thread endpoint ungated: " +
+        "re-run `dawn build` and deploy the whole build output together.",
+    )
+    this.name = "StaleThreadAccessManifestError"
+  }
+}
+
 function threadAccessSourceLabel(source: {
   readonly fromManifest: boolean
   readonly fromOptions: boolean
@@ -311,6 +336,19 @@ export async function createRuntimeFetchHandler(
     // Middleware is optional by contract, so a runtime with no filesystem
     // fallback resolves "none" rather than failing the boot.
     (await fallbacks?.loadMiddleware(options.appRoot))
+  // BEFORE the resolution below, because the resolution cannot tell the
+  // difference this catches: a stale manifest resolves to `undefined` exactly
+  // like an app that never had a policy. `in`, not truthiness — a key present
+  // and bound to undefined is a build that considered the policy and bound
+  // nothing, which is a legitimate (if unusual) hand-rolled embed, whereas a
+  // key that was never emitted means the manifest predates the policy.
+  //
+  // Scoped to a manifest boot on purpose: without `modules` the policy comes
+  // from the disk probe, which reads the app's CURRENT state and so cannot be
+  // stale in this way.
+  if (options.threadAccessExpected && options.modules && !("threadAccess" in options.modules)) {
+    throw new StaleThreadAccessManifestError()
+  }
   // Authorization, unlike middleware, must never resolve to "allow all" by
   // accident: `loadThreadAccess` throws DAWN_E3003 rather than degrading when a
   // policy file exists but cannot be bound. An absent file resolves to

--- a/packages/cli/src/lib/dev/runtime-fetch-core.ts
+++ b/packages/cli/src/lib/dev/runtime-fetch-core.ts
@@ -2234,7 +2234,6 @@ async function handleApPendingInterruptsRequest(options: {
       status: 404,
     })
   const thread = await threadsStore.getThread(threadId)
-  if (!thread) return notFound()
 
   // Thread access, IN ADDITION to the route identity resolved below — the two
   // compose as AND, and neither replaces the other.
@@ -2264,6 +2263,16 @@ async function handleApPendingInterruptsRequest(options: {
   // authenticating middleware, a caller who would have received a middleware
   // 401 receives the 404 instead. The two checks still compose as AND; only
   // which one answers first is decided here.
+  //
+  // ABOVE the missing-row 404, and invoked with `thread: undefined` when there
+  // is no row — same as GET /threads/:id and GET /threads/:id/state, and what
+  // `ThreadAccessRequest.thread` promises: the policy is invoked on every gated
+  // request, never short-circuited to the endpoint's natural 404. Ordering it
+  // the other way is only invisible while the deny keeps its 404 default. An
+  // app that overrides a read deny to 403 would get 403 for a thread that
+  // exists and 404 for one that does not — the enumeration oracle, reopened by
+  // the one endpoint that answered before asking. And a policy that audits
+  // denials would never see the miss at all.
   if (threadAccess) {
     const gate = makeThreadGate(threadAccess, request)
     const g = gate({
@@ -2271,11 +2280,12 @@ async function handleApPendingInterruptsRequest(options: {
       notFound,
       operation: "thread.pending_interrupts",
       threadId,
-      thread,
+      ...(thread ? { thread } : {}),
     })
     const settled = isThenable(g) ? await g : g
     if (!settled.ok) return settled.response
   }
+  if (!thread) return notFound()
 
   // Route identity for middleware. The PARKING route wins — the route whose own
   // turn left these interrupts in the checkpoint (see PARKED_ROUTE_KEY) — and

--- a/packages/cli/src/lib/dev/runtime-fetch-core.ts
+++ b/packages/cli/src/lib/dev/runtime-fetch-core.ts
@@ -1625,6 +1625,7 @@ export function buildRouteTable(ctx: {
           ...(sandboxManager ? { sandboxManager } : {}),
           signal: getShutdownSignal(request),
           ...(staticModules ? { staticModules } : {}),
+          threadAccess,
           threadId: params.thread_id ?? "",
           threadRouteMap,
           threadsStore: getThreadsStore(request),
@@ -2524,6 +2525,7 @@ async function handleResumeRequest(options: {
   readonly sandboxManager?: SandboxManager
   readonly signal: AbortSignal
   readonly staticModules?: DawnStaticModules
+  readonly threadAccess: ThreadAccessPolicy | undefined
   readonly threadId: string
   readonly threadRouteMap: Map<string, string>
   readonly threadsStore: ThreadsStore
@@ -2543,6 +2545,7 @@ async function handleResumeRequest(options: {
     sandboxManager,
     signal,
     staticModules,
+    threadAccess,
     threadId,
     threadRouteMap,
     threadsStore,
@@ -2561,6 +2564,47 @@ async function handleResumeRequest(options: {
   }
 
   const body = parsedBody.value
+
+  // The ordering exception. Every other run endpoint gates AFTER `runMiddleware`
+  // so that an existing 401 never silently becomes a 403; here the gate runs
+  // before `tryClaim`, and therefore before the middleware. Two holes make the
+  // usual ordering unsatisfiable on this endpoint:
+  //
+  //   1. `tryClaim` is a side effect a denied caller must not be able to cause.
+  //      A caller the policy would deny still takes the victim's resume claim,
+  //      so a legitimate resume racing it gets 409 resume_in_progress — a
+  //      targeted denial of service against a parked turn, needing no
+  //      credential at all.
+  //   2. `resolvePendingResume` answers questions about the victim's parked
+  //      interrupts: distinct 400/409 codes tell a denied caller whether the
+  //      thread has anything parked and whether a guessed
+  //      `interruptId`/`resumeKey` is valid. That pair is the credential for
+  //      resuming someone else's turn, and it is exactly what the
+  //      `/pending_interrupts` gate exists to protect — leaking it here would
+  //      make that gate pointless.
+  //
+  // The cost, stated rather than hidden: on THIS endpoint alone, a caller who
+  // would have received a middleware 401 receives a thread-access deny instead.
+  // That is not a preference. `runMiddleware` needs `routeKey`, and `routeKey`
+  // is read from the resuming thread's own metadata — so the route identity the
+  // middleware would authorize against is itself derived from the thread this
+  // caller has not yet been authorized to read. "After middleware" and "before
+  // any side effect" cannot both hold, and the two holes above decide it.
+  //
+  // `update`, like every other `run.*` operation — see ThreadOperation.
+  if (threadAccess) {
+    const existing = await threadsStore.getThread(threadId)
+    const gate = makeThreadGate(threadAccess, request)
+    const g = gate({
+      action: "update",
+      operation: "run.resume",
+      threadId,
+      ...(existing ? { thread: existing } : {}),
+    })
+    const settled = isThenable(g) ? await g : g
+    if (!settled.ok) return settled.response
+  }
+
   const releaseResumeClaim = resumeClaims.tryClaim(threadId)
   if (!releaseResumeClaim) {
     return Response.json(

--- a/packages/cli/src/lib/dev/runtime-fetch-core.ts
+++ b/packages/cli/src/lib/dev/runtime-fetch-core.ts
@@ -1533,6 +1533,7 @@ export function buildRouteTable(ctx: {
           ...(sandboxManager ? { sandboxManager } : {}),
           signal: getShutdownSignal(request),
           ...(staticModules ? { staticModules } : {}),
+          threadAccess,
           threadId: params.thread_id ?? "",
           threadRouteMap,
           threadsStore: getThreadsStore(request),
@@ -1986,6 +1987,7 @@ async function handleApWaitRequest(options: {
   readonly sandboxManager?: SandboxManager
   readonly signal: AbortSignal
   readonly staticModules?: DawnStaticModules
+  readonly threadAccess: ThreadAccessPolicy | undefined
   readonly threadId: string
   readonly threadRouteMap: Map<string, string>
   readonly threadsStore: ThreadsStore
@@ -2003,6 +2005,7 @@ async function handleApWaitRequest(options: {
     sandboxManager,
     signal,
     staticModules,
+    threadAccess,
     threadId,
     threadRouteMap,
     threadsStore,
@@ -2050,6 +2053,23 @@ async function handleApWaitRequest(options: {
 
   // Idempotently ensure the thread exists
   let thread: Thread | undefined = await threadsStore.getThread(threadId)
+
+  // Gated as "update" unconditionally, same reasoning as handleApStreamRequest:
+  // this endpoint picks the thread id the same way /runs/stream does, so a
+  // denial must create no row and take no run slot. AFTER the middleware
+  // reject above and BEFORE both `createThread` and `runRegistry.begin` below.
+  if (threadAccess) {
+    const gate = makeThreadGate(threadAccess, request)
+    const g = gate({
+      action: "update",
+      operation: "run.wait",
+      threadId,
+      ...(thread ? { thread } : {}),
+    })
+    const settled = isThenable(g) ? await g : g
+    if (!settled.ok) return settled.response
+  }
+
   if (!thread) {
     thread = await threadsStore.createThread({ thread_id: threadId })
   }

--- a/packages/cli/src/lib/dev/runtime-fetch-core.ts
+++ b/packages/cli/src/lib/dev/runtime-fetch-core.ts
@@ -1438,6 +1438,7 @@ export function buildRouteTable(ctx: {
           runRegistry: getRunRegistry(request),
           signal: getShutdownSignal(request),
           ...(staticModules ? { staticModules } : {}),
+          threadAccess,
           threadId: params.thread_id ?? "",
           threadRouteMap,
           threadsStore: getThreadsStore(request),
@@ -1680,6 +1681,7 @@ async function handleApStreamRequest(options: {
   readonly sandboxManager?: SandboxManager
   readonly signal: AbortSignal
   readonly staticModules?: DawnStaticModules
+  readonly threadAccess: ThreadAccessPolicy | undefined
   readonly threadId: string
   readonly threadRouteMap: Map<string, string>
   readonly threadsStore: ThreadsStore
@@ -1698,6 +1700,7 @@ async function handleApStreamRequest(options: {
     sandboxManager,
     signal,
     staticModules,
+    threadAccess,
     threadId,
     threadRouteMap,
     threadsStore,
@@ -1745,6 +1748,26 @@ async function handleApStreamRequest(options: {
 
   // Idempotently ensure the thread exists
   let thread: Thread | undefined = await threadsStore.getThread(threadId)
+
+  // Gated as "update" unconditionally — never "create", even for a thread
+  // this call is about to create. See ThreadOperation's `run.stream` doc:
+  // the client picks this thread id (unlike POST /threads' server-generated
+  // one), so starting a run is authorized the same way whether or not the
+  // row exists yet. AFTER the middleware reject above and BEFORE both
+  // `createThread` and `runRegistry.begin` below — a denial must create no
+  // row and take no run slot.
+  if (threadAccess) {
+    const gate = makeThreadGate(threadAccess, request)
+    const g = gate({
+      action: "update",
+      operation: "run.stream",
+      threadId,
+      ...(thread ? { thread } : {}),
+    })
+    const settled = isThenable(g) ? await g : g
+    if (!settled.ok) return settled.response
+  }
+
   if (!thread) {
     thread = await threadsStore.createThread({ thread_id: threadId })
   }

--- a/packages/cli/src/lib/dev/runtime-fetch-core.ts
+++ b/packages/cli/src/lib/dev/runtime-fetch-core.ts
@@ -1,16 +1,7 @@
 import { seedDawnConfig } from "@dawn-ai/core"
 import type { MemoryStore } from "@dawn-ai/memory"
 import type { PermissionsStore } from "@dawn-ai/permissions"
-import type {
-  DawnMiddleware,
-  MiddlewareRequest,
-  ThreadAccessDeny,
-  ThreadAccessPolicy,
-  ThreadAccessRequest,
-  ThreadAction,
-  ThreadOperation,
-  ThreadSubject,
-} from "@dawn-ai/sdk"
+import type { DawnMiddleware, MiddlewareRequest, ThreadAccessPolicy } from "@dawn-ai/sdk"
 import { THREAD_ACCESS_METADATA_KEY } from "@dawn-ai/sdk"
 import type { Thread, ThreadStatus, ThreadsStore } from "@dawn-ai/sqlite-storage"
 import type { BaseCheckpointSaver } from "@langchain/langgraph-checkpoint"
@@ -60,11 +51,8 @@ import {
 } from "./server-errors.js"
 import { statusResponse } from "./status-response.js"
 import { terminalStatus } from "./terminal-status.js"
-import {
-  normalizeThreadAccessResult,
-  threadAccessBootLine,
-  validateThreadAccessPolicy,
-} from "./thread-access.js"
+import { threadAccessBootLine, validateThreadAccessPolicy } from "./thread-access.js"
+import { isThenable, makeThreadGate } from "./thread-gate.js"
 import { assertNoReservedKey, stripReservedThreadMetadata } from "./thread-metadata.js"
 
 // ---------------------------------------------------------------------------
@@ -892,86 +880,11 @@ function trackStreamSettled(
 }
 
 // ---------------------------------------------------------------------------
-// Thread access gate
+// Create-thread collision detection
+//
+// The gate itself (`makeThreadGate`, `isThenable`, `GateSpec`) lives in
+// `thread-gate.ts`, not here — see that module's header for why.
 // ---------------------------------------------------------------------------
-
-type GateOk = { readonly ok: true; readonly stamp?: Record<string, unknown> }
-type GateDenied = { readonly ok: false; readonly response: Response }
-type Gate = GateOk | GateDenied
-
-interface GateSpec {
-  readonly action: ThreadAction
-  readonly operation: ThreadOperation
-  readonly threadId?: string
-  readonly thread?: Thread
-  readonly requestedMetadata?: Record<string, unknown>
-  /** The response a denied READ must be indistinguishable from. Supply it whenever action is "read". */
-  readonly notFound?: () => Response
-}
-
-/** Allocated once: every no-op gate and every stamp-less allow returns this. */
-const GATE_OK: Gate = { ok: true }
-
-/**
- * A stamp is honored on `create` ONLY. Carrying one on any other allow is a
- * policy-authoring mistake rather than a request failure, so it is reported
- * once per process rather than once per request — unlike the malformed-return
- * warn, which is a bug that should stay noisy.
- */
-let warnedIgnoredStamp = false
-
-/**
- * Narrowing rather than a boolean, so the `await` branch typechecks. Nothing in
- * `packages/cli/src` had one before this.
- */
-function isThenable<T>(value: T | Promise<T>): value is Promise<T> {
-  return (
-    typeof value === "object" &&
-    value !== null &&
-    typeof (value as { then?: unknown }).then === "function"
-  )
-}
-
-function isPlainRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value)
-}
-
-/**
- * Split the stored metadata: `access` is the server stamp, `metadata` is
- * everything else. A policy therefore never sees the reserved key inside
- * `metadata` and is never tempted to authorize against the untrusted sibling.
- *
- * Own properties only, both ways. The reserved key is read with `hasOwn` rather
- * than off the object, and each survivor is DEFINED rather than assigned: the
- * stored metadata is client-authored JSON, so it can carry `__proto__` as an
- * own data property, and `copy[key] = value` for that key runs the inherited
- * setter and swaps the copy's prototype instead of adding a property. Either
- * shortcut would let a forged stamp resolve through the chain on an object that
- * reports it stripped.
- */
-function toThreadSubject(thread: Thread): ThreadSubject {
-  const reserved = Object.hasOwn(thread.metadata, THREAD_ACCESS_METADATA_KEY)
-    ? thread.metadata[THREAD_ACCESS_METADATA_KEY]
-    : undefined
-  const metadata: Record<string, unknown> = {}
-  for (const [key, value] of Object.entries(thread.metadata)) {
-    if (key === THREAD_ACCESS_METADATA_KEY) continue
-    Object.defineProperty(metadata, key, {
-      configurable: true,
-      enumerable: true,
-      value,
-      writable: true,
-    })
-  }
-  return {
-    access: isPlainRecord(reserved) ? reserved : undefined,
-    created_at: thread.created_at,
-    metadata,
-    status: thread.status,
-    thread_id: thread.thread_id,
-    updated_at: thread.updated_at,
-  }
-}
 
 /** Structural equality over JSON-shaped values (no Dates, no Maps, no cycles). */
 function jsonDeepEqual(a: unknown, b: unknown): boolean {
@@ -999,93 +912,6 @@ function jsonDeepEqual(a: unknown, b: unknown): boolean {
  */
 function isRowWeJustWrote(thread: Thread, stored: Record<string, unknown> | undefined): boolean {
   return thread.created_at === thread.updated_at && jsonDeepEqual(thread.metadata, stored ?? {})
-}
-
-/**
- * Every deny becomes bytes here.
- *
- * `{ code: … }` is the SECOND positional argument — `details`, not `options` —
- * so it lands at `error.details.code` with no `error.code` / `docsUrl`, exactly
- * as `run_in_flight` and `thread_not_found` do. Deliberately no registry code
- * on the deny path: `DAWN_E3003` is for load failures, and a docs URL on a 403
- * is noise.
- *
- * Every branch supplies a literal body, and the guard is on
- * `result.body !== undefined` rather than on key presence, because
- * `Response.json(undefined)` throws and `statusResponse` would turn that into a
- * 500. A deny must never be able to 500.
- */
-function denyResponse(
-  action: ThreadAction,
-  result: ThreadAccessDeny,
-  notFound: (() => Response) | undefined,
-): Response {
-  const status = result.status ?? (action === "read" ? 404 : 403)
-  if (result.body !== undefined) return statusResponse(status, result.body)
-  if (status === 404 && notFound) return notFound()
-  if (status === 404) {
-    return Response.json(createRequestErrorBody("Thread not found"), { status: 404 })
-  }
-  return Response.json(createRequestErrorBody("Forbidden", { code: "thread_access_denied" }), {
-    status: 403,
-  })
-}
-
-/**
- * Build this request's gate.
- *
- * Returns a no-op gate when the app has no policy — the ONLY thing a hook-less
- * app pays is this closure allocation. No store read, no reordering, nothing.
- *
- * `Gate | Promise<Gate>`, never `Promise<Gate>`: a policy handler that returns a
- * plain object (the header-only case) is resolved with ZERO microtask
- * boundaries, which is what keeps the `/cancel` claim binding meaningful.
- * Callers do `const settled = isThenable(g) ? await g : g`.
- */
-function makeThreadGate(
-  policy: ThreadAccessPolicy | undefined,
-  request: Request,
-): (spec: GateSpec) => Gate | Promise<Gate> {
-  if (!policy) return () => GATE_OK
-  const headers = headersToRecord(request.headers)
-  const method = request.method
-  const parsed = new URL(request.url)
-  const url = `${parsed.pathname}${parsed.search}`
-  return (spec) => {
-    const handler = policy[spec.action] ?? policy.fallback
-    const accessRequest: ThreadAccessRequest = {
-      action: spec.action,
-      headers,
-      method,
-      operation: spec.operation,
-      requestedMetadata: spec.requestedMetadata,
-      thread: spec.thread ? toThreadSubject(spec.thread) : undefined,
-      threadId: spec.threadId,
-      url,
-    }
-    const settle = (value: unknown): Gate => {
-      const result = normalizeThreadAccessResult(value, spec.operation, spec.threadId)
-      if (result.decision === "allow") {
-        if (!result.stamp) return GATE_OK
-        if (spec.action === "create") return { ok: true, stamp: result.stamp }
-        // Dropped, not merged: the stamp is the server's answer to "who created
-        // this thread", and honoring it here would let any later allow rewrite
-        // it through the store's shallow merge.
-        if (!warnedIgnoredStamp) {
-          warnedIgnoredStamp = true
-          console.warn(
-            `Dawn thread access: the policy returned a stamp on a ${spec.action} allow ` +
-              `(${spec.operation}). Stamps are honored on create only, so it was ignored. ` +
-              "This warning is emitted once per process.",
-          )
-        }
-        return GATE_OK
-      }
-      return { ok: false, response: denyResponse(spec.action, result, spec.notFound) }
-    }
-    const returned = handler(accessRequest) as unknown
-    return isThenable(returned) ? returned.then(settle) : settle(returned)
-  }
 }
 
 // ---------------------------------------------------------------------------
@@ -1462,6 +1288,7 @@ export function buildRouteTable(ctx: {
           registry,
           resumeClaims,
           runRegistry: getRunRegistry(request),
+          threadAccess,
           threadsStore: getThreadsStore(request),
           ...(sandboxManager ? { sandboxManager } : {}),
           signal: getShutdownSignal(request),

--- a/packages/cli/src/lib/dev/runtime-server.ts
+++ b/packages/cli/src/lib/dev/runtime-server.ts
@@ -90,6 +90,24 @@ export interface StartRuntimeServerOptions {
    * the dynamic src/thread-access.ts probe.
    */
   readonly threadAccess?: ThreadAccessPolicy
+  /**
+   * What the BUILD saw: true when `dawn build` found a thread-access policy
+   * file for this app. Set by the generated entry point, which is a different
+   * artifact from the manifest it imports — that separation is the whole point.
+   *
+   * With it set, a `modules` manifest that carries no `threadAccess` KEY fails
+   * the boot: the two artifacts cannot have come from the same build, and the
+   * runtime this matters on (a bundled one) has no filesystem probe to fall
+   * back to, so it would otherwise come up with every thread endpoint open and
+   * log that the app has no policy. That is a real deployment shape — a
+   * manifest generated before the app grew a policy, shipped beside a newer
+   * entry point.
+   *
+   * The check is `"threadAccess" in modules`, not a truthiness test: a key
+   * present and bound to undefined is a build that considered the policy and
+   * bound nothing, which is a different fact from a key that was never emitted.
+   */
+  readonly threadAccessExpected?: boolean
   /** Boot-resolved sandbox manager. Absent: built from `config.sandbox`. */
   readonly sandboxManager?: SandboxManager
   /**

--- a/packages/cli/src/lib/dev/thread-access-node.ts
+++ b/packages/cli/src/lib/dev/thread-access-node.ts
@@ -72,6 +72,26 @@ function candidateExists(path: string, statPath: StatPath): boolean {
 }
 
 /**
+ * The first policy candidate that EXISTS, or undefined when every one of them
+ * is definitively absent.
+ *
+ * Shared with the build (`emitWebRuntimeArtifacts`) so a bundled target binds
+ * the same file, by the same rule, that the dynamic probe would. It is this
+ * function rather than an `existsSync` scan for the reason `candidateExists`
+ * exists at all: `existsSync` answers false for EVERY error, so an app whose
+ * policy file is present but unprobeable would fail `dawn dev` and still build
+ * an artifact with no policy in it — the fail-open moved rather than fixed.
+ */
+export function findThreadAccessFile(
+  appRoot: string,
+  statPath: StatPath = lstatSync,
+): string | undefined {
+  return threadAccessCandidatePaths(appRoot).find((candidate) =>
+    candidateExists(candidate, statPath),
+  )
+}
+
+/**
  * Load the app's thread-access policy.
  *
  * This deliberately does NOT copy `loadMiddleware` (`./middleware.ts`), which
@@ -97,10 +117,7 @@ export async function loadThreadAccess(
   appRoot: string,
   options?: LoadThreadAccessOptions,
 ): Promise<ThreadAccessPolicy | undefined> {
-  const statPath = options?.statPath ?? lstatSync
-  const path = threadAccessCandidatePaths(appRoot).find((candidate) =>
-    candidateExists(candidate, statPath),
-  )
+  const path = findThreadAccessFile(appRoot, options?.statPath ?? lstatSync)
   if (!path) return undefined
 
   let mod: unknown

--- a/packages/cli/src/lib/dev/thread-gate.ts
+++ b/packages/cli/src/lib/dev/thread-gate.ts
@@ -1,0 +1,196 @@
+import type {
+  ThreadAccessDeny,
+  ThreadAccessPolicy,
+  ThreadAccessRequest,
+  ThreadAction,
+  ThreadOperation,
+  ThreadSubject,
+} from "@dawn-ai/sdk"
+import { THREAD_ACCESS_METADATA_KEY } from "@dawn-ai/sdk"
+import type { Thread } from "@dawn-ai/sqlite-storage"
+import { headersToRecord } from "./middleware.js"
+import { createRequestErrorBody } from "./server-errors.js"
+import { statusResponse } from "./status-response.js"
+import { normalizeThreadAccessResult } from "./thread-access.js"
+
+/**
+ * The thread-access gate: every gated endpoint builds one of these per
+ * request and calls it to authorize against a `ThreadAccessPolicy`.
+ *
+ * Its own module rather than living in `runtime-fetch-core.ts` — the obvious
+ * home, since every Agent Protocol handler already lives there. But
+ * `runtime-fetch-core.ts` also imports the AG-UI handler, to wire
+ * `POST /agui/:routeId` into the route table, and that endpoint's pattern
+ * carries no `threads` segment — it gates itself inline rather than through
+ * one of `runtime-fetch-core.ts`'s own handlers. Exporting the gate FROM
+ * `runtime-fetch-core.ts` for the AG-UI handler to import back would have
+ * made that import a cycle. This is the same shape of problem `terminal-
+ * status.ts` was pulled out to solve in #462, after `terminalStatus` drifted
+ * into two copies across this exact file pair: one shared module both
+ * callers import, rather than either importing the other.
+ */
+
+export type GateOk = { readonly ok: true; readonly stamp?: Record<string, unknown> }
+export type GateDenied = { readonly ok: false; readonly response: Response }
+export type Gate = GateOk | GateDenied
+
+export interface GateSpec {
+  readonly action: ThreadAction
+  readonly operation: ThreadOperation
+  readonly threadId?: string
+  readonly thread?: Thread
+  readonly requestedMetadata?: Record<string, unknown>
+  /** The response a denied READ must be indistinguishable from. Supply it whenever action is "read". */
+  readonly notFound?: () => Response
+}
+
+/** Allocated once: every no-op gate and every stamp-less allow returns this. */
+const GATE_OK: Gate = { ok: true }
+
+/**
+ * A stamp is honored on `create` ONLY. Carrying one on any other allow is a
+ * policy-authoring mistake rather than a request failure, so it is reported
+ * once per process rather than once per request — unlike the malformed-return
+ * warn, which is a bug that should stay noisy.
+ */
+let warnedIgnoredStamp = false
+
+/**
+ * Narrowing rather than a boolean, so the `await` branch typechecks. Nothing
+ * in `packages/cli/src` had one before this.
+ */
+export function isThenable<T>(value: T | Promise<T>): value is Promise<T> {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    typeof (value as { then?: unknown }).then === "function"
+  )
+}
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+/**
+ * Split the stored metadata: `access` is the server stamp, `metadata` is
+ * everything else. A policy therefore never sees the reserved key inside
+ * `metadata` and is never tempted to authorize against the untrusted sibling.
+ *
+ * Own properties only, both ways. The reserved key is read with `hasOwn` rather
+ * than off the object, and each survivor is DEFINED rather than assigned: the
+ * stored metadata is client-authored JSON, so it can carry `__proto__` as an
+ * own data property, and `copy[key] = value` for that key runs the inherited
+ * setter and swaps the copy's prototype instead of adding a property. Either
+ * shortcut would let a forged stamp resolve through the chain on an object that
+ * reports it stripped.
+ */
+function toThreadSubject(thread: Thread): ThreadSubject {
+  const reserved = Object.hasOwn(thread.metadata, THREAD_ACCESS_METADATA_KEY)
+    ? thread.metadata[THREAD_ACCESS_METADATA_KEY]
+    : undefined
+  const metadata: Record<string, unknown> = {}
+  for (const [key, value] of Object.entries(thread.metadata)) {
+    if (key === THREAD_ACCESS_METADATA_KEY) continue
+    Object.defineProperty(metadata, key, {
+      configurable: true,
+      enumerable: true,
+      value,
+      writable: true,
+    })
+  }
+  return {
+    access: isPlainRecord(reserved) ? reserved : undefined,
+    created_at: thread.created_at,
+    metadata,
+    status: thread.status,
+    thread_id: thread.thread_id,
+    updated_at: thread.updated_at,
+  }
+}
+
+/**
+ * Every deny becomes bytes here.
+ *
+ * `{ code: … }` is the SECOND positional argument — `details`, not `options` —
+ * so it lands at `error.details.code` with no `error.code` / `docsUrl`, exactly
+ * as `run_in_flight` and `thread_not_found` do. Deliberately no registry code
+ * on the deny path: `DAWN_E3003` is for load failures, and a docs URL on a 403
+ * is noise.
+ *
+ * Every branch supplies a literal body, and the guard is on
+ * `result.body !== undefined` rather than on key presence, because
+ * `Response.json(undefined)` throws and `statusResponse` would turn that into a
+ * 500. A deny must never be able to 500.
+ */
+function denyResponse(
+  action: ThreadAction,
+  result: ThreadAccessDeny,
+  notFound: (() => Response) | undefined,
+): Response {
+  const status = result.status ?? (action === "read" ? 404 : 403)
+  if (result.body !== undefined) return statusResponse(status, result.body)
+  if (status === 404 && notFound) return notFound()
+  if (status === 404) {
+    return Response.json(createRequestErrorBody("Thread not found"), { status: 404 })
+  }
+  return Response.json(createRequestErrorBody("Forbidden", { code: "thread_access_denied" }), {
+    status: 403,
+  })
+}
+
+/**
+ * Build this request's gate.
+ *
+ * Returns a no-op gate when the app has no policy — the ONLY thing a hook-less
+ * app pays is this closure allocation. No store read, no reordering, nothing.
+ *
+ * `Gate | Promise<Gate>`, never `Promise<Gate>`: a policy handler that returns a
+ * plain object (the header-only case) is resolved with ZERO microtask
+ * boundaries, which is what keeps the `/cancel` claim binding meaningful.
+ * Callers do `const settled = isThenable(g) ? await g : g`.
+ */
+export function makeThreadGate(
+  policy: ThreadAccessPolicy | undefined,
+  request: Request,
+): (spec: GateSpec) => Gate | Promise<Gate> {
+  if (!policy) return () => GATE_OK
+  const headers = headersToRecord(request.headers)
+  const method = request.method
+  const parsed = new URL(request.url)
+  const url = `${parsed.pathname}${parsed.search}`
+  return (spec) => {
+    const handler = policy[spec.action] ?? policy.fallback
+    const accessRequest: ThreadAccessRequest = {
+      action: spec.action,
+      headers,
+      method,
+      operation: spec.operation,
+      requestedMetadata: spec.requestedMetadata,
+      thread: spec.thread ? toThreadSubject(spec.thread) : undefined,
+      threadId: spec.threadId,
+      url,
+    }
+    const settle = (value: unknown): Gate => {
+      const result = normalizeThreadAccessResult(value, spec.operation, spec.threadId)
+      if (result.decision === "allow") {
+        if (!result.stamp) return GATE_OK
+        if (spec.action === "create") return { ok: true, stamp: result.stamp }
+        // Dropped, not merged: the stamp is the server's answer to "who created
+        // this thread", and honoring it here would let any later allow rewrite
+        // it through the store's shallow merge.
+        if (!warnedIgnoredStamp) {
+          warnedIgnoredStamp = true
+          console.warn(
+            `Dawn thread access: the policy returned a stamp on a ${spec.action} allow ` +
+              `(${spec.operation}). Stamps are honored on create only, so it was ignored. ` +
+              "This warning is emitted once per process.",
+          )
+        }
+        return GATE_OK
+      }
+      return { ok: false, response: denyResponse(spec.action, result, spec.notFound) }
+    }
+    const returned = handler(accessRequest) as unknown
+    return isThenable(returned) ? returned.then(settle) : settle(returned)
+  }
+}

--- a/packages/cli/src/lib/runtime/static-modules-core.ts
+++ b/packages/cli/src/lib/runtime/static-modules-core.ts
@@ -14,6 +14,7 @@ import {
 import type { DawnMiddleware, ThreadAccessPolicy } from "@dawn-ai/sdk"
 
 import { selectMiddlewareExport } from "../dev/middleware.js"
+import { selectThreadAccessExport, validateThreadAccessPolicy } from "../dev/thread-access.js"
 import { pureDirname, pureJoin } from "./pure-path.js"
 import { createRouteAssistantId } from "./route-identity.js"
 import { type LoadedRouteMemory, normalizeRouteMemoryExport } from "./route-memory-shape.js"
@@ -229,4 +230,56 @@ export function buildStaticRouteModule(input: StaticRouteModuleInput): StaticRou
  */
 export function normalizeMiddlewareModule(mod: unknown): DawnMiddleware | undefined {
   return selectMiddlewareExport(mod)
+}
+
+/**
+ * A manifest whose thread-access entry bound nothing usable.
+ *
+ * A local class rather than `CliError`: `../output.js` is node-only and this
+ * module is in the `@dawn-ai/cli/fetch` graph — the same reason
+ * `runtime-fetch-core.ts` rolls its own. `dawnErrorCodeOf` reads the code back.
+ */
+class ManifestThreadAccessError extends Error {
+  /** Registry code, the same one the dynamic loader raises. */
+  readonly code = "DAWN_E3003"
+  constructor(reason: string) {
+    super(
+      `The thread access policy in this app's static module manifest is not usable: ${reason}. ` +
+        "The manifest carries a policy only for an app that HAS a policy file, so Dawn will not " +
+        "boot with every thread endpoint ungated — fix the policy file and re-run `dawn build`.",
+    )
+    this.name = "ManifestThreadAccessError"
+  }
+}
+
+/**
+ * Runtime companion for the manifest's thread-access entry: pick the policy out
+ * of the statically-imported `import * as` namespace using the SAME selection
+ * rule the dynamic probe (`loadThreadAccess`) applies — `default` first, then
+ * the named `threadAccess` export — and validate it with the same shape check.
+ *
+ * Deliberately NOT `normalizeMiddlewareModule`'s ending: that one returns
+ * undefined when a middleware file binds nothing, because dev ignores such a
+ * file too. Here, "binds nothing" THROWS, for the reason `loadThreadAccess`
+ * throws on it: the emitter only ever writes this call for an app that has a
+ * policy file, so a selection that comes back empty means the built app would
+ * serve every thread endpoint ungated while logging that it has no policy —
+ * degrading to `undefined` would make that failure indistinguishable from an
+ * app that never had a policy at all.
+ *
+ * Throwing here also runs at manifest LINK time, on both targets: the edge
+ * flavor is imported directly by the generated `app.mjs`, never through
+ * `loadStaticModules`, so this is the only seam a bundled deploy passes.
+ */
+export function normalizeThreadAccessModule(mod: unknown): ThreadAccessPolicy {
+  const selected = selectThreadAccessExport(mod)
+  if (selected === undefined || selected === null) {
+    throw new ManifestThreadAccessError(
+      "the built module has no `default` or `threadAccess` export " +
+        "(export the policy with `export default defineThreadAccess({ … })`)",
+    )
+  }
+  const reason = validateThreadAccessPolicy(selected)
+  if (reason) throw new ManifestThreadAccessError(reason)
+  return selected as ThreadAccessPolicy
 }

--- a/packages/cli/src/runtime-exports.ts
+++ b/packages/cli/src/runtime-exports.ts
@@ -58,6 +58,7 @@ export {
   type DawnStaticModules,
   loadStaticModules,
   normalizeMiddlewareModule,
+  normalizeThreadAccessModule,
   type StaticRouteModule,
   type StaticRouteModuleInput,
   type StaticToolModuleInput,

--- a/packages/cli/test/agui-endpoint.test.ts
+++ b/packages/cli/test/agui-endpoint.test.ts
@@ -187,6 +187,7 @@ async function setupControlledServer(controlled: ControlledServerOptions): Promi
       routeKey: "/chat#agent",
       signal: controlled.shutdownSignal ?? new AbortController().signal,
       streamRoute: controlled.streamRoute,
+      threadAccess: undefined,
       threadsStore: {
         createThread: async ({ thread_id }: { thread_id?: string }) => {
           const threadId = thread_id ?? "generated"

--- a/packages/cli/test/edge-modules-emitter.test.ts
+++ b/packages/cli/test/edge-modules-emitter.test.ts
@@ -257,6 +257,36 @@ describe("emitEdgeModulesFile — golden", () => {
     expect(text).not.toContain("node:")
     expect(text).not.toContain(appRoot)
   })
+
+  it("imports normalizeThreadAccessModule from the fetch entry too", async () => {
+    const appRoot = await fixtureApp()
+    const discoveries = await collectFixtureDiscoveries(appRoot)
+    const text = emitEdgeModulesFile({
+      appRoot,
+      buildDir: join(appRoot, ".dawn", "build"),
+      discoveries,
+      middlewareFile: join(appRoot, "src", "middleware.ts"),
+      threadAccessFile: join(appRoot, "src", "thread-access.ts"),
+    })
+
+    // One import line, composed from a list — the edge manifest links against
+    // `@dawn-ai/cli/fetch`, so the fetch barrel must export this too or the
+    // deployed bundle fails at link time rather than at boot.
+    expect(text).toContain(
+      'import { buildStaticRouteModule, normalizeMiddlewareModule, normalizeThreadAccessModule } from "@dawn-ai/cli/fetch"',
+    )
+    expect(text).toContain('import * as threadAccessModule from "../../src/thread-access.ts"')
+    expect(text).toContain("  threadAccess: normalizeThreadAccessModule(threadAccessModule),")
+    // middleware → threadAccess → routes, matching the node manifest.
+    expect(text.indexOf("middleware: normalizeMiddlewareModule")).toBeLessThan(
+      text.indexOf("threadAccess: normalizeThreadAccessModule"),
+    )
+    expect(text.indexOf("threadAccess: normalizeThreadAccessModule")).toBeLessThan(
+      text.indexOf("routes: ["),
+    )
+    expect(text).not.toContain("node:")
+    expect(text).not.toContain(appRoot)
+  })
 })
 
 // ---------------------------------------------------------------------------

--- a/packages/cli/test/pending-interrupts-endpoint.test.ts
+++ b/packages/cli/test/pending-interrupts-endpoint.test.ts
@@ -1177,7 +1177,7 @@ const ALLOW: Record<string, string> = { "x-allow": "1" }
 // ---------------------------------------------------------------------------
 
 describe("GET /threads/:thread_id/pending_interrupts thread access", () => {
-  it("denies a read the policy rejects, byte-identically to a genuine miss", async () => {
+  it("denies a read the policy rejects, in the same bytes as a genuine miss", async () => {
     await withAimock(
       script().user("deploy to staging").callsTool("deployProd", { env: "staging" }).build(),
     )

--- a/packages/cli/test/pending-interrupts-endpoint.test.ts
+++ b/packages/cli/test/pending-interrupts-endpoint.test.ts
@@ -471,6 +471,17 @@ const ADMIN_PARK_MIDDLEWARE = [
   "",
 ].join("\n")
 
+/**
+ * The ROUTE-IDENTITY axis of this endpoint's gating: which route's middleware
+ * authorizes the read, and the parking route being pinned as that identity so a
+ * run on a weaker route cannot repoint it.
+ *
+ * It is one of two axes, not the whole gate. Thread access is the other, and
+ * they compose as AND — see the `pending_interrupts thread access` block below
+ * for that half and for why one axis was not enough. Every case here installs
+ * no policy, which is the hook-less app: route identity is then the only thing
+ * refusing, so these assertions stay about it alone.
+ */
 describe("GET /threads/:thread_id/pending_interrupts — gating", () => {
   it("refuses a thread that has never run with 409 thread_route_unknown", async () => {
     const handler = await createHandler(await fixtureApp())
@@ -569,8 +580,13 @@ describe("GET /threads/:thread_id/pending_interrupts — gating", () => {
     const body = (await response.json()) as ErrorBody
     // Same code as the never-ran arm: both mean "no usable route identity".
     expect(body.error.details?.code).toBe("thread_route_unknown")
-    // The caller is still UNGATED here, so the server-derived key must not come
-    // back — it would tell anyone who can name a thread id which route it ran.
+    // Route middleware has NOT run at this point — it cannot, since resolving
+    // the identity it gates on is what just failed — so on a hook-less app like
+    // this one the caller is entirely ungated here. The server-derived key must
+    // therefore not come back: it would tell anyone who can name a thread id
+    // which route it ran. (With a policy installed, thread access has already
+    // allowed this caller by now; that is a second axis, not a substitute, and
+    // an app with no policy is exactly the case this has to hold for.)
     // The sibling `Unknown route: ...` sites may echo because there the key came
     // from the caller's own request body.
     expect(body.error.message).not.toContain("/retired-route")
@@ -1122,6 +1138,102 @@ function heldDenyOwnerOnlyPolicy(): HeldDenyPolicy {
     releaseDeny: () => release(),
   }
 }
+
+/** Allows every action for every caller. The point of it is to be uninteresting:
+ * it proves that installing a policy does not switch the route-identity check
+ * off. */
+function allowEverythingPolicy(): ThreadAccessPolicy {
+  return { fallback: () => ({ decision: "allow" }) }
+}
+
+/**
+ * Rejects with 401 unless `x-allow` is present. 401 SPECIFICALLY, and not the
+ * 403 the sibling fixtures use: the thread-access gate answers 404 for a denied
+ * read and 403 for everything else, and never 401 — so a 401 out of this
+ * endpoint can only have come from route middleware. That is what makes the
+ * composition assertion below unambiguous rather than a coincidence of codes.
+ */
+const UNAUTHENTICATED_MIDDLEWARE = [
+  'import { allow, defineMiddleware, reject } from "@dawn-ai/sdk"',
+  "export default defineMiddleware((req) =>",
+  '  req.headers["x-allow"] ? allow() : reject(401, { code: "unauthenticated" }),',
+  ")",
+  "",
+].join("\n")
+
+const ALLOW: Record<string, string> = { "x-allow": "1" }
+
+// ---------------------------------------------------------------------------
+// GET /threads/:thread_id/pending_interrupts, gated on thread access.
+//
+// Option A: this endpoint gates on route identity AND thread access, composed
+// as AND. Route identity alone is not enough, because the common middleware
+// shape AUTHENTICATES rather than authorizes per user — a shared API key, or
+// any-valid-user. Under that shape every caller satisfies the parking route's
+// middleware, so a low-privilege one could read another user's parked
+// `interruptId`/`resumeKey` pair: the credential POST /resume takes, and the
+// thing /resume itself is now gated on (see the block below). The weaker gate
+// must not be the one guarding the more sensitive thing.
+// ---------------------------------------------------------------------------
+
+describe("GET /threads/:thread_id/pending_interrupts thread access", () => {
+  it("denies a read the policy rejects, byte-identically to a genuine miss", async () => {
+    await withAimock(
+      script().user("deploy to staging").callsTool("deployProd", { env: "staging" }).build(),
+    )
+    // No middleware fixture, deliberately: this app AUTHENTICATES nobody, so
+    // route identity admits every caller and thread access is the only thing
+    // that can refuse. That is the shape the disclosure lives in.
+    const handler = await createHandler(await fixtureApp(), undefined, ownerOnlyPolicy())
+    const threadId = "t-victim"
+
+    const parkText = await readSseText(
+      await handler.fetch(parkRunRequest(threadId, "deploy to staging", OWNER)),
+    )
+    expect(parkText).toContain("event: interrupt")
+    // Pins the premise rather than assuming it: there is a real credential
+    // parked on this thread for a denied caller to walk off with.
+    const parked = (await readPendingInterruptsBody(handler, threadId, OWNER)).interrupts[0]
+    expect(parked?.resumeKey).toMatch(/^[0-9a-f]{32}$/)
+
+    const denied = await handler.fetch(pendingInterruptsRequest(threadId))
+    const missing = await handler.fetch(pendingInterruptsRequest("t-never-existed"))
+
+    // A denied read must be indistinguishable from a thread that never existed,
+    // or the 404/403 split becomes an enumeration oracle for thread ids.
+    // Asserted before the status below, as in the /resume oracle test: the
+    // indistinguishability IS the property.
+    expect(denied.status).toBe(missing.status)
+    expect(await denied.text()).toBe(await missing.text())
+    expect(missing.status).toBe(404)
+  }, 60_000)
+
+  it("still enforces the parking route's middleware — the checks compose as AND", async () => {
+    const handler = await createHandler(
+      await fixtureApp({ "src/middleware.ts": UNAUTHENTICATED_MIDDLEWARE }),
+      undefined,
+      allowEverythingPolicy(),
+    )
+    const threadId = "t-and-composed"
+
+    // Seeds the thread and its route identity, so the GET below reaches
+    // middleware rather than short-circuiting on 409 thread_route_unknown.
+    const seeded = await handler.fetch(runStreamRequest(threadId, "/echo#graph", {}, ALLOW))
+    expect(seeded.status).toBe(200)
+    await drain(seeded)
+
+    // A policy that allows everything must NOT make the route-identity check
+    // vanish.
+    const response = await handler.fetch(pendingInterruptsRequest(threadId))
+    expect(response.status).toBe(401)
+
+    // The other half of the AND, so the 401 above cannot be a fixture that
+    // refuses everything: the same caller with credentials gets served.
+    const allowed = await handler.fetch(pendingInterruptsRequest(threadId, ALLOW))
+    expect(allowed.status).toBe(200)
+    expect(await allowed.json()).toEqual({ interrupts: [] })
+  }, 30_000)
+})
 
 describe("POST /threads/:thread_id/resume thread access", () => {
   it("denies before taking the resume claim, so a legitimate resume is not DoSed", async () => {

--- a/packages/cli/test/pending-interrupts-endpoint.test.ts
+++ b/packages/cli/test/pending-interrupts-endpoint.test.ts
@@ -1,6 +1,7 @@
 import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { dirname, join } from "node:path"
+import type { ThreadAccessPolicy } from "@dawn-ai/sdk"
 import type { RunnableConfig } from "@langchain/core/runnables"
 import { MemorySaver } from "@langchain/langgraph"
 import {
@@ -147,13 +148,20 @@ async function withAimock(fixtures: ReturnType<ReturnType<typeof script>["build"
 /** drainDeadlineMs keeps afterEach from waiting the 30s default when a test
  * deliberately abandons a still-running route; the long heartbeat interval
  * keeps asserted SSE text free of `: ping` frames. `checkpointer` is the seam
- * the malformed-write and postgres cases inject through. */
-async function createHandler(appRoot: string, checkpointer?: BaseCheckpointSaver) {
+ * the malformed-write and postgres cases inject through. `threadAccess` is the
+ * seam the resume-gate cases inject through; every other case leaves it unset,
+ * which is the hook-less app. */
+async function createHandler(
+  appRoot: string,
+  checkpointer?: BaseCheckpointSaver,
+  threadAccess?: ThreadAccessPolicy,
+) {
   const handler = await createRuntimeFetchHandler({
     appRoot,
     apSseHeartbeatIntervalMs: 60_000,
     drainDeadlineMs: 250,
     ...(checkpointer ? { checkpointer } : {}),
+    ...(threadAccess ? { threadAccess } : {}),
   })
   cleanup.push(() => handler.close())
   return handler
@@ -296,8 +304,9 @@ async function waitForParkedWrite(
 async function readPendingInterruptsBody(
   handler: Handler,
   threadId: string,
+  headers: Record<string, string> = {},
 ): Promise<PendingInterruptsBody> {
-  const response = await handler.fetch(pendingInterruptsRequest(threadId))
+  const response = await handler.fetch(pendingInterruptsRequest(threadId, headers))
   expect(response.status).toBe(200)
   return (await response.json()) as PendingInterruptsBody
 }
@@ -1056,6 +1065,141 @@ describe("thread status after a resumed turn", () => {
     // does not re-render a decision the human already made.
     const after = await readPendingInterruptsBody(handler, threadId)
     expect(after.interrupts).toEqual([])
+  }, 60_000)
+})
+
+// ---------------------------------------------------------------------------
+// POST /threads/:thread_id/resume, gated on thread access.
+//
+// These live here rather than in thread-access-run-endpoints.test.ts because
+// both need a REAL parked turn — a genuine interruptId/resumeKey pair written
+// by a genuine HITL interrupt — and this file is where that is already driven.
+// ---------------------------------------------------------------------------
+
+const OWNER: Record<string, string> = { "x-actor": "owner" }
+
+/** Allows the thread's owner and denies everyone else, on every action. */
+function ownerOnlyPolicy(): ThreadAccessPolicy {
+  return {
+    fallback: (request) =>
+      request.headers["x-actor"] === "owner" ? { decision: "allow" } : { decision: "deny" },
+  }
+}
+
+interface HeldDenyPolicy {
+  readonly policy: ThreadAccessPolicy
+  /** Resolves once a denied caller is inside the policy and cannot advance. */
+  readonly denyEntered: Promise<void>
+  readonly releaseDeny: () => void
+}
+
+/**
+ * `ownerOnlyPolicy`, except the DENY is held open until the test releases it —
+ * an async policy is the normal case (a real one looks the caller up), and
+ * holding it is what pins a denied caller mid-flight, so the test can ask what
+ * it has already taken. A gate placed anywhere after `tryClaim` is holding the
+ * victim's resume claim across this await.
+ */
+function heldDenyOwnerOnlyPolicy(): HeldDenyPolicy {
+  let markEntered: () => void = () => undefined
+  const denyEntered = new Promise<void>((resolve) => {
+    markEntered = () => resolve()
+  })
+  let release: () => void = () => undefined
+  const held = new Promise<void>((resolve) => {
+    release = () => resolve()
+  })
+  return {
+    denyEntered,
+    policy: {
+      fallback: async (request) => {
+        if (request.headers["x-actor"] === "owner") return { decision: "allow" }
+        markEntered()
+        await held
+        return { decision: "deny" }
+      },
+    },
+    releaseDeny: () => release(),
+  }
+}
+
+describe("POST /threads/:thread_id/resume thread access", () => {
+  it("denies before taking the resume claim, so a legitimate resume is not DoSed", async () => {
+    await withAimock(
+      script()
+        .user("deploy to staging")
+        .callsTool("deployProd", { env: "staging" })
+        .replies("Deployed.")
+        .build(),
+    )
+    const gate = heldDenyOwnerOnlyPolicy()
+    const handler = await createHandler(await fixtureApp(), undefined, gate.policy)
+    const threadId = "t-resume-claim"
+
+    const parkText = await readSseText(
+      await handler.fetch(parkRunRequest(threadId, "deploy to staging", OWNER)),
+    )
+    expect(parkText).toContain("event: interrupt")
+    const parkedId = (await readPendingInterruptsBody(handler, threadId, OWNER)).interrupts[0]
+      ?.interruptId
+    expect(parkedId).toBeTruthy()
+
+    // Fired and deliberately not awaited: this caller is now pinned inside the
+    // policy and cannot advance, so whatever it has already taken it is still
+    // holding while the owner's resume below runs to completion. That is the
+    // whole design — the claim is released in a `finally`, so a denied caller
+    // that has already returned can never be caught holding anything.
+    const attacker = handler.fetch(resumeRequest(threadId, "perm-guessed"))
+    await Promise.race([
+      gate.denyEntered,
+      // A gate placed after `runMiddleware` never reaches the policy for this
+      // caller at all — `resolvePendingResume` rejects the wrong guess first.
+      // Fall through rather than hang; the 403 at the bottom catches it.
+      new Promise((resolve) => setTimeout(resolve, 2_000)),
+    ])
+
+    const allowed = await handler.fetch(resumeRequest(threadId, parkedId ?? "", OWNER))
+    // The claim assertion. 409 resume_in_progress here means the denied caller
+    // still parked in the policy above had already taken the victim's claim.
+    expect(allowed.status).not.toBe(409)
+    expect(allowed.status).toBe(200)
+    await drain(allowed)
+
+    gate.releaseDeny()
+    expect((await attacker).status).toBe(403)
+  }, 60_000)
+
+  it("does not leak whether a guessed interruptId is valid", async () => {
+    await withAimock(
+      script()
+        .user("deploy to staging")
+        .callsTool("deployProd", { env: "staging" })
+        .replies("Deployed.")
+        .build(),
+    )
+    const handler = await createHandler(await fixtureApp(), undefined, ownerOnlyPolicy())
+    const threadId = "t-resume-oracle"
+
+    const parkText = await readSseText(
+      await handler.fetch(parkRunRequest(threadId, "deploy to staging", OWNER)),
+    )
+    expect(parkText).toContain("event: interrupt")
+    const parkedId = (await readPendingInterruptsBody(handler, threadId, OWNER)).interrupts[0]
+      ?.interruptId
+    expect(parkedId).toBeTruthy()
+
+    // Both denied, so the 400/409 codes `resolvePendingResume` derives from the
+    // victim's parked interrupts must be unreachable: a wrong guess and the
+    // real credential have to be indistinguishable, byte for byte.
+    const wrong = await handler.fetch(resumeRequest(threadId, "perm-guessed"))
+    const right = await handler.fetch(resumeRequest(threadId, parkedId ?? ""))
+
+    // Asserted BEFORE the 403 below on purpose: the indistinguishability IS the
+    // property, and asserting the status first would fail this test on the deny
+    // code without ever showing that the two answers differ.
+    expect(right.status).toBe(wrong.status)
+    expect(await right.text()).toBe(await wrong.text())
+    expect(wrong.status).toBe(403)
   }, 60_000)
 })
 

--- a/packages/cli/test/pending-interrupts-endpoint.test.ts
+++ b/packages/cli/test/pending-interrupts-endpoint.test.ts
@@ -1102,6 +1102,39 @@ function ownerOnlyPolicy(): ThreadAccessPolicy {
   }
 }
 
+interface RecordingPolicy {
+  readonly policy: ThreadAccessPolicy
+  /** Every operation the policy was asked about, in order. */
+  readonly operations: string[]
+}
+
+/**
+ * `ownerOnlyPolicy`, except a denied READ answers 403 rather than the 404
+ * default — the override `ThreadAccessDeny.status` exists for, and the shape
+ * that makes the gate's ordering observable.
+ *
+ * Under the 404 default a handler that short-circuits its own miss BEFORE the
+ * gate is indistinguishable from one that does not: both answer 404. Override
+ * the deny to 403 and the two separate — a pre-gate 404 for a missing thread
+ * against a 403 for one that exists is exactly the enumeration oracle the
+ * shared response exists to close. It also records what it was asked, because a
+ * policy that audits denials must SEE the denial: never being invoked at all is
+ * its own failure, distinct from the status the caller receives.
+ */
+function forbiddenReadOwnerOnlyPolicy(): RecordingPolicy {
+  const operations: string[] = []
+  return {
+    operations,
+    policy: {
+      fallback: (request) => {
+        operations.push(request.operation)
+        if (request.headers["x-actor"] === "owner") return { decision: "allow" }
+        return request.action === "read" ? { decision: "deny", status: 403 } : { decision: "deny" }
+      },
+    },
+  }
+}
+
 interface HeldDenyPolicy {
   readonly policy: ThreadAccessPolicy
   /** Resolves once a denied caller is inside the policy and cannot advance. */
@@ -1207,6 +1240,37 @@ describe("GET /threads/:thread_id/pending_interrupts thread access", () => {
     expect(await denied.text()).toBe(await missing.text())
     expect(missing.status).toBe(404)
   }, 60_000)
+
+  it("invokes the policy for a missing thread, so a 403-overriding app keeps no oracle", async () => {
+    const gate = forbiddenReadOwnerOnlyPolicy()
+    const handler = await createHandler(await fixtureApp(), undefined, gate.policy)
+    const threadId = "t-403-existing"
+
+    // Seeds a real row for the id below to differ from. `/echo` is a plain
+    // graph, so this needs no model at all — the property under test is the
+    // gate's ORDER, not anything about a parked turn.
+    const seeded = await handler.fetch(runStreamRequest(threadId, "/echo#graph", {}, OWNER))
+    expect(seeded.status).toBe(200)
+    await drain(seeded)
+
+    gate.operations.length = 0
+    const existing = await handler.fetch(pendingInterruptsRequest(threadId))
+    const askedAboutExisting = [...gate.operations]
+    gate.operations.length = 0
+    const missing = await handler.fetch(pendingInterruptsRequest("t-403-never-existed"))
+    const askedAboutMissing = [...gate.operations]
+
+    // The oracle assertion, ahead of the status: what matters is that the two
+    // answers are the SAME, whatever the app chose them to be.
+    expect(existing.status).toBe(missing.status)
+    expect(await existing.text()).toBe(await missing.text())
+    expect(existing.status).toBe(403)
+
+    // And the audit assertion. A policy that logs denials is blind on any
+    // endpoint that answers before asking it, however the status came out.
+    expect(askedAboutExisting).toContain("thread.pending_interrupts")
+    expect(askedAboutMissing).toContain("thread.pending_interrupts")
+  }, 30_000)
 
   it("still enforces the parking route's middleware — the checks compose as AND", async () => {
     const handler = await createHandler(

--- a/packages/cli/test/runtime-fetch-parity.test.ts
+++ b/packages/cli/test/runtime-fetch-parity.test.ts
@@ -133,6 +133,7 @@ describe("AG-UI middleware reject", () => {
       }),
       routeKey: "/chat#agent",
       signal: new AbortController().signal,
+      threadAccess: undefined,
       threadsStore: {} as unknown as ThreadsStore, // never reached on reject
     })
 

--- a/packages/cli/test/static-middleware.test.ts
+++ b/packages/cli/test/static-middleware.test.ts
@@ -140,6 +140,10 @@ describe("emitModulesFile — middleware", () => {
     })
     expect(text).not.toContain("normalizeMiddlewareModule")
     expect(text).not.toContain("middlewareModule")
+    // The thread-access twin: this fixture has no policy file either, and the
+    // named-import line is now composed from a list — a hook entry appearing
+    // for an app that never asked for one would otherwise go unnoticed.
+    expect(text).not.toContain("normalizeThreadAccessModule")
     expect(text).toContain('import { buildStaticRouteModule } from "@dawn-ai/cli/runtime"')
   })
 })
@@ -424,5 +428,8 @@ describe("node target — middleware probe", () => {
     const text = await emitFixture(appRoot)
     expect(text).not.toContain("middlewareModule")
     expect(text).not.toContain("normalizeMiddlewareModule")
+    // Same twin as the emitter-level case above: the node target's fixture has
+    // no `thread-access.ts`, so no hook entry may appear in its manifest.
+    expect(text).not.toContain("normalizeThreadAccessModule")
   })
 })

--- a/packages/cli/test/static-thread-access.test.ts
+++ b/packages/cli/test/static-thread-access.test.ts
@@ -1,0 +1,253 @@
+import { mkdir, mkdtemp, realpath, rm, symlink, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { dirname, join, resolve } from "node:path"
+import { fileURLToPath, pathToFileURL } from "node:url"
+import { discoverRoutes } from "@dawn-ai/core/node"
+import { afterEach, describe, expect, it } from "vitest"
+
+import * as fetchBarrel from "../src/fetch-exports.js"
+import {
+  collectRouteStaticDiscovery,
+  emitModulesFile,
+  type RouteStaticDiscovery,
+} from "../src/lib/build/targets/modules-emitter.js"
+import {
+  loadStaticModules,
+  normalizeThreadAccessModule,
+} from "../src/lib/runtime/static-modules.js"
+import * as runtimeBarrel from "../src/runtime-exports.js"
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..", "..")
+
+const cleanup: Array<() => Promise<void> | void> = []
+
+afterEach(async () => {
+  for (const fn of cleanup.splice(0).reverse()) await fn()
+})
+
+const VALID_POLICY_FILE =
+  'import { defineThreadAccess } from "@dawn-ai/sdk"\n' +
+  "export default defineThreadAccess({\n" +
+  '  fallback: () => ({ decision: "allow" }),\n' +
+  "})\n"
+
+async function fixtureApp(
+  files: Readonly<Record<string, string>> = { "src/thread-access.ts": VALID_POLICY_FILE },
+): Promise<string> {
+  // realpath: on macOS the tmpdir is behind a /var → /private/var symlink, and
+  // the loader resolves module URLs to their real paths.
+  const appRoot = await realpath(await mkdtemp(join(tmpdir(), "dawn-static-thread-access-")))
+  cleanup.push(() => rm(appRoot, { force: true, maxRetries: 5, recursive: true, retryDelay: 100 }))
+  const appFiles: Record<string, string> = {
+    "dawn.config.ts": "export default {}\n",
+    "package.json": '{ "name": "static-thread-access-fixture", "type": "module" }\n',
+    "src/app/chat/index.ts":
+      'import { agent } from "@dawn-ai/sdk"\n' +
+      'export default agent({ model: "gpt-5-mini", systemPrompt: "You are helpful." })\n',
+    ...files,
+  }
+  for (const [relativePath, source] of Object.entries(appFiles)) {
+    const filePath = join(appRoot, relativePath)
+    await mkdir(dirname(filePath), { recursive: true })
+    await writeFile(filePath, source, "utf8")
+  }
+  return appRoot
+}
+
+async function collectFixtureDiscoveries(appRoot: string): Promise<RouteStaticDiscovery[]> {
+  const manifest = await discoverRoutes({ appRoot })
+  const discoveries: RouteStaticDiscovery[] = []
+  for (const route of manifest.routes) {
+    discoveries.push(await collectRouteStaticDiscovery({ appRoot, route }))
+  }
+  return discoveries
+}
+
+/** Link the real @dawn-ai/cli package into the fixture so the emitted
+ * manifest's `"@dawn-ai/cli/runtime"` import resolves from the tmpdir. */
+async function linkCliPackage(appRoot: string): Promise<void> {
+  await mkdir(join(appRoot, "node_modules", "@dawn-ai"), { recursive: true })
+  await symlink(
+    join(repoRoot, "packages", "cli"),
+    join(appRoot, "node_modules", "@dawn-ai", "cli"),
+    "dir",
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Emitter: threadAccessFile produces a namespace import (JSON.stringify'd
+// specifier) and a `threadAccess: normalizeThreadAccessModule(...)` entry
+// AFTER middleware and BEFORE routes; omitting it emits neither.
+// ---------------------------------------------------------------------------
+
+describe("emitModulesFile — thread access", () => {
+  it("emits the namespace import and normalize call when threadAccessFile is set", async () => {
+    const appRoot = await fixtureApp()
+    const discoveries = await collectFixtureDiscoveries(appRoot)
+
+    const text = emitModulesFile({
+      appRoot,
+      buildDir: join(appRoot, ".dawn", "build"),
+      discoveries,
+      threadAccessFile: join(appRoot, "src", "thread-access.ts"),
+    })
+
+    expect(text).toContain(
+      'import { buildStaticRouteModule, normalizeThreadAccessModule } from "@dawn-ai/cli/runtime"',
+    )
+    expect(text).toContain('import * as threadAccessModule from "../../src/thread-access.ts"')
+    expect(text).toContain("  threadAccess: normalizeThreadAccessModule(threadAccessModule),")
+    // Before routes in the default export.
+    expect(text.indexOf("threadAccess: normalizeThreadAccessModule")).toBeGreaterThan(0)
+    expect(text.indexOf("threadAccess: normalizeThreadAccessModule")).toBeLessThan(
+      text.indexOf("routes: ["),
+    )
+  })
+
+  it("composes one import line with middleware, in a fixed order", async () => {
+    const appRoot = await fixtureApp({
+      "src/middleware.ts":
+        'import { allow, defineMiddleware } from "@dawn-ai/sdk"\n' +
+        "export default defineMiddleware(() => allow())\n",
+      "src/thread-access.ts": VALID_POLICY_FILE,
+    })
+    const discoveries = await collectFixtureDiscoveries(appRoot)
+
+    const text = emitModulesFile({
+      appRoot,
+      buildDir: join(appRoot, ".dawn", "build"),
+      discoveries,
+      middlewareFile: join(appRoot, "src", "middleware.ts"),
+      threadAccessFile: join(appRoot, "src", "thread-access.ts"),
+    })
+
+    expect(text).toContain(
+      'import { buildStaticRouteModule, normalizeMiddlewareModule, normalizeThreadAccessModule } from "@dawn-ai/cli/runtime"',
+    )
+    // middleware → threadAccess → routes, so the middleware entry keeps the
+    // position the existing manifest assertions pin it to.
+    expect(text.indexOf("middleware: normalizeMiddlewareModule")).toBeLessThan(
+      text.indexOf("threadAccess: normalizeThreadAccessModule"),
+    )
+    expect(text.indexOf("threadAccess: normalizeThreadAccessModule")).toBeLessThan(
+      text.indexOf("routes: ["),
+    )
+  })
+
+  it("JSON-escapes hostile thread-access specifiers", () => {
+    const text = emitModulesFile({
+      appRoot: "/app",
+      buildDir: "/app/.dawn/build",
+      discoveries: [],
+      threadAccessFile: '/app/src/thread"access.ts',
+    })
+    expect(text).toContain(
+      String.raw`import * as threadAccessModule from "../../src/thread\"access.ts"`,
+    )
+    expect(text).not.toContain('from "../../src/thread"access.ts"')
+  })
+
+  it("emits no thread-access artifacts when threadAccessFile is absent", async () => {
+    const appRoot = await fixtureApp({})
+    const discoveries = await collectFixtureDiscoveries(appRoot)
+    const text = emitModulesFile({
+      appRoot,
+      buildDir: join(appRoot, ".dawn", "build"),
+      discoveries,
+    })
+    expect(text).not.toContain("normalizeThreadAccessModule")
+    expect(text).not.toContain("threadAccessModule")
+    expect(text).not.toContain("threadAccess:")
+    expect(text).toContain('import { buildStaticRouteModule } from "@dawn-ai/cli/runtime"')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Both barrels, or the generated manifest cannot link: the node flavor imports
+// `@dawn-ai/cli/runtime` and the edge flavor `@dawn-ai/cli/fetch`, each by
+// literal specifier.
+// ---------------------------------------------------------------------------
+
+describe("normalizeThreadAccessModule — barrels", () => {
+  it("is exported from the runtime entry and the fetch entry, as one function", () => {
+    expect(typeof runtimeBarrel.normalizeThreadAccessModule).toBe("function")
+    expect(typeof fetchBarrel.normalizeThreadAccessModule).toBe("function")
+    expect(runtimeBarrel.normalizeThreadAccessModule).toBe(fetchBarrel.normalizeThreadAccessModule)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// normalizeThreadAccessModule: the SAME export selection the dynamic probe
+// uses, and — unlike normalizeMiddlewareModule — a THROW when the selection
+// binds nothing usable. The emitter only ever calls it for an app that has a
+// policy file, so "bound nothing" means the built app would serve every thread
+// endpoint ungated while logging that it has no policy.
+// ---------------------------------------------------------------------------
+
+describe("normalizeThreadAccessModule — selection parity and fail-closed", () => {
+  const policy = { fallback: () => ({ decision: "allow" }) as const }
+
+  it("selects a default export", () => {
+    expect(normalizeThreadAccessModule({ default: policy })).toBe(policy)
+  })
+
+  it("falls back to a named `threadAccess` export", () => {
+    expect(normalizeThreadAccessModule({ threadAccess: policy })).toBe(policy)
+    expect(normalizeThreadAccessModule({ default: undefined, threadAccess: policy })).toBe(policy)
+  })
+
+  it("throws when the module binds no policy at all", () => {
+    expect(() => normalizeThreadAccessModule({})).toThrow(/default.*threadAccess/s)
+    expect(() => normalizeThreadAccessModule(null)).toThrow(/default.*threadAccess/s)
+    expect(() => normalizeThreadAccessModule(undefined)).toThrow(/default.*threadAccess/s)
+  })
+
+  it("throws DAWN_E3003 rather than degrading to `no policy`", () => {
+    try {
+      normalizeThreadAccessModule({})
+      expect.unreachable("expected a throw")
+    } catch (error) {
+      expect(error).toMatchObject({ code: "DAWN_E3003" })
+    }
+  })
+
+  it("throws on a selected value that is not a well-formed policy", () => {
+    expect(() => normalizeThreadAccessModule({ default: "nope" })).toThrow(/not an object/)
+    expect(() =>
+      normalizeThreadAccessModule({ default: { read: () => ({ decision: "allow" }) } }),
+    ).toThrow(/`fallback`/)
+    expect(() =>
+      normalizeThreadAccessModule({ default: { fallback: () => ({}), read: 1 } }),
+    ).toThrow(/`read`/)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Round-trip: the emitted manifest carries a working policy, bound through the
+// published `@dawn-ai/cli/runtime` specifier the generated file imports.
+// ---------------------------------------------------------------------------
+
+describe("static manifest thread access — round-trip", () => {
+  it("binds the policy from the manifest with the source file deleted", async () => {
+    const appRoot = await fixtureApp()
+    await linkCliPackage(appRoot)
+
+    const discoveries = await collectFixtureDiscoveries(appRoot)
+    const buildDir = join(appRoot, ".dawn", "build")
+    await mkdir(buildDir, { recursive: true })
+    const modulesPath = join(buildDir, "modules.mjs")
+    await writeFile(
+      modulesPath,
+      emitModulesFile({
+        appRoot,
+        buildDir,
+        discoveries,
+        threadAccessFile: join(appRoot, "src", "thread-access.ts"),
+      }),
+      "utf8",
+    )
+
+    const modules = await loadStaticModules(pathToFileURL(modulesPath))
+    expect(typeof modules.threadAccess?.fallback).toBe("function")
+  }, 30_000)
+})

--- a/packages/cli/test/thread-access-boot.test.ts
+++ b/packages/cli/test/thread-access-boot.test.ts
@@ -8,6 +8,7 @@ import { afterEach, describe, expect, it, vi } from "vitest"
 import { createRuntimeFetchHandler } from "../src/lib/dev/runtime-fetch-handler.js"
 import { loadThreadAccess } from "../src/lib/dev/thread-access-node.js"
 import { nodeBootFallbacks } from "../src/lib/runtime/execute-route.js"
+import type { DawnStaticModules } from "../src/lib/runtime/static-modules.js"
 import { loadStaticModules } from "../src/lib/runtime/static-modules.js"
 
 const cleanup: Array<() => Promise<void> | void> = []
@@ -186,6 +187,74 @@ describe("thread-access boot resolution", () => {
       log.mockRestore()
     }
     expect(lines).not.toContain("Dawn: no thread access policy (all thread endpoints are open)")
+  })
+})
+
+// ---------------------------------------------------------------------------
+// The manifest-staleness guard: a build that SAW a policy file stamps a record
+// into the artifact it generates alongside the manifest. If the manifest that
+// reaches the runtime does not carry a thread-access entry, the two artifacts
+// did not come from the same build — the exact shape of the failure this
+// closes: a manifest generated before the app grew a policy, deployed to edge
+// (where there is no filesystem to fall back to), silently ungated.
+// ---------------------------------------------------------------------------
+
+describe("thread-access manifest staleness", () => {
+  const emptyManifest = { routes: [] } as const
+
+  it("fails the boot when the build saw a policy and the manifest has no entry", async () => {
+    const appRoot = await fixtureApp()
+    const failure = await bootFailure({
+      appRoot,
+      modules: emptyManifest,
+      threadAccessExpected: true,
+    })
+    expect(failure.code).toBe("DAWN_E3003")
+    expect(failure.message).toContain("re-run `dawn build`")
+  })
+
+  it("does not log a boot line for the manifest it rejected", async () => {
+    const appRoot = await fixtureApp()
+    const lines: string[] = []
+    const log = vi.spyOn(console, "log").mockImplementation((line: unknown) => {
+      lines.push(String(line))
+    })
+    try {
+      await bootFailure({ appRoot, modules: emptyManifest, threadAccessExpected: true })
+    } finally {
+      log.mockRestore()
+    }
+    expect(lines).not.toContain("Dawn: no thread access policy (all thread endpoints are open)")
+  })
+
+  it("accepts a manifest that carries the key bound to nothing", async () => {
+    // `in`, not truthiness: an entry present and undefined is a build that
+    // considered the policy and bound nothing (a hand-rolled embed's
+    // `threadAccess: undefined`), which is a different fact from an entry that
+    // was never emitted at all. Conflating them is the bug.
+    const appRoot = await fixtureApp()
+    // Cast because `exactOptionalPropertyTypes` forbids writing the key as
+    // undefined in TypeScript at all — which is exactly why the runtime must
+    // handle it: a generated `.mjs` manifest carries no types.
+    const modules = { routes: [], threadAccess: undefined } as unknown as DawnStaticModules
+    const lines = await bootWithLog({ appRoot, modules, threadAccessExpected: true })
+    expect(lines).toContain("Dawn: no thread access policy (all thread endpoints are open)")
+  })
+
+  it("accepts a manifest that carries the policy", async () => {
+    const appRoot = await fixtureApp()
+    const lines = await bootWithLog({
+      appRoot,
+      modules: { routes: [], threadAccess: allowAll },
+      threadAccessExpected: true,
+    })
+    expect(lines).toContain("Dawn: thread access policy bound from the build manifest")
+  })
+
+  it("leaves a build that saw no policy alone", async () => {
+    const appRoot = await fixtureApp()
+    const lines = await bootWithLog({ appRoot, modules: emptyManifest })
+    expect(lines).toContain("Dawn: no thread access policy (all thread endpoints are open)")
   })
 })
 

--- a/packages/cli/test/thread-access-build-targets.test.ts
+++ b/packages/cli/test/thread-access-build-targets.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises"
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { dirname, join } from "node:path"
 import type { RouteManifest } from "@dawn-ai/core"
@@ -6,6 +6,8 @@ import { afterEach, describe, expect, it } from "vitest"
 
 import { buildTargets } from "../src/lib/build/targets/index.js"
 import { assertNoThreadAccessPolicy } from "../src/lib/build/targets/thread-access-probe.js"
+import { emitWebRuntimeArtifacts } from "../src/lib/build/targets/web-runtime.js"
+import { findThreadAccessFile } from "../src/lib/dev/thread-access-node.js"
 
 const tempDirs: string[] = []
 
@@ -64,13 +66,6 @@ describe("assertNoThreadAccessPolicy", () => {
 })
 
 describe("build targets that cannot carry a policy", () => {
-  it("fails the hono build", async () => {
-    const appRoot = await fixtureApp({ "src/thread-access.ts": POLICY_FILE })
-    await expect(buildTargets.hono?.emit(emitContext(appRoot))).rejects.toMatchObject({
-      code: "DAWN_E1005",
-    })
-  })
-
   it("fails the langsmith build", async () => {
     const appRoot = await fixtureApp({ "src/thread-access.ts": POLICY_FILE })
     await expect(buildTargets.langsmith?.emit(emitContext(appRoot))).rejects.toMatchObject({
@@ -78,20 +73,87 @@ describe("build targets that cannot carry a policy", () => {
     })
   })
 
-  // `vercel` landed on main while this branch was open. It shares `hono`'s
-  // bundled web runtime and so shares its inability to probe a policy file at
-  // boot — but the guard was enumerated per target, so it inherited nothing.
-  // The probe now sits in `emitWebRuntimeArtifacts`; this is the test that
-  // would have caught the gap, and that a third web target gets for free.
-  it("fails the vercel build", async () => {
+  it("names the target that refused", async () => {
     const appRoot = await fixtureApp({ "src/thread-access.ts": POLICY_FILE })
-    await expect(buildTargets.vercel?.emit(emitContext(appRoot))).rejects.toMatchObject({
-      code: "DAWN_E1005",
-    })
+    await expect(buildTargets.langsmith?.emit(emitContext(appRoot))).rejects.toThrow(/langsmith/)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// The web targets CAN carry a policy now: the manifest binds it through a
+// static import, and the entry point stamps what the build saw so a manifest
+// that predates the policy cannot boot silently ungated.
+//
+// `vercel` is covered alongside `hono` because there is one shared emitter, not
+// because the plan asked for it: the two targets differ only in the handful of
+// lines `edgeFlavor` changes, so a hono-only assertion would prove nothing
+// about the code path vercel actually runs — and refusing vercel would now be a
+// false refusal for a runtime that carries the policy perfectly well.
+// ---------------------------------------------------------------------------
+
+describe("web targets carry the policy", () => {
+  it("emits the thread-access entry into the hono manifest", async () => {
+    const appRoot = await fixtureApp({ "src/thread-access.ts": POLICY_FILE })
+    await buildTargets.hono?.emit(emitContext(appRoot))
+
+    const modules = await readFile(join(appRoot, ".dawn/build/modules.edge.mjs"), "utf8")
+    expect(modules).toContain(
+      'import { buildStaticRouteModule, normalizeThreadAccessModule } from "@dawn-ai/cli/fetch"',
+    )
+    expect(modules).toContain('import * as threadAccessModule from "../../src/thread-access.ts"')
+    expect(modules).toContain("  threadAccess: normalizeThreadAccessModule(threadAccessModule),")
   })
 
-  it("names the target that refused, not the shared emitter", async () => {
+  it("stamps what the build saw into the hono entry point", async () => {
     const appRoot = await fixtureApp({ "src/thread-access.ts": POLICY_FILE })
-    await expect(buildTargets.vercel?.emit(emitContext(appRoot))).rejects.toThrow(/vercel/)
+    await buildTargets.hono?.emit(emitContext(appRoot))
+
+    const entry = await readFile(join(appRoot, ".dawn/build/app.mjs"), "utf8")
+    expect(entry).toContain("threadAccessExpected: true,")
+  })
+
+  it("emits neither for an app with no policy file", async () => {
+    const appRoot = await fixtureApp()
+    await buildTargets.hono?.emit(emitContext(appRoot))
+
+    const modules = await readFile(join(appRoot, ".dawn/build/modules.edge.mjs"), "utf8")
+    const entry = await readFile(join(appRoot, ".dawn/build/app.mjs"), "utf8")
+    expect(modules).not.toContain("normalizeThreadAccessModule")
+    expect(modules).not.toContain("threadAccessModule")
+    expect(entry).not.toContain("threadAccessExpected")
+  })
+
+  it("carries it through the shared web emitter for vercel too", async () => {
+    const appRoot = await fixtureApp({ "src/thread-access.ts": POLICY_FILE })
+    const outputDir = join(appRoot, ".vercel/.dawn-vercel-test/runtime")
+    const runtime = await emitWebRuntimeArtifacts(emitContext(appRoot), {
+      outputDir,
+      targetName: "vercel",
+    })
+
+    const modules = await readFile(runtime.modulesPath, "utf8")
+    const entry = await readFile(runtime.appPath, "utf8")
+    expect(modules).toContain("Generated by dawn build (vercel target)")
+    expect(modules).toContain("  threadAccess: normalizeThreadAccessModule(threadAccessModule),")
+    expect(entry).toContain("threadAccessExpected: true,")
+  })
+
+  it("probes the policy file the way the loader does, not with existsSync", async () => {
+    // `existsSync` answers false for EVERY error, so an EACCES on the policy
+    // file would drop it out of the manifest and ship a bundle with every
+    // thread endpoint open — the fail-open moved into the build rather than
+    // fixed. Only the syscall is stubbed; the real candidate list runs.
+    const appRoot = await fixtureApp({ "src/thread-access.ts": POLICY_FILE })
+    expect(() =>
+      findThreadAccessFile(appRoot, (path) => {
+        throw Object.assign(new Error(`EACCES: lstat '${path}'`), { code: "EACCES" })
+      }),
+    ).toThrow(/EACCES|could not be probed/)
+  })
+
+  it("finds the first existing candidate, and nothing when there is none", async () => {
+    const appRoot = await fixtureApp({ "thread-access.js": POLICY_FILE })
+    expect(findThreadAccessFile(appRoot)).toBe(`${appRoot}/thread-access.js`)
+    expect(findThreadAccessFile(await fixtureApp())).toBeUndefined()
   })
 })

--- a/packages/cli/test/thread-access-coverage.test.ts
+++ b/packages/cli/test/thread-access-coverage.test.ts
@@ -17,37 +17,39 @@ function routeKey(method: string, pattern: RegExp): string {
   return `${method} ${pattern.source}`
 }
 
-/** Gated in PR A: the five endpoints that ran no middleware at all. */
+/**
+ * Gated in PR A: the five endpoints that ran no middleware at all.
+ *
+ * Gated in PR B: the four run endpoints (`runs/stream`, `runs/wait`,
+ * `resume`, and `POST /agui/:routeId`, which carries no "threads" in its
+ * pattern but still resolves a client-supplied thread id) plus
+ * `GET /pending_interrupts`. That last one is the exception whose gating is
+ * not the whole story: it arrived with PR #443 already gated on ROUTE
+ * IDENTITY, and PR B adds the thread-access axis on top, the two composing as
+ * AND rather than one replacing the other. The endpoint reads back the parked
+ * prompt's `interruptId`/`resumeKey` pair — the credential for resuming
+ * someone else's turn — and middleware that merely authenticates admits every
+ * caller alike, so the weaker gate cannot be the one in front of it.
+ */
 const GATED: readonly string[] = [
   routeKey("POST", /^\/threads(?:\?.*)?$/),
   routeKey("GET", /^\/threads\/(?<thread_id>[^/?#]+)(?:\?.*)?$/),
   routeKey("DELETE", /^\/threads\/(?<thread_id>[^/?#]+)(?:\?.*)?$/),
   routeKey("GET", /^\/threads\/(?<thread_id>[^/?#]+)\/state(?:\?.*)?$/),
   routeKey("POST", /^\/threads\/(?<thread_id>[^/?#]+)\/cancel(?:\?.*)?$/),
-]
-
-/**
- * Thread-scoped and NOT gated by this PR — they are gated by route middleware
- * only. PR B moves the first four onto GATED. `POST /agui/:routeId` is on this
- * list precisely because its pattern contains no "threads" — it still resolves
- * a client-supplied thread id, creates the row and writes its metadata.
- *
- * `GET /pending_interrupts` arrived with PR #443, which gates it on ROUTE
- * IDENTITY. Whether it ALSO moves onto the thread-access axis was the spec's
- * open question, and it has now been answered: it does, in addition to the
- * route-identity check, with the two composing as AND. The endpoint reads back
- * the parked prompt's `interruptId`/`resumeKey` pair — the credential for
- * resuming someone else's turn — and middleware that merely authenticates
- * admits every caller alike, so the weaker gate cannot be the one in front of
- * it. Its gate is in place; this list entry is what moves next.
- */
-const DEFERRED: readonly string[] = [
   routeKey("POST", /^\/threads\/(?<thread_id>[^/?#]+)\/runs\/stream(?:\?.*)?$/),
   routeKey("POST", /^\/threads\/(?<thread_id>[^/?#]+)\/runs\/wait(?:\?.*)?$/),
   routeKey("POST", /^\/threads\/(?<thread_id>[^/?#]+)\/resume(?:\?.*)?$/),
   routeKey("POST", /^\/agui\/(?<routeId>[^/?#]+)(?:\?.*)?$/),
   routeKey("GET", /^\/threads\/(?<thread_id>[^/?#]+)\/pending_interrupts(?:\?.*)?$/),
 ]
+
+/**
+ * Empty since PR B. Every thread-scoped route is now gated on the thread-access
+ * axis. A new thread endpoint belongs on GATED; putting it here again needs a
+ * reason written down, because "deferred" was a slice boundary, not a category.
+ */
+const DEFERRED: readonly string[] = []
 
 /**
  * Not thread-scoped, so there is no thread subject to authorize against. A
@@ -72,7 +74,7 @@ describe("route-table coverage", () => {
   it("has 14 entries on this branch", () => {
     // 14 since PR #443 merged and this branch took `main` in, adding
     // `GET /threads/:thread_id/pending_interrupts`. It is CLASSIFIED (see
-    // DEFERRED) rather than counted, which is the whole point of this pair of
+    // GATED) rather than counted, which is the whole point of this pair of
     // assertions: bumping the number without adding the route to a list would
     // let a new thread endpoint ship ungated and silent.
     expect(actual).toHaveLength(14)

--- a/packages/cli/test/thread-access-coverage.test.ts
+++ b/packages/cli/test/thread-access-coverage.test.ts
@@ -33,11 +33,13 @@ const GATED: readonly string[] = [
  * a client-supplied thread id, creates the row and writes its metadata.
  *
  * `GET /pending_interrupts` arrived with PR #443, which gates it on ROUTE
- * IDENTITY. Whether it also moves onto the thread-access axis in PR B is the
- * spec's open question and is still undecided; it sits here either way, because
- * under both answers this PR leaves it gated by route middleware alone. If the
- * answer is "one axis" it joins GATED in PR B; if it is "two axes" it moves to
- * its own documented list rather than staying here.
+ * IDENTITY. Whether it ALSO moves onto the thread-access axis was the spec's
+ * open question, and it has now been answered: it does, in addition to the
+ * route-identity check, with the two composing as AND. The endpoint reads back
+ * the parked prompt's `interruptId`/`resumeKey` pair — the credential for
+ * resuming someone else's turn — and middleware that merely authenticates
+ * admits every caller alike, so the weaker gate cannot be the one in front of
+ * it. Its gate is in place; this list entry is what moves next.
  */
 const DEFERRED: readonly string[] = [
   routeKey("POST", /^\/threads\/(?<thread_id>[^/?#]+)\/runs\/stream(?:\?.*)?$/),

--- a/packages/cli/test/thread-access-run-endpoints.test.ts
+++ b/packages/cli/test/thread-access-run-endpoints.test.ts
@@ -58,6 +58,65 @@ function post(path: string, payload?: unknown, headers: Record<string, string> =
   })
 }
 
+/**
+ * A minimal, schema-valid `RunAgentInput` body for `POST /agui/:routeId`.
+ * `routeKey` is URL-encoded into the path — the route table has no `threads`
+ * segment here, so the client-supplied `threadId` in the body is the only
+ * thread identity this endpoint sees.
+ */
+function aguiPost(
+  routeKey: string,
+  payload: { readonly threadId: string; readonly runId: string } & Record<string, unknown>,
+  headers: Record<string, string> = {},
+): Request {
+  return new Request(new URL(`/agui/${encodeURIComponent(routeKey)}`, "http://localhost"), {
+    headers: {
+      "content-type": "application/json",
+      accept: "text/event-stream",
+      ...headers,
+    },
+    method: "POST",
+    body: JSON.stringify({ state: {}, tools: [], context: [], forwardedProps: {}, ...payload }),
+  })
+}
+
+/**
+ * `ownerOnlyPolicy`, except the deny is held open until the test releases
+ * it. Pins a denied caller mid-flight — INSIDE the policy, before it can
+ * reach any side effect — so a test can prove that side effect was never
+ * taken. A gate placed after the side effect would be holding it while this
+ * caller is still parked here.
+ */
+interface HeldDenyPolicy {
+  readonly policy: ThreadAccessPolicy
+  /** Resolves once a denied caller is inside the policy and cannot advance. */
+  readonly denyEntered: Promise<void>
+  readonly releaseDeny: () => void
+}
+
+function heldDenyOwnerOnlyPolicy(): HeldDenyPolicy {
+  let markEntered: () => void = () => undefined
+  const denyEntered = new Promise<void>((resolve) => {
+    markEntered = () => resolve()
+  })
+  let release: () => void = () => undefined
+  const held = new Promise<void>((resolve) => {
+    release = () => resolve()
+  })
+  return {
+    denyEntered,
+    policy: {
+      fallback: async (request) => {
+        if (request.headers["x-actor"] === "owner") return { decision: "allow" }
+        markEntered()
+        await held
+        return { decision: "deny" }
+      },
+    },
+    releaseDeny: () => release(),
+  }
+}
+
 /** Reads the response body to completion so a streaming run finishes and releases its slot. */
 async function drain(response: Response): Promise<void> {
   const reader = response.body?.getReader()
@@ -230,4 +289,130 @@ describe("POST /threads/:id/runs/wait", () => {
     )
     expect(allowed.status).not.toBe(409)
   })
+})
+
+describe("POST /agui/:routeId", () => {
+  it("denies an unauthorized run without creating the row or taking a run slot", async () => {
+    const seen: ThreadAccessRequest["operation"][] = []
+    const created: string[] = []
+    const threadsStore = recordingThreadsStore((id) => created.push(id))
+    const { handler } = await setup({
+      threadAccess: {
+        fallback: () => {
+          throw new Error("fallback should not be reached for run.agui")
+        },
+        update: (request) => {
+          seen.push(request.operation)
+          return { decision: "deny" }
+        },
+      },
+      threadsStore,
+    })
+
+    const response = await handler.fetch(
+      aguiPost(HELLO_ROUTE, { threadId: "t-victim", runId: "run-1", messages: [] }),
+    )
+
+    expect(response.status).toBe(403)
+    expect(seen).toEqual(["run.agui"])
+    expect(created).toEqual([])
+    expect(await threadsStore.getThread("t-victim")).toBeUndefined()
+  })
+
+  it("allows an authorized run", async () => {
+    const { handler } = await setup({ threadAccess: { fallback: () => ({ decision: "allow" }) } })
+    const response = await handler.fetch(
+      aguiPost(HELLO_ROUTE, { threadId: "t-mine", runId: "run-1", messages: [] }),
+    )
+    expect(response.status).toBe(200)
+    await drain(response)
+  })
+
+  it("does not take the run slot on a denied request: a second, authorized run on the same thread still succeeds", async () => {
+    // Same reasoning as the /runs/stream and /runs/wait siblings above: a
+    // gate placed after `runRegistry.begin` would leave the slot held
+    // (nothing releases a slot it never legitimately finished with), and
+    // this second call would 409 with run_in_flight instead of completing.
+    let calls = 0
+    const threadAccess: ThreadAccessPolicy = {
+      fallback: () => {
+        calls += 1
+        return calls === 1 ? { decision: "deny" } : { decision: "allow" }
+      },
+    }
+    const { handler } = await setup({ threadAccess })
+
+    const denied = await handler.fetch(
+      aguiPost(HELLO_ROUTE, { threadId: "t-retry", runId: "run-1", messages: [] }),
+    )
+    expect(denied.status).toBe(403)
+
+    const allowed = await handler.fetch(
+      aguiPost(HELLO_ROUTE, { threadId: "t-retry", runId: "run-2", messages: [] }),
+    )
+    expect(allowed.status).toBe(200)
+    await drain(allowed)
+  })
+
+  it("does not take the resume claim on a denied request, so a legitimate resume attempt on the same thread is not DoSed", async () => {
+    // The sequential deny-then-allow idiom above cannot prove anything
+    // about `resumeClaims`: the claim is released in a top-level `finally`
+    // that runs on every early return, so by the time a denied fetch()
+    // resolves the claim is already free again regardless of where the
+    // gate sits. Proving the ordering needs a caller pinned INSIDE the
+    // policy, still holding whatever it holds, while a second request
+    // probes the claim.
+    const gate = heldDenyOwnerOnlyPolicy()
+    const { handler } = await setup({ threadAccess: gate.policy })
+    const threadId = "t-agui-claim"
+
+    // Fired and deliberately not awaited: this caller is now pinned inside
+    // the policy. If the gate correctly runs before `resumeClaims.tryClaim`,
+    // it never reached the claim at all.
+    const attacker = handler.fetch(
+      aguiPost(HELLO_ROUTE, {
+        threadId,
+        runId: "attacker-run",
+        messages: [],
+        resume: [{ interruptId: "guessed-1", status: "resolved" }],
+      }),
+    )
+    await Promise.race([
+      gate.denyEntered,
+      // A gate placed after the claim never reaches the policy via
+      // `fallback` for a caller that already 409'd on the claim itself.
+      // Fall through rather than hang; the assertions below catch it.
+      new Promise((resolve) => setTimeout(resolve, 2_000)),
+    ])
+
+    // An owner call on the SAME thread, also resume-shaped so it reaches
+    // `resumeClaims.tryClaim` itself. Nothing ever parked on this thread,
+    // so the claim being free resolves as 409 stale_interrupt (no pending
+    // interrupts to match against) rather than 409 resume_in_progress
+    // (the claim already held). The two are the same HTTP status and
+    // differ only in the error code, which is exactly what this test has
+    // to distinguish.
+    const second = await handler.fetch(
+      aguiPost(
+        HELLO_ROUTE,
+        {
+          threadId,
+          runId: "owner-run",
+          messages: [],
+          resume: [{ interruptId: "guessed-2", status: "resolved" }],
+        },
+        { "x-actor": "owner" },
+      ),
+    )
+    const body = (await second.json()) as { error: { details?: { code?: string } } }
+    // Both outcomes are a 409, so `expect(second.status).toBe(409)` alone
+    // would pass either way and could never catch a gate placed after the
+    // claim — the `code` assertion below is the one doing the work and must
+    // stay. Do not "simplify" this to a status-only check.
+    expect(second.status).toBe(409)
+    expect(body.error.details?.code).toBe("stale_interrupt")
+
+    gate.releaseDeny()
+    expect((await attacker).status).toBe(403)
+  }, 10_000)
 })

--- a/packages/cli/test/thread-access-run-endpoints.test.ts
+++ b/packages/cli/test/thread-access-run-endpoints.test.ts
@@ -1,0 +1,171 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { dirname, join } from "node:path"
+import type { ThreadAccessPolicy, ThreadAccessRequest } from "@dawn-ai/sdk"
+import type { Thread, ThreadsStore } from "@dawn-ai/sqlite-storage"
+import { afterEach, describe, expect, it } from "vitest"
+
+import { createRuntimeFetchHandler } from "../src/lib/dev/runtime-fetch-handler.js"
+
+const cleanup: Array<() => Promise<void> | void> = []
+
+afterEach(async () => {
+  for (const fn of cleanup.splice(0).reverse()) await fn()
+})
+
+const TRIVIAL_ROUTE = "export const graph = async () => ({ ok: true })\n"
+const HELLO_ROUTE = "/hello#graph"
+
+/**
+ * Same fixture-app shape as `thread-access-endpoints.test.ts`: a scratch app
+ * with one trivial graph route, `threadAccess`/`threadsStore` injected through
+ * `StartRuntimeServerOptions` (this package cannot import the harness in
+ * `@dawn-ai/testing` without a build cycle).
+ */
+async function setup(
+  options: {
+    readonly threadAccess?: ThreadAccessPolicy
+    readonly threadsStore?: ThreadsStore
+  } = {},
+): Promise<{ readonly handler: Awaited<ReturnType<typeof createRuntimeFetchHandler>> }> {
+  const appRoot = await mkdtemp(join(tmpdir(), "dawn-thread-access-run-endpoints-"))
+  cleanup.push(() => rm(appRoot, { force: true, recursive: true }))
+  const files: Record<string, string> = {
+    "dawn.config.ts": "export default {}\n",
+    "package.json": '{ "name": "thread-access-run-endpoints-fixture", "type": "module" }\n',
+    "src/app/hello/index.ts": TRIVIAL_ROUTE,
+  }
+  for (const [relativePath, source] of Object.entries(files)) {
+    const filePath = join(appRoot, relativePath)
+    await mkdir(dirname(filePath), { recursive: true })
+    await writeFile(filePath, source, "utf8")
+  }
+  const handler = await createRuntimeFetchHandler({
+    appRoot,
+    drainDeadlineMs: 250,
+    ...(options.threadAccess ? { threadAccess: options.threadAccess } : {}),
+    ...(options.threadsStore ? { threadsStore: options.threadsStore } : {}),
+  })
+  cleanup.push(() => handler.close())
+  return { handler }
+}
+
+function post(path: string, payload?: unknown, headers: Record<string, string> = {}): Request {
+  return new Request(new URL(path, "http://localhost"), {
+    headers: { "content-type": "application/json", ...headers },
+    method: "POST",
+    ...(payload !== undefined ? { body: JSON.stringify(payload) } : {}),
+  })
+}
+
+/** Reads the response body to completion so a streaming run finishes and releases its slot. */
+async function drain(response: Response): Promise<void> {
+  const reader = response.body?.getReader()
+  if (!reader) return
+  for (;;) {
+    const { done } = await reader.read()
+    if (done) return
+  }
+}
+
+/**
+ * An in-memory `ThreadsStore` that reports every id handed to `createThread` —
+ * the HTTP response alone cannot answer "was a row created", only the store
+ * the endpoint actually wrote to can.
+ */
+function recordingThreadsStore(onCreate: (threadId: string) => void): ThreadsStore {
+  const threads = new Map<string, Thread>()
+  let seq = 0
+  return {
+    createThread: async (input) => {
+      const now = new Date().toISOString()
+      const thread: Thread = {
+        created_at: now,
+        metadata: input.metadata ?? {},
+        status: "idle",
+        thread_id: input.thread_id ?? `t-rec-${++seq}`,
+        updated_at: now,
+      }
+      threads.set(thread.thread_id, thread)
+      onCreate(thread.thread_id)
+      return thread
+    },
+    deleteThread: async (threadId) => {
+      threads.delete(threadId)
+    },
+    getThread: async (threadId) => threads.get(threadId),
+    listThreads: async () => [...threads.values()],
+    updateMetadata: async (threadId, patch) => {
+      const thread = threads.get(threadId)
+      if (thread) threads.set(threadId, { ...thread, metadata: { ...thread.metadata, ...patch } })
+    },
+    updateStatus: async (threadId, status) => {
+      const thread = threads.get(threadId)
+      if (thread) threads.set(threadId, { ...thread, status })
+    },
+  }
+}
+
+describe("POST /threads/:id/runs/stream", () => {
+  it("denies an unauthorized run without creating the row or taking a run slot", async () => {
+    const seen: ThreadAccessRequest["operation"][] = []
+    const created: string[] = []
+    const threadsStore = recordingThreadsStore((id) => created.push(id))
+    const { handler } = await setup({
+      threadAccess: {
+        fallback: () => {
+          throw new Error("fallback should not be reached for run.stream")
+        },
+        update: (request) => {
+          seen.push(request.operation)
+          return { decision: "deny" }
+        },
+      },
+      threadsStore,
+    })
+
+    const response = await handler.fetch(
+      post("/threads/t-victim/runs/stream", { input: {}, route: HELLO_ROUTE }),
+    )
+
+    expect(response.status).toBe(403)
+    expect(seen).toEqual(["run.stream"])
+    expect(created).toEqual([])
+    expect(await threadsStore.getThread("t-victim")).toBeUndefined()
+  })
+
+  it("allows an authorized run", async () => {
+    const { handler } = await setup({ threadAccess: { fallback: () => ({ decision: "allow" }) } })
+    const response = await handler.fetch(
+      post("/threads/t-mine/runs/stream", { input: {}, route: HELLO_ROUTE }),
+    )
+    expect(response.status).toBe(200)
+    await drain(response)
+  })
+
+  it("does not take the run slot on a denied request: a second, authorized run on the same thread still succeeds", async () => {
+    // If the denied request had reached `runRegistry.begin` before the gate
+    // rejected it, the slot would still be held (nothing ever releases a slot
+    // it never legitimately finished with), and this second call would 409
+    // with run_in_flight instead of completing normally.
+    let calls = 0
+    const threadAccess: ThreadAccessPolicy = {
+      fallback: () => {
+        calls += 1
+        return calls === 1 ? { decision: "deny" } : { decision: "allow" }
+      },
+    }
+    const { handler } = await setup({ threadAccess })
+
+    const denied = await handler.fetch(
+      post("/threads/t-retry/runs/stream", { input: {}, route: HELLO_ROUTE }),
+    )
+    expect(denied.status).toBe(403)
+
+    const allowed = await handler.fetch(
+      post("/threads/t-retry/runs/stream", { input: {}, route: HELLO_ROUTE }),
+    )
+    expect(allowed.status).toBe(200)
+    await drain(allowed)
+  })
+})

--- a/packages/cli/test/thread-access-run-endpoints.test.ts
+++ b/packages/cli/test/thread-access-run-endpoints.test.ts
@@ -169,3 +169,65 @@ describe("POST /threads/:id/runs/stream", () => {
     await drain(allowed)
   })
 })
+
+describe("POST /threads/:id/runs/wait", () => {
+  it("denies an unauthorized run without creating the row or taking a run slot", async () => {
+    const seen: ThreadAccessRequest["operation"][] = []
+    const created: string[] = []
+    const threadsStore = recordingThreadsStore((id) => created.push(id))
+    const { handler } = await setup({
+      threadAccess: {
+        fallback: () => {
+          throw new Error("fallback should not be reached for run.wait")
+        },
+        update: (request) => {
+          seen.push(request.operation)
+          return { decision: "deny" }
+        },
+      },
+      threadsStore,
+    })
+
+    const response = await handler.fetch(
+      post("/threads/t-victim/runs/wait", { input: {}, route: HELLO_ROUTE }),
+    )
+
+    expect(response.status).toBe(403)
+    expect(seen).toEqual(["run.wait"])
+    expect(created).toEqual([])
+    expect(await threadsStore.getThread("t-victim")).toBeUndefined()
+  })
+
+  it("allows an authorized run", async () => {
+    const { handler } = await setup({ threadAccess: { fallback: () => ({ decision: "allow" }) } })
+    const response = await handler.fetch(
+      post("/threads/t-mine/runs/wait", { input: {}, route: HELLO_ROUTE }),
+    )
+    expect(response.status).toBe(200)
+  })
+
+  it("does not take the run slot on a denied request: a second, authorized run on the same thread still succeeds", async () => {
+    // If the denied request had reached `runRegistry.begin` before the gate
+    // rejected it, the slot would still be held (nothing ever releases a slot
+    // it never legitimately finished with), and this second call would 409
+    // with run_in_flight instead of completing normally.
+    let calls = 0
+    const threadAccess: ThreadAccessPolicy = {
+      fallback: () => {
+        calls += 1
+        return calls === 1 ? { decision: "deny" } : { decision: "allow" }
+      },
+    }
+    const { handler } = await setup({ threadAccess })
+
+    const denied = await handler.fetch(
+      post("/threads/t-retry/runs/wait", { input: {}, route: HELLO_ROUTE }),
+    )
+    expect(denied.status).toBe(403)
+
+    const allowed = await handler.fetch(
+      post("/threads/t-retry/runs/wait", { input: {}, route: HELLO_ROUTE }),
+    )
+    expect(allowed.status).not.toBe(409)
+  })
+})

--- a/packages/cli/test/thread-access-scaffold.test.ts
+++ b/packages/cli/test/thread-access-scaffold.test.ts
@@ -1,0 +1,235 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { dirname, join } from "node:path"
+import { fileURLToPath } from "node:url"
+import { afterEach, describe, expect, it } from "vitest"
+
+import { createRuntimeFetchHandler } from "../src/lib/dev/runtime-fetch-handler.js"
+import { loadThreadAccess } from "../src/lib/dev/thread-access-node.js"
+
+/**
+ * The SCAFFOLD, executed rather than grepped.
+ *
+ * `packages/devkit/test/template-thread-access.test.ts` string-matches the
+ * template — it can say the file contains a deny, never what the deny does to a
+ * request. This file copies the real `thread-access.ts.example` and
+ * `auth.ts.example` into a fixture app, loads them through the real loader, and
+ * drives the real endpoints, so the scaffold's documented behavior is pinned by
+ * the thing that actually decides it.
+ *
+ * It lives in `packages/cli` because that is where the runtime handler is; the
+ * devkit package cannot import it without a build cycle.
+ */
+
+const cleanup: Array<() => Promise<void> | void> = []
+
+afterEach(async () => {
+  for (const fn of cleanup.splice(0).reverse()) await fn()
+})
+
+const TRIVIAL_ROUTE = "export const graph = async () => ({ ok: true })\n"
+const ROUTE_KEY = "/hello#graph"
+
+/** The shipped scaffold, verbatim. Not a paraphrase of it. */
+const templateSource = (name: string): Promise<string> =>
+  readFile(
+    fileURLToPath(
+      new URL(`../../devkit/templates/app-basic/src/${name}.ts.example`, import.meta.url),
+    ),
+    "utf8",
+  )
+
+type Handler = Awaited<ReturnType<typeof createRuntimeFetchHandler>>
+
+async function setup(): Promise<Handler> {
+  const appRoot = await mkdtemp(join(tmpdir(), "dawn-thread-access-scaffold-"))
+  cleanup.push(() => rm(appRoot, { force: true, recursive: true }))
+  const files: Record<string, string> = {
+    "dawn.config.ts": "export default {}\n",
+    "package.json": '{ "name": "thread-access-scaffold-fixture", "type": "module" }\n',
+    "src/app/hello/index.ts": TRIVIAL_ROUTE,
+    // The rename the scaffold's own header tells the app to do.
+    "src/auth.ts": await templateSource("auth"),
+    "src/thread-access.ts": await templateSource("thread-access"),
+  }
+  for (const [relativePath, source] of Object.entries(files)) {
+    const filePath = join(appRoot, relativePath)
+    await mkdir(dirname(filePath), { recursive: true })
+    await writeFile(filePath, source, "utf8")
+  }
+  // Through the real loader, so a template that stopped binding a policy fails
+  // here rather than silently running this suite with no gate at all.
+  const threadAccess = await loadThreadAccess(appRoot)
+  expect(typeof threadAccess?.fallback).toBe("function")
+  const handler = await createRuntimeFetchHandler({
+    appRoot,
+    drainDeadlineMs: 250,
+    ...(threadAccess ? { threadAccess } : {}),
+  })
+  cleanup.push(() => handler.close())
+  return handler
+}
+
+/** The scaffolded `principalOf` reads exactly these two headers. */
+const ALICE: Record<string, string> = { "x-user-id": "alice", "x-user-org": "acme" }
+const BOB: Record<string, string> = { "x-user-id": "bob", "x-user-org": "acme" }
+const ANONYMOUS: Record<string, string> = {}
+
+function post(path: string, payload?: unknown, headers: Record<string, string> = {}): Request {
+  return new Request(new URL(path, "http://localhost"), {
+    headers: { "content-type": "application/json", ...headers },
+    method: "POST",
+    ...(payload !== undefined ? { body: JSON.stringify(payload) } : {}),
+  })
+}
+
+function runStream(threadId: string, headers: Record<string, string>): Request {
+  return post(`/threads/${threadId}/runs/stream`, { input: {}, route: ROUTE_KEY }, headers)
+}
+
+/** The body CopilotKit posts: the thread id is chosen in the browser. */
+function aguiTurn(threadId: string, headers: Record<string, string>): Request {
+  return new Request(new URL(`/agui/${encodeURIComponent(ROUTE_KEY)}`, "http://localhost"), {
+    body: JSON.stringify({
+      context: [],
+      forwardedProps: {},
+      messages: [{ content: "hi", id: "m1", role: "user" }],
+      runId: "r1",
+      state: {},
+      threadId,
+      tools: [],
+    }),
+    headers: { accept: "text/event-stream", "content-type": "application/json", ...headers },
+    method: "POST",
+  })
+}
+
+async function drain(response: Response): Promise<void> {
+  const reader = response.body?.getReader()
+  if (!reader) return
+  while (!(await reader.read()).done) {
+    // Runs release their slot on drain; nothing here reads the frames.
+  }
+}
+
+/** Mint a thread the way the scaffold supports: server-generated id, stamped owner. */
+async function mintThread(handler: Handler, headers: Record<string, string>): Promise<string> {
+  const created = await handler.fetch(post("/threads", {}, headers))
+  expect(created.status).toBe(200)
+  return ((await created.json()) as { readonly thread_id: string }).thread_id
+}
+
+describe("the scaffolded thread-access policy, driven end to end", () => {
+  it("serves the owner and denies everyone else, on every axis", async () => {
+    const handler = await setup()
+    const threadId = await mintThread(handler, ALICE)
+
+    const mine = await handler.fetch(runStream(threadId, ALICE))
+    expect(mine.status).toBe(200)
+    await drain(mine)
+
+    const theirs = await handler.fetch(runStream(threadId, BOB))
+    expect(theirs.status).toBe(403)
+    await drain(theirs)
+
+    const anon = await handler.fetch(runStream(threadId, ANONYMOUS))
+    expect(anon.status).toBe(403)
+    await drain(anon)
+
+    expect(
+      (await handler.fetch(new Request(`http://localhost/threads/${threadId}`, { headers: ALICE })))
+        .status,
+    ).toBe(200)
+    expect(
+      (await handler.fetch(new Request(`http://localhost/threads/${threadId}`, { headers: BOB })))
+        .status,
+    ).toBe(404)
+    expect(
+      (
+        await handler.fetch(
+          new Request(`http://localhost/threads/${threadId}`, { headers: BOB, method: "DELETE" }),
+        )
+      ).status,
+    ).toBe(403)
+  }, 30_000)
+
+  it("runs AG-UI turns on a thread the caller minted, and keeps running them", async () => {
+    const handler = await setup()
+    // The recipe the scaffold documents for a client that picks its own thread
+    // id: mint the id through POST /threads, which is the ONLY path that stamps
+    // an owner, then hand that id to the AG-UI client as its `threadId`.
+    const threadId = await mintThread(handler, ALICE)
+
+    const first = await handler.fetch(aguiTurn(threadId, ALICE))
+    expect(first.status).toBe(200)
+    await drain(first)
+
+    // The second turn, deliberately. A thread whose row exists but carries no
+    // stamp is admin-only under this policy, so a recipe that authorizes turn
+    // one and denies turn two would pass a one-turn test and brick a real
+    // conversation.
+    const second = await handler.fetch(aguiTurn(threadId, ALICE))
+    expect(second.status).toBe(200)
+    await drain(second)
+
+    const intruder = await handler.fetch(aguiTurn(threadId, BOB))
+    expect(intruder.status).toBe(403)
+    await drain(intruder)
+  }, 30_000)
+
+  it("denies a run on an unminted id, identically for every caller", async () => {
+    const handler = await setup()
+    const threadId = "t-client-chosen"
+
+    // The scaffold's documented limitation, pinned so it stays a decision. The
+    // run endpoints create the row they are given, and that implicit create
+    // writes NO access stamp — so there is no owner for a later turn to match,
+    // and permitting the first turn here would authorize a thread that nothing
+    // can own afterwards. The scaffold denies instead, and says so.
+    const authenticated = await handler.fetch(aguiTurn(threadId, ALICE))
+    const other = await handler.fetch(aguiTurn(threadId, BOB))
+    const anonymous = await handler.fetch(aguiTurn(threadId, ANONYMOUS))
+
+    expect(authenticated.status).toBe(403)
+    expect(other.status).toBe(403)
+    expect(anonymous.status).toBe(403)
+
+    // And no row was created by the denial, so a denied caller cannot squat an
+    // id the way an allowed one would.
+    const probe = await handler.fetch(
+      new Request(`http://localhost/threads/${threadId}`, { headers: ALICE }),
+    )
+    expect(probe.status).toBe(404)
+
+    const streamed = await handler.fetch(runStream(threadId, ALICE))
+    expect(streamed.status).toBe(403)
+    await drain(streamed)
+  }, 30_000)
+
+  it("keeps the missing-row oracle shut on read and delete", async () => {
+    const handler = await setup()
+    const owned = await mintThread(handler, ALICE)
+
+    // "not yours" and "never existed" must be the same answer, or a caller who
+    // can guess ids learns which ones are real.
+    const notYours = await handler.fetch(
+      new Request(`http://localhost/threads/${owned}`, { headers: BOB }),
+    )
+    const neverExisted = await handler.fetch(
+      new Request("http://localhost/threads/t-never-existed", { headers: BOB }),
+    )
+    expect(notYours.status).toBe(neverExisted.status)
+    expect(await notYours.text()).toBe(await neverExisted.text())
+    expect(notYours.status).toBe(404)
+
+    const deleteNotYours = await handler.fetch(
+      new Request(`http://localhost/threads/${owned}`, { headers: BOB, method: "DELETE" }),
+    )
+    const deleteNeverExisted = await handler.fetch(
+      new Request("http://localhost/threads/t-never-existed", { headers: BOB, method: "DELETE" }),
+    )
+    expect(deleteNotYours.status).toBe(deleteNeverExisted.status)
+    expect(await deleteNotYours.text()).toBe(await deleteNeverExisted.text())
+    expect(deleteNotYours.status).toBe(403)
+  }, 30_000)
+})

--- a/packages/devkit/templates/app-basic/src/auth.ts.example
+++ b/packages/devkit/templates/app-basic/src/auth.ts.example
@@ -1,0 +1,49 @@
+/**
+ * The one place this app turns a request into a principal.
+ *
+ * Rename to `src/auth.ts` — drop the `.example` — to activate it, together with
+ * `src/thread-access.ts.example`.
+ *
+ * Dawn has two authorization files with two different jobs. `src/middleware.ts`
+ * answers "may this caller run this route"; `src/thread-access.ts` answers "may
+ * this caller create, read, mutate or destroy this thread". Nothing makes them
+ * agree, and two independent header parsers is a confused deputy waiting to
+ * happen — middleware admits the caller as org A while the policy derives org
+ * B. So both import this module, and neither parses a header of its own.
+ *
+ * Replace the body. A trusted header is only as trustworthy as the proxy in
+ * front of it; verify a signed token wherever the deployment allows one.
+ */
+
+export interface Principal {
+  readonly id: string
+  readonly isAdmin: boolean
+  readonly org: string
+}
+
+/**
+ * Resolve the caller, or `undefined` when there is no principal.
+ *
+ * `undefined` means "no principal", and every caller must read it as a denial —
+ * never as an anonymous allow. Returning a principal here is the only thing
+ * that opens any thread endpoint.
+ *
+ * `headers` arrives with lowercase keys and repeated headers joined with ", ",
+ * so `X-User-Id: victim` plus `X-User-Id: attacker` is the single string
+ * `"victim, attacker"`. That is safe under `===` and quietly wrong under
+ * `includes`, `startsWith` or `split(",")`. Compare with strict equality.
+ *
+ * It is `async` because a real implementation calls out to verify a token; a
+ * synchronous implementation is equally fine, and Dawn awaits either.
+ */
+export async function principalOf(
+  headers: Readonly<Record<string, string>>,
+): Promise<Principal | undefined> {
+  // REPLACE THIS. It trusts two raw headers, which is only correct behind a
+  // proxy that strips and re-sets them on every inbound request.
+  const id = headers["x-user-id"]
+  const org = headers["x-user-org"]
+  if (id === undefined || org === undefined) return undefined
+
+  return await Promise.resolve({ id, isAdmin: false, org })
+}

--- a/packages/devkit/templates/app-basic/src/thread-access.ts.example
+++ b/packages/devkit/templates/app-basic/src/thread-access.ts.example
@@ -1,0 +1,66 @@
+/**
+ * Thread authorization: may this caller create, read, mutate or destroy this
+ * thread?
+ *
+ * Rename to `src/thread-access.ts` — drop the `.example` — to activate it,
+ * together with `src/auth.ts.example`. Until you do, every thread endpoint is
+ * open to anyone who can name a thread id, and ids are neither secret nor
+ * collision-proof (`t-` plus four random bytes). Activating it before you have
+ * an authenticated caller will deny every request, which is the point: this
+ * policy is deny-by-default and only `principalOf` can open it.
+ *
+ * This is NOT route middleware. Middleware is keyed on route identity, and a
+ * thread has no owning route — every endpoint that starts a turn overwrites the
+ * thread's `route` metadata, so anyone allowed to run any route on a thread can
+ * move that identity onto a route of their choosing. Two concepts, two files.
+ *
+ * Run `dawn docs thread-access` for the full reference.
+ */
+
+import { defineThreadAccess, deny, permit, type ThreadAccessRequest } from "@dawn-ai/sdk"
+
+import { principalOf } from "./auth.js"
+
+const owned = async (req: ThreadAccessRequest) => {
+  const user = await principalOf(req.headers)
+  if (!user) return deny()
+
+  // `thread: undefined` reaches `delete`, `update` and `read` alike — Dawn
+  // invokes the policy on every gated request rather than short-circuiting to
+  // the endpoint's natural 404 or 204. Denying it FIRST, ahead of any admin
+  // branch, is what keeps "not yours" and "never existed" the same answer. An
+  // admin allowed to delete a row that never existed reopens the existence
+  // oracle this default closes.
+  if (req.thread === undefined) return deny()
+
+  // `req.thread.access`, never `req.thread.metadata`. Metadata is
+  // client-supplied and untrusted — anyone who can create a thread can write
+  // anything into it. `access` is the stamp this policy's own `create` decision
+  // returned, stored under a reserved key Dawn strips from client input on
+  // every create path, so a client cannot forge one.
+  const owner = req.thread.access?.ownerId
+
+  // `undefined` means a thread created before this app had a policy. Dawn does
+  // not guess what that should mean. Admin-only is the conservative answer; a
+  // one-time backfill is the other one. Do not permit it outright.
+  if (owner === undefined) return user.isAdmin ? permit() : deny()
+
+  if (owner === user.id) return permit()
+  if (req.action === "read" && user.isAdmin) return permit()
+  return deny()
+}
+
+export default defineThreadAccess({
+  create: async (req) => {
+    const user = await principalOf(req.headers)
+    return user ? permit({ ownerId: user.id, org: user.org }) : deny()
+  },
+  // `fallback` is required, and it is the deny-by-default floor: an action with
+  // no handler of its own lands here rather than falling through to an allow.
+  //
+  // It also handles the `update` recheck Dawn runs after every create. The row
+  // just stamped has `ownerId === user.id`, so `owned` permits it; a row the
+  // store handed back on an id collision carries someone else's, so `owned`
+  // denies and the caller never receives a thread they do not own.
+  fallback: owned,
+})

--- a/packages/devkit/templates/app-basic/src/thread-access.ts.example
+++ b/packages/devkit/templates/app-basic/src/thread-access.ts.example
@@ -31,6 +31,29 @@ const owned = async (req: ThreadAccessRequest) => {
   // branch, is what keeps "not yours" and "never existed" the same answer. An
   // admin allowed to delete a row that never existed reopens the existence
   // oracle this default closes.
+  //
+  // READ THIS BEFORE YOU SHIP AN AG-UI APP. This line also refuses every
+  // `run.*` operation on a thread id whose row does not exist yet, and those
+  // endpoints are the ones that would have created it: `POST /agui/{routeId}`,
+  // `/runs/stream`, `/runs/wait` and `/resume` all arrive here under
+  // `action: "update"` with `req.thread === undefined`. CopilotKit picks its
+  // `threadId` in the browser and never calls `POST /threads`, so under this
+  // policy every AG-UI turn on a fresh id is denied with a 403.
+  //
+  // Relaxing this line for `update` is NOT the fix, however obvious it looks.
+  // The implicit create those endpoints do writes the row with no access stamp,
+  // so the next turn on the same thread reaches the `owner === undefined`
+  // branch below and is denied anyway: you would authorize turn one and refuse
+  // turn two, which is worse than refusing honestly.
+  //
+  // Mint the thread with `POST /threads` and hand the returned `thread_id` to
+  // the client as its thread id. That is the only path that stamps an owner, so
+  // every later turn matches `owner === user.id` and is served. If you must
+  // authorize client-chosen ids instead, record the id-to-owner mapping
+  // yourself — in your own store, from this policy — and consult it here.
+  // Whatever you do, do not relax `delete` or `read`: those endpoints answer
+  // 204/404 for a row that never existed, and permitting them on a missing row
+  // is exactly what reopens the existence oracle.
   if (req.thread === undefined) return deny()
 
   // `req.thread.access`, never `req.thread.metadata`. Metadata is

--- a/packages/devkit/templates/app-research/src/auth.ts.example
+++ b/packages/devkit/templates/app-research/src/auth.ts.example
@@ -1,0 +1,49 @@
+/**
+ * The one place this app turns a request into a principal.
+ *
+ * Rename to `src/auth.ts` — drop the `.example` — to activate it, together with
+ * `src/thread-access.ts.example`.
+ *
+ * Dawn has two authorization files with two different jobs. `src/middleware.ts`
+ * answers "may this caller run this route"; `src/thread-access.ts` answers "may
+ * this caller create, read, mutate or destroy this thread". Nothing makes them
+ * agree, and two independent header parsers is a confused deputy waiting to
+ * happen — middleware admits the caller as org A while the policy derives org
+ * B. So both import this module, and neither parses a header of its own.
+ *
+ * Replace the body. A trusted header is only as trustworthy as the proxy in
+ * front of it; verify a signed token wherever the deployment allows one.
+ */
+
+export interface Principal {
+  readonly id: string
+  readonly isAdmin: boolean
+  readonly org: string
+}
+
+/**
+ * Resolve the caller, or `undefined` when there is no principal.
+ *
+ * `undefined` means "no principal", and every caller must read it as a denial —
+ * never as an anonymous allow. Returning a principal here is the only thing
+ * that opens any thread endpoint.
+ *
+ * `headers` arrives with lowercase keys and repeated headers joined with ", ",
+ * so `X-User-Id: victim` plus `X-User-Id: attacker` is the single string
+ * `"victim, attacker"`. That is safe under `===` and quietly wrong under
+ * `includes`, `startsWith` or `split(",")`. Compare with strict equality.
+ *
+ * It is `async` because a real implementation calls out to verify a token; a
+ * synchronous implementation is equally fine, and Dawn awaits either.
+ */
+export async function principalOf(
+  headers: Readonly<Record<string, string>>,
+): Promise<Principal | undefined> {
+  // REPLACE THIS. It trusts two raw headers, which is only correct behind a
+  // proxy that strips and re-sets them on every inbound request.
+  const id = headers["x-user-id"]
+  const org = headers["x-user-org"]
+  if (id === undefined || org === undefined) return undefined
+
+  return await Promise.resolve({ id, isAdmin: false, org })
+}

--- a/packages/devkit/templates/app-research/src/thread-access.ts.example
+++ b/packages/devkit/templates/app-research/src/thread-access.ts.example
@@ -1,0 +1,66 @@
+/**
+ * Thread authorization: may this caller create, read, mutate or destroy this
+ * thread?
+ *
+ * Rename to `src/thread-access.ts` — drop the `.example` — to activate it,
+ * together with `src/auth.ts.example`. Until you do, every thread endpoint is
+ * open to anyone who can name a thread id, and ids are neither secret nor
+ * collision-proof (`t-` plus four random bytes). Activating it before you have
+ * an authenticated caller will deny every request, which is the point: this
+ * policy is deny-by-default and only `principalOf` can open it.
+ *
+ * This is NOT route middleware. Middleware is keyed on route identity, and a
+ * thread has no owning route — every endpoint that starts a turn overwrites the
+ * thread's `route` metadata, so anyone allowed to run any route on a thread can
+ * move that identity onto a route of their choosing. Two concepts, two files.
+ *
+ * Run `dawn docs thread-access` for the full reference.
+ */
+
+import { defineThreadAccess, deny, permit, type ThreadAccessRequest } from "@dawn-ai/sdk"
+
+import { principalOf } from "./auth.js"
+
+const owned = async (req: ThreadAccessRequest) => {
+  const user = await principalOf(req.headers)
+  if (!user) return deny()
+
+  // `thread: undefined` reaches `delete`, `update` and `read` alike — Dawn
+  // invokes the policy on every gated request rather than short-circuiting to
+  // the endpoint's natural 404 or 204. Denying it FIRST, ahead of any admin
+  // branch, is what keeps "not yours" and "never existed" the same answer. An
+  // admin allowed to delete a row that never existed reopens the existence
+  // oracle this default closes.
+  if (req.thread === undefined) return deny()
+
+  // `req.thread.access`, never `req.thread.metadata`. Metadata is
+  // client-supplied and untrusted — anyone who can create a thread can write
+  // anything into it. `access` is the stamp this policy's own `create` decision
+  // returned, stored under a reserved key Dawn strips from client input on
+  // every create path, so a client cannot forge one.
+  const owner = req.thread.access?.ownerId
+
+  // `undefined` means a thread created before this app had a policy. Dawn does
+  // not guess what that should mean. Admin-only is the conservative answer; a
+  // one-time backfill is the other one. Do not permit it outright.
+  if (owner === undefined) return user.isAdmin ? permit() : deny()
+
+  if (owner === user.id) return permit()
+  if (req.action === "read" && user.isAdmin) return permit()
+  return deny()
+}
+
+export default defineThreadAccess({
+  create: async (req) => {
+    const user = await principalOf(req.headers)
+    return user ? permit({ ownerId: user.id, org: user.org }) : deny()
+  },
+  // `fallback` is required, and it is the deny-by-default floor: an action with
+  // no handler of its own lands here rather than falling through to an allow.
+  //
+  // It also handles the `update` recheck Dawn runs after every create. The row
+  // just stamped has `ownerId === user.id`, so `owned` permits it; a row the
+  // store handed back on an id collision carries someone else's, so `owned`
+  // denies and the caller never receives a thread they do not own.
+  fallback: owned,
+})

--- a/packages/devkit/templates/app-research/src/thread-access.ts.example
+++ b/packages/devkit/templates/app-research/src/thread-access.ts.example
@@ -31,6 +31,29 @@ const owned = async (req: ThreadAccessRequest) => {
   // branch, is what keeps "not yours" and "never existed" the same answer. An
   // admin allowed to delete a row that never existed reopens the existence
   // oracle this default closes.
+  //
+  // READ THIS BEFORE YOU SHIP AN AG-UI APP. This line also refuses every
+  // `run.*` operation on a thread id whose row does not exist yet, and those
+  // endpoints are the ones that would have created it: `POST /agui/{routeId}`,
+  // `/runs/stream`, `/runs/wait` and `/resume` all arrive here under
+  // `action: "update"` with `req.thread === undefined`. CopilotKit picks its
+  // `threadId` in the browser and never calls `POST /threads`, so under this
+  // policy every AG-UI turn on a fresh id is denied with a 403.
+  //
+  // Relaxing this line for `update` is NOT the fix, however obvious it looks.
+  // The implicit create those endpoints do writes the row with no access stamp,
+  // so the next turn on the same thread reaches the `owner === undefined`
+  // branch below and is denied anyway: you would authorize turn one and refuse
+  // turn two, which is worse than refusing honestly.
+  //
+  // Mint the thread with `POST /threads` and hand the returned `thread_id` to
+  // the client as its thread id. That is the only path that stamps an owner, so
+  // every later turn matches `owner === user.id` and is served. If you must
+  // authorize client-chosen ids instead, record the id-to-owner mapping
+  // yourself — in your own store, from this policy — and consult it here.
+  // Whatever you do, do not relax `delete` or `read`: those endpoints answer
+  // 204/404 for a row that never existed, and permitting them on a missing row
+  // is exactly what reopens the existence oracle.
   if (req.thread === undefined) return deny()
 
   // `req.thread.access`, never `req.thread.metadata`. Metadata is

--- a/packages/devkit/test/template-thread-access.test.ts
+++ b/packages/devkit/test/template-thread-access.test.ts
@@ -1,8 +1,18 @@
 import { existsSync, readFileSync } from "node:fs"
+import { dirname, resolve } from "node:path"
 import { fileURLToPath } from "node:url"
 import { describe, expect, it } from "vitest"
 
 const templates = ["app-basic", "app-research"] as const
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../../..")
+
+/** Every place the same two authorization files are shipped from. */
+const copies = [
+  fileURLToPath(new URL("../templates/app-basic/src/", import.meta.url)),
+  fileURLToPath(new URL("../templates/app-research/src/", import.meta.url)),
+  `${resolve(repoRoot, "examples/research/server/src")}/`,
+] as const
 
 const read = (name: string, file: string): string =>
   readFileSync(fileURLToPath(new URL(`../templates/${name}/${file}`, import.meta.url)), "utf8")
@@ -65,5 +75,33 @@ describe("scaffolded thread-access policy", () => {
         "Rename to `src/thread-access.ts`",
       )
     })
+
+    it(`${name} tells the reader what the missing-row deny costs them`, () => {
+      const policy = read(name, "src/thread-access.ts.example")
+
+      // The deny on `req.thread === undefined` is justified in this file on
+      // DELETE-existence-oracle grounds. It ALSO refuses every `run.*`
+      // operation on a thread id whose row does not exist yet — which is every
+      // AG-UI turn, because CopilotKit picks its `threadId` in the browser and
+      // never calls `POST /threads`. A scaffold that refuses a first-class flow
+      // and does not say so gets copied, then cursed.
+      expect(policy).toContain("run.*")
+      expect(policy).toContain("/agui/")
+      // And the supported way through it, which is not "relax this line": the
+      // implicit create those endpoints do writes no access stamp, so a
+      // relaxed line authorizes one turn and denies the next. Minting the id
+      // through POST /threads is the only path that stamps an owner.
+      expect(policy).toContain("POST /threads")
+      expect(policy).toContain("no access stamp")
+    })
   }
+
+  it("keeps every shipped copy in byte-for-byte parity", () => {
+    for (const file of ["thread-access.ts.example", "auth.ts.example"]) {
+      const [first, ...rest] = copies.map((dir) => readFileSync(`${dir}${file}`, "utf8"))
+      // Three copies of an authorization scaffold that drift are three
+      // different security postures, only one of which anybody reviewed.
+      for (const other of rest) expect(other).toBe(first)
+    }
+  })
 })

--- a/packages/devkit/test/template-thread-access.test.ts
+++ b/packages/devkit/test/template-thread-access.test.ts
@@ -1,0 +1,69 @@
+import { existsSync, readFileSync } from "node:fs"
+import { fileURLToPath } from "node:url"
+import { describe, expect, it } from "vitest"
+
+const templates = ["app-basic", "app-research"] as const
+
+const read = (name: string, file: string): string =>
+  readFileSync(fileURLToPath(new URL(`../templates/${name}/${file}`, import.meta.url)), "utf8")
+
+const exists = (name: string, file: string): boolean =>
+  existsSync(fileURLToPath(new URL(`../templates/${name}/${file}`, import.meta.url)))
+
+/** Line-oriented and deliberately crude: enough to tell code from commentary. */
+const stripComments = (source: string): string =>
+  source
+    .split(/\r?\n/u)
+    .filter((line) => {
+      const trimmed = line.trim()
+      return !(
+        trimmed.startsWith("//") ||
+        trimmed.startsWith("*") ||
+        trimmed.startsWith("/*") ||
+        trimmed === ""
+      )
+    })
+    .join("\n")
+
+describe("scaffolded thread-access policy", () => {
+  for (const name of templates) {
+    it(`${name} ships a deny-by-default policy and the shared auth module`, () => {
+      const policy = read(name, "src/thread-access.ts.example")
+
+      expect(policy).toContain("defineThreadAccess")
+      // `fallback` is the deny-by-default floor: an action with no handler of
+      // its own lands there rather than falling through to an allow.
+      expect(policy).toContain("fallback: owned")
+      // The DELETE existence oracle: a missing row is denied ahead of any admin
+      // branch, so "not yours" and "never existed" answer identically.
+      expect(policy).toContain("if (req.thread === undefined) return deny()")
+      expect(read(name, "src/auth.ts.example")).toContain("export async function principalOf")
+      // One principal, imported by both authorization files — not two header
+      // parsers that can disagree.
+      expect(policy).toContain('from "./auth.js"')
+    })
+
+    it(`${name}'s policy authorizes against the server stamp, never client metadata`, () => {
+      const policy = read(name, "src/thread-access.ts.example")
+
+      expect(policy).toContain("req.thread.access?.ownerId")
+      // `thread.metadata` is client-supplied and untrusted. A scaffold that
+      // read the owner out of it would ship the forgery it exists to prevent.
+      // Comments are stripped first — the file explains the rule, in prose that
+      // necessarily names the field it forbids.
+      expect(stripComments(policy)).not.toContain("thread.metadata")
+    })
+
+    it(`${name} leaves the policy inert until the app renames it`, () => {
+      // Deliberate: the templates are also the quickstart and the base fixture
+      // for the Agent Protocol runtime harness, and an active deny-by-default
+      // policy denies every request from an app that has no authenticated
+      // caller yet. The scaffold is one `mv` from active, and the file says so.
+      expect(exists(name, "src/thread-access.ts")).toBe(false)
+      expect(exists(name, "src/auth.ts")).toBe(false)
+      expect(read(name, "src/thread-access.ts.example")).toContain(
+        "Rename to `src/thread-access.ts`",
+      )
+    })
+  }
+})

--- a/packages/sdk/src/thread-access.ts
+++ b/packages/sdk/src/thread-access.ts
@@ -41,6 +41,14 @@ export type ThreadOperation =
   | "thread.state"
   | "thread.delete"
   | "thread.cancel"
+  /**
+   * `GET /threads/:id/pending_interrupts`. Gated on this axis IN ADDITION to
+   * the route that parked the interrupts — the two compose as AND. The parked
+   * prompt's `interruptId`/`resumeKey` pair is the credential an attacker needs
+   * to resume someone else's turn, so it answers to the same policy as every
+   * other read of the thread.
+   */
+  | "thread.pending_interrupts"
   | "run.stream"
   | "run.wait"
   | "run.resume"

--- a/packages/sdk/src/thread-access.ts
+++ b/packages/sdk/src/thread-access.ts
@@ -24,16 +24,15 @@ export type ThreadAction = "create" | "read" | "update" | "delete"
  * - `thread.state` — `GET /threads/:id/state` — `read`
  * - `thread.delete` — `DELETE /threads/:id` — `delete`
  * - `thread.cancel` — `POST /threads/:id/cancel` — `update`
+ * - `thread.pending_interrupts` — `GET /threads/:id/pending_interrupts` — `read`
  * - `run.stream` — `POST /threads/:id/runs/stream` — `update`
  * - `run.wait` — `POST /threads/:id/runs/wait` — `update`
  * - `run.resume` — `POST /threads/:id/resume` — `update`
  * - `run.agui` — `POST /agui/:routeId` — `update`
  *
- * The union ships whole, but the four `run.*` members are not gated yet: a
- * policy may match them today and simply will not be invoked for them until the
- * run endpoints are wired. They are here so that wiring adds no published type
- * change, and so nobody writes an exhaustive `switch` that a later release
- * breaks.
+ * Every `run.*` operation arrives under `update`, without exception. Starting a
+ * turn on a thread mutates it; none of them is a `create`, including the ones
+ * whose endpoint will create the row when it is missing.
  */
 export type ThreadOperation =
   | "thread.create"

--- a/packages/sdk/test/thread-access.contract.ts
+++ b/packages/sdk/test/thread-access.contract.ts
@@ -32,6 +32,7 @@ type _Operation = Expect<
     | "thread.state"
     | "thread.delete"
     | "thread.cancel"
+    | "thread.pending_interrupts"
     | "run.stream"
     | "run.wait"
     | "run.resume"

--- a/packages/testing/src/threads-conformance.ts
+++ b/packages/testing/src/threads-conformance.ts
@@ -232,7 +232,60 @@ export function runThreadsStoreConformance(opts: {
         const fetched = await s.getThread("t-dup")
         expect(fetched?.status).toBe("idle")
         expect(fetched?.created_at).toMatch(ISO_MS)
-        expect([{ v: 1 }, { v: 2 }]).toContainEqual(fetched?.metadata)
+        // WHICH metadata survives is not "either one" — it is pinned by the
+        // next case, which is stricter than anything that belongs here.
+      } finally {
+        await close?.(s)
+      }
+    })
+    test("a colliding createThread never applies the caller's metadata", async () => {
+      const s = await makeStore()
+      try {
+        // The two conformant outcomes above diverge by backend: sqlite's bare
+        // INSERT throws, a multi-writer backend upserts and hands back the row
+        // that is already there. The THIRD outcome — the caller's metadata
+        // overwriting the stored row's — is not conformant on either.
+        //
+        // Thread ids are `t-` plus four random bytes, so collisions are a
+        // 32-bit birthday problem, not a hypothetical. Dawn stores each
+        // thread's authorization stamp under a reserved metadata key, so a
+        // store that let a second create rewrite metadata would let whoever
+        // draws (or guesses) a live id restamp someone else's thread and then
+        // read it legally.
+        await s.createThread({ thread_id: "t-collide", metadata: { owner: "first" } })
+        await s
+          .createThread({ thread_id: "t-collide", metadata: { owner: "second" } })
+          .catch(() => undefined)
+        expect((await s.getThread("t-collide"))?.metadata).toEqual({ owner: "first" })
+      } finally {
+        await close?.(s)
+      }
+    })
+    test("updateMetadata leaves a top-level key the patch does not name intact", async () => {
+      const s = await makeStore()
+      try {
+        // The companion to the shallow-merge case above. That one pins what a
+        // patch REPLACES; this one pins what it must not touch.
+        //
+        // `dawn:access` is the reserved key Dawn's thread-access stamp lives
+        // under (`THREAD_ACCESS_METADATA_KEY`), written once at create and
+        // never again. Every later `route` and `parked_route` write is a patch
+        // like the two below. If a patch could drop an unrelated key, a thread
+        // would silently lose its stamp on its next run and read back as an
+        // unstamped legacy thread — which a policy is entitled to treat as
+        // admin-only, or as nobody's.
+        await s.createThread({
+          thread_id: "t-untouched",
+          metadata: { "dawn:access": { ownerId: "u-1" }, user: "brian" },
+        })
+        await s.updateMetadata("t-untouched", { route: "/chat#agent" })
+        await s.updateMetadata("t-untouched", { parked_route: "/chat#agent" })
+        expect((await s.getThread("t-untouched"))?.metadata).toEqual({
+          "dawn:access": { ownerId: "u-1" },
+          parked_route: "/chat#agent",
+          route: "/chat#agent",
+          user: "brian",
+        })
       } finally {
         await close?.(s)
       }


### PR DESCRIPTION
## Summary

PR B of the thread authorization work, following #460. PR A closed the five endpoints that ran **no authorization at all**; this closes the rest of the surface. After it, `thread-access-coverage.test.ts`'s `DEFERRED` list is **empty** — every thread-scoped route answers to `defineThreadAccess`.

| Endpoint | Operation | Action |
|---|---|---|
| `POST /threads/:id/runs/stream` | `run.stream` | `update` |
| `POST /threads/:id/runs/wait` | `run.wait` | `update` |
| `POST /threads/:id/resume` | `run.resume` | `update` |
| `POST /agui/:routeId` | `run.agui` | `update` |
| `GET /threads/:id/pending_interrupts` | `thread.pending_interrupts` | `read` |

Plus: the static-module manifest now carries a policy, so `hono` and `vercel` builds keep their gate; a staleness guard fails the boot when a policy-built app deploys a policy-less manifest; and the docs that PR A made false are reconciled.

## The open question is decided: Option A

The spec left one call to the repo owner — does `/pending_interrupts` move onto the thread-access axis, or stay on route identity? **It moves, in addition to #443's route-identity check. The two compose as AND.**

The reason is concrete, and the red step proved it rather than argued it. Before the gate, a denied caller received:

```
200 {"interrupts":[{"interruptId":"perm-1786636636469-cdj24d",
  "resumeKey":"ff5e1ad992a929efef2c9f16192d4a11", ...}]}
```

That `resumeKey` is the credential needed to resume someone else's parked turn. In an app whose middleware **authenticates** rather than authorizes per user — a shared API key, or any-valid-user, which is the common shape — every caller satisfies the parked route's middleware, so any user could read another user's resume credential and then use it.

A denied read returns the handler's own existing 404 literal, identical to a genuine miss, so the 403/404 split cannot be used to enumerate thread ids. That indistinguishability is pinned by a test.

**Cost of the decision:** `ThreadOperation` gains a tenth member. The spec wanted this settled *before* PR A so the union would ship whole; PR A merged with nine, so this widens a published union. Additive, but an exhaustive `switch` over it stops compiling. Called out in the changeset.

## `/resume` is an ordering exception, and it is not a preference

The other gates sit after `runMiddleware`, so an existing 401 does not silently become a 403. On `/resume` that is unsatisfiable, and gating after middleware left two real holes — both reproduced before the fix:

1. **A targeted DoS on a parked turn.** A denied caller still reached `resumeClaims.tryClaim` and took the victim's claim, so a concurrent legitimate resume got `409 resume_in_progress`.
2. **Full unauthorized resume.** The red step showed a wrong credential getting `409 interrupt_set_mismatch` and the *correct* one getting **`200`** — an unauthorized caller resuming the victim's turn, with the 400/409 codes acting as an oracle on a guessed `interruptId`/`resumeKey` along the way.

So the gate runs immediately after body parse, before `tryClaim`, and therefore before `runMiddleware`. Both rules cannot hold: `runMiddleware` needs `routeKey`, and `routeKey` is read from the thread's metadata.

**The consequence, stated rather than hidden:** on `/resume` and `/pending_interrupts` alone, a caller who would have received a middleware 401 receives a thread-access deny instead — because the route identity middleware would authorize against is itself derived from the thread the caller is not yet authorized to read. Documented in the source and in `thread-access.mdx`.

The placement is mutation-tested: moving the gate after `tryClaim` fails the DoS test; moving it after `runMiddleware` fails both.

## Two deviations from the plan, both deliberate

**The scaffolded policy ships as `.example`, not live.** The spec wanted a deny-by-default `src/thread-access.ts` active in the templates. The templates are also the quickstart *and* the base fixture `test/runtime/run-agent-protocol.test.ts` builds its app from — a lane that drives unauthenticated `POST /threads`, `/runs/wait`, `/resume` and `/state`, and that `verify:harness` runs inside `ci:validate`. A live deny-by-default policy 403s all of it, so `create-dawn-app` → `dawn dev` would deny every request before the app has an identity provider at all. Shipping `src/thread-access.ts.example` keeps PR A's contract — *no policy file means today's behavior, exactly* — and puts adoption one rename away. A test pins that no live policy ships, so this cannot rot into an accident. **Reversing it means adjusting the runtime, smoke and generated lanes with it.**

**`vercel` is lifted alongside `hono`.** There was no hono-only branch to remove: PR A's refusal is a single call in the *shared* `emitWebRuntimeArtifacts`, which both targets use, along with the same `app.mjs` template and the same `createRuntimeFetchHandler`. Keeping `vercel` refusing would have required *adding* a branch raising `DAWN_E1005` ("unsupported by the build target") for a target that now supports it. **`langsmith` still refuses**, with its test.

This branch also corrects PR A's own unreleased changeset, which still claimed hono fails and the run endpoints are not on the policy. Both entries land in one CHANGELOG and would have contradicted each other.

## Validation

- **`pnpm ci:validate` — `EXIT=0`** on the merged tree, Node 24, exit code captured explicitly rather than inferred from a wrapper. That includes `verify:harness`'s framework, runtime and smoke lanes — the parts most exposed to the scaffold change.
- Full `@dawn-ai/cli` suite: **1543 passed, 5 skipped**.
- Every gate was written test-first with the red step **observed**, not assumed. Two of them reproduced live disclosures (above) rather than merely returning the wrong status.
- The route-coverage test was re-proven to still guard: removing an entry from `GATED` without reclassifying it fails with an unclassified-route error.

- [x] `pnpm lint`
- [x] `pnpm build`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `node scripts/check-docs.mjs`
- [x] `pnpm pack:check`
- [x] Harness verification

## Release Notes

- [x] Changeset added — `@dawn-ai/sdk`, `@dawn-ai/cli`, `@dawn-ai/testing`, all patch. It leads with the migration hazard: **a policy written against PR A's five endpoints will now be invoked on five more**, so a `fallback` returning a bare `{ allow: false }` starts denying traffic it previously permitted.

## Checklist

- [x] I read `CONTRIBUTING.md`.
- [x] I followed `CODE_OF_CONDUCT.md`.
- [x] I did not include secrets, credentials, or private data.
- [x] I am not disclosing a security vulnerability publicly — the endpoints this hardens were already documented as ungated in PR A's own notes.
