### PR TITLE
ci: prime the kubectl tool cache to close the second kind.sh curl gap

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -599,22 +599,25 @@ jobs:
       - name: Setup Helm
         uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
 
-      # helm/kind-action installs kind with `curl -sSLo` and no `--fail`, so a
-      # transient GitHub-releases 429/5xx writes the error page into the
-      # checksum file and the step dies with "no properly formatted checksum
-      # lines found". Priming RUNNER_TOOL_CACHE with a verified binary makes
-      # the action's `[[ ! -x ... ]]` guard skip that download entirely.
+      # helm/kind-action installs kind and kubectl with `curl -sSLo` and no
+      # `--fail`, so a transient upstream 429/5xx writes the error page into
+      # the checksum file and the step dies with "no properly formatted
+      # checksum lines found". Priming RUNNER_TOOL_CACHE with verified
+      # binaries makes the action's `[[ ! -x ... ]]` guards skip both
+      # downloads entirely.
       #
-      # The version here must match the `version:` input on the step below. If
-      # the two ever drift, this step primes a path the action does not read,
-      # the action downloads as it does today, and CI is degraded — not broken.
+      # The versions here must match the `version:` and `kubectl_version:`
+      # inputs on the step below. If any of them ever drift, this step primes
+      # a path the action does not read, the action downloads that tool as it
+      # does today, and CI is degraded — not broken.
       - name: Prime kind tool cache
-        run: scripts/prime-kind-cache.sh v0.31.0
+        run: scripts/prime-kind-cache.sh v0.31.0 v1.35.0
 
       - name: Create kind cluster (no default CNI)
         uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
         with:
           version: v0.31.0
+          kubectl_version: v1.35.0
           config: .github/kind/kind-calico.yaml
           node_image: kindest/node:v1.35.0@sha256:4613778f3cfcd10e615029370f5786704559103cf27bef934597ba562b269661
 
@@ -694,15 +697,16 @@ jobs:
         uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
 
       # See the sandbox-k8s lane: primes the tool cache so the action skips its
-      # own no-`--fail` kind download. Keep this version and the `version:`
-      # input below in lockstep.
+      # own no-`--fail` kind and kubectl downloads. Keep these versions and
+      # the `version:`/`kubectl_version:` inputs below in lockstep.
       - name: Prime kind tool cache
-        run: scripts/prime-kind-cache.sh v0.31.0
+        run: scripts/prime-kind-cache.sh v0.31.0 v1.35.0
 
       - name: Create kind cluster (no default CNI)
         uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
         with:
           version: v0.31.0
+          kubectl_version: v1.35.0
           config: .github/kind/kind-calico.yaml
           cluster_name: dawn-smoke
           node_image: kindest/node:v1.35.0@sha256:4613778f3cfcd10e615029370f5786704559103cf27bef934597ba562b269661
@@ -882,15 +886,16 @@ jobs:
         uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
 
       # See the sandbox-k8s lane: primes the tool cache so the action skips its
-      # own no-`--fail` kind download. Keep this version and the `version:`
-      # input below in lockstep.
+      # own no-`--fail` kind and kubectl downloads. Keep these versions and
+      # the `version:`/`kubectl_version:` inputs below in lockstep.
       - name: Prime kind tool cache
-        run: scripts/prime-kind-cache.sh v0.31.0
+        run: scripts/prime-kind-cache.sh v0.31.0 v1.35.0
 
       - name: Create kind cluster
         uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
         with:
           version: v0.31.0
+          kubectl_version: v1.35.0
           node_image: kindest/node:v1.35.0@sha256:4613778f3cfcd10e615029370f5786704559103cf27bef934597ba562b269661
 
       - name: Install dawn-app (placeholder image) and verify it serves

--- a/scripts/prime-kind-cache.sh
+++ b/scripts/prime-kind-cache.sh
@@ -1,15 +1,15 @@
 #!/usr/bin/env bash
 #
