### PR TITLE
fix(cli): check the model package each app actually needs

### DIFF
--- a/.changeset/verify-provider-model-packages.md
+++ b/.changeset/verify-provider-model-packages.md
@@ -1,0 +1,23 @@
+---
+"@dawn-ai/cli": patch
+---
+
+Check the model package each app actually needs in `dawn verify`.
+
+The dependency probe hardcoded `@langchain/openai` and looked for it in the
+app's own `node_modules`, which was wrong in both directions.
+
+An app whose routes use Anthropic was told to install `@langchain/openai`, which
+it never imports, and was told nothing about `@langchain/anthropic`, which it
+does — an optional peer no install step provides, so the app passed verify and
+then failed at its first model call. The required package now comes from the
+providers the routes use, read from the same provider map `dawn build` uses to
+decide which specifiers to bake into an edge bundle.
+
+In the other direction, the probe reported packages that were installed and
+working. `@langchain/core`, `@langchain/langgraph` and the provider packages are
+imported by `@dawn-ai/langchain`, not by the app, so the walk now starts at that
+package — resolving its symlink first — and falls back to the app root. Under
+pnpm a package's dependencies sit in the store beside it, reachable from the
+importer and deliberately not from the app, so every pnpm-based Dawn app saw
+three warnings telling it to install packages it already had.

--- a/packages/cli/src/lib/verify/check-dependencies.ts
+++ b/packages/cli/src/lib/verify/check-dependencies.ts
@@ -1,5 +1,6 @@
-import { existsSync, readFileSync } from "node:fs"
+import { existsSync, readFileSync, realpathSync } from "node:fs"
 import { dirname, join, resolve } from "node:path"
+import { providerPackages } from "@dawn-ai/langchain"
 import type { BuiltInModelProviderId } from "@dawn-ai/sdk"
 import { resolveEnvPath } from "../dev/resolve-env-path.js"
 import { loadDawnConfig } from "../node-config.js"
@@ -23,10 +24,36 @@ export interface CheckDependenciesOptions {
 }
 
 /**
- * Required peer packages for Dawn LangChain/LangGraph routes.
- * These must be installed in the user's app for routes to function.
+ * The packages Dawn's own LangChain/LangGraph layer imports no matter which
+ * model an app runs. Every Dawn app needs both.
+ *
+ * The provider packages are NOT here: which one an app needs is a function of
+ * the providers its routes use, exactly as the required API-key env var is.
+ * See {@link requiredPackages}.
  */
