### PR TITLE
feat(create-dawn-app): tell new users how to see their agent

### DIFF
--- a/.changeset/scaffold-ui-signposts.md
+++ b/.changeset/scaffold-ui-signposts.md
@@ -1,0 +1,9 @@
+---
+"create-dawn-ai-app": patch
+"@dawn-ai/devkit": patch
+---
+
+Point new users at a UI after scaffolding. The research template's next steps
+now name `npx dawn inspect` (the Inspector the template already installs) and
+link the web UI recipe, and the basic template no longer points at a README it
+does not ship.

--- a/apps/web/content/docs/getting-started.mdx
+++ b/apps/web/content/docs/getting-started.mdx
@@ -193,6 +193,16 @@ curl -s -X POST http://127.0.0.1:3000/threads/$THREAD_ID/runs/wait \
 
 The `#agent` suffix is required — it selects the agent entry on the route. The report lands in `workspace/reports/` inside the project. Thread state checkpoints to `.dawn/checkpoints.sqlite`; threads persist across dev-server restarts.
 
+## 5. See it in a UI
+
+`curl` is not the only surface. The scaffold already installs `@dawn-ai/inspector`, so in another terminal you can open the [Inspector](/docs/inspector) — a browser UI over the app's live memory store, where the records the agent writes with `remember` show up for review:
+
+```bash
+npx dawn inspect
+```
+
+For a chat UI in front of the agent, follow the [Research assistant web UI](/docs/recipes/research-web-ui) recipe. Dawn ships the plan and subagent activity renderers as a package, so a React client passes `dawnActivityRenderers` from [`@dawn-ai/ag-ui/react`](/docs/ag-ui) to CopilotKit's `renderActivityMessages` rather than hand-building cards. The scaffold itself stays server-first and has no client dependencies.
+
 When you are ready to ship, compare [Deployment Options](/docs/deployment) and follow [Node and Docker](/docs/deployment/node) for the default self-hosted path.
 
 ## Where to go next