-# Pre-populate the `kind` binary in the GitHub Actions tool cache so that
-# helm/kind-action skips its own fragile installer.
+# Pre-populate the `kind` and `kubectl` binaries in the GitHub Actions tool
+# cache so that helm/kind-action skips its own fragile installers for both.
 #
 # Why this exists
 # ---------------
-# helm/kind-action's `kind.sh` downloads the binary and its checksum with
-# `curl -sSLo` and *no* `--fail`. When GitHub releases answers with a 429, a
-# 5xx, or a CDN error page, curl writes that HTML body into the checksum file
-# and still exits 0. The follow-up `grep ... | sha256sum -c` then receives
-# empty stdin and dies with
+# helm/kind-action's `kind.sh` downloads both binaries (and their checksums)
+# with `curl -sSLo` and *no* `--fail`. When the upstream host answers with a
+# 429, a 5xx, or a CDN error page, curl writes that HTML body into the
+# checksum file and still exits 0. The follow-up `sha256sum -c` then receives
+# garbage stdin and dies with
 #
 #     sha256sum: 'standard input': no properly formatted checksum lines found
 #
@@ -18,24 +18,24 @@
 # the "No such container: kind-registry" line in Post-job cleanup is unrelated
 # noise.
 #
-# `kind.sh` guards the install with
+# `kind.sh` guards each install independently:
 #
-#     local kind_dir="${RUNNER_TOOL_CACHE}/kind/${version}/${arch}/kind/bin/"
+#     local cache_dir="${RUNNER_TOOL_CACHE}/kind/${version}/${arch}"
+#     local kind_dir="${cache_dir}/kind/bin/"
 #     if [[ ! -x "${kind_dir}/kind" ]]; then install_kind; fi
+#     local kubectl_dir="${cache_dir}/kubectl/bin/"
+#     if [[ ! -x "${kubectl_dir}/kubectl" ]]; then install_kubectl; fi
 #
-# so writing a verified binary to exactly that path makes the action skip the
-# download altogether.
+# so writing verified binaries to exactly those paths makes the action skip
+# both downloads altogether. Note the path detail that is easy to get wrong:
+# kubectl is cached under the *kind* version directory (`${cache_dir}` is
+# keyed by `${version}`, the kind version), not a kubectl-versioned one.
 #
-# Known, deliberately unfixed: the same `kind.sh` has the identical bug in
-# `install_kubectl`, which fetches the kubectl binary and its `.sha256` from
-# dl.k8s.io with the same no-`--fail` curl and then runs
-# `echo "$(cat kubectl.sha256) kubectl" | sha256sum -c`. If you are reading
-# this because a lane failed just after printing "Installing kubectl...", that
-# is the cause, and the fix is this same lever applied one directory over:
-# prime "${RUNNER_TOOL_CACHE}/kind/${version}/${arch}/kubectl/bin/kubectl",
-# which kind.sh guards with the same `[[ ! -x ... ]]` check. It was left alone
-# because it hits a different, more reliable CDN than GitHub releases and we
-# have never observed it failing — not because it is safe.
+# Both halves of this bug are closed here: kind fetches from GitHub releases,
+# kubectl fetches from dl.k8s.io. kubectl was left open longer than kind
+# because dl.k8s.io is a more reliable CDN and the failure had never been
+# observed there — but the same curl footgun is present in the same script,
+# so it is primed preventively rather than reactively.
 #
 # Contract
 # --------
@@ -43,24 +43,27 @@
 #     and a persistent one is a loud, non-zero failure — never a corrupt file.
 #   * The checksum is verified and a mismatch aborts. Failing silently is the
 #     exact bug being fixed here.
-#   * The binary is only moved into the cache path after it verifies, so a
-#     failed run can never leave a broken `kind` that the action would then
+#   * Each binary is only moved into the cache path after it verifies, so a
+#     failed run can never leave a broken binary that the action would then
 #     happily skip over.
