### PR TITLE
fix(cli): stamp the threads run endpoints create implicitly

### DIFF
--- a/.changeset/thread-access-run-endpoints.md
+++ b/.changeset/thread-access-run-endpoints.md
@@ -20,17 +20,13 @@ gated on the thread-access axis. The migration hazard is a policy whose
 `fallback` returns a bare `{ allow: false }`, or denies any operation it does
 not recognize: it will start denying traffic it permitted before, on endpoints
 that previously answered to route middleware alone. Read your `fallback` before
-upgrading. Every `run.*` operation arrives under `action: "update"` — including
-on a thread id with no row yet, which those endpoints create, and which reaches
-the policy as `thread: undefined`. A policy that permits `update` for the
-thread's owner therefore needs one more decision than it did before: what to
-answer when there is no row to own yet. A policy that denies a missing row —
-correct for `delete` and `read`, and what closes the existence oracle there —
-now refuses every AG-UI turn, because `POST /agui/{routeId}` runs on a thread id
-the client picked and never created. Only `POST /threads` writes an access
-stamp, so relaxing `update` for a missing row authorizes the first turn and
-denies the second; mint the id through `POST /threads` instead, or keep your own
-id-to-owner record.
+upgrading. A `run.*` operation on a thread that exists arrives under
+`action: "update"`; on a thread id with no row yet, `run.stream`, `run.wait` and
+`run.agui` arrive under `action: "create"` — see the companion note on stamping
+the implicit create, which lands in the same release. A policy that permits
+`update` for the thread's owner therefore needs one more decision than it did
+before: what its `create` handler should answer for a thread id the client
+picked. `run.resume` never creates and is always an `update`.
 
 These gates compose with route middleware as AND rather than replacing it;
 middleware still answers "may this caller run this route" and keeps doing the

--- a/.changeset/thread-access-stamp-implicit-create.md
+++ b/.changeset/thread-access-stamp-implicit-create.md
@@ -1,0 +1,58 @@
+---
+"@dawn-ai/sdk": patch
+"@dawn-ai/cli": patch
+---
+
+Threads created implicitly by a run endpoint are now stamped with the caller who
+created them.
+
+`POST /threads/:id/runs/stream`, `/runs/wait` and `POST /agui/{routeId}` create
+the thread when the id they were given names no row. That create wrote no
+metadata, so the row carried no access stamp — and two things followed from
+that.
+
+**A policy's legacy branch means only "created before the policy existed"
+again.** `thread.access === undefined` is the branch an app writes when it
+adopts a policy on an existing store, usually admin-only or backfilled. Because
+an unstamped row could be manufactured on demand — by naming any thread id at a
+run endpoint — that branch had quietly widened to "predates the policy, **or**
+was created by anyone a moment ago", which turns a permissive legacy branch
+(the common shape mid-rollout) into an escalation path. The implicit create now
+carries the stamp your `create` handler returns, so the branch means what it
+says.
+
+**The caller who created a thread can take a second turn on it.** Previously the
+row it had just made read back with no owner, so a policy that authorizes
+against `thread.access` denied its own author from turn two onward. This is the
+flow `POST /agui/{routeId}` drives, since CopilotKit picks its `threadId` in the
+browser and never calls `POST /threads`.
+
+**`run.*` operations can now arrive under `action: "create"`.** When the row is
+absent, `run.stream`, `run.wait` and `run.agui` are asked under `create` — then
+again as the `update` recheck that follows every create, the same two-step
+`thread.create` already used. The `operation` is unchanged throughout; only the
+`action` differs. `run.resume` is untouched: it requires an already-parked
+thread and creates nothing.
+
+Read your `create` handler before upgrading. It now decides runs on thread ids
+the client picked, not just `POST /threads`, and the stamp it returns is what
+every later turn on those threads authorizes against. A policy that denied
+`create` outright — or that relied on `update` seeing `thread: undefined` for a
+first turn — changes behavior here. Ownership of a client-chosen id is first
+come, first served: whoever names an unused id is stamped as its owner and can
+hold it against the caller who meant to use it. Mint ids with `POST /threads`
+if that matters; those are server-generated and nobody can call them first.
+
+The `update` recheck is not optional and is not a stamp comparison. Two callers
+can both find the row absent, and a store that upserts on collision hands the
+loser the winner's row; Dawn re-authorizes the row that actually came back
+before the run proceeds. Comparing the minted stamp with the returned one would
+not catch it — a `permit()` with no stamp leaves both sides `undefined`.
+
+An app with no policy file is unaffected: the implicit create still passes the
+thread id and nothing else, with no extra gate call and no extra store read.
+
+The scaffolded `src/thread-access.ts` gains the AG-UI flow as a consequence: its
+`create` handler stamps an authenticated caller, so a browser-chosen `threadId`
+is served and stays served. Its commentary, and the thread-access docs, are
+updated to match.

--- a/apps/web/content/docs/thread-access.mdx
+++ b/apps/web/content/docs/thread-access.mdx
@@ -161,14 +161,16 @@ This is in the same class as `dawn inspect` and `dawn memory`: a local operator 
 
 The run endpoints — `POST /threads/:thread_id/runs/stream`, `/runs/wait`, `/resume` and `POST /agui/{routeId}` — plus `GET /threads/:thread_id/pending_interrupts` are on this policy **as well as** [route middleware](/docs/middleware). The two compose as AND: middleware answers "may this caller run this route", the policy answers "may this caller touch this thread", and a request needs both. Neither replaces the other, so keep middleware doing the per-caller work it does today.
 
-All four `run.*` operations arrive under `action: "update"` — including on an id with no row yet, which those endpoints create. Starting a turn on a thread mutates it; none of them is a `create`.
+A `run.*` operation on a thread that exists arrives under `action: "update"` — starting a turn mutates the thread. Three of these endpoints (`/runs/stream`, `/runs/wait`, `POST /agui/{routeId}`) also **create** the thread when the id names no row, and Dawn asks about that under `action: "create"`, then again as the `update` recheck that follows every create — the same two-step `POST /threads` uses. `/resume` is the exception: it needs an already-parked thread, creates nothing, and is only ever an `update`.
 
-<Callout type="warn" title="A policy that denies a missing row denies every AG-UI turn">
-The scaffolded `src/thread-access.ts` denies when `req.thread === undefined`, which is correct for `delete` and `read` and is what keeps the existence oracle shut. It also refuses every `run.*` operation on a thread id that has no row yet — and `POST /agui/{routeId}` is exactly that case, because CopilotKit picks its `threadId` in the browser and never calls `POST /threads`. An app that activates the scaffold unchanged answers `403` to every AG-UI turn.
+The stamp your `create` handler returns is written into the row, exactly as it is on `POST /threads`. So a thread born on a run endpoint has an owner from its first turn, and `access === undefined` keeps its one meaning: **created before you adopted a policy**.
 
-**Relaxing that line for `update` is not the fix.** The implicit create the run endpoints do writes the row with **no access stamp** — only `POST /threads` stamps — so the next turn on the same thread reaches the `access === undefined` branch and is denied anyway. A relaxed policy authorizes the first turn and refuses the second.
+<Callout type="warn" title="On a client-chosen id, ownership is first come, first served">
+`POST /threads` mints the id itself. The run endpoints take the one the caller sent — `POST /agui/{routeId}` especially, because CopilotKit picks its `threadId` in the browser and never calls `POST /threads`. Whoever names an unused id gets stamped as its owner, which also means anyone your `create` handler admits can claim an id **before** the user who meant to use it, and hold it against them.
 
-Mint the thread with `POST /threads` and pass the returned `thread_id` to the client as its thread id. That is the path that records an owner, so every later turn matches it. If client-chosen ids are non-negotiable, record the id-to-owner mapping yourself, from inside the policy, and consult it on `update`. Do not relax `delete` or `read` to get there.
+If that matters, mint ids with `POST /threads` and hand the returned `thread_id` to the client. Those ids are server-generated, so nobody can call them first.
+
+The recheck is what makes the race safe rather than merely unlikely: two callers can both find the row absent, and a store that upserts hands the loser the winner's row. Dawn re-authorizes the row that actually came back, under `update`, before the run proceeds — it never compares stamps, because a `permit()` with no stamp leaves both sides `undefined` and the comparison would pass.
 </Callout>
 
 `GET /threads/:thread_id/pending_interrupts` composes both checks as AND — the route that parked the interrupts must admit the caller *and* this policy must permit the read — and which one refused is deliberately not visible in the response: a thread-access deny returns the handler's own `404 thread_not_found`, the same bytes a genuine miss returns, while a route-identity refusal returns whatever your middleware returns. Dawn logs neither, so log the denial inside your own policy if you need to tell them apart.

