### PR TITLE
ci: stop silently installing HTTP error pages as tools

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -576,9 +576,22 @@ jobs:
       - name: Setup Helm
         uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
 
+      # helm/kind-action installs kind with `curl -sSLo` and no `--fail`, so a
+      # transient GitHub-releases 429/5xx writes the error page into the
+      # checksum file and the step dies with "no properly formatted checksum
+      # lines found". Priming RUNNER_TOOL_CACHE with a verified binary makes
+      # the action's `[[ ! -x ... ]]` guard skip that download entirely.
+      #
+      # The version here must match the `version:` input on the step below. If
+      # the two ever drift, this step primes a path the action does not read,
+      # the action downloads as it does today, and CI is degraded — not broken.
+      - name: Prime kind tool cache
+        run: scripts/prime-kind-cache.sh v0.31.0
+
       - name: Create kind cluster (no default CNI)
         uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
         with:
+          version: v0.31.0
           config: .github/kind/kind-calico.yaml
           node_image: kindest/node:v1.35.0@sha256:4613778f3cfcd10e615029370f5786704559103cf27bef934597ba562b269661
 
@@ -657,9 +670,16 @@ jobs:
       - name: Setup Helm
         uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
 
+      # See the sandbox-k8s lane: primes the tool cache so the action skips its
+      # own no-`--fail` kind download. Keep this version and the `version:`
+      # input below in lockstep.
+      - name: Prime kind tool cache
+        run: scripts/prime-kind-cache.sh v0.31.0
+
       - name: Create kind cluster (no default CNI)
         uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
         with:
+          version: v0.31.0
           config: .github/kind/kind-calico.yaml
           cluster_name: dawn-smoke
           node_image: kindest/node:v1.35.0@sha256:4613778f3cfcd10e615029370f5786704559103cf27bef934597ba562b269661
@@ -838,9 +858,16 @@ jobs:
       - name: Setup Helm
         uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
 
+      # See the sandbox-k8s lane: primes the tool cache so the action skips its
+      # own no-`--fail` kind download. Keep this version and the `version:`
+      # input below in lockstep.
+      - name: Prime kind tool cache
+        run: scripts/prime-kind-cache.sh v0.31.0
+
       - name: Create kind cluster
         uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
         with:
+          version: v0.31.0
           node_image: kindest/node:v1.35.0@sha256:4613778f3cfcd10e615029370f5786704559103cf27bef934597ba562b269661
 
       - name: Install dawn-app (placeholder image) and verify it serves

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -497,9 +497,32 @@ jobs:
         uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
 
       - name: Install kubeconform
+        # This step extracts a tarball from the internet and `sudo install`s it
+        # into /usr/local/bin — the same trust boundary as a GitHub Action, and
+        # every action in this repo is SHA-pinned. So pin the artifact too.
+        #
+        # The checksum is a literal on purpose. Fetching the release CHECKSUMS
+        # file over the same channel and trusting it verifies nothing: whoever
+        # can serve a bad tarball can serve a matching checksum. That is the
+        # mistake upstream kind.sh makes. This value was read from the v0.8.0
+        # release CHECKSUMS and confirmed against a locally computed sha256 of
+        # the downloaded artifact.
+        #
+        # --fail so a 429/5xx is an error rather than an HTML error page written
+        # into the tarball (which surfaced as "tar: Error is not recoverable"),
+        # and --retry so a transient blip is retried instead of failing CI.
         run: |
-          curl -sSL -o /tmp/kubeconform.tar.gz \
+          set -euo pipefail
+          expected=9bc2bffbf71f261128533edaf912153948b7ff238f9a531ae6d34466ec287883
+          curl --fail --retry 5 --retry-all-errors --retry-delay 2 -sSL -o /tmp/kubeconform.tar.gz \
             https://github.com/yannh/kubeconform/releases/download/v0.8.0/kubeconform-linux-amd64.tar.gz
+          actual="$(sha256sum /tmp/kubeconform.tar.gz | cut -d' ' -f1)"
+          if [ "$actual" != "$expected" ]; then
+            echo "kubeconform-linux-amd64.tar.gz checksum mismatch" >&2
+            echo "  expected $expected" >&2
+            echo "  actual   $actual" >&2
+            exit 1
+          fi
           tar -xzf /tmp/kubeconform.tar.gz -C /tmp kubeconform
           sudo install /tmp/kubeconform /usr/local/bin/kubeconform
           kubeconform -v