-#   * Idempotent: a second run with an already-verified binary exits 0 without
+#   * Idempotent: a second run with already-verified binaries exits 0 without
 #     touching the network.
 #
-# Usage: scripts/prime-kind-cache.sh <kind-version>   (e.g. v0.31.0)
+# Usage: scripts/prime-kind-cache.sh <kind-version> <kubectl-version>
+#        (e.g. v0.31.0 v1.35.0)
 #
-# The version argument MUST match the `version:` input given to the
-# helm/kind-action step that follows. If they ever drift, this script simply
-# primes a path the action does not consult, the action falls back to its own
-# download, and CI behaves exactly as it does today — degraded, not broken.
+# Both arguments MUST match the `version:` and `kubectl_version:` inputs given
+# to the helm/kind-action step that follows. If any of them ever drift, this
+# script simply primes a path the action does not consult, the action falls
+# back to its own download for that tool, and CI behaves exactly as it does
+# today — degraded, not broken.
 
 set -euo pipefail
 
-VERSION="${1:-}"
-if [[ -z "${VERSION}" ]]; then
-  echo "prime-kind-cache: usage: $0 <kind-version>  (e.g. v0.31.0)" >&2
+KIND_VERSION="${1:-}"
+KUBECTL_VERSION="${2:-}"
+if [[ -z "${KIND_VERSION}" || -z "${KUBECTL_VERSION}" ]]; then
+  echo "prime-kind-cache: usage: $0 <kind-version> <kubectl-version>  (e.g. v0.31.0 v1.35.0)" >&2
   exit 2
 fi
 
@@ -69,7 +72,9 @@ if [[ -z "${RUNNER_TOOL_CACHE:-}" ]]; then
   exit 2
 fi
 
-# Mirrors the architecture mapping in helm/kind-action's kind.sh.
+# Mirrors the architecture mapping in helm/kind-action's kind.sh. Both the
+# kind and kubectl downloads below reuse this same mapping, exactly as
+# kind.sh does.
 case "$(uname -m)" in
 i386 | i686) ARCH="386" ;;
 x86_64) ARCH="amd64" ;;
@@ -80,12 +85,6 @@ arm | aarch64 | arm64) ARCH="arm64" ;;
   ;;
 esac
 
