### PR TITLE
fix(example): type chat stylesheet imports before build

### DIFF
--- a/examples/chat/web/app/globals.d.ts
+++ b/examples/chat/web/app/globals.d.ts
@@ -1,0 +1,3 @@
+// Next normally supplies this declaration through the generated next-env.d.ts.
+// Keep stylesheet side-effect imports type-safe before the first Next build.
+declare module "*.css" {}


### PR DESCRIPTION
## Summary
- add the missing ambient CSS declaration to the chat web example
- make a clean checkout typecheck before Next generates `next-env.d.ts`
- keep the declaration aligned with the existing research web example

## Root cause
The chat app imports two stylesheet side effects, but unlike the research app it did not provide a `*.css` declaration before the first Next build. A clean TypeScript run therefore failed with TS2882.

## Test plan
- [x] reproduced both TS2882 failures on a clean worktree
- [x] `pnpm --dir examples/chat/web typecheck`
- [x] `pnpm --dir examples/chat/web build`
- [x] `pnpm ci:validate`
- [x] framework, runtime, and smoke harness lanes