### PR TITLE
test(sandbox): stop asserting a keeper recycle the test cannot force

### DIFF
--- a/packages/sandbox/test/docker-sandbox.integration.test.ts
+++ b/packages/sandbox/test/docker-sandbox.integration.test.ts
@@ -69,14 +69,6 @@ async function waitForContainerFile(
   }
 }
 
-async function keeperId(docker: Docker, container: string): Promise<string> {
-  const result = await docker.run(["inspect", "--format", "{{.Id}}", container])
-  if (result.exitCode !== 0 || !result.stdout.trim()) {
-    throw new Error(`Could not inspect keeper ${container}: ${JSON.stringify(result)}`)
-  }
-  return result.stdout.trim()
-}
-
 describe.skipIf(!enabled)("dockerSandbox (real Docker)", { timeout: 120_000 }, () => {
   runProviderConformance({
     name: "dockerSandbox",
@@ -252,7 +244,6 @@ describe.skipIf(!enabled)("dockerSandbox (real Docker)", { timeout: 120_000 }, (
         signal: ctx("/").signal,
       })
       await h.filesystem.writeFile(sentinelPath, sentinel, ctx(h.workspaceRoot))
-      const originalKeeperId = await keeperId(docker, container)
       const saturator = `
         const { renameSync, rmSync, writeFileSync } = require("node:fs")
         const { Worker } = require("node:worker_threads")
@@ -332,15 +323,32 @@ describe.skipIf(!enabled)("dockerSandbox (real Docker)", { timeout: 120_000 }, (
       ])
       expect(saturatedPids).toMatchObject({ exitCode: 0, stdout: `${pidsLimit}\n` })
 
-      // Docker Desktop may admit a single exec task into a full cgroup. A bounded
-      // concurrent wave makes OCI startup contend at the limit; the keeper-ID
-      // assertion proves that at least one command actually triggered recovery.
+      // What this test can guarantee, and what it deliberately does not.
+      //
+      // The cgroup is verifiably full above (EAGAIN from the saturator, and
+      // `docker stats` reporting exactly `pidsLimit`). Under that pressure every
+      // command must still succeed and the workspace must survive. Those are the
+      // real contract and they are asserted below.
+      //
+      // Whether a keeper RECYCLE was needed to achieve it is not something this
+      // test can force. Recovery in `docker-exec.ts` fires only when a command
+      // fails to start with a PID-exhaustion signature; if Docker admits every
+      // exec into the full cgroup — which it does on some engine and kernel
+      // versions — nothing fails, so nothing is recovered, and the keeper is
+      // correctly left alone. Asserting a recycle here therefore asserted a race,
+      // and it failed intermittently on `main` while reporting "keeper did not
+      // recycle", which reads like a product defect and is not one.
+      //
+      // The recovery path itself is covered deterministically in
+      // `docker-backends.test.ts`, which injects a PID-exhaustion failure and
+      // pins the whole contract: one token captured before the attempt, the
+      // retry issued with an identical command, and the retried result returned.
+      // That is a stronger check than this one was, and it cannot flake.
       const recovered = await Promise.all(
         Array.from({ length: recoveryCommands }, (_, index) =>
           h.exec.runCommand({ command: `echo recovered-${index}` }, ctx(h.workspaceRoot)),
         ),
       )
-      const replacementKeeperId = await keeperId(docker, container)
       expect(recovered).toEqual(
         Array.from({ length: recoveryCommands }, (_, index) => ({
           exitCode: 0,
@@ -348,10 +356,6 @@ describe.skipIf(!enabled)("dockerSandbox (real Docker)", { timeout: 120_000 }, (
           stdout: `recovered-${index}\n`,
         })),
       )
-      expect(
-        replacementKeeperId,
-        `keeper did not recycle; command results: ${JSON.stringify(recovered)}`,
-      ).not.toBe(originalKeeperId)
       const persisted = await h.filesystem.readFile(sentinelPath, ctx(h.workspaceRoot))
       expect(persisted).toBe(sentinel)
     } finally {


### PR DESCRIPTION
## Summary

The `sandbox-docker` lane fails intermittently **on `main`** — twice in the last twelve CI runs, both on main — with:

```
recycles a PID-exhausted keeper and preserves its workspace
AssertionError: keeper did not recycle
  all 24 commands exitCode 0, keeper id unchanged
```

That message reads as a product defect. It is not one. The sandbox behaved correctly every time.

## Why it cannot pass reliably

Recovery in `docker-exec.ts` fires only when a command **fails to start** with a PID-exhaustion signature:

```js
if (opts.pidExhaustionRecovery !== undefined &&
    !firstAttempt.started &&
    isPidExhaustion(r)) { … recoverAndRetry … }
```

The test saturates the cgroup — and that half is solid, asserted before the failing line and therefore passing every time: the saturator reports `ERR_WORKER_INIT_FAILED` with `EAGAIN`, and `docker stats` reports PIDs at exactly `pidsLimit`. It then fires 24 concurrent execs hoping at least one loses the race at OCI startup, which is the only way a recycle can be triggered. Its own comment admits the shape of the problem:

> Docker Desktop may admit a single exec task into a full cgroup. A bounded concurrent wave makes OCI startup contend at the limit

On engine and kernel versions that admit **every** exec into a full cgroup, nothing fails, nothing needs recovering, and the keeper is correctly left alone. The assertion was a race, not a contract.

## It also duplicated stronger coverage

`docker-backends.test.ts` already covers the recovery path deterministically, by injecting a PID-exhaustion failure through the `pidExhaustionRecovery` seam. It pins strictly more than this ever did:

- one token captured **before** the attempt (so a queued command records the generation it actually enters)
- the retry issued with an identical command and the same signal
- the retried result returned to the caller
- plus a `test.each` over the trigger conditions

So removing the racing assertion loses no correctness coverage.

## What is kept

Everything this test uniquely proves, all of it deterministic:

- the cgroup really is saturated (`EAGAIN`, and `docker stats` at exactly the limit)
- **every command still succeeds** under that pressure
- the workspace sentinel survives

The comment now records why a recycle is not assertable here and points at the test that does assert it, so the next person doesn't re-add it. `keeperId` and `originalKeeperId` are removed — nothing else used them.

## Validation

`pnpm build` 0, `tsc --noEmit` on `@dawn-ai/sandbox` **0 errors**, `biome check` 0.

**Local run of the lane was not possible** — the Docker daemon on this machine is stopped, so the test fails at `ensureContainer` with `Cannot connect to the Docker daemon` before reaching any assertion. That is environmental and unrelated. Local verification would be weak evidence regardless: the whole defect is that behavior differs across engine and kernel versions, and CI's `sandbox-docker` lane is the environment that actually exhibited it. **That lane is the check that matters on this PR.**

Note the change only *removes* an assertion and dead code, so it cannot make the lane more likely to fail.

- [x] `pnpm build`
- [x] `pnpm typecheck` (`@dawn-ai/sandbox`)
- [x] `biome check`
- [ ] Real-Docker lane — deferred to CI, see above

## Release Notes

- [x] Not needed. Test-only; the changesets gate covers `packages/*/src/` and READMEs.

## Checklist

- [x] I read `CONTRIBUTING.md`.
- [x] I followed `CODE_OF_CONDUCT.md`.
- [x] I did not include secrets, credentials, or private data.
- [x] I am not disclosing a security vulnerability publicly.