-KIND_DIR="${RUNNER_TOOL_CACHE}/kind/${VERSION}/${ARCH}/kind/bin"
-KIND_BIN="${KIND_DIR}/kind"
-KIND_SUM="${KIND_DIR}/kind.sha256"
-ASSET="kind-linux-${ARCH}"
-BASE_URL="https://github.com/kubernetes-sigs/kind/releases/download/${VERSION}"
-
 # macOS lacks sha256sum; keep the script runnable outside the Linux runner.
 sha256_of() {
   if command -v sha256sum >/dev/null 2>&1; then
@@ -95,58 +94,149 @@ sha256_of() {
   fi
 }
 
-# Idempotent fast path: an already-verified binary needs no network at all.
-if [[ -x "${KIND_BIN}" && -s "${KIND_SUM}" ]]; then
-  cached="$(cat "${KIND_SUM}")"
-  if [[ "$(sha256_of "${KIND_BIN}")" == "${cached}" ]]; then
-    echo "prime-kind-cache: kind ${VERSION} (${ARCH}) already cached at ${KIND_BIN}"
-    exit 0
-  fi
-  echo "prime-kind-cache: cached kind ${VERSION} (${ARCH}) failed its recorded checksum; refetching" >&2
-fi
-
-WORK_DIR="$(mktemp -d)"
-trap 'rm -rf "${WORK_DIR}"' EXIT
-
+# --fail turns an HTTP error into a non-zero exit instead of a body that looks
+# like a download; --retry-all-errors also retries the 4xx/5xx that --fail
+# surfaces, so throttling is a retry and a real outage is a failure.
 fetch() {
-  # --fail turns an HTTP error into a non-zero exit instead of a body that
-  # looks like a download; --retry-all-errors also retries the 4xx/5xx that
-  # --fail surfaces, so throttling is a retry and a real outage is a failure.
   curl --fail --retry 5 --retry-all-errors --retry-delay 2 -sSL -o "$2" "$1"
 }
 
-echo "prime-kind-cache: downloading kind ${VERSION} (${ARCH})"
-if ! fetch "${BASE_URL}/${ASSET}" "${WORK_DIR}/${ASSET}"; then
-  echo "prime-kind-cache: failed to download ${BASE_URL}/${ASSET}" >&2
-  exit 1
-fi
-if ! fetch "${BASE_URL}/${ASSET}.sha256sum" "${WORK_DIR}/${ASSET}.sha256sum"; then
-  echo "prime-kind-cache: failed to download ${BASE_URL}/${ASSET}.sha256sum" >&2
-  exit 1
-fi
+# Shared scratch space for both downloads below, created lazily so the fully
+# idempotent fast path (both tools already cached) never touches disk beyond
+# the cache itself, let alone the network.
+WORK_DIR=""
+ensure_work_dir() {
+  if [[ -z "${WORK_DIR}" ]]; then
+    WORK_DIR="$(mktemp -d)"
+    trap 'rm -rf "${WORK_DIR}"' EXIT
+  fi
+}
 
-expected="$(awk -v asset="${ASSET}" '
-  { name = $2; sub(/^\*/, "", name) }
-  name == asset { print $1; exit }
-' "${WORK_DIR}/${ASSET}.sha256sum")"
+CACHE_DIR="${RUNNER_TOOL_CACHE}/kind/${KIND_VERSION}/${ARCH}"
 
-if [[ ! "${expected}" =~ ^[0-9a-f]{64}$ ]]; then
-  echo "prime-kind-cache: no checksum for ${ASSET} in ${BASE_URL}/${ASSET}.sha256sum" >&2
-  exit 1
-fi
+# ---------------------------------------------------------------------------
+# kind
+# ---------------------------------------------------------------------------
+prime_kind() {
+  local dir="${CACHE_DIR}/kind/bin"
+  local bin="${dir}/kind"
+  local sum="${dir}/kind.sha256"
+  local asset="kind-linux-${ARCH}"
+  local base_url="https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}"
 
-actual="$(sha256_of "${WORK_DIR}/${ASSET}")"
-if [[ "${actual}" != "${expected}" ]]; then
-  echo "prime-kind-cache: checksum mismatch for ${ASSET}" >&2
-  echo "prime-kind-cache:   expected ${expected}" >&2
-  echo "prime-kind-cache:   actual   ${actual}" >&2
-  exit 1
-fi
+  # Idempotent fast path: an already-verified binary needs no network at all.
+  if [[ -x "${bin}" && -s "${sum}" ]]; then
+    local cached
+    cached="$(cat "${sum}")"
+    if [[ "$(sha256_of "${bin}")" == "${cached}" ]]; then
+      echo "prime-kind-cache: kind ${KIND_VERSION} (${ARCH}) already cached at ${bin}"
+      return 0
+    fi
+    echo "prime-kind-cache: cached kind ${KIND_VERSION} (${ARCH}) failed its recorded checksum; refetching" >&2
+  fi
 
-chmod +x "${WORK_DIR}/${ASSET}"
-mkdir -p "${KIND_DIR}"
-# Publish the checksum only after the binary lands, so an interrupted run
-# cannot leave a binary that the fast path would trust.
-mv -f "${WORK_DIR}/${ASSET}" "${KIND_BIN}"
-printf '%s\n' "${expected}" >"${KIND_SUM}"
-echo "prime-kind-cache: verified kind ${VERSION} (${ARCH}) at ${KIND_BIN}"
+  ensure_work_dir
+
+  echo "prime-kind-cache: downloading kind ${KIND_VERSION} (${ARCH})"
+  if ! fetch "${base_url}/${asset}" "${WORK_DIR}/${asset}"; then
+    echo "prime-kind-cache: failed to download ${base_url}/${asset}" >&2
+    return 1
+  fi
+  if ! fetch "${base_url}/${asset}.sha256sum" "${WORK_DIR}/${asset}.sha256sum"; then
+    echo "prime-kind-cache: failed to download ${base_url}/${asset}.sha256sum" >&2
+    return 1
+  fi
+
+  local expected
+  expected="$(awk -v asset="${asset}" '
+    { name = $2; sub(/^\*/, "", name) }
+    name == asset { print $1; exit }
+  ' "${WORK_DIR}/${asset}.sha256sum")"
+
+  if [[ ! "${expected}" =~ ^[0-9a-f]{64}$ ]]; then
+    echo "prime-kind-cache: no checksum for ${asset} in ${base_url}/${asset}.sha256sum" >&2
+    return 1
+  fi
+
+  local actual
+  actual="$(sha256_of "${WORK_DIR}/${asset}")"
+  if [[ "${actual}" != "${expected}" ]]; then
+    echo "prime-kind-cache: checksum mismatch for ${asset}" >&2
+    echo "prime-kind-cache:   expected ${expected}" >&2
+    echo "prime-kind-cache:   actual   ${actual}" >&2
+    return 1
+  fi
+
+  chmod +x "${WORK_DIR}/${asset}"
+  mkdir -p "${dir}"
+  # Publish the checksum only after the binary lands, so an interrupted run
+  # cannot leave a binary that the fast path would trust.
+  mv -f "${WORK_DIR}/${asset}" "${bin}"
+  printf '%s\n' "${expected}" >"${sum}"
+  echo "prime-kind-cache: verified kind ${KIND_VERSION} (${ARCH}) at ${bin}"
+}
+
+# ---------------------------------------------------------------------------
+# kubectl
+# ---------------------------------------------------------------------------
+prime_kubectl() {
+  # Cached under the *kind* version directory — see the path-detail note at
+  # the top of this file. This is what kind.sh's own guard reads.
+  local dir="${CACHE_DIR}/kubectl/bin"
+  local bin="${dir}/kubectl"
+  local sum="${dir}/kubectl.sha256"
+  local base_url="https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${ARCH}"
+
+  # Idempotent fast path: an already-verified binary needs no network at all.
+  if [[ -x "${bin}" && -s "${sum}" ]]; then
+    local cached
+    cached="$(cat "${sum}")"
+    if [[ "$(sha256_of "${bin}")" == "${cached}" ]]; then
+      echo "prime-kind-cache: kubectl ${KUBECTL_VERSION} (${ARCH}) already cached at ${bin}"
+      return 0
+    fi
+    echo "prime-kind-cache: cached kubectl ${KUBECTL_VERSION} (${ARCH}) failed its recorded checksum; refetching" >&2
+  fi
+
+  ensure_work_dir
+
+  echo "prime-kind-cache: downloading kubectl ${KUBECTL_VERSION} (${ARCH})"
+  if ! fetch "${base_url}/kubectl" "${WORK_DIR}/kubectl"; then
+    echo "prime-kind-cache: failed to download ${base_url}/kubectl" >&2
+    return 1
+  fi
+  if ! fetch "${base_url}/kubectl.sha256" "${WORK_DIR}/kubectl.sha256"; then
+    echo "prime-kind-cache: failed to download ${base_url}/kubectl.sha256" >&2
+    return 1
+  fi
+
+  # Unlike kind's checksum file, kubectl's `.sha256` contains only the bare
+  # hex digest — no filename, no leading `*`/` ` markers to strip.
+  local expected
+  expected="$(tr -d '[:space:]' <"${WORK_DIR}/kubectl.sha256")"
+
+  if [[ ! "${expected}" =~ ^[0-9a-f]{64}$ ]]; then
+    echo "prime-kind-cache: malformed checksum for kubectl at ${base_url}/kubectl.sha256" >&2
+    return 1
+  fi
+
+  local actual
+  actual="$(sha256_of "${WORK_DIR}/kubectl")"
+  if [[ "${actual}" != "${expected}" ]]; then
+    echo "prime-kind-cache: checksum mismatch for kubectl" >&2
+    echo "prime-kind-cache:   expected ${expected}" >&2
+    echo "prime-kind-cache:   actual   ${actual}" >&2
+    return 1
+  fi
+
+  chmod +x "${WORK_DIR}/kubectl"
+  mkdir -p "${dir}"
+  # Publish the checksum only after the binary lands, so an interrupted run
+  # cannot leave a binary that the fast path would trust.
+  mv -f "${WORK_DIR}/kubectl" "${bin}"
+  printf '%s\n' "${expected}" >"${sum}"
+  echo "prime-kind-cache: verified kubectl ${KUBECTL_VERSION} (${ARCH}) at ${bin}"
+}
+
+prime_kind
+prime_kubectl

--- a/scripts/release/test/fixtures/workflow-entrypoints.json
+++ b/scripts/release/test/fixtures/workflow-entrypoints.json
@@ -117,7 +117,7 @@
               "classification": "safe",
               "descriptor": {
                 "name": "Prime kind tool cache",
-                "run": "scripts/prime-kind-cache.sh v0.31.0"
+                "run": "scripts/prime-kind-cache.sh v0.31.0 v1.35.0"
               }
             },
             {
@@ -127,6 +127,7 @@
                 "uses": "helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc",
                 "with": {
                   "version": "v0.31.0",
+                  "kubectl_version": "v1.35.0",
                   "node_image": "kindest/node:v1.35.0@sha256:4613778f3cfcd10e615029370f5786704559103cf27bef934597ba562b269661"
                 }
               }