--- a/packages/create-dawn-app/src/index.ts
+++ b/packages/create-dawn-app/src/index.ts
@@ -64,6 +64,10 @@ function printNextSteps(options: CliOptions): void {
     "  # add OPENAI_API_KEY",
     "  npm run verify",
     "  npm run dev       # Dawn dev server on http://127.0.0.1:3000",
+    "",
+    "See your agent:",
+    "  npx dawn inspect  # memory Inspector (browser UI), in a second terminal",
+    "  # chat UI: https://dawnai.org/docs/recipes/research-web-ui",
   ]
   const basicSteps = [
     changeDirectoryStep,
@@ -82,7 +86,9 @@ function printNextSteps(options: CliOptions): void {
     isWindows ? "Next steps (PowerShell):" : "Next steps:",
     ...(options.template === "research" ? researchSteps : basicSteps),
     "",
-    "See README.md for the full tour, or https://github.com/cacheplane/dawnai",
+    options.template === "research"
+      ? "See README.md for the full tour, or https://github.com/cacheplane/dawnai"
+      : "See AGENTS.md for the app's conventions, or https://dawnai.org/docs/getting-started",
     "",
   ]
   process.stdout.write(`${lines.join("\n")}\n`)

--- a/packages/create-dawn-app/test/create-app.test.ts
+++ b/packages/create-dawn-app/test/create-app.test.ts
@@ -172,8 +172,13 @@ describe("create-dawn-ai-app", () => {
         "  # add OPENAI_API_KEY",
         "  npm run verify",
         "  npm run dev       # Dawn dev server on http://127.0.0.1:3000",
+        "",
+        "See your agent:",
+        "  npx dawn inspect  # memory Inspector (browser UI), in a second terminal",
+        "  # chat UI: https://dawnai.org/docs/recipes/research-web-ui",
       ].join("\n"),
     )
+    expect(scaffoldResult.stdout).toContain("See README.md for the full tour")
     expect(scaffoldResult.stdout).not.toContain("npm run check")
     expect(scaffoldResult.stdout).not.toContain("npm test")
     expect(scaffoldResult.stdout).not.toContain("export OPENAI_API_KEY")
@@ -198,6 +203,10 @@ describe("create-dawn-ai-app", () => {
         "  # add OPENAI_API_KEY",
         "  npm run verify",
         "  npm run dev       # Dawn dev server on http://127.0.0.1:3000",
+        "",
+        "See your agent:",
+        "  npx dawn inspect  # memory Inspector (browser UI), in a second terminal",
+        "  # chat UI: https://dawnai.org/docs/recipes/research-web-ui",
       ].join("\n"),
     )
     expect(stdout).not.toContain("npm run check")
@@ -224,6 +233,10 @@ describe("create-dawn-ai-app", () => {
         "  # add OPENAI_API_KEY",
         "  npm run verify",
         "  npm run dev       # Dawn dev server on http://127.0.0.1:3000",
+        "",
+        "See your agent:",
+        "  npx dawn inspect  # memory Inspector (browser UI), in a second terminal",
+        "  # chat UI: https://dawnai.org/docs/recipes/research-web-ui",
       ].join("\n"),
     )
     expect(stdout).not.toContain("  cp .env.example .env")
@@ -314,6 +327,11 @@ describe("create-dawn-ai-app", () => {
         "  npm run dev       # Dawn dev server on http://127.0.0.1:3000",
       ].join("\n"),
     )
+    expect(stdout).toContain(
+      "See AGENTS.md for the app's conventions, or https://dawnai.org/docs/getting-started",
+    )
+    expect(stdout).not.toContain("See README.md")
+    expect(stdout).not.toContain("npx dawn inspect")
     expect(stdout).not.toContain("generate route + tool types")
     expect(stdout).not.toContain(".env.example")
     expect(stdout).not.toContain("npm run verify")
@@ -351,6 +369,11 @@ describe("create-dawn-ai-app", () => {
         "  npm run dev       # Dawn dev server on http://127.0.0.1:3000",
       ].join("\n"),
     )
+    expect(stdout).toContain(
+      "See AGENTS.md for the app's conventions, or https://dawnai.org/docs/getting-started",
+    )
+    expect(stdout).not.toContain("See README.md")
+    expect(stdout).not.toContain("npx dawn inspect")
     expect(stdout).not.toContain("export OPENAI_API_KEY")
     expect(stdout).not.toContain(".env.example")
     expect(stdout).not.toContain("Copy-Item")

--- a/packages/devkit/templates/app-research/README.md
+++ b/packages/devkit/templates/app-research/README.md
@@ -43,6 +43,9 @@ ships them, so a React client passes `dawnActivityRenderers` to CopilotKit's
 and also provides cited reports, generic tool cards, suggestion prompts,
 standard permission handling, and memory-candidate review. This generated
 starter remains server-first and contains no web UI or client dependencies.
+Separately, `npx dawn inspect` opens the
+[Dawn Inspector](https://dawnai.org/docs/inspector) — a browser UI over this
+app's live memory store, already installed here as a devDependency.
 
 ## Check it offline
 


### PR DESCRIPTION
## Summary

A newcomer scaffolds a Dawn app and the CLI's last words are:

```
  npm run dev       # Dawn dev server on http://127.0.0.1:3000
```

Nothing about how to *see* the agent. Two concrete gaps that closes:

- The templates already install `@dawn-ai/inspector` — a real browser UI, launched with `dawn inspect` — and never mention it.
- There's no pointer to an agent UI at all, even though #484 made that an install plus one prop.

The research next-steps now end with:

```
See your agent:
  npx dawn inspect  # memory Inspector (browser UI), in a second terminal
  # chat UI: https://dawnai.org/docs/recipes/research-web-ui
```

Also fixes a dangling pointer: the `basic` branch told users to "See README.md", but `packages/devkit/templates/app-basic/` has no README. It now points at `AGENTS.md`, which exists.

`getting-started.mdx` gains a short "See it in a UI" step after the `curl` walkthrough, and the research template README gains one sentence about the Inspector it installs.

## Notes

- Every command was verified against real code: `@dawn-ai/cli` is a runtime dependency of both templates so `node_modules/.bin/dawn` exists, `registerInspectCommand` is wired, and `resolveInspectorServer` walks the app's own `node_modules`.
- A fourth "Where to go next" card was attempted and reverted — `scripts/check-docs.mjs:1508` pins that set to exactly three titles, so the guidance is a prose step instead.
- The new lines are identical on POSIX and PowerShell (`npx dawn inspect` is cross-platform), and the basic template asserts negatively that it prints neither the research lines nor the stale README pointer.

## Test Plan

- [x] `create-dawn-ai-app` 11 passed (assertions updated for both platforms, not weakened)
- [x] `@dawn-ai/devkit` 33 passed, `@dawn-ai/cli` 1583 passed / 3 skipped
- [x] `check-docs` and `pnpm lint` exit 0

## What this does not do

Promote a web client into the scaffold. That is a genuine product decision — it would mean restructuring the single-package template into npm workspaces, negotiating ports, extending the byte-for-byte example↔template parity guard, teaching the generated-app harness to orchestrate two processes, and building the browser activation gate the earlier design named as its prerequisite. Signposting is the honest fix until that call is made.

🤖 Generated with [Claude Code](https://claude.com/claude-code)