-const REQUIRED_PACKAGES = ["@langchain/core", "@langchain/openai", "@langchain/langgraph"] as const
+const DAWN_LAYER_PACKAGES = ["@langchain/core", "@langchain/langgraph"] as const
+
+/** The package that imports {@link DAWN_LAYER_PACKAGES} and every provider package. */
+const IMPORTING_PACKAGE = "@dawn-ai/langchain"
+
+/**
+ * Every package this app must be able to resolve: Dawn's own layer, plus one
+ * model package per provider its routes use.
+ *
+ * `providerPackages` is the same provider→package map `dawn build`'s
+ * web-runtime target bakes into an edge bundle, so verify and build answer
+ * "which model package does this app need" from one source. A provider with no
+ * entry is skipped rather than guessed at — `providers` is derived from route
+ * model ids, and an id Dawn cannot map must not invent a package name.
+ */
+function requiredPackages(providers: readonly string[]): readonly string[] {
+  const forProviders = new Set<string>()
+  for (const provider of providers) {
+    const packageName = providerPackages[provider as BuiltInModelProviderId]
+    if (packageName) forProviders.add(packageName)
+  }
+  return [...DAWN_LAYER_PACKAGES, ...[...forProviders].sort()]
+}
 
 /**
  * Provider → the API-key env var it authenticates with. `null` means the
@@ -46,35 +73,73 @@ const PROVIDER_ENV_VAR: Record<BuiltInModelProviderId, string | null> = {
 }
 
 /**
- * Is `pkg` installed somewhere Node would find it from `appRoot`?
+ * Is `pkg` installed somewhere Node would find it from `from`?
  *
- * Walks `<dir>/node_modules/<pkg>` up from `appRoot` to the filesystem root, the
+ * Walks `<dir>/node_modules/<pkg>` up from `from` to the filesystem root, the
  * way Node's own resolution walk does. The upward walk is the point: in an npm
  * workspace the generated app's `dawn.config.ts` lives in `<app>/server`, so
- * `appRoot` is the workspace MEMBER, while npm hoists dependencies to
- * `<app>/node_modules` one level up. A probe that looks only in
- * `appRoot/node_modules` reports every hoisted package as missing.
+ * the app root is the workspace MEMBER, while npm hoists dependencies to
+ * `<app>/node_modules` one level up. A probe that looks only in one directory
+ * reports every hoisted package as missing.
  *
  * Deliberately `existsSync` rather than `require.resolve(pkg)` or
  * `require.resolve(`${pkg}/package.json`)`: both consult the package's `exports`
  * map and throw ERR_PACKAGE_PATH_NOT_EXPORTED for packages that are genuinely
  * installed but do not export that subpath — trading a false "missing" warning
  * for a worse failure. A directory probe sidesteps `exports` entirely.
- *
- * pnpm needs no special casing: its public `node_modules/<pkg>` entries are
- * symlinks into the `.pnpm` store and `existsSync` follows symlinks, so a linked
- * package resolves true exactly as a copied one does. Packages that pnpm's
- * strict layout deliberately hides (transitive deps reachable only inside
- * `.pnpm`) stay hidden here — but Node would not resolve them from `appRoot`
- * either, so matching the resolution walk is the honest answer.
  */
