### PR TITLE
test(harness): boot two processes and prove the web hop

### DIFF
--- a/docs/superpowers/plans/2026-08-26-harness-two-process.md
+++ b/docs/superpowers/plans/2026-08-26-harness-two-process.md
@@ -93,7 +93,7 @@ W4/W5 use **dedicated prompts and fixtures**, not `SAFE_PROMPT`/`GATED_PROMPT`, 
 
 **C7 — against the background: "`script === "start"` injects `HOST`/`PORT` — a Next process would interpret those differently."** Sharper than that: Next **ignores** them. `PORT=45322 HOST=127.0.0.1 next start -p 3010` binds `*:3010`, and `HOST`/`HOSTNAME` are ignored entirely (wildcard bind). So a hypothetical `script: "start:web"` would boot the web client on hard-coded 3010 — colliding with a developer's own workbench — while the harness polled the allocated port to death. Not a problem in this slice (D1 chooses `dev:web`), but it is why `start:web` must not be added without also fixing the port branch. Recorded in §6.
 
-No other contradictions. All three investigations agree on: nesting over multi-child, `-- --port N` last-flag-wins for Next, module-scope `DAWN_SERVER_URL` read at runtime, `GENERATED_APP_UNSET_ENV` ordering, telemetry env vars, and process-group kill reaping the whole `next dev` tree (5-process group, 0 survivors, 1183ms).
+No other contradictions. All three investigations agree on: nesting over multi-child, `-- --port N` last-flag-wins for Next, module-scope `DAWN_SERVER_URL` read at runtime, `GENERATED_APP_UNSET_ENV` ordering, telemetry env vars, and process-group kill reaping the whole `next dev` tree (5-process group, 0 survivors). *Amended after implementation:* the 1183ms once quoted for that reap does not reproduce — five runs through the real `terminateSubprocess` at load average 21.65 gave 56/57/60/134/145ms, still with zero survivors.
 
 ---
 
@@ -326,8 +326,20 @@ function assertRecordedServerExit(
       (line[opening.length] === " " || line[opening.length] === ")"),
   )
   expect(commandLineIndex).toBeGreaterThanOrEqual(0)
