### PR TITLE
feat(langchain): logical-identity AG-UI tool projection

### DIFF
--- a/.changeset/logical-tool-identity.md
+++ b/.changeset/logical-tool-identity.md
@@ -1,0 +1,10 @@
+---
+"@dawn-ai/langchain": patch
+---
+
+Key root AG-UI/Agent-Protocol tool events by the model's tool-call ID
+(logical identity) whenever the model provides one, instead of the internal
+execution run ID. Interrupted-and-resumed tool calls now re-emit under the
+same ID, so standard AG-UI clients converge them into a single tool card
+instead of showing a duplicate. Streams without model tool-call IDs keep the
+previous behavior.

--- a/packages/ag-ui/test/conformance.test.ts
+++ b/packages/ag-ui/test/conformance.test.ts
@@ -30,11 +30,15 @@ const CANNED: DawnAgentStreamChunk[] = [
   { type: "token", data: "Researching" },
   {
     type: "tool_call",
-    data: { id: "root-tool-1", name: "searchCorpus", input: { query: "agents" } },
+    data: { id: "call_searchCorpus_0_0", name: "searchCorpus", input: { query: "agents" } },
   },
   {
     type: "tool_result",
-    data: { id: "root-tool-1", name: "searchCorpus", output: [{ path: "corpus/a.md" }] },
+    data: {
+      id: "call_searchCorpus_0_0",
+      name: "searchCorpus",
+      output: [{ path: "corpus/a.md" }],
+    },
   },
   { type: "plan_update", data: { todos: [{ content: "search", status: "completed" }] } },
   { type: "subagent.start", data: childIdentity },

--- a/packages/langchain/src/agent-adapter.ts
+++ b/packages/langchain/src/agent-adapter.ts
@@ -569,11 +569,17 @@ function classifyStreamEvent(
       const logicalId = readLogicalToolCallId(event.data.output)
       const id = logicalId ?? event.run_id
       const chunks: AgentStreamChunk[] = []
-      if (!rootTools.announcedToolCallIds.has(id) && (held !== undefined || logicalId !== undefined)) {
+      if (
+        !rootTools.announcedToolCallIds.has(id) &&
+        (held !== undefined || logicalId !== undefined)
+      ) {
         rootTools.announcedToolCallIds.add(id)
         chunks.push({ type: "tool_call", data: { id, name: event.name, input: held?.input } })
       }
-      chunks.push({ type: "tool_result", data: { id, name: event.name, output: event.data.output } })
+      chunks.push({
+        type: "tool_result",
+        data: { id, name: event.name, output: event.data.output },
+      })
       return {
         capturesFinalOutput: false,
         child,

--- a/packages/langchain/src/agent-adapter.ts
+++ b/packages/langchain/src/agent-adapter.ts
@@ -6,6 +6,7 @@ import { type BaseMessageLike, HumanMessage } from "@langchain/core/messages"
 import { Command } from "@langchain/langgraph"
 import type { BaseCheckpointSaver } from "@langchain/langgraph-checkpoint"
 import { createChatModel } from "./chat-model-factory.js"
+import { readLogicalToolCallId } from "./logical-tool-call-id.js"
 import { resolveProvider } from "./model-provider-resolver.js"
 import { isRetryableError, withRetry } from "./retry.js"
 import { materializeStateSchema, type ResolvedStateField } from "./state-adapter.js"
@@ -273,6 +274,13 @@ interface SubagentToolRunContexts {
   readonly contextsByToolRunId: Map<string, SubagentContext | null>
 }
 
+interface RootToolProjectionState {
+  /** Logical/fallback ids whose root tool_call chunk was already emitted this stream. */
+  readonly announcedToolCallIds: Set<string>
+  /** Root on_tool_start data awaiting resolution at on_tool_end, keyed by execution run id. */
+  readonly heldRootToolStarts: Map<string, { readonly name: string; readonly input: unknown }>
+}
+
 interface SubagentPhaseProjection {
   readonly chunk: AgentStreamChunk
   readonly context: SubagentContext
@@ -420,6 +428,7 @@ function parseSubagentPhaseEvent(event: LangChainStreamEvent): SubagentPhaseProj
 function classifyStreamEvent(
   event: LangChainStreamEvent,
   toolRuns: SubagentToolRunContexts,
+  rootTools: RootToolProjectionState,
 ): StreamEventProjection {
   const phase = parseSubagentPhaseEvent(event)
   if (phase) {
@@ -452,56 +461,92 @@ function classifyStreamEvent(
         interrupts: [],
       }
     }
+    case "on_chat_model_end": {
+      if (child) break
+      const output = event.data.output as { tool_calls?: unknown } | undefined
+      const calls = Array.isArray(output?.tool_calls) ? output.tool_calls : []
+      const chunks: AgentStreamChunk[] = []
+      for (const call of calls) {
+        if (!isRecord(call)) continue
+        const id = typeof call.id === "string" && call.id !== "" ? call.id : undefined
+        const name = typeof call.name === "string" && call.name !== "" ? call.name : undefined
+        if (id === undefined || name === undefined) continue
+        if (rootTools.announcedToolCallIds.has(id)) continue
+        rootTools.announcedToolCallIds.add(id)
+        chunks.push({ type: "tool_call", data: { id, name, input: call.args } })
+      }
+      if (chunks.length === 0) break
+      return {
+        capturesFinalOutput: false,
+        child,
+        chunks,
+        finalOutput: undefined,
+        interrupts: [],
+      }
+    }
     case "on_tool_start":
+      if (child) {
+        return {
+          capturesFinalOutput: false,
+          child,
+          chunks: [
+            {
+              type: "subagent.tool_call",
+              data: {
+                ...childIdentity(child),
+                id: event.run_id,
+                tool: event.name,
+                input: event.data.input ?? event.data.chunk ?? event.data.output,
+              },
+            },
+          ],
+          finalOutput: undefined,
+          interrupts: [],
+        }
+      }
+      rootTools.heldRootToolStarts.set(event.run_id, {
+        name: event.name,
+        input: event.data.input ?? event.data.chunk ?? event.data.output,
+      })
+      break
+    case "on_tool_end": {
+      if (child) {
+        return {
+          capturesFinalOutput: false,
+          child,
+          chunks: [
+            {
+              type: "subagent.tool_result",
+              data: {
+                ...childIdentity(child),
+                id: event.run_id,
+                tool: event.name,
+                output: event.data.output,
+              },
+            },
+          ],
+          finalOutput: undefined,
+          interrupts: [],
+        }
+      }
+      const held = rootTools.heldRootToolStarts.get(event.run_id)
+      rootTools.heldRootToolStarts.delete(event.run_id)
+      const logicalId = readLogicalToolCallId(event.data.output)
+      const id = logicalId ?? event.run_id
+      const chunks: AgentStreamChunk[] = []
+      if (!rootTools.announcedToolCallIds.has(id) && (held !== undefined || logicalId !== undefined)) {
+        rootTools.announcedToolCallIds.add(id)
+        chunks.push({ type: "tool_call", data: { id, name: event.name, input: held?.input } })
+      }
+      chunks.push({ type: "tool_result", data: { id, name: event.name, output: event.data.output } })
       return {
         capturesFinalOutput: false,
         child,
-        chunks: [
-          child
-            ? {
-                type: "subagent.tool_call",
-                data: {
-                  ...childIdentity(child),
-                  id: event.run_id,
-                  tool: event.name,
-                  input: event.data.input ?? event.data.chunk ?? event.data.output,
-                },
-              }
-            : {
-                type: "tool_call",
-                data: {
-                  id: event.run_id,
-                  name: event.name,
-                  input: event.data.input ?? event.data.chunk ?? event.data.output,
-                },
-              },
-        ],
+        chunks,
         finalOutput: undefined,
         interrupts: [],
       }
-    case "on_tool_end":
-      return {
-        capturesFinalOutput: false,
-        child,
-        chunks: [
-          child
-            ? {
-                type: "subagent.tool_result",
-                data: {
-                  ...childIdentity(child),
-                  id: event.run_id,
-                  tool: event.name,
-                  output: event.data.output,
-                },
-              }
-            : {
-                type: "tool_result",
-                data: { id: event.run_id, name: event.name, output: event.data.output },
-              },
-        ],
-        finalOutput: undefined,
-        interrupts: [],
-      }
+    }
     case "on_custom_event": {
       if (event.name !== "dawn.capability") break
       const payload = parseCapabilityEvent(event.data)
@@ -527,6 +572,7 @@ function classifyStreamEvent(
         interrupts: extractInterrupts(event.data.chunk) ?? [],
       }
     case "on_tool_error":
+      if (!child) rootTools.heldRootToolStarts.delete(event.run_id)
       return {
         capturesFinalOutput: false,
         child,
@@ -942,13 +988,17 @@ async function* streamFromRunnable(
       capturedInterrupts = []
       emittedInterruptIds = new Set()
       const subagentToolRuns: SubagentToolRunContexts = { contextsByToolRunId: new Map() }
+      const rootTools: RootToolProjectionState = {
+        announcedToolCallIds: new Set(),
+        heldRootToolStarts: new Map(),
+      }
 
       try {
         for await (const event of streamEventsFn(invocationInput, {
           ...invocationConfig,
           version: "v2",
         })) {
-          const projection = classifyStreamEvent(event, subagentToolRuns)
+          const projection = classifyStreamEvent(event, subagentToolRuns, rootTools)
           if (projection.capturesFinalOutput) {
             finalOutput = projection.finalOutput
           }

--- a/packages/langchain/src/agent-adapter.ts
+++ b/packages/langchain/src/agent-adapter.ts
@@ -461,6 +461,18 @@ function classifyStreamEvent(
         interrupts: [],
       }
     }
+    /**
+     * Root tool calls are announced here, from the model turn, rather than
+     * from `on_tool_start`'s execution run id. LangGraph re-executes an
+     * interrupted tool node from scratch on resume — the ToolNode callback
+     * gets a FRESH `run_id` each pass — but the checkpointed `AIMessage`
+     * keeps the SAME model/provider tool-call id across that whole
+     * interrupt→resume cycle. Announcing under that stable id lets an AG-UI
+     * client dedupe the pre-interrupt and post-resume streams into one card
+     * instead of rendering a duplicate. Execution run ids stay purely
+     * internal bookkeeping (see `heldRootToolStarts` below) and never reach
+     * the wire as an identity by themselves when a logical id is available.
+     */
     case "on_chat_model_end": {
       if (child) break
       const output = event.data.output as { tool_calls?: unknown } | undefined
@@ -529,6 +541,29 @@ function classifyStreamEvent(
           interrupts: [],
         }
       }
+      /**
+       * Three-way resolution for the root announce/result pairing:
+       *
+       *  (a) The call was already announced from `on_chat_model_end` (its id
+       *      is in `announcedToolCallIds`) — this event only ever needs to
+       *      emit the matching `tool_result`, keyed by that same id.
+       *  (b) The call was never announced from a model turn at all. This is
+       *      the resume-replay path: LangGraph re-executes an interrupted
+       *      tool node with NO new model turn, so `on_chat_model_end` never
+       *      fires for it — the only signals we get are this `on_tool_end`
+       *      (plus, usually, a held `on_tool_start`). We announce here,
+       *      preferring the logical id recovered from the output and
+       *      falling back to the held start's input for `data.input`; when
+       *      the provider/output carries no logical id either (e.g. a tool
+       *      returning a bare string), we fall back further to the
+       *      execution `run_id` itself so ID-less providers still get a
+       *      paired announce+result.
+       *  (c) An orphan result — no held `on_tool_start` AND no logical id —
+       *      means the stream began observation mid-execution (or the tool
+       *      genuinely returned nothing identifiable). There is nothing to
+       *      announce, so this stays result-only, matching the pre-rekey
+       *      behavior for that case exactly.
+       */
       const held = rootTools.heldRootToolStarts.get(event.run_id)
       rootTools.heldRootToolStarts.delete(event.run_id)
       const logicalId = readLogicalToolCallId(event.data.output)

--- a/packages/langchain/src/logical-tool-call-id.ts
+++ b/packages/langchain/src/logical-tool-call-id.ts
@@ -1,0 +1,43 @@
+/**
+ * Recover the model/provider tool-call ID (logical identity) from a tool
+ * execution's output, per the amended AG-UI orchestration projection design
+ * ("Identity model"). Handles the two root output shapes LangGraph's prebuilt
+ * ToolNode produces for Dawn tools:
+ *
+ *  - a ToolMessage (string-returning tools): `output.tool_call_id`
+ *  - a Command ({result, state}-returning tools): the last ToolMessage-shaped
+ *    entry in `output.update.messages`
+ *
+ * Returns undefined — never throws — for anything else, including hostile
+ * getters. Callers fall back to the execution run ID.
+ */
+export function readLogicalToolCallId(output: unknown): string | undefined {
+  try {
+    if (typeof output !== "object" || output === null) return undefined
+
+    const direct = readId(output)
+    if (direct !== undefined) return direct
+
+    const update = (output as { update?: unknown }).update
+    if (typeof update !== "object" || update === null) return undefined
+    const messages = (update as { messages?: unknown }).messages
+    if (!Array.isArray(messages)) return undefined
+    for (let index = messages.length - 1; index >= 0; index--) {
+      const id = readId(messages[index])
+      if (id !== undefined) return id
+    }
+    return undefined
+  } catch {
+    return undefined
+  }
+}
+
+function readId(value: unknown): string | undefined {
+  try {
+    if (typeof value !== "object" || value === null) return undefined
+    const id = (value as { tool_call_id?: unknown }).tool_call_id
+    return typeof id === "string" && id !== "" ? id : undefined
+  } catch {
+    return undefined
+  }
+}

--- a/packages/langchain/test/agent-adapter.test.ts
+++ b/packages/langchain/test/agent-adapter.test.ts
@@ -1230,6 +1230,75 @@ describe("logical-identity root tool projection", () => {
     ])
   })
 
+  test("a duplicate on_tool_end for the same run id never re-announces or swallows output", async () => {
+    const entry = streamOf([
+      {
+        event: "on_tool_start",
+        run_id: "dup-run-1",
+        name: "probe",
+        data: { input: { q: "x" } },
+      },
+      {
+        event: "on_tool_end",
+        run_id: "dup-run-1",
+        name: "probe",
+        data: { output: "first result" },
+      },
+      {
+        event: "on_tool_end",
+        run_id: "dup-run-1",
+        name: "probe",
+        data: { output: "second result" },
+      },
+      { event: "on_chain_end", run_id: "root", name: "LangGraph", data: { output: { ok: true } } },
+    ])
+
+    await expect(collect(entry)).resolves.toEqual([
+      { type: "tool_call", data: { id: "dup-run-1", name: "probe", input: { q: "x" } } },
+      { type: "tool_result", data: { id: "dup-run-1", name: "probe", output: "first result" } },
+      { type: "tool_result", data: { id: "dup-run-1", name: "probe", output: "second result" } },
+      { type: "done", data: { ok: true } },
+    ])
+  })
+
+  test("an unrelated execution whose output forges an already-announced id is keyed under that id", async () => {
+    const entry = streamOf([
+      {
+        event: "on_chat_model_end",
+        run_id: "model-1",
+        name: "model",
+        data: {
+          output: {
+            content: "",
+            tool_calls: [{ id: "call_x_1", name: "alpha", args: {} }],
+          },
+        },
+      },
+      {
+        event: "on_tool_start",
+        run_id: "beta-run",
+        name: "beta",
+        data: { input: {} },
+      },
+      {
+        event: "on_tool_end",
+        run_id: "beta-run",
+        name: "beta",
+        data: { output: { tool_call_id: "call_x_1", content: "beta-ok" } },
+      },
+      { event: "on_chain_end", run_id: "root", name: "LangGraph", data: { output: { ok: true } } },
+    ])
+
+    await expect(collect(entry)).resolves.toEqual([
+      { type: "tool_call", data: { id: "call_x_1", name: "alpha", input: {} } },
+      {
+        type: "tool_result",
+        data: { id: "call_x_1", name: "beta", output: { tool_call_id: "call_x_1", content: "beta-ok" } },
+      },
+      { type: "done", data: { ok: true } },
+    ])
+  })
+
   test("child tool events are untouched by the root re-key", async () => {
     const metadata = {
       dawn: {

--- a/packages/langchain/test/agent-adapter.test.ts
+++ b/packages/langchain/test/agent-adapter.test.ts
@@ -1293,7 +1293,11 @@ describe("logical-identity root tool projection", () => {
       { type: "tool_call", data: { id: "call_x_1", name: "alpha", input: {} } },
       {
         type: "tool_result",
-        data: { id: "call_x_1", name: "beta", output: { tool_call_id: "call_x_1", content: "beta-ok" } },
+        data: {
+          id: "call_x_1",
+          name: "beta",
+          output: { tool_call_id: "call_x_1", content: "beta-ok" },
+        },
       },
       { type: "done", data: { ok: true } },
     ])

--- a/packages/langchain/test/agent-adapter.test.ts
+++ b/packages/langchain/test/agent-adapter.test.ts
@@ -294,14 +294,6 @@ describe("native subagent event projection", () => {
     }
     expect(chunks).toEqual([
       { type: "token", data: "Parent " },
-      {
-        type: "tool_call",
-        data: {
-          id: "parent-task-run",
-          name: "task",
-          input: { subagent: "researcher", input: "Investigate" },
-        },
-      },
       { type: "subagent.start", data: childIdentity },
       {
         type: "subagent.message",
@@ -332,6 +324,14 @@ describe("native subagent event projection", () => {
       {
         type: "subagent.end",
         data: { ...childIdentity, final_message: "evidence" },
+      },
+      {
+        type: "tool_call",
+        data: {
+          id: "parent-task-run",
+          name: "task",
+          input: { subagent: "researcher", input: "Investigate" },
+        },
       },
       {
         type: "tool_result",
@@ -1010,5 +1010,272 @@ describe("executeAgent with DawnAgent descriptors", () => {
 
     const invokeConfig = invoke.mock.calls[0]?.[1] as { recursionLimit?: number }
     expect(invokeConfig?.recursionLimit).toBeUndefined()
+  })
+})
+
+describe("logical-identity root tool projection", () => {
+  function streamOf(events: readonly Record<string, unknown>[]) {
+    return {
+      invoke: vi.fn(),
+      async *streamEvents() {
+        yield* events
+      },
+    }
+  }
+
+  async function collect(entry: { invoke: unknown; streamEvents: unknown }) {
+    const chunks = []
+    for await (const chunk of streamAgent({
+      checkpointer: new MemorySaver(),
+      entry: entry as never,
+      input: { question: "hi" },
+      routeParamNames: [],
+      signal: new AbortController().signal,
+      tools: [],
+    })) {
+      chunks.push(chunk)
+    }
+    return chunks
+  }
+
+  test("announces root calls from on_chat_model_end and keys results by the ToolMessage id", async () => {
+    const entry = streamOf([
+      {
+        event: "on_chat_model_end",
+        run_id: "model-1",
+        name: "model",
+        data: {
+          output: {
+            content: "",
+            tool_calls: [{ id: "call_probe_1", name: "probe", args: { q: "x" } }],
+          },
+        },
+      },
+      {
+        event: "on_tool_start",
+        run_id: "probe-run-1",
+        name: "probe",
+        data: { input: { q: "x" } },
+      },
+      {
+        event: "on_tool_end",
+        run_id: "probe-run-1",
+        name: "probe",
+        data: { output: { tool_call_id: "call_probe_1", content: "probe-ok" } },
+      },
+      { event: "on_chain_end", run_id: "root", name: "LangGraph", data: { output: { ok: true } } },
+    ])
+
+    await expect(collect(entry)).resolves.toEqual([
+      { type: "tool_call", data: { id: "call_probe_1", name: "probe", input: { q: "x" } } },
+      {
+        type: "tool_result",
+        data: {
+          id: "call_probe_1",
+          name: "probe",
+          output: { tool_call_id: "call_probe_1", content: "probe-ok" },
+        },
+      },
+      { type: "done", data: { ok: true } },
+    ])
+  })
+
+  test("emits held frames at on_tool_end for a resume replay with no model turn", async () => {
+    const entry = streamOf([
+      {
+        event: "on_tool_start",
+        run_id: "replay-run-1",
+        name: "runBash",
+        data: { input: { command: "fetch" } },
+      },
+      {
+        event: "on_tool_end",
+        run_id: "replay-run-1",
+        name: "runBash",
+        data: { output: { tool_call_id: "call_runBash_0_0", content: "stdout" } },
+      },
+      { event: "on_chain_end", run_id: "root", name: "LangGraph", data: { output: { ok: true } } },
+    ])
+
+    await expect(collect(entry)).resolves.toEqual([
+      {
+        type: "tool_call",
+        data: { id: "call_runBash_0_0", name: "runBash", input: { command: "fetch" } },
+      },
+      {
+        type: "tool_result",
+        data: {
+          id: "call_runBash_0_0",
+          name: "runBash",
+          output: { tool_call_id: "call_runBash_0_0", content: "stdout" },
+        },
+      },
+      { type: "done", data: { ok: true } },
+    ])
+  })
+
+  test("falls back to the execution run id when no logical id exists anywhere", async () => {
+    const entry = streamOf([
+      {
+        event: "on_tool_start",
+        run_id: "legacy-run-1",
+        name: "probe",
+        data: { input: { q: "x" } },
+      },
+      {
+        event: "on_tool_end",
+        run_id: "legacy-run-1",
+        name: "probe",
+        data: { output: "plain string result" },
+      },
+      { event: "on_chain_end", run_id: "root", name: "LangGraph", data: { output: { ok: true } } },
+    ])
+
+    await expect(collect(entry)).resolves.toEqual([
+      { type: "tool_call", data: { id: "legacy-run-1", name: "probe", input: { q: "x" } } },
+      {
+        type: "tool_result",
+        data: { id: "legacy-run-1", name: "probe", output: "plain string result" },
+      },
+      { type: "done", data: { ok: true } },
+    ])
+  })
+
+  test("announced calls with no matching execution leave no stray result", async () => {
+    const entry = streamOf([
+      {
+        event: "on_chat_model_end",
+        run_id: "model-1",
+        name: "model",
+        data: {
+          output: {
+            content: "",
+            tool_calls: [{ id: "call_ghost_1", name: "ghost", args: {} }],
+          },
+        },
+      },
+      { event: "on_chain_end", run_id: "root", name: "LangGraph", data: { output: { ok: true } } },
+    ])
+
+    await expect(collect(entry)).resolves.toEqual([
+      { type: "tool_call", data: { id: "call_ghost_1", name: "ghost", input: {} } },
+      { type: "done", data: { ok: true } },
+    ])
+  })
+
+  test("ignores tool_calls with missing or empty ids and never announces twice", async () => {
+    const entry = streamOf([
+      {
+        event: "on_chat_model_end",
+        run_id: "model-1",
+        name: "model",
+        data: {
+          output: {
+            content: "",
+            tool_calls: [
+              { id: "", name: "probe", args: {} },
+              { name: "probe", args: {} },
+              { id: "call_probe_1", name: "probe", args: { q: 1 } },
+              { id: "call_probe_1", name: "probe", args: { q: 1 } },
+            ],
+          },
+        },
+      },
+      { event: "on_chain_end", run_id: "root", name: "LangGraph", data: { output: { ok: true } } },
+    ])
+
+    await expect(collect(entry)).resolves.toEqual([
+      { type: "tool_call", data: { id: "call_probe_1", name: "probe", input: { q: 1 } } },
+      { type: "done", data: { ok: true } },
+    ])
+  })
+
+  test("on_tool_error discards the held start without emitting frames", async () => {
+    const entry = streamOf([
+      {
+        event: "on_chat_model_end",
+        run_id: "model-1",
+        name: "model",
+        data: {
+          output: {
+            content: "",
+            tool_calls: [{ id: "call_gated_1", name: "runBash", args: { command: "x" } }],
+          },
+        },
+      },
+      {
+        event: "on_tool_start",
+        run_id: "gated-run-1",
+        name: "runBash",
+        data: { input: { command: "x" } },
+      },
+      {
+        event: "on_tool_error",
+        run_id: "gated-run-1",
+        name: "runBash",
+        data: {
+          error: {
+            name: "GraphInterrupt",
+            interrupts: [{ id: "int-1", value: { interruptId: "int-1", kind: "command" } }],
+          },
+        },
+      },
+      { event: "on_chain_end", run_id: "root", name: "LangGraph", data: { output: {} } },
+    ])
+
+    await expect(collect(entry)).resolves.toEqual([
+      { type: "tool_call", data: { id: "call_gated_1", name: "runBash", input: { command: "x" } } },
+      { type: "interrupt", data: { interruptId: "int-1", kind: "command" } },
+      { type: "done", data: {} },
+    ])
+  })
+
+  test("child tool events are untouched by the root re-key", async () => {
+    const metadata = {
+      dawn: {
+        subagent_stack: [{ callId: "call-child", name: "researcher", routeId: "/researcher" }],
+      },
+    }
+    const entry = streamOf([
+      {
+        event: "on_tool_start",
+        run_id: "child-tool-run",
+        name: "readFile",
+        data: { input: { path: "a.md" } },
+        metadata,
+      },
+      {
+        event: "on_tool_end",
+        run_id: "child-tool-run",
+        name: "readFile",
+        data: { output: { tool_call_id: "call_should_be_ignored", content: "text" } },
+        metadata,
+      },
+      { event: "on_chain_end", run_id: "root", name: "LangGraph", data: { output: {} } },
+    ])
+
+    const chunks = await collect(entry)
+    const childIdentity = {
+      call_id: "call-child",
+      subagent: "researcher",
+      route_id: "/researcher",
+      depth: 1,
+    }
+    expect(chunks).toEqual([
+      {
+        type: "subagent.tool_call",
+        data: { ...childIdentity, id: "child-tool-run", tool: "readFile", input: { path: "a.md" } },
+      },
+      {
+        type: "subagent.tool_result",
+        data: {
+          ...childIdentity,
+          id: "child-tool-run",
+          tool: "readFile",
+          output: { tool_call_id: "call_should_be_ignored", content: "text" },
+        },
+      },
+      { type: "done", data: {} },
+    ])
   })
 })

--- a/packages/langchain/test/logical-identity-graph.test.ts
+++ b/packages/langchain/test/logical-identity-graph.test.ts
@@ -170,7 +170,10 @@ describe("real-graph pins for logical tool identity", () => {
   }
 
   it("streamAgent keys root tool chunks by the model's tool-call id (string tool)", async () => {
-    const probe = convertToolToLangChain({ name: "probe", run: async () => ({ result: "probe-ok" }) })
+    const probe = convertToolToLangChain({
+      name: "probe",
+      run: async () => ({ result: "probe-ok" }),
+    })
     const graph = createReactAgent({
       llm: scriptedModel("call_probe_1", "probe", { q: "x" }),
       tools: [probe],
@@ -185,7 +188,7 @@ describe("real-graph pins for logical tool identity", () => {
       { type: "tool_call", data: { id: "call_probe_1", name: "probe", input: { q: "x" } } },
     ])
     expect(toolResults).toHaveLength(1)
-    expect((toolResults[0]?.data as { id?: unknown }).id).toBe("call_probe_1")
+    expect((toolResults[0]?.data as { id?: unknown } | undefined)?.id).toBe("call_probe_1")
   })
 
   it("streamAgent keys root tool chunks by the model's tool-call id (Command tool)", async () => {
@@ -210,8 +213,8 @@ describe("real-graph pins for logical tool identity", () => {
     const toolCalls = chunks.filter((c) => c.type === "tool_call")
     const toolResults = chunks.filter((c) => c.type === "tool_result")
     expect(toolCalls).toHaveLength(1)
-    expect((toolCalls[0]?.data as { id?: unknown }).id).toBe("call_writeTodos_1")
+    expect((toolCalls[0]?.data as { id?: unknown } | undefined)?.id).toBe("call_writeTodos_1")
     expect(toolResults).toHaveLength(1)
-    expect((toolResults[0]?.data as { id?: unknown }).id).toBe("call_writeTodos_1")
+    expect((toolResults[0]?.data as { id?: unknown } | undefined)?.id).toBe("call_writeTodos_1")
   })
 })

--- a/packages/langchain/test/logical-identity-graph.test.ts
+++ b/packages/langchain/test/logical-identity-graph.test.ts
@@ -17,6 +17,7 @@ import type { ChatResult } from "@langchain/core/outputs"
 import { MemorySaver } from "@langchain/langgraph"
 import { createReactAgent } from "@langchain/langgraph/prebuilt"
 import { describe, expect, it } from "vitest"
+import { streamAgent } from "../src/agent-adapter.js"
 import { materializeStateSchema } from "../src/state-adapter.js"
 import { convertToolToLangChain } from "../src/tool-converter.js"
 
@@ -150,5 +151,67 @@ describe("real-graph pins for logical tool identity", () => {
       (m: { tool_call_id?: unknown }) => typeof m?.tool_call_id === "string",
     )
     expect(toolMessage?.tool_call_id).toBe("call_writeTodos_1")
+  })
+
+  async function collectAgentChunks(graph: unknown) {
+    const chunks = []
+    for await (const chunk of streamAgent({
+      checkpointer: new MemorySaver(),
+      entry: graph as never,
+      input: { messages: [{ role: "user", content: "go" }] },
+      routeParamNames: [],
+      signal: new AbortController().signal,
+      threadId: "spike-thread-e2e",
+      tools: [],
+    })) {
+      chunks.push(chunk)
+    }
+    return chunks
+  }
+
+  it("streamAgent keys root tool chunks by the model's tool-call id (string tool)", async () => {
+    const probe = convertToolToLangChain({ name: "probe", run: async () => ({ result: "probe-ok" }) })
+    const graph = createReactAgent({
+      llm: scriptedModel("call_probe_1", "probe", { q: "x" }),
+      tools: [probe],
+      checkpointer: new MemorySaver(),
+      // biome-ignore lint/suspicious/noExplicitAny: dynamically-built options
+    } as any)
+
+    const chunks = await collectAgentChunks(graph)
+    const toolCalls = chunks.filter((c) => c.type === "tool_call")
+    const toolResults = chunks.filter((c) => c.type === "tool_result")
+    expect(toolCalls).toEqual([
+      { type: "tool_call", data: { id: "call_probe_1", name: "probe", input: { q: "x" } } },
+    ])
+    expect(toolResults).toHaveLength(1)
+    expect((toolResults[0]?.data as { id?: unknown }).id).toBe("call_probe_1")
+  })
+
+  it("streamAgent keys root tool chunks by the model's tool-call id (Command tool)", async () => {
+    const writeTodos = convertToolToLangChain({
+      name: "writeTodos",
+      run: (input: unknown) => {
+        const todos = (input as { todos: unknown }).todos
+        return { result: { todos }, state: { todos } }
+      },
+    })
+    const graph = createReactAgent({
+      llm: scriptedModel("call_writeTodos_1", "writeTodos", {
+        todos: [{ content: "first", status: "in_progress" }],
+      }),
+      tools: [writeTodos],
+      stateSchema: materializeStateSchema([{ name: "todos", reducer: "replace", default: [] }]),
+      checkpointer: new MemorySaver(),
+      // biome-ignore lint/suspicious/noExplicitAny: dynamically-built options
+    } as any)
+
+    const chunks = await collectAgentChunks(graph)
+    const toolCalls = chunks.filter((c) => c.type === "tool_call")
+    const toolResults = chunks.filter((c) => c.type === "tool_result")
+    expect(toolCalls).toHaveLength(1)
+    expect((toolCalls[0]?.data as { id?: unknown }).id).toBe("call_writeTodos_1")
+    expect(toolResults).toHaveLength(1)
+    expect((toolResults[0]?.data as { id?: unknown }).id).toBe("call_writeTodos_1")
   })
 })

--- a/packages/langchain/test/logical-identity-graph.test.ts
+++ b/packages/langchain/test/logical-identity-graph.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Real-graph pins for logical-identity tool projection (design Part A).
+ *
+ * Runs an actual createReactAgent graph under streamEvents v2 and pins the
+ * upstream shapes the agent-adapter re-key depends on:
+ *   - on_chat_model_end carries output.tool_calls with {id, name, args}
+ *   - on_tool_end (string tool) carries a ToolMessage with tool_call_id
+ *   - on_tool_end (Command tool) carries a Command whose update.messages
+ *     contains that ToolMessage
+ * If these fail after a LangChain upgrade, the projection re-key is broken
+ * upstream — fix the adapter, do not delete the pins.
+ */
+
+import { BaseChatModel } from "@langchain/core/language_models/chat_models"
+import { AIMessage, type BaseMessage } from "@langchain/core/messages"
+import type { ChatResult } from "@langchain/core/outputs"
+import { MemorySaver } from "@langchain/langgraph"
+import { createReactAgent } from "@langchain/langgraph/prebuilt"
+import { describe, expect, it } from "vitest"
+import { materializeStateSchema } from "../src/state-adapter.js"
+import { convertToolToLangChain } from "../src/tool-converter.js"
+
+class SequencedChatModel extends BaseChatModel {
+  private cursor = 0
+  constructor(private readonly responses: AIMessage[]) {
+    super({})
+  }
+  _llmType(): string {
+    return "sequenced-fake"
+  }
+  async _generate(_messages: BaseMessage[]): Promise<ChatResult> {
+    const msg = this.responses[this.cursor]
+    this.cursor += 1
+    if (!msg) throw new Error("SequencedChatModel ran out of canned responses")
+    return {
+      generations: [
+        {
+          text: typeof msg.content === "string" ? msg.content : "",
+          message: msg,
+        },
+      ],
+    }
+  }
+  // biome-ignore lint/suspicious/noExplicitAny: bindTools signature in the BaseChatModel hierarchy is loose
+  bindTools(_tools: any): any {
+    return this
+  }
+}
+
+interface RawEvent {
+  readonly event: string
+  readonly name: string
+  readonly run_id: string
+  // biome-ignore lint/suspicious/noExplicitAny: raw upstream surface under test
+  readonly data: any
+}
+
+async function collectRawEvents(graph: {
+  streamEvents: (input: unknown, options: Record<string, unknown>) => AsyncIterable<unknown>
+}): Promise<RawEvent[]> {
+  const events: RawEvent[] = []
+  for await (const event of graph.streamEvents(
+    { messages: [{ role: "user", content: "go" }] },
+    { version: "v2", configurable: { thread_id: "spike-thread" } },
+  )) {
+    events.push(event as RawEvent)
+  }
+  return events
+}
+
+function scriptedModel(toolCallId: string, toolName: string, args: Record<string, unknown>) {
+  return new SequencedChatModel([
+    new AIMessage({
+      content: "",
+      tool_calls: [{ id: toolCallId, name: toolName, args, type: "tool_call" }],
+    }),
+    new AIMessage({ content: "final answer" }),
+  ])
+}
+
+describe("real-graph pins for logical tool identity", () => {
+  it("on_chat_model_end exposes output.tool_calls with id/name/args at the root", async () => {
+    const probe = convertToolToLangChain({
+      name: "probe",
+      run: async () => ({ result: "probe-ok" }),
+    })
+    const graph = createReactAgent({
+      llm: scriptedModel("call_probe_1", "probe", { q: "x" }),
+      tools: [probe],
+      checkpointer: new MemorySaver(),
+      // biome-ignore lint/suspicious/noExplicitAny: dynamically-built options
+    } as any)
+
+    const events = await collectRawEvents(graph)
+    const modelEnds = events.filter((e) => e.event === "on_chat_model_end")
+    expect(modelEnds.length).toBeGreaterThanOrEqual(2)
+
+    const withCalls = modelEnds
+      .map((e) => e.data?.output?.tool_calls)
+      .filter((calls: unknown) => Array.isArray(calls) && calls.length > 0)
+    expect(withCalls).toHaveLength(1)
+    expect(withCalls[0]).toMatchObject([{ id: "call_probe_1", name: "probe", args: { q: "x" } }])
+  })
+
+  it("on_tool_end for a string tool exposes a ToolMessage with the model's tool_call_id", async () => {
+    const probe = convertToolToLangChain({
+      name: "probe",
+      run: async () => ({ result: "probe-ok" }),
+    })
+    const graph = createReactAgent({
+      llm: scriptedModel("call_probe_1", "probe", { q: "x" }),
+      tools: [probe],
+      checkpointer: new MemorySaver(),
+      // biome-ignore lint/suspicious/noExplicitAny: dynamically-built options
+    } as any)
+
+    const events = await collectRawEvents(graph)
+    const toolEnds = events.filter((e) => e.event === "on_tool_end" && e.name === "probe")
+    expect(toolEnds).toHaveLength(1)
+    const output = toolEnds[0]?.data?.output
+    expect(output?.tool_call_id).toBe("call_probe_1")
+    expect(String(output?.content)).toBe("probe-ok")
+  })
+
+  it("on_tool_end for a Command tool exposes the ToolMessage inside update.messages", async () => {
+    const writeTodos = convertToolToLangChain({
+      name: "writeTodos",
+      run: (input: unknown) => {
+        const todos = (input as { todos: unknown }).todos
+        return { result: { todos }, state: { todos } }
+      },
+    })
+    const graph = createReactAgent({
+      llm: scriptedModel("call_writeTodos_1", "writeTodos", {
+        todos: [{ content: "first", status: "in_progress" }],
+      }),
+      tools: [writeTodos],
+      stateSchema: materializeStateSchema([{ name: "todos", reducer: "replace", default: [] }]),
+      checkpointer: new MemorySaver(),
+      // biome-ignore lint/suspicious/noExplicitAny: dynamically-built options
+    } as any)
+
+    const events = await collectRawEvents(graph)
+    const toolEnds = events.filter((e) => e.event === "on_tool_end" && e.name === "writeTodos")
+    expect(toolEnds).toHaveLength(1)
+    const output = toolEnds[0]?.data?.output
+    const messages = output?.update?.messages
+    expect(Array.isArray(messages)).toBe(true)
+    const toolMessage = messages.find(
+      (m: { tool_call_id?: unknown }) => typeof m?.tool_call_id === "string",
+    )
+    expect(toolMessage?.tool_call_id).toBe("call_writeTodos_1")
+  })
+})

--- a/packages/langchain/test/logical-tool-call-id.test.ts
+++ b/packages/langchain/test/logical-tool-call-id.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest"
+import { readLogicalToolCallId } from "../src/logical-tool-call-id.js"
+
+describe("readLogicalToolCallId", () => {
+  it("reads tool_call_id from a ToolMessage-shaped output", () => {
+    expect(readLogicalToolCallId({ tool_call_id: "call_a_1", content: "ok" })).toBe("call_a_1")
+  })
+
+  it("reads tool_call_id from the ToolMessage inside a Command's update.messages", () => {
+    const command = {
+      update: {
+        todos: [],
+        messages: [{ tool_call_id: "call_b_2", content: "ok", name: "writeTodos" }],
+      },
+    }
+    expect(readLogicalToolCallId(command)).toBe("call_b_2")
+  })
+
+  it("prefers the last ToolMessage when update.messages has several", () => {
+    const command = {
+      update: {
+        messages: [
+          { tool_call_id: "call_old", content: "" },
+          { tool_call_id: "call_new", content: "" },
+        ],
+      },
+    }
+    expect(readLogicalToolCallId(command)).toBe("call_new")
+  })
+
+  it("returns undefined for empty-string ids", () => {
+    expect(readLogicalToolCallId({ tool_call_id: "" })).toBeUndefined()
+    expect(readLogicalToolCallId({ update: { messages: [{ tool_call_id: "" }] } })).toBeUndefined()
+  })
+
+  it("returns undefined for strings, null, undefined, arrays, and id-less records", () => {
+    expect(readLogicalToolCallId("plain result")).toBeUndefined()
+    expect(readLogicalToolCallId(null)).toBeUndefined()
+    expect(readLogicalToolCallId(undefined)).toBeUndefined()
+    expect(readLogicalToolCallId([])).toBeUndefined()
+    expect(readLogicalToolCallId({ content: "no id" })).toBeUndefined()
+    expect(readLogicalToolCallId({ update: { messages: "not-an-array" } })).toBeUndefined()
+  })
+
+  it("fails closed on hostile getters", () => {
+    const hostile = {}
+    Object.defineProperty(hostile, "tool_call_id", {
+      enumerable: true,
+      get() {
+        throw new Error("boom")
+      },
+    })
+    expect(readLogicalToolCallId(hostile)).toBeUndefined()
+  })
+})

--- a/test/generated/run-generated-research-activation.test.ts
+++ b/test/generated/run-generated-research-activation.test.ts
@@ -123,6 +123,9 @@ function correlateRootToolCalls(events: readonly AgUiEvent[]): Map<string, unkno
     expect(typeof event.toolCallId).toBe("string")
     expect(knownIds.has(event.toolCallId)).toBe(true)
   }
+  for (const { event } of starts) {
+    expect(String(event.toolCallId)).toMatch(/^call_/)
+  }
 
   const parsedArgsByName = new Map<string, unknown>()
   for (const { event: start } of starts) {
@@ -609,6 +612,12 @@ function assertSafeResearchJourney(
   ]) {
     expect(serializedActivityContent).not.toContain(privateValue)
   }
+  // Logical tool-call ids are the public tool identity now (amended AG-UI
+  // orchestration projection design): present as toolCallId, but never
+  // inside activity content.
+  for (const activity of events.filter((event) => event.type === "ACTIVITY_SNAPSHOT")) {
+    expect(JSON.stringify(activity.content)).not.toMatch(/call_[A-Za-z]+_\d+_\d+/)
+  }
   const kinds = events.map((event) => event.type)
   expect(kinds).not.toContain("ACTIVITY_DELTA")
   expect(kinds).not.toContain("CUSTOM")
@@ -619,7 +628,7 @@ function assertSafeResearchJourney(
 function assertGatedResearchInterrupt(
   events: readonly AgUiEvent[],
   ids: { readonly runId: string; readonly threadId: string },
-): { readonly interruptId: string } {
+): { readonly gatedToolCallId: string; readonly interruptId: string } {
   expect(events[0]).toMatchObject({
     type: "RUN_STARTED",
     runId: ids.runId,
@@ -670,6 +679,7 @@ function assertGatedResearchInterrupt(
   if (typeof toolCallId !== "string") {
     throw new Error("Gated runBash start omitted its tool-call id")
   }
+  expect(toolCallId).toBe("call_runBash_0_0")
   const correlated = events.filter((event) => event.toolCallId === toolCallId)
   const argEvents = correlated.filter((event) => event.type === "TOOL_CALL_ARGS")
   expect(argEvents.length).toBeGreaterThan(0)
@@ -686,10 +696,9 @@ function assertGatedResearchInterrupt(
       return event.delta
     })
     .join("")
-  const outerArgs = JSON.parse(encodedArgs) as { readonly input?: unknown }
-  expect(Object.keys(outerArgs)).toEqual(["input"])
-  expect(typeof outerArgs.input).toBe("string")
-  expect(JSON.parse(String(outerArgs.input))).toEqual({ command: FETCH_COMMAND })
+  // The re-keyed projection announces root tool calls from the model turn,
+  // so ARGS carry the model's parsed args directly (no ToolNode {input} wrapper).
+  expect(JSON.parse(encodedArgs)).toEqual({ command: FETCH_COMMAND })
   expect(events.filter((event) => event.type === "TOOL_CALL_RESULT")).toEqual([])
   expect(
     events.filter(
@@ -699,12 +708,13 @@ function assertGatedResearchInterrupt(
   expect(events.filter((event) => event.type === "TEXT_MESSAGE_CONTENT")).toEqual([])
   expectNoActivitySnapshots(events)
 
-  return { interruptId }
+  return { gatedToolCallId: toolCallId, interruptId }
 }
 
 function assertResumedGatedJourney(
   events: readonly AgUiEvent[],
   ids: { readonly runId: string; readonly threadId: string },
+  gatedToolCallId: string,
 ): void {
   assertSuccessfulTerminal(events, ids)
 
@@ -714,6 +724,7 @@ function assertResumedGatedJourney(
   if (typeof toolCallId !== "string") {
     throw new Error("Resumed runBash start omitted its tool-call id")
   }
+  expect(toolCallId).toBe(gatedToolCallId)
   const correlated = events.filter((event) => event.toolCallId === toolCallId)
   const argEvents = correlated.filter((event) => event.type === "TOOL_CALL_ARGS")
   expect(argEvents.length).toBeGreaterThan(0)
@@ -1053,7 +1064,7 @@ test("activates the default research scaffold through the complete npm lifecycle
         })
         expect(gatedJourney.status).toBe(200)
         expect(activeAimock.getRequests()).toHaveLength(gatedJournalStart + 1)
-        const { interruptId } = assertGatedResearchInterrupt(gatedJourney.events, {
+        const { gatedToolCallId, interruptId } = assertGatedResearchInterrupt(gatedJourney.events, {
           runId: gatedRunId,
           threadId: gatedThreadId,
         })
@@ -1073,10 +1084,14 @@ test("activates the default research scaffold through the complete npm lifecycle
         expect(resumedJourney.status).toBe(200)
         expect(activeAimock.getRequests()).toHaveLength(resumeJournalStart + 1)
         expect(resumeRunId).not.toBe(gatedRunId)
-        assertResumedGatedJourney(resumedJourney.events, {
-          runId: resumeRunId,
-          threadId: gatedThreadId,
-        })
+        assertResumedGatedJourney(
+          resumedJourney.events,
+          {
+            runId: resumeRunId,
+            threadId: gatedThreadId,
+          },
+          gatedToolCallId,
+        )
         return { interruptId }
       },
     )
@@ -1159,13 +1174,6 @@ test("activates the default research scaffold through the complete npm lifecycle
       builtThreadId,
       builtRunId,
       builtMessageId,
-      "call_recall_0_0",
-      "call_writeTodos_0_1",
-      "call_task_0_2",
-      "call_searchCorpus_0_3",
-      "call_readDoc_0_4",
-      "call_writeFile_0_5",
-      "call_runBash_0_0",
       "test-not-used",
       "ambient-secret",
     ]) {


### PR DESCRIPTION
## Summary

PR 1 of 3 for the amended AG-UI orchestration projection design (`docs/superpowers/specs/2026-08-18-ag-ui-orchestration-projection-design.md` on `blove/ag-ui-orchestration-projection`, commits `be9f64e6`/`569fcce9`).

- Re-keys Dawn's root AG-UI/Agent-Protocol `tool_call`/`tool_result` events from ephemeral LangChain execution run IDs to the **model's own tool-call IDs** (logical identity): calls are announced from `on_chat_model_end`, `on_tool_start` data is held per run ID, and results resolve at `on_tool_end` via a new `readLogicalToolCallId` helper (ToolMessage / Command shapes) with run-ID fallback.
- **Fixes a shipped defect:** an interrupted-then-resumed tool call (the gated `runBash` journey) previously rendered as two cards — one stuck "in progress" forever — because resume re-executes the tool node under a fresh run ID. Both runs now stream under the same logical ID (`call_runBash_0_0`, proven end-to-end in the generated activation lane), so standard AG-UI clients converge them into one card.
- Adds real-`createReactAgent` regression pins for the upstream LangChain shapes the re-key depends on, plus end-to-end `streamAgent` pins (string and Command tools).
- Patch changeset for `@dawn-ai/langchain`.

## Behavior notes (intentional, test-pinned)

- `TOOL_CALL_ARGS` on the announce path now carry the model's parsed args directly (e.g. `{"command": ...}`) instead of the LangChain tracer's `{"input": "<json>"}` wrapper; the resume-replay announce (no model turn) retains the held wrapper shape.
- ID-less streams (legacy/synthetic) keep their identity behavior, but the generic `tool_call` frame now emits at `on_tool_end` adjacent to its result rather than at `on_tool_start`; erroring ID-less executions emit no `tool_call` (real providers always announce from the model turn).
- Duplicate model tool-call IDs in one stream collapse to one announce (convergence semantics).

## Test Plan

- [x] Real-graph spike pins: `on_chat_model_end` tool_calls, `ToolMessage.tool_call_id`, Command `update.messages` (3 tests)
- [x] `readLogicalToolCallId` unit tests incl. hostile getters (6 tests)
- [x] Adapter re-key: 9 new projection tests (announce/resume-replay/fallback/ghost/dup-ids/error-discard/child-untouched/orphan+collision policy pins)
- [x] End-to-end `streamAgent` pins on real graphs (2 tests)
- [x] AG-UI conformance stream with logical-style IDs (`verifyEvents` green, 82/82)
- [x] Generated research activation lane: safe journey `^call_` positive assertions, gated/resumed ID convergence, activity-content exclusion (1/1, ~90s)
- [x] `pnpm build`, `pnpm lint`, langchain 217/217, core 504/504, cli 1583 passed / 3 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)