@@ -722,7 +723,7 @@
               "classification": "safe",
               "descriptor": {
                 "name": "Prime kind tool cache",
-                "run": "scripts/prime-kind-cache.sh v0.31.0"
+                "run": "scripts/prime-kind-cache.sh v0.31.0 v1.35.0"
               }
             },
             {
@@ -732,6 +733,7 @@
                 "uses": "helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc",
                 "with": {
                   "version": "v0.31.0",
+                  "kubectl_version": "v1.35.0",
                   "config": ".github/kind/kind-calico.yaml",
                   "node_image": "kindest/node:v1.35.0@sha256:4613778f3cfcd10e615029370f5786704559103cf27bef934597ba562b269661"
                 }
@@ -849,7 +851,7 @@
               "classification": "safe",
               "descriptor": {
                 "name": "Prime kind tool cache",
-                "run": "scripts/prime-kind-cache.sh v0.31.0"
+                "run": "scripts/prime-kind-cache.sh v0.31.0 v1.35.0"
               }
             },
             {
@@ -859,6 +861,7 @@
                 "uses": "helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc",
                 "with": {
                   "version": "v0.31.0",
+                  "kubectl_version": "v1.35.0",
                   "config": ".github/kind/kind-calico.yaml",
                   "cluster_name": "dawn-smoke",
                   "node_image": "kindest/node:v1.35.0@sha256:4613778f3cfcd10e615029370f5786704559103cf27bef934597ba562b269661"

--- a/scripts/release/test/fixtures/workflow-safe-executables.json
+++ b/scripts/release/test/fixtures/workflow-safe-executables.json
@@ -754,7 +754,7 @@
         "stepIndex": 6,
         "step": "Prime kind tool cache",
         "kind": "run",
-        "value": "scripts/prime-kind-cache.sh v0.31.0"
+        "value": "scripts/prime-kind-cache.sh v0.31.0 v1.35.0"
       },
       {
         "classification": "safe",
@@ -866,7 +866,7 @@
         "stepIndex": 6,
         "step": "Prime kind tool cache",
         "kind": "run",
-        "value": "scripts/prime-kind-cache.sh v0.31.0"
+        "value": "scripts/prime-kind-cache.sh v0.31.0 v1.35.0"
       },
       {
         "classification": "safe",
@@ -1050,7 +1050,7 @@
         "stepIndex": 2,
         "step": "Prime kind tool cache",
         "kind": "run",
-        "value": "scripts/prime-kind-cache.sh v0.31.0"
+        "value": "scripts/prime-kind-cache.sh v0.31.0 v1.35.0"
       },
       {
         "classification": "safe",


### PR DESCRIPTION
## Summary

Closes the half of the `helm/kind-action` download bug that #470 deliberately left open.

That action downloads two tools, both with `curl` lacking `--fail`, so an HTTP error page lands on disk and is consumed as if valid. #470 fixed **kind** by pre-populating the action's tool cache — `kind.sh` skips its own download when the cached binary exists. **kubectl had the identical bug** and was documented as knowingly unfixed in `scripts/prime-kind-cache.sh`, on the grounds that it hits `dl.k8s.io` rather than GitHub releases and had never been observed failing. This closes it preventively, so the class is gone rather than half-gone.

```bash
curl -sSLo kubectl        ".../bin/linux/${arch}/kubectl"
curl -sSLo kubectl.sha256 ".../bin/linux/${arch}/kubectl.sha256"
echo "$(cat kubectl.sha256) kubectl" | sha256sum -c
```

## What changed

`scripts/prime-kind-cache.sh` is extended in place rather than duplicated — the two halves share arch detection, the curl flags, the sidecar-idempotency pattern and the verify-then-move discipline. It now takes `<kind-version> <kubectl-version>`.

Two details that are easy to get wrong, both handled:

- **kubectl is cached under the *kind* version directory** — `${RUNNER_TOOL_CACHE}/kind/${KIND_VERSION}/${ARCH}/kubectl/bin/kubectl`, not a kubectl-keyed path.
- **kubectl's `.sha256` holds a bare hash** with no filename, unlike kind's, so it needs different parsing; the value is validated as 64 hex chars before use.

`kubectl_version: v1.35.0` is now passed explicitly to all three `helm/kind-action` steps and to the prime step, so the pinned value and the action's default cannot drift. If they ever do, the prime step simply misses and behavior degrades to today's rather than breaking.

The "Known, deliberately unfixed" comment block is rewritten rather than left stale — it described a gap that no longer exists.

## Validation

Exercised against a real `RUNNER_TOOL_CACHE`:

| Case | Result |
|---|---|
| Fresh download of both | both verified, `file` confirms real linux ELF binaries at the correct paths |
| Idempotent re-run | both hit the cached fast path, 0.079s, **no network** |
| Bad kubectl version | `--fail` exhausts retries on 404, exits 1, **no kubectl cache dir created** (kind still primed) |
| Corrupted cached kubectl | mismatch detected against the sidecar, refetched, re-verified, exit 0 |

The audit chain broke first as designed — `Workflow entrypoint is not explicitly audited`, captured before fixing — and both fixtures were updated from the **parsed** YAML rather than hand-typed, then Biome-reformatted and diffed to confirm only intended lines moved.

`pnpm test:release-controller` **525/525**, `ci-workflow-pins` **16/16** (untouched, as predicted — bodies changed, no step added), `pnpm lint` 0 errors, `shellcheck` 0, `check:release-inventory` 0. `preflight.mjs` and `ci-workflow-pins.test.ts` deliberately untouched.

- [x] `pnpm lint`
- [x] `pnpm test:release-controller` / `ci-workflow-pins`
- [x] Shellcheck
- [ ] Full `pnpm ci:validate` — deferred to CI

## Release Notes

- [x] Not needed. `.github/` and `scripts/` only.

## Checklist

- [x] I read `CONTRIBUTING.md`.
- [x] I followed `CODE_OF_CONDUCT.md`.
- [x] I did not include secrets, credentials, or private data.
- [x] I am not disclosing a security vulnerability publicly.