### PR TITLE
feat(sdk): tell a policy when a request will resume a parked turn

### DIFF
--- a/.changeset/thread-access-resuming.md
+++ b/.changeset/thread-access-resuming.md
@@ -1,0 +1,26 @@
+---
+"@dawn-ai/sdk": patch
+"@dawn-ai/cli": patch
+"@dawn-ai/testing": patch
+---
+
+Add `resuming` to `ThreadAccessRequest`: a required boolean that is `true` when
+the request carries a resume credential and will continue a parked turn. It is
+additive — an existing policy compiles and behaves exactly as before.
+
+A policy that wants resumes treated differently from ordinary turns — step-up
+auth, a second approver, extra logging — should check `req.resuming` rather than
+`req.operation`. Two endpoints resume, and only one of them says so in its
+operation: `POST /threads/{thread_id}/resume` reports `run.resume`, but a
+`POST /agui/{routeId}` carrying a `resume` array reports `run.agui`, exactly as
+an ordinary AG-UI turn does. The request body is the only thing that separates
+them, and a policy never sees it, so keying the rule on `operation` leaves every
+AG-UI resume ungoverned.
+
+`resuming` is `false` everywhere else and never absent, so no policy needs
+`?? false`. An endpoint that gates more than once for one request — the gate
+before its side effects, the mid-flight recheck, the implicit create's recheck —
+reports the same value at every site.
+
+`createThreadAccessHarness().check()` accepts an optional `resuming`, defaulting
+to `false`.

--- a/apps/web/content/docs/thread-access.mdx
+++ b/apps/web/content/docs/thread-access.mdx
@@ -57,6 +57,42 @@ Dawn probes four paths, in order: `src/thread-access.ts`, `src/thread-access.js`
 | `headers` | Lowercase keys, repeated headers joined with `", "`. |
 | `method`, `url` | The originating request's method, and its path plus query. |
 | `requestedMetadata` | Client-supplied metadata on a create, already stripped of Dawn's reserved key. `undefined` everywhere else. |
+| `resuming` | `true` when this request carries a resume credential and will continue a parked turn. Always a boolean. See below. |
+
+### `resuming`: which requests continue a parked turn
+
+`resuming` is `true` when the request answers a parked human-approval prompt — it carries an `interruptId`/`resumeKey` credential and will continue an already-interrupted run rather than start a fresh one. It is `false` on every other request, and it is never absent, so a policy writes `if (req.resuming)` and never `?? false`.
+
+**Both doors resume.** Two different endpoints continue a parked turn, and only one of them says so in its `operation`:
+
+| Request | `operation` | `resuming` |
+|---|---|---|
+| `POST /threads/:thread_id/resume` | `run.resume` | always `true` |
+| `POST /agui/{routeId}` carrying a `resume` array | `run.agui` | `true` |
+| `POST /agui/{routeId}` with no `resume` | `run.agui` | `false` |
+| everything else | — | `false` |
+
+That middle row is the reason this field exists. An AG-UI resume reports `run.agui`, exactly as an ordinary AG-UI turn does — the only thing that distinguishes them is the request body, which a policy never sees. So **a policy that wants resumes held to a higher bar — step-up auth, a second approver, extra logging — must check `req.resuming`, not `req.operation`.** Keying that rule on `operation === "run.resume"` leaves every CopilotKit-driven resume ungoverned.
+
+`operation` and `resuming` answer different questions and neither replaces the other: `operation` is endpoint identity ("which door did this come through"), `resuming` is request shape ("what is in the body").
+
+An endpoint that gates more than once for a single request — the gate before its side effects, the mid-flight recheck, the implicit create's recheck — reports the **same** `resuming` at every one of them. One request, one value.
+
+```ts
+import { defineThreadAccess, deny, permit } from "@dawn-ai/sdk"
+
+export default defineThreadAccess({
+  // ...
+  update: (req) => {
+    if (!owns(req)) return deny()
+    // Resuming a parked approval is the moment the agent gets to act, so it
+    // costs a fresh step-up — on BOTH doors, which `operation` alone cannot see.
+    if (req.resuming && !hasStepUp(req.headers)) return deny({ status: 403 })
+    return permit()
+  },
+  fallback: (req) => (owns(req) ? permit() : deny()),
+})
+```
 
 `thread.metadata` is client-supplied and untrusted — anyone who can create a thread can write anything into it. **Authorize against `thread.access`**, which is the stamp your own `create` decision returned. Dawn stores it under a reserved key (`dawn:access`) that it strips from client input on every create path, so a client cannot forge one, and it is lifted out of `metadata` before your policy sees the row.
 