--- a/scripts/prime-kind-cache.sh
+++ b/scripts/prime-kind-cache.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+#
+# Pre-populate the `kind` binary in the GitHub Actions tool cache so that
+# helm/kind-action skips its own fragile installer.
+#
+# Why this exists
+# ---------------
+# helm/kind-action's `kind.sh` downloads the binary and its checksum with
+# `curl -sSLo` and *no* `--fail`. When GitHub releases answers with a 429, a
+# 5xx, or a CDN error page, curl writes that HTML body into the checksum file
+# and still exits 0. The follow-up `grep ... | sha256sum -c` then receives
+# empty stdin and dies with
+#
+#     sha256sum: 'standard input': no properly formatted checksum lines found
+#
+# which `set -o errexit` turns into a failed step. That is the real cause of
+# the intermittent sandbox-k8s / sandbox-k8s-e2e / chart-apply-smoke failures;
+# the "No such container: kind-registry" line in Post-job cleanup is unrelated
+# noise.
+#
+# `kind.sh` guards the install with
+#
+#     local kind_dir="${RUNNER_TOOL_CACHE}/kind/${version}/${arch}/kind/bin/"
+#     if [[ ! -x "${kind_dir}/kind" ]]; then install_kind; fi
+#
+# so writing a verified binary to exactly that path makes the action skip the
+# download altogether.
+#
+# Contract
+# --------
+#   * Every fetch uses `curl --fail --retry ...`: a transient error is retried
+#     and a persistent one is a loud, non-zero failure — never a corrupt file.
+#   * The checksum is verified and a mismatch aborts. Failing silently is the
+#     exact bug being fixed here.
+#   * The binary is only moved into the cache path after it verifies, so a
+#     failed run can never leave a broken `kind` that the action would then
+#     happily skip over.
+#   * Idempotent: a second run with an already-verified binary exits 0 without
+#     touching the network.
+#
+# Usage: scripts/prime-kind-cache.sh <kind-version>   (e.g. v0.31.0)
+#
+# The version argument MUST match the `version:` input given to the
+# helm/kind-action step that follows. If they ever drift, this script simply
+# primes a path the action does not consult, the action falls back to its own
+# download, and CI behaves exactly as it does today — degraded, not broken.
+
+set -euo pipefail
+
+VERSION="${1:-}"
+if [[ -z "${VERSION}" ]]; then
+  echo "prime-kind-cache: usage: $0 <kind-version>  (e.g. v0.31.0)" >&2
+  exit 2
+fi
+
+if [[ -z "${RUNNER_TOOL_CACHE:-}" ]]; then
+  echo "prime-kind-cache: RUNNER_TOOL_CACHE is not set" >&2
+  exit 2
+fi
+
+# Mirrors the architecture mapping in helm/kind-action's kind.sh.
+case "$(uname -m)" in
+i386 | i686) ARCH="386" ;;
+x86_64) ARCH="amd64" ;;
+arm | aarch64 | arm64) ARCH="arm64" ;;
+*)
+  echo "prime-kind-cache: unsupported architecture $(uname -m)" >&2
+  exit 1
+  ;;
+esac
+
+KIND_DIR="${RUNNER_TOOL_CACHE}/kind/${VERSION}/${ARCH}/kind/bin"
+KIND_BIN="${KIND_DIR}/kind"
+KIND_SUM="${KIND_DIR}/kind.sha256"
+ASSET="kind-linux-${ARCH}"
+BASE_URL="https://github.com/kubernetes-sigs/kind/releases/download/${VERSION}"
+
+# macOS lacks sha256sum; keep the script runnable outside the Linux runner.
+sha256_of() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | cut -d' ' -f1
+  else
+    shasum -a 256 "$1" | cut -d' ' -f1
+  fi
+}
+
+# Idempotent fast path: an already-verified binary needs no network at all.
+if [[ -x "${KIND_BIN}" && -s "${KIND_SUM}" ]]; then
+  cached="$(cat "${KIND_SUM}")"
+  if [[ "$(sha256_of "${KIND_BIN}")" == "${cached}" ]]; then
+    echo "prime-kind-cache: kind ${VERSION} (${ARCH}) already cached at ${KIND_BIN}"
+    exit 0
+  fi
+  echo "prime-kind-cache: cached kind ${VERSION} (${ARCH}) failed its recorded checksum; refetching" >&2
+fi
+
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "${WORK_DIR}"' EXIT
+
+fetch() {
+  # --fail turns an HTTP error into a non-zero exit instead of a body that
+  # looks like a download; --retry-all-errors also retries the 4xx/5xx that
+  # --fail surfaces, so throttling is a retry and a real outage is a failure.
+  curl --fail --retry 5 --retry-all-errors --retry-delay 2 -sSL -o "$2" "$1"
+}
+
+echo "prime-kind-cache: downloading kind ${VERSION} (${ARCH})"
+if ! fetch "${BASE_URL}/${ASSET}" "${WORK_DIR}/${ASSET}"; then
+  echo "prime-kind-cache: failed to download ${BASE_URL}/${ASSET}" >&2
+  exit 1
+fi
+if ! fetch "${BASE_URL}/${ASSET}.sha256sum" "${WORK_DIR}/${ASSET}.sha256sum"; then
+  echo "prime-kind-cache: failed to download ${BASE_URL}/${ASSET}.sha256sum" >&2
+  exit 1
+fi
+
+expected="$(awk -v asset="${ASSET}" '
+  { name = $2; sub(/^\*/, "", name) }
+  name == asset { print $1; exit }
+' "${WORK_DIR}/${ASSET}.sha256sum")"
+
+if [[ ! "${expected}" =~ ^[0-9a-f]{64}$ ]]; then
+  echo "prime-kind-cache: no checksum for ${ASSET} in ${BASE_URL}/${ASSET}.sha256sum" >&2
+  exit 1
+fi
+
+actual="$(sha256_of "${WORK_DIR}/${ASSET}")"
+if [[ "${actual}" != "${expected}" ]]; then
+  echo "prime-kind-cache: checksum mismatch for ${ASSET}" >&2
+  echo "prime-kind-cache:   expected ${expected}" >&2
+  echo "prime-kind-cache:   actual   ${actual}" >&2
+  exit 1
+fi
+
+chmod +x "${WORK_DIR}/${ASSET}"
+mkdir -p "${KIND_DIR}"
+# Publish the checksum only after the binary lands, so an interrupted run
+# cannot leave a binary that the fast path would trust.
+mv -f "${WORK_DIR}/${ASSET}" "${KIND_BIN}"
+printf '%s\n' "${expected}" >"${KIND_SUM}"
+echo "prime-kind-cache: verified kind ${VERSION} (${ARCH}) at ${KIND_BIN}"

