### PR TITLE
fix(web): build workspace dependencies before the docs site

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -11,6 +11,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@dawn-ai/sdk": "workspace:*",
     "@mdx-js/loader": "^3.1.1",
     "@mdx-js/mdx": "^3.1.1",
     "@mdx-js/react": "^3.1.1",

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "buildCommand": "cd ../.. && pnpm turbo run build --filter='./packages/*' --filter='!@dawn-ai/inspector' --filter=@dawn-ai/web"
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,6 +65,9 @@ importers:
 
   apps/web:
     dependencies:
+      '@dawn-ai/sdk':
+        specifier: workspace:*
+        version: link:../../packages/sdk
       '@mdx-js/loader':
         specifier: ^3.1.1
         version: 3.1.1


### PR DESCRIPTION
Fixes the Vercel deployment, which has been failing on **every commit** — not just PRs. I scanned back through `main` and found zero successful deployments in the last 21 commits carrying a Vercel status, so the published docs site has not deployed in some time.

## The failure

```
Error: Command "pnpm run build" exited with 1
```

The project's effective settings (read from the Vercel API) are Root Directory `apps/web`, Build Command `pnpm run build`, Node `24.x`. So Vercel runs `apps/web`'s own script — bare `next build` — and nothing else.

The build log shows the sequence:

1. `pnpm install` warns seven times: `Failed to create bin … ENOENT: /vercel/path0/packages/cli/dist/index.js`. Normal at install time — no workspace package has been built yet.
2. `✓ Compiled successfully in 14.2s`.
3. `Running TypeScript ...` → eight `TS2307`s, all raised from `packages/core/src/**`: `@dawn-ai/permissions`, `@dawn-ai/sdk`, `@dawn-ai/workspace`, `@dawn-ai/sqlite-storage` cannot be resolved.

No workspace package has a `dist/`, so type resolution falls through to `packages/core/src`, whose own sibling imports cannot resolve either.

**Why it never reproduced locally:** the root `pnpm build` is `turbo run build`, and turbo's build task carries `dependsOn: ["^build"]` — so every package is built before `apps/web` typechecks. Vercel bypasses turbo entirely by running the package script directly. `apps/web`'s `build` is plain `next build`, with no dependency ordering of its own.

## The fix

An `apps/web/vercel.json` routing the build back through turbo. `vercel.json` is read from the configured Root Directory, hence the placement; the full repo is present at `/vercel/path0` (the install warnings above prove it), so `cd ../..` reaches the workspace root.

**Two things had to be right, and the first attempt got both wrong.**

*The three excluded Next apps are not an optimization.* My first version ran the whole workspace and still failed — on `@dawn-ai/inspector`, with `ENOENT: packages/inspector/.next/next-server.js.nft.json`. Vercel injects config into every Next build it finds (`Applying modifyConfig from Vercel` appears in the log), and under that the inspector's build dies. It builds fine locally. The docs site does not need it, nor the two example web apps.

*And `apps/web` never declared `@dawn-ai/sdk`,* which it imports in `app/components/landing/FeatureRouting.tsx`. It resolved only through a root-level pnpm hoist (`node_modules/@dawn-ai/sdk -> ../../packages/sdk`, at the workspace root — not linked into `apps/web` at all). No declaration means **no turbo edge**, so turbo scheduled `sdk` and `web` in *parallel* and `apps/web`'s typecheck raced `sdk`'s build. The full-workspace build passed locally by scheduling luck. That declaration is now in the diff.

I tried the narrower `--filter=@dawn-ai/web...` first and it failed even after declaring `sdk`: `@dawn-ai/sdk` itself declares no dependencies while its source imports `@dawn-ai/core`, so the undeclared chain continues. Untangling those package boundaries is a real cleanup but not this PR's job — a broken deploy should not wait on it.

## Verification

From a clean worktree off `main`, `pnpm install --frozen-lockfile`, no `dist/` anywhere:

- **Reproduced the failure**: `pnpm run build` in `apps/web` → exit 1, the same eight `TS2307`s.
- **Confirmed the mechanism**: moving a single `packages/permissions/dist` aside in an otherwise-built tree produces the identical error at `packages/core/src/capabilities/types.ts(1,39)`, and restoring it clears the error.
- **Verified the fix as Vercel runs it** — from `apps/web`, forced and uncached: `Tasks: 25 successful, 25 total`, `Cached: 0 cached, 25 total`, exit 0, `.next` produced. (My first two verification runs hit turbo's cache and were worthless; `--force` is what makes this evidence real.)

`check-docs`, `check-changesets` and `pnpm lint` all exit 0. No changeset — `@dawn-ai/web` is private and this ships nothing to consumers.

## Follow-up, not in this PR

`apps/web` importing `@dawn-ai/sdk` without declaring it. It works today only because pnpm's layout resolves it anyway, and it is exactly what made the narrower build filter fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