--- a/packages/cli/src/lib/dev/agui-handler.ts
+++ b/packages/cli/src/lib/dev/agui-handler.ts
@@ -226,6 +226,13 @@ export async function handleAgUiFetchRequest(options: AgUiFetchRequestOptions): 
 
     const requestUrl = new URL(request.url)
     const dawnInput = fromRunAgentInput(input)
+    // The one place this turn decides it is a resume. Computed HERE, above
+    // every gate site, because this endpoint gates up to twice per request and
+    // a turn that reported `resuming: true` at one gate and `false` at another
+    // would be describing two different requests. `fromRunAgentInput` leaves
+    // `resume` undefined for an absent OR empty array, so this is exactly the
+    // condition the resume claim below takes itself on.
+    const resuming = dawnInput.resume !== undefined
     const middlewareRequest: MiddlewareRequest = {
       assistantId: route.assistantId,
       headers: headersToRecord(request.headers),
@@ -259,6 +266,7 @@ export async function handleAgUiFetchRequest(options: AgUiFetchRequestOptions): 
       const g = gate({
         action: existing ? "update" : "create",
         operation: "run.agui",
+        resuming,
         threadId: input.threadId,
         ...(existing ? { thread: existing } : {}),
       })
@@ -270,7 +278,7 @@ export async function handleAgUiFetchRequest(options: AgUiFetchRequestOptions): 
       }
     }
 