--- a/scripts/prime-kind-cache.sh
+++ b/scripts/prime-kind-cache.sh
@@ -26,6 +26,17 @@
 # so writing a verified binary to exactly that path makes the action skip the
 # download altogether.
 #
+# Known, deliberately unfixed: the same `kind.sh` has the identical bug in
+# `install_kubectl`, which fetches the kubectl binary and its `.sha256` from
+# dl.k8s.io with the same no-`--fail` curl and then runs
+# `echo "$(cat kubectl.sha256) kubectl" | sha256sum -c`. If you are reading
+# this because a lane failed just after printing "Installing kubectl...", that
+# is the cause, and the fix is this same lever applied one directory over:
+# prime "${RUNNER_TOOL_CACHE}/kind/${version}/${arch}/kubectl/bin/kubectl",
+# which kind.sh guards with the same `[[ ! -x ... ]]` check. It was left alone
+# because it hits a different, more reliable CDN than GitHub releases and we
+# have never observed it failing — not because it is safe.
+#
 # Contract
 # --------
 #   * Every fetch uses `curl --fail --retry ...`: a transient error is retried

--- a/scripts/release/test/fixtures/workflow-entrypoints.json
+++ b/scripts/release/test/fixtures/workflow-entrypoints.json
@@ -166,7 +166,7 @@
               "classification": "safe",
               "descriptor": {
                 "name": "Install kubeconform",
-                "run": "curl -sSL -o /tmp/kubeconform.tar.gz \\\n  https://github.com/yannh/kubeconform/releases/download/v0.8.0/kubeconform-linux-amd64.tar.gz\ntar -xzf /tmp/kubeconform.tar.gz -C /tmp kubeconform\nsudo install /tmp/kubeconform /usr/local/bin/kubeconform\nkubeconform -v\n"
+                "run": "set -euo pipefail\nexpected=9bc2bffbf71f261128533edaf912153948b7ff238f9a531ae6d34466ec287883\ncurl --fail --retry 5 --retry-all-errors --retry-delay 2 -sSL -o /tmp/kubeconform.tar.gz \\\n  https://github.com/yannh/kubeconform/releases/download/v0.8.0/kubeconform-linux-amd64.tar.gz\nactual=\"$(sha256sum /tmp/kubeconform.tar.gz | cut -d' ' -f1)\"\nif [ \"$actual\" != \"$expected\" ]; then\n  echo \"kubeconform-linux-amd64.tar.gz checksum mismatch\" >&2\n  echo \"  expected $expected\" >&2\n  echo \"  actual   $actual\" >&2\n  exit 1\nfi\ntar -xzf /tmp/kubeconform.tar.gz -C /tmp kubeconform\nsudo install /tmp/kubeconform /usr/local/bin/kubeconform\nkubeconform -v\n"
               }
             },
             {

--- a/scripts/release/test/fixtures/workflow-entrypoints.json
+++ b/scripts/release/test/fixtures/workflow-entrypoints.json
@@ -116,9 +116,17 @@
             {
               "classification": "safe",
               "descriptor": {
+                "name": "Prime kind tool cache",
+                "run": "scripts/prime-kind-cache.sh v0.31.0"
+              }
+            },
+            {
+              "classification": "safe",
+              "descriptor": {
                 "name": "Create kind cluster",
                 "uses": "helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc",
                 "with": {
+                  "version": "v0.31.0",
                   "node_image": "kindest/node:v1.35.0@sha256:4613778f3cfcd10e615029370f5786704559103cf27bef934597ba562b269661"
                 }
               }
@@ -713,9 +721,17 @@
             {
               "classification": "safe",
               "descriptor": {
+                "name": "Prime kind tool cache",
+                "run": "scripts/prime-kind-cache.sh v0.31.0"
+              }
+            },
+            {
+              "classification": "safe",
+              "descriptor": {
                 "name": "Create kind cluster (no default CNI)",
                 "uses": "helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc",
                 "with": {
+                  "version": "v0.31.0",
                   "config": ".github/kind/kind-calico.yaml",
                   "node_image": "kindest/node:v1.35.0@sha256:4613778f3cfcd10e615029370f5786704559103cf27bef934597ba562b269661"
                 }
@@ -832,9 +848,17 @@
             {
               "classification": "safe",
               "descriptor": {
+                "name": "Prime kind tool cache",
+                "run": "scripts/prime-kind-cache.sh v0.31.0"
+              }
+            },
+            {
+              "classification": "safe",
+              "descriptor": {
                 "name": "Create kind cluster (no default CNI)",
                 "uses": "helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc",
                 "with": {
+                  "version": "v0.31.0",
                   "config": ".github/kind/kind-calico.yaml",
                   "cluster_name": "dawn-smoke",
                   "node_image": "kindest/node:v1.35.0@sha256:4613778f3cfcd10e615029370f5786704559103cf27bef934597ba562b269661"

--- a/scripts/release/test/fixtures/workflow-safe-executables.json
+++ b/scripts/release/test/fixtures/workflow-safe-executables.json
@@ -752,6 +752,14 @@
         "classification": "safe",
         "job": "sandbox-k8s",
         "stepIndex": 6,
+        "step": "Prime kind tool cache",
+        "kind": "run",
+        "value": "scripts/prime-kind-cache.sh v0.31.0"
+      },
+      {
+        "classification": "safe",
+        "job": "sandbox-k8s",
+        "stepIndex": 7,
         "step": "Create kind cluster (no default CNI)",
         "kind": "step-uses",
         "value": "helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc"
@@ -759,7 +767,7 @@
       {
         "classification": "safe",
         "job": "sandbox-k8s",
-        "stepIndex": 7,
+        "stepIndex": 8,
         "step": "Install Calico (enforces NetworkPolicy)",
         "kind": "run",
         "value": "kubectl apply -f https://raw.githubusercontent.com/projectcalico/calico/v3.32.1/manifests/calico.yaml\nkubectl -n kube-system rollout status daemonset/calico-node --timeout=180s\nkubectl wait --for=condition=Ready nodes --all --timeout=180s\n"
@@ -767,7 +775,7 @@
       {
         "classification": "safe",
         "job": "sandbox-k8s",
-        "stepIndex": 8,
+        "stepIndex": 9,
         "step": "Install sandbox-infra chart",
         "kind": "run",
         "value": "helm install dawn-sandbox-infra charts/dawn-sandbox-infra --wait\nkubectl -n dawn-sandboxes get role,rolebinding,networkpolicy,resourcequota,limitrange,cronjob,serviceaccount\n"
@@ -775,7 +783,7 @@
       {
         "classification": "safe",
         "job": "sandbox-k8s",
-        "stepIndex": 9,
+        "stepIndex": 10,
         "step": "Prepare chart NetworkPolicy control",
         "kind": "run",
         "value": "sh test/k8s-smoke/setup-network-policy-control.sh"
@@ -783,7 +791,7 @@
       {
         "classification": "safe",
         "job": "sandbox-k8s",
-        "stepIndex": 10,
+        "stepIndex": 11,
         "step": "Assert orchestrator RBAC (least privilege)",
         "kind": "run",
         "value": "SA=system:serviceaccount:dawn-sandboxes:dawn-orchestrator\nkubectl auth can-i create pods --as=$SA -n dawn-sandboxes | grep -qx yes\nkubectl auth can-i create pods/exec --as=$SA -n dawn-sandboxes | grep -qx yes\n# WebSocket exec (@kubernetes/client-node) authorizes as `get pods/exec`\nkubectl auth can-i get pods/exec --as=$SA -n dawn-sandboxes | grep -qx yes\nkubectl auth can-i create persistentvolumeclaims --as=$SA -n dawn-sandboxes | grep -qx yes\nkubectl auth can-i create networkpolicies.networking.k8s.io --as=$SA -n dawn-sandboxes | grep -qx yes\nkubectl auth can-i create secrets --as=$SA -n dawn-sandboxes | grep -qx no\n"
@@ -791,7 +799,7 @@
       {
         "classification": "safe",
         "job": "sandbox-k8s",
-        "stepIndex": 11,
+        "stepIndex": 12,
         "step": "Real-cluster sandbox conformance + e2e",
         "kind": "run",
         "value": "DAWN_TEST_K8S=1 pnpm --filter @dawn-ai/sandbox test kube-sandbox.integration"
@@ -799,7 +807,7 @@
       {
         "classification": "safe",
         "job": "sandbox-k8s",
-        "stepIndex": 12,
+        "stepIndex": 13,
         "step": "Exercise PVC reaper",
         "kind": "run",
         "value": "sh test/k8s-smoke/assert-reaper.sh"
@@ -856,6 +864,14 @@
         "classification": "safe",
         "job": "sandbox-k8s-e2e",
         "stepIndex": 6,
+        "step": "Prime kind tool cache",
+        "kind": "run",
+        "value": "scripts/prime-kind-cache.sh v0.31.0"
+      },
+      {
+        "classification": "safe",
+        "job": "sandbox-k8s-e2e",
+        "stepIndex": 7,
         "step": "Create kind cluster (no default CNI)",
         "kind": "step-uses",
         "value": "helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc"
@@ -863,7 +879,7 @@
       {
         "classification": "safe",
         "job": "sandbox-k8s-e2e",
-        "stepIndex": 7,
+        "stepIndex": 8,
         "step": "Install Calico (enforces NetworkPolicy)",
         "kind": "run",
         "value": "kubectl apply -f https://raw.githubusercontent.com/projectcalico/calico/v3.32.1/manifests/calico.yaml\nkubectl -n kube-system rollout status daemonset/calico-node --timeout=180s\nkubectl wait --for=condition=Ready nodes --all --timeout=180s\n"
@@ -871,7 +887,7 @@
       {
         "classification": "safe",
         "job": "sandbox-k8s-e2e",
-        "stepIndex": 8,
+        "stepIndex": 9,
         "step": "Preload sandbox workload image into kind",
         "kind": "run",
         "value": "docker pull node:22-slim\nkind load docker-image node:22-slim --name \"$KIND_CLUSTER\"\n"
@@ -879,7 +895,7 @@
       {
         "classification": "safe",
         "job": "sandbox-k8s-e2e",
-        "stepIndex": 9,
+        "stepIndex": 10,
         "step": "Build and load smoke app image (Verdaccio)",
         "kind": "run",
         "value": "set -eu\nURLFILE=\"$(mktemp)\"\npnpm exec tsx test/k8s-smoke/serve-registry.ts \"$URLFILE\" &\nREG_PID=$!\nfor _ in $(seq 1 180); do\n  [ -s \"$URLFILE\" ] && break\n  kill -0 \"$REG_PID\" 2>/dev/null || { echo \"serve-registry exited before publishing\"; exit 1; }\n  sleep 1\ndone\n[ -s \"$URLFILE\" ] || { echo \"registry URL never became ready\"; kill \"$REG_PID\" 2>/dev/null || true; exit 1; }\nREG_URL=\"$(cat \"$URLFILE\")\"\necho \"registry ready at $REG_URL\"\nsh test/k8s-smoke/build-image.sh k8s \"$REG_URL\"\nkill \"$REG_PID\" 2>/dev/null || true\nkind load docker-image dawn-smoke-app:k8s --name \"$KIND_CLUSTER\"\n"
@@ -887,7 +903,7 @@
       {
         "classification": "safe",
         "job": "sandbox-k8s-e2e",
-        "stepIndex": 10,
+        "stepIndex": 11,
         "step": "Build and load aimock image",
         "kind": "run",
         "value": "docker build -t dawn-smoke-aimock:latest -f test/k8s-smoke/aimock/Dockerfile test/k8s-smoke\nkind load docker-image dawn-smoke-aimock:latest --name \"$KIND_CLUSTER\"\n"
@@ -895,7 +911,7 @@
       {
         "classification": "safe",
         "job": "sandbox-k8s-e2e",
-        "stepIndex": 11,
+        "stepIndex": 12,
         "step": "Create app namespace",
         "kind": "run",
         "value": "kubectl create namespace dawn-app"
@@ -903,7 +919,7 @@
       {
         "classification": "safe",
         "job": "sandbox-k8s-e2e",
-        "stepIndex": 12,
+        "stepIndex": 13,
         "step": "Install sandbox-infra chart",
         "kind": "run",
         "value": "helm install dawn-sandbox-infra charts/dawn-sandbox-infra \\\n  -n dawn-sandboxes --create-namespace \\\n  -f test/k8s-smoke/values-sandbox-infra.yaml --wait\n"
@@ -911,7 +927,7 @@
       {
         "classification": "safe",
         "job": "sandbox-k8s-e2e",
-        "stepIndex": 13,
+        "stepIndex": 14,
         "step": "Deploy aimock",
         "kind": "run",
         "value": "kubectl apply -f test/k8s-smoke/aimock.k8s.yaml\nkubectl -n dawn-app rollout status deploy/aimock --timeout=120s\n"
@@ -919,7 +935,7 @@
       {
         "classification": "safe",
         "job": "sandbox-k8s-e2e",
-        "stepIndex": 14,
+        "stepIndex": 15,
         "step": "Install dawn-app chart",
         "kind": "run",
         "value": "helm install dawn-app charts/dawn-app \\\n  -n dawn-app \\\n  -f test/k8s-smoke/values-dawn-app.yaml --wait\n"
@@ -927,7 +943,7 @@
       {
         "classification": "safe",
         "job": "sandbox-k8s-e2e",
-        "stepIndex": 15,
+        "stepIndex": 16,
         "step": "Run full-arc assertions",
         "kind": "run",
         "value": "sh test/k8s-smoke/assert-k8s.sh"
@@ -935,7 +951,7 @@
       {
         "classification": "safe",
         "job": "sandbox-k8s-e2e",
-        "stepIndex": 16,
+        "stepIndex": 17,
         "step": "Diagnostics + cleanup",
         "kind": "run",
         "value": "echo \"----- app -----\"\nkubectl -n dawn-app get pods,svc -o wide || true\nkubectl -n dawn-app logs deploy/dawn-app --tail=120 || true\necho \"----- aimock -----\"\nkubectl -n dawn-app logs -l app.kubernetes.io/name=aimock --tail=120 --all-containers || true\nkubectl -n dawn-app describe pods -l app.kubernetes.io/name=aimock || true\necho \"----- sandboxes -----\"\nkubectl -n dawn-sandboxes get pods,pvc,networkpolicy -o wide || true\necho \"----- teardown -----\"\nhelm uninstall dawn-app -n dawn-app || true\nhelm uninstall dawn-sandbox-infra -n dawn-sandboxes || true\nkubectl delete namespace dawn-app --ignore-not-found --wait=false || true\nkubectl delete namespace dawn-sandboxes --ignore-not-found --wait=false || true\n"
@@ -1032,6 +1048,14 @@
         "classification": "safe",
         "job": "chart-apply-smoke",
         "stepIndex": 2,
+        "step": "Prime kind tool cache",
+        "kind": "run",
+        "value": "scripts/prime-kind-cache.sh v0.31.0"
+      },
+      {
+        "classification": "safe",
+        "job": "chart-apply-smoke",
+        "stepIndex": 3,
         "step": "Create kind cluster",
         "kind": "step-uses",
         "value": "helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc"
@@ -1039,7 +1063,7 @@
       {
         "classification": "safe",
         "job": "chart-apply-smoke",
-        "stepIndex": 3,
+        "stepIndex": 4,
         "step": "Install dawn-app (placeholder image) and verify it serves",
         "kind": "run",
         "value": "helm install dawn-app charts/dawn-app \\\n  --set image.repository=nginxinc/nginx-unprivileged --set image.tag=stable-alpine \\\n  --set containerPort=8080 --set healthPath=/ \\\n  --set serviceAccount.create=true --set serviceAccount.name=dawn-app-smoke \\\n  --wait --timeout 3m\nkubectl rollout status deploy/dawn-app --timeout=120s\nkubectl run curl --image=curlimages/curl:8.10.1 --restart=Never --rm -i --quiet -- \\\n  curl -sf http://dawn-app.default.svc.cluster.local/ >/dev/null && echo \"app served OK\"\n"

--- a/scripts/release/test/fixtures/workflow-safe-executables.json
+++ b/scripts/release/test/fixtures/workflow-safe-executables.json
@@ -626,7 +626,7 @@
         "stepIndex": 2,
         "step": "Install kubeconform",
         "kind": "run",
-        "value": "curl -sSL -o /tmp/kubeconform.tar.gz \\\n  https://github.com/yannh/kubeconform/releases/download/v0.8.0/kubeconform-linux-amd64.tar.gz\ntar -xzf /tmp/kubeconform.tar.gz -C /tmp kubeconform\nsudo install /tmp/kubeconform /usr/local/bin/kubeconform\nkubeconform -v\n"
+        "value": "set -euo pipefail\nexpected=9bc2bffbf71f261128533edaf912153948b7ff238f9a531ae6d34466ec287883\ncurl --fail --retry 5 --retry-all-errors --retry-delay 2 -sSL -o /tmp/kubeconform.tar.gz \\\n  https://github.com/yannh/kubeconform/releases/download/v0.8.0/kubeconform-linux-amd64.tar.gz\nactual=\"$(sha256sum /tmp/kubeconform.tar.gz | cut -d' ' -f1)\"\nif [ \"$actual\" != \"$expected\" ]; then\n  echo \"kubeconform-linux-amd64.tar.gz checksum mismatch\" >&2\n  echo \"  expected $expected\" >&2\n  echo \"  actual   $actual\" >&2\n  exit 1\nfi\ntar -xzf /tmp/kubeconform.tar.gz -C /tmp kubeconform\nsudo install /tmp/kubeconform /usr/local/bin/kubeconform\nkubeconform -v\n"
       },
       {
         "classification": "safe",


### PR DESCRIPTION
## Summary

Four CI lanes — `sandbox-k8s`, `sandbox-k8s-e2e`, `chart-apply-smoke`, `chart-validate` — fail intermittently, including on `main`. They are not required checks, which is the actual problem: routine red makes a genuine regression indistinguishable from noise.

**They were previously reported as a "kind-registry" flake. That was a misdiagnosis** — `kind-registry` appears in post-job cleanup, harmlessly failing to remove a registry that was never created (`registry: false`). The real failure is two lines earlier:

```
Installing kind...
sha256sum: 'standard input': no properly formatted checksum lines found   ← the actual failure
Post job cleanup.
Error response from daemon: No such container: kind-registry              ← cleanup noise
```

Verified byte-identical on jobs 94271193972 (`sandbox-k8s`) and 94253657462 (`chart-apply-smoke`).

## One class of bug, two places

Both are `curl` writing an HTTP error page to disk as if it were a valid file, then failing at the parse step.

**Upstream — `helm/kind-action@v1.14.0`** (`kind.sh`), which is the latest release, so there is no version to upgrade to:

```bash
curl -sSLo "kind-linux-${arch}.sha256sum" ".../kind-linux-${arch}.sha256sum"
grep "kind-linux-${arch}" < "kind-linux-${arch}.sha256sum" | sha256sum -c
```

No `--fail`, so a 429/5xx writes the error body and exits 0; `grep` matches nothing; `sha256sum -c` gets empty stdin; `errexit` kills the step.

**Ours — `chart-validate`'s kubeconform install:**

```bash
curl -sSL -o /tmp/kubeconform.tar.gz  https://github.com/.../kubeconform-linux-amd64.tar.gz
tar -xzf /tmp/kubeconform.tar.gz -C /tmp kubeconform
sudo install /tmp/kubeconform /usr/local/bin/kubeconform
```

No `--fail`, no retry, **and no checksum at all** — an error page becomes the tarball and `tar` dies with `Error is not recoverable: exiting now`, the observed `chart-validate` failure. It also means CI `sudo install`s an unverified internet binary into `/usr/local/bin`, which sits oddly beside this repo's six-site SHA pinning of every GitHub Action.

## The fixes

**`scripts/prime-kind-cache.sh`** exploits the action's own guard — `kind.sh` skips its download when `${RUNNER_TOOL_CACHE}/kind/${version}/${arch}/kind/bin/kind` already exists, then smoke-tests it with `kind version`. The script fetches with `--fail --retry 5 --retry-all-errors`, verifies, and moves into the cache **only after verification**, so a failed run cannot leave a half-file the action's `-x` guard would skip past. It is idempotent via a `kind.sha256` sidecar (second run touches no network) and refetches a corrupted cached binary. `version: v0.31.0` is now passed explicitly to all three `helm/kind-action` steps and to the prime step, so the two cannot drift; if they ever do, the prime step simply misses and behavior degrades to today's rather than breaking.

**kubeconform** gets `--fail`, retries, `set -euo pipefail`, and a **pinned SHA256 verified before extraction**, failing loudly with expected/actual on mismatch.

The hash is a literal by design. Fetching the release `CHECKSUMS` over the same channel as the artifact and trusting it verifies nothing — whoever can serve a bad tarball can serve a matching checksum. That is precisely the mistake upstream `kind.sh` makes. Pinning freezes the value at review time, so a future substituted artifact fails against a hash a human approved.

## Verification

- The script was exercised three ways: fresh download (`EXIT=0`, verified ELF), idempotent re-run (`EXIT=0`, no network), and a bad version (`EXIT=1`, retries exhausted, **no cache directory created**). Corrupt-cache branch also confirmed to refetch.
- The kubeconform step body was run verbatim: correct hash passes; tampered `expected` prints the mismatch and exits 1; a 404 URL exhausts retries and aborts **before** `tar`, leaving no tarball.
- The pinned hash `9bc2bff…87883` was confirmed against the published `CHECKSUMS` asset and by hashing the downloaded bytes — and independently re-checked by the reviewer before merge. Both paths originate from GitHub releases, so this confirms the bytes match the publisher's manifest rather than establishing two independent roots of trust; the value is that it is now frozen.
- `pnpm test:release-controller` **525/525**, `ci-workflow-pins` **16/16**, `pnpm lint` 0, `shellcheck` 0 on both the script and the inline body, `pnpm check:release-inventory` 0.

The audit chain broke first, exactly as designed — `Workflow entrypoint is not explicitly audited`, captured before fixing — and `workflow-entrypoints.json` / `workflow-safe-executables.json` were updated from the *parsed* YAML rather than hand-typed.

## Two things worth knowing

**`install_kubectl` upstream has the identical bug** and is deliberately not fixed here — it hits `dl.k8s.io` rather than GitHub releases and has never been observed failing. The same lever is available one directory over. This is recorded in `prime-kind-cache.sh` so whoever meets `Installing kubectl...` in a failed log finds the answer beside the analogous fix.

**A modest gap in the audit model, found while deciding inline-vs-helper:** `workflow-entrypoints.json` pins `run:` bodies byte-exact, but does **not** cover the body of a `scripts/*.sh` file a `run:` invokes. That is why the kubeconform `sudo install` stayed inline — moving it behind a script would have moved a system-path install *out* of the fail-closed audit. The same asymmetry applies to `prime-kind-cache.sh`: only the one-line invocation is pinned. Pre-existing, not introduced here, but worth a decision.

- [x] `pnpm lint`
- [x] `pnpm test:release-controller` / `ci-workflow-pins`
- [ ] Full `pnpm ci:validate` — deferred to CI
- [x] Shellcheck

## Release Notes

- [x] Not needed. `.github/workflows/` and `scripts/` only; the changesets gate covers `packages/*/src/` and READMEs.

## Checklist

- [x] I read `CONTRIBUTING.md`.
- [x] I followed `CODE_OF_CONDUCT.md`.
- [x] I did not include secrets, credentials, or private data.
- [x] I am not disclosing a security vulnerability publicly.