-  const commandBlock = lines.slice(commandLineIndex).join("
-")
+  // Bound the block at the NEXT recorded command too. Nesting appends the inner
+  // (web) child FIRST, so a slice that ran to the end of the file would read the
+  // SERVER block's exit line and pronounce the web child recorded no matter what
+  // the web block actually says. (Amended after implementation: this plan shipped
+  // the unbounded `lines.slice(commandLineIndex)` here, which passes on the very
+  // `webFirst` fixture Step 2 prescribes. The anchor alone is not sufficient.)
+  const nextCommandOffset = lines
+    .slice(commandLineIndex + 1)
+    .findIndex((line) => /^\$ \(cd .+ && .+\)$/.test(line))
+  const commandBlock = (
+    nextCommandOffset < 0
+      ? lines.slice(commandLineIndex)
+      : lines.slice(commandLineIndex, commandLineIndex + 1 + nextCommandOffset)
+  ).join("\n")
   expect(commandBlock).not.toContain("[exit pending")
   expect(commandBlock).not.toContain("[exit unavailable")
   expect(commandBlock).toMatch(/\[exit (?:-?\d+|null) signal (?:[A-Z0-9]+|none)\]/)
@@ -642,7 +654,7 @@ export PATH=~/.nvm/versions/node/v24.19.0/bin:$PATH && pnpm ci:validate
 
 **T1 — A stray Dawn server on port 3002 makes a completely unwired proxy look correct.** If `DAWN_SERVER_URL` never reaches the web child, the handlers fall back to `http://127.0.0.1:3002`. On a clean CI box nothing listens there, so readiness 502s and fails loudly. **On a developer's machine running their own workbench, readiness returns 200 from the wrong server, and W1 and W3 also pass.** W2 — `/threads/<safeThreadId>/state` → 200 — is the only assertion that distinguishes "reached a Dawn server" from "reached THIS one". Do not weaken it, do not make it conditional, and do not replace the 200 with a "not 502" check.
 
-**T2 — `+2` on the W4 aimock delta is the only assertion that proves the run reached a model at all.** If you soften it to `toBeGreaterThanOrEqual` because the first run disagreed, W4 degrades into "CopilotKit returned some SSE" and the whole hop claim goes dark. Correct the constant instead.
+**T2 — `+2` on the W4 aimock delta is the assertion that pins the run to EXACTLY two model calls.** It is not what proves a model was reached — `assertWebHopJourney`'s `reconstructAssistantText(events) === WEB_REPLY` does that, and `WEB_REPLY` appears nowhere in the repo but the aimock fixture. What `+2` catches is a hop that invoked the run twice: that lands `+4` with the same reply text and passes every other W4 assertion. If you soften it to `toBeGreaterThanOrEqual` because the first run disagreed, that whole class goes dark. Correct the constant instead.
 
 **T3 — `assertRecordedServerExit`'s bare prefix is green by accident.** `$ (cd <appRoot> && npm run dev` is a prefix of the `dev:web` line too. It lands on the right block today only because nesting appends the inner child first. Task 3 anchors it; a reviewer will read the anchor as unnecessary churn, so the comment and the commit message must say *why*. Without Task 3 Step 2, the anchor itself is untested until the full lane runs.
 
@@ -660,7 +672,7 @@ export PATH=~/.nvm/versions/node/v24.19.0/bin:$PATH && pnpm ci:validate
 
 **T10 — Next 16 refuses a second `next dev` from the same project directory** ("Another next dev server is already running", PID-liveness based). Every lane run scaffolds a fresh temp dir, so this cannot bite today — but a leaked child breaks the *next* run in that directory, not the current one, so the failure appears unrelated to whatever caused it.
 
-**T11 — `next dev` releases its port ~1183ms after SIGTERM.** `terminateSubprocess`'s stop oracle is "port stopped accepting", and `graceMs` is 2s. Under CI contention it can escalate to SIGKILL — still correct. A `subprocess group … did not stop within 4000ms` error is the grace window, not a leak.
+**T11 — a `next dev` group can escalate to SIGKILL under contention, and that is still correct.** `terminateSubprocess`'s stop oracle is "port stopped accepting", with `graceMs` 2s and `forceMs` 2s. A `subprocess group … did not stop within 4000ms` error is the grace window, not a leak. *Amended after implementation:* the "~1183ms to release the port" figure this trap once led with does not reproduce — five runs through the real `terminateSubprocess` at load average 21.65 gave 56/57/60/134/145ms with zero survivors. Do not use it, or the fixture delays in `packaged-app.test.ts`, to size `PACKAGED_NPM_ACTION_SETTLE_MS`: that constant budgets a nested session's whole `finally` (its own settle, then a 2s + 2s terminate, then a transcript append), not a reap.
 
 **T12 — Two servers double the ways one failure masks another.** With nesting, an inner start failure surfaces the *inner's* message and the outer's stdout only reaches the transcript. The readiness message now names the script (`npm run dev:web`) and the probe; keep it that way or a web failure will read as a Dawn-server failure.
 

--- a/docs/superpowers/plans/2026-08-26-harness-two-process.md
+++ b/docs/superpowers/plans/2026-08-26-harness-two-process.md
@@ -1,0 +1,699 @@
+# Two-Process Activation Lane Implementation Plan (SP3b)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` (recommended) or `superpowers:executing-plans` to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Teach `withPackagedNpmServer` to boot a second child with no `/healthz`, nest the generated Next web client inside the existing Dawn dev session, and prove — over plain `fetch`, no browser — that the generated web client reaches **this** generated server through both of its route handlers.
+
+**Architecture:** Two nested `withPackagedNpmServer` calls, server outer / web inner. The helper gains one option (`readiness`) and one widened enum (`script`); everything else about spawn, teardown, transcript and abort plumbing is untouched. The web child runs `npm run dev:web` — the documented command — and never requests `/`.
+
+**Spec authority:** `docs/superpowers/specs/2026-08-19-dawn-workbench-design.md:277` — "teaching the generated-app harness to build a web workspace and **boot two processes**". The Playwright gate is SP4 and is out of scope (§5).
+
+**Execution baseline:** branch `blove/harness-two-process` off `ba84ad89`.
+
+**Toolchain traps:** Prefix every node/pnpm command with `export PATH=~/.nvm/versions/node/v24.19.0/bin:$PATH && `. Never bare `biome check --write`. Never pipe a gate through `tail` (it hides the exit code). Verify `git branch --show-current` before starting and before each commit.
+
+---
+
+## 1. DECISIONS
+
+### D1 — The web child boots with `next dev`, via `npm run dev:web`, from the app root
+
+`npm run dev:web` is the command the scaffold's next-steps text tells a user to run on minute one; nothing currently proves it works, including the `--` terminator on the root delegator that `packages/devkit/test/template-root-scripts.test.ts` exists to protect.
+
+**Not `next start`.** A production boot would re-prove what `npm run build` already proved (the lane runs `next build` and asserts `web/.next` exists at `run-generated-research-activation.test.ts:1046`), and it needs a root `start:web` script the template does not have — a template edit plus the `rootManifest.scripts` `toEqual` pin at `:1063`, for ~1.5s of marginal coverage. See §6 STILL OPEN.
+
+Cost is bounded because **the lane never requests `/`**: `/` costs 15–36s cold in dev (35.9s measured), while `/api/dawn/*` costs 0.66–1.7s and `/api/copilotkit/info` 2.4–8.6s.
+
+### D2 — Readiness is `GET /api/dawn/memory/candidates` → 2xx
+
+Next compiles route handlers lazily, so a 2xx here means the route's whole module graph compiled **and** the proxy reached a Dawn server. Readied at 2486ms / 0.66s across two independent measurements against a 60s budget.
+
+Rejected: stdout `Ready in Xms` (fires 12–29s early; fired at 597ms on a build whose `/` then served 500 for 180s), TCP connect (fires within ~15ms of the stdout line — same lie), `/` (10.9–30.6s), `/api/copilotkit/info` (returned **200 with the upstream dead** — it never contacts Dawn), a template `/api/health` route (a trivial route readied at 3666ms while `/` needed 16,116ms more; it certifies only "Next is listening", which TCP gives free — plus it would ship an unasked-for public endpoint in every scaffolded app and move the `templates.test.ts:457` parity counts).
+
+**False-ready does not error, it hangs.** A request issued at the `Ready in` line blocked 20,676ms and then returned 200. That is why the probe must be an HTTP 2xx on a route the journeys use.
+
+`GET /api/dawn/threads` → 403 was the other candidate. It is kept — as an **assertion** (W1), not as the ready gate, because 403 never touches the Dawn server and so proves strictly less.
+
+### D3 — `PACKAGED_NPM_READY_TIMEOUT_MS` stays 60_000, and there is no `warmUp` hook
+
+24–90x headroom on the measured probe. The `/api/copilotkit/*` lazy compile (2.4–8.6s, worst right after a `next build` — this lane's exact sequence) is paid inside W3, an ordinary `fetch` with a 60s per-request budget, so it needs no separate warm-up machinery. Do not raise the budget; do not add `warmUp`.
+
+### D4 — Compose by nesting; do not make the helper multi-child
+
+Nesting already gives LIFO teardown, per-child `finally`, per-child transcripts, and a per-child `terminateSubprocess(child, groupPid, closed, url)` that probes *that* child's port. Measured non-abort semantics are all correct: inner-fails-to-start tears down the outer and propagates the inner's error unwrapped; inner-action-throws dies `inner -> outer` with error identity preserved. Nesting also makes port allocation safer, not riskier: when the inner allocates, the outer server is already **bound** (0 hits in 3,000 allocations against a held port).
+
+### D5 — Fix the abort path in the same change
+
+On abort, `awaitWithAbort` (`packaged-app.ts:713`) stops awaiting the action and the outer runs its `finally` — measured 29ms after abort, with the inner child **still alive** for another 500–1000ms. Today that leaks a dangling fetch; with nesting it leaks a live `next` process group, loses LIFO order, and lets two children `appendFile` the same `commands.log` concurrently. Four lines, one test.
+
+### D6 — `DAWN_SERVER_URL` is injected at spawn, not at build
+
+Both handlers read it at module scope with `export const runtime = "nodejs"`, and Next does **not** inline it: the built server chunk contains `process.env.DAWN_SERVER_URL??"http://127.0.0.1:3002"` verbatim, and a build at port 4713 started at 4711 answered 4711's body. Pass `env: { DAWN_SERVER_URL: url }` on the inner call. This composes with the credential machinery unchanged: `removeEnvironmentVariables(env, GENERATED_APP_UNSET_ENV)` runs at `:631`, **before** `Object.assign(env, {…, ...options.env})` at `:632`.
+
+Also set `COPILOTKIT_TELEMETRY_DISABLED=true` and `DO_NOT_TRACK=1`: without them the runtime prints "anonymous telemetry enabled" and makes an outbound call, in a lane whose entire claim is hermeticity.
+
+### D7 — Leave `allocatePort` alone; assert the two ports differ instead
+
+3,000 serial allocations → 3,000 distinct; 3,000 sequential pairs → 0 collisions; 3,000 concurrent pairs → 0; a port only recurs after 16,355 allocations. A speculative rewrite buys nothing. One `expect(webPort).not.toBe(serverPort)` line closes the residual.
+
+### D8 — The assertion set: six web assertions, none of which duplicate an existing one
+
+`write-template.ts:53` renames `*.test.ts.template` → `*.test.ts`, and the root `test` script fans out `--workspaces`, so `npm test` in this lane **already** runs the web workspace's own suite: proxy allowlist forward + reject, the 502 body, header passthrough, ConnectScreen-on-502, hydrate, transcript, MemoryPanel. Do not re-prove any of it over HTTP.
+
+| | Assertion | What only two processes can prove |
+|---|---|---|
+| W1 | `GET /api/dawn/threads` → 403 `{"error":"Not proxied"}` | the allowlist denies by default in a real Next process |
+| W2 | `GET /api/dawn/threads/<safeThreadId>/state` → 200 echoing the thread id and the safe journey's citation; a random id → 404 | **the proxy reached THIS server** — not the hard-coded `:3002` default, not a stray dev server. The single highest-value assertion in the slice |
+| W3 | `GET /api/copilotkit/info` → 200, `agents` has `default`, `mode === "sse"`, `telemetryDisabled === true` | the runtime is mounted at the basePath the client uses, under the agent id every hook resolves, and is not phoning home |
+| W4 | one full run through `POST /api/copilotkit/agent/default/run` → success terminal, exact assistant text, one `dawn.plan` `ACTIVITY_SNAPSHOT` whose `content` deep-equals the fixture, `writeTodos` still suppressed, +2 aimock, then `/threads/<webThreadId>/state` → 200 | Dawn's events survive a third-party runtime that re-validates and re-encodes every frame — and our ids reached Dawn's checkpointer through the hop |
+| W5 | gated run → `outcome.type === "interrupt"` with `metadata.detail.command`; resume run carrying `resume[]` → success + `TOOL_CALL_RESULT` on the same tool-call id | the interrupt outcome and the resume envelope survive the CopilotKit hop. Highest-risk contract in the app; it regressed once (#360) |
+| W6 | W1–W3 move the aimock journal by **zero**; the commands transcript contains no `ambient-secret`; the web child's exit is recorded | the web tier has no model path except through Dawn, and the second child dies |
+
+W4/W5 use **dedicated prompts and fixtures**, not `SAFE_PROMPT`/`GATED_PROMPT`, so the existing journeys' aimock accounting is untouched and no assumption is made about whether aimock fixtures are consumed or reusable.
+
+**Never assert `info.agents.default.className`** — it is minified and varies across builds (`Fe` / `xe` / `nm`).
+
+**Never assert `RUN_STARTED.runId`/`threadId` equality through the hop.** CopilotKit adds an `input` echo to that frame, and id echo is a property of a third-party runtime. W2/W4's thread-state reads prove id round-trip in a way that does not depend on it.
+
+---
+
+## 2. CONTRADICTIONS
+
+**C1 — dev vs. start for the web child. Three investigations, three answers.** Investigation 1 said `next dev` with a proxy-route probe; investigation 2 said `next start` because dev's cold `/` is 25–36s against a 60s ready budget; investigation 3 said both. **Resolution: `next dev` only.** Investigation 2's objection is entirely about `/`, and D1/D2 never request `/`: readiness is the proxy route at 0.66–2.5s, which investigation 2 did not measure as a readiness candidate. Its own numbers agree — it measured `/api/dawn/*` at 0.66s in dev. Verified by reading `packages/devkit/templates/app-research/package.json.template`: there is no `start:web`, so investigation 2's recommendation silently requires a template change it did not cost.
+
+**C2 — the readiness probe.** Investigation 1: `/api/dawn/memory/candidates` → 200. Investigation 2: `/api/copilotkit/info` → 200. Investigation 3: `/api/dawn/threads` → 403. **Investigation 1 is right, and investigation 2's choice is disqualified by investigation 2's own evidence** — `/info` returned 200 with the Dawn server dead, because `HttpAgent` does not implement `getCapabilities`, so `/info` never dials upstream. Investigation 3's 403 probe is safe but proves less. Confirmed by reading `AppShell.tsx:61`: `SERVER_PROBE_PATH = "/api/dawn/memory/candidates"` — the app's own definition of "connected" is exactly the chosen probe.
+
+**C3 — `warmUp`.** Investigation 1 designed a `warmUp` hook; 2 and 3 did not. **Rejected.** The compile it would pay for lands inside W3, an assertion that must run anyway. Nothing in this lane charges a request to a budget tight enough to flake on 8.6s.
+
+**C4 — `assertRecordedServerExit` prefix collision.** Investigation 3 flags it as an active hazard; investigation 2 flags it as a reason to use `<app>/web` as the cwd. **Both overstate it today, and both are right that it must be fixed.** Verified by reading `:806-818`: it uses `lastIndexOf`, and nesting appends the inner (web) block **first**, so the server block is always last and the match lands correctly by accident. That is precisely the latent, green-while-broken shape this harness has a history of. Anchor the match (Task 3) — as trap prevention, not as a bug fix; say so in the commit message so a reviewer does not delete it as unnecessary.
+
+**C5 — helper signature scope.** Investigation 1 proposed `readiness` + `warmUp` + `timeoutMs` + a four-value `script` union. Investigation 2 proposed `readiness` + a `portInjection` option. Investigation 3 proposed a `readyProbe` + widening `script` to arbitrary strings. **Narrowest sufficient version wins:** `readiness` plus a three-value closed union `"dev" | "dev:web" | "start"`. No `timeoutMs` (D3), no `warmUp` (C3), no `portInjection` (with `start:web` out of scope there is exactly one web target, and a closed union keeps the port branch exhaustive).
+
+**C6 — against the background: "a bind-close-rebind window that is fine for one process and racier for two."** Two independent measurements say otherwise (0 collisions in 500 and in 3,000 sequential pairs; 0 in 3,000 concurrent pairs; reuse distance 16,355). The background's caution is not wrong in principle but is not supported by measurement, and nesting shrinks rather than widens the window (D4). No code change.
+
+**C7 — against the background: "`script === "start"` injects `HOST`/`PORT` — a Next process would interpret those differently."** Sharper than that: Next **ignores** them. `PORT=45322 HOST=127.0.0.1 next start -p 3010` binds `*:3010`, and `HOST`/`HOSTNAME` are ignored entirely (wildcard bind). So a hypothetical `script: "start:web"` would boot the web client on hard-coded 3010 — colliding with a developer's own workbench — while the harness polled the allocated port to death. Not a problem in this slice (D1 chooses `dev:web`), but it is why `start:web` must not be added without also fixing the port branch. Recorded in §6.
+
+No other contradictions. All three investigations agree on: nesting over multi-child, `-- --port N` last-flag-wins for Next, module-scope `DAWN_SERVER_URL` read at runtime, `GENERATED_APP_UNSET_ENV` ordering, telemetry env vars, and process-group kill reaping the whole `next dev` tree (5-process group, 0 survivors, 1183ms).
+
+---
+
+## 3. TASKS
+
+### Task 0: Baseline — record the numbers you must not regress
+
+- [ ] **Step 1: Confirm branch and capture green counts.**
+
+```bash
+git branch --show-current    # blove/harness-two-process
+export PATH=~/.nvm/versions/node/v24.19.0/bin:$PATH && \
+  pnpm exec vitest --run --config test/generated/vitest.config.ts test/harness/packaged-app.test.ts
+```
+
+Expected: all pass. **Record the file's test count** — every later gate compares against it. Note this config's `globalSetup` boots Verdaccio, so first run is slow; that is normal.
+
+- [ ] **Step 2: Record the activation lane's current wall time.**
+
+```bash
+export PATH=~/.nvm/versions/node/v24.19.0/bin:$PATH && time pnpm exec vitest --run \
+  --config test/generated/vitest.config.ts -t "activates the default research scaffold"
+```
+
+Expected: pass, ~144s body. Record the number; Task 6 compares against it.
+
+---
+
+### Task 1 (judgment): Give `withPackagedNpmServer` a readiness seam and a web target
+
+**Files:** `test/harness/packaged-app.ts`, `test/harness/packaged-app.test.ts`
+
+- [ ] **Step 1: Add the readiness types and the two implementations**, above `assertPackagedNpmChildRunning` (currently `:458`).
+
+```ts
+export type PackagedNpmScript = "dev" | "dev:web" | "start"
+
+export interface PackagedNpmReadiness {
+  /** Quoted in every readiness failure, e.g. `GET /healthz -> {"status":"ready"}`. */
+  readonly describe: string
+  /**
+   * One probe attempt. `detail` from the LAST attempt is quoted in the timeout
+   * message: with two children, a 502 body naming an unreachable upstream is the
+   * difference between a five-minute diagnosis and an hour spent blaming the
+   * wrong process.
+   */
+  readonly probe: (
+    baseUrl: string,
+    signal: AbortSignal,
+  ) => Promise<{ readonly detail?: string; readonly ready: boolean }>
+}
+
+export const dawnHealthzReadiness: PackagedNpmReadiness = {
+  describe: `GET /healthz -> {"status":"ready"}`,
+  async probe(baseUrl, signal) {
+    const response = await fetch(new URL("/healthz", baseUrl), { signal })
+    const body = (await response.json().catch(() => undefined)) as unknown
+    if (
+      response.ok &&
+      typeof body === "object" &&
+      body !== null &&
+      Reflect.get(body, "status") === "ready"
+    ) {
+      return { ready: true }
+    }
+    return { detail: `HTTP ${response.status} ${JSON.stringify(body) ?? "<unparsed>"}`.slice(0, 300), ready: false }
+  },
+}
+
+/**
+ * Readiness for a child with no `/healthz`. Next compiles route handlers lazily,
+ * so a 2xx here means that route's whole module graph compiled — not merely that
+ * the port is listening. Readying on stdout or on a TCP connect does NOT fail
+ * cleanly when it is wrong: a request issued at Next's own `Ready in` line
+ * blocked 20,676ms before answering.
+ */
+export function httpOkReadiness(path: string): PackagedNpmReadiness {
+  return {
+    describe: `GET ${path} -> 2xx`,
+    async probe(baseUrl, signal) {
+      const response = await fetch(new URL(path, baseUrl), { signal })
+      if (response.ok) {
+        await response.body?.cancel()
+        return { ready: true }
+      }
+      const detail = await response.text().catch(() => "")
+      return { detail: `HTTP ${response.status} ${detail}`.slice(0, 300), ready: false }
+    },
+  }
+}
+```
+
+- [ ] **Step 2: Rewrite `waitForPackagedNpmReady` (`:485-543`) to take `readiness` + `url` instead of `healthUrl`.** Keep the loop, the deadline, the per-attempt `AbortSignal.timeout(Math.min(1_000, remainingMs))`, the `AbortSignal.any` composition and the child-state checks **verbatim**; replace only the inline fetch/json/status block with `await options.readiness.probe(options.url, attemptSignal)`, track `let lastDetail = "<no probe completed>"` (set it from `attempt.detail` and from `formatError(error)` in the existing catch), and end with:
+
+```ts
+  throw new Error(
+    withProcessOutput(
+      `Timed out waiting for npm run ${options.script} readiness (${options.readiness.describe}) at ${options.url} within ${PACKAGED_NPM_READY_TIMEOUT_MS}ms; last probe: ${lastDetail}`,
+      options.readStdout(),
+      options.readStderr(),
+    ),
+  )
+```
+
+- [ ] **Step 3: Update `assertPackagedNpmChildRunning` (`:458-483`)** — swap `healthUrl: string` for `readiness: PackagedNpmReadiness` + `url: string`, and change its two messages to `… failed before ${options.readiness.describe} at ${options.url} succeeded: …` / `… exited before ${options.readiness.describe} at ${options.url} succeeded (exit …, signal …)`. **`(exit 23, signal none)` must stay character-for-character intact** — `packaged-app.test.ts:996` asserts `toContain("exit 23, signal none")`. No test asserts the rest of either string (verified by grep for `became healthy`).
+
+- [ ] **Step 4: Widen `script` in all three places (`:462`, `:491`, `:611`)** from `"dev" | "start"` to `PackagedNpmScript`.
+
+- [ ] **Step 5: Add `readiness` to the options object and key the port plumbing on the target.** Replace `:623` (`const healthUrl = …`) and `:626`:
+
+```ts
+    readonly readiness?: PackagedNpmReadiness
+```
+
+```ts
+  const readiness = options.readiness ?? dawnHealthzReadiness
+  const args = ["run", options.script, ...(options.scriptArgs ?? [])]
+  const npmLaunch = resolveNpmLaunch()
+  // Port plumbing is keyed on the TARGET, not on the script string. `next` binds
+  // the IPv6 wildcard by default, and `-H 127.0.0.1` is the flag it honours —
+  // `HOST`/`HOSTNAME`/`PORT` are all ignored when a `-p` flag is present.
+  if (options.script === "dev") args.push("--", "--port", String(port))
+  else if (options.script === "dev:web") args.push("--", "--port", String(port), "-H", "127.0.0.1")
+```
+
+Leave `:637`'s `options.script === "start" ? { HOST, PORT }` exactly as-is — it is the Dawn server's plumbing and no web target reaches it.
+
+Then update the `waitForPackagedNpmReady` call at `:703` to pass `readiness` and `url` instead of `healthUrl`.
+
+- [ ] **Step 6: Extend the test fixture** in `packaged-app.test.ts` (`createNpmServerFixture`, `:95-142`). Add `"dev:web": "node server.mjs dev:web"` to the fixture's `scripts`, make port/host derive from args for every non-`start` mode, and add a `/ready` branch **before** the 404:
+
+```js
+'const port = mode === "start" ? Number(process.env.PORT) : Number(args[args.indexOf("--port") + 1])',
+'const host = mode === "start" ? process.env.HOST : (args.includes("-H") ? args[args.indexOf("-H") + 1] : "127.0.0.1")',
+'const readyAfter = Number(process.env.FIXTURE_READY_AFTER ?? "0")',
+'let readyRequestCount = 0',
+// …inside the request handler, before the /healthz check:
+'  if (request.url === "/ready") {',
+'    readyRequestCount += 1',
+'    const ok = readyRequestCount > readyAfter',
+'    response.writeHead(ok ? 200 : 503, { "content-type": "application/json" })',
+'    response.end(JSON.stringify(ok ? { ok: true } : { error: "fixture not ready yet" }))',
+'    return',
+'  }',
+```
+
+- [ ] **Step 7: Add two tests** to the `withPackagedNpmServer` describe block (`:729`):
+
+1. *"waits for a custom readiness probe on a child with no health endpoint"* — `script: "dev:web"`, `readiness: httpOkReadiness("/ready")`, `env: { FIXTURE_READY_AFTER: "2" }`. Assert the action ran, and read `observed.json` to assert `args` contains `["--port", String(port), "-H", "127.0.0.1"]`, `host === "127.0.0.1"`, and `runtimeEnv` is `{apiKey:"missing", baseUrl:"missing", dockerSandbox:"missing"}`. **That last clause is the sibling to the existing `runGeneratedAppNpmCommand` ambient-strip test (`:507`) that investigation 3 asked for: it proves `GENERATED_APP_UNSET_ENV` protection holds on the web spawn path too, rather than being assumed.**
+2. *"names the readiness contract when the child exits first"* — `script: "dev:web"`, `readiness: httpOkReadiness("/ready")`, `env: { FIXTURE_EXIT_CODE: "23" }`; assert the thrown message contains `GET /ready -> 2xx` and `exit 23, signal none`. (Do **not** write a test that lets readiness time out — that burns the full 60s.)
+
+**Gate:**
+```bash
+export PATH=~/.nvm/versions/node/v24.19.0/bin:$PATH && \
+  pnpm exec vitest --run --config test/generated/vitest.config.ts test/harness/packaged-app.test.ts
+```
+Expected: Task 0 Step 1's count **+2**, all passing. Every pre-existing test must still pass unchanged — they all use the defaulted `readiness`.
+
+---
+
+### Task 2 (judgment): Settle the action before teardown
+
+**Files:** `test/harness/packaged-app.ts`, `test/harness/packaged-app.test.ts`
+
+- [ ] **Step 1: Add the constant** next to `PACKAGED_NPM_READY_TIMEOUT_MS` (`:25`):
+
+```ts
+// On abort, `awaitWithAbort` stops WAITING on the action but the action keeps
+// unwinding — and a nested `withPackagedNpmServer` call is exactly such an
+// action, with a live child process of its own. Measured: the outer settled 29ms
+// after abort while the inner child stayed alive another 500-1000ms. Tearing
+// down before the action settles loses LIFO order and lets two children append
+// to one transcript at once. A real `next dev` group takes ~1.2s to reap, so
+// this is ~4x that.
+const PACKAGED_NPM_ACTION_SETTLE_MS = 5_000
+```
+
+- [ ] **Step 2: Hold the action promise and await it in the `finally`.** At `:713`:
+
+```ts
+    options.signal?.throwIfAborted()
+    pendingAction = action({ url })
+    actionResult = { value: await awaitWithAbort(pendingAction, options.signal) }
+```
+
+with `let pendingAction: Promise<T> | undefined` declared beside `actionResult`, and as the **first** statement of the `finally` block (`:717`), before the `terminateSubprocess` branch:
+
+```ts
+    if (pendingAction !== undefined) {
+      await Promise.race([
+        pendingAction.catch(() => undefined),
+        delay(PACKAGED_NPM_ACTION_SETTLE_MS),
+      ])
+    }
+```
+
+- [ ] **Step 3: Add a test** — *"settles a nested server before tearing down the outer one"*: two fixtures, outer `script: "start"`, inner `script: "start"` inside the outer's action; abort mid-action; assert (a) the thrown value is the abort reason, (b) **both** children's ports stopped accepting by the time the outer promise settles (reuse `expectServerStopped`), and (c) the transcript contains both `[exit … signal …]` blocks with the **inner block first**.
+
+**Gate:**
+```bash
+export PATH=~/.nvm/versions/node/v24.19.0/bin:$PATH && \
+  pnpm exec vitest --run --config test/generated/vitest.config.ts test/harness/packaged-app.test.ts
+```
+Expected: Task 0 count **+3**. The pre-existing *"aborts readiness after a real health probe and settles cleanup before rejecting"* test still asserts `< 3_000ms` — it aborts during **readiness**, so `pendingAction` is `undefined` and the new wait is skipped. If that test slows down, you wired the settle into the wrong place.
+
+---
+
+### Task 3 (mechanical): Anchor `assertRecordedServerExit`
+
+**Files:** `test/generated/run-generated-research-activation.test.ts`
+
+- [ ] **Step 1: Replace the prefix match (`:806-818`).**
+
+```ts
+function assertRecordedServerExit(
+  transcript: string,
+  options: { readonly appRoot: string; readonly script: "dev" | "dev:web" | "start" },
+): void {
+  // `npm run dev` is a PREFIX of `npm run dev:web`, and the two-process dev
+  // session records both. `lastIndexOf` on a bare prefix happens to land on the
+  // right block today only because nesting appends the inner child FIRST — a
+  // green-by-accident that would flip the day the ordering changes. Match the
+  // whole command line instead.
+  const lines = transcript.split("
+")
+  const opening = `$ (cd ${options.appRoot} && npm run ${options.script}`
+  const commandLineIndex = lines.findLastIndex(
+    (line) =>
+      line.startsWith(opening) &&
+      (line[opening.length] === " " || line[opening.length] === ")"),
+  )
+  expect(commandLineIndex).toBeGreaterThanOrEqual(0)
+  const commandBlock = lines.slice(commandLineIndex).join("
+")
+  expect(commandBlock).not.toContain("[exit pending")
+  expect(commandBlock).not.toContain("[exit unavailable")
+  expect(commandBlock).toMatch(/\[exit (?:-?\d+|null) signal (?:[A-Z0-9]+|none)\]/)
+}
+```
+
+- [ ] **Step 2: Prove the anchor works before it has a second block to disambiguate.** Add a focused unit assertion (or a temporary local check you delete) confirming `assertRecordedServerExit` on a synthetic transcript containing a `dev:web` block *after* a `dev` block still selects the `dev` block. If you skip this, the anchor is untested until Task 6.
+
+**Gate:** `git diff` shows only this function changed; the lane is not run yet.
+
+---
+
+### Task 4 (judgment): Nest the web client and assert the hop
+
+**Files:** `test/generated/run-generated-research-activation.test.ts`
+
+- [ ] **Step 1: Add the web fixtures and constants** next to the existing ones (`:47-56`, `:99-110`).
+
+```ts
+const WEB_PROMPT = "Web hop smoke: outline the workbench check."
+const WEB_REPLY = "Workbench reached the Dawn server through the CopilotKit runtime."
+const WEB_TODOS = [
+  { content: "Confirm the web client reaches the Dawn server", status: "completed" },
+]
+const WEB_GATED_PROMPT = "Web hop gate: run the external fetch script for the workbench check."
+const WEB_FETCH_COMMAND = "node scripts/fetch-source.mjs workbench hop"
+const WEB_GATED_REPLY = "Fetched external context after approval through the web client."
+// CopilotKit's fetch-router matches `agent/<agentId>/run`; `default` is the id
+// the runtime route registers and every CopilotKit hook resolves.
+const COPILOTKIT_RUN_PATH = "/api/copilotkit/agent/default/run"
+
+function createWebHopFixtures() {
+  return [
+    ...script().user(WEB_PROMPT).callsTool("writeTodos", { todos: WEB_TODOS }).replies(WEB_REPLY).build(),
+    ...script().user(WEB_GATED_PROMPT).callsTool("runBash", { command: WEB_FETCH_COMMAND }).replies(WEB_GATED_REPLY).build(),
+  ]
+}
+```
+
+Register them alongside the others at `:887`: `aimock.addFixtures([...createSafeResearchFixtures(), ...createGatedAndBuiltFixtures(), ...createWebHopFixtures()])`.
+
+**Dedicated prompts are deliberate** — they keep the three existing journeys' aimock accounting untouched and remove any dependence on whether aimock fixtures are consumed or reusable.
+
+- [ ] **Step 2: Give `postAgui` an endpoint override.** Add `readonly endpointPath?: string` to its options (`:363`) and change `:381`:
+
+```ts
+  const routeKey = encodeURIComponent("/research#agent")
+  const endpoint = new URL(options.endpointPath ?? `/agui/${routeKey}`, options.baseUrl)
+```
+
+Nothing else changes: the CopilotKit runtime accepts a plain AG-UI `RunAgentInput` (the same object `postAgui` already builds, `RunAgentInputSchema.parse`d) and answers `text/event-stream` of raw `data: {...}` AG-UI frames, so `parseAgUiSse` works unchanged.
+
+- [ ] **Step 3: Add a web fetch helper** next to `assertReadyHealth`:
+
+```ts
+async function fetchWeb(baseUrl: string, path: string, signal: AbortSignal): Promise<Response> {
+  // 60s, not 10s: Next compiles route handlers lazily and `/api/copilotkit/*`
+  // took 2.4-8.6s on its first hit, worst immediately after a `next build` —
+  // which is exactly the sequence this lane runs.
+  return await fetch(new URL(path, baseUrl), {
+    signal: AbortSignal.any([signal, AbortSignal.timeout(60_000)]),
+  })
+}
+```
+
+- [ ] **Step 4: Add three assertion functions** (`assertWebHopJourney`, `assertWebGatedInterrupt`, `assertWebResumedJourney`) next to the existing journey assertions.
+
+```ts
+function assertWebHopJourney(events: readonly AgUiEvent[]): void {
+  expect(events.filter((event) => event.type === "RUN_ERROR")).toEqual([])
+  const finished = events.filter((event) => event.type === "RUN_FINISHED")
+  expect(finished).toHaveLength(1)
+  expect(finished[0]?.outcome).toEqual({ type: "success" })
+  expect(events.at(-1)).toEqual(finished[0])
+  expect(reconstructAssistantText(events)).toBe(WEB_REPLY)
+  // Dawn's activity projection survives a third-party runtime that re-validates
+  // and re-encodes every frame. CONTENT equality, not mere presence: a runtime
+  // that dropped `content` would still emit the event.
+  const activities = events.filter((event) => event.type === "ACTIVITY_SNAPSHOT")
+  expect(activities).toHaveLength(1)
+  expect(activities[0]).toMatchObject({
+    activityType: "dawn.plan",
+    content: { todos: WEB_TODOS },
+    replace: true,
+  })
+  // Not the exact `dawn:plan:<runId>`: id echo through CopilotKit is a property
+  // of a third-party runtime. W4's thread-state read proves id round-trip.
+  expect(String(activities[0]?.messageId)).toMatch(/^dawn:plan:/)
+  expect(
+    events.filter((event) => event.type === "TOOL_CALL_START").map((event) => event.toolCallName),
+  ).not.toContain("writeTodos")
+}
+```
+
+`assertWebGatedInterrupt` mirrors `assertGatedResearchInterrupt` (`:636`) minus the run/thread id equality: one `RUN_FINISHED` with `outcome.type === "interrupt"`, exactly one interrupt whose `metadata` matches `{ type: "permission-request", kind: "command", detail: { command: WEB_FETCH_COMMAND } }`, exactly one `runBash` `TOOL_CALL_START` (return its `toolCallId` and the `interruptId`), no `TOOL_CALL_RESULT`, no `TEXT_MESSAGE_CONTENT`, and `expectNoActivitySnapshots`.
+
+`assertWebResumedJourney(events, gatedToolCallId)`: success terminal (no id equality), one `runBash` start whose `toolCallId` **equals** `gatedToolCallId`, a `TOOL_CALL_RESULT` correlated to it, and `reconstructAssistantText(events) === WEB_GATED_REPLY`. Do **not** re-assert the ToolMessage envelope shape — `assertResumedGatedJourney` already pins that against the server directly; this one asserts the hop.
+
+- [ ] **Step 5: Declare the web ids** beside the existing id block (`:1094-1103`) — `webThreadId`, `webRunId`, `webMessageId`, `webGatedThreadId`, `webGatedRunId`, `webGatedMessageId`, `webResumeRunId`, all `` `web-…-${randomUUID()}` `` — plus `let webClientUrl: string | undefined`.
+
+- [ ] **Step 6: Nest the web session inside the dev session's action**, immediately after `assertResumedGatedJourney(...)` and before `return { interruptId }` (`:1157`). Change that return to `return { interruptId, ...webResult }`.
+
+```ts
+        // The generated web client, against the SAME Dawn server. Nested rather
+        // than sequential: the server is already BOUND when the web child
+        // allocates its port, and LIFO teardown kills the web half first.
+        const webResult = await withPackagedNpmServer(
+          {
+            appRoot,
+            env: {
+              DAWN_SERVER_URL: url,
+              // The CopilotKit runtime otherwise prints "anonymous telemetry
+              // enabled" and makes an outbound call, in a lane whose whole claim
+              // is that a generated app inherits no ambient endpoints or
+              // credentials.
+              COPILOTKIT_TELEMETRY_DISABLED: "true",
+              DO_NOT_TRACK: "1",
+            },
+            // No `/healthz` on Next, and no readying on stdout: Next prints
+            // `Ready in Xms` 12-29s before it can serve, and a request issued at
+            // that line blocked 20.7s. A 2xx on the proxy route means the route
+            // compiled AND reached a Dawn server — it is also the exact path
+            // AppShell.tsx probes (`SERVER_PROBE_PATH`).
+            readiness: httpOkReadiness("/api/dawn/memory/candidates"),
+            script: "dev:web",
+            signal: lifecycleSignal,
+            transcriptPath: commandsTranscriptPath,
+          },
+          async ({ url: webUrl }) => {
+            webClientUrl = webUrl
+            agUiRecorder.registerServerUrl(webUrl)
+            expect(new URL(webUrl).port).not.toBe(new URL(url).port)
+
+            const webIdleJournalStart = activeAimock.getRequests().length
+
+            // W1 — the allowlist denies by default in a real Next process.
+            const denied = await fetchWeb(webUrl, "/api/dawn/threads", lifecycleSignal)
+            expect(denied.status).toBe(403)
+            await expect(denied.json()).resolves.toEqual({ error: "Not proxied" })
+
+            // W2 — the proxy reached THIS server. A mis-wired DAWN_SERVER_URL
+            // cannot pass: only this server has a checkpoint for the thread the
+            // safe journey just drove. 403 (refused) and 404 (no checkpoint)
+            // stay distinguishable, which is the distinction route.ts argues for.
+            const state = await fetchWeb(
+              webUrl,
+              `/api/dawn/threads/${encodeURIComponent(safeThreadId)}/state`,
+              lifecycleSignal,
+            )
+            expect(state.status).toBe(200)
+            const threadState = (await state.json()) as {
+              readonly config?: unknown
+              readonly values?: unknown
+            }
+            expect(JSON.stringify(threadState.config)).toContain(safeThreadId)
+            expect(JSON.stringify(threadState.values)).toContain("[corpus/agent-architectures.md]")
+            const absent = await fetchWeb(
+              webUrl,
+              `/api/dawn/threads/${encodeURIComponent(`absent-${randomUUID()}`)}/state`,
+              lifecycleSignal,
+            )
+            expect(absent.status).toBe(404)
+
+            // W3 — the CopilotKit runtime is mounted at the basePath the client
+            // uses, under the agent id every hook resolves. `className` is
+            // MINIFIED and varies across builds — never assert on it.
+            const info = await fetchWeb(webUrl, "/api/copilotkit/info", lifecycleSignal)
+            expect(info.status).toBe(200)
+            const infoBody = (await info.json()) as {
+              readonly agents?: Record<string, unknown>
+              readonly mode?: unknown
+              readonly telemetryDisabled?: unknown
+            }
+            expect(Object.keys(infoBody.agents ?? {})).toContain("default")
+            expect(infoBody.mode).toBe("sse")
+            expect(infoBody.telemetryDisabled).toBe(true)
+
+            // W6 — the web tier's ONLY path to a model is through Dawn, and only
+            // for an actual run. Nothing above may move the journal.
+            expect(activeAimock.getRequests()).toHaveLength(webIdleJournalStart)
+
+            // W4 — Next route -> CopilotRuntime -> HttpAgent -> Dawn /agui ->
+            // LangGraph -> aimock, and back.
+            const webJournalStart = activeAimock.getRequests().length
+            const webJourney = await postAgui({
+              baseUrl: webUrl,
+              endpointPath: COPILOTKIT_RUN_PATH,
+              messages: [{ id: webMessageId, role: "user", content: WEB_PROMPT }],
+              recorder: agUiRecorder,
+              runId: webRunId,
+              signal: lifecycleSignal,
+              threadId: webThreadId,
+            })
+            expect(webJourney.status).toBe(200)
+            expect(activeAimock.getRequests()).toHaveLength(webJournalStart + 2)
+            assertWebHopJourney(webJourney.events)
+            // Our thread id survived the hop into Dawn's checkpointer.
+            const webState = await fetchWeb(
+              webUrl,
+              `/api/dawn/threads/${encodeURIComponent(webThreadId)}/state`,
+              lifecycleSignal,
+            )
+            expect(webState.status).toBe(200)
+
+            // W5 — the interrupt outcome and the resume envelope survive the hop.
+            const webGatedJournalStart = activeAimock.getRequests().length
+            const webGated = await postAgui({
+              baseUrl: webUrl,
+              endpointPath: COPILOTKIT_RUN_PATH,
+              messages: [{ id: webGatedMessageId, role: "user", content: WEB_GATED_PROMPT }],
+              recorder: agUiRecorder,
+              runId: webGatedRunId,
+              signal: lifecycleSignal,
+              threadId: webGatedThreadId,
+            })
+            expect(webGated.status).toBe(200)
+            expect(activeAimock.getRequests()).toHaveLength(webGatedJournalStart + 1)
+            const webInterrupt = assertWebGatedInterrupt(webGated.events)
+
+            const webResumeJournalStart = activeAimock.getRequests().length
+            const webResumed = await postAgui({
+              baseUrl: webUrl,
+              endpointPath: COPILOTKIT_RUN_PATH,
+              messages: [],
+              recorder: agUiRecorder,
+              resumeFields: {
+                resume: [
+                  { interruptId: webInterrupt.interruptId, status: "resolved", payload: "once" },
+                ],
+              },
+              runId: webResumeRunId,
+              signal: lifecycleSignal,
+              threadId: webGatedThreadId,
+            })
+            expect(webResumed.status).toBe(200)
+            expect(activeAimock.getRequests()).toHaveLength(webResumeJournalStart + 1)
+            assertWebResumedJourney(webResumed.events, webInterrupt.gatedToolCallId)
+
+            return { webInterruptId: webInterrupt.interruptId }
+          },
+        )
+```
+
+Add `if (webClientUrl === undefined) throw new Error("Generated web client did not start")` after the dev session returns.
+
+**The `+2` on W4 is the one constant you must confirm, not trust.** One tool turn plus one text turn is two model calls, matching the existing accounting (`.user().replies()` → `+1`; the gated interrupt stops after turn one → `+1`). If the first run disagrees, read `getRequests()` and correct the constant — do not loosen the assertion to `toBeGreaterThan`.
+
+**Gate:** `pnpm exec vitest --run --config test/generated/vitest.config.ts -t "activates the default research scaffold"` — expected pass. If readiness times out, the message now quotes the last probe body; a 502 naming `http://127.0.0.1:3002` means `DAWN_SERVER_URL` did not reach the child.
+
+---
+
+### Task 5 (mechanical): Close the transcript and sanitizer gaps
+
+**Files:** `test/generated/run-generated-research-activation.test.ts`
+
+- [ ] **Step 1: Assert the web child died and no secret leaked.** After `assertRecordedServerExit(transcriptAfterDev, { appRoot, script: "dev" })` (`:1164`):
+
+```ts
+    assertRecordedServerExit(transcriptAfterDev, { appRoot, script: "dev:web" })
+    // The second child inherits the same ambient-credential protection. Nothing
+    // asserted this before there was a second child to get it wrong.
+    expect(transcriptAfterDev).not.toContain("ambient-secret")
+```
+
+- [ ] **Step 2: Extend the AG-UI sanitizer assertions (`:1240-1252`).** The web URL registers second, so it takes `<server-url-2>` and the built server takes `<server-url-3>`:
+
+```ts
+    expect(sanitizedAgUiTranscript).toContain("<server-url-2>")
+    if (builtServerUrl !== devServerUrl && builtServerUrl !== webClientUrl) {
+      expect(sanitizedAgUiTranscript).toContain("<server-url-3>")
+    }
+```
+
+Add to the `not.toContain` sweep list: `webClientUrl`, `webThreadId`, `webRunId`, `webMessageId`, `webGatedThreadId`, `webGatedRunId`, `webGatedMessageId`, `webResumeRunId`, `devResult.webInterruptId`.
+
+- [ ] **Step 3: Update the measured-times comment (`:25-33`)** with the numbers Task 6 produces. Leave `ACTIVATION_TIMEOUT_MS`, `ACTIVATION_CLEANUP_RESERVE_MS`, `PACKAGED_COMMAND_TIMEOUT_MS` and `PACKAGED_NPM_READY_TIMEOUT_MS` **unchanged** — the added cost is ~6–15s on a 144s body, and D3 explains why the ready budget still has 6x headroom at CI's 2–4x.
+
+**Gate:** re-run the lane; expected pass.
+
+---
+
+### Task 6 (judgment): Full-lane verification and honest timing
+
+- [ ] **Step 1: Run the real gate.**
+
+```bash
+export PATH=~/.nvm/versions/node/v24.19.0/bin:$PATH && pnpm verify:harness:framework
+```
+
+The wrapper swallows assertion output — real failures live in `artifacts/testing/harness-*/framework/transcript.log` and `vitest-report.json`.
+
+- [ ] **Step 2: Confirm no leaked children.** Immediately after the run:
+
+```bash
+ps -eo pid,ppid,pgid,command | grep -E "next (dev|start)|next-server" | grep -v grep
+```
+Expected: no rows referencing a path under the lane's temp root. Other agents' `next dev` trees may exist on a shared box — check the cwd before concluding anything, and do not kill them.
+
+- [ ] **Step 3: Read the commands transcript by hand once.** In the preserved (or artifact) `commands.log`, confirm the dev session's blocks appear in **inner-first** order — `npm run dev:web …` then `npm run dev …` — each ending in `[exit <code> signal <sig>]`. This is the only human check that the settle fix (Task 2) actually ordered teardown; the assertions alone would pass on interleaved output.
+
+- [ ] **Step 4: Record measured times** for Task 5 Step 3: web boot+readiness, first `/api/copilotkit/info`, the three hop runs, web teardown, and the new whole-body wall time.
+
+- [ ] **Step 5: Full validate.**
+
+```bash
+export PATH=~/.nvm/versions/node/v24.19.0/bin:$PATH && pnpm ci:validate
+```
+
+---
+
+## 4. TRAPS — ranked by how quietly they stay green
+
+**T1 — A stray Dawn server on port 3002 makes a completely unwired proxy look correct.** If `DAWN_SERVER_URL` never reaches the web child, the handlers fall back to `http://127.0.0.1:3002`. On a clean CI box nothing listens there, so readiness 502s and fails loudly. **On a developer's machine running their own workbench, readiness returns 200 from the wrong server, and W1 and W3 also pass.** W2 — `/threads/<safeThreadId>/state` → 200 — is the only assertion that distinguishes "reached a Dawn server" from "reached THIS one". Do not weaken it, do not make it conditional, and do not replace the 200 with a "not 502" check.
+
+**T2 — `+2` on the W4 aimock delta is the only assertion that proves the run reached a model at all.** If you soften it to `toBeGreaterThanOrEqual` because the first run disagreed, W4 degrades into "CopilotKit returned some SSE" and the whole hop claim goes dark. Correct the constant instead.
+
+**T3 — `assertRecordedServerExit`'s bare prefix is green by accident.** `$ (cd <appRoot> && npm run dev` is a prefix of the `dev:web` line too. It lands on the right block today only because nesting appends the inner child first. Task 3 anchors it; a reviewer will read the anchor as unnecessary churn, so the comment and the commit message must say *why*. Without Task 3 Step 2, the anchor itself is untested until the full lane runs.
+
+**T4 — Readying on Next's stdout or on a TCP connect does not fail, it hangs.** `Ready in 455ms` printed for a build whose `/` then served 500 for a full 180s. A request issued at the `Ready in` line blocked 20,676ms. If anyone "optimizes" readiness later by watching stdout, the symptom will be a ~20s stall in a random assertion, nowhere near the cause.
+
+**T5 — `script: "start:web"` is a live footgun the moment someone adds it.** Next ignores `PORT` and `HOST` when `-p` is present: `PORT=45322 next start -p 3010` binds `*:3010`. The `:637` env branch would boot the web client on the developer's own port while the harness polled the allocated one to death, reporting only "timed out waiting for readiness". The `script` union is deliberately closed to three verified values — keep it closed.
+
+**T6 — The abort path leaks a `next` process group, not just a fetch.** Without Task 2, the lane's `ACTIVATION_TIMEOUT_MS - 30_000` deadline can return with a live web child and two concurrent `appendFile`s to one transcript. It will not fail the run; it will corrupt the artifact and orphan a process. Ship Task 2 with the second child, not after.
+
+**T7 — Never request `/` from the dev-mode web child.** 15–36s cold (35.9s measured), and a prior `next build` does **not** warm the Turbopack dev compile — re-measured with a full production `.next` present, `/` still took 16.7s and `/api/copilotkit/[...path]` still logged a cold compile at 8.6s.
+
+**T8 — `info.agents.default.className` is minified** (`Fe`, `xe`, `nm` across builds). Asserting `"HttpAgent"` reds on an unrelated dependency bump.
+
+**T9 — `telemetryDisabled === true` proves the LANE's hermeticity, not the template's.** The harness sets the env var. It is the right call for CI, but do not read a green W3 as evidence that a freshly scaffolded app does not phone home on `npm run dev:web` — it does. See §6.
+
+**T10 — Next 16 refuses a second `next dev` from the same project directory** ("Another next dev server is already running", PID-liveness based). Every lane run scaffolds a fresh temp dir, so this cannot bite today — but a leaked child breaks the *next* run in that directory, not the current one, so the failure appears unrelated to whatever caused it.
+
+**T11 — `next dev` releases its port ~1183ms after SIGTERM.** `terminateSubprocess`'s stop oracle is "port stopped accepting", and `graceMs` is 2s. Under CI contention it can escalate to SIGKILL — still correct. A `subprocess group … did not stop within 4000ms` error is the grace window, not a leak.
+
+**T12 — Two servers double the ways one failure masks another.** With nesting, an inner start failure surfaces the *inner's* message and the outer's stdout only reaches the transcript. The readiness message now names the script (`npm run dev:web`) and the probe; keep it that way or a web failure will read as a Dawn-server failure.
+
+---
+
+## 5. OUT OF SCOPE — the SP4 boundary
+
+**The rule: if an assertion needs a browser to have parsed the page, it is SP4.** This lane asserts only over `fetch()`.
+
+Explicitly excluded: the workbench shell rendering its rail/composer/transcript; `ConnectScreen` appearing; plan, subagent or tool cards rendering; memory approve/reject buttons; the permission prompt UI; thread selection and `localStorage`; `defaultThrottleMs`; `useSingleEndpoint={false}`; `enableInspector={false}` not fetching `cdn.copilotkit.ai`; incremental streaming into the transcript; any click. `examples/research/web/e2e/copilotkit-v2.spec.ts` already covers several of these against the example.
+
+Also out of scope, deliberately:
+
+- **Re-proving the three existing AG-UI journeys through the web client.** W4/W5 use their own small fixtures precisely so they assert the **hop**, not the agent.
+- **Re-proving anything the generated app's own `npm test` already runs in this lane** — proxy allowlist forward/reject, the 502 body, header passthrough, `ConnectScreen`-on-502, hydrate, transcript, thread-source, MemoryPanel.
+- **A `next start` web boot, a root `start:web` script, and any template edit.** See §6.
+- **The ConnectScreen 502 over real HTTP.** Reachable without a browser, but `route.test.ts` and `AppShell.test.tsx` already assert both halves inside this lane; buying the marginal "a real undici ECONNREFUSED yields 502, not 500 or a hang" would require ordering web-outer/server-inner. Not worth restructuring for.
+- **Any change to `allocatePort`, `GENERATED_APP_UNSET_ENV`, the sentinel sweep, or the timeout budgets.**
+
+---
+
+## 6. STILL OPEN
+
+**S1 — The generated app has no root command to start its built web half.** The root manifest ships `dev`, `dev:server`, `dev:web` and `start` (server only). A user who runs `npm run build` cannot start the web client from the root. This is a plausible template defect, not a harness one. *Settled by:* a product call from Brian. If a `start:web` lands, it must ship with T5's port-plumbing fix (`start:web` → `-- --port N -H 127.0.0.1`, never the `HOST`/`PORT` env branch), a `rootManifest.scripts` `toEqual` update at `:1063`, and — only then — the ~1.5s built-web session (`/` → 200 with the layout title, `/api/dawn/memory/candidates` → 200, one hop run).
+
+**S2 — A freshly scaffolded app phones home on `npm run dev:web`.** The CopilotKit runtime prints "anonymous telemetry enabled" and captures unless `COPILOTKIT_TELEMETRY_DISABLED`/`DO_NOT_TRACK` are set; `examples/research/web/playwright.config.ts` already sets both, and this plan sets them on the harness child. The template itself does not. *Settled by:* a product decision on whether the scaffold should default them off — raise it as its own issue rather than letting a green W3 bury it.
+
+**S3 — Whether the FULL real subagent `ACTIVITY_SNAPSHOT` sequence survives the CopilotKit hop.** W4 proves one snapshot survives with `content` intact, against a real Dawn server. The 7-snapshot subagent sequence has only ever been proven **direct**, and the hop evidence for it came from probes against a stub server. *Settled by:* if you want it, add `.callsTool("task", …)` to the W4 fixture and deep-equal the full sequence — but only after the first green run, and note it roughly doubles W4's aimock delta.
+
+**S4 — Exact aimock turn counts for the new fixtures.** `+2` (W4), `+1` (W5 gate), `+1` (W5 resume) are reasoned from the existing journeys' accounting, not measured. *Settled by:* reading `getRequests()` on the first run (T2).
+
+**S5 — CI runner timings.** Every measurement in this plan is macOS, node 24.19.0, on a machine running concurrent agents (load avg 12–20 during some runs), against pnpm-linked deps in `examples/research` rather than the generated app's hoisted npm workspace. The 2–4x cold-runner rule the test's own comment establishes still leaves 6x headroom on the 60s ready budget. *Settled by:* one CI run logging the web child's ready-wait duration.
+
+**S6 — `next dev` recompiling mid-session.** The lane writes files during the run (the `checkSentinel` round-trip, `server/.env`). None land under `web/`, so Turbopack should never invalidate — but this was reasoned, not tested. *Settled by:* if a hop assertion ever stalls unexpectedly, grep the lane for writes under the web root before suspecting anything else.
+
+**S7 — Windows.** `terminateSubprocess` takes the `taskkill /T /F` branch there; all reaping evidence is macOS. Pre-existing gap for every lane, not new here.

--- a/test/generated/run-generated-research-activation.test.ts
+++ b/test/generated/run-generated-research-activation.test.ts
@@ -12,6 +12,7 @@ import {
   cleanupTrackedTempDirs,
   createTrackedTempDir,
   GENERATED_APP_UNSET_ENV,
+  httpOkReadiness,
   installRegistryScaffolderWithNpm,
   markTrackedTempDirForPreserve,
   runGeneratedAppNpmCommand,
@@ -22,22 +23,40 @@ import {
 import { writeRegistryNpmrc } from "../harness/scaffold-packaging.ts"
 
 const tempDirs: TrackedTempDir[] = []
-// Measured on 2026-08-25 (macOS, node 24.19.0 / npm 11.17.0, warm npm cache,
-// Verdaccio uplink already populated), whole test body 144s:
-//   root `npm install`  92.2s   typegen 2.0s   check 1.2s   typecheck 4.0s
-//   `npm test` 4.4s     eval 1.6s   verify 1.6s   `npm run build` 16.1s
-//   dev session (boot + 3 AG-UI journeys + shutdown) 3.2s   start session 1.6s
+// Measured on 2026-08-26, two-process session (macOS, node 24.19.0 / npm
+// 11.17.0, warm npm cache, Verdaccio uplink already populated, box running
+// other agents' builds). Body totals across three green runs: 174s / 203s /
+// 230s. Per-command, from the 203s run:
+//   root `npm install` 136.6s          `npm run build` 23.1s
+//   `dawn dev` boot+readiness 4.9s     `npm start` boot+readiness 1.6s
+//   dev session total 12.3s, of which the NESTED web client is:
+//     `npm run dev:web` boot + /api/dawn/memory/candidates readiness  2.6s
+//     the six web assertions (incl. a 3.8s cold /api/copilotkit compile) 3.9s
+//     web teardown 87ms; the Dawn child's own teardown after it, 58ms
+// So the web tier costs ~6.6s. Do not read a body total as a regression signal:
+// `npm install` alone swung 92-137s across measurements, several times the
+// web tier's whole cost.
+// (2026-08-25 single-process reference, body 144s: install 92.2s, typegen 2.0s,
+// check 1.2s, typecheck 4.0s, `npm test` 4.4s, eval 1.6s, verify 1.6s, build
+// 16.1s, dev session 3.2s, start session 1.6s.)
 // Raised from 600_000 because the workspace restructure added the web client's
 // dependency set to the install and a `next build` to the build. A cold CI
 // runner is the pessimistic case: ~3x on the network-bound install, ~4x on the
-// rest, which lands near 350s — this leaves better than 3x headroom on that.
+// rest. Off the 144s reference that landed near 350s; off the slowest install
+// measured here it lands near 670s, which still leaves ~1.8x headroom.
 const ACTIVATION_TIMEOUT_MS = 1_200_000
+// Covers everything after the lifecycle deadline fires. The non-aborted cost is
+// tiny — 87ms + 58ms + 29ms to reap all three children — but the ABORTED path is
+// what this reserves for: each nesting level waits up to
+// PACKAGED_NPM_ACTION_SETTLE_MS (5s) for its action to unwind, then up to a 2s
+// grace plus a 2s force window per child, plus the transcript appends.
 const ACTIVATION_CLEANUP_RESERVE_MS = 30_000
 // The install is the one command with no headroom under the harness-wide
-// PACKAGED_COMMAND_TIMEOUT_MS (180_000): 92.2s measured warm, and it resolves
-// ~1.3GB across both workspace members through Verdaccio's npmjs uplink, so a
-// cold registry plausibly overruns 180s. Nothing else does — `npm run build`
-// measured 16.1s against that same 180s budget — so this is the only override.
+// PACKAGED_COMMAND_TIMEOUT_MS (180_000): 92.2-136.6s measured warm, and it
+// resolves ~1.3GB across both workspace members through Verdaccio's npmjs
+// uplink, so a cold registry plausibly overruns 180s. Nothing else does —
+// `npm run build` measured 16.1-23.1s against that same 180s budget — so this
+// is the only override.
 const WORKSPACE_INSTALL_TIMEOUT_MS = 600_000
 const SAFE_PROMPT = "What are common agent architectures? Write a short cited report."
 const SUBQUESTION = "Identify common agent architectures and cite the corpus."
@@ -51,6 +70,24 @@ const GATED_REPLY = "Fetched external context after approval."
 const BUILT_REPLY = "built-env-smoke-ok"
 const FETCH_STDOUT =
   'No external source configured for "quantum computing". Edit workspace/scripts/fetch-source.mjs to fetch real content.\n'
+// The web hop's own journeys. Dedicated prompts, not SAFE_PROMPT/GATED_PROMPT:
+// they keep the three direct journeys' aimock accounting untouched and remove
+// any dependence on whether an aimock fixture is consumed or reusable.
+const WEB_PROMPT = "Web hop smoke: outline the workbench check."
+const WEB_REPLY = "Workbench reached the Dawn server through the CopilotKit runtime."
+const WEB_TODOS = [
+  { content: "Confirm the web client reaches the Dawn server", status: "completed" },
+]
+const WEB_GATED_PROMPT = "Web hop gate: run the external fetch script for the workbench check."
+const WEB_FETCH_COMMAND = "node scripts/fetch-source.mjs workbench hop"
+const WEB_GATED_REPLY = "Fetched external context after approval through the web client."
+// CopilotKit's fetch-router matches `agent/<agentId>/run`; `default` is the id
+// the runtime route registers and every CopilotKit hook resolves.
+const COPILOTKIT_RUN_PATH = "/api/copilotkit/agent/default/run"
+// The allowlisted read the generated app itself treats as "the Dawn server
+// answered" (`AppShell.tsx`'s SERVER_PROBE_PATH). A 2xx means the route's whole
+// module graph compiled AND the proxy reached a Dawn server.
+const WEB_READY_PATH = "/api/dawn/memory/candidates"
 const todos = [
   { content: "Restate the question and list the sub-questions to research", status: "completed" },
   { content: "Search the corpus for each sub-question", status: "in_progress" },
@@ -109,6 +146,21 @@ function createGatedAndBuiltFixtures() {
       .replies(GATED_REPLY)
       .build(),
     ...script().user(BUILT_PROMPT).replies(BUILT_REPLY).build(),
+  ]
+}
+
+function createWebHopFixtures() {
+  return [
+    ...script()
+      .user(WEB_PROMPT)
+      .callsTool("writeTodos", { todos: WEB_TODOS })
+      .replies(WEB_REPLY)
+      .build(),
+    ...script()
+      .user(WEB_GATED_PROMPT)
+      .callsTool("runBash", { command: WEB_FETCH_COMMAND })
+      .replies(WEB_GATED_REPLY)
+      .build(),
   ]
 }
 
@@ -364,6 +416,13 @@ async function appendAgUiFailure(
 
 async function postAgui(options: {
   readonly baseUrl: string
+  /**
+   * Where to POST. Defaults to the Dawn server's own AG-UI route; the web hop
+   * points it at CopilotKit's runtime instead. Nothing else changes: the
+   * runtime accepts a plain AG-UI `RunAgentInput` — the same object built below
+   * — and answers `text/event-stream` of raw `data: {...}` AG-UI frames.
+   */
+  readonly endpointPath?: string
   readonly messages: readonly {
     readonly content: string
     readonly id: string
@@ -386,7 +445,7 @@ async function postAgui(options: {
     ...options.resumeFields,
   }
   const routeKey = encodeURIComponent("/research#agent")
-  const endpoint = new URL(`/agui/${routeKey}`, options.baseUrl)
+  const endpoint = new URL(options.endpointPath ?? `/agui/${routeKey}`, options.baseUrl)
   const requestSignal = AbortSignal.any([options.signal, AbortSignal.timeout(60_000)])
   await options.recorder.append({ type: "request", endpoint: endpoint.href, body })
 
@@ -803,6 +862,111 @@ function assertBuiltArtifactJourney(
   expectNoActivitySnapshots(events)
 }
 
+/**
+ * W4 — Dawn's events survive a third-party runtime that re-validates and
+ * re-encodes every frame.
+ *
+ * Deliberately without run/thread id equality on the terminal frames: CopilotKit
+ * adds an `input` echo to RUN_STARTED, and id echo is a property of a
+ * third-party runtime rather than of Dawn. The thread-state read at the call
+ * site proves the id round-trip in a way that does not depend on it.
+ */
+function assertWebHopJourney(events: readonly AgUiEvent[]): void {
+  expect(events.filter((event) => event.type === "RUN_ERROR")).toEqual([])
+  const finished = events.filter((event) => event.type === "RUN_FINISHED")
+  expect(finished).toHaveLength(1)
+  expect(finished[0]?.outcome).toEqual({ type: "success" })
+  expect(events.at(-1)).toEqual(finished[0])
+  expect(reconstructAssistantText(events)).toBe(WEB_REPLY)
+
+  // CONTENT equality, not mere presence: a runtime that dropped `content` would
+  // still emit the event, and this assertion would still be green.
+  const activities = events.filter((event) => event.type === "ACTIVITY_SNAPSHOT")
+  expect(activities).toHaveLength(1)
+  expect(activities[0]).toMatchObject({
+    activityType: "dawn.plan",
+    content: { todos: WEB_TODOS },
+    replace: true,
+  })
+  expect(String(activities[0]?.messageId)).toMatch(/^dawn:plan:/)
+  expect(
+    events.filter((event) => event.type === "TOOL_CALL_START").map((event) => event.toolCallName),
+  ).not.toContain("writeTodos")
+}
+
+/**
+ * W5, first half — the interrupt outcome survives the CopilotKit hop. Mirrors
+ * `assertGatedResearchInterrupt` minus the run/thread id equality.
+ */
+function assertWebGatedInterrupt(events: readonly AgUiEvent[]): {
+  readonly gatedToolCallId: string
+  readonly interruptId: string
+} {
+  expect(events.filter((event) => event.type === "RUN_ERROR")).toEqual([])
+  const finished = events.filter((event) => event.type === "RUN_FINISHED")
+  expect(finished).toHaveLength(1)
+  expect(finished[0]).toMatchObject({ outcome: { type: "interrupt" } })
+  expect(events.at(-1)).toEqual(finished[0])
+
+  const outcome = finished[0]?.outcome as
+    | { readonly interrupts?: readonly unknown[]; readonly type?: unknown }
+    | undefined
+  expect(outcome?.interrupts).toHaveLength(1)
+  const interrupt = outcome?.interrupts?.[0]
+  if (interrupt === null || typeof interrupt !== "object" || Array.isArray(interrupt)) {
+    throw new Error("Web gated journey omitted its permission interrupt")
+  }
+  const interruptRecord = interrupt as Record<string, unknown>
+  const interruptId = interruptRecord.id
+  if (typeof interruptId !== "string") {
+    throw new Error("Web gated permission interrupt omitted its id")
+  }
+  expect(interruptRecord.reason).toBe("command")
+  expect(interruptRecord.metadata).toMatchObject({
+    type: "permission-request",
+    kind: "command",
+    detail: { command: WEB_FETCH_COMMAND },
+  })
+
+  const starts = events.filter((event) => event.type === "TOOL_CALL_START")
+  expect(starts.map((event) => event.toolCallName)).toEqual(["runBash"])
+  const toolCallId = starts[0]?.toolCallId
+  if (typeof toolCallId !== "string") {
+    throw new Error("Web gated runBash start omitted its tool-call id")
+  }
+  expect(events.filter((event) => event.type === "TOOL_CALL_RESULT")).toEqual([])
+  expect(events.filter((event) => event.type === "TEXT_MESSAGE_CONTENT")).toEqual([])
+  expectNoActivitySnapshots(events)
+
+  return { gatedToolCallId: toolCallId, interruptId }
+}
+
+/**
+ * W5, second half — the resume envelope survives the hop and lands on the SAME
+ * tool call. The serialized ToolMessage envelope is deliberately not re-checked:
+ * `assertResumedGatedJourney` already pins that against the server directly.
+ */
+function assertWebResumedJourney(events: readonly AgUiEvent[], gatedToolCallId: string): void {
+  expect(events.filter((event) => event.type === "RUN_ERROR")).toEqual([])
+  const finished = events.filter((event) => event.type === "RUN_FINISHED")
+  expect(finished).toHaveLength(1)
+  expect(finished[0]?.outcome).toEqual({ type: "success" })
+  expect(events.at(-1)).toEqual(finished[0])
+
+  const starts = events.filter((event) => event.type === "TOOL_CALL_START")
+  expect(starts.map((event) => event.toolCallName)).toEqual(["runBash"])
+  expect(starts[0]?.toolCallId).toBe(gatedToolCallId)
+  const correlated = events.filter((event) => event.toolCallId === gatedToolCallId)
+  const result = correlated.find((event) => event.type === "TOOL_CALL_RESULT")
+  if (result === undefined) {
+    throw new Error("Resumed web runBash omitted its tool result")
+  }
+  const resultIndex = events.indexOf(result)
+  const firstTextIndex = events.findIndex((event) => event.type === "TEXT_MESSAGE_CONTENT")
+  expect(firstTextIndex).toBeGreaterThan(resultIndex)
+  expect(reconstructAssistantText(events)).toBe(WEB_GATED_REPLY)
+}
+
 function assertRecordedServerExit(
   transcript: string,
   options: { readonly appRoot: string; readonly script: "dev" | "dev:web" | "start" },
@@ -843,6 +1007,17 @@ async function assertReadyHealth(baseUrl: string, signal: AbortSignal): Promise<
   healthSignal.throwIfAborted()
   expect(response.status).toBe(200)
   expect(body).toEqual({ status: "ready" })
+}
+
+async function fetchWeb(baseUrl: string, path: string, signal: AbortSignal): Promise<Response> {
+  // 60s, not the 10s `assertReadyHealth` uses: Next compiles route handlers
+  // lazily and `/api/copilotkit/*` took 2.4-8.6s on its first hit, worst
+  // immediately after a `next build` — which is exactly the sequence this lane
+  // runs. Never request `/`: 15-36s cold, and a prior `next build` does not warm
+  // the dev compile.
+  return await fetch(new URL(path, baseUrl), {
+    signal: AbortSignal.any([signal, AbortSignal.timeout(60_000)]),
+  })
 }
 
 afterEach(async () => {
@@ -939,7 +1114,11 @@ test("activates the default research scaffold through the complete npm lifecycle
     await writeFile(agUiTranscriptPath, "", "utf8")
 
     aimock = await createAimock({ fixtures: [] })
-    aimock.addFixtures([...createSafeResearchFixtures(), ...createGatedAndBuiltFixtures()])
+    aimock.addFixtures([
+      ...createSafeResearchFixtures(),
+      ...createGatedAndBuiltFixtures(),
+      ...createWebHopFixtures(),
+    ])
     const activeAimock = aimock
     const agUiRecorder = createAgUiTranscriptRecorder({
       aimockUrl: activeAimock.baseUrl,
@@ -1155,7 +1334,15 @@ test("activates the default research scaffold through the complete npm lifecycle
     const builtThreadId = `built-thread-${randomUUID()}`
     const builtRunId = `built-run-${randomUUID()}`
     const builtMessageId = `built-message-${randomUUID()}`
+    const webThreadId = `web-thread-${randomUUID()}`
+    const webRunId = `web-run-${randomUUID()}`
+    const webMessageId = `web-message-${randomUUID()}`
+    const webGatedThreadId = `web-gated-thread-${randomUUID()}`
+    const webGatedRunId = `web-gated-run-${randomUUID()}`
+    const webGatedMessageId = `web-gated-message-${randomUUID()}`
+    const webResumeRunId = `web-resume-run-${randomUUID()}`
     let devServerUrl: string | undefined
+    let webClientUrl: string | undefined
     const devResult = await withPackagedNpmServer(
       {
         appRoot,
@@ -1223,13 +1410,175 @@ test("activates the default research scaffold through the complete npm lifecycle
           },
           gatedToolCallId,
         )
-        return { interruptId }
+
+        // The generated web client, against the SAME Dawn server. Nested rather
+        // than sequential: the server is already BOUND when the web child
+        // allocates its port, and LIFO teardown kills the web half first.
+        const webResult = await withPackagedNpmServer(
+          {
+            appRoot,
+            env: {
+              DAWN_SERVER_URL: url,
+              // Both route handlers read DAWN_SERVER_URL at module scope under
+              // `runtime = "nodejs"`, and Next does NOT inline it — the built
+              // chunk carries `process.env.DAWN_SERVER_URL??"http://127.0.0.1:3002"`
+              // verbatim — so injecting it at spawn is what points this child at
+              // this server rather than at that hard-coded default.
+              //
+              // Without the two below, the CopilotKit runtime prints "anonymous
+              // telemetry enabled" and makes an outbound call, in a lane whose
+              // whole claim is that a generated app inherits no ambient
+              // endpoints or credentials.
+              COPILOTKIT_TELEMETRY_DISABLED: "true",
+              DO_NOT_TRACK: "1",
+            },
+            // Next has no `/healthz`, and readying on its stdout is not merely
+            // imprecise — it is wrong in a way that HANGS: `Ready in Xms` prints
+            // 12-29s before the process can serve, and a request issued at that
+            // line blocked 20.7s. A 2xx on the proxy route means the route's
+            // whole module graph compiled AND the proxy reached a Dawn server.
+            readiness: httpOkReadiness(WEB_READY_PATH),
+            script: "dev:web",
+            signal: lifecycleSignal,
+            transcriptPath: commandsTranscriptPath,
+          },
+          async ({ url: webUrl }) => {
+            webClientUrl = webUrl
+            agUiRecorder.registerServerUrl(webUrl)
+            expect(new URL(webUrl).port).not.toBe(new URL(url).port)
+
+            const webIdleJournalStart = activeAimock.getRequests().length
+
+            // W1 — the allowlist denies by default in a real Next process.
+            const denied = await fetchWeb(webUrl, "/api/dawn/threads", lifecycleSignal)
+            expect(denied.status).toBe(403)
+            await expect(denied.json()).resolves.toEqual({ error: "Not proxied" })
+
+            // W2 — the proxy reached THIS server. A mis-wired DAWN_SERVER_URL
+            // cannot pass: only this server has a checkpoint for the thread the
+            // safe journey just drove, so a stray Dawn server on the hard-coded
+            // :3002 default answers 404 here while W1 and W3 stay green. Do not
+            // weaken the 200 to a "not 502" check — that is the whole assertion.
+            const state = await fetchWeb(
+              webUrl,
+              `/api/dawn/threads/${encodeURIComponent(safeThreadId)}/state`,
+              lifecycleSignal,
+            )
+            expect(state.status).toBe(200)
+            const threadState = (await state.json()) as {
+              readonly config?: unknown
+              readonly values?: unknown
+            }
+            expect(JSON.stringify(threadState.config)).toContain(safeThreadId)
+            expect(JSON.stringify(threadState.values)).toContain("[corpus/agent-architectures.md]")
+            // 403 (refused) and 404 (no checkpoint) stay distinguishable, which
+            // is the distinction the proxy route argues for — and it is what
+            // makes the 200 above evidence rather than coincidence.
+            const absent = await fetchWeb(
+              webUrl,
+              `/api/dawn/threads/${encodeURIComponent(`absent-${randomUUID()}`)}/state`,
+              lifecycleSignal,
+            )
+            expect(absent.status).toBe(404)
+
+            // W3 — the CopilotKit runtime is mounted at the basePath the client
+            // uses, under the agent id every hook resolves. Never assert
+            // `agents.default.className`: it is MINIFIED and varies by build.
+            const info = await fetchWeb(webUrl, "/api/copilotkit/info", lifecycleSignal)
+            expect(info.status).toBe(200)
+            const infoBody = (await info.json()) as {
+              readonly agents?: Record<string, unknown>
+              readonly mode?: unknown
+              readonly telemetryDisabled?: unknown
+            }
+            expect(Object.keys(infoBody.agents ?? {})).toContain("default")
+            expect(infoBody.mode).toBe("sse")
+            expect(infoBody.telemetryDisabled).toBe(true)
+
+            // W6 — the web tier's ONLY path to a model is through Dawn, and only
+            // for an actual run. Nothing above may move the journal.
+            expect(activeAimock.getRequests()).toHaveLength(webIdleJournalStart)
+
+            // W4 — Next route -> CopilotRuntime -> HttpAgent -> Dawn /agui ->
+            // LangGraph -> aimock, and back. The +2 is one tool turn plus one
+            // text turn; if it ever disagrees, correct the constant rather than
+            // loosening it — it is the only assertion proving the run reached a
+            // model at all.
+            const webJournalStart = activeAimock.getRequests().length
+            const webJourney = await postAgui({
+              baseUrl: webUrl,
+              endpointPath: COPILOTKIT_RUN_PATH,
+              messages: [{ id: webMessageId, role: "user", content: WEB_PROMPT }],
+              recorder: agUiRecorder,
+              runId: webRunId,
+              signal: lifecycleSignal,
+              threadId: webThreadId,
+            })
+            expect(webJourney.status).toBe(200)
+            expect(activeAimock.getRequests()).toHaveLength(webJournalStart + 2)
+            assertWebHopJourney(webJourney.events)
+            // Our thread id survived the hop into Dawn's checkpointer.
+            const webState = await fetchWeb(
+              webUrl,
+              `/api/dawn/threads/${encodeURIComponent(webThreadId)}/state`,
+              lifecycleSignal,
+            )
+            expect(webState.status).toBe(200)
+
+            // W5 — the interrupt outcome and the resume envelope survive the
+            // hop. Highest-risk contract in the app; it regressed once.
+            const webGatedJournalStart = activeAimock.getRequests().length
+            const webGated = await postAgui({
+              baseUrl: webUrl,
+              endpointPath: COPILOTKIT_RUN_PATH,
+              messages: [{ id: webGatedMessageId, role: "user", content: WEB_GATED_PROMPT }],
+              recorder: agUiRecorder,
+              runId: webGatedRunId,
+              signal: lifecycleSignal,
+              threadId: webGatedThreadId,
+            })
+            expect(webGated.status).toBe(200)
+            expect(activeAimock.getRequests()).toHaveLength(webGatedJournalStart + 1)
+            const webInterrupt = assertWebGatedInterrupt(webGated.events)
+
+            const webResumeJournalStart = activeAimock.getRequests().length
+            const webResumed = await postAgui({
+              baseUrl: webUrl,
+              endpointPath: COPILOTKIT_RUN_PATH,
+              messages: [],
+              recorder: agUiRecorder,
+              resumeFields: {
+                resume: [
+                  { interruptId: webInterrupt.interruptId, status: "resolved", payload: "once" },
+                ],
+              },
+              runId: webResumeRunId,
+              signal: lifecycleSignal,
+              threadId: webGatedThreadId,
+            })
+            expect(webResumed.status).toBe(200)
+            expect(activeAimock.getRequests()).toHaveLength(webResumeJournalStart + 1)
+            expect(webResumeRunId).not.toBe(webGatedRunId)
+            assertWebResumedJourney(webResumed.events, webInterrupt.gatedToolCallId)
+
+            return { webInterruptId: webInterrupt.interruptId }
+          },
+        )
+        return { interruptId, ...webResult }
       },
     )
     if (devServerUrl === undefined) throw new Error("Generated dev server did not start")
+    if (webClientUrl === undefined) throw new Error("Generated web client did not start")
 
     const transcriptAfterDev = await readFile(commandsTranscriptPath, "utf8")
     assertRecordedServerExit(transcriptAfterDev, { appRoot, script: "dev" })
+    // W6, second half — the SECOND child dies too, and its own block says so.
+    assertRecordedServerExit(transcriptAfterDev, { appRoot, script: "dev:web" })
+    // The web child inherits the same ambient-credential protection as the
+    // server child: `GENERATED_APP_UNSET_ENV` is stripped before `options.env`
+    // is applied. Nothing asserted this on the transcript before there was a
+    // second child to get it wrong.
+    expect(transcriptAfterDev).not.toContain("ambient-secret")
     expect(transcriptAfterDev).not.toContain(`$ (cd ${appRoot} && npm run start`)
 
     let builtServerUrl: string | undefined
@@ -1277,8 +1626,10 @@ test("activates the default research scaffold through the complete npm lifecycle
     expect(() => JSON.parse(sanitizedAgUiTranscript)).not.toThrow()
     expect(sanitizedAgUiTranscript).toContain("<temp-root>")
     expect(sanitizedAgUiTranscript).toContain("<server-url-1>")
-    if (builtServerUrl !== devServerUrl) {
-      expect(sanitizedAgUiTranscript).toContain("<server-url-2>")
+    // The web client registers second, so the built server takes the third slot.
+    expect(sanitizedAgUiTranscript).toContain("<server-url-2>")
+    if (builtServerUrl !== devServerUrl && builtServerUrl !== webClientUrl) {
+      expect(sanitizedAgUiTranscript).toContain("<server-url-3>")
     }
     expect(sanitizedAgUiTranscript).toContain("<aimock-url>")
     expect(sanitizedAgUiTranscript).toContain("<aimock-origin>")
@@ -1291,6 +1642,7 @@ test("activates the default research scaffold through the complete npm lifecycle
       tempRoot,
       `/private${tempRoot}`,
       devServerUrl,
+      webClientUrl,
       builtServerUrl,
       activeAimock.baseUrl,
       new URL(activeAimock.baseUrl).origin,
@@ -1305,6 +1657,14 @@ test("activates the default research scaffold through the complete npm lifecycle
       builtThreadId,
       builtRunId,
       builtMessageId,
+      webThreadId,
+      webRunId,
+      webMessageId,
+      webGatedThreadId,
+      webGatedRunId,
+      webGatedMessageId,
+      webResumeRunId,
+      devResult.webInterruptId,
       "test-not-used",
       "ambient-secret",
     ]) {

--- a/test/generated/run-generated-research-activation.test.ts
+++ b/test/generated/run-generated-research-activation.test.ts
@@ -805,13 +805,32 @@ function assertBuiltArtifactJourney(
 
 function assertRecordedServerExit(
   transcript: string,
-  options: { readonly appRoot: string; readonly script: "dev" | "start" },
+  options: { readonly appRoot: string; readonly script: "dev" | "dev:web" | "start" },
 ): void {
-  const commandPrefix = `$ (cd ${options.appRoot} && npm run ${options.script}`
-  const commandIndex = transcript.lastIndexOf(commandPrefix)
-  expect(commandIndex).toBeGreaterThanOrEqual(0)
-  if (commandIndex < 0) throw new Error(`Missing ${options.script} server transcript`)
-  const commandBlock = transcript.slice(commandIndex)
+  // `npm run dev` is a PREFIX of `npm run dev:web`, and the two-process dev
+  // session records both. `lastIndexOf` on a bare prefix happens to land on the
+  // right block today only because nesting appends the inner child FIRST — a
+  // green-by-accident that would flip the day the ordering changes. Match the
+  // whole command line instead.
+  const lines = transcript.split("\n")
+  const opening = `$ (cd ${options.appRoot} && npm run ${options.script}`
+  const commandLineIndex = lines.findLastIndex(
+    (line) =>
+      line.startsWith(opening) && (line[opening.length] === " " || line[opening.length] === ")"),
+  )
+  expect(commandLineIndex).toBeGreaterThanOrEqual(0)
+  // Bound the block at the NEXT recorded command too. Nesting appends the inner
+  // (web) child FIRST, so a slice that ran to the end of the file would read the
+  // SERVER block's exit line and pronounce the web child recorded no matter what
+  // the web block actually says.
+  const nextCommandOffset = lines
+    .slice(commandLineIndex + 1)
+    .findIndex((line) => /^\$ \(cd .+ && .+\)$/.test(line))
+  const commandBlock = (
+    nextCommandOffset < 0
+      ? lines.slice(commandLineIndex)
+      : lines.slice(commandLineIndex, commandLineIndex + 1 + nextCommandOffset)
+  ).join("\n")
   expect(commandBlock).not.toContain("[exit pending")
   expect(commandBlock).not.toContain("[exit unavailable")
   expect(commandBlock).toMatch(/\[exit (?:-?\d+|null) signal (?:[A-Z0-9]+|none)\]/)
@@ -828,6 +847,42 @@ async function assertReadyHealth(baseUrl: string, signal: AbortSignal): Promise<
 
 afterEach(async () => {
   await cleanupTrackedTempDirs(tempDirs)
+})
+
+// Proves the anchor before the lane has a second block to disambiguate: the
+// `dev:web` line starts with the whole `npm run dev` prefix, so an unanchored
+// `lastIndexOf` selects the WRONG block the moment a web child is recorded after
+// the server child.
+test("anchors the recorded server exit to a whole command line", () => {
+  const appRoot = "/tmp/anchored-activation-app"
+  const serverBlock = [
+    `$ (cd ${appRoot} && npm run dev -- --port 4711)`,
+    "dawn dev stdout",
+    "[exit 0 signal none]",
+    "",
+  ]
+  const leakedWebBlock = [
+    `$ (cd ${appRoot} && npm run dev:web -- --port 4712 -H 127.0.0.1)`,
+    "next dev stdout",
+    "[exit pending signal pending]",
+    "",
+  ]
+
+  // A `dev:web` block recorded AFTER the server block must not be mistaken for it.
+  const webLast = [...serverBlock, ...leakedWebBlock].join("\n")
+  assertRecordedServerExit(webLast, { appRoot, script: "dev" })
+  expect(() => assertRecordedServerExit(webLast, { appRoot, script: "dev:web" })).toThrow()
+
+  // And in the order nesting actually produces — inner (web) first, server last —
+  // a web block whose own exit line never landed must not borrow the server's.
+  const webFirst = [
+    `$ (cd ${appRoot} && npm run dev:web -- --port 4712 -H 127.0.0.1)`,
+    "next dev stdout",
+    "",
+    ...serverBlock,
+  ].join("\n")
+  assertRecordedServerExit(webFirst, { appRoot, script: "dev" })
+  expect(() => assertRecordedServerExit(webFirst, { appRoot, script: "dev:web" })).toThrow()
 })
 
 test("activates the default research scaffold through the complete npm lifecycle", {

--- a/test/generated/run-generated-research-activation.test.ts
+++ b/test/generated/run-generated-research-activation.test.ts
@@ -1501,9 +1501,12 @@ test("activates the default research scaffold through the complete npm lifecycle
 
             // W4 — Next route -> CopilotRuntime -> HttpAgent -> Dawn /agui ->
             // LangGraph -> aimock, and back. The +2 is one tool turn plus one
-            // text turn; if it ever disagrees, correct the constant rather than
-            // loosening it — it is the only assertion proving the run reached a
-            // model at all.
+            // text turn. `assertWebHopJourney` already proves the run reached a
+            // model — `WEB_REPLY` exists nowhere but the fixture — so what this
+            // adds is the EXACT count: a run the hop invoked twice would land
+            // +4 with the same reply text and pass every other assertion here.
+            // If it ever disagrees, correct the constant rather than loosening
+            // it to a lower bound.
             const webJournalStart = activeAimock.getRequests().length
             const webJourney = await postAgui({
               baseUrl: webUrl,
@@ -1574,10 +1577,14 @@ test("activates the default research scaffold through the complete npm lifecycle
     assertRecordedServerExit(transcriptAfterDev, { appRoot, script: "dev" })
     // W6, second half — the SECOND child dies too, and its own block says so.
     assertRecordedServerExit(transcriptAfterDev, { appRoot, script: "dev:web" })
-    // The web child inherits the same ambient-credential protection as the
-    // server child: `GENERATED_APP_UNSET_ENV` is stripped before `options.env`
-    // is applied. Nothing asserted this on the transcript before there was a
-    // second child to get it wrong.
+    // A leak canary, not a proof of the strip. It says only that nothing echoed
+    // the ambient key into a transcript this lane preserves and CI uploads —
+    // which holds largely because the web tier has no model path except through
+    // Dawn, so there is little to echo it. Breaking `GENERATED_APP_UNSET_ENV`
+    // for `dev:web` leaves this green; the assertion that actually fails is
+    // `observed.runtimeEnv` in `test/harness/packaged-app.test.ts:1114`. Kept
+    // anyway: it is nearly free and mirrors the same sweep over the AG-UI
+    // transcript below.
     expect(transcriptAfterDev).not.toContain("ambient-secret")
     expect(transcriptAfterDev).not.toContain(`$ (cd ${appRoot} && npm run start`)
 

--- a/test/generated/vitest.config.ts
+++ b/test/generated/vitest.config.ts
@@ -3,6 +3,19 @@ import { defineConfig } from "vitest/config"
 export default defineConfig({
   test: {
     environment: "node",
+    // Set on the WORKER, which is how they reach every child this lane spawns:
+    // `spawnProcess` builds `{...process.env, ...options.env}` and neither name
+    // is in `GENERATED_APP_UNSET_ENV`. Without them the generated app's
+    // `npm run build` fans out to `next build`, which evaluates the CopilotKit
+    // runtime handler at module scope during "Collecting page data" and fires a
+    // real POST to telemetry.copilotkit.ai — an outbound call from a lane whose
+    // whole claim is that a generated app reaches nothing but the local aimock.
+    // (Whether the SCAFFOLD should default these off is a separate product
+    // question; this only closes the test lane. See the plan's S2.)
+    env: {
+      COPILOTKIT_TELEMETRY_DISABLED: "true",
+      DO_NOT_TRACK: "1",
+    },
     exclude: ["test/generated/fixtures/**"],
     fileParallelism: false,
     globalSetup: ["test/harness/registry-global-setup.ts"],

--- a/test/harness/packaged-app.test.ts
+++ b/test/harness/packaged-app.test.ts
@@ -145,7 +145,9 @@ async function createNpmServerFixture(prefix: string, targetRoot?: string): Prom
       "server.listen(port, host)",
       "const close = () => server.close(() => process.exit(0))",
       // A nested child that dies slower than its parent is the shape the action
-      // settle fix exists for: `next dev` released its port ~1183ms after SIGTERM.
+      // settle fix exists for, so this fixture is slow on purpose. The delay is
+      // NOT a measurement of anything real — see PACKAGED_NPM_ACTION_SETTLE_MS
+      // for what actually sets that budget.
       "const closeAfterDelay = () => { if (sigtermDelayMs > 0) setTimeout(close, sigtermDelayMs); else close() }",
       'process.once("SIGTERM", closeAfterDelay)',
       'process.once("SIGINT", closeAfterDelay)',
@@ -967,9 +969,12 @@ describe("withPackagedNpmServer", () => {
           return await withPackagedNpmServer(
             {
               appRoot: innerRoot,
-              // The inner child releases its port ~600ms after SIGTERM, the way a
-              // real `next dev` group does (~1183ms measured). Without the settle
-              // the outer tears down first and both children append at once.
+              // The inner child releases its port ~600ms after SIGTERM: slower
+              // than its parent on purpose, which is the only property this test
+              // needs. Without the settle the outer tears down first and both
+              // children append at once. Do not read 600ms as a bound on
+              // PACKAGED_NPM_ACTION_SETTLE_MS — that constant explains why any
+              // value large enough to pass here can still be far too small.
               env: { FIXTURE_SIGTERM_DELAY_MS: "600" },
               script: "start",
               signal: controller.signal,

--- a/test/harness/packaged-app.test.ts
+++ b/test/harness/packaged-app.test.ts
@@ -8,6 +8,7 @@ import { describe, expect, it } from "vitest"
 
 import { getTestRegistryUrl } from "./local-registry.ts"
 import {
+  httpOkReadiness,
   installRegistryScaffolderWithNpm,
   resolveNpmLaunch,
   runGeneratedAppNpmCommand,
@@ -87,6 +88,7 @@ async function createNpmServerFixture(prefix: string, targetRoot?: string): Prom
         private: true,
         scripts: {
           dev: "node server.mjs dev",
+          "dev:web": "node server.mjs dev:web",
           start: "node server.mjs start",
         },
         type: "module",
@@ -104,13 +106,15 @@ async function createNpmServerFixture(prefix: string, targetRoot?: string): Prom
       'import { createServer } from "node:http"',
       "const mode = process.argv[2]",
       "const args = process.argv.slice(3)",
-      'const portIndex = args.indexOf("--port")',
-      'const port = mode === "dev" ? Number(args[portIndex + 1]) : Number(process.env.PORT)',
-      'const host = mode === "start" ? process.env.HOST : "127.0.0.1"',
+      'const port = mode === "start" ? Number(process.env.PORT) : Number(args[args.indexOf("--port") + 1])',
+      'const host = mode === "start" ? process.env.HOST : (args.includes("-H") ? args[args.indexOf("-H") + 1] : "127.0.0.1")',
       'const startingResponses = Number(process.env.FIXTURE_STARTING_RESPONSES ?? "0")',
+      'const readyAfter = Number(process.env.FIXTURE_READY_AFTER ?? "0")',
       'const exitCode = Number(process.env.FIXTURE_EXIT_CODE ?? "0")',
       'const forcedExitMs = Number(process.env.FIXTURE_FORCED_EXIT_MS ?? "0")',
+      'const sigtermDelayMs = Number(process.env.FIXTURE_SIGTERM_DELAY_MS ?? "0")',
       "let healthRequestCount = 0",
+      "let readyRequestCount = 0",
       'await writeFile(new URL("./observed.json", import.meta.url), JSON.stringify({ args, host, mode, pid: process.pid, port, runtimeEnv: { apiKey: process.env.OPENAI_API_KEY ?? "missing", baseUrl: process.env.OPENAI_BASE_URL ?? "missing", dockerSandbox: process.env.DAWN_DEMO_DOCKER_SANDBOX ?? "missing" }, unsetEnv: process.env.DAWN_TEST_SERVER_UNSET_ENV ?? "missing" }))',
       'process.stdout.write("fixture " + mode + " stdout\\n")',
       'process.stderr.write("fixture " + mode + " stderr\\n")',
@@ -120,6 +124,14 @@ async function createNpmServerFixture(prefix: string, targetRoot?: string): Prom
       "  process.exit(exitCode)",
       "}",
       "const server = createServer((request, response) => {",
+      '  if (request.url === "/ready") {',
+      "    readyRequestCount += 1",
+      '    writeFileSync(new URL("./ready-count.txt", import.meta.url), String(readyRequestCount))',
+      "    const ok = readyRequestCount > readyAfter",
+      '    response.writeHead(ok ? 200 : 503, { "content-type": "application/json" })',
+      '    response.end(JSON.stringify(ok ? { ok: true } : { error: "fixture not ready yet" }))',
+      "    return",
+      "  }",
       '  if (request.url !== "/healthz") {',
       "    response.writeHead(404)",
       "    response.end()",
@@ -132,8 +144,11 @@ async function createNpmServerFixture(prefix: string, targetRoot?: string): Prom
       "})",
       "server.listen(port, host)",
       "const close = () => server.close(() => process.exit(0))",
-      'process.once("SIGTERM", close)',
-      'process.once("SIGINT", close)',
+      // A nested child that dies slower than its parent is the shape the action
+      // settle fix exists for: `next dev` released its port ~1183ms after SIGTERM.
+      "const closeAfterDelay = () => { if (sigtermDelayMs > 0) setTimeout(close, sigtermDelayMs); else close() }",
+      'process.once("SIGTERM", closeAfterDelay)',
+      'process.once("SIGINT", closeAfterDelay)',
       "if (forcedExitMs > 0) setTimeout(close, forcedExitMs).unref()",
       "",
     ].join("\n"),
@@ -826,7 +841,9 @@ describe("withPackagedNpmServer", () => {
     const actionWait = new Promise<void>((resolvePromise) => {
       releaseAction = resolvePromise
     })
-    const fallback = setTimeout(() => releaseAction?.(), 5_000)
+    // Long enough that only the harness's own settle budget can end this test:
+    // the action deliberately never unwinds, which is the case the budget bounds.
+    const fallback = setTimeout(() => releaseAction?.(), 30_000)
     fallback.unref()
     let serverResult: Promise<string> | undefined
     let serverUrl = ""
@@ -852,7 +869,11 @@ describe("withPackagedNpmServer", () => {
         thrown = error
       }
 
-      expect(Date.now() - abortedAt).toBeLessThan(3_000)
+      // Teardown now gives the action PACKAGED_NPM_ACTION_SETTLE_MS (5s) to finish
+      // unwinding before killing the child, so a hung action costs that budget —
+      // and no more. Without the upper bound a nested lane could hang cleanup for
+      // the whole run; the nested test below covers the fast path (~1s).
+      expect(Date.now() - abortedAt).toBeLessThan(10_000)
       expect(thrown).toBe(abortReason)
       await expectServerStopped(serverUrl)
       const transcript = await readFile(transcriptPath, "utf8")
@@ -917,6 +938,88 @@ describe("withPackagedNpmServer", () => {
     }
   })
 
+  it("settles a nested server before tearing down the outer one", async () => {
+    const outerRoot = await createNpmServerFixture("dawn-npm-nested-outer-")
+    const innerRoot = await createNpmServerFixture("dawn-npm-nested-inner-")
+    // One transcript for both children, exactly as the activation lane does.
+    const transcriptPath = join(outerRoot, "nested.log")
+    const controller = new AbortController()
+    const abortReason = new Error("cancel the nested npm servers")
+    let innerStartedResolve: (() => void) | undefined
+    const innerStarted = new Promise<void>((resolvePromise) => {
+      innerStartedResolve = resolvePromise
+    })
+    let releaseInner: (() => void) | undefined
+    const innerWait = new Promise<void>((resolvePromise) => {
+      releaseInner = resolvePromise
+    })
+    const fallback = setTimeout(() => releaseInner?.(), 5_000)
+    fallback.unref()
+    let outerResult: Promise<string> | undefined
+    let outerUrl = ""
+    let innerUrl = ""
+
+    try {
+      outerResult = withPackagedNpmServer(
+        { appRoot: outerRoot, script: "start", signal: controller.signal, transcriptPath },
+        async ({ url }) => {
+          outerUrl = url
+          return await withPackagedNpmServer(
+            {
+              appRoot: innerRoot,
+              // The inner child releases its port ~600ms after SIGTERM, the way a
+              // real `next dev` group does (~1183ms measured). Without the settle
+              // the outer tears down first and both children append at once.
+              env: { FIXTURE_SIGTERM_DELAY_MS: "600" },
+              script: "start",
+              signal: controller.signal,
+              transcriptPath,
+            },
+            async ({ url: nestedUrl }) => {
+              innerUrl = nestedUrl
+              innerStartedResolve?.()
+              await innerWait
+              return "inner-action-complete"
+            },
+          )
+        },
+      )
+
+      await innerStarted
+      controller.abort(abortReason)
+      // The inner action keeps unwinding past the abort — that is the whole point.
+      await delay(50)
+      releaseInner?.()
+
+      let thrown: unknown
+      try {
+        await outerResult
+      } catch (error) {
+        thrown = error
+      }
+
+      expect(thrown).toBe(abortReason)
+      // LIFO: both children are gone by the time the OUTER promise settles.
+      await expectServerStopped(innerUrl)
+      await expectServerStopped(outerUrl)
+
+      const transcript = await readFile(transcriptPath, "utf8")
+      expect(transcript).not.toContain("[exit pending")
+      expect(transcript.match(/\[exit (?:-?\d+|null) signal (?:[A-Z0-9]+|none)\]/g)).toHaveLength(2)
+      const innerIndex = transcript.indexOf(`$ (cd ${innerRoot} && npm run start)`)
+      const outerIndex = transcript.indexOf(`$ (cd ${outerRoot} && npm run start)`)
+      expect(innerIndex).toBeGreaterThanOrEqual(0)
+      expect(outerIndex).toBeGreaterThan(innerIndex)
+    } finally {
+      clearTimeout(fallback)
+      releaseInner?.()
+      controller.abort(abortReason)
+      await outerResult?.catch(() => undefined)
+      await rm(outerRoot, { force: true, recursive: true })
+      await rm(innerRoot, { force: true, recursive: true })
+    }
+  })
+
   it.skipIf(process.platform !== "win32")(
     "launches npm scripts through argv from a Windows metacharacter path",
     async () => {
@@ -964,6 +1067,96 @@ describe("withPackagedNpmServer", () => {
 
       expect(healthRequestCount).toBeGreaterThanOrEqual(3)
       await expectServerStopped(serverUrl)
+    } finally {
+      await rm(appRoot, { force: true, recursive: true })
+    }
+  })
+
+  it("waits for a custom readiness probe on a child with no health endpoint", async () => {
+    const appRoot = await createNpmServerFixture("dawn-npm-web-readiness-")
+    const transcriptPath = join(appRoot, "web-readiness.log")
+    const restoreDockerSandbox = setTestEnvironmentVariable("DAWN_DEMO_DOCKER_SANDBOX", "1")
+    const restoreBaseUrl = setTestEnvironmentVariable("OPENAI_BASE_URL", "ambient-base-url")
+    const restoreApiKey = setTestEnvironmentVariable("OPENAI_API_KEY", "ambient-api-key")
+    let serverUrl = ""
+
+    try {
+      const session = await withPackagedNpmServer(
+        {
+          appRoot,
+          env: { FIXTURE_READY_AFTER: "2" },
+          readiness: httpOkReadiness("/ready"),
+          script: "dev:web",
+          transcriptPath,
+        },
+        async ({ url }) => {
+          serverUrl = url
+          // The default `/healthz` probe never ran: the fixture only writes
+          // health-count.txt when something asks for `/healthz`.
+          await expect(readFile(join(appRoot, "health-count.txt"), "utf8")).rejects.toMatchObject({
+            code: "ENOENT",
+          })
+          return {
+            observed: await readObservedServer(appRoot),
+            readyRequestCount: Number(await readFile(join(appRoot, "ready-count.txt"), "utf8")),
+          }
+        },
+      )
+
+      const port = new URL(serverUrl).port
+      // Two 503s were rejected before the 200 released the action.
+      expect(session.readyRequestCount).toBeGreaterThanOrEqual(3)
+      expect(session.observed.args).toEqual(["--port", port, "-H", "127.0.0.1"])
+      expect(session.observed.host).toBe("127.0.0.1")
+      expect(session.observed.mode).toBe("dev:web")
+      expect(session.observed.port).toBe(Number(port))
+      // GENERATED_APP_UNSET_ENV protection holds on the web spawn path too.
+      expect(session.observed.runtimeEnv).toEqual({
+        apiKey: "missing",
+        baseUrl: "missing",
+        dockerSandbox: "missing",
+      })
+      await expectServerStopped(serverUrl)
+      await expect(readFile(transcriptPath, "utf8")).resolves.toContain(
+        `$ (cd ${appRoot} && npm run dev:web -- --port ${port} -H 127.0.0.1)`,
+      )
+    } finally {
+      restoreApiKey()
+      restoreBaseUrl()
+      restoreDockerSandbox()
+      await rm(appRoot, { force: true, recursive: true })
+    }
+  })
+
+  it("names the readiness contract when the child exits first", async () => {
+    const appRoot = await createNpmServerFixture("dawn-npm-web-early-exit-")
+    const transcriptPath = join(appRoot, "web-early-exit.log")
+    let actionRan = false
+    let thrown: unknown
+
+    try {
+      try {
+        await withPackagedNpmServer(
+          {
+            appRoot,
+            env: { FIXTURE_EXIT_CODE: "23" },
+            readiness: httpOkReadiness("/ready"),
+            script: "dev:web",
+            transcriptPath,
+          },
+          async () => {
+            actionRan = true
+          },
+        )
+      } catch (error) {
+        thrown = error
+      }
+
+      expect(actionRan).toBe(false)
+      expect(thrown).toBeInstanceOf(Error)
+      expect((thrown as Error).message).toContain("npm run dev:web")
+      expect((thrown as Error).message).toContain("GET /ready -> 2xx")
+      expect((thrown as Error).message).toContain("exit 23, signal none")
     } finally {
       await rm(appRoot, { force: true, recursive: true })
     }

--- a/test/harness/packaged-app.ts
+++ b/test/harness/packaged-app.ts
@@ -23,6 +23,14 @@ import { candidateRegistryNpmArgs, writeRegistryNpmrc } from "./scaffold-packagi
 const REPO_ROOT = resolve(import.meta.dirname, "../..")
 const PACKAGED_COMMAND_TIMEOUT_MS = 180_000
 const PACKAGED_NPM_READY_TIMEOUT_MS = 60_000
+// On abort, `awaitWithAbort` stops WAITING on the action but the action keeps
+// unwinding — and a nested `withPackagedNpmServer` call is exactly such an
+// action, with a live child process of its own. Measured: the outer settled 29ms
+// after abort while the inner child stayed alive another 500-1000ms. Tearing
+// down before the action settles loses LIFO order and lets two children append
+// to one transcript at once. A real `next dev` group takes ~1.2s to reap, so
+// this is ~4x that.
+const PACKAGED_NPM_ACTION_SETTLE_MS = 5_000
 export const GENERATED_APP_UNSET_ENV = [
   "DAWN_DEMO_DOCKER_SANDBOX",
   "OPENAI_BASE_URL",
@@ -455,17 +463,77 @@ function withProcessOutput(message: string, stdout: string, stderr: string): str
     .join("\n")
 }
 
+export type PackagedNpmScript = "dev" | "dev:web" | "start"
+
+export interface PackagedNpmReadiness {
+  /** Quoted in every readiness failure, e.g. `GET /healthz -> {"status":"ready"}`. */
+  readonly describe: string
+  /**
+   * One probe attempt. `detail` from the LAST attempt is quoted in the timeout
+   * message: with two children, a 502 body naming an unreachable upstream is the
+   * difference between a five-minute diagnosis and an hour spent blaming the
+   * wrong process.
+   */
+  readonly probe: (
+    baseUrl: string,
+    signal: AbortSignal,
+  ) => Promise<{ readonly detail?: string; readonly ready: boolean }>
+}
+
+export const dawnHealthzReadiness: PackagedNpmReadiness = {
+  describe: `GET /healthz -> {"status":"ready"}`,
+  async probe(baseUrl, signal) {
+    const response = await fetch(new URL("/healthz", baseUrl), { signal })
+    const body = (await response.json().catch(() => undefined)) as unknown
+    if (
+      response.ok &&
+      typeof body === "object" &&
+      body !== null &&
+      Reflect.get(body, "status") === "ready"
+    ) {
+      return { ready: true }
+    }
+    return {
+      detail: `HTTP ${response.status} ${JSON.stringify(body) ?? "<unparsed>"}`.slice(0, 300),
+      ready: false,
+    }
+  },
+}
+
+/**
+ * Readiness for a child with no `/healthz`. Next compiles route handlers lazily,
+ * so a 2xx here means that route's whole module graph compiled — not merely that
+ * the port is listening. Readying on stdout or on a TCP connect does NOT fail
+ * cleanly when it is wrong: a request issued at Next's own `Ready in` line
+ * blocked 20,676ms before answering.
+ */
+export function httpOkReadiness(path: string): PackagedNpmReadiness {
+  return {
+    describe: `GET ${path} -> 2xx`,
+    async probe(baseUrl, signal) {
+      const response = await fetch(new URL(path, baseUrl), { signal })
+      if (response.ok) {
+        await response.body?.cancel()
+        return { ready: true }
+      }
+      const detail = await response.text().catch(() => "")
+      return { detail: `HTTP ${response.status} ${detail}`.slice(0, 300), ready: false }
+    },
+  }
+}
+
 function assertPackagedNpmChildRunning(options: {
-  readonly healthUrl: string
+  readonly readiness: PackagedNpmReadiness
   readonly readStderr: () => string
   readonly readStdout: () => string
-  readonly script: "dev" | "start"
+  readonly script: PackagedNpmScript
   readonly state: PackagedNpmChildState
+  readonly url: string
 }): void {
   if (options.state.failed) {
     throw new Error(
       withProcessOutput(
-        `npm run ${options.script} failed before ${options.healthUrl} became healthy: ${formatError(options.state.error)}`,
+        `npm run ${options.script} failed before ${options.readiness.describe} at ${options.url} succeeded: ${formatError(options.state.error)}`,
         options.readStdout(),
         options.readStderr(),
       ),
@@ -475,7 +543,7 @@ function assertPackagedNpmChildRunning(options: {
   if (options.state.closed) {
     throw new Error(
       withProcessOutput(
-        `npm run ${options.script} exited before ${options.healthUrl} became healthy (exit ${options.state.exitCode ?? "null"}, signal ${options.state.signal ?? "none"})`,
+        `npm run ${options.script} exited before ${options.readiness.describe} at ${options.url} succeeded (exit ${options.state.exitCode ?? "null"}, signal ${options.state.signal ?? "none"})`,
         options.readStdout(),
         options.readStderr(),
       ),
@@ -485,14 +553,16 @@ function assertPackagedNpmChildRunning(options: {
 
 async function waitForPackagedNpmReady(options: {
   readonly closed: Promise<void>
-  readonly healthUrl: string
+  readonly readiness: PackagedNpmReadiness
   readonly readStderr: () => string
   readonly readStdout: () => string
-  readonly script: "dev" | "start"
+  readonly script: PackagedNpmScript
   readonly signal?: AbortSignal
   readonly state: PackagedNpmChildState
+  readonly url: string
 }): Promise<void> {
   const deadline = Date.now() + PACKAGED_NPM_READY_TIMEOUT_MS
+  let lastDetail = "<no probe completed>"
 
   while (Date.now() < deadline) {
     options.signal?.throwIfAborted()
@@ -502,20 +572,17 @@ async function waitForPackagedNpmReady(options: {
     let ready = false
     try {
       const requestTimeoutSignal = AbortSignal.timeout(Math.min(1_000, remainingMs))
-      const response = await fetch(options.healthUrl, {
-        signal:
-          options.signal === undefined
-            ? requestTimeoutSignal
-            : AbortSignal.any([options.signal, requestTimeoutSignal]),
-      })
-      const body = await response.json().catch(() => undefined)
-      ready =
-        response.ok &&
-        typeof body === "object" &&
-        body !== null &&
-        Reflect.get(body, "status") === "ready"
-    } catch {
+      const attempt = await options.readiness.probe(
+        options.url,
+        options.signal === undefined
+          ? requestTimeoutSignal
+          : AbortSignal.any([options.signal, requestTimeoutSignal]),
+      )
+      ready = attempt.ready
+      if (attempt.detail !== undefined) lastDetail = attempt.detail
+    } catch (error) {
       options.signal?.throwIfAborted()
+      lastDetail = formatError(error)
       // The server may still be starting. Child state is checked again below.
     }
 
@@ -536,7 +603,7 @@ async function waitForPackagedNpmReady(options: {
 
   throw new Error(
     withProcessOutput(
-      `Timed out waiting for npm run ${options.script} readiness at ${options.healthUrl} within ${PACKAGED_NPM_READY_TIMEOUT_MS}ms`,
+      `Timed out waiting for npm run ${options.script} readiness (${options.readiness.describe}) at ${options.url} within ${PACKAGED_NPM_READY_TIMEOUT_MS}ms; last probe: ${lastDetail}`,
       options.readStdout(),
       options.readStderr(),
     ),
@@ -608,7 +675,8 @@ export async function withPackagedNpmServer<T>(
   options: {
     readonly appRoot: string
     readonly env?: Readonly<Record<string, string>>
-    readonly script: "dev" | "start"
+    readonly readiness?: PackagedNpmReadiness
+    readonly script: PackagedNpmScript
     readonly scriptArgs?: readonly string[]
     readonly signal?: AbortSignal
     readonly transcriptPath: string
@@ -620,10 +688,14 @@ export async function withPackagedNpmServer<T>(
   const port = await allocatePort()
   options.signal?.throwIfAborted()
   const url = `http://127.0.0.1:${port}`
-  const healthUrl = new URL("/healthz", url).href
+  const readiness = options.readiness ?? dawnHealthzReadiness
   const args = ["run", options.script, ...(options.scriptArgs ?? [])]
   const npmLaunch = resolveNpmLaunch()
+  // Port plumbing is keyed on the TARGET, not on the script string. `next` binds
+  // the IPv6 wildcard by default, and `-H 127.0.0.1` is the flag it honours —
+  // `HOST`/`HOSTNAME`/`PORT` are all ignored when a `-p` flag is present.
   if (options.script === "dev") args.push("--", "--port", String(port))
+  else if (options.script === "dev:web") args.push("--", "--port", String(port), "-H", "127.0.0.1")
 
   const env: NodeJS.ProcessEnv = {
     ...process.env,
@@ -653,6 +725,7 @@ export async function withPackagedNpmServer<T>(
   let spawnFailure: { readonly error: unknown } | undefined
   let failure: { readonly error: unknown } | undefined
   let actionResult: { readonly value: T } | undefined
+  let pendingAction: Promise<T> | undefined
 
   const recordFailure = (error: unknown, message: string): void => {
     failure = failure ? { error: new AggregateError([failure.error, error], message) } : { error }
@@ -701,18 +774,30 @@ export async function withPackagedNpmServer<T>(
 
     await waitForPackagedNpmReady({
       closed,
-      healthUrl,
+      readiness,
       readStderr: () => stderr,
       readStdout: () => stdout,
       script: options.script,
       ...(options.signal !== undefined ? { signal: options.signal } : {}),
       state,
+      url,
     })
     options.signal?.throwIfAborted()
-    actionResult = { value: await awaitWithAbort(action({ url }), options.signal) }
+    pendingAction = action({ url })
+    actionResult = { value: await awaitWithAbort(pendingAction, options.signal) }
   } catch (error) {
     recordFailure(error, `npm run ${options.script} failed and cleanup also failed`)
   } finally {
+    // Let the action finish unwinding before this child dies. A nested session
+    // is still tearing down its own child here; without this the two teardowns
+    // interleave and both append to `transcriptPath` at once.
+    if (pendingAction !== undefined) {
+      await Promise.race([
+        pendingAction.catch(() => undefined),
+        delay(PACKAGED_NPM_ACTION_SETTLE_MS),
+      ])
+    }
+
     if (child && closed && groupPid !== undefined) {
       try {
         await terminateSubprocess(child, groupPid, closed, url)

--- a/test/harness/packaged-app.ts
+++ b/test/harness/packaged-app.ts
@@ -28,8 +28,23 @@ const PACKAGED_NPM_READY_TIMEOUT_MS = 60_000
 // action, with a live child process of its own. Measured: the outer settled 29ms
 // after abort while the inner child stayed alive another 500-1000ms. Tearing
 // down before the action settles loses LIFO order and lets two children append
-// to one transcript at once. A real `next dev` group takes ~1.2s to reap, so
-// this is ~4x that.
+// to one transcript at once.
+//
+// This does NOT budget for reaping a child — it budgets for a nested session's
+// ENTIRE `finally`: that session's own settle, then its `terminateSubprocess`,
+// then its transcript append. `terminateSubprocess` defaults to graceMs 2_000 +
+// forceMs 2_000 (`packages/testing/src/subprocess.ts:20-24`) and this file
+// passes no timings, so a child that needs SIGKILL puts a hard 4s floor under
+// the wait. 5_000 sits ~1s above that floor.
+//
+// So do not trim this toward what the tests appear to need. The nested fixture
+// releases its port after 600ms, and any value at or above ~1s keeps that test
+// green — while breaking the LIFO/transcript invariant the first time a real
+// inner child escalates to SIGKILL, which T11 concedes happens under CI
+// contention. (The "~1.2s for a `next dev` group" figure this constant once
+// cited does not reproduce: five runs through the real `terminateSubprocess` at
+// load average 21.65 gave 56/57/60/134/145ms with zero survivors. It was never
+// the right bound anyway.)
 const PACKAGED_NPM_ACTION_SETTLE_MS = 5_000
 export const GENERATED_APP_UNSET_ENV = [
   "DAWN_DEMO_DOCKER_SANDBOX",
@@ -691,9 +706,15 @@ export async function withPackagedNpmServer<T>(
   const readiness = options.readiness ?? dawnHealthzReadiness
   const args = ["run", options.script, ...(options.scriptArgs ?? [])]
   const npmLaunch = resolveNpmLaunch()
-  // Port plumbing is keyed on the TARGET, not on the script string. `next` binds
-  // the IPv6 wildcard by default, and `-H 127.0.0.1` is the flag it honours —
-  // `HOST`/`HOSTNAME`/`PORT` are all ignored when a `-p` flag is present.
+  // Which flags go on is decided by the BINARY each script fronts — `dev` fronts
+  // `dawn dev`, `dev:web` fronts `next dev` — even though the branch below can
+  // only read the script name to tell them apart. `next` binds the IPv6 wildcard
+  // by default (contradicting its own help text), and `-H 127.0.0.1` is the flag
+  // it honours. `HOST`/`HOSTNAME` are ignored UNCONDITIONALLY, not merely when a
+  // `-p` is present: Next's commander definition carries `.env('PORT')` on `-p`
+  // and nothing on `-H`, and a live bind with all three set and no `-p` still
+  // took the wildcard while honouring the port. So dropping `-p` does not make
+  // `HOST` start working — it binds the LAN.
   if (options.script === "dev") args.push("--", "--port", String(port))
   else if (options.script === "dev:web") args.push("--", "--port", String(port), "-H", "127.0.0.1")
 
@@ -792,10 +813,23 @@ export async function withPackagedNpmServer<T>(
     // is still tearing down its own child here; without this the two teardowns
     // interleave and both append to `transcriptPath` at once.
     if (pendingAction !== undefined) {
-      await Promise.race([
-        pendingAction.catch(() => undefined),
-        delay(PACKAGED_NPM_ACTION_SETTLE_MS),
-      ])
+      // The timer is cancelled rather than left to fire: on every SUCCESSFUL
+      // teardown this race is decided in a microtask, and a bare `delay()` would
+      // still leave a live 5s handle behind — measured, the call returned at
+      // 264ms and the handle was still in the process census at 5237ms. NOT
+      // `.unref()`: that trades the stray handle for a silent exit-0 in the
+      // middle of teardown whenever an action genuinely never settles.
+      let settleTimer: NodeJS.Timeout | undefined
+      try {
+        await Promise.race([
+          pendingAction.catch(() => undefined),
+          new Promise<void>((settle) => {
+            settleTimer = setTimeout(settle, PACKAGED_NPM_ACTION_SETTLE_MS)
+          }),
+        ])
+      } finally {
+        if (settleTimer !== undefined) clearTimeout(settleTimer)
+      }
     }
 
     if (child && closed && groupPid !== undefined) {


### PR DESCRIPTION
Teaches the generated-app activation lane to boot **both** processes and prove the generated web client reaches **this** generated server. SP3b of the scaffold-UI arc; follows #494 (SP3a). Test infrastructure and docs only — no published package changes, so no changeset.

Until now the lane booted one process (the Dawn agent) and never started the web client at all. `npm run dev:web` — the command the scaffold's own next-steps text tells a user to run on minute one — had nothing proving it worked, including the trailing ` --` on the root delegator that `template-root-scripts.test.ts` exists to protect.

## Three things a reviewer needs that the diff won't give them

**1. `/api/copilotkit/info` returns 200 with the Dawn server dead.** It never dials upstream. That rules it out as a readiness probe, and it is exactly the kind of signal that looks authoritative and proves nothing. Readiness is `GET /api/dawn/memory/candidates` → 2xx instead: a 2xx there means the route's whole module graph compiled *and* the proxy reached a Dawn server.

**2. False-ready doesn't error — it hangs.** A request issued at Next's `Ready in Xms` stdout line blocked **20,676ms** and then returned 200. TCP-connect readiness fires within ~15ms of that same line, so it tells the same lie. Both were measured and rejected. This is why readiness had to be an HTTP 2xx on a route the journeys actually use.

**3. W2 is the only assertion that catches a proxy talking to the wrong server**, and there is a full-lane mutation proving it. With the `DAWN_SERVER_URL` injection removed (so the web child falls back to its hard-coded `:3002`) and a Dawn-shaped stub parked on 3002 — the real case of a developer's own workbench already running — readiness passed, W1 passed, and W3 would have passed. Only W2 failed: `expected 404 to be 200`. Do not soften it to "not 502".

## What's here

- **A readiness seam** on `withPackagedNpmServer`: `dawnHealthzReadiness` stays the default for every existing caller, `httpOkReadiness(path)` serves Next, which has no `/healthz`. `script` widens to `"dev" | "dev:web" | "start"`.
- **The web client nested inside the dev session** — server outer, web inner. Nesting already gives LIFO teardown, per-child transcripts, and a per-child port probe; making the helper multi-child would buy nothing.
- **Six assertions over plain `fetch`**, none duplicating the web workspace's own vitest suite (which the lane already runs via `npm test --workspaces`): allowlist 403; the thread-state read that proves the hop; `/api/copilotkit/info`; a full agent run through the third-party runtime; a gated run plus resume on the same tool-call id; and transcript/sanitizer coverage for the second child.
- `DAWN_SERVER_URL` injected at spawn — verified Next does **not** inline it; the built chunk keeps `process.env.DAWN_SERVER_URL??"http://127.0.0.1:3002"` verbatim.

## Two pre-existing bugs fixed on the way

- **The abort path leaked a live child.** `awaitWithAbort` stopped awaiting the action and the outer `finally` ran ~29ms later while the child was alive another 500–1000ms. Harmless with one process; with two it leaks a live `next` process group, breaks LIFO teardown, and lets two children append to one transcript concurrently. Now the action settles first.
- **`assertRecordedServerExit` was unbounded.** Anchoring fixed *which* line was found but not where the block *ended*, so a `dev:web` block missing its own exit line would borrow the server block's `[exit 0]` and be pronounced recorded — the exact green-while-broken shape the assertion exists to prevent.

## A hermeticity hole, closed with end-to-end proof

The lane's `npm run build` fans out to `next build`, which evaluates the CopilotKit runtime at module scope during "Collecting page data" and fires a live `POST https://telemetry.copilotkit.ai/ingest` — in a lane whose entire claim is that the generated app never reaches the network. Pre-existing on `main`. Closed at the vitest-config level (the per-command fix doesn't typecheck — `runGeneratedAppNpmCommand` has no `env` parameter). Confirmed by transcript: `anonymous telemetry enabled` appears **1× before, 0× after**.

Whether the *scaffold itself* should default telemetry off is a product question, deliberately left as a separate task rather than decided here.

## Verification

Five green lane runs plus one through `pnpm verify:harness:framework` (exit 0, 50 tests). Harness suite 28 (baseline 25, +3). `pnpm build` · `pnpm lint` · `check-docs` · `check-changesets` · devkit 43 · research-web 209 — all exit 0.

Mutations: the full-lane W2 one above; an offline suite over real captured events (9 mutations, all throw, negative control exits 1); the abort fix (inner child still serving when the outer settled); the readiness seam (both new tests red); the anchor and the block bound (a web block borrowing the server's exit line looked green).

**Web tier's measured cost: ~6.6s.** I am not claiming a clean total delta — body totals ranged 174–230s across runs on identical code, driven by an `npm install` that swung 92–137s, several times the whole web tier. That's recorded in the source so a future 230s run reads as noise, not regression.

## What this lane still won't catch

Anything needing a browser: rendering, React state, streaming into a transcript, clicking. That's SP4's Playwright gate, and the boundary is stated in the plan so implementation didn't drift across it.

## Notes

Four comment rationales were corrected in review, two of which had handed a future maintainer an argument for deleting a live assertion — including one that claimed the transcript check proves the web child inherits the credential strip. It doesn't: breaking the strip for `dev:web` leaves the full lane green while the harness's own unit test reds in 33s. The assertion stays as a leak canary; the comment now says so and points at where the strip is genuinely proven.

Also worth knowing: the root `test/` tree is covered by neither `pnpm lint` (root biome checks only `package.json` and `scripts`) nor `pnpm typecheck` (only `test/security-dependencies` has a tsconfig). Everything here was verified with a scratch config, which also surfaced **3 pre-existing type errors** in files this branch never touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