-    if (dawnInput.resume !== undefined) {
+    if (resuming) {
       releaseResumeClaim = resumeClaims.tryClaim(input.threadId)
       if (!releaseResumeClaim) {
         return Response.json(
@@ -326,6 +334,7 @@ export async function handleAgUiFetchRequest(options: AgUiFetchRequestOptions): 
       const recheck = createGate({
         action: "update",
         operation: "run.agui",
+        resuming,
         thread: existingThread,
         threadId,
       })
@@ -335,6 +344,7 @@ export async function handleAgUiFetchRequest(options: AgUiFetchRequestOptions): 
       const created = await createGatedThreadForRun({
         gate: createGate,
         operation: "run.agui",
+        resuming,
         stamp: createStamp,
         store: threadsStore,
         threadId,

--- a/packages/cli/src/lib/dev/runtime-fetch-core.ts
+++ b/packages/cli/src/lib/dev/runtime-fetch-core.ts
@@ -2553,6 +2553,9 @@ async function handleResumeRequest(options: {
     const g = gate({
       action: "update",
       operation: "run.resume",
+      // Unconditionally: this endpoint continues a parked turn or it does
+      // nothing at all. See ThreadAccessRequest.resuming.
+      resuming: true,
       threadId,
       ...(existing ? { thread: existing } : {}),
     })

--- a/packages/cli/src/lib/dev/thread-gate.ts
+++ b/packages/cli/src/lib/dev/thread-gate.ts
@@ -40,6 +40,16 @@ export interface GateSpec {
   readonly threadId?: string
   readonly thread?: Thread
   readonly requestedMetadata?: Record<string, unknown>
+  /**
+   * Whether this request continues a parked turn — see
+   * `ThreadAccessRequest.resuming`. Optional HERE so the many call sites that
+   * can never be a resume say nothing; the gate defaults it to `false` and the
+   * policy always receives a boolean.
+   *
+   * An endpoint that gates more than once for one request must pass the SAME
+   * value at every site. Compute it once at the top of the handler.
+   */
+  readonly resuming?: boolean
   /** The response a denied READ must be indistinguishable from. Supply it whenever action is "read". */
   readonly notFound?: () => Response
 }
@@ -166,6 +176,9 @@ export function makeThreadGate(
       method,
       operation: spec.operation,
       requestedMetadata: spec.requestedMetadata,
+      // Required on the published type, optional on the spec: an omitted spec
+      // field is "this endpoint cannot resume", which is `false`.
+      resuming: spec.resuming ?? false,
       thread: spec.thread ? toThreadSubject(spec.thread) : undefined,
       threadId: spec.threadId,
       url,
@@ -222,16 +235,28 @@ export function makeThreadGate(
 export async function createGatedThreadForRun(args: {
   readonly gate: (spec: GateSpec) => Gate | Promise<Gate>
   readonly operation: ThreadOperation
+  /**
+   * The caller's own `resuming` — the recheck is the SAME request as the gate
+   * that authorized the create, so it must report the same value. Defaults to
+   * `false` for the endpoints that can never resume.
+   */
+  readonly resuming?: boolean
   readonly stamp: Record<string, unknown> | undefined
   readonly store: ThreadsStore
   readonly threadId: string
 }): Promise<{ readonly ok: true; readonly thread: Thread } | GateDenied> {
-  const { gate, operation, stamp, store, threadId } = args
+  const { gate, operation, resuming, stamp, store, threadId } = args
   const thread = await store.createThread({
     thread_id: threadId,
     ...(stamp ? { metadata: { [THREAD_ACCESS_METADATA_KEY]: stamp } } : {}),
   })
-  const recheck = gate({ action: "update", operation, thread, threadId: thread.thread_id })
+  const recheck = gate({
+    action: "update",
+    operation,
+    resuming: resuming ?? false,
+    thread,
+    threadId: thread.thread_id,
+  })
   const settled = isThenable(recheck) ? await recheck : recheck
   if (!settled.ok) return settled
   return { ok: true, thread }

--- a/packages/cli/test/thread-access-resuming.test.ts
+++ b/packages/cli/test/thread-access-resuming.test.ts
@@ -1,0 +1,318 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { dirname, join } from "node:path"
+import type { ThreadAccessPolicy, ThreadAccessRequest } from "@dawn-ai/sdk"
+import type { ThreadsStore } from "@dawn-ai/sqlite-storage"
+import type { RunnableConfig } from "@langchain/core/runnables"
+import type {
+  BaseCheckpointSaver,
+  CheckpointPendingWrite,
+  CheckpointTuple,
+} from "@langchain/langgraph-checkpoint"
+import { emptyCheckpoint, MemorySaver } from "@langchain/langgraph-checkpoint"
+import { afterEach, describe, expect, it } from "vitest"
+
+import { createRuntimeFetchHandler } from "../src/lib/dev/runtime-fetch-handler.js"
+
+const cleanup: Array<() => Promise<void> | void> = []
+
+afterEach(async () => {
+  for (const fn of cleanup.splice(0).reverse()) await fn()
+})
+
+const TRIVIAL_ROUTE = "export const graph = async () => ({ ok: true })\n"
+const HELLO_ROUTE = "/hello#graph"
+
+/**
+ * Same fixture-app shape as `thread-access-run-endpoints.test.ts`, plus the
+ * `checkpointer` seam — the AG-UI resume path only reaches its later gate sites
+ * when `resolvePendingResume` succeeds, and that needs a parked interrupt.
+ */
+async function setup(
+  options: {
+    readonly checkpointer?: BaseCheckpointSaver
+    readonly threadAccess?: ThreadAccessPolicy
+    readonly threadsStore?: ThreadsStore
+  } = {},
+): Promise<{
+  readonly handler: Awaited<ReturnType<typeof createRuntimeFetchHandler>>
+}> {
+  const appRoot = await mkdtemp(join(tmpdir(), "dawn-thread-access-resuming-"))
+  cleanup.push(() => rm(appRoot, { force: true, recursive: true }))
+  const files: Record<string, string> = {
+    "dawn.config.ts": "export default {}\n",
+    "package.json": '{ "name": "thread-access-resuming-fixture", "type": "module" }\n',
+    "src/app/hello/index.ts": TRIVIAL_ROUTE,
+  }
+  for (const [relativePath, source] of Object.entries(files)) {
+    const filePath = join(appRoot, relativePath)
+    await mkdir(dirname(filePath), { recursive: true })
+    await writeFile(filePath, source, "utf8")
+  }
+  const handler = await createRuntimeFetchHandler({
+    appRoot,
+    ...(options.checkpointer ? { checkpointer: options.checkpointer } : {}),
+    drainDeadlineMs: 250,
+    ...(options.threadAccess ? { threadAccess: options.threadAccess } : {}),
+    ...(options.threadsStore ? { threadsStore: options.threadsStore } : {}),
+  })
+  cleanup.push(() => handler.close())
+  return { handler }
+}
+
+function post(path: string, payload?: unknown, headers: Record<string, string> = {}): Request {
+  return new Request(new URL(path, "http://localhost"), {
+    headers: { "content-type": "application/json", ...headers },
+    method: "POST",
+    ...(payload !== undefined ? { body: JSON.stringify(payload) } : {}),
+  })
+}
+
+function get(path: string, headers: Record<string, string> = {}): Request {
+  return new Request(new URL(path, "http://localhost"), {
+    headers,
+    method: "GET",
+  })
+}
+
+/** A minimal, schema-valid `RunAgentInput` body for `POST /agui/:routeId`. */
+function aguiPost(
+  routeKey: string,
+  payload: { readonly threadId: string; readonly runId: string } & Record<string, unknown>,
+): Request {
+  return new Request(new URL(`/agui/${encodeURIComponent(routeKey)}`, "http://localhost"), {
+    headers: {
+      "content-type": "application/json",
+      accept: "text/event-stream",
+    },
+    method: "POST",
+    body: JSON.stringify({
+      state: {},
+      tools: [],
+      context: [],
+      forwardedProps: {},
+      ...payload,
+    }),
+  })
+}
+
+/** Reads the response body to completion so a streaming run finishes and releases its slot. */
+async function drain(response: Response): Promise<void> {
+  const reader = response.body?.getReader()
+  if (!reader) return
+  for (;;) {
+    const { done } = await reader.read()
+    if (done) return
+  }
+}
+
+/** What a policy was asked, request by request, in order. */
+interface Seen {
+  readonly action: ThreadAccessRequest["action"]
+  readonly operation: ThreadAccessRequest["operation"]
+  readonly resuming: unknown
+}
+
+interface RecordingPolicy {
+  readonly policy: ThreadAccessPolicy
+  readonly seen: Seen[]
+}
+
+/** Allows everything and records the shape of every request the gate built. */
+function recordingAllowPolicy(): RecordingPolicy {
+  const seen: Seen[] = []
+  return {
+    seen,
+    policy: {
+      fallback: (request) => {
+        seen.push({
+          action: request.action,
+          operation: request.operation,
+          resuming: request.resuming,
+        })
+        return { decision: "allow" }
+      },
+    },
+  }
+}
+
+const PARKED_THREAD_ID = "t-parked"
+const PARKED_INTERRUPT_ID = "perm-1786"
+const PARKED_RESUME_KEY = "ff5e1ad9ff5e1ad9ff5e1ad9ff5e1ad9"
+
+const PARKED_WRITE: CheckpointPendingWrite = [
+  "task-1",
+  "__interrupt__",
+  { id: PARKED_RESUME_KEY, value: { interruptId: PARKED_INTERRUPT_ID } },
+]
+
+/**
+ * Reports one well-formed parked interrupt on `PARKED_THREAD_ID`, so an AG-UI
+ * request carrying a matching `resume` gets past `resolvePendingResume` and
+ * reaches the gate sites that sit behind it. The route here never parks for
+ * real — this endpoint's gate sites read nothing but `pendingWrites`.
+ */
+class ParkedInterruptSaver extends MemorySaver {
+  override async getTuple(config: RunnableConfig): Promise<CheckpointTuple | undefined> {
+    const tuple = await super.getTuple(config)
+    if (config.configurable?.thread_id !== PARKED_THREAD_ID) return tuple
+    return {
+      checkpoint: tuple?.checkpoint ?? emptyCheckpoint(),
+      config,
+      ...(tuple?.metadata ? { metadata: tuple.metadata } : {}),
+      pendingWrites: [PARKED_WRITE],
+    }
+  }
+}
+
+describe("ThreadAccessRequest.resuming", () => {
+  it("is true on POST /threads/:id/resume", async () => {
+    const { policy, seen } = recordingAllowPolicy()
+    const { handler } = await setup({ threadAccess: policy })
+
+    await drain(
+      await handler.fetch(
+        post("/threads/t-resume/resume", {
+          resume: [
+            {
+              interruptId: PARKED_INTERRUPT_ID,
+              payload: "once",
+              status: "resolved",
+            },
+          ],
+          route: HELLO_ROUTE,
+        }),
+      ),
+    )
+
+    expect(seen).toEqual([{ action: "update", operation: "run.resume", resuming: true }])
+  })
+
+  it("is true on an AG-UI request that carries a resume", async () => {
+    const { policy, seen } = recordingAllowPolicy()
+    const { handler } = await setup({ threadAccess: policy })
+
+    await drain(
+      await handler.fetch(
+        aguiPost(HELLO_ROUTE, {
+          messages: [],
+          resume: [
+            {
+              interruptId: PARKED_INTERRUPT_ID,
+              payload: "once",
+              status: "resolved",
+            },
+          ],
+          runId: "run-1",
+          threadId: "t-agui-resume",
+        }),
+      ),
+    )
+
+    expect(seen[0]).toEqual({
+      action: "create",
+      operation: "run.agui",
+      resuming: true,
+    })
+  })
+
+  it("is false on an ordinary AG-UI turn that carries no resume", async () => {
+    const { policy, seen } = recordingAllowPolicy()
+    const { handler } = await setup({ threadAccess: policy })
+
+    await drain(
+      await handler.fetch(
+        aguiPost(HELLO_ROUTE, {
+          messages: [],
+          runId: "run-1",
+          threadId: "t-agui-turn",
+        }),
+      ),
+    )
+
+    expect(seen.length).toBeGreaterThan(0)
+    for (const entry of seen) {
+      expect(entry).toMatchObject({ operation: "run.agui", resuming: false })
+    }
+  })
+
+  it("is false on an empty AG-UI resume array, which carries no resume at all", async () => {
+    const { policy, seen } = recordingAllowPolicy()
+    const { handler } = await setup({ threadAccess: policy })
+
+    await drain(
+      await handler.fetch(
+        aguiPost(HELLO_ROUTE, {
+          messages: [],
+          resume: [],
+          runId: "run-1",
+          threadId: "t-agui-empty",
+        }),
+      ),
+    )
+
+    expect(seen.length).toBeGreaterThan(0)
+    for (const entry of seen) {
+      expect(entry).toMatchObject({ operation: "run.agui", resuming: false })
+    }
+  })
+
+  it("is false on POST /threads/:id/runs/stream", async () => {
+    const { policy, seen } = recordingAllowPolicy()
+    const { handler } = await setup({ threadAccess: policy })
+
+    await drain(
+      await handler.fetch(
+        post("/threads/t-stream/runs/stream", {
+          input: {},
+          route: HELLO_ROUTE,
+        }),
+      ),
+    )
+
+    expect(seen.length).toBeGreaterThan(0)
+    for (const entry of seen) {
+      expect(entry).toMatchObject({ operation: "run.stream", resuming: false })
+    }
+  })
+
+  it("is false on a thread read", async () => {
+    const { policy, seen } = recordingAllowPolicy()
+    const { handler } = await setup({ threadAccess: policy })
+
+    await handler.fetch(get("/threads/t-read"))
+
+    expect(seen).toEqual([{ action: "read", operation: "thread.get", resuming: false }])
+  })
+
+  it("reports the same value at every gate site one AG-UI resume passes through", async () => {
+    const { policy, seen } = recordingAllowPolicy()
+    const { handler } = await setup({
+      checkpointer: new ParkedInterruptSaver(),
+      threadAccess: policy,
+    })
+
+    // No threads-store row for this id, so the request gates as a `create` and
+    // then again as the `update` recheck inside `createGatedThreadForRun` — two
+    // gate sites, one request.
+    await drain(
+      await handler.fetch(
+        aguiPost(HELLO_ROUTE, {
+          messages: [],
+          resume: [
+            {
+              interruptId: PARKED_INTERRUPT_ID,
+              payload: "once",
+              status: "resolved",
+            },
+          ],
+          runId: "run-1",
+          threadId: PARKED_THREAD_ID,
+        }),
+      ),
+    )
+
+    expect(seen.length).toBeGreaterThan(1)
+    expect(new Set(seen.map((entry) => entry.resuming))).toEqual(new Set([true]))
+  })
+})

--- a/packages/sdk/src/thread-access.ts
+++ b/packages/sdk/src/thread-access.ts
@@ -121,6 +121,32 @@ export interface ThreadAccessRequest {
    * `run.*` create: those endpoints accept no thread metadata at all.
    */
   readonly requestedMetadata: Readonly<Record<string, unknown>> | undefined
+  /**
+   * This request carries a resume credential and will CONTINUE a parked turn —
+   * an already-interrupted run answering the `interruptId`/`resumeKey` pair a
+   * human-approval prompt parked — rather than start a fresh one.
+   *
+   * Separate from `operation` on purpose. `operation` is endpoint identity
+   * ("which door did this come through"); this is request SHAPE ("what is in
+   * the body"). Two different endpoints resume, and only one of them says so in
+   * its name:
+   *
+   * - `POST /threads/:id/resume` — `run.resume`. Always `true`; the endpoint
+   *   exists for nothing else.
+   * - `POST /agui/:routeId` — `run.agui`, exactly as an ordinary AG-UI turn
+   *   does. `true` when the AG-UI input carries a resume, `false` otherwise.
+   *   Nothing in `operation` distinguishes the two, which is what this field is
+   *   for.
+   *
+   * `false` everywhere else. Always a boolean, never absent — a policy that
+   * wants resumes held to a higher bar (step-up auth, a second approver, extra
+   * logging) writes `if (req.resuming)` and never `?? false`.
+   *
+   * One request reports ONE value: an endpoint that gates more than once — the
+   * gate before its side effects, the mid-flight recheck, the implicit create's
+   * recheck — reports the same `resuming` at every one of them.
+   */
+  readonly resuming: boolean
 }
 
 export interface ThreadAccessAllow {

--- a/packages/sdk/test/thread-access.contract.ts
+++ b/packages/sdk/test/thread-access.contract.ts
@@ -82,8 +82,20 @@ const request: ThreadAccessRequest = {
   method: "GET",
   url: "/threads/t-1/state",
   requestedMetadata: undefined,
+  resuming: false,
 }
 void request
+
+// Required and a plain boolean, never `boolean | undefined`: a policy that
+// treats resumes differently must be able to write `if (req.resuming)` with no
+// `?? false`, and a runtime that forgets to pass it must not compile.
+type _Resuming = Expect<Equal<ThreadAccessRequest["resuming"], boolean>>
+
+// A resume-aware policy: the AG-UI door reports `run.agui` whether or not it is
+// resuming, so `operation` cannot answer this question and `resuming` must.
+const stepUpOnResume: DawnThreadAccess = (req) =>
+  req.resuming && req.headers["x-step-up"] === undefined ? deny({ status: 403 }) : permit()
+void stepUpOnResume
 
 declare function sessionFor(
   token: string | undefined,

--- a/packages/testing/src/thread-access-harness.ts
+++ b/packages/testing/src/thread-access-harness.ts
@@ -19,6 +19,13 @@ export interface ThreadAccessCheckSpec {
   readonly method?: string
   readonly url?: string
   readonly requestedMetadata?: Readonly<Record<string, unknown>>
+  /**
+   * Whether this request continues a parked turn — see
+   * `ThreadAccessRequest.resuming`. Defaults to `false`, the value every
+   * endpoint but `POST /threads/:id/resume` and a resume-carrying
+   * `POST /agui/:routeId` reports.
+   */
+  readonly resuming?: boolean
 }
 
 export interface ThreadAccessHarness {
@@ -63,6 +70,7 @@ export function createThreadAccessHarness(options: {
         method: spec.method ?? defaultMethod(spec.action),
         operation,
         requestedMetadata: spec.requestedMetadata,
+        resuming: spec.resuming ?? false,
         thread: spec.thread,
         threadId: spec.threadId,
         url: spec.url ?? (spec.threadId ? `/threads/${spec.threadId}` : "/threads"),

--- a/packages/testing/test/thread-access-harness.test.ts
+++ b/packages/testing/test/thread-access-harness.test.ts
@@ -83,6 +83,26 @@ describe("createThreadAccessHarness", () => {
     expect(received?.requestedMetadata).toEqual({ tenant: "acme" })
   })
 
+  it("defaults resuming to false and passes an explicit one through", async () => {
+    const received: ThreadAccessRequest[] = []
+    const harness = createThreadAccessHarness({
+      policy: defineThreadAccess({
+        fallback: (req) => {
+          received.push(req)
+          return permit()
+        },
+      }),
+    })
+    await harness.check({ action: "read", threadId: "t-1" })
+    await harness.check({
+      action: "update",
+      operation: "run.resume",
+      resuming: true,
+      threadId: "t-1",
+    })
+    expect(received.map((req) => req.resuming)).toEqual([false, true])
+  })
+
   it("runs the result through the runtime's own normalization, so a malformed return denies", async () => {
     const harness = createThreadAccessHarness({
       policy: { fallback: () => undefined as never },


### PR DESCRIPTION
## Summary

Two endpoints resume a parked turn — continuing an agent run that paused for human approval, using an `interruptId`/`resumeKey` credential:

```http
POST /threads/t-abc/resume
{ "resume": { "interruptId": "perm-1786…", "resumeKey": "ff5e1ad9…" } }
```
```http
POST /agui/support-agent
{ "threadId": "t-abc", "messages": [...],
  "resume": [{ "interruptId": "perm-1786…", "status": "resolved" }] }
```

The first declares `operation: "run.resume"`; the second declares `run.agui`, because AG-UI is how CopilotKit's human-in-the-loop flow resumes. Both are gated and both require `update`, **so an owner-only policy — including the shipped scaffold — is unaffected.**

The gap is for a policy that wants resumes to be *harder* than ordinary turns — step-up auth, a second approver, extra logging:

```ts
update: (req) => req.operation === "run.resume" ? requireStepUp(req) : ownerOnly(req)
```

That author believes they have covered resumes. They have not: the same payload sent to `/agui` takes the `ownerOnly` path. And they could not fix it if told, because the only fact that distinguishes an AG-UI resume from an ordinary AG-UI turn lives in the request body, and `ThreadAccessRequest` never receives the body.

## The fix

`ThreadAccessRequest` gains `readonly resuming: boolean` — required, so no policy writes `?? false`.

**`ThreadOperation` is deliberately untouched.** Its doc defines it as "which endpoint asked", and every member names one endpoint; that stays true. Reporting `run.resume` from `/agui` would have made the union mean two different things, and adding a `run.agui.resume` member would have forced resume-hardening policies to match two values instead of one. This separates the two axes instead: `operation` is endpoint identity, `resuming` is request shape.

`true` on `POST /threads/:id/resume` and on `POST /agui/:routeId` when the AG-UI input carries a resume; `false` everywhere else.

**AG-UI derives it once.** A single hoisted `const resuming = dawnInput.resume !== undefined` feeds all three gate sites *and* the resume-claim branch that previously re-derived the condition inline — so one request cannot report `true` at one gate and `false` at another, and there is now exactly one place that decides.

## Validation

Every behavioral test was red first, and the reds were checked for being red for the *right* reason. One initially failed with `expected 0 to be greater than 0` because the request body was wrong for that endpoint and the policy was never invoked at all — fixed, then it failed on `resuming: undefined` like the rest.

**Mutation-tested where it counts.** Replacing the derivation with `const resuming = true` failed exactly the two `false` cases (ordinary AG-UI turn, empty resume array) and passed the other five — so the `resuming: false` assertions are load-bearing rather than decorative. The harness passthrough was mutation-tested the same way.

**The contract pin fired**, which is the guard working:

```
thread-access.contract.ts(76,7): error TS2741: Property 'resuming' is missing … but required in type 'ThreadAccessRequest'
```

It now also pins `Expect<Equal<ThreadAccessRequest["resuming"], boolean>>`, so the required-not-optional decision cannot silently become optional later.

`pnpm build` 0 · `typecheck` 0 · `lint` 0 · `check-docs` 0 · sdk 110 · cli **1578 passed** · testing 258.

## Two limits, stated

**An empty `resume: []` reports `false`.** `fromRunAgentInput` maps both an absent `resume` and an empty array to `undefined`, and that is the same condition the resume claim and `resolvePendingResume` already act on — an empty array takes no claim and resolves as an ordinary turn. So `false` matches what the request actually does. It has its own test, so the coupling is deliberate: if `fromRunAgentInput` ever preserves empty arrays, that test fails.

**AG-UI gate 2 has no direct assertion.** The mid-flight recheck is reached only when a row appears between the gate and the create; covering it needs both a synthetic checkpointer and the row-appears-after-the-gate store fixture. Gates 1 and 3 are tested. Since all sites read the same hoisted const, divergence is not reachable without deleting that const — but it is asserted by construction, not by a test.

- [x] `pnpm lint`
- [x] `pnpm build`
- [x] `pnpm typecheck`
- [x] `pnpm test` (sdk, cli, testing)
- [x] `node scripts/check-docs.mjs`
- [ ] Full `pnpm ci:validate` — deferred to CI

## Release Notes

- [x] Changeset added — `@dawn-ai/sdk`, `@dawn-ai/cli`, `@dawn-ai/testing`, all patch. Additive field; it says plainly that a policy wanting resumes treated differently should check `req.resuming` rather than `operation`, because AG-UI resumes report `run.agui`.

## Checklist

- [x] I read `CONTRIBUTING.md`.
- [x] I followed `CODE_OF_CONDUCT.md`.
- [x] I did not include secrets, credentials, or private data.
- [x] I am not disclosing a security vulnerability publicly — both routes are gated today; this adds granularity, it does not close an open door.