### PR TITLE
ci: pin the bytes of every script a release runs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -187,6 +187,18 @@ deployed-app smoke), `chart-validate` (Helm lint + kubeconform), and
   `scripts/check-docs.mjs` for the exact patterns.
 - **Always run commands from the repo root.** Turbo and workspace-package
   resolution assume it.
+- **Four release scripts are content-pinned.** `scripts/backfill-release-tags.mjs`,
+  `scripts/release-publish.mjs`, `scripts/sync-chart-appversion.mjs`, and
+  `scripts/upload-release-assets.mjs`
+  run during a release, so their SHA256 is recorded in
+  `scripts/release/test/fixtures/release-script-hashes.json`. Editing one fails
+  `pnpm test:release-controller` until the hash is updated in the same commit;
+  the failure prints the expected and actual hash and the recompute command.
+  The suite also re-derives which scripts `release.yml` reaches — through `run:`
+  steps and through action `with:` inputs — so a fifth script cannot join the
+  release path unpinned. This is deliberately limited to the release path;
+  CI-only scripts are not pinned. See `CONTRIBUTORS.md`'s "Release Integrity
+  Coverage" for what the release controller does and does not cover.
 
 ## Where things live
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -83,6 +83,15 @@ The repo uses a layered verification model:
 
 Treat these lanes as distinct: package tests prove package behavior, harness lanes prove repo-level runtime behavior, and publish smoke proves the distribution surface.
 
+## Release Integrity Coverage
+
+`pnpm test:release-controller` pins the release path. It is worth knowing exactly how far that pin reaches, because the answer is narrower than "the release is pinned":
+
+- **Workflow structure and command lines are pinned.** `scripts/release/test/fixtures/workflow-entrypoints.json` and `workflow-safe-executables.json` record every workflow's jobs, steps, and `run:` bodies byte-for-byte, and `scripts/release/preflight.mjs` re-checks `.github/workflows/release.yml` against its own expected shape before a release publishes. Drift fails closed, and there is no regeneration script: an intended edit has to be transcribed into the fixture and reviewed.
+- **The bytes of the four scripts `release.yml` runs are pinned.** `scripts/release/test/fixtures/release-script-hashes.json` records the SHA256 of `scripts/backfill-release-tags.mjs`, `scripts/release-publish.mjs`, `scripts/sync-chart-appversion.mjs`, and `scripts/upload-release-assets.mjs`. Two are `run:` steps; the other two are reached through the changesets action's `publish:` and `version:` inputs. Editing any of them fails the release-controller suite until its hash is updated in the same commit, so the diff is reviewed as a release-integrity change rather than landing invisibly behind an already-audited command line.
+- **A fifth script cannot join `release.yml` unpinned.** The suite re-derives which repository scripts `release.yml` reaches, by both routes a script can enter it — a literal `scripts/...` path in a `run:` body or in an action `with:` input, and a `pnpm <name>` input resolved one step through `package.json` — and requires that set to equal the pinned set exactly. Commands it cannot follow fail rather than being skipped: a `run:` step may only invoke the pnpm scripts named in its audited list, and a `with:` input that names an unknown pnpm script, or one that resolves to something with no visible script path, is reported. It does **not** follow the pnpm scripts inside `run:` bodies (`ci:validate`, `published:verify`, `published:smoke`), so editing one of *those* package.json entries to reach a new script is not caught here — review is what covers that.
+- **In-repo scripts generally are not pinned.** Everything else under `scripts/` — including `check-docs.mjs`, `check-changesets.mjs`, and `prime-kind-cache.sh`, which run in CI rather than in the release — is covered by branch protection and review, not by a content hash.
+
 ## Documentation Sources
 
 - Root docs (`README.md` and this file) are the primary repo entrypoints.

--- a/scripts/release/test/fixtures/release-script-hashes.json
+++ b/scripts/release/test/fixtures/release-script-hashes.json
@@ -1,0 +1,17 @@
+{
+  "schemaVersion": 1,
+  "scripts": {
+    "scripts/backfill-release-tags.mjs": {
+      "sha256": "54ca2306204e1e78f3fbc9f78a8375e42ed3a17eed2d6a4fc1b3d1ff233743f1"
+    },
+    "scripts/release-publish.mjs": {
+      "sha256": "fc111388f247c66a27154c3a1862ac0c0ece9cf5f9d61848632e6578cbdfa5b0"
+    },
+    "scripts/sync-chart-appversion.mjs": {
+      "sha256": "a676484449091e5c7fc891c75b014ab92c3b6319201871ba7fcb42817c4c5ed7"
+    },
+    "scripts/upload-release-assets.mjs": {
+      "sha256": "b4bac9fd5052487bebf26f59d5e0e211cde15c3e37561fb44eb2a8037a938417"
+    }
+  }
+}

