### PR TITLE
fix(build): make turbo's typecheck graph produce what it consumes

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -33,6 +33,7 @@
   },
   "devDependencies": {
     "@dawn-ai/config-typescript": "workspace:*",
+    "@dawn-ai/core": "workspace:*",
     "@types/mdx": "^2.0.14",
     "@types/node": "26.1.2",
     "@types/react": "19.2.18",

--- a/examples/chat/web/app/globals.d.ts
+++ b/examples/chat/web/app/globals.d.ts
@@ -1,0 +1,17 @@
+// Ambient declarations for the stylesheet imports in `layout.tsx`.
+//
+// Next ships `declare module "*.css"` in its own `global.d.ts`, but that file
+// is only reachable through the `/// <reference types="next" />` inside
+// `next-env.d.ts` — which Next writes during `next dev`/`next build` and which
+// `.gitignore` keeps out of the repo. So on a fresh clone, before anyone has
+// built, `tsc` has no declaration for a side-effect stylesheet import and
+// `npm run typecheck` fails with TS2882 on every `import "...css"` below.
+//
+// The empty body deliberately matches Next's own declaration: a stylesheet is
+// typed identically before and after the first build. The shorthand form
+// (`declare module "*.css";`) would instead widen every stylesheet import to
+// `any`, so pre-build and post-build type checking would disagree.
+//
+// Only `*.css` is declared because that is all this app imports. Add the
+// matching `*.module.css` shape here too if you start using CSS modules.
+declare module "*.css" {}

--- a/examples/chat/web/package.json
+++ b/examples/chat/web/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "next dev -p 3000",
     "build": "node -e \"require('node:fs').rmSync('.next', { recursive: true, force: true })\" && next build",
+    "lint": "biome check --config-path ../../../packages/config-biome/biome.json package.json app e2e tsconfig.json next.config.mjs playwright.config.ts",
     "start": "next start -p 3000",
     "test:e2e": "playwright test --config playwright.config.ts",
     "typecheck": "tsc -p . --noEmit"

--- a/examples/chat/web/tsconfig.json
+++ b/examples/chat/web/tsconfig.json
@@ -17,6 +17,12 @@
     "plugins": [{ "name": "next" }],
     "paths": { "@/*": ["./*"] }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts", ".next/dev/types/**/*.ts"],
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts",
+    ".next/dev/types/**/*.ts"
+  ],
   "exclude": ["node_modules"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -126,6 +126,9 @@ importers:
       '@dawn-ai/config-typescript':
         specifier: workspace:*
         version: link:../../packages/config-typescript
+      '@dawn-ai/core':
+        specifier: workspace:*
+        version: link:../../packages/core
       '@types/mdx':
         specifier: ^2.0.14
         version: 2.0.14

--- a/scripts/check-build-cache-config.mjs
+++ b/scripts/check-build-cache-config.mjs
@@ -88,8 +88,19 @@ if (!buildOutputs.includes(".dawn/build/**")) {
 // Tests import their workspace dependencies through `exports`, which resolve to
 // `dist/`. Without a build edge the test graph produces no `dist/` at all and
 // runs against whatever happens to be on disk.
+//
+// `typecheck` needs the same edge for the same reason, plus one of its own: a
+// package's typecheck compiles files that may import its OWN `dist/`
+// (packages/memory's benches do), and `tsc --noEmit` writes
+// `dist/tsconfig.tsbuildinfo` — the very file `build` writes. Without a self
+// edge those two tasks are unordered, so a clean-tree `turbo run typecheck`
+// passes or fails on scheduling luck and the two can write one incremental-state
+// file concurrently. `"build"` subsumes `"^build"`, since `build` already
+// declares `dependsOn: ["^build"]`.
 for (const [taskName, task] of Object.entries(turboConfig.tasks ?? {})) {
-  if (taskName !== "test" && !taskName.endsWith("#test")) {
+  const bareName = taskName.includes("#") ? taskName.slice(taskName.indexOf("#") + 1) : taskName
+
+  if (bareName !== "test" && bareName !== "typecheck") {
     continue
   }
 

--- a/turbo.json
+++ b/turbo.json
@@ -35,7 +35,18 @@
       "dependsOn": ["build", "^test"]
     },
     "@dawn-ai/cli#test": {
-      "dependsOn": ["build", "^test", "@dawn-ai/testing#build", "@dawn-ai/postgres-storage#build"],
+      "dependsOn": [
+        "build",
+        "^test",
+        "@dawn-ai/testing#build",
+        "@dawn-ai/postgres-storage#build",
+        "@dawn-ai/evals#build",
+        "@dawn-ai/memory-pgvector#build",
+        "@dawn-ai/devkit#build",
+        "@dawn-ai/vite-plugin#build",
+        "@dawn-ai/inspector#build",
+        "create-dawn-ai-app#build"
+      ],
       "inputs": [
         "$TURBO_DEFAULT$",
         "$TURBO_ROOT$/apps/web/content/docs/**",
@@ -99,7 +110,10 @@
       "inputs": ["$TURBO_DEFAULT$", "$TURBO_ROOT$/test/harness/**"]
     },
     "typecheck": {
-      "dependsOn": ["^typecheck"]
+      "dependsOn": ["build"]
+    },
+    "@dawn-ai/cli#typecheck": {
+      "dependsOn": ["build", "@dawn-ai/testing#build", "@dawn-ai/postgres-storage#build"]
     }
   }
 }


### PR DESCRIPTION
`typecheck` depended on `^typecheck`, but typechecking a package consumes its dependencies' emitted `.d.ts` — and `tsc --noEmit` emits nothing. On a clean tree the repo's own `pnpm typecheck` fails:

```
$ pnpm turbo run typecheck          # every dist/ and *.tsbuildinfo removed
@dawn-ai/testing:typecheck: src/harness.ts(14,8): error TS2307: Cannot find module '@dawn-ai/cli/runtime' …
@dawn-ai/testing:typecheck: src/harness.ts(15,48): error TS2307: Cannot find module '@dawn-ai/core' …
… cascading TS2307 across many packages, plus a flood of consequent TS7006
```

CI only survives this because it runs a full `pnpm build` before `pnpm typecheck`. Scope note: CI does **not** run `turbo run test` (`pnpm test` is a plain vitest workspace run), so the `#test` edges below fix the local/dev path; `pnpm typecheck` *is* `turbo run typecheck`, so that half does reach CI.

## Why `["build"]` and not `["^build"]`

`^build` was my first fix and it is not enough. A package's typecheck can consume its **own** build output — `packages/memory/tsconfig.test.json` includes `bench/**/*.mts`, and those benches `import { sqliteMemoryStore } from "../dist/index.js"`. With only `^build`, `memory#typecheck` and `memory#build` have identical dependency sets and are unordered, so a clean-tree run passes or fails on scheduling luck. Filtered, it fails every time:

```
$ rm -rf packages/memory/dist
$ pnpm turbo run typecheck --filter=@dawn-ai/memory --force
bench/browse-budgets.mts(23,8): error TS2307: Cannot find module '../dist/browse-budget.js'
Failed: @dawn-ai/memory#typecheck
```

There is a second reason: `tsc --noEmit` **writes** `dist/tsconfig.tsbuildinfo`, the same path `build`'s `tsc -b` writes. Unordered, the two tasks race on one incremental-state file. The self edge serializes them. `build` already declares `dependsOn: ["^build"]`, so `["build"]` subsumes `["^build"]`.

## The missing package edges

`@dawn-ai/testing`, `@dawn-ai/postgres-storage`, `@dawn-ai/evals` and `@dawn-ai/memory-pgvector` all **depend on `@dawn-ai/cli`**, so `@dawn-ai/cli` cannot declare them without a package cycle. `packages/cli`'s tests reach them by relative path into `dist/` instead, and the explicit `pkg#build` edges are the established workaround — `@dawn-ai/cli#test` already carried two. It was missing the rest:

```
$ pnpm turbo run test --filter=@dawn-ai/cli    # clean tree
CliError: Eval-load failure: Failed to resolve entry for package "@dawn-ai/evals".
Error: ENOENT: no such file or directory, open '…/packages/create-dawn-app/dist/bin.js'
Test Files  5 failed | 129 passed | 1 skipped (135)
```

`@dawn-ai/inspector` is in that list because the API-reference registry has an **operated** artifact at `.next/standalone/packages/inspector/server.js`, which `assertNodeOperated` reads off disk. Worth flagging: I missed this at first because my "clean tree" only deleted `dist/`, so a stale `.next/` kept the test green.

`apps/web` is the same defect one level out: `app/components/docs/api-reference-inventory.test.ts:8` imports `../../../../../packages/core/src/typegen/render-route-types`, which drags in `@dawn-ai/permissions`, `@dawn-ai/sqlite-storage` and `@dawn-ai/workspace` `.d.ts` — while the package declared only `@dawn-ai/sdk`. Its filtered typecheck built none of them. Declaring `@dawn-ai/core` gives `^build` the exact closure.

## The guard that should have caught this

`scripts/check-build-cache-config.mjs` already asserts every `test` task lists `build` in `dependsOn`. It never covered `typecheck` — which is why this shipped and why `pnpm check:build-cache` passed on the broken config. It covers both now, with a negative control:

```
$ # with the original "typecheck": { "dependsOn": ["^typecheck"] } restored
$ pnpm check:build-cache
Build cache config check failed.
- turbo.json typecheck must include "build" in dependsOn
```

## Two latent bugs this surfaced

Fixing the graph let `examples/chat/web`'s typecheck run for the first time, and it failed with TS2882 — no ambient `*.css` declaration, the identical bug `examples/research/web` fixed in SP3a. It was invisible twice over: typecheck never got far enough to report it, and `turbo run lint` skipped the package entirely because it had no `lint` script. Both are fixed here (the lint script also caught an unformatted `tsconfig.json`).

## Verification

On a genuinely clean tree — `dist/`, `.next/`, `.dawn/`, `.turbo/` and every `*.tsbuildinfo` removed:

| | before | after |
|---|---|---|
| `turbo run typecheck` | cascading TS2307 | **51/51 pass** |
| `turbo run test --filter=@dawn-ai/cli` | **5 test files failed** | **134 passed, 1 skipped** |
| `pnpm lint` | 23 packages (chat-web skipped) | **24/24 pass** |
| `pnpm check:build-cache` | passed on the broken config | passes, and rejects it |

Whole-repo `--dry=json` for `build`, `test` and `typecheck` all exit 0, so no edge introduces a cycle.

A separate pre-existing flake turned up and is **not** addressed here: `packages/core/test/render-route-types.test.ts` spawns TypeScript on vitest's default 5000ms timeout with roughly 2× headroom, and times out under a saturated `turbo run test --force`. Reproduced identically with this change stashed, and it is not on a path CI runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)