--- a/docs/superpowers/plans/2026-08-13-thread-access-stamp-implicit-create.md
+++ b/docs/superpowers/plans/2026-08-13-thread-access-stamp-implicit-create.md
@@ -42,6 +42,10 @@ When a run endpoint finds the row absent **and a policy is installed**:
 
 A backend whose `createThread` throws on a duplicate id (sqlite's bare `INSERT`; the conformance kit deliberately admits both outcomes) surfaces exactly as it does today. That path never reaches the recheck because it never gets a row.
 
+### The AG-UI window
+
+On `/runs/stream` and `/runs/wait` the create is the statement after the gate. On `/agui/:routeId` it cannot be: it has always sat after `resumeClaims.tryClaim`, `runRegistry.begin` and a checkpointer read, and moving it would move side effects a denial must not take. So the `create` decision is carried down in two locals, and that handler additionally re-reads the row before creating: if one has appeared in the meantime, the turn is authorized under `update` against **that** row rather than proceeding on a decision made about a thread that did not exist. Same principle as the post-create recheck, applied to a window that is several statements wide instead of one.
+
 ## Published contract change
 
 `packages/sdk/src/thread-access.ts`'s `ThreadOperation` doc says every `run.*` operation arrives under `update`, "without exception". That becomes false: `run.stream`, `run.wait` and `run.agui` now arrive under `create`, **then** `update`, when the row is absent — the same two-step shape `thread.create` already documents. Update those lines in the same style. Weaken nothing else in the comment.

--- a/docs/superpowers/plans/2026-08-13-thread-access-stamp-implicit-create.md
+++ b/docs/superpowers/plans/2026-08-13-thread-access-stamp-implicit-create.md
@@ -1,0 +1,70 @@
+# Thread Access PR C — stamp the implicit create
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:test-driven-development. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** The three run endpoints that create a thread row when it is missing must stamp the creating caller into it, the same way `POST /threads` already does. One coherent change; no new authorization concepts.
+
+**Base:** `origin/main` at `782568a9` (PR B merged).
+
+---
+
+## Why
+
+PR A established that `POST /threads` stamps its caller into a reserved metadata key, so a policy can later authorize against `req.thread.access` — an unforgeable, server-issued owner record. PR B gated the run endpoints but left their own implicit create passing no metadata at all:
+
+- `packages/cli/src/lib/dev/runtime-fetch-core.ts:1640` — `/runs/stream`
+- `packages/cli/src/lib/dev/runtime-fetch-core.ts:1941` — `/runs/wait`
+- `packages/cli/src/lib/dev/agui-handler.ts:307` — `/agui/:routeId`
+
+all `createThread({ thread_id: threadId })`, on a **client-supplied** id. A thread born there has `access === undefined` forever, and that costs two things.
+
+**The flow breaks on turn two.** The caller who created the thread is denied on their own thread, because the row records no owner. This is what makes the scaffolded policy refuse every AG-UI conversation on a browser-chosen `threadId`.
+
+**The migration story is unsound — and this is the real reason for the PR.** An app adopting a policy is told to write a legacy branch: `access === undefined` means "this thread predates the policy", handled admin-only or backfilled. After PR B an attacker can manufacture an unstamped row on demand, by naming any thread id at `POST /threads/<id>/runs/stream`. `unstamped` stops meaning "pre-policy" and starts meaning "pre-policy, **or created by anyone just now**". A permissive legacy branch — the common shape mid-rollout — becomes an escalation path.
+
+`POST /threads/:id/resume` is NOT in scope: it requires an already-parked thread and performs no implicit create.
+
+## The design
+
+Mirror `POST /threads` (`runtime-fetch-core.ts:1067-1110`), which is the reference implementation.
+
+When a run endpoint finds the row absent **and a policy is installed**:
+
+1. Gate under **`action: "create"`**, keeping the endpoint's own `operation` (`run.stream` / `run.wait` / `run.agui` — never rewritten to `thread.create`). No client metadata reaches these paths, so no `requestedMetadata`.
+2. Apply the returned stamp to the create: `{ metadata: { [THREAD_ACCESS_METADATA_KEY]: stamp } }`, exactly as `POST /threads` builds `stored`.
+3. **Recheck under `action: "update"` against the row that actually came back.** Security-critical and not optional. The id is client-chosen, so two callers can both see an absent row and both call `createThread`; an upsert backend hands the loser the winner's row. The recheck authorizes the ROW, not the intent. **Never a stamp comparison** — `POST /threads:1097-1100` explains why: with `permit()` and no stamp both sides are `undefined`, the comparison passes, and the loser proceeds on a stranger's row with no authorization at all.
+4. Row already present: unchanged, the `action: "update"` gate PR B added.
+5. **A hook-less app is untouched.** No extra gate call, no metadata, no extra store read — PR A's contract is "no policy file means today's behavior, exactly." All new work stays inside `if (threadAccess)`.
+
+### What differs from `POST /threads`, and why no retry
+
+`POST /threads` retries its create up to three times, because its id is server-generated and 32 bits wide: a collision there is a birthday problem, and a fresh draw is very likely to succeed. **A run endpoint cannot retry** — the caller named the id, so a second attempt collides identically, forever. Adoption of an existing row is therefore a permanent outcome on these paths and the `update` recheck is the *only* thing standing between the caller and a stranger's thread. `isRowWeJustWrote` has no role here.
+
+A backend whose `createThread` throws on a duplicate id (sqlite's bare `INSERT`; the conformance kit deliberately admits both outcomes) surfaces exactly as it does today. That path never reaches the recheck because it never gets a row.
+
+## Published contract change
+
+`packages/sdk/src/thread-access.ts`'s `ThreadOperation` doc says every `run.*` operation arrives under `update`, "without exception". That becomes false: `run.stream`, `run.wait` and `run.agui` now arrive under `create`, **then** `update`, when the row is absent — the same two-step shape `thread.create` already documents. Update those lines in the same style. Weaken nothing else in the comment.
+
+## Tasks
+
+- [ ] **Task 1 — plan.** This file, committed first.
+- [ ] **Task 2 — failing tests.** `packages/cli/test/thread-access-run-endpoints.test.ts`, all three endpoints:
+  - the creating caller takes a **second turn** on a thread the run endpoint created (the flow broken today — write it first and watch it fail);
+  - an **intruder is denied** on a thread another caller's run endpoint created;
+  - the **race**: a fake `ThreadsStore` whose `createThread` returns a foreign row, and the recheck denies;
+  - a **hook-less app writes no metadata** on the implicit create.
+  Observe every red step. A test that cannot fail is worse than no test.
+- [ ] **Task 3 — implementation.** A shared create-and-recheck helper in `thread-gate.ts` (the module both `runtime-fetch-core.ts` and `agui-handler.ts` already import — the import back the other way would be a cycle), plus the `action: thread ? "update" : "create"` selection at the three gate sites. On `/agui` the gate is early (before `tryClaim` / `runRegistry.begin`) and the create is late, so the stamp is carried across in a local.
+- [ ] **Task 4 — SDK doc.** `ThreadOperation`'s comment.
+- [ ] **Task 5 — reconcile what is now false.** `apps/web/content/docs/thread-access.mdx` (the "denies a missing row denies every AG-UI turn" callout, and the "all four arrive under `update`" line), the three byte-for-byte copies of the scaffolded `thread-access.ts.example`, and the tests that string-match them (`packages/devkit/test/template-thread-access.test.ts`) or execute them (`packages/cli/test/thread-access-scaffold.test.ts`). The scaffold's behavior changes for the better and on its own — its `create` handler stamps an authenticated caller — so what changes here is prose that has stopped being true, plus the pinned expectations of it.
+- [ ] **Task 6 — changeset.** `@dawn-ai/sdk` patch, `@dawn-ai/cli` patch. It must say plainly that a thread created implicitly by a run endpoint is now stamped, so a policy's legacy/unstamped branch again means only "created before the policy existed"; and that `run.*` operations can now arrive under `create`. PR B's own unreleased changeset states the opposite in two places and ships in the same release — amend it rather than contradict it.
+
+## Verification
+
+Node 24 (`export PATH="$HOME/.nvm/versions/node/v24.19.0/bin:$PATH"`). Capture exit codes explicitly (`cmd > /tmp/x.log 2>&1; echo "EXIT=$?"`) — a pipe reports the pipe's status and has produced false greens here. **Build before typecheck**: cross-package types resolve through `dist/`, so an unbuilt edit does not error, it lies.
+
+- `pnpm --filter @dawn-ai/cli exec vitest --run --config vitest.config.ts`
+- `pnpm --filter @dawn-ai/devkit exec vitest --run`
+- `node scripts/check-docs.mjs` (bans the literal phrase "byte-identical"; use "byte-for-byte")
+- `pnpm typecheck`, `pnpm lint`

--- a/examples/research/server/src/thread-access.ts.example
+++ b/examples/research/server/src/thread-access.ts.example
@@ -30,30 +30,23 @@ const owned = async (req: ThreadAccessRequest) => {
   // the endpoint's natural 404 or 204. Denying it FIRST, ahead of any admin
   // branch, is what keeps "not yours" and "never existed" the same answer. An
   // admin allowed to delete a row that never existed reopens the existence
-  // oracle this default closes.
+  // oracle this default closes. Do not relax this line for `delete` or `read`.
   //
-  // READ THIS BEFORE YOU SHIP AN AG-UI APP. This line also refuses every
-  // `run.*` operation on a thread id whose row does not exist yet, and those
-  // endpoints are the ones that would have created it: `POST /agui/{routeId}`,
-  // `/runs/stream`, `/runs/wait` and `/resume` all arrive here under
-  // `action: "update"` with `req.thread === undefined`. CopilotKit picks its
-  // `threadId` in the browser and never calls `POST /threads`, so under this
-  // policy every AG-UI turn on a fresh id is denied with a 403.
+  // It does NOT refuse a first AG-UI turn, which is the thing people expect it
+  // to. `POST /agui/{routeId}`, `/runs/stream` and `/runs/wait` create the row
+  // when the id names none, and Dawn asks about that create under
+  // `action: "create"` — the handler below, not this one. CopilotKit picking
+  // its `threadId` in the browser is therefore served, and the row it writes
+  // carries the stamp that create returned, so every later turn matches
+  // `owner === user.id`. Only `/resume` arrives here with no row, because it
+  // needs an already-parked thread and creates nothing.
   //
-  // Relaxing this line for `update` is NOT the fix, however obvious it looks.
-  // The implicit create those endpoints do writes the row with no access stamp,
-  // so the next turn on the same thread reaches the `owner === undefined`
-  // branch below and is denied anyway: you would authorize turn one and refuse
-  // turn two, which is worse than refusing honestly.
-  //
-  // Mint the thread with `POST /threads` and hand the returned `thread_id` to
-  // the client as its thread id. That is the only path that stamps an owner, so
-  // every later turn matches `owner === user.id` and is served. If you must
-  // authorize client-chosen ids instead, record the id-to-owner mapping
-  // yourself — in your own store, from this policy — and consult it here.
-  // Whatever you do, do not relax `delete` or `read`: those endpoints answer
-  // 204/404 for a row that never existed, and permitting them on a missing row
-  // is exactly what reopens the existence oracle.
+  // What that costs, and it is a real cost: ownership of a client-chosen id is
+  // first come, first served. Any authenticated caller can claim an unused id
+  // by naming it — including claiming one your user was about to use, which
+  // then denies it to them for good. Mint ids with `POST /threads` and hand the
+  // returned `thread_id` to the client if that matters to you; those ids are
+  // server-generated, so nobody can call them first.
   if (req.thread === undefined) return deny()
 
   // `req.thread.access`, never `req.thread.metadata`. Metadata is
@@ -74,6 +67,10 @@ const owned = async (req: ThreadAccessRequest) => {
 }
 
 export default defineThreadAccess({
+  // `POST /threads`, and every run endpoint that finds no row for the thread id
+  // it was given. The stamp this returns is the thread's owner record: Dawn
+  // stores it under a reserved key no client can write, and it is what `owned`
+  // above authorizes against for the whole life of the thread.
   create: async (req) => {
     const user = await principalOf(req.headers)
     return user ? permit({ ownerId: user.id, org: user.org }) : deny()
@@ -81,9 +78,10 @@ export default defineThreadAccess({
   // `fallback` is required, and it is the deny-by-default floor: an action with
   // no handler of its own lands here rather than falling through to an allow.
   //
-  // It also handles the `update` recheck Dawn runs after every create. The row
-  // just stamped has `ownerId === user.id`, so `owned` permits it; a row the
-  // store handed back on an id collision carries someone else's, so `owned`
-  // denies and the caller never receives a thread they do not own.
+  // It also handles the `update` recheck Dawn runs after every create, on
+  // `POST /threads` and on a run endpoint's implicit create alike. The row just
+  // stamped has `ownerId === user.id`, so `owned` permits it; a row the store
+  // handed back on an id collision carries someone else's, so `owned` denies
+  // and the caller never receives a thread they do not own.
   fallback: owned,
 })

--- a/packages/cli/src/lib/dev/agui-handler.ts
+++ b/packages/cli/src/lib/dev/agui-handler.ts
@@ -26,7 +26,8 @@ import type { RuntimeRegistry } from "./runtime-registry-core.js"
 import { createRequestErrorBody } from "./server-errors.js"
 import { statusResponse } from "./status-response.js"
 import { terminalStatus } from "./terminal-status.js"
-import { isThenable, makeThreadGate } from "./thread-gate.js"
+import type { Gate, GateSpec } from "./thread-gate.js"
+import { createGatedThreadForRun, isThenable, makeThreadGate } from "./thread-gate.js"
 import { assertNoReservedKey } from "./thread-metadata.js"
 
 export interface AgUiFetchRequestOptions {
@@ -238,24 +239,35 @@ export async function handleAgUiFetchRequest(options: AgUiFetchRequestOptions): 
       return statusResponse(middlewareResult.status, middlewareResult.body)
     }
 
-    // Unconditionally `update`, like every other `run.*` operation — see
-    // ThreadOperation. AFTER the middleware reject above and BEFORE every
-    // side effect below (`resumeClaims.tryClaim`, `runRegistry.begin`,
-    // `threadsStore.createThread`): a denial must take no claim, no run
-    // slot, and create no row. This route has no `threads` segment — the
+    // `update` on a row that exists, `create` on one this turn is about to
+    // make — see ThreadOperation. AFTER the middleware reject above and BEFORE
+    // every side effect below (`resumeClaims.tryClaim`, `runRegistry.begin`,
+    // `threadsStore.createThread`): a denial must take no claim, no run slot,
+    // and create no row. This route has no `threads` segment — the
     // client-supplied `input.threadId` is the only thread identity a caller
     // controls here, and it names any thread id it likes.
+    //
+    // The create itself cannot happen here: it must land after the run slot is
+    // claimed, where it has always been. These two carry the `create` decision
+    // down to it. Both stay `undefined` on a row that already exists and on a
+    // hook-less app, which is what the create site branches on.
+    let createGate: ((spec: GateSpec) => Gate | Promise<Gate>) | undefined
+    let createStamp: Record<string, unknown> | undefined
     if (threadAccess) {
       const existing = await threadsStore.getThread(input.threadId)
       const gate = makeThreadGate(threadAccess, request)
       const g = gate({
-        action: "update",
+        action: existing ? "update" : "create",
         operation: "run.agui",
         threadId: input.threadId,
         ...(existing ? { thread: existing } : {}),
       })
       const settled = isThenable(g) ? await g : g
       if (!settled.ok) return settled.response
+      if (!existing) {
+        createGate = gate
+        createStamp = settled.stamp
+      }
     }
 
     if (dawnInput.resume !== undefined) {
@@ -303,7 +315,33 @@ export async function handleAgUiFetchRequest(options: AgUiFetchRequestOptions): 
     // caveat as the Agent Protocol handlers: only the CLEAR consults it.
     const existingThread = await threadsStore.getThread(threadId)
     const previousParkedRoute = readParkedRoute(existingThread)
-    if (!existingThread) {
+    if (createGate && existingThread) {
+      // A row appeared between the gate and here. The window is wide on this
+      // endpoint — a resume claim, a run slot and a checkpointer read sit
+      // inside it — and the id is client-chosen, so the row that turned up may
+      // be anybody's. The `create` decision authorized a thread that did not
+      // exist; this one does, so it is authorized as what it now is. Skipping
+      // this on the strength of the earlier decision would run the turn on a
+      // thread nothing admitted this caller to.
+      const recheck = createGate({
+        action: "update",
+        operation: "run.agui",
+        thread: existingThread,
+        threadId,
+      })
+      const settled = isThenable(recheck) ? await recheck : recheck
+      if (!settled.ok) return settled.response
+    } else if (createGate) {
+      const created = await createGatedThreadForRun({
+        gate: createGate,
+        operation: "run.agui",
+        stamp: createStamp,
+        store: threadsStore,
+        threadId,
+      })
+      if (!created.ok) return created.response
+    } else if (!existingThread) {
+      // Hook-less: unchanged.
       await threadsStore.createThread({ thread_id: threadId })
     }
     // The last-run route, and therefore NOT the identity

--- a/packages/cli/src/lib/dev/runtime-fetch-core.ts
+++ b/packages/cli/src/lib/dev/runtime-fetch-core.ts
@@ -52,7 +52,7 @@ import {
 import { statusResponse } from "./status-response.js"
 import { terminalStatus } from "./terminal-status.js"
 import { threadAccessBootLine, validateThreadAccessPolicy } from "./thread-access.js"
-import { isThenable, makeThreadGate } from "./thread-gate.js"
+import { createGatedThreadForRun, isThenable, makeThreadGate } from "./thread-gate.js"
 import { assertNoReservedKey, stripReservedThreadMetadata } from "./thread-metadata.js"
 
 // ---------------------------------------------------------------------------
@@ -1617,25 +1617,40 @@ async function handleApStreamRequest(options: {
   // Idempotently ensure the thread exists
   let thread: Thread | undefined = await threadsStore.getThread(threadId)
 
-  // Gated as "update" unconditionally — never "create", even for a thread
-  // this call is about to create. See ThreadOperation's `run.stream` doc:
-  // the client picks this thread id (unlike POST /threads' server-generated
-  // one), so starting a run is authorized the same way whether or not the
-  // row exists yet. AFTER the middleware reject above and BEFORE both
-  // `createThread` and `runRegistry.begin` below — a denial must create no
-  // row and take no run slot.
+  // Gated as "update" on a thread that exists, and as "create" — then "update"
+  // again, on the row that came back — when this call is the one that brings it
+  // into being. The operation stays `run.stream` throughout: it names the
+  // endpoint, not the action. See ThreadOperation.
+  //
+  // AFTER the middleware reject above and BEFORE both `createThread` and
+  // `runRegistry.begin` below — a denial must create no row and take no run
+  // slot.
   if (threadAccess) {
     const gate = makeThreadGate(threadAccess, request)
     const g = gate({
-      action: "update",
+      action: thread ? "update" : "create",
       operation: "run.stream",
       threadId,
       ...(thread ? { thread } : {}),
     })
     const settled = isThenable(g) ? await g : g
     if (!settled.ok) return settled.response
+    if (!thread) {
+      const created = await createGatedThreadForRun({
+        gate,
+        operation: "run.stream",
+        stamp: settled.stamp,
+        store: threadsStore,
+        threadId,
+      })
+      if (!created.ok) return created.response
+      thread = created.thread
+    }
   }
 
+  // Hook-less only: the policied path created its row above, stamped and
+  // re-authorized. PR A's contract is that an app with no policy file behaves
+  // exactly as it did, and this line is what that means here.
   if (!thread) {
     thread = await threadsStore.createThread({ thread_id: threadId })
   }
@@ -1921,22 +1936,36 @@ async function handleApWaitRequest(options: {
   // Idempotently ensure the thread exists
   let thread: Thread | undefined = await threadsStore.getThread(threadId)
 
-  // Gated as "update" unconditionally, same reasoning as handleApStreamRequest:
-  // this endpoint picks the thread id the same way /runs/stream does, so a
-  // denial must create no row and take no run slot. AFTER the middleware
-  // reject above and BEFORE both `createThread` and `runRegistry.begin` below.
+  // "update" on an existing row, "create" then an "update" recheck on the one
+  // this call brings into being — same reasoning, and the same two-step, as
+  // handleApStreamRequest: this endpoint picks the thread id the same way
+  // /runs/stream does. A denial must create no row and take no run slot. AFTER
+  // the middleware reject above and BEFORE both `createThread` and
+  // `runRegistry.begin` below.
   if (threadAccess) {
     const gate = makeThreadGate(threadAccess, request)
     const g = gate({
-      action: "update",
+      action: thread ? "update" : "create",
       operation: "run.wait",
       threadId,
       ...(thread ? { thread } : {}),
     })
     const settled = isThenable(g) ? await g : g
     if (!settled.ok) return settled.response
+    if (!thread) {
+      const created = await createGatedThreadForRun({
+        gate,
+        operation: "run.wait",
+        stamp: settled.stamp,
+        store: threadsStore,
+        threadId,
+      })
+      if (!created.ok) return created.response
+      thread = created.thread
+    }
   }
 
+  // Hook-less only — see the same line in handleApStreamRequest.
   if (!thread) {
     thread = await threadsStore.createThread({ thread_id: threadId })
   }

--- a/packages/cli/src/lib/dev/thread-gate.ts
+++ b/packages/cli/src/lib/dev/thread-gate.ts
@@ -7,7 +7,7 @@ import type {
   ThreadSubject,
 } from "@dawn-ai/sdk"
 import { THREAD_ACCESS_METADATA_KEY } from "@dawn-ai/sdk"
-import type { Thread } from "@dawn-ai/sqlite-storage"
+import type { Thread, ThreadsStore } from "@dawn-ai/sqlite-storage"
 import { headersToRecord } from "./middleware.js"
 import { createRequestErrorBody } from "./server-errors.js"
 import { statusResponse } from "./status-response.js"
@@ -193,4 +193,46 @@ export function makeThreadGate(
     const returned = handler(accessRequest) as unknown
     return isThenable(returned) ? returned.then(settle) : settle(returned)
   }
+}
+
+/**
+ * The implicit thread create a run endpoint performs when the row is missing,
+ * with the policy's stamp applied and the resulting ROW re-authorized.
+ *
+ * Called ONLY when a policy is installed — a hook-less app keeps its bare
+ * `createThread({ thread_id })` at the call site and pays nothing for this.
+ *
+ * Mirrors `POST /threads` (`runtime-fetch-core.ts`), with two differences that
+ * both come from the id being CLIENT-chosen here rather than server-generated:
+ *
+ * - **No retry.** `POST /threads` retries a create that collided, because it
+ *   can draw a fresh 32-bit id and very likely win. A caller named this id, so
+ *   every retry collides identically. Adoption of an existing row is permanent
+ *   on this path.
+ * - **The recheck is therefore the only boundary.** Unconditional, and never a
+ *   stamp comparison: a `permit()` with no stamp leaves both sides `undefined`,
+ *   the comparison passes, and the loser of a race proceeds on the winner's row
+ *   with nothing having authorized it. Authorize the ROW.
+ *
+ * A store whose `createThread` throws on a duplicate id (sqlite's bare INSERT;
+ * the conformance kit admits that and the upsert-and-return-the-existing-row
+ * shape alike) propagates exactly as it does today — that path never obtains a
+ * row, so there is nothing to re-authorize and nothing to hand back.
+ */
+export async function createGatedThreadForRun(args: {
+  readonly gate: (spec: GateSpec) => Gate | Promise<Gate>
+  readonly operation: ThreadOperation
+  readonly stamp: Record<string, unknown> | undefined
+  readonly store: ThreadsStore
+  readonly threadId: string
+}): Promise<{ readonly ok: true; readonly thread: Thread } | GateDenied> {
+  const { gate, operation, stamp, store, threadId } = args
+  const thread = await store.createThread({
+    thread_id: threadId,
+    ...(stamp ? { metadata: { [THREAD_ACCESS_METADATA_KEY]: stamp } } : {}),
+  })
+  const recheck = gate({ action: "update", operation, thread, threadId: thread.thread_id })
+  const settled = isThenable(recheck) ? await recheck : recheck
+  if (!settled.ok) return settled
+  return { ok: true, thread }
 }

--- a/packages/cli/test/thread-access-run-endpoints.test.ts
+++ b/packages/cli/test/thread-access-run-endpoints.test.ts
@@ -1,8 +1,9 @@
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { dirname, join } from "node:path"
-import type { ThreadAccessPolicy, ThreadAccessRequest } from "@dawn-ai/sdk"
-import type { Thread, ThreadsStore } from "@dawn-ai/sqlite-storage"
+import type { ThreadAccessPolicy, ThreadAccessRequest, ThreadOperation } from "@dawn-ai/sdk"
+import { THREAD_ACCESS_METADATA_KEY } from "@dawn-ai/sdk"
+import type { CreateThreadInput, Thread, ThreadsStore } from "@dawn-ai/sqlite-storage"
 import { afterEach, describe, expect, it } from "vitest"
 
 import { createRuntimeFetchHandler } from "../src/lib/dev/runtime-fetch-handler.js"
@@ -172,12 +173,19 @@ describe("POST /threads/:id/runs/stream", () => {
     const threadsStore = recordingThreadsStore((id) => created.push(id))
     const { handler } = await setup({
       threadAccess: {
+        // The row does not exist, so this run's own create is the decision
+        // being asked for — `update` would be asking about a thread that is
+        // not there. Both other handlers throw rather than record: a denial
+        // that arrived on the wrong axis is not the denial this test claims.
+        create: (request) => {
+          seen.push(request.operation)
+          return { decision: "deny" }
+        },
         fallback: () => {
           throw new Error("fallback should not be reached for run.stream")
         },
-        update: (request) => {
-          seen.push(request.operation)
-          return { decision: "deny" }
+        update: () => {
+          throw new Error("a missing row is a create, not an update, for run.stream")
         },
       },
       threadsStore,
@@ -236,12 +244,19 @@ describe("POST /threads/:id/runs/wait", () => {
     const threadsStore = recordingThreadsStore((id) => created.push(id))
     const { handler } = await setup({
       threadAccess: {
+        // The row does not exist, so this run's own create is the decision
+        // being asked for — `update` would be asking about a thread that is
+        // not there. Both other handlers throw rather than record: a denial
+        // that arrived on the wrong axis is not the denial this test claims.
+        create: (request) => {
+          seen.push(request.operation)
+          return { decision: "deny" }
+        },
         fallback: () => {
           throw new Error("fallback should not be reached for run.wait")
         },
-        update: (request) => {
-          seen.push(request.operation)
-          return { decision: "deny" }
+        update: () => {
+          throw new Error("a missing row is a create, not an update, for run.wait")
         },
       },
       threadsStore,
@@ -298,12 +313,19 @@ describe("POST /agui/:routeId", () => {
     const threadsStore = recordingThreadsStore((id) => created.push(id))
     const { handler } = await setup({
       threadAccess: {
+        // The row does not exist, so this run's own create is the decision
+        // being asked for — `update` would be asking about a thread that is
+        // not there. Both other handlers throw rather than record: a denial
+        // that arrived on the wrong axis is not the denial this test claims.
+        create: (request) => {
+          seen.push(request.operation)
+          return { decision: "deny" }
+        },
         fallback: () => {
           throw new Error("fallback should not be reached for run.agui")
         },
-        update: (request) => {
-          seen.push(request.operation)
-          return { decision: "deny" }
+        update: () => {
+          throw new Error("a missing row is a create, not an update, for run.agui")
         },
       },
       threadsStore,
@@ -415,4 +437,328 @@ describe("POST /agui/:routeId", () => {
     gate.releaseDeny()
     expect((await attacker).status).toBe(403)
   }, 10_000)
+})
+
+// ---------------------------------------------------------------------------
+// The implicit create
+//
+// All three endpoints below create the thread row when it is missing, on an id
+// the CLIENT picked. Until this PR that create passed no metadata, so the row
+// carried no access stamp and `thread.access === undefined` stopped meaning
+// "created before the policy existed".
+// ---------------------------------------------------------------------------
+
+interface RunEndpoint {
+  readonly name: string
+  readonly operation: ThreadOperation
+  readonly request: (threadId: string, headers: Record<string, string>) => Request
+}
+
+let runSeq = 0
+
+/** The three endpoints that perform an implicit create, driven identically. */
+const RUN_ENDPOINTS: readonly RunEndpoint[] = [
+  {
+    name: "POST /threads/:id/runs/stream",
+    operation: "run.stream",
+    request: (threadId, headers) =>
+      post(`/threads/${threadId}/runs/stream`, { input: {}, route: HELLO_ROUTE }, headers),
+  },
+  {
+    name: "POST /threads/:id/runs/wait",
+    operation: "run.wait",
+    request: (threadId, headers) =>
+      post(`/threads/${threadId}/runs/wait`, { input: {}, route: HELLO_ROUTE }, headers),
+  },
+  {
+    name: "POST /agui/:routeId",
+    operation: "run.agui",
+    request: (threadId, headers) =>
+      aguiPost(HELLO_ROUTE, { threadId, runId: `run-${++runSeq}`, messages: [] }, headers),
+  },
+]
+
+/**
+ * The policy shape the docs teach and the scaffold ships: `create` stamps the
+ * caller, everything else authorizes against the stamp the row carries.
+ *
+ * `legacyUnstamped` is the branch an app writes for a thread that predates the
+ * policy, and it is the whole reason this PR exists — both answers are in the
+ * docs and both are wrong in a different way while the implicit create writes
+ * no stamp. `"deny"` (the conservative one the scaffold ships, modulo its
+ * admin escape hatch) locks the creating caller out of its own thread on turn
+ * two. `"allow"` keeps the conversation working and hands every later caller
+ * the same row, because an attacker can manufacture an unstamped row on demand
+ * by naming an id at a run endpoint.
+ */
+function stampingOwnerPolicy(legacyUnstamped: "allow" | "deny"): ThreadAccessPolicy {
+  return {
+    create: (request) => {
+      const actor = request.headers["x-actor"]
+      return actor ? { decision: "allow", stamp: { ownerId: actor } } : { decision: "deny" }
+    },
+    fallback: (request) => {
+      const actor = request.headers["x-actor"]
+      if (!actor) return { decision: "deny" }
+      // No row yet: the endpoint is about to make one, and only the `create`
+      // handler above decides who owns it. Denying here instead would refuse
+      // the first turn outright, which is the other half of the same bind.
+      if (request.thread === undefined) return { decision: "allow" }
+      const owner = request.thread.access?.ownerId
+      if (owner === undefined) return { decision: legacyUnstamped } // legacy thread
+      return owner === actor ? { decision: "allow" } : { decision: "deny" }
+    },
+  }
+}
+
+/** Records the whole `createThread` input, not just the id — metadata is the point here. */
+function capturingThreadsStore(captured: CreateThreadInput[]): ThreadsStore {
+  const threads = new Map<string, Thread>()
+  let seq = 0
+  return {
+    createThread: async (input) => {
+      captured.push(input)
+      const now = new Date().toISOString()
+      const thread: Thread = {
+        created_at: now,
+        metadata: input.metadata ?? {},
+        status: "idle",
+        thread_id: input.thread_id ?? `t-cap-${++seq}`,
+        updated_at: now,
+      }
+      threads.set(thread.thread_id, thread)
+      return thread
+    },
+    deleteThread: async (threadId) => {
+      threads.delete(threadId)
+    },
+    getThread: async (threadId) => threads.get(threadId),
+    listThreads: async () => [...threads.values()],
+    updateMetadata: async (threadId, patch) => {
+      const thread = threads.get(threadId)
+      if (thread) threads.set(threadId, { ...thread, metadata: { ...thread.metadata, ...patch } })
+    },
+    updateStatus: async (threadId, status) => {
+      const thread = threads.get(threadId)
+      if (thread) threads.set(threadId, { ...thread, status })
+    },
+  }
+}
+
+/**
+ * The lost side of a create race, made deterministic: `getThread` reports the
+ * row absent, so the endpoint takes the create path, and `createThread` hands
+ * back a row that belongs to somebody else — what an upsert backend does when
+ * two callers both saw an absent row and one of them got there first.
+ *
+ * Not hypothetical on these endpoints in the way it is on `POST /threads`: the
+ * id is client-chosen, so a caller can address any row in the store by name.
+ */
+function collidingThreadsStore(foreign: Thread): ThreadsStore {
+  return {
+    createThread: async () => foreign,
+    deleteThread: async () => undefined,
+    getThread: async () => undefined,
+    listThreads: async () => [foreign],
+    updateMetadata: async () => undefined,
+    updateStatus: async () => undefined,
+  }
+}
+
+/**
+ * `getThread` reports the row absent on the FIRST read and present, owned by a
+ * stranger, on every read after it. Reproduces a row appearing between the gate
+ * and the create — a window that is a couple of statements wide on the Agent
+ * Protocol handlers and much wider on AG-UI, which claims a resume and reads
+ * the checkpointer's pending interrupts in between.
+ */
+function rowAppearsAfterTheGate(foreign: Thread): ThreadsStore {
+  let reads = 0
+  return {
+    createThread: async () => foreign,
+    deleteThread: async () => undefined,
+    getThread: async () => (++reads === 1 ? undefined : foreign),
+    listThreads: async () => [foreign],
+    updateMetadata: async () => undefined,
+    updateStatus: async () => undefined,
+  }
+}
+
+describe("a row that appears between the gate and the create", () => {
+  it("POST /agui/:routeId: re-authorizes it as an update, and denies a stranger", async () => {
+    const now = new Date().toISOString()
+    const foreign: Thread = {
+      created_at: now,
+      metadata: { [THREAD_ACCESS_METADATA_KEY]: { ownerId: "victim" } },
+      status: "idle",
+      thread_id: "t-appeared",
+      updated_at: now,
+    }
+    const { handler } = await setup({
+      threadAccess: stampingOwnerPolicy("deny"),
+      threadsStore: rowAppearsAfterTheGate(foreign),
+    })
+
+    // The `create` decision permitted mallory, for a thread that did not exist
+    // when it was asked. By the time the run reaches the create, one does — and
+    // it is the victim's. Proceeding on the strength of the earlier decision
+    // would be running on a thread nothing authorized this caller to touch.
+    const response = await handler.fetch(
+      aguiPost(
+        HELLO_ROUTE,
+        { threadId: "t-appeared", runId: "run-appeared", messages: [] },
+        {
+          "x-actor": "mallory",
+        },
+      ),
+    )
+    expect(response.status).toBe(403)
+    await drain(response)
+  }, 30_000)
+})
+
+describe("the implicit create a run endpoint performs", () => {
+  for (const endpoint of RUN_ENDPOINTS) {
+    it(`${endpoint.name}: the creating caller can take a SECOND turn on the thread it created`, async () => {
+      // The conservative legacy branch: an unstamped row is nobody's. Until
+      // the implicit create was stamped, this policy served turn one and then
+      // refused its own author on turn two, because the row it had just made
+      // read back as a thread that predated the policy.
+      const { handler } = await setup({ threadAccess: stampingOwnerPolicy("deny") })
+      const threadId = "t-implicit-second-turn"
+      const actor = { "x-actor": "alice" }
+
+      const first = await handler.fetch(endpoint.request(threadId, actor))
+      expect(first.status).toBe(200)
+      await drain(first)
+
+      // The turn that was broken: the row exists now, and until this PR it
+      // carried no stamp, so its own creator arrived as a stranger.
+      const second = await handler.fetch(endpoint.request(threadId, actor))
+      expect(second.status).toBe(200)
+      await drain(second)
+    }, 30_000)
+
+    it(`${endpoint.name}: stamps the creating caller into the row`, async () => {
+      const captured: CreateThreadInput[] = []
+      const { handler } = await setup({
+        threadAccess: stampingOwnerPolicy("deny"),
+        threadsStore: capturingThreadsStore(captured),
+      })
+
+      const response = await handler.fetch(endpoint.request("t-stamped", { "x-actor": "alice" }))
+      expect(response.status).toBe(200)
+      await drain(response)
+
+      expect(captured).toEqual([
+        {
+          metadata: { [THREAD_ACCESS_METADATA_KEY]: { ownerId: "alice" } },
+          thread_id: "t-stamped",
+        },
+      ])
+    }, 30_000)
+
+    it(`${endpoint.name}: an intruder is denied on a thread another caller's run created`, async () => {
+      // The migration hazard in one test. `fallback` admits an unstamped row as
+      // a legacy thread, which is the common shape mid-rollout. Before the
+      // implicit create was stamped, alice's turn manufactured exactly such a
+      // row on demand and bob walked straight into it.
+      const { handler } = await setup({ threadAccess: stampingOwnerPolicy("allow") })
+      const threadId = "t-implicit-intruder"
+
+      const mine = await handler.fetch(endpoint.request(threadId, { "x-actor": "alice" }))
+      expect(mine.status).toBe(200)
+      await drain(mine)
+
+      const theirs = await handler.fetch(endpoint.request(threadId, { "x-actor": "bob" }))
+      expect(theirs.status).toBe(403)
+      await drain(theirs)
+    }, 30_000)
+
+    it(`${endpoint.name}: denies when the store hands back a row that belongs to someone else`, async () => {
+      const now = new Date().toISOString()
+      const foreign: Thread = {
+        created_at: now,
+        metadata: { [THREAD_ACCESS_METADATA_KEY]: { ownerId: "victim" } },
+        status: "idle",
+        thread_id: "t-collided",
+        updated_at: now,
+      }
+      const { handler } = await setup({
+        threadAccess: stampingOwnerPolicy("deny"),
+        threadsStore: collidingThreadsStore(foreign),
+      })
+
+      // The `create` decision permits mallory and mints a stamp — and is
+      // irrelevant, because the row that came back is the victim's. Only a
+      // recheck against the ROW catches that; comparing the returned row's
+      // stamp with the minted one would not, since a `permit()` with no stamp
+      // makes both sides `undefined`.
+      const response = await handler.fetch(endpoint.request("t-collided", { "x-actor": "mallory" }))
+      expect(response.status).toBe(403)
+      await drain(response)
+    }, 30_000)
+
+    it(`${endpoint.name}: asks under create, then rechecks the row under update`, async () => {
+      const seen: ThreadAccessRequest[] = []
+      const { handler } = await setup({
+        threadAccess: {
+          create: (request) => {
+            seen.push(request)
+            return { decision: "allow", stamp: { ownerId: "alice" } }
+          },
+          fallback: (request) => {
+            seen.push(request)
+            return { decision: "allow" }
+          },
+        },
+      })
+
+      const response = await handler.fetch(endpoint.request("t-two-step", { "x-actor": "alice" }))
+      expect(response.status).toBe(200)
+      await drain(response)
+
+      expect(seen.map((request) => request.action)).toEqual(["create", "update"])
+      // The endpoint's own operation throughout — never rewritten to
+      // `thread.create`, which names a different endpoint.
+      expect(seen.map((request) => request.operation)).toEqual([
+        endpoint.operation,
+        endpoint.operation,
+      ])
+      // No client metadata reaches these paths at all.
+      expect(seen[0]?.requestedMetadata).toBeUndefined()
+      expect(seen[0]?.thread).toBeUndefined()
+      expect(seen[0]?.threadId).toBe("t-two-step")
+      // The recheck authorizes the row that actually came back.
+      expect(seen[1]?.thread?.access).toEqual({ ownerId: "alice" })
+      expect(seen[1]?.threadId).toBe("t-two-step")
+    }, 30_000)
+
+    it(`${endpoint.name}: writes no metadata on the implicit create when the app has no policy`, async () => {
+      // PR A's contract: no policy file means today's behavior, exactly. Not
+      // `metadata: {}` either — the store distinguishes them.
+      const captured: CreateThreadInput[] = []
+      const { handler } = await setup({ threadsStore: capturingThreadsStore(captured) })
+
+      const response = await handler.fetch(endpoint.request("t-hookless", {}))
+      expect(response.status).toBe(200)
+      await drain(response)
+
+      expect(captured).toEqual([{ thread_id: "t-hookless" }])
+    }, 30_000)
+
+    it(`${endpoint.name}: writes no metadata when the policy allows the create without a stamp`, async () => {
+      const captured: CreateThreadInput[] = []
+      const { handler } = await setup({
+        threadAccess: { fallback: () => ({ decision: "allow" }) },
+        threadsStore: capturingThreadsStore(captured),
+      })
+
+      const response = await handler.fetch(endpoint.request("t-unstamped", {}))
+      expect(response.status).toBe(200)
+      await drain(response)
+
+      expect(captured).toEqual([{ thread_id: "t-unstamped" }])
+    }, 30_000)
+  }
 })

--- a/packages/cli/test/thread-access-scaffold.test.ts
+++ b/packages/cli/test/thread-access-scaffold.test.ts
@@ -177,33 +177,68 @@ describe("the scaffolded thread-access policy, driven end to end", () => {
     await drain(intruder)
   }, 30_000)
 
-  it("denies a run on an unminted id, identically for every caller", async () => {
+  it("serves a run on a client-chosen id, and gives that id to the caller who named it first", async () => {
     const handler = await setup()
     const threadId = "t-client-chosen"
 
-    // The scaffold's documented limitation, pinned so it stays a decision. The
-    // run endpoints create the row they are given, and that implicit create
-    // writes NO access stamp — so there is no owner for a later turn to match,
-    // and permitting the first turn here would authorize a thread that nothing
-    // can own afterwards. The scaffold denies instead, and says so.
-    const authenticated = await handler.fetch(aguiTurn(threadId, ALICE))
+    // The flow CopilotKit actually drives: an id picked in the browser, never
+    // minted through POST /threads. The run endpoint creates the row, and Dawn
+    // asks the scaffold's `create` handler about it — which stamps the caller,
+    // so the thread has an owner from its first breath.
+    const first = await handler.fetch(aguiTurn(threadId, ALICE))
+    expect(first.status).toBe(200)
+    await drain(first)
+
+    // Turn two, on the row turn one created. This is what the missing stamp
+    // used to break: alice arrived at her own thread as a stranger.
+    const second = await handler.fetch(aguiTurn(threadId, ALICE))
+    expect(second.status).toBe(200)
+    await drain(second)
+
+    // First come, first served — and everyone who comes later is a stranger,
+    // on both run endpoints.
     const other = await handler.fetch(aguiTurn(threadId, BOB))
-    const anonymous = await handler.fetch(aguiTurn(threadId, ANONYMOUS))
-
-    expect(authenticated.status).toBe(403)
     expect(other.status).toBe(403)
-    expect(anonymous.status).toBe(403)
+    await drain(other)
+    const streamed = await handler.fetch(runStream(threadId, BOB))
+    expect(streamed.status).toBe(403)
+    await drain(streamed)
 
-    // And no row was created by the denial, so a denied caller cannot squat an
-    // id the way an allowed one would.
+    // The thread is alice's on every axis, not just the run endpoints.
+    expect(
+      (await handler.fetch(new Request(`http://localhost/threads/${threadId}`, { headers: ALICE })))
+        .status,
+    ).toBe(200)
+    expect(
+      (await handler.fetch(new Request(`http://localhost/threads/${threadId}`, { headers: BOB })))
+        .status,
+    ).toBe(404)
+  }, 30_000)
+
+  it("denies an unauthenticated run on a client-chosen id, and creates no row for it", async () => {
+    const handler = await setup()
+    const threadId = "t-anonymous-chosen"
+
+    // The scaffold is deny-by-default and `principalOf` is the only thing that
+    // opens it — on the implicit create as much as anywhere else.
+    const anonymous = await handler.fetch(aguiTurn(threadId, ANONYMOUS))
+    expect(anonymous.status).toBe(403)
+    await drain(anonymous)
+
+    const streamed = await handler.fetch(runStream(threadId, ANONYMOUS))
+    expect(streamed.status).toBe(403)
+    await drain(streamed)
+
+    // A denied caller must not be able to squat an id the way an allowed one
+    // does: the gate runs before the create, so nothing was written.
     const probe = await handler.fetch(
       new Request(`http://localhost/threads/${threadId}`, { headers: ALICE }),
     )
     expect(probe.status).toBe(404)
-
-    const streamed = await handler.fetch(runStream(threadId, ALICE))
-    expect(streamed.status).toBe(403)
-    await drain(streamed)
+    // And the id is still free for a caller who can authenticate.
+    const claimed = await handler.fetch(aguiTurn(threadId, ALICE))
+    expect(claimed.status).toBe(200)
+    await drain(claimed)
   }, 30_000)
 
   it("keeps the missing-row oracle shut on read and delete", async () => {

--- a/packages/devkit/templates/app-basic/src/thread-access.ts.example
+++ b/packages/devkit/templates/app-basic/src/thread-access.ts.example
@@ -30,30 +30,23 @@ const owned = async (req: ThreadAccessRequest) => {
   // the endpoint's natural 404 or 204. Denying it FIRST, ahead of any admin
   // branch, is what keeps "not yours" and "never existed" the same answer. An
   // admin allowed to delete a row that never existed reopens the existence
-  // oracle this default closes.
+  // oracle this default closes. Do not relax this line for `delete` or `read`.
   //
-  // READ THIS BEFORE YOU SHIP AN AG-UI APP. This line also refuses every
-  // `run.*` operation on a thread id whose row does not exist yet, and those
-  // endpoints are the ones that would have created it: `POST /agui/{routeId}`,
-  // `/runs/stream`, `/runs/wait` and `/resume` all arrive here under
-  // `action: "update"` with `req.thread === undefined`. CopilotKit picks its
-  // `threadId` in the browser and never calls `POST /threads`, so under this
-  // policy every AG-UI turn on a fresh id is denied with a 403.
+  // It does NOT refuse a first AG-UI turn, which is the thing people expect it
+  // to. `POST /agui/{routeId}`, `/runs/stream` and `/runs/wait` create the row
+  // when the id names none, and Dawn asks about that create under
+  // `action: "create"` — the handler below, not this one. CopilotKit picking
+  // its `threadId` in the browser is therefore served, and the row it writes
+  // carries the stamp that create returned, so every later turn matches
+  // `owner === user.id`. Only `/resume` arrives here with no row, because it
+  // needs an already-parked thread and creates nothing.
   //
-  // Relaxing this line for `update` is NOT the fix, however obvious it looks.
-  // The implicit create those endpoints do writes the row with no access stamp,
-  // so the next turn on the same thread reaches the `owner === undefined`
-  // branch below and is denied anyway: you would authorize turn one and refuse
-  // turn two, which is worse than refusing honestly.
-  //
-  // Mint the thread with `POST /threads` and hand the returned `thread_id` to
-  // the client as its thread id. That is the only path that stamps an owner, so
-  // every later turn matches `owner === user.id` and is served. If you must
-  // authorize client-chosen ids instead, record the id-to-owner mapping
-  // yourself — in your own store, from this policy — and consult it here.
-  // Whatever you do, do not relax `delete` or `read`: those endpoints answer
-  // 204/404 for a row that never existed, and permitting them on a missing row
-  // is exactly what reopens the existence oracle.
+  // What that costs, and it is a real cost: ownership of a client-chosen id is
+  // first come, first served. Any authenticated caller can claim an unused id
+  // by naming it — including claiming one your user was about to use, which
+  // then denies it to them for good. Mint ids with `POST /threads` and hand the
+  // returned `thread_id` to the client if that matters to you; those ids are
+  // server-generated, so nobody can call them first.
   if (req.thread === undefined) return deny()
 
   // `req.thread.access`, never `req.thread.metadata`. Metadata is
@@ -74,6 +67,10 @@ const owned = async (req: ThreadAccessRequest) => {
 }
 
 export default defineThreadAccess({
+  // `POST /threads`, and every run endpoint that finds no row for the thread id
+  // it was given. The stamp this returns is the thread's owner record: Dawn
+  // stores it under a reserved key no client can write, and it is what `owned`
+  // above authorizes against for the whole life of the thread.
   create: async (req) => {
     const user = await principalOf(req.headers)
     return user ? permit({ ownerId: user.id, org: user.org }) : deny()
@@ -81,9 +78,10 @@ export default defineThreadAccess({
   // `fallback` is required, and it is the deny-by-default floor: an action with
   // no handler of its own lands here rather than falling through to an allow.
   //
-  // It also handles the `update` recheck Dawn runs after every create. The row
-  // just stamped has `ownerId === user.id`, so `owned` permits it; a row the
-  // store handed back on an id collision carries someone else's, so `owned`
-  // denies and the caller never receives a thread they do not own.
+  // It also handles the `update` recheck Dawn runs after every create, on
+  // `POST /threads` and on a run endpoint's implicit create alike. The row just
+  // stamped has `ownerId === user.id`, so `owned` permits it; a row the store
+  // handed back on an id collision carries someone else's, so `owned` denies
+  // and the caller never receives a thread they do not own.
   fallback: owned,
 })

--- a/packages/devkit/templates/app-research/src/thread-access.ts.example
+++ b/packages/devkit/templates/app-research/src/thread-access.ts.example
@@ -30,30 +30,23 @@ const owned = async (req: ThreadAccessRequest) => {
   // the endpoint's natural 404 or 204. Denying it FIRST, ahead of any admin
   // branch, is what keeps "not yours" and "never existed" the same answer. An
   // admin allowed to delete a row that never existed reopens the existence
-  // oracle this default closes.
+  // oracle this default closes. Do not relax this line for `delete` or `read`.
   //
-  // READ THIS BEFORE YOU SHIP AN AG-UI APP. This line also refuses every
-  // `run.*` operation on a thread id whose row does not exist yet, and those
-  // endpoints are the ones that would have created it: `POST /agui/{routeId}`,
-  // `/runs/stream`, `/runs/wait` and `/resume` all arrive here under
-  // `action: "update"` with `req.thread === undefined`. CopilotKit picks its
-  // `threadId` in the browser and never calls `POST /threads`, so under this
-  // policy every AG-UI turn on a fresh id is denied with a 403.
+  // It does NOT refuse a first AG-UI turn, which is the thing people expect it
+  // to. `POST /agui/{routeId}`, `/runs/stream` and `/runs/wait` create the row
+  // when the id names none, and Dawn asks about that create under
+  // `action: "create"` — the handler below, not this one. CopilotKit picking
+  // its `threadId` in the browser is therefore served, and the row it writes
+  // carries the stamp that create returned, so every later turn matches
+  // `owner === user.id`. Only `/resume` arrives here with no row, because it
+  // needs an already-parked thread and creates nothing.
   //
-  // Relaxing this line for `update` is NOT the fix, however obvious it looks.
-  // The implicit create those endpoints do writes the row with no access stamp,
-  // so the next turn on the same thread reaches the `owner === undefined`
-  // branch below and is denied anyway: you would authorize turn one and refuse
-  // turn two, which is worse than refusing honestly.
-  //
-  // Mint the thread with `POST /threads` and hand the returned `thread_id` to
-  // the client as its thread id. That is the only path that stamps an owner, so
-  // every later turn matches `owner === user.id` and is served. If you must
-  // authorize client-chosen ids instead, record the id-to-owner mapping
-  // yourself — in your own store, from this policy — and consult it here.
-  // Whatever you do, do not relax `delete` or `read`: those endpoints answer
-  // 204/404 for a row that never existed, and permitting them on a missing row
-  // is exactly what reopens the existence oracle.
+  // What that costs, and it is a real cost: ownership of a client-chosen id is
+  // first come, first served. Any authenticated caller can claim an unused id
+  // by naming it — including claiming one your user was about to use, which
+  // then denies it to them for good. Mint ids with `POST /threads` and hand the
+  // returned `thread_id` to the client if that matters to you; those ids are
+  // server-generated, so nobody can call them first.
   if (req.thread === undefined) return deny()
 
   // `req.thread.access`, never `req.thread.metadata`. Metadata is
@@ -74,6 +67,10 @@ const owned = async (req: ThreadAccessRequest) => {
 }
 
 export default defineThreadAccess({
+  // `POST /threads`, and every run endpoint that finds no row for the thread id
+  // it was given. The stamp this returns is the thread's owner record: Dawn
+  // stores it under a reserved key no client can write, and it is what `owned`
+  // above authorizes against for the whole life of the thread.
   create: async (req) => {
     const user = await principalOf(req.headers)
     return user ? permit({ ownerId: user.id, org: user.org }) : deny()
@@ -81,9 +78,10 @@ export default defineThreadAccess({
   // `fallback` is required, and it is the deny-by-default floor: an action with
   // no handler of its own lands here rather than falling through to an allow.
   //
-  // It also handles the `update` recheck Dawn runs after every create. The row
-  // just stamped has `ownerId === user.id`, so `owned` permits it; a row the
-  // store handed back on an id collision carries someone else's, so `owned`
-  // denies and the caller never receives a thread they do not own.
+  // It also handles the `update` recheck Dawn runs after every create, on
+  // `POST /threads` and on a run endpoint's implicit create alike. The row just
+  // stamped has `ownerId === user.id`, so `owned` permits it; a row the store
+  // handed back on an id collision carries someone else's, so `owned` denies
+  // and the caller never receives a thread they do not own.
   fallback: owned,
 })

--- a/packages/devkit/test/template-thread-access.test.ts
+++ b/packages/devkit/test/template-thread-access.test.ts
@@ -76,23 +76,24 @@ describe("scaffolded thread-access policy", () => {
       )
     })
 
-    it(`${name} tells the reader what the missing-row deny costs them`, () => {
+    it(`${name} says what the missing-row deny does and does not reach`, () => {
       const policy = read(name, "src/thread-access.ts.example")
 
       // The deny on `req.thread === undefined` is justified in this file on
-      // DELETE-existence-oracle grounds. It ALSO refuses every `run.*`
-      // operation on a thread id whose row does not exist yet — which is every
-      // AG-UI turn, because CopilotKit picks its `threadId` in the browser and
-      // never calls `POST /threads`. A scaffold that refuses a first-class flow
-      // and does not say so gets copied, then cursed.
-      expect(policy).toContain("run.*")
+      // DELETE-existence-oracle grounds, and the obvious misreading of it is
+      // that it also refuses every AG-UI turn on a browser-chosen `threadId`.
+      // It does not: a run endpoint that finds no row asks under `create`, and
+      // the row it writes carries that decision's stamp. A scaffold whose
+      // commentary describes a first-class flow wrongly gets copied, then
+      // cursed.
       expect(policy).toContain("/agui/")
-      // And the supported way through it, which is not "relax this line": the
-      // implicit create those endpoints do writes no access stamp, so a
-      // relaxed line authorizes one turn and denies the next. Minting the id
-      // through POST /threads is the only path that stamps an owner.
+      expect(policy).toContain('`action: "create"`')
+      // And the cost that comes with it, which is the one thing a reader
+      // cannot infer from the code: the ids are client-chosen, so whoever
+      // names an unused one owns it, and can deny it to the caller who meant
+      // to use it. `POST /threads` mints ids nobody can call first.
+      expect(policy).toContain("first come, first served")
       expect(policy).toContain("POST /threads")
-      expect(policy).toContain("no access stamp")
     })
   }
 

--- a/packages/sdk/src/thread-access.ts
+++ b/packages/sdk/src/thread-access.ts
@@ -25,14 +25,21 @@ export type ThreadAction = "create" | "read" | "update" | "delete"
  * - `thread.delete` — `DELETE /threads/:id` — `delete`
  * - `thread.cancel` — `POST /threads/:id/cancel` — `update`
  * - `thread.pending_interrupts` — `GET /threads/:id/pending_interrupts` — `read`
- * - `run.stream` — `POST /threads/:id/runs/stream` — `update`
- * - `run.wait` — `POST /threads/:id/runs/wait` — `update`
+ * - `run.stream` — `POST /threads/:id/runs/stream` — `update`; on a thread id
+ *   with no row yet, `create`, then again as the `update` recheck that follows
+ *   every create
+ * - `run.wait` — `POST /threads/:id/runs/wait` — `update`, or the same
+ *   `create`-then-`update` pair on a thread id with no row yet
  * - `run.resume` — `POST /threads/:id/resume` — `update`
- * - `run.agui` — `POST /agui/:routeId` — `update`
+ * - `run.agui` — `POST /agui/:routeId` — `update`, or the same
+ *   `create`-then-`update` pair on a thread id with no row yet
  *
- * Every `run.*` operation arrives under `update`, without exception. Starting a
- * turn on a thread mutates it; none of them is a `create`, including the ones
- * whose endpoint will create the row when it is missing.
+ * Starting a turn on a thread that exists mutates it, so it is an `update`.
+ * Three of these endpoints also CREATE the thread when the id names no row, and
+ * that create is a create: it decides who owns a thread that did not exist a
+ * moment ago, and the stamp it returns is what every later turn authorizes
+ * against. `run.resume` is the exception — it requires an already-parked thread
+ * and creates nothing, so it is only ever an `update`.
  */
 export type ThreadOperation =
   | "thread.create"
@@ -83,7 +90,9 @@ export interface ThreadAccessRequest {
   /**
    * `undefined` only when the runtime has no id yet: `action: "create"` on
    * `POST /threads`, whose id is server-generated. Present everywhere else,
-   * INCLUDING the `action: "update"` recheck that follows every create.
+   * INCLUDING the `action: "update"` recheck that follows every create — and
+   * including a `create` on a run endpoint, where the id is the one the client
+   * named.
    */
   readonly threadId: string | undefined
   /**
@@ -108,7 +117,8 @@ export interface ThreadAccessRequest {
   /**
    * Client-supplied `metadata` on a create, already stripped of the reserved
    * key. `undefined` on every non-create — and on the create recheck, whose
-   * metadata was already adjudicated by the create call.
+   * metadata was already adjudicated by the create call. Also `undefined` on a
+   * `run.*` create: those endpoints accept no thread metadata at all.
    */
   readonly requestedMetadata: Readonly<Record<string, unknown>> | undefined
 }


### PR DESCRIPTION
## Summary

PR C of the thread authorization work, after #460 (PR A) and #468 (PR B). It closes a gap PR B made reachable.

The run endpoints create a thread when the row is missing, and that implicit create passed **no metadata** — so no owner stamp:

```ts
// /runs/stream, /runs/wait, /agui — thread_id is CLIENT-supplied
thread = await threadsStore.createThread({ thread_id: threadId })
```

Two consequences, the second being the real motivation:

1. **The flow broke on turn two.** The creating caller was denied on their own thread, because the row carried no owner.
2. **The migration story was unsound.** Apps adopting a policy are expected to have a legacy branch — *"`access === undefined` means this thread predates the policy"* — with an operator backfill script (spec §6). After PR B, an attacker could manufacture an unstamped row on demand by naming any id at `POST /threads/<id>/runs/stream`. So `unstamped` stopped meaning "pre-policy" and started meaning "pre-policy, **or created by anyone, just now**". A permissive legacy branch — the common shape during rollout — became an escalation path.

## The fix

When a run endpoint finds the row absent and a policy is installed, it now mirrors what `POST /threads` already does:

1. gate under **`action: "create"`**, keeping the endpoint's own operation (`run.stream` / `run.wait` / `run.agui`);
2. apply the returned stamp to `createThread`;
3. **recheck under `action: "update"` against the row that actually came back.**

Step 3 is the security-critical one and is not decoration. The thread id here is **client-chosen**, so two concurrent callers can both see an absent row and both create; the store returns the existing row on collision, which may belong to someone else. The recheck authorizes the **row**, never a stamp comparison — with `permit()` and no stamp both sides are `undefined`, the comparison passes, and the loser proceeds on the winner's row with no authorization at all.

A hook-less app is untouched: no extra gate call, no metadata, no extra store read. PR A's contract — *no policy file means today's behavior, exactly* — still holds.

`/resume` is not in scope: it requires an already-parked thread and performs no implicit create.

### A hazard `POST /threads` does not have

Found while implementing, and not in the original brief. AG-UI's create must stay **after** `tryClaim`, `runRegistry.begin` and the checkpointer read, because a denial must take none of those. That leaves a window several statements wide in which a row can appear between the gate decision and the create. The handler now re-reads: if a row appeared meanwhile, the turn is authorized under `update` against **that** row rather than proceeding on a decision made about a thread that no longer doesn't exist. It has its own test.

## Published contract change

`ThreadOperation`'s doc said every `run.*` operation arrives under `update`. That is now false — when the row is absent they arrive under `create`, **then** `update`, the same two-step shape `thread.create` already documented. Updated in that entry's style.

## Validation

Every behavioral test was written first with the **red step observed**:

| Test (× 3 endpoints) | How it failed before the fix |
|---|---|
| creating caller takes a second turn | `expected 403 to be 200` — locked out of her own thread |
| the create is stamped | `expected [{thread_id:'t-stamped'}] to deeply equal [{metadata:{…}}]` |
| intruder denied | `expected 200 to be 403` — walked in via the legacy-permissive branch |
| race: store returns a foreign row | `expected 200 to be 403` — no recheck existed |
| asks under `create`, then rechecks | `expected ['update'] to deeply equal ['create','update']` |
| AG-UI: row appears after the gate | `expected 200 to be 403` |
| hook-less app writes no metadata | shown by making the hook-less create pass `metadata: {}` |

One test that **could not fail** was caught and fixed during implementation: the second-turn test initially used a legacy-*permissive* policy, which passes today. The legacy branch is now parameterized, and that difference is the point of the helper.

Local: `@dawn-ai/sdk` 110 passed, `@dawn-ai/devkit` 33 passed, `@dawn-ai/testing` 257 passed, docs guard `EXIT=0`, `typecheck` 26/26, `lint` 22/22. Two Docker-backed CLI tests (`hono-node-roundtrip`, `vercel-target` round-trip) timed out on container startup locally and were confirmed failing identically on a pristine tree — CI runs those lanes in a clean environment.

## Known consequences, stated rather than buried

- **Squatting.** `POST /threads` mints the id, so nobody can call it first. Here, any caller the `create` handler admits can claim an unused id by naming it, and hold it. It is a denial-of-service on ids, not an escalation, and it is inherent to letting clients choose ids. Documented in the changeset, the docs and the scaffold.
- **A policy can reveal thread existence through its own deny shapes** — which handler fires (`create` vs `update`) says whether the row existed. Not new to the app (`req.thread` already said so), but visible to the caller if an app gives the two different deny statuses. Dawn's defaults are both 403, so nothing leaks by default.
- **The scaffold's behavior changed, deliberately.** Its `create` handler stamps an authenticated caller, so AG-UI turns on browser-chosen ids now work out of the box — which is what PR B's docs had to warn against. The scaffold test's "denies a run on an unminted id" premise is the thing this PR removes; it is replaced by two tests (authenticated caller served and keeps the thread; anonymous caller denied and creates no row, leaving the id free).
- **Concurrent create on sqlite still 500s** — its bare `INSERT` throws on a duplicate. Pre-existing and unchanged; safe (no row leaks, nothing is authorized) but ugly. Catching it would mean swallowing genuine store errors.

This also amends PR B's unreleased changeset, which stated the opposite ("Only `POST /threads` writes an access stamp… relaxing `update` authorizes the first turn and denies the second"). Both entries ship in the same release and would otherwise contradict each other.

- [x] `pnpm lint`
- [x] `pnpm build`
- [x] `pnpm typecheck`
- [x] `pnpm test` (see the Docker note above)
- [x] `node scripts/check-docs.mjs`
- [ ] `pnpm pack:check` — deferred to CI
- [ ] Harness verification — deferred to CI

## Release Notes

- [x] Changeset added — `@dawn-ai/sdk` and `@dawn-ai/cli`, both patch.

## Checklist

- [x] I read `CONTRIBUTING.md`.
- [x] I followed `CODE_OF_CONDUCT.md`.
- [x] I did not include secrets, credentials, or private data.
- [x] I am not disclosing a security vulnerability publicly — the gap exists only between PR B and this PR, neither of which has shipped in a release.