--- a/scripts/release/test/workflow-contracts.test.mjs
+++ b/scripts/release/test/workflow-contracts.test.mjs
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict"
+import { createHash } from "node:crypto"
 import {
   lstat,
   mkdir,
@@ -33,6 +34,33 @@ const EXECUTABLE_ALLOWLIST_PATH = path.join(
 const EXECUTABLE_ALLOWLIST = JSON.parse(
   await readBoundedFixture(EXECUTABLE_ALLOWLIST_PATH, { root: ROOT }),
 )
+const SCRIPT_PIN_FIXTURE = "scripts/release/test/fixtures/release-script-hashes.json"
+const SCRIPT_PIN_PATH = path.join(ROOT, SCRIPT_PIN_FIXTURE)
+// The four repository scripts release.yml executes: two as `run:` steps, and two
+// through the changesets action's `version:` and `publish:` inputs. The entrypoint
+// allowlist pins the command lines; these pins cover the bytes those commands run.
+// Deliberately narrow: scripts reached only from ci.yml (check-docs.mjs,
+// check-changesets.mjs, prime-kind-cache.sh) change often and are covered by branch
+// protection and review, not by a hash.
+const PINNED_RELEASE_SCRIPTS = [
+  "scripts/backfill-release-tags.mjs",
+  "scripts/release-publish.mjs",
+  "scripts/sync-chart-appversion.mjs",
+  "scripts/upload-release-assets.mjs",
+]
+// pnpm indirections release.yml uses inside `run:` bodies. Each reaches validation or
+// post-publish verification scripts rather than publishing ones, so those scripts are
+// covered by review rather than a content pin. Adding a name here is a deliberate,
+// reviewed decision; a `run:` step invoking any other pnpm script fails closed.
+const AUDITED_RELEASE_RUN_INDIRECTIONS = new Set([
+  "install",
+  "ci:validate",
+  "published:verify",
+  "published:smoke",
+])
+const SHA256_HEX = /^[0-9a-f]{64}$/u
+const SCRIPT_REFERENCE = /(?:^|[\s;&|"'(])(scripts\/[\w.-]+(?:\/[\w.-]+)*)/gu
+const PNPM_REFERENCE = /(?:^|[\s;&|"'(])pnpm\s+(?:run\s+)?([\w:.-]+)/gu
 const LEGACY_SAFE_ENTRYPOINTS = new Set([
   "step-uses:actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1",
   "step-uses:actions/setup-node@820762786026740c76f36085b0efc47a31fe5020",
@@ -617,6 +645,120 @@ test("legacy publication indirection is bound to exact root scripts and regular 
   await assert.rejects(() => assertReleaseIndirection(root), /not explicitly audited/u)
 })
 
+test("release scripts match their audited content pins", async () => {
+  const pins = JSON.parse(await readBoundedFixture(SCRIPT_PIN_PATH, { root: ROOT }))
+
+  assert.deepEqual(Object.keys(pins).sort(), ["schemaVersion", "scripts"])
+  assert.equal(pins.schemaVersion, 1)
+  assert.deepEqual(
+    Object.keys(pins.scripts).sort(),
+    [...PINNED_RELEASE_SCRIPTS].sort(),
+    `${SCRIPT_PIN_FIXTURE} must pin exactly the scripts listed in PINNED_RELEASE_SCRIPTS (scripts/release/test/workflow-contracts.test.mjs). Add or remove the pin and the constant together.`,
+  )
+  await assertPinnedScriptContents(ROOT, pins)
+})
+
+test("release.yml reaches no repository script that is left unpinned", async () => {
+  const sources = await readWorkflowSourcesFromRoot(ROOT)
+  const packageJson = JSON.parse(await readFile(path.join(ROOT, "package.json"), "utf8"))
+
+  assertReleaseScriptCoverage(sources["release.yml"], packageJson)
+  assert.deepEqual(
+    releaseWorkflowScriptReferences(sources["release.yml"], packageJson).referenced,
+    [...PINNED_RELEASE_SCRIPTS].sort(),
+    "every repository script release.yml reaches must be pinned, and every pin must still be reached",
+  )
+})
+
+test("the release.yml reachability scan fails closed on a fifth script added by either route", async (t) => {
+  const packageJson = { scripts: { "release:publish": "node scripts/release-publish.mjs" } }
+  const step = (body) => `jobs:\n  release:\n    steps:\n      - name: Publish\n${body}`
+  const cases = [
+    ["run step", step("        run: node scripts/evil.mjs\n"), /scripts\/evil\.mjs/u],
+    [
+      "action input literal",
+      step(
+        "        uses: example/action@x\n        with:\n          publish: node scripts/evil.mjs\n",
+      ),
+      /scripts\/evil\.mjs/u,
+    ],
+    [
+      "action input pnpm indirection",
+      step("        uses: example/action@x\n        with:\n          publish: pnpm release:evil\n"),
+      /cannot follow|scripts\/evil\.mjs/u,
+    ],
+    [
+      "unaudited run indirection",
+      step("        run: pnpm sneak\n"),
+      /cannot follow to a repository script/u,
+    ],
+  ]
+  for (const [name, source, pattern] of cases) {
+    await t.test(name, () => {
+      assert.throws(
+        () =>
+          assertReleaseScriptCoverage(source, {
+            scripts: { ...packageJson.scripts, "release:evil": "node scripts/evil.mjs" },
+          }),
+        pattern,
+        name,
+      )
+    })
+  }
+
+  await t.test("action input naming no package.json script", () => {
+    assert.throws(
+      () =>
+        assertReleaseScriptCoverage(
+          step("        uses: example/action@x\n        with:\n          publish: pnpm ghost\n"),
+          packageJson,
+        ),
+      /cannot follow to a repository script/u,
+    )
+  })
+
+  await t.test("a stale pin whose step disappeared", () => {
+    assert.throws(
+      () => assertReleaseScriptCoverage(step("        run: pnpm ci:validate\n"), packageJson),
+      /no longer reaches/u,
+    )
+  })
+})
+
+test("script content pins fail closed on drift and on a pinned script that went missing", async (t) => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "dawn-script-pins-"))
+  t.after(() => rm(root, { recursive: true, force: true }))
+  await mkdir(path.join(root, "scripts"))
+  const file = PINNED_RELEASE_SCRIPTS[0]
+  const body = "export {}\n"
+  const pins = {
+    schemaVersion: 1,
+    scripts: { [file]: { sha256: createHash("sha256").update(body).digest("hex") } },
+  }
+  await writeFile(path.join(root, file), body)
+  await assertPinnedScriptContents(root, pins, [file])
+
+  await writeFile(path.join(root, file), `${body}// appended\n`)
+  await assert.rejects(
+    () => assertPinnedScriptContents(root, pins, [file]),
+    (error) =>
+      error.message.includes(file) &&
+      error.message.includes(pins.scripts[file].sha256) &&
+      error.message.includes(SCRIPT_PIN_FIXTURE),
+    "drift must report the file, both hashes, and the fixture to update",
+  )
+
+  await rm(path.join(root, file))
+  await assert.rejects(
+    () => assertPinnedScriptContents(root, pins, [file]),
+    (error) => error.message.includes(file) && /missing|not a regular file/u.test(error.message),
+    "a pinned script that disappeared must fail rather than silently pass",
+  )
+
+  await symlink(path.join(root, "scripts"), path.join(root, file))
+  await assert.rejects(() => assertPinnedScriptContents(root, pins, [file]))
+})
+
 test("root scripts expose shadow and preflight without adding the slow workflow test to fast scripts", async () => {
   const packageJson = JSON.parse(await readFile(path.join(ROOT, "package.json"), "utf8"))
 
@@ -696,6 +838,121 @@ async function assertReleaseIndirection(root) {
     }
   } catch {
     throw unauditedEntrypoint()
+  }
+}
+
+// Collects the repository scripts release.yml reaches, by both routes a script can
+// enter the workflow: a `run:` body and an action `with:` input. Literal `scripts/...`
+// paths are collected directly; a `pnpm <name>` inside a `with:` input is resolved one
+// step through package.json. Anything this cannot follow is reported rather than
+// dropped, so an unfollowable indirection fails instead of silently widening the gap.
+function releaseWorkflowScriptReferences(source, packageJson) {
+  const workflow = parse(source, { maxAliasCount: 0, uniqueKeys: true })
+  const referenced = new Set()
+  const unfollowable = []
+  for (const [job, descriptor] of Object.entries(workflow.jobs ?? {})) {
+    for (const [stepIndex, step] of (descriptor.steps ?? []).entries()) {
+      const where = `${job} step ${stepIndex}${step.name ? ` ("${step.name}")` : ""}`
+      if (typeof step.run === "string") {
+        for (const file of matchAllGroups(step.run, SCRIPT_REFERENCE)) referenced.add(file)
+        for (const name of matchAllGroups(step.run, PNPM_REFERENCE)) {
+          if (!AUDITED_RELEASE_RUN_INDIRECTIONS.has(name))
+            unfollowable.push(`${where} runs \`pnpm ${name}\``)
+        }
+      }
+      for (const [key, value] of Object.entries(step.with ?? {})) {
+        if (typeof value !== "string") continue
+        for (const file of matchAllGroups(value, SCRIPT_REFERENCE)) referenced.add(file)
+        for (const name of matchAllGroups(value, PNPM_REFERENCE)) {
+          const command = packageJson.scripts?.[name]
+          if (typeof command !== "string") {
+            unfollowable.push(
+              `${where} passes \`${key}: ${value}\`, and \`${name}\` is not a package.json script`,
+            )
+            continue
+          }
+          const files = matchAllGroups(command, SCRIPT_REFERENCE)
+          for (const file of files) referenced.add(file)
+          if (files.length === 0 || matchAllGroups(command, PNPM_REFERENCE).length > 0)
+            unfollowable.push(
+              `${where} passes \`${key}: ${value}\`, which resolves to \`${command}\``,
+            )
+        }
+      }
+    }
+  }
+  return { referenced: [...referenced].sort(), unfollowable }
+}
+
+function assertReleaseScriptCoverage(source, packageJson, pinned = PINNED_RELEASE_SCRIPTS) {
+  const { referenced, unfollowable } = releaseWorkflowScriptReferences(source, packageJson)
+  if (unfollowable.length > 0) {
+    throw new Error(
+      [
+        `Release workflow reaches a command this check cannot follow to a repository script:`,
+        ...unfollowable.map((entry) => `  ${entry}`),
+        `An unfollowable command could run an unpinned script. Either invoke the script directly so its path is visible in release.yml, or — if it reaches only validation and verification scripts that are covered by review rather than a content pin — add its name to AUDITED_RELEASE_RUN_INDIRECTIONS in scripts/release/test/workflow-contracts.test.mjs with a comment recording why.`,
+      ].join("\n"),
+    )
+  }
+  for (const file of referenced) {
+    if (pinned.includes(file)) continue
+    throw new Error(
+      [
+        `Release workflow reaches a repository script with no content pin: ${file}`,
+        `.github/workflows/release.yml runs it, directly or through a package.json script, so its bytes have to be pinned alongside the command line.`,
+        `Add its sha256 to ${SCRIPT_PIN_FIXTURE} and its path to PINNED_RELEASE_SCRIPTS in scripts/release/test/workflow-contracts.test.mjs. Compute the hash with:`,
+        `  node -p "require('node:crypto').createHash('sha256').update(require('node:fs').readFileSync('${file}')).digest('hex')"`,
+      ].join("\n"),
+    )
+  }
+  for (const file of pinned) {
+    if (referenced.includes(file)) continue
+    throw new Error(
+      [
+        `Release script pin is stale: ${file} is pinned but .github/workflows/release.yml no longer reaches it.`,
+        `Either restore the step that runs it, or remove its entry from ${SCRIPT_PIN_FIXTURE} and its path from PINNED_RELEASE_SCRIPTS in scripts/release/test/workflow-contracts.test.mjs.`,
+      ].join("\n"),
+    )
+  }
+}
+
+function matchAllGroups(value, pattern) {
+  return [...value.matchAll(pattern)].map(([, group]) => group)
+}
+
+async function assertPinnedScriptContents(root, pins, files = PINNED_RELEASE_SCRIPTS) {
+  for (const file of files) {
+    const expected = pins.scripts?.[file]?.sha256
+    if (typeof expected !== "string" || !SHA256_HEX.test(expected)) {
+      throw new Error(
+        `Release script pin for ${file} is missing or is not a 64-character lowercase sha256 in ${SCRIPT_PIN_FIXTURE}.`,
+      )
+    }
+    let source
+    try {
+      source = await readBoundedFixture(path.join(root, file), { root, maxBytes: 1024 * 1024 })
+    } catch {
+      throw new Error(
+        [
+          `Release script ${file} is pinned in ${SCRIPT_PIN_FIXTURE} but is missing or not a regular file inside the repository.`,
+          `A pinned script must exist: release.yml runs it. If it was intentionally removed, delete its entry from ${SCRIPT_PIN_FIXTURE} and its path from PINNED_RELEASE_SCRIPTS in scripts/release/test/workflow-contracts.test.mjs, and remove the step that runs it from .github/workflows/release.yml.`,
+        ].join("\n"),
+      )
+    }
+    const actual = createHash("sha256").update(Buffer.from(source, "utf8")).digest("hex")
+    if (actual !== expected) {
+      throw new Error(
+        [
+          `Release script content pin mismatch: ${file}`,
+          `  expected sha256: ${expected}`,
+          `  actual   sha256: ${actual}`,
+          `This script runs during a release, so its bytes are pinned alongside the command line in the workflow entrypoint allowlist.`,
+          `If you meant to change it, update the "sha256" for ${file} in ${SCRIPT_PIN_FIXTURE} in the same commit, and have the script diff reviewed as a release-integrity change. Recompute with:`,
+          `  node -p "require('node:crypto').createHash('sha256').update(require('node:fs').readFileSync('${file}')).digest('hex')"`,
+        ].join("\n"),
+      )
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

This repo's release-integrity story is unusually strong: `preflight.mjs` holds a byte-for-byte `EXPECTED_RELEASE_WORKFLOW` checked before publishing, and two fixtures pin every workflow's `run:` body fail-closed, with no regeneration script.

**None of it pinned the *content* of the scripts those commands execute.** The controller verified the command line that publishes, not the code that publishes — so editing a release script changed what a release *does*, invisibly to a control whose premise is "the release does exactly what was audited".

Four scripts are now pinned by SHA256, reviewed in a fixture rather than computed at test time:

| Script | Reached via |
|---|---|
| `scripts/release-publish.mjs` | `changesets/action` `publish:` input → `pnpm release:publish` |
| `scripts/sync-chart-appversion.mjs` | `changesets/action` `version:` input → `pnpm run version` |
| `scripts/backfill-release-tags.mjs` | `run:` |
| `scripts/upload-release-assets.mjs` | `run:` |

**Two of the four arrive through action inputs, not `run:` steps** — including `release-publish.mjs`, the npm publisher, which has the most direct authority over what ships. That is why the initial scope of this work listed only the two `run:` scripts: a `run:`-body grep structurally cannot see them.

## The scan matters more than the hashes

Hashes go stale the moment someone adds a fifth script. So the check derives the reachable set from the real `release.yml` and asserts it **equals** the pinned set:

- literal `scripts/...` paths in `run:` bodies **and** in action `with:` values;
- `pnpm <name>` in a `with:` value resolved one step through `package.json`.

It is fail-closed rather than best-effort. Anything it cannot follow is **reported, not skipped**: a `with:` input naming an unknown pnpm script, or one resolving to a command with no visible script path, throws. `run:` bodies may only invoke pnpm scripts named in a small reviewed constant, so `run: pnpm anything-else` fails. A stale pin whose step disappeared fails too.

**One limit, stated rather than implied away:** the scan does not follow pnpm scripts *inside* `run:` bodies. Following `pnpm ci:validate` would transitively pull in ~15 validation scripts including `check-docs.mjs`, recreating exactly the churn that made this scope deliberately narrow. So reaching a new script by editing `ci:validate` in `package.json` is not caught here, and is covered by review. That is written into CONTRIBUTORS.md.

## Proven able to fail

A control that cannot fail is worthless, so both halves were exercised against the real tree, and independently re-verified before merge:

- **Content drift:** a one-line append to `release-publish.mjs` → exit 1, naming the file, expected and actual hashes, the fixture to edit, and the recompute command.
- **Unpinned script via an action input:** swapping `publish: pnpm release:publish` for `publish: node scripts/publish-smoke.mjs` in the actual workflow → exit 1 with instructions. That run also confirmed the widening works end to end, since `release-publish.mjs` is derived *only* from the `with:` input and vanished from the derived set when it changed.

Six in-suite negative subtests keep this provable in CI rather than depending on a manual probe: `run:` literal, `with:` literal, `with:` pnpm indirection, unaudited `run:` pnpm, `with:` naming a nonexistent script, and a stale pin.

The failure messages carry the recompute command deliberately. The person who trips this will be mid-release-change; a cryptic failure is how controls get disabled rather than maintained.

## Validation

`pnpm test:release-controller` **535 pass / 0 fail**, `pnpm lint` 0, `node scripts/check-docs.mjs` 0, `pnpm check:release-inventory` 0. Biome-scoped to the changed files; `git diff --stat` shows insertions only.

Docs: CONTRIBUTORS.md gains a "Release Integrity Coverage" section stating what is pinned and what is not — in-repo scripts generally remain covered by branch protection and review, not by this control. AGENTS.md cross-links it so whoever trips the check knows what to do.

## Release Notes

- [x] Not needed. `scripts/`, fixtures and root docs only.

## Checklist

- [x] I read `CONTRIBUTING.md`.
- [x] I followed `CODE_OF_CONDUCT.md`.
- [x] I did not include secrets, credentials, or private data.
- [x] I am not disclosing a security vulnerability publicly.