-function isPackageInstalled(appRoot: string, pkg: string): boolean {
-  let dir = resolve(appRoot)
+function isPackageInstalled(from: string, pkg: string): boolean {
+  let dir = resolve(from)
   for (;;) {
     if (existsSync(join(dir, "node_modules", pkg))) return true
     const parent = dirname(dir)
     // dirname() is a fixed point at the filesystem root ("/" → "/", "C:\" → "C:\").
     if (parent === dir) return false
+    dir = parent
+  }
+}
+
+/**
+ * Where to start the walk, nearest importer first.
+ *
+ * These packages are imported by `@dawn-ai/langchain`, not by the user's app,
+ * so the question Node will actually ask at runtime is whether THAT package can
+ * resolve them. Rooting the walk only at the app is what made the flagship
+ * example report all three Dawn-layer packages missing on every `dawn verify`
+ * while they were installed and working: pnpm keeps a package's dependencies in
+ * the store beside it, reachable from the importer and deliberately not from
+ * the app. npm's layout is a subset of that — a hoisted dependency sits above
+ * the importer and is found by the same walk.
+ *
+ * `realpathSync` is what crosses pnpm's symlink: the app's entry is a link into
+ * the store, and the dependencies sit beside the REAL directory, not the link.
+ * A link that cannot be resolved falls back to its own path rather than
+ * dropping the root, so a broken install degrades to today's answer instead of
+ * throwing.
+ *
+ * The app root stays in the list. An app may declare and import these packages
+ * itself, and when `@dawn-ai/langchain` is not installed at all it is the only
+ * root there is.
+ */
+function resolutionRoots(appRoot: string): readonly string[] {
+  const importer = importingPackageDir(appRoot)
+  return importer ? [importer, appRoot] : [appRoot]
+}
+
+/** The real directory of the installed `@dawn-ai/langchain`, or undefined. */
+function importingPackageDir(appRoot: string): string | undefined {
+  let dir = resolve(appRoot)
+  for (;;) {
+    const candidate = join(dir, "node_modules", IMPORTING_PACKAGE)
+    if (existsSync(candidate)) {
+      try {
+        return realpathSync(candidate)
+      } catch {
+        return candidate
+      }
+    }
+    const parent = dirname(dir)
+    if (parent === dir) return undefined
     dir = parent
   }
 }
@@ -113,11 +178,16 @@ export async function checkDependencies(
     return { missingPackages: [], missingEnvVars: [] }
   }
 
-  for (const pkg of REQUIRED_PACKAGES) {
-    if (!declaredDeps.has(pkg)) {
-      // Also check if it's resolvable (might be a transitive dep, or hoisted to
-      // a workspace root above appRoot) — hence the upward walk.
-      if (!isPackageInstalled(appRoot, pkg)) {
+  // A declared dependency is satisfied by declaration alone. Filtering first
+  // keeps the filesystem out of it entirely for an app that declares everything.
+  const undeclared = requiredPackages(options.providers ?? []).filter(
+    (pkg) => !declaredDeps.has(pkg),
+  )
+
+  if (undeclared.length > 0) {
+    const roots = resolutionRoots(appRoot)
+    for (const pkg of undeclared) {
+      if (!roots.some((root) => isPackageInstalled(root, pkg))) {
         missingPackages.push(pkg)
       }
     }

--- a/packages/cli/test/check-dependencies.test.ts
+++ b/packages/cli/test/check-dependencies.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { existsSync, mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest"
@@ -45,7 +45,7 @@ describe("checkDependencies", () => {
       }),
     )
 
-    const result = await checkDependencies({ appRoot: tempDir })
+    const result = await checkDependencies({ appRoot: tempDir, providers: ["openai"] })
 
     expect(result.missingPackages).toContain("@langchain/core")
     expect(result.missingPackages).toContain("@langchain/openai")
@@ -256,12 +256,13 @@ describe("checkDependencies package resolution", () => {
     mkdirSync(join(appRoot, "node_modules"), { recursive: true })
     installInto(tempDir, ["some-other-package"])
 
-    const result = await checkDependencies({ appRoot })
+    const result = await checkDependencies({ appRoot, providers: ["openai"] })
 
+    // Dawn's own layer first, then the app's provider packages.
     expect(result.missingPackages).toEqual([
       "@langchain/core",
-      "@langchain/openai",
       "@langchain/langgraph",
+      "@langchain/openai",
     ])
   })
 
@@ -300,5 +301,184 @@ describe("checkDependencies package resolution", () => {
       .mock.calls.map(([path]) => String(path))
       .filter((path) => path.includes("node_modules"))
     expect(probed).toEqual([])
+  })
+})
+
+/**
+ * Which model package an app needs is a function of the providers its routes
+ * use — the same input the env-var check already derives `OPENAI_API_KEY` vs
+ * `ANTHROPIC_API_KEY` from.
+ *
+ * Two defects motivated this, one in each direction. An Anthropic-only app was
+ * told to install `@langchain/openai`, which it does not import, and was NOT
+ * told about `@langchain/anthropic`, which it does — an optional peer of
+ * `@dawn-ai/langchain` that no install step provides, so the app builds green
+ * and dies at the first model call with ERR_MODULE_NOT_FOUND. That is precisely
+ * the failure `dawn verify` exists to catch, and it was the one provider case
+ * the check could not see.
+ *
+ * `providerPackages` is the same map `dawn build`'s web-runtime target uses to
+ * decide which specifiers to bake into an edge bundle, so verify and build now
+ * answer "which model package does this app need" from one source.
+ */
+describe("checkDependencies provider packages", () => {
+  /** An app that declares the Dawn-layer packages, so only provider packages can be reported. */
+  function writeAppDeclaring(...packages: readonly string[]) {
+    writeFileSync(
+      join(tempDir, "package.json"),
+      JSON.stringify({
+        dependencies: Object.fromEntries(packages.map((name) => [name, "1.0.0"])),
+      }),
+    )
+  }
+
+  const DAWN_LAYER = ["@langchain/core", "@langchain/langgraph"] as const
+
+  test("reports the provider package an Anthropic app needs", async () => {
+    writeAppDeclaring(...DAWN_LAYER)
+
+    const result = await checkDependencies({ appRoot: tempDir, providers: ["anthropic"] })
+
+    expect(result.missingPackages).toEqual(["@langchain/anthropic"])
+  })
+
+  test("does not report @langchain/openai for an app with no OpenAI route", async () => {
+    writeAppDeclaring(...DAWN_LAYER)
+
+    const result = await checkDependencies({ appRoot: tempDir, providers: ["groq"] })
+
+    expect(result.missingPackages).not.toContain("@langchain/openai")
+  })
+
+  test("reports one package per provider, deduped and ordered", async () => {
+    writeAppDeclaring(...DAWN_LAYER)
+
+    const result = await checkDependencies({
+      appRoot: tempDir,
+      providers: ["openai", "anthropic", "openai"],
+    })
+
+    expect(result.missingPackages).toEqual(["@langchain/anthropic", "@langchain/openai"])
+  })
+
+  test("passes when the provider package is declared", async () => {
+    writeAppDeclaring(...DAWN_LAYER, "@langchain/anthropic")
+
+    const result = await checkDependencies({ appRoot: tempDir, providers: ["anthropic"] })
+
+    expect(result.missingPackages).toEqual([])
+  })
+
+  test("requires no provider package for a keyless local provider", async () => {
+    // Ollama needs no API key, but it does need its model package — the package
+    // check and the env-var check are independent.
+    writeAppDeclaring(...DAWN_LAYER)
+
+    const result = await checkDependencies({ appRoot: tempDir, providers: ["ollama"] })
+
+    expect(result.missingPackages).toEqual(["@langchain/ollama"])
+  })
+
+  test("checks no provider package when the app has no routes", async () => {
+    writeAppDeclaring(...DAWN_LAYER)
+
+    const result = await checkDependencies({ appRoot: tempDir, providers: [] })
+
+    expect(result.missingPackages).toEqual([])
+  })
+
+  test("ignores a provider with no known model package", async () => {
+    // `providers` comes from route model ids; an id Dawn cannot map must not
+    // crash verify or invent a package name.
+    writeAppDeclaring(...DAWN_LAYER)
+
+    const result = await checkDependencies({ appRoot: tempDir, providers: ["not-a-provider"] })
+
+    expect(result.missingPackages).toEqual([])
+  })
+})
+
+/**
+ * The Dawn-layer packages are imported by `@dawn-ai/langchain`, not by the
+ * user's app — so the question is whether THAT package can resolve them, not
+ * whether the app can.
+ *
+ * Motivating regression: under pnpm's strict layout the flagship example
+ * reported all three of `@langchain/core`, `@langchain/openai` and
+ * `@langchain/langgraph` missing on every `dawn verify`, telling the user to
+ * install packages that were installed and working. pnpm keeps a package's own
+ * dependencies inside the store next to it, reachable from the importer and
+ * deliberately not from the app — exactly the layout the appRoot-only walk
+ * cannot see.
+ */
+describe("checkDependencies importer resolution", () => {
+  /** Lay out `<app>/node_modules/@dawn-ai/langchain` with its own deps beside it. */
+  function installLangchainPackage(appRoot: string, ownDeps: readonly string[]) {
+    const pkgDir = join(appRoot, "node_modules", "@dawn-ai", "langchain")
+    mkdirSync(pkgDir, { recursive: true })
+    for (const dep of ownDeps) {
+      mkdirSync(join(pkgDir, "node_modules", dep), { recursive: true })
+    }
+    return pkgDir
+  }
+
+  test("finds packages resolvable only from @dawn-ai/langchain", async () => {
+    writeFileSync(join(tempDir, "package.json"), JSON.stringify({ dependencies: {} }))
+    installLangchainPackage(tempDir, ["@langchain/core", "@langchain/langgraph"])
+
+    const result = await checkDependencies({ appRoot: tempDir })
+
+    expect(result.missingPackages).toEqual([])
+  })
+
+  test("follows a symlinked @dawn-ai/langchain to where its real deps live", async () => {
+    // pnpm's layout: the app's entry is a symlink into the store, and the
+    // package's dependencies sit beside the REAL directory, not the link.
+    const store = join(tempDir, "store", "@dawn-ai", "langchain")
+    mkdirSync(join(store, "node_modules", "@langchain", "core"), { recursive: true })
+    mkdirSync(join(store, "node_modules", "@langchain", "langgraph"), { recursive: true })
+
+    const appRoot = join(tempDir, "app")
+    mkdirSync(join(appRoot, "node_modules", "@dawn-ai"), { recursive: true })
+    writeFileSync(join(appRoot, "package.json"), JSON.stringify({ dependencies: {} }))
+    symlinkSync(store, join(appRoot, "node_modules", "@dawn-ai", "langchain"), "dir")
+
+    const result = await checkDependencies({ appRoot })
+
+    expect(result.missingPackages).toEqual([])
+  })
+
+  test("still reports packages neither root can resolve", async () => {
+    writeFileSync(join(tempDir, "package.json"), JSON.stringify({ dependencies: {} }))
+    installLangchainPackage(tempDir, ["@langchain/core"])
+
+    const result = await checkDependencies({ appRoot: tempDir })
+
+    expect(result.missingPackages).toEqual(["@langchain/langgraph"])
+  })
+
+  test("falls back to the appRoot walk when @dawn-ai/langchain is absent", async () => {
+    writeFileSync(join(tempDir, "package.json"), JSON.stringify({ dependencies: {} }))
+    mkdirSync(join(tempDir, "node_modules", "@langchain", "core"), { recursive: true })
+    mkdirSync(join(tempDir, "node_modules", "@langchain", "langgraph"), { recursive: true })
+
+    const result = await checkDependencies({ appRoot: tempDir })
+
+    expect(result.missingPackages).toEqual([])
+  })
+
+  test("resolves a provider package from the importer too", async () => {
+    // Optional peers are hoisted next to `@dawn-ai/langchain` by npm and kept in
+    // the store by pnpm; either way the importer is what has to see them.
+    writeFileSync(join(tempDir, "package.json"), JSON.stringify({ dependencies: {} }))
+    installLangchainPackage(tempDir, [
+      "@langchain/core",
+      "@langchain/langgraph",
+      "@langchain/anthropic",
+    ])
+
+    const result = await checkDependencies({ appRoot: tempDir, providers: ["anthropic"] })
+
+    expect(result.missingPackages).toEqual([])
   })
 })

--- a/test/generated/fixtures/basic.expected.json
+++ b/test/generated/fixtures/basic.expected.json
@@ -53,13 +53,9 @@
       },
       {
         "missingEnvVars": [],
-        "missingPackages": [
-          "@langchain/core",
-          "@langchain/openai",
-          "@langchain/langgraph"
-        ],
+        "missingPackages": [],
         "name": "deps",
-        "status": "warning"
+        "status": "passed"
       },
       {
         "name": "runtime",

--- a/test/generated/fixtures/custom-app-dir.expected.json
+++ b/test/generated/fixtures/custom-app-dir.expected.json
@@ -53,13 +53,9 @@
       },
       {
         "missingEnvVars": [],
-        "missingPackages": [
-          "@langchain/core",
-          "@langchain/openai",
-          "@langchain/langgraph"
-        ],
+        "missingPackages": [],
         "name": "deps",
-        "status": "warning"
+        "status": "passed"
       },
       {
         "name": "runtime",


### PR DESCRIPTION
`dawn verify`'s dependency probe hardcoded `@langchain/openai` and looked for it in the app's own `node_modules`. Both halves were wrong, in opposite directions.

## The false negative

Which API-key env var an app needs is already derived from the providers its routes use — an Anthropic app is checked for `ANTHROPIC_API_KEY`. The package check was not. It asked for `@langchain/openai` on every app, and never asked for `@langchain/anthropic`, `@langchain/groq`, `@langchain/ollama` or any other provider package.

Those are **optional peers** of `@dawn-ai/langchain`. No install step provides them. So a non-OpenAI app passed `dawn verify`, then failed at its first model call with a module-not-found — precisely the failure verify exists to catch, and the one provider case it could not see.

The required set now comes from `providerPackages`, the same provider→package map `dawn build`'s web-runtime target already uses to decide which specifiers to bake into an edge bundle. Verify and build now answer "which model package does this app need" from one source.

## The false positive

These packages are imported by `@dawn-ai/langchain`, not by the user's app, so the question Node asks at runtime is whether *that* package can resolve them. Walking up from the app root only is what produced this on `main`:

```
$ cd examples/research/server && dawn verify
Dawn app integrity OK: 5 checks passed, 2 routes discovered.
Warning: Missing packages: @langchain/core, @langchain/openai, @langchain/langgraph.
         Install with: npm install @langchain/core @langchain/openai @langchain/langgraph
```

All three were installed and working. pnpm keeps a package's dependencies in the store beside it, reachable from the importer and deliberately not from the app — the one layout the app-rooted walk cannot see. Every pnpm-based Dawn app has been told to install three packages it already had.

The walk now starts at `@dawn-ai/langchain`'s **real** directory (`realpathSync` is what crosses pnpm's symlink and `create-dawn-ai-app --mode internal`'s `file:` link), and falls back to the app root — which stays in the list, since an app may import these itself and it is the only root when `@dawn-ai/langchain` is not installed at all.

## Verification

Reproduced and confirmed against the built `dist`, not just unit tests.

**Before**, on the flagship example and on a real generated app: three warnings, and `@langchain/openai` reported missing on a `create-dawn-ai-app` output *whose model run through the Workbench had just succeeded* — found during the workbench arc's live verification.

**After**, same commands:

```
$ cd examples/research/server && dawn verify
Dawn app integrity OK: 5 checks passed, 2 routes discovered.
Warning: Missing environment variables: OPENAI_API_KEY. ...
```

```
$ cd <generated-app> && npm run verify
Dawn app integrity OK: 5 checks passed, 2 routes discovered.
Warning: Missing environment variables: OPENAI_API_KEY. ...
```

Only the genuine warning is left. Negative control on the generated app first: `@langchain/openai` is confirmed absent from `<app>/node_modules`, so the old probe would still warn there — the fix is the importer root, not a changed install.

**Negative control for the other direction.** Internal mode symlinks `@dawn-ai/langchain` to the worktree, where every provider is a devDependency, so every provider resolves — honest for that layout, but it cannot exercise a miss. Rebuilding npm's external-mode layout (a real `@dawn-ai/langchain` carrying only its production dependencies) and running the built `dist`:

```
openai     clean
anthropic  REPORTS @langchain/anthropic
groq       REPORTS @langchain/groq
ollama     REPORTS @langchain/ollama
```

12 new tests cover both directions, including the pnpm symlink layout, an unknown provider id (skipped, never guessed), and a provider with no API key but a required package. Two existing tests that hardcoded the OpenAI triple now name the provider, which is what they always meant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## The harness fixture this changed

`validate` went red on the first push, correctly. The generated-app harness runs `pnpm install` then `dawn verify --json` and asserted the exact result — including that all three Dawn-layer packages were missing. That fixture was a record of the bug.

The app it generates is the clearest possible demonstration. Its `@dawn-ai/langchain` is a symlink into `.pnpm/@dawn-ai+langchain@0.8.21_…/node_modules/`, and `@langchain/openai` is reachable from there and deliberately not from the app root — so the old probe warned while the app worked. And the "basic" scenario first rewrites the route to a handwritten `agent = { async invoke() }` with **no model at all**, so verify was telling an app that runs no model to install the OpenAI package.

Both fixtures now assert the deps check passes with nothing missing, which turns them from a record of the false positive into a guard against it. I took the values by running the harness locally and reading `dawn verify --json` out of the app it generated, rather than predicting an exact-match diff:

```
deps  -> {"missingEnvVars": [], "missingPackages": [], "name": "deps", "status": "passed"}
counts-> {"failed": 0, "passed": 5, "total": 5} status: passed
```

`test/generated/run-generated-app.test.ts` now passes 5/5 locally.

Note `test/generated/run-generated-research-activation.test.ts:1271` already asserted `not.toContain("Missing packages")`, added for this same defect class during SP3a. It stayed green because that lane installs with **npm**, which hoists `@langchain/openai` to the app root; the false positive only appears under pnpm's strict layout and under `create-dawn-ai-app --mode internal`'s `file:` links.
