### PR TITLE
build: close the remaining lint and test-timeout coverage holes

### DIFF
--- a/apps/web/app/components/docs/api-reference-inventory.test.ts
+++ b/apps/web/app/components/docs/api-reference-inventory.test.ts
@@ -1819,7 +1819,12 @@ const analyses = subprocesses.flatMap((subprocess) =>
 )
 const byName = new Map(analyses.map((analysis) => [analysis.name, analysis]))
 
-describe("API reference wrapper contracts", () => {
+// These suites shell out to Node subprocesses (`check-docs.mjs`, bundling
+// probes, the sitemap generator), so their runtime tracks machine load rather
+// than the work in the test. Under a saturated parallel run they have exceeded
+// vitest's 5000ms default and failed as timeouts rather than as anything real.
+// The explicit suite timeout leaves room for that without hiding a genuine hang.
+describe("API reference wrapper contracts", { timeout: 30_000 }, () => {
   it("structurally pairs every API wrapper with its canonical content, route, and title", () => {
     const wrapperSources = allReferencePages.map((page) => foundationalWrapper(page.slug))
     const wrapperAnalyses = analyzeWrapperContracts(wrapperSources)
@@ -1866,7 +1871,7 @@ describe("API reference wrapper contracts", () => {
   })
 })
 
-describe("foundational API reference pages", () => {
+describe("foundational API reference pages", { timeout: 30_000 }, () => {
   it.each(foundationalPages)("uses the exact H1 for $href", (page) => {
     const content = foundationalContent(page.slug)
 
@@ -2020,7 +2025,7 @@ describe("foundational API reference pages", () => {
   })
 })
 
-describe("package API reference pages", () => {
+describe("package API reference pages", { timeout: 30_000 }, () => {
   it.each(packagePages)("uses the exact H1 for $href", (page) => {
     const content = foundationalContent(page.slug)
 
@@ -2481,7 +2486,7 @@ ${packageExample("memory-pgvector").replace(
   })
 })
 
-describe("source-derived API inventory", () => {
+describe("source-derived API inventory", { timeout: 30_000 }, () => {
   it("runs every isolated fixture through one compact stdin-fed process", () => {
     expect(fixtures).toHaveLength(165)
     expect(Buffer.byteLength(JSON.stringify(baseline()))).toBeLessThan(16 * 1024)

--- a/apps/web/app/components/docs/api-reference.test.ts
+++ b/apps/web/app/components/docs/api-reference.test.ts
@@ -437,7 +437,12 @@ function expectRegistryRejection(artifact: Record<string, unknown>, message: Reg
   ).toThrow(message)
 }
 
-describe("API reference page registry", () => {
+// These suites shell out to Node subprocesses (`check-docs.mjs`, bundling
+// probes, the sitemap generator), so their runtime tracks machine load rather
+// than the work in the test. Under a saturated parallel run they have exceeded
+// vitest's 5000ms default and failed as timeouts rather than as anything real.
+// The explicit suite timeout leaves room for that without hiding a genuine hang.
+describe("API reference page registry", { timeout: 30_000 }, () => {
   it("pins the approved surfaces, destinations, ownership, and parent hub", () => {
     expect(
       API_REFERENCE_PAGES.map(({ label, href, surfaceName, ownerPackageNames }) => [
@@ -481,7 +486,7 @@ describe("API reference page registry", () => {
   })
 })
 
-describe("client navigation dependency boundary", () => {
+describe("client navigation dependency boundary", { timeout: 30_000 }, () => {
   it("preserves the page registry exports on the server registry entrypoint", () => {
     const exports = apiReferenceExports as Record<string, unknown>
     const registrySource = readFileSync(
@@ -516,7 +521,7 @@ describe("client navigation dependency boundary", () => {
   })
 })
 
-describe("artifact registry", () => {
+describe("artifact registry", { timeout: 30_000 }, () => {
   it("renders stable public documentation labels without delivery-state coverage names", () => {
     const forbidden = /\b(?:detailed|catalog-only)\b/
     for (const artifact of ARTIFACT_REGISTRY) {
@@ -936,7 +941,7 @@ describe("artifact registry", () => {
   })
 })
 
-describe("published manifest address inventory", () => {
+describe("published manifest address inventory", { timeout: 30_000 }, () => {
   it("matches exports, bins, and the Inspector server while ignoring package imports", () => {
     const manifests = publicPackageManifests()
     expect(analyzeApiReferenceManifests(manifests).failures).toEqual([])
@@ -1031,7 +1036,7 @@ describe("published manifest address inventory", () => {
   })
 })
 
-describe("package catalog", () => {
+describe("package catalog", { timeout: 30_000 }, () => {
   it("pins the exact twelve-package patch changeset", () => {
     const source = readFileSync(CHANGESET_PATH, "utf8")
     const entries = [...source.matchAll(/^"([^"]+)": (\w+)$/gm)].map((match) => [

--- a/apps/web/app/components/docs/api-reference.ts
+++ b/apps/web/app/components/docs/api-reference.ts
@@ -663,7 +663,7 @@ export const API_BEHAVIOR_CONTRACTS = [
         file: "packages/workspace/test/local-exec.test.ts",
         testNames: ["runCommand enforces timeout"],
         assertionFingerprint:
-          'await expect ( exec . runCommand ( { command : "sleep 1" } , ctx ( root ) ) , ) . rejects . toThrow ( /timeout/i )',
+          'await expect ( exec . runCommand ( { command : "sleep 1" } , ctx ( root ) ) ) . rejects . toThrow ( /timeout/i )',
       },
     ],
   },

--- a/apps/web/app/components/docs/nav.test.ts
+++ b/apps/web/app/components/docs/nav.test.ts
@@ -415,7 +415,12 @@ function topologyFailures(
   return failures
 }
 
-describe("documentation registry invariants", () => {
+// These suites shell out to Node subprocesses (`check-docs.mjs`, bundling
+// probes, the sitemap generator), so their runtime tracks machine load rather
+// than the work in the test. Under a saturated parallel run they have exceeded
+// vitest's 5000ms default and failed as timeouts rather than as anything real.
+// The explicit suite timeout leaves room for that without hiding a genuine hang.
+describe("documentation registry invariants", { timeout: 30_000 }, () => {
   it("uses the exact eight-section foundation", () => {
     expect(DOCS_NAV).toEqual(FOUNDATION_DOCS_NAV)
   })
@@ -693,7 +698,7 @@ describe("documentation registry invariants", () => {
   })
 })
 
-describe("documentation title analysis", () => {
+describe("documentation title analysis", { timeout: 30_000 }, () => {
   const wrapper = `import type { Metadata } from "next"
 export const metadata: Metadata = { title: "Real Title" }
 `
@@ -1289,7 +1294,7 @@ ${pageSource}`,
   })
 })
 
-describe("maintained documentation heading identity analysis", () => {
+describe("maintained documentation heading identity analysis", { timeout: 30_000 }, () => {
   it("accepts analyzer input larger than an argv payload", () => {
     const source = `## Large fixture\n${" ".repeat(1_100_000)}`
 
@@ -1391,7 +1396,7 @@ describe("maintained documentation heading identity analysis", () => {
   })
 })
 
-describe("compatibility stub analysis", () => {
+describe("compatibility stub analysis", { timeout: 30_000 }, () => {
   const canonicalHref = "/docs/canonical"
 
   it("recognizes retained heading text that contains inline code", () => {
@@ -1556,7 +1561,7 @@ ${"x".repeat(650)}
   })
 })
 
-describe("canonical docs link guard analysis", () => {
+describe("canonical docs link guard analysis", { timeout: 30_000 }, () => {
   it("uses standard Markdown grammar for README ownership guards", () => {
     const requiredHref = "/docs/ag-ui"
     const source = `<!-- README ownership note -->

--- a/apps/web/app/seo/generate-lastmod.test.ts
+++ b/apps/web/app/seo/generate-lastmod.test.ts
@@ -26,7 +26,12 @@ afterEach(() => {
   for (const directory of temporaryDirectories.splice(0)) rmSync(directory, { recursive: true })
 })
 
-describe("generate-seo-lastmod", () => {
+// These suites shell out to Node subprocesses (`check-docs.mjs`, bundling
+// probes, the sitemap generator), so their runtime tracks machine load rather
+// than the work in the test. Under a saturated parallel run they have exceeded
+// vitest's 5000ms default and failed as timeouts rather than as anything real.
+// The explicit suite timeout leaves room for that without hiding a genuine hang.
+describe("generate-seo-lastmod", { timeout: 30_000 }, () => {
   it(
     "runs a freshness check for the checked-in manifest using today's production visibility",
     () => {

--- a/apps/web/content/prompts/index.ts
+++ b/apps/web/content/prompts/index.ts
@@ -1,15 +1,10 @@
-export type PromptSlug =
-	| "scaffold"
-	| "add-a-tool"
-	| "write-a-route"
-	| "write-a-test"
-	| "deploy";
+export type PromptSlug = "scaffold" | "add-a-tool" | "write-a-route" | "write-a-test" | "deploy"
 
 export interface PromptEntry {
-	readonly slug: PromptSlug;
-	readonly title: string;
-	readonly description: string;
-	readonly body: string;
+  readonly slug: PromptSlug
+  readonly title: string
+  readonly description: string
+  readonly body: string
 }
 
 const SCAFFOLD = `Help me scaffold a new Dawn app from the default research starter. Dawn is a TypeScript-first meta-framework for building graph-based AI agents with file-system routing, shared and route-local tools, and inferred types.
@@ -75,7 +70,7 @@ const SCAFFOLD = `Help me scaffold a new Dawn app from the default research star
 Key packages: \`@dawn-ai/sdk\` (authoring contract), \`@dawn-ai/langgraph\` (graphs/workflows), \`@dawn-ai/langchain\` (LCEL and provider-aware agent materialization), \`@dawn-ai/cli\` (CLI).
 
 Reference: https://dawnai.org/llms.txt
-`;
+`
 
 const ADD_A_TOOL = `Help me add a new tool to an existing Dawn app. Dawn discovers shared tools in \`src/tools/*.ts\` and route-local tools in \`src/app/<route>/tools/*.ts\`; their types are generated from TypeScript — no Zod schemas or manual type wiring.
 
@@ -107,7 +102,7 @@ Constraints:
 - \`readonly\` is recommended on input fields; Dawn preserves it through type generation.
 
 Reference: https://dawnai.org/llms.txt
-`;
+`
 
 const WRITE_A_ROUTE = `Help me add a new route to an existing Dawn app. Routes are directories under \`src/app/\` where each directory maps to a URL-style pathname (minus route groups).
 
@@ -169,7 +164,7 @@ Constraints:
 - The \`RouteTools<"/path">\` type is generated from the shared and route-local tools available to that route.
 
 Reference: https://dawnai.org/llms.txt
-`;
+`
 
 const WRITE_A_TEST = `Help me write tests for a Dawn route. Pick the right style for the route kind:
 
@@ -263,7 +258,7 @@ Constraints:
 - In-process scenarios can replace selected application tools with \`.mockTool()\` and assert calls with \`.expectTool()\`; server-backed scenarios cannot use tool mocks.
 
 Reference: https://dawnai.org/llms.txt
-`;
+`
 
 const DEPLOY = `Help me choose and deploy the right Dawn build target. Dawn can emit a self-hosted Node server, an opt-in edge app, generated LangGraph entries, or any combination named in \`build.targets\`.
 
@@ -315,45 +310,45 @@ const DEPLOY = `Help me choose and deploy the right Dawn build target. Dawn can 
 5. Show me the exact files the build emitted, the command that starts or deploys them, the required runtime environment and storage, and one target-boundary smoke test. Refer to https://dawnai.org/docs/deployment for the full service and limitation matrix rather than reproducing it.
 
 Reference: https://dawnai.org/llms.txt
-`;
+`
 
 export const PROMPTS: readonly PromptEntry[] = [
-	{
-		slug: "scaffold",
-		title: "Scaffold a new Dawn app",
-		description: "Create a new Dawn project and walk through the structure.",
-		body: SCAFFOLD,
-	},
-	{
-		slug: "add-a-tool",
-		title: "Add a tool",
-		description: "Add a type-inferred tool to an existing route.",
-		body: ADD_A_TOOL,
-	},
-	{
-		slug: "write-a-route",
-		title: "Write a route",
-		description: "Create a new route with workflow/graph/chain.",
-		body: WRITE_A_ROUTE,
-	},
-	{
-		slug: "write-a-test",
-		title: "Write a test",
-		description: "Choose agent harness tests or deterministic route scenarios.",
-		body: WRITE_A_TEST,
-	},
-	{
-		slug: "deploy",
-		title: "Choose a deployment target",
-		description: "Build for the Dawn Node runtime, a compatible edge app, or LangSmith.",
-		body: DEPLOY,
-	},
-];
+  {
+    slug: "scaffold",
+    title: "Scaffold a new Dawn app",
+    description: "Create a new Dawn project and walk through the structure.",
+    body: SCAFFOLD,
+  },
+  {
+    slug: "add-a-tool",
+    title: "Add a tool",
+    description: "Add a type-inferred tool to an existing route.",
+    body: ADD_A_TOOL,
+  },
+  {
+    slug: "write-a-route",
+    title: "Write a route",
+    description: "Create a new route with workflow/graph/chain.",
+    body: WRITE_A_ROUTE,
+  },
+  {
+    slug: "write-a-test",
+    title: "Write a test",
+    description: "Choose agent harness tests or deterministic route scenarios.",
+    body: WRITE_A_TEST,
+  },
+  {
+    slug: "deploy",
+    title: "Choose a deployment target",
+    description: "Build for the Dawn Node runtime, a compatible edge app, or LangSmith.",
+    body: DEPLOY,
+  },
+]
 
 export function getPrompt(slug: PromptSlug): PromptEntry {
-	const entry = PROMPTS.find((p) => p.slug === slug);
-	if (!entry) {
-		throw new Error(`Unknown prompt slug: ${slug}`);
-	}
-	return entry;
+  const entry = PROMPTS.find((p) => p.slug === slug)
+  if (!entry) {
+    throw new Error(`Unknown prompt slug: ${slug}`)
+  }
+  return entry
 }

--- a/apps/web/lib/github-contributors.ts
+++ b/apps/web/lib/github-contributors.ts
@@ -17,7 +17,7 @@ export async function getGitHubContributors(): Promise<number> {
     }
     const response = await fetch(
       `https://api.github.com/repos/${REPO}/contributors?per_page=1&anon=true`,
-      { headers, next: { revalidate: 3600 } }
+      { headers, next: { revalidate: 3600 } },
     )
     if (!response.ok) return FALLBACK
     const link = response.headers.get("link") ?? ""

--- a/apps/web/lib/shiki/highlight-light.ts
+++ b/apps/web/lib/shiki/highlight-light.ts
@@ -1,4 +1,4 @@
-import { createHighlighter, type BundledLanguage } from "shiki"
+import { type BundledLanguage, createHighlighter } from "shiki"
 
 let highlighterPromise: ReturnType<typeof createHighlighter> | null = null
 
@@ -17,10 +17,7 @@ function getHighlighter() {
  * cream SaaS-rebrand surfaces where a dark theme would be unreadable.
  * Background is owned by the surrounding container (transparent).
  */
-export async function highlightLight(
-  code: string,
-  lang: BundledLanguage
-): Promise<string> {
+export async function highlightLight(code: string, lang: BundledLanguage): Promise<string> {
   const highlighter = await getHighlighter()
   return highlighter.codeToHtml(code, {
     lang,

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "next build",
     "dev": "next dev",
-    "lint": "biome check --config-path ../../packages/config-biome/biome.json --css-parse-tailwind-directives=true package.json app scripts next.config.ts tsconfig.json mdx-components.tsx",
+    "lint": "biome check --config-path ../../packages/config-biome/biome.json --css-parse-tailwind-directives=true package.json app content lib scripts mdx-components.tsx next.config.ts postcss.config.mjs vercel.json vitest.config.ts tsconfig.json",
     "seo:audit-built": "node scripts/audit-built-seo.mjs",
     "seo:lastmod": "node scripts/generate-seo-lastmod.mjs",
     "seo:lastmod:check": "node scripts/generate-seo-lastmod.mjs --check",

--- a/examples/chat/server/package.json
+++ b/examples/chat/server/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "node node_modules/@dawn-ai/cli/dist/index.js dev --port 3001",
     "build": "node node_modules/@dawn-ai/cli/dist/index.js build",
+    "lint": "biome check --config-path ../../../packages/config-biome/biome.json package.json dawn.config.ts src test tsconfig.json vitest.config.ts",
     "typecheck": "tsc -p . --noEmit",
     "check": "node node_modules/@dawn-ai/cli/dist/index.js check",
     "test": "vitest run"

--- a/examples/chat/server/src/app/chat/capabilities.test.ts
+++ b/examples/chat/server/src/app/chat/capabilities.test.ts
@@ -45,24 +45,28 @@ describe("chat route — autowired capabilities", () => {
   })
 
   it("includes both planning and agents-md contributions for the chat route", async () => {
-    const registry = createCapabilityRegistry([
-      createPlanningMarker(),
-      createAgentsMdMarker(),
-    ])
-    const result = await applyCapabilities(registry, ROUTE_DIR, { routeManifest: { appRoot: ROUTE_DIR, routes: [] }, descriptor: undefined, appRoot: ROUTE_DIR, markerFs: nodeMarkerFs })
+    const registry = createCapabilityRegistry([createPlanningMarker(), createAgentsMdMarker()])
+    const result = await applyCapabilities(registry, ROUTE_DIR, {
+      routeManifest: { appRoot: ROUTE_DIR, routes: [] },
+      descriptor: undefined,
+      appRoot: ROUTE_DIR,
+      markerFs: nodeMarkerFs,
+    })
 
     expect(result.errors).toEqual([])
-    expect(result.contributions.map((c) => c.markerName)).toEqual([
-      "planning",
-      "agents-md",
-    ])
+    expect(result.contributions.map((c) => c.markerName)).toEqual(["planning", "agents-md"])
   })
 
   it("planning contribution comes from this route's plan.md", async () => {
     expect(existsSync(resolve(ROUTE_DIR, "plan.md"))).toBe(true)
 
     const registry = createCapabilityRegistry([createPlanningMarker()])
-    const result = await applyCapabilities(registry, ROUTE_DIR, { routeManifest: { appRoot: ROUTE_DIR, routes: [] }, descriptor: undefined, appRoot: ROUTE_DIR, markerFs: nodeMarkerFs })
+    const result = await applyCapabilities(registry, ROUTE_DIR, {
+      routeManifest: { appRoot: ROUTE_DIR, routes: [] },
+      descriptor: undefined,
+      appRoot: ROUTE_DIR,
+      markerFs: nodeMarkerFs,
+    })
     const planning = result.contributions[0]?.contribution
 
     expect(planning?.tools?.map((t) => t.name)).toEqual(["writeTodos"])
@@ -79,7 +83,12 @@ describe("chat route — autowired capabilities", () => {
 
     const registry = createCapabilityRegistry([createAgentsMdMarker()])
     // Pass workDir as appRoot so the marker resolves AGENTS.md from workDir/workspace/.
-    const result = await applyCapabilities(registry, ROUTE_DIR, { routeManifest: { appRoot: workDir, routes: [] }, descriptor: undefined, appRoot: workDir, markerFs: nodeMarkerFs })
+    const result = await applyCapabilities(registry, ROUTE_DIR, {
+      routeManifest: { appRoot: workDir, routes: [] },
+      descriptor: undefined,
+      appRoot: workDir,
+      markerFs: nodeMarkerFs,
+    })
     const fragment = result.contributions[0]?.contribution.promptFragment
     const rendered = fragment?.render({}) ?? ""
 
@@ -89,7 +98,11 @@ describe("chat route — autowired capabilities", () => {
 
   it("agents-md fragment is empty when workspace/AGENTS.md is absent", async () => {
     const registry = createCapabilityRegistry([createAgentsMdMarker()])
-    const result = await applyCapabilities(registry, ROUTE_DIR, { routeManifest: { appRoot: workDir, routes: [] }, descriptor: undefined, appRoot: workDir })
+    const result = await applyCapabilities(registry, ROUTE_DIR, {
+      routeManifest: { appRoot: workDir, routes: [] },
+      descriptor: undefined,
+      appRoot: workDir,
+    })
     const fragment = result.contributions[0]?.contribution.promptFragment
     expect(fragment?.render({})).toBe("")
   })
@@ -101,7 +114,12 @@ describe("chat route — autowired capabilities", () => {
     writeFileSync(path, "Iteration 1: tools should be camelCase")
     const registry = createCapabilityRegistry([createAgentsMdMarker()])
     // Pass workDir as appRoot so AGENTS.md is read from workDir/workspace/.
-    const result = await applyCapabilities(registry, ROUTE_DIR, { routeManifest: { appRoot: workDir, routes: [] }, descriptor: undefined, appRoot: workDir, markerFs: nodeMarkerFs })
+    const result = await applyCapabilities(registry, ROUTE_DIR, {
+      routeManifest: { appRoot: workDir, routes: [] },
+      descriptor: undefined,
+      appRoot: workDir,
+      markerFs: nodeMarkerFs,
+    })
     const fragment = result.contributions[0]?.contribution.promptFragment
 
     const first = fragment?.render({}) ?? ""
@@ -117,7 +135,12 @@ describe("chat route — autowired capabilities", () => {
 
   it("planning prompt re-renders todos from live state on each call", async () => {
     const registry = createCapabilityRegistry([createPlanningMarker()])
-    const result = await applyCapabilities(registry, ROUTE_DIR, { routeManifest: { appRoot: ROUTE_DIR, routes: [] }, descriptor: undefined, appRoot: ROUTE_DIR, markerFs: nodeMarkerFs })
+    const result = await applyCapabilities(registry, ROUTE_DIR, {
+      routeManifest: { appRoot: ROUTE_DIR, routes: [] },
+      descriptor: undefined,
+      appRoot: ROUTE_DIR,
+      markerFs: nodeMarkerFs,
+    })
     const fragment = result.contributions[0]?.contribution.promptFragment
 
     const empty = fragment?.render({ todos: [] }) ?? ""

--- a/examples/chat/server/test/agent.test.ts
+++ b/examples/chat/server/test/agent.test.ts
@@ -1,12 +1,15 @@
 import { fileURLToPath } from "node:url"
-import { afterAll, it } from "vitest"
 import { createAgentHarness, expectFinalMessage, script } from "@dawn-ai/testing"
+import { afterAll, it } from "vitest"
 
 const appRoot = fileURLToPath(new URL("..", import.meta.url))
 const h = await createAgentHarness({ appRoot, route: "/chat#agent" })
 afterAll(() => h.close())
 
 it("greets the user", async () => {
-  const run = await h.run({ input: "hello", fixtures: script().user("hello").replies("Hi! How can I help?") })
+  const run = await h.run({
+    input: "hello",
+    fixtures: script().user("hello").replies("Hi! How can I help?"),
+  })
   expectFinalMessage(run).toContain("help")
 }, 60_000)

--- a/examples/chat/server/tsconfig.json
+++ b/examples/chat/server/tsconfig.json
@@ -5,9 +5,5 @@
     "noEmit": true,
     "rootDir": "."
   },
-  "include": [
-    "dawn.config.ts",
-    "src/**/*.ts",
-    ".dawn/dawn.generated.d.ts"
-  ]
+  "include": ["dawn.config.ts", "src/**/*.ts", ".dawn/dawn.generated.d.ts"]
 }

--- a/examples/memory/server/package.json
+++ b/examples/memory/server/package.json
@@ -10,7 +10,7 @@
     "typecheck": "tsc -p . --noEmit",
     "check": "node node_modules/@dawn-ai/cli/dist/index.js check",
     "inspect": "node node_modules/@dawn-ai/cli/dist/index.js inspect",
-    "test": "vitest run"
+    "test": "vitest run --passWithNoTests"
   },
   "dependencies": {
     "@dawn-ai/cli": "workspace:*",

--- a/examples/memory/server/package.json
+++ b/examples/memory/server/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "node node_modules/@dawn-ai/cli/dist/index.js dev --port 3002",
     "build": "node node_modules/@dawn-ai/cli/dist/index.js build",
+    "lint": "biome check --config-path ../../../packages/config-biome/biome.json package.json dawn.config.ts src tsconfig.json",
     "typecheck": "tsc -p . --noEmit",
     "check": "node node_modules/@dawn-ai/cli/dist/index.js check",
     "inspect": "node node_modules/@dawn-ai/cli/dist/index.js inspect",

--- a/examples/research/server/package.json
+++ b/examples/research/server/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "node node_modules/@dawn-ai/cli/dist/index.js dev --port 3002",
     "build": "node node_modules/@dawn-ai/cli/dist/index.js build",
+    "lint": "biome check --config-path ../../../packages/config-biome/biome.json package.json dawn.config.ts src test tsconfig.json vitest.config.ts",
     "typecheck": "tsc -p . --noEmit",
     "check": "node node_modules/@dawn-ai/cli/dist/index.js check",
     "test": "vitest run",

--- a/examples/research/server/src/app/research/evals/research-quality.eval.ts
+++ b/examples/research/server/src/app/research/evals/research-quality.eval.ts
@@ -1,8 +1,7 @@
 import { contains, custom, defineEval, gate, llmJudge, toolCalled } from "@dawn-ai/evals"
 import { script } from "@dawn-ai/testing"
 
-const JUDGE_CRITERIA =
-  "The report answers the question and cites at least one source document."
+const JUDGE_CRITERIA = "The report answers the question and cites at least one source document."
 
 export default defineEval({
   name: "research quality",
@@ -25,9 +24,7 @@ export default defineEval({
       fixtures: script()
         .user("How should I evaluate an LLM app?")
         .callsTool("searchCorpus", { query: "evaluate llm app" })
-        .replies(
-          "Use scorers and a gate over a dataset of cases. [corpus/evaluating-llm-apps.md]",
-        )
+        .replies("Use scorers and a gate over a dataset of cases. [corpus/evaluating-llm-apps.md]")
         .user("cites at least one source")
         .replies('{"score":1,"reason":"answers and cites a source"}'),
     },

--- a/examples/research/server/test/sandbox-docker.test.ts
+++ b/examples/research/server/test/sandbox-docker.test.ts
@@ -2,14 +2,9 @@ import { constants } from "node:fs"
 import { access, rm } from "node:fs/promises"
 import { join } from "node:path"
 import { fileURLToPath } from "node:url"
-import { expect, it } from "vitest"
-import {
-  createAgentHarness,
-  expectFinalMessage,
-  expectToolCalled,
-  script,
-} from "@dawn-ai/testing"
 import { dockerSandbox } from "@dawn-ai/sandbox"
+import { createAgentHarness, expectFinalMessage, expectToolCalled, script } from "@dawn-ai/testing"
+import { expect, it } from "vitest"
 
 const appRoot = fileURLToPath(new URL("..", import.meta.url))
 const enabled = process.env.DAWN_DEMO_DOCKER_SANDBOX === "1"

--- a/examples/research/server/tsconfig.json
+++ b/examples/research/server/tsconfig.json
@@ -5,9 +5,5 @@
     "noEmit": true,
     "rootDir": "."
   },
-  "include": [
-    "dawn.config.ts",
-    "src/**/*.ts",
-    ".dawn/dawn.generated.d.ts"
-  ]
+  "include": ["dawn.config.ts", "src/**/*.ts", ".dawn/dawn.generated.d.ts"]
 }

--- a/examples/research/web/package.json
+++ b/examples/research/web/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "next dev -p 3010",
     "build": "next build",
-    "lint": "biome check --config-path ../../../packages/config-biome/biome.json --css-parse-tailwind-directives=true package.json app tsconfig.json vitest.config.ts next.config.mjs postcss.config.mjs",
+    "lint": "biome check --config-path ../../../packages/config-biome/biome.json --css-parse-tailwind-directives=true package.json app e2e tsconfig.json vitest.config.ts next.config.mjs postcss.config.mjs playwright.config.ts",
     "start": "next start -p 3010",
     "test": "vitest --run --config vitest.config.ts --passWithNoTests",
     "test:e2e": "playwright test --config playwright.config.ts",

--- a/packages/ag-ui/package.json
+++ b/packages/ag-ui/package.json
@@ -40,7 +40,7 @@
   },
   "scripts": {
     "build": "node -e \"const fs = require('node:fs'); const path = require('node:path'); if (fs.existsSync('dist')) for (const entry of fs.readdirSync('dist', { withFileTypes: true })) if (entry.isFile() && /^(?:encode|run-input|translate)\\./.test(entry.name)) fs.rmSync(path.join('dist', entry.name))\" && tsc -b tsconfig.json && node -e \"const fs = require('node:fs'); fs.mkdirSync('dist/react', { recursive: true }); fs.copyFileSync('src/react/styles.css', 'dist/react/styles.css')\"",
-    "lint": "biome check --config-path ../config-biome/biome.json package.json src tsconfig.json vitest.config.ts",
+    "lint": "biome check --config-path ../config-biome/biome.json package.json src test tsconfig.json vitest.config.ts",
     "test": "vitest --run --config vitest.config.ts --passWithNoTests",
     "typecheck": "tsc --noEmit"
   },

--- a/packages/ag-ui/test/inbound.test.ts
+++ b/packages/ag-ui/test/inbound.test.ts
@@ -48,7 +48,11 @@ describe("fromRunAgentInput", () => {
 
   test("falls back to String() when JSON.stringify returns undefined", () => {
     const content = Symbol.for("x")
-    const message = { id: "m1", role: "user", content } as unknown as RunAgentInput["messages"][number]
+    const message = {
+      id: "m1",
+      role: "user",
+      content,
+    } as unknown as RunAgentInput["messages"][number]
     const input = baseInput({ messages: [message] })
     expect(fromRunAgentInput(input).messages[0]?.content).toBe(String(content))
   })

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -48,7 +48,7 @@
   },
   "scripts": {
     "build": "tsc -b tsconfig.build.json && node scripts/generate-docs.mjs",
-    "lint": "biome check --config-path ../config-biome/biome.json package.json src test tsconfig.json tsconfig.build.json vitest.config.ts",
+    "lint": "biome check --config-path ../config-biome/biome.json package.json src test scripts tsconfig.json tsconfig.build.json vitest.config.ts",
     "test": "vitest --run --config vitest.config.ts",
     "typecheck": "tsc -p tsconfig.json"
   },

--- a/packages/config-biome/biome.json
+++ b/packages/config-biome/biome.json
@@ -2,7 +2,7 @@
   "$schema": "https://biomejs.dev/schemas/2.4.11/schema.json",
   "files": {
     "ignoreUnknown": true,
-    "includes": ["**", "!**/.dawn/**"]
+    "includes": ["**", "!**/.dawn"]
   },
   "formatter": {
     "enabled": true,

--- a/packages/config-biome/package.json
+++ b/packages/config-biome/package.json
@@ -28,6 +28,6 @@
   },
   "scripts": {
     "check": "biome check --config-path ./biome.json ./biome.json",
-    "lint": "biome check --config-path ./biome.json ./biome.json package.json"
+    "lint": "biome check --config-path ../config-biome/biome.json package.json biome.json"
   }
 }

--- a/packages/core/test/compiler-dependency-boundary.test.ts
+++ b/packages/core/test/compiler-dependency-boundary.test.ts
@@ -19,7 +19,13 @@ function readManifest(url: URL): PackageManifest {
   return JSON.parse(readFileSync(url, "utf8")) as PackageManifest
 }
 
-describe("compiler dependency boundary", () => {
+// These suites drive the TypeScript compiler through
+// `src/compiler/typescript-backend.ts`, so their runtime tracks machine load
+// rather than the work in the test. Idle they finish well inside a second; under
+// a saturated parallel run they have exceeded vitest's 5000ms default and failed
+// as timeouts rather than as anything real. The explicit suite timeout leaves
+// room for that without hiding a genuine hang.
+describe("compiler dependency boundary", { timeout: 30_000 }, () => {
   test("keeps the TypeScript 6 compiler API isolated in Core", () => {
     const core = readManifest(corePackageUrl)
     const vite = readManifest(vitePackageUrl)

--- a/packages/core/test/compiler-json-schema-parity.test.ts
+++ b/packages/core/test/compiler-json-schema-parity.test.ts
@@ -46,7 +46,13 @@ async function parametersFromSource(source: string): Promise<{
   return { existing: extracted.map((tool) => tool.parameters), projected }
 }
 
-describe("compiler-neutral JSON Schema behavior", () => {
+// These suites drive the TypeScript compiler through
+// `src/compiler/typescript-backend.ts`, so their runtime tracks machine load
+// rather than the work in the test. Idle they finish well inside a second; under
+// a saturated parallel run they have exceeded vitest's 5000ms default and failed
+// as timeouts rather than as anything real. The explicit suite timeout leaves
+// room for that without hiding a genuine hang.
+describe("compiler-neutral JSON Schema behavior", { timeout: 30_000 }, () => {
   test("keeps a top-level optional object parameter empty", async () => {
     await compareParameters(
       "export default async function tool(input?: { id: string }) { return input }",

--- a/packages/core/test/compiler-route-analysis.test.ts
+++ b/packages/core/test/compiler-route-analysis.test.ts
@@ -107,7 +107,13 @@ function compileScenarioDeclaration(options: {
   return { diagnostics }
 }
 
-describe("analyzeRouteTools", () => {
+// These suites drive the TypeScript compiler through
+// `src/compiler/typescript-backend.ts`, so their runtime tracks machine load
+// rather than the work in the test. Idle they finish well inside a second; under
+// a saturated parallel run they have exceeded vitest's 5000ms default and failed
+// as timeouts rather than as anything real. The explicit suite timeout leaves
+// room for that without hiding a genuine hang.
+describe("analyzeRouteTools", { timeout: 30_000 }, () => {
   test("analyzes the effective sorted tool set with one compiler program", () => {
     const routeDir = join(tempDir, "route")
     const sharedToolsDir = join(tempDir, "shared")

--- a/packages/core/test/compiler-source-analysis.test.ts
+++ b/packages/core/test/compiler-source-analysis.test.ts
@@ -29,7 +29,13 @@ function analyzeRootIntersection(source: string) {
   return parameter
 }
 
-describe("analyzeToolSource", () => {
+// These suites drive the TypeScript compiler through
+// `src/compiler/typescript-backend.ts`, so their runtime tracks machine load
+// rather than the work in the test. Idle they finish well inside a second; under
+// a saturated parallel run they have exceeded vitest's 5000ms default and failed
+// as timeouts rather than as anything real. The explicit suite timeout leaves
+// room for that without hiding a genuine hang.
+describe("analyzeToolSource", { timeout: 30_000 }, () => {
   test("analyzes a typed default-exported tool from one callable signature", () => {
     const source = `
 /**

--- a/packages/core/test/extract-tool-schema.test.ts
+++ b/packages/core/test/extract-tool-schema.test.ts
@@ -27,7 +27,13 @@ async function extractSchemasFromSource(source: string) {
   return extractToolSchemasForRoute({ routeDir, sharedToolsDir: undefined })
 }
 
-describe("extractToolSchemasForRoute", () => {
+// These suites drive the TypeScript compiler through
+// `src/compiler/typescript-backend.ts`, so their runtime tracks machine load
+// rather than the work in the test. Idle they finish well inside a second; under
+// a saturated parallel run they have exceeded vitest's 5000ms default and failed
+// as timeouts rather than as anything real. The explicit suite timeout leaves
+// room for that without hiding a genuine hang.
+describe("extractToolSchemasForRoute", { timeout: 30_000 }, () => {
   test("extracts full JSON Schema with JSDoc descriptions", async () => {
     const routeDir = join(tempDir, "route")
     writeToolFile(

--- a/packages/core/test/render-route-types.test.ts
+++ b/packages/core/test/render-route-types.test.ts
@@ -83,7 +83,13 @@ function ambientModuleExports(
     .sort()
 }
 
-describe("renderDawnTypes", () => {
+// These suites drive the TypeScript compiler through
+// `src/compiler/typescript-backend.ts`, so their runtime tracks machine load
+// rather than the work in the test. Idle they finish well inside a second; under
+// a saturated parallel run they have exceeded vitest's 5000ms default and failed
+// as timeouts rather than as anything real. The explicit suite timeout leaves
+// room for that without hiding a genuine hang.
+describe("renderDawnTypes", { timeout: 30_000 }, () => {
   test("loads the exact stable no-state dawn:routes exports through TypeScript", () => {
     const manifest: RouteManifest = {
       appRoot: "/tmp/example-app",
@@ -333,7 +339,7 @@ describe("renderDawnTypes", () => {
   })
 })
 
-describe("renderScenarioTypes", () => {
+describe("renderScenarioTypes", { timeout: 30_000 }, () => {
   test("renders an external testing module augmentation with route-aware tool types", () => {
     const manifest: RouteManifest = {
       appRoot: "/tmp/example-app",
@@ -425,7 +431,7 @@ describe("renderScenarioTypes", () => {
   })
 })
 
-describe("renderRouteTypes", () => {
+describe("renderRouteTypes", { timeout: 30_000 }, () => {
   test("renders valid TypeScript for an empty manifest", () => {
     const manifest: RouteManifest = {
       appRoot: "/tmp/example-app",

--- a/packages/devkit/package.json
+++ b/packages/devkit/package.json
@@ -32,7 +32,7 @@
   },
   "scripts": {
     "build": "tsc -b tsconfig.json",
-    "lint": "biome check --config-path ../config-biome/biome.json package.json src test tsconfig.json vitest.config.ts",
+    "lint": "biome check --config-path ../config-biome/biome.json --css-parse-tailwind-directives=true package.json src test templates tsconfig.json vitest.config.ts",
     "test": "vitest --run --config vitest.config.ts",
     "typecheck": "tsc --noEmit -p tsconfig.json"
   },

--- a/packages/devkit/templates/app-basic/dawn.config.ts
+++ b/packages/devkit/templates/app-basic/dawn.config.ts
@@ -1,1 +1,1 @@
-export default {};
+export default {}

--- a/packages/devkit/templates/app-research/server/src/app/research/evals/research-quality.eval.ts.template
+++ b/packages/devkit/templates/app-research/server/src/app/research/evals/research-quality.eval.ts.template
@@ -1,8 +1,7 @@
 import { contains, custom, defineEval, gate, llmJudge, toolCalled } from "@dawn-ai/evals"
 import { script } from "@dawn-ai/testing"
 
-const JUDGE_CRITERIA =
-  "The report answers the question and cites at least one source document."
+const JUDGE_CRITERIA = "The report answers the question and cites at least one source document."
 
 export default defineEval({
   name: "research quality",
@@ -25,9 +24,7 @@ export default defineEval({
       fixtures: script()
         .user("How should I evaluate an LLM app?")
         .callsTool("searchCorpus", { query: "evaluate llm app" })
-        .replies(
-          "Use scorers and a gate over a dataset of cases. [corpus/evaluating-llm-apps.md]",
-        )
+        .replies("Use scorers and a gate over a dataset of cases. [corpus/evaluating-llm-apps.md]")
         .user("cites at least one source")
         .replies('{"score":1,"reason":"answers and cites a source"}'),
     },

--- a/packages/devkit/templates/app-research/server/test/sandbox-docker.test.ts.template
+++ b/packages/devkit/templates/app-research/server/test/sandbox-docker.test.ts.template
@@ -2,14 +2,9 @@ import { constants } from "node:fs"
 import { access, rm } from "node:fs/promises"
 import { join } from "node:path"
 import { fileURLToPath } from "node:url"
-import { expect, it } from "vitest"
-import {
-  createAgentHarness,
-  expectFinalMessage,
-  expectToolCalled,
-  script,
-} from "@dawn-ai/testing"
 import { dockerSandbox } from "@dawn-ai/sandbox"
+import { createAgentHarness, expectFinalMessage, expectToolCalled, script } from "@dawn-ai/testing"
+import { expect, it } from "vitest"
 
 const appRoot = fileURLToPath(new URL("..", import.meta.url))
 const enabled = process.env.DAWN_DEMO_DOCKER_SANDBOX === "1"

--- a/packages/evals/package.json
+++ b/packages/evals/package.json
@@ -31,7 +31,7 @@
   },
   "scripts": {
     "build": "tsc -b tsconfig.json",
-    "lint": "biome check --config-path ../config-biome/biome.json package.json src tsconfig.json vitest.config.ts",
+    "lint": "biome check --config-path ../config-biome/biome.json package.json src test tsconfig.json vitest.config.ts",
     "test": "vitest --run --config vitest.config.ts --passWithNoTests",
     "typecheck": "tsc --noEmit"
   },

--- a/packages/evals/test/define-eval.test.ts
+++ b/packages/evals/test/define-eval.test.ts
@@ -26,8 +26,8 @@ describe("defineEval", () => {
     expect(defineEval({ name: "e", dataset: "cases.jsonl", scorers: [scorer] }).dataset).toBe(
       "cases.jsonl",
     )
-    expect(typeof defineEval({ name: "e", dataset: () => [{ input: "x" }], scorers: [scorer] }).dataset).toBe(
-      "function",
-    )
+    expect(
+      typeof defineEval({ name: "e", dataset: () => [{ input: "x" }], scorers: [scorer] }).dataset,
+    ).toBe("function")
   })
 })

--- a/packages/evals/test/llm-judge.test.ts
+++ b/packages/evals/test/llm-judge.test.ts
@@ -1,25 +1,41 @@
-import { describe, expect, it, vi } from "vitest"
 import type { AgentRunResult } from "@dawn-ai/testing"
+import { describe, expect, it, vi } from "vitest"
 import { llmJudge } from "../src/llm-judge.js"
 import { normalizeScore } from "../src/score.js"
 
 function run(finalMessage: string): AgentRunResult {
   return {
-    finalMessage, messages: [], toolCalls: [], tokens: [], state: {}, threadId: "t",
-    interrupts: [], planUpdates: [], todos: [], subagents: [], subagentEvents: [], systemPrompt: "",
+    finalMessage,
+    messages: [],
+    toolCalls: [],
+    tokens: [],
+    state: {},
+    threadId: "t",
+    interrupts: [],
+    planUpdates: [],
+    todos: [],
+    subagents: [],
+    subagentEvents: [],
+    systemPrompt: "",
   }
 }
 
 function fakeFetch(content: string) {
-  return vi.fn(async () =>
-    new Response(JSON.stringify({ choices: [{ message: { content } }] }), { status: 200 }),
+  return vi.fn(
+    async () =>
+      new Response(JSON.stringify({ choices: [{ message: { content } }] }), { status: 200 }),
   )
 }
 
 describe("llmJudge", () => {
   it("parses a {score,reason} verdict from the model", async () => {
     const fetchImpl = fakeFetch('{"score":0.8,"reason":"close enough"}')
-    const s = llmJudge({ criteria: "Answer reflects {{expected}}", fetchImpl, baseUrl: "http://x/v1", apiKey: "k" })
+    const s = llmJudge({
+      criteria: "Answer reflects {{expected}}",
+      fetchImpl,
+      baseUrl: "http://x/v1",
+      apiKey: "k",
+    })
     const v = normalizeScore(await s.score(run("hello"), { input: "hi", expected: "hello" }))
     expect(v.score).toBe(0.8)
     expect(v.reason).toBe("close enough")
@@ -28,7 +44,12 @@ describe("llmJudge", () => {
     expect(JSON.stringify(body.messages)).toContain("hello")
   })
   it("scores 0 with a reason when the verdict is unparseable", async () => {
-    const s = llmJudge({ criteria: "x", fetchImpl: fakeFetch("not json"), baseUrl: "http://x/v1", apiKey: "k" })
+    const s = llmJudge({
+      criteria: "x",
+      fetchImpl: fakeFetch("not json"),
+      baseUrl: "http://x/v1",
+      apiKey: "k",
+    })
     const v = normalizeScore(await s.score(run("y"), { input: "i" }))
     expect(v.score).toBe(0)
     expect(v.reason).toMatch(/parse|verdict/i)

--- a/packages/evals/test/memory-scorers.test.ts
+++ b/packages/evals/test/memory-scorers.test.ts
@@ -1,7 +1,7 @@
-import { describe, expect, it } from "vitest"
 import type { AgentRunResult } from "@dawn-ai/testing"
-import { memoryFresh, memoryIsolated, memoryRecalled } from "../src/scorers.js"
+import { describe, expect, it } from "vitest"
 import { normalizeScore } from "../src/score.js"
+import { memoryFresh, memoryIsolated, memoryRecalled } from "../src/scorers.js"
 
 function run(partial: Partial<AgentRunResult>): AgentRunResult {
   return {
@@ -31,7 +31,10 @@ function recallResult(content: string) {
 describe("memoryRecalled", () => {
   it("scores 1 when all expected ids appear in recall tool output", async () => {
     const r = run({
-      toolResults: [recallResult('{"id":"mem-1","value":"foo"}'), recallResult('{"id":"mem-2","value":"bar"}')],
+      toolResults: [
+        recallResult('{"id":"mem-1","value":"foo"}'),
+        recallResult('{"id":"mem-2","value":"bar"}'),
+      ],
     })
     const result = normalizeScore(await memoryRecalled(["mem-1", "mem-2"]).score(r, noCase))
     expect(result.score).toBe(1)
@@ -54,10 +57,7 @@ describe("memoryRecalled", () => {
 
   it("ignores tool results from other tools", async () => {
     const r = run({
-      toolResults: [
-        { name: "store", content: "mem-1", isError: false },
-        recallResult("mem-2"),
-      ],
+      toolResults: [{ name: "store", content: "mem-1", isError: false }, recallResult("mem-2")],
     })
     const result = normalizeScore(await memoryRecalled(["mem-1", "mem-2"]).score(r, noCase))
     expect(result.score).toBe(0)

--- a/packages/evals/test/run-eval.test.ts
+++ b/packages/evals/test/run-eval.test.ts
@@ -1,13 +1,23 @@
-import { describe, expect, it } from "vitest"
 import type { AgentRunResult } from "@dawn-ai/testing"
+import { describe, expect, it } from "vitest"
+import { gate } from "../src/gate.js"
 import { runEval } from "../src/run-eval.js"
 import { contains, toolCalled } from "../src/scorers.js"
-import { gate } from "../src/gate.js"
 
 function run(finalMessage: string, toolCalls: AgentRunResult["toolCalls"] = []): AgentRunResult {
   return {
-    finalMessage, messages: [], toolCalls, tokens: [], state: {}, threadId: "t",
-    interrupts: [], planUpdates: [], todos: [], subagents: [], subagentEvents: [], systemPrompt: "",
+    finalMessage,
+    messages: [],
+    toolCalls,
+    tokens: [],
+    state: {},
+    threadId: "t",
+    interrupts: [],
+    planUpdates: [],
+    todos: [],
+    subagents: [],
+    subagentEvents: [],
+    systemPrompt: "",
   }
 }
 
@@ -43,7 +53,12 @@ describe("runEval", () => {
         name: "e",
         dataset: [{ input: "x" }],
         scorers: [
-          { name: "boom", score: () => { throw new Error("kaboom") } },
+          {
+            name: "boom",
+            score: () => {
+              throw new Error("kaboom")
+            },
+          },
           contains("x"),
         ],
         threshold: 0,

--- a/packages/evals/test/scorers.test.ts
+++ b/packages/evals/test/scorers.test.ts
@@ -1,5 +1,5 @@
-import type { AgentRunResult } from "@dawn-ai/testing"
 import { spawnSync } from "node:child_process"
+import type { AgentRunResult } from "@dawn-ai/testing"
 import { describe, expect, it } from "vitest"
 import { createSafeRegexTester } from "../src/regex-safety.js"
 import { normalizeScore } from "../src/score.js"
@@ -51,33 +51,66 @@ const noCase = { input: "" }
 
 describe("built-in scorers", () => {
   it("contains scores 1 when finalMessage includes the substring, else 0", async () => {
-    expect(normalizeScore(await contains("Found").score(run({ finalMessage: "Found 2" }), noCase)).score).toBe(1)
-    expect(normalizeScore(await contains("Found").score(run({ finalMessage: "none" }), noCase)).score).toBe(0)
+    expect(
+      normalizeScore(await contains("Found").score(run({ finalMessage: "Found 2" }), noCase)).score,
+    ).toBe(1)
+    expect(
+      normalizeScore(await contains("Found").score(run({ finalMessage: "none" }), noCase)).score,
+    ).toBe(0)
   })
   it("regex matches finalMessage", async () => {
-    expect(normalizeScore(await regex(/\d+ items/).score(run({ finalMessage: "3 items" }), noCase)).score).toBe(1)
+    expect(
+      normalizeScore(await regex(/\d+ items/).score(run({ finalMessage: "3 items" }), noCase))
+        .score,
+    ).toBe(1)
   })
   it("exactMatch compares finalMessage to case.expected", async () => {
-    expect(normalizeScore(await exactMatch().score(run({ finalMessage: "ok" }), { input: "", expected: "ok" })).score).toBe(1)
-    expect(normalizeScore(await exactMatch().score(run({ finalMessage: "ok" }), { input: "", expected: "no" })).score).toBe(0)
+    expect(
+      normalizeScore(
+        await exactMatch().score(run({ finalMessage: "ok" }), { input: "", expected: "ok" }),
+      ).score,
+    ).toBe(1)
+    expect(
+      normalizeScore(
+        await exactMatch().score(run({ finalMessage: "ok" }), { input: "", expected: "no" }),
+      ).score,
+    ).toBe(0)
   })
   it("jsonEquals deep-compares parsed finalMessage to case.expected", async () => {
     const r = run({ finalMessage: '{"a":1,"b":[2,3]}' })
-    expect(normalizeScore(await jsonEquals().score(r, { input: "", expected: { a: 1, b: [2, 3] } })).score).toBe(1)
+    expect(
+      normalizeScore(await jsonEquals().score(r, { input: "", expected: { a: 1, b: [2, 3] } }))
+        .score,
+    ).toBe(1)
   })
   it("toolCalled scores 1 when the named tool was called", async () => {
     const r = run({ toolCalls: [{ name: "applyFilter", args: { status: "open" } }] })
     expect(normalizeScore(await toolCalled("applyFilter").score(r, noCase)).score).toBe(1)
-    expect(normalizeScore(await toolCalled("applyFilter", { withArgs: { status: "open" } }).score(r, noCase)).score).toBe(1)
-    expect(normalizeScore(await toolCalled("applyFilter", { withArgs: { status: "closed" } }).score(r, noCase)).score).toBe(0)
+    expect(
+      normalizeScore(
+        await toolCalled("applyFilter", { withArgs: { status: "open" } }).score(r, noCase),
+      ).score,
+    ).toBe(1)
+    expect(
+      normalizeScore(
+        await toolCalled("applyFilter", { withArgs: { status: "closed" } }).score(r, noCase),
+      ).score,
+    ).toBe(0)
     expect(normalizeScore(await toolCalled("missing").score(r, noCase)).score).toBe(0)
   })
   it("tokensUnder scores 1 when streamed token count is under the budget", async () => {
-    expect(normalizeScore(await tokensUnder(5).score(run({ tokens: ["a", "b"] }), noCase)).score).toBe(1)
-    expect(normalizeScore(await tokensUnder(1).score(run({ tokens: ["a", "b"] }), noCase)).score).toBe(0)
+    expect(
+      normalizeScore(await tokensUnder(5).score(run({ tokens: ["a", "b"] }), noCase)).score,
+    ).toBe(1)
+    expect(
+      normalizeScore(await tokensUnder(1).score(run({ tokens: ["a", "b"] }), noCase)).score,
+    ).toBe(0)
   })
   it("custom wraps an async function and carries name + threshold", async () => {
-    const s = custom(async (r) => (r.toolCalls.length <= 2 ? 1 : 0), { name: "few-tools", threshold: 1 })
+    const s = custom(async (r) => (r.toolCalls.length <= 2 ? 1 : 0), {
+      name: "few-tools",
+      threshold: 1,
+    })
     expect(s.name).toBe("few-tools")
     expect(s.threshold).toBe(1)
     expect(normalizeScore(await s.score(run({}), noCase)).score).toBe(1)

--- a/packages/inspector/package.json
+++ b/packages/inspector/package.json
@@ -4,7 +4,7 @@
   "private": false,
   "type": "module",
   "license": "MIT",
-  "description": "Dawn runtime inspector — browser UI for inspecting a Dawn app (memory panel).",
+  "description": "Dawn runtime inspector \u2014 browser UI for inspecting a Dawn app (memory panel).",
   "homepage": "https://github.com/cacheplane/dawnai/tree/main/packages/inspector#readme",
   "repository": {
     "type": "git",
@@ -30,7 +30,7 @@
   "scripts": {
     "build": "next build && node scripts/post-build.mjs",
     "dev": "next dev",
-    "lint": "biome check --config-path ../config-biome/biome.json package.json next.config.ts postcss.config.mjs vitest.config.ts vitest.components.config.ts vitest.e2e.config.ts src app scripts test e2e playwright.config.ts",
+    "lint": "biome check --config-path ../config-biome/biome.json package.json next.config.ts postcss.config.mjs vitest.config.ts vitest.components.config.ts vitest.e2e.config.ts src app scripts test e2e playwright.config.ts tsconfig.json tsconfig.e2e.json",
     "test": "vitest --run --config vitest.config.ts --passWithNoTests",
     "test:e2e": "playwright test --config playwright.config.ts",
     "typecheck": "tsc --noEmit && tsc --noEmit -p tsconfig.e2e.json"

--- a/packages/permissions/package.json
+++ b/packages/permissions/package.json
@@ -35,7 +35,7 @@
   },
   "scripts": {
     "build": "tsc -b tsconfig.json",
-    "lint": "biome check --config-path ../config-biome/biome.json package.json src test tsconfig.json vitest.config.ts",
+    "lint": "biome check --config-path ../config-biome/biome.json package.json src test tsconfig.json tsconfig.contracts.json vitest.config.ts",
     "test": "vitest --run --config vitest.config.ts --passWithNoTests",
     "typecheck": "tsc --noEmit && tsc -p tsconfig.contracts.json"
   },

--- a/packages/sandbox/package.json
+++ b/packages/sandbox/package.json
@@ -35,7 +35,7 @@
   },
   "scripts": {
     "build": "tsc -b tsconfig.json",
-    "lint": "biome check --config-path ../config-biome/biome.json package.json src tsconfig.json vitest.config.ts",
+    "lint": "biome check --config-path ../config-biome/biome.json package.json src test tsconfig.json vitest.config.ts",
     "test": "vitest --run --config vitest.config.ts --passWithNoTests",
     "typecheck": "tsc --noEmit"
   },

--- a/packages/sandbox/test/fake-sandbox.test.ts
+++ b/packages/sandbox/test/fake-sandbox.test.ts
@@ -6,33 +6,63 @@ const ctx = (workspaceRoot: string) => ({ signal: new AbortController().signal, 
 describe("fakeSandbox", () => {
   test("isolates filesystem per thread, persists across acquire (reattach)", async () => {
     const provider = fakeSandbox()
-    const a1 = await provider.acquire({ threadId: "a", policy: { network: { mode: "allow" } }, signal: ctx("/x").signal })
+    const a1 = await provider.acquire({
+      threadId: "a",
+      policy: { network: { mode: "allow" } },
+      signal: ctx("/x").signal,
+    })
     await a1.filesystem.writeFile("/workspace/note.txt", "hello", ctx(a1.workspaceRoot))
 
-    const a2 = await provider.acquire({ threadId: "a", policy: { network: { mode: "allow" } }, signal: ctx("/x").signal })
+    const a2 = await provider.acquire({
+      threadId: "a",
+      policy: { network: { mode: "allow" } },
+      signal: ctx("/x").signal,
+    })
     expect(await a2.filesystem.readFile("/workspace/note.txt", ctx(a2.workspaceRoot))).toBe("hello")
 
-    const b = await provider.acquire({ threadId: "b", policy: { network: { mode: "allow" } }, signal: ctx("/x").signal })
+    const b = await provider.acquire({
+      threadId: "b",
+      policy: { network: { mode: "allow" } },
+      signal: ctx("/x").signal,
+    })
     expect(await b.filesystem.listDir("/workspace", ctx(b.workspaceRoot))).toEqual([])
   })
 
   test("release keeps the volume, destroy clears it", async () => {
     const provider = fakeSandbox()
-    const h = await provider.acquire({ threadId: "a", policy: { network: { mode: "allow" } }, signal: ctx("/x").signal })
+    const h = await provider.acquire({
+      threadId: "a",
+      policy: { network: { mode: "allow" } },
+      signal: ctx("/x").signal,
+    })
     await h.filesystem.writeFile("/workspace/f", "1", ctx(h.workspaceRoot))
 
     await provider.release("a")
-    const after = await provider.acquire({ threadId: "a", policy: { network: { mode: "allow" } }, signal: ctx("/x").signal })
+    const after = await provider.acquire({
+      threadId: "a",
+      policy: { network: { mode: "allow" } },
+      signal: ctx("/x").signal,
+    })
     expect(await after.filesystem.readFile("/workspace/f", ctx(after.workspaceRoot))).toBe("1")
 
     await provider.destroy("a")
-    const fresh = await provider.acquire({ threadId: "a", policy: { network: { mode: "allow" } }, signal: ctx("/x").signal })
+    const fresh = await provider.acquire({
+      threadId: "a",
+      policy: { network: { mode: "allow" } },
+      signal: ctx("/x").signal,
+    })
     expect(await fresh.filesystem.listDir("/workspace", ctx(fresh.workspaceRoot))).toEqual([])
   })
 
   test("exec is scripted + records commands; runBash sees fs writes", async () => {
-    const provider = fakeSandbox({ exec: async ({ command }) => ({ stdout: `ran:${command}`, stderr: "", exitCode: 0 }) })
-    const h = await provider.acquire({ threadId: "a", policy: { network: { mode: "allow" } }, signal: ctx("/x").signal })
+    const provider = fakeSandbox({
+      exec: async ({ command }) => ({ stdout: `ran:${command}`, stderr: "", exitCode: 0 }),
+    })
+    const h = await provider.acquire({
+      threadId: "a",
+      policy: { network: { mode: "allow" } },
+      signal: ctx("/x").signal,
+    })
     const r = await h.exec.runCommand({ command: "echo hi" }, ctx(h.workspaceRoot))
     expect(r).toEqual({ stdout: "ran:echo hi", stderr: "", exitCode: 0 })
   })

--- a/packages/sandbox/test/kube-backends.test.ts
+++ b/packages/sandbox/test/kube-backends.test.ts
@@ -9,8 +9,15 @@ async function withPod() {
   const k = fakeKubeClient()
   await k.createNamespacedPvcIfAbsent("ns", { name: "vol", labels: {}, storageGi: 1 })
   await k.createNamespacedPod("ns", {
-    name: "p", image: "i", labels: {}, pvcName: "vol", env: [], limits: {},
-    podSecurityContext: {}, containerSecurityContext: {}, readOnlyRootFilesystem: true,
+    name: "p",
+    image: "i",
+    labels: {},
+    pvcName: "vol",
+    env: [],
+    limits: {},
+    podSecurityContext: {},
+    containerSecurityContext: {},
+    readOnlyRootFilesystem: true,
     automountServiceAccountToken: false,
   })
   return k
@@ -26,9 +33,13 @@ test("runCommand execs sh -c and returns the exit code", async () => {
 test("cwd defaults to workspaceRoot; invalid env key throws", async () => {
   const k = await withPod()
   const seen: string[] = []
-  const spy = { ...k, exec: async (ns: string, pod: string, argv: readonly string[]) => {
-    seen.push(argv.join(" ")); return k.exec(ns, pod, argv)
-  } }
+  const spy = {
+    ...k,
+    exec: async (ns: string, pod: string, argv: readonly string[]) => {
+      seen.push(argv.join(" "))
+      return k.exec(ns, pod, argv)
+    },
+  }
   const exec = kubeExec(spy, "ns", "p", {})
   await exec.runCommand({ command: "true" }, ctx("/workspace"))
   expect(seen[0]).toContain("cd '/workspace' &&")
@@ -59,7 +70,7 @@ test("kubeFilesystem readFile honors maxBytes", async () => {
   const k = await withPod()
   const fs = kubeFilesystem(k, "ns", "p")
   await fs.writeFile("/workspace/big", "0123456789", ctx("/workspace"))
-  await expect(
-    fs.readFile("/workspace/big", ctx("/workspace"), { maxBytes: 4 }),
-  ).rejects.toThrow(/exceeds maxBytes/)
+  await expect(fs.readFile("/workspace/big", ctx("/workspace"), { maxBytes: 4 })).rejects.toThrow(
+    /exceeds maxBytes/,
+  )
 })

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -39,7 +39,7 @@
   },
   "scripts": {
     "build": "tsc -b tsconfig.json",
-    "lint": "biome check --config-path ../config-biome/biome.json package.json src test tsconfig.json vitest.config.ts",
+    "lint": "biome check --config-path ../config-biome/biome.json package.json src test tsconfig.json tsconfig.contracts.json vitest.config.ts",
     "test": "vitest --run --config vitest.config.ts",
     "typecheck": "tsc --noEmit && tsc -p tsconfig.contracts.json"
   },

--- a/packages/sqlite-storage/package.json
+++ b/packages/sqlite-storage/package.json
@@ -31,7 +31,7 @@
   },
   "scripts": {
     "build": "tsc -b tsconfig.json",
-    "lint": "biome check --config-path ../config-biome/biome.json package.json src tsconfig.json vitest.config.ts",
+    "lint": "biome check --config-path ../config-biome/biome.json package.json src test tsconfig.json vitest.config.ts",
     "test": "vitest --run --config vitest.config.ts --passWithNoTests",
     "typecheck": "tsc --noEmit"
   },

--- a/packages/sqlite-storage/test/checkpointer.test.ts
+++ b/packages/sqlite-storage/test/checkpointer.test.ts
@@ -1,16 +1,22 @@
 import { mkdtempSync, rmSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
-import { HumanMessage, AIMessage } from "@langchain/core/messages"
+import { AIMessage, HumanMessage } from "@langchain/core/messages"
 import { afterEach, beforeEach, describe, expect, it } from "vitest"
 import { sqliteCheckpointer } from "../src/checkpointer/index.js"
 
 describe("DawnSqliteSaver", () => {
   let dir: string
-  beforeEach(() => { dir = mkdtempSync(join(tmpdir(), "dawn-ckpt-")) })
-  afterEach(() => { rmSync(dir, { recursive: true, force: true }) })
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "dawn-ckpt-"))
+  })
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true })
+  })
 
-  function newSaver() { return sqliteCheckpointer({ path: join(dir, "ckpt.sqlite") }) }
+  function newSaver() {
+    return sqliteCheckpointer({ path: join(dir, "ckpt.sqlite") })
+  }
 
   it("put + getTuple round-trip preserves checkpoint payload", async () => {
     const saver = newSaver()
@@ -38,10 +44,26 @@ describe("DawnSqliteSaver", () => {
     const saver = newSaver()
     const cfg = { configurable: { thread_id: "t1", checkpoint_ns: "" } }
     const mk = (id: string) => ({
-      v: 1, id, ts: "x", channel_values: {}, channel_versions: {}, versions_seen: {}, pending_sends: [],
+      v: 1,
+      id,
+      ts: "x",
+      channel_values: {},
+      channel_versions: {},
+      versions_seen: {},
+      pending_sends: [],
     })
-    await saver.put(cfg, mk("a") as never, { source: "input", step: 0, writes: null, parents: {} } as never, {})
-    await saver.put(cfg, mk("b") as never, { source: "input", step: 1, writes: null, parents: {} } as never, {})
+    await saver.put(
+      cfg,
+      mk("a") as never,
+      { source: "input", step: 0, writes: null, parents: {} } as never,
+      {},
+    )
+    await saver.put(
+      cfg,
+      mk("b") as never,
+      { source: "input", step: 1, writes: null, parents: {} } as never,
+      {},
+    )
     const t = await saver.getTuple(cfg)
     expect(t?.checkpoint.id).toBe("b")
   })
@@ -50,10 +72,26 @@ describe("DawnSqliteSaver", () => {
     const saver = newSaver()
     const cfg = { configurable: { thread_id: "t1", checkpoint_ns: "" } }
     const mk = (id: string) => ({
-      v: 1, id, ts: "x", channel_values: {}, channel_versions: {}, versions_seen: {}, pending_sends: [],
+      v: 1,
+      id,
+      ts: "x",
+      channel_values: {},
+      channel_versions: {},
+      versions_seen: {},
+      pending_sends: [],
     })
-    await saver.put(cfg, mk("a") as never, { source: "input", step: 0, writes: null, parents: {} } as never, {})
-    await saver.put(cfg, mk("b") as never, { source: "input", step: 1, writes: null, parents: {} } as never, {})
+    await saver.put(
+      cfg,
+      mk("a") as never,
+      { source: "input", step: 0, writes: null, parents: {} } as never,
+      {},
+    )
+    await saver.put(
+      cfg,
+      mk("b") as never,
+      { source: "input", step: 1, writes: null, parents: {} } as never,
+      {},
+    )
     const ids: string[] = []
     for await (const t of saver.list(cfg)) ids.push(t.checkpoint.id)
     expect(ids).toEqual(["b", "a"])
@@ -71,10 +109,25 @@ describe("DawnSqliteSaver", () => {
     const path = join(dir, "ckpt.sqlite")
     const s1 = sqliteCheckpointer({ path })
     const cfg = { configurable: { thread_id: "t1", checkpoint_ns: "" } }
-    const c = { v: 1, id: "c1", ts: "x", channel_values: { x: 1 }, channel_versions: {}, versions_seen: {}, pending_sends: [] }
-    await s1.put(cfg, c as never, { source: "input", step: 0, writes: null, parents: {} } as never, {})
+    const c = {
+      v: 1,
+      id: "c1",
+      ts: "x",
+      channel_values: { x: 1 },
+      channel_versions: {},
+      versions_seen: {},
+      pending_sends: [],
+    }
+    await s1.put(
+      cfg,
+      c as never,
+      { source: "input", step: 0, writes: null, parents: {} } as never,
+      {},
+    )
     const s2 = sqliteCheckpointer({ path })
-    const t = await s2.getTuple({ configurable: { thread_id: "t1", checkpoint_ns: "", checkpoint_id: "c1" } })
+    const t = await s2.getTuple({
+      configurable: { thread_id: "t1", checkpoint_ns: "", checkpoint_id: "c1" },
+    })
     expect(t?.checkpoint.channel_values).toEqual({ x: 1 })
   })
 
@@ -84,7 +137,10 @@ describe("DawnSqliteSaver", () => {
     // The saver must use JsonPlusSerializer (not plain JSON) to preserve instances.
     const saver = newSaver()
     const human = new HumanMessage("hello")
-    const ai = new AIMessage({ content: "hi", tool_calls: [{ name: "runBash", args: { command: "echo hi" }, id: "call_1" }] })
+    const ai = new AIMessage({
+      content: "hi",
+      tool_calls: [{ name: "runBash", args: { command: "echo hi" }, id: "call_1" }],
+    })
     const cfg = { configurable: { thread_id: "t-msg", checkpoint_ns: "" } }
     const checkpoint = {
       v: 1,
@@ -95,7 +151,12 @@ describe("DawnSqliteSaver", () => {
       versions_seen: { agent: { "branch:to:agent": 2 } },
       pending_sends: [],
     }
-    await saver.put(cfg, checkpoint as never, { source: "loop", step: 1, writes: null, parents: {} } as never, {})
+    await saver.put(
+      cfg,
+      checkpoint as never,
+      { source: "loop", step: 1, writes: null, parents: {} } as never,
+      {},
+    )
 
     // Also store a pending write (the interrupt) — must also survive serde
     await saver.putWrites(

--- a/packages/sqlite-storage/test/db.test.ts
+++ b/packages/sqlite-storage/test/db.test.ts
@@ -6,8 +6,12 @@ import { openDb } from "../src/internal/db.js"
 
 describe("openDb", () => {
   let dir: string
-  beforeEach(() => { dir = mkdtempSync(join(tmpdir(), "dawn-sqlite-")) })
-  afterEach(() => { rmSync(dir, { recursive: true, force: true }) })
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "dawn-sqlite-"))
+  })
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true })
+  })
 
   it("opens a database with WAL journal_mode, foreign_keys ON, and synchronous=NORMAL", () => {
     const db = openDb(join(dir, "test.sqlite"))

--- a/packages/sqlite-storage/test/migrate.test.ts
+++ b/packages/sqlite-storage/test/migrate.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from "vitest"
 import { DatabaseSync } from "node:sqlite"
+import { describe, expect, it } from "vitest"
 import { runMigrations } from "../src/internal/migrate.js"
 
 function memDb(): DatabaseSync {

--- a/packages/sqlite-storage/test/threads.test.ts
+++ b/packages/sqlite-storage/test/threads.test.ts
@@ -6,10 +6,16 @@ import { createThreadsStore } from "../src/threads/index.js"
 
 describe("createThreadsStore", () => {
   let dir: string
-  beforeEach(() => { dir = mkdtempSync(join(tmpdir(), "dawn-threads-")) })
-  afterEach(() => { rmSync(dir, { recursive: true, force: true }) })
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "dawn-threads-"))
+  })
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true })
+  })
 
-  function newStore() { return createThreadsStore({ path: join(dir, "threads.sqlite") }) }
+  function newStore() {
+    return createThreadsStore({ path: join(dir, "threads.sqlite") })
+  }
 
   it("create + get round-trips metadata and assigns timestamps", async () => {
     const store = newStore()

--- a/packages/workspace/package.json
+++ b/packages/workspace/package.json
@@ -35,7 +35,7 @@
   },
   "scripts": {
     "build": "tsc -b tsconfig.json",
-    "lint": "biome check --config-path ../config-biome/biome.json package.json src tsconfig.json vitest.config.ts",
+    "lint": "biome check --config-path ../config-biome/biome.json package.json src test tsconfig.json vitest.config.ts",
     "test": "vitest --run --config vitest.config.ts --passWithNoTests",
     "typecheck": "tsc --noEmit"
   },

--- a/packages/workspace/test/compose.test.ts
+++ b/packages/workspace/test/compose.test.ts
@@ -3,10 +3,18 @@ import { compose } from "../src/compose.js"
 import type { FilesystemBackend, FilesystemMiddleware } from "../src/types.js"
 
 const base: FilesystemBackend = {
-  async readFile() { return "BASE" },
-  async writeFile() { return { bytesWritten: 0 } },
-  async listDir() { return [] },
-  async realPath(p) { return p },
+  async readFile() {
+    return "BASE"
+  },
+  async writeFile() {
+    return { bytesWritten: 0 }
+  },
+  async listDir() {
+    return []
+  },
+  async realPath(p) {
+    return p
+  },
 }
 
 describe("compose", () => {
@@ -45,7 +53,10 @@ describe("compose", () => {
         return r
       },
     })
-    await compose(a, b)(base).readFile("x", {
+    await compose(
+      a,
+      b,
+    )(base).readFile("x", {
       signal: new AbortController().signal,
       workspaceRoot: "/",
     })

--- a/packages/workspace/test/local-exec.test.ts
+++ b/packages/workspace/test/local-exec.test.ts
@@ -1,7 +1,7 @@
-import { describe, expect, it } from "vitest"
 import { mkdtempSync, rmSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
+import { describe, expect, it } from "vitest"
 import { localExec } from "../src/local-exec.js"
 
 function ctx(workspaceRoot: string) {
@@ -36,9 +36,7 @@ describe("localExec", () => {
     const root = mkdtempSync(join(tmpdir(), "dawn-localexec-"))
     try {
       const exec = localExec({ timeout: 100 })
-      await expect(
-        exec.runCommand({ command: "sleep 1" }, ctx(root)),
-      ).rejects.toThrow(/timeout/i)
+      await expect(exec.runCommand({ command: "sleep 1" }, ctx(root))).rejects.toThrow(/timeout/i)
     } finally {
       rmSync(root, { recursive: true, force: true })
     }
@@ -50,9 +48,9 @@ describe("localExec", () => {
       const exec = localExec({ allowedCommands: [/^echo\b/, /^ls\b/] })
       const ok = await exec.runCommand({ command: "echo allowed" }, ctx(root))
       expect(ok.stdout.trim()).toBe("allowed")
-      await expect(
-        exec.runCommand({ command: "rm -rf /" }, ctx(root)),
-      ).rejects.toThrow(/not allowed/i)
+      await expect(exec.runCommand({ command: "rm -rf /" }, ctx(root))).rejects.toThrow(
+        /not allowed/i,
+      )
     } finally {
       rmSync(root, { recursive: true, force: true })
     }

--- a/packages/workspace/test/local-filesystem.test.ts
+++ b/packages/workspace/test/local-filesystem.test.ts
@@ -1,7 +1,7 @@
-import { describe, expect, it, beforeEach, afterEach } from "vitest"
-import { mkdtempSync, realpathSync, rmSync, symlinkSync, writeFileSync, mkdirSync } from "node:fs"
+import { mkdirSync, mkdtempSync, realpathSync, rmSync, symlinkSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
 import { localFilesystem } from "../src/local-filesystem.js"
 
 function ctx(workspaceRoot: string) {
@@ -130,8 +130,10 @@ describe("localFilesystem", () => {
     const fs = localFilesystem({ maxFileBytes: 10 })
     const p = join(root, "big.txt")
     await fs.writeFile(p, "x".repeat(100), ctx(root))
-    await expect(fs.readFile(p, ctx(root))).rejects.toThrow(/too large/)            // default cap rejects
-    expect(await fs.readFile(p, ctx(root), { maxBytes: Number.POSITIVE_INFINITY })).toBe("x".repeat(100)) // override allows
+    await expect(fs.readFile(p, ctx(root))).rejects.toThrow(/too large/) // default cap rejects
+    expect(await fs.readFile(p, ctx(root), { maxBytes: Number.POSITIVE_INFINITY })).toBe(
+      "x".repeat(100),
+    ) // override allows
   })
 
   it("readBinaryFile returns the exact bytes as a Uint8Array", async () => {
@@ -146,7 +148,9 @@ describe("localFilesystem", () => {
   it("readBinaryFile rejects files larger than maxFileBytes", async () => {
     writeFileSync(join(root, "big.bin"), Buffer.alloc(2048))
     const fs = localFilesystem({ maxFileBytes: 1024 })
-    await expect(fs.readBinaryFile?.(join(root, "big.bin"), ctx(root))).rejects.toThrow(/too large/i)
+    await expect(fs.readBinaryFile?.(join(root, "big.bin"), ctx(root))).rejects.toThrow(
+      /too large/i,
+    )
   })
 
   it("readBinaryFile honors a per-call maxBytes override", async () => {

--- a/packages/workspace/test/sandbox-types.test.ts
+++ b/packages/workspace/test/sandbox-types.test.ts
@@ -32,7 +32,12 @@ describe("sandbox contract types", () => {
   test("a handle exposes workspace backends + an in-sandbox root", () => {
     const fs = {} as FilesystemBackend
     const exec = {} as ExecBackend
-    const handle: SandboxHandle = { threadId: "t1", filesystem: fs, exec, workspaceRoot: "/workspace" }
+    const handle: SandboxHandle = {
+      threadId: "t1",
+      filesystem: fs,
+      exec,
+      workspaceRoot: "/workspace",
+    }
     expect(handle.workspaceRoot).toBe("/workspace")
   })
 
@@ -55,7 +60,11 @@ describe("sandbox contract types", () => {
       release: async () => {},
       destroy: async () => {},
     }
-    const h = await provider.acquire({ threadId: "t1", policy: { network: { mode: "allow" } }, signal: new AbortController().signal })
+    const h = await provider.acquire({
+      threadId: "t1",
+      policy: { network: { mode: "allow" } },
+      signal: new AbortController().signal,
+    })
     expect(h.threadId).toBe("t1")
     const cfg: SandboxConfig = { provider }
     expect(cfg.provider.name).toBe("noop")

--- a/packages/workspace/test/with-logging.test.ts
+++ b/packages/workspace/test/with-logging.test.ts
@@ -1,12 +1,20 @@
 import { describe, expect, it } from "vitest"
-import { withFilesystemLogging } from "../src/with-logging.js"
 import type { FilesystemBackend } from "../src/types.js"
+import { withFilesystemLogging } from "../src/with-logging.js"
 
 const base: FilesystemBackend = {
-  async readFile() { return "ok" },
-  async writeFile() { return { bytesWritten: 5 } },
-  async listDir() { return ["a"] },
-  async realPath(p) { return p },
+  async readFile() {
+    return "ok"
+  },
+  async writeFile() {
+    return { bytesWritten: 5 }
+  },
+  async listDir() {
+    return ["a"]
+  },
+  async realPath(p) {
+    return p
+  },
 }
 
 const ctx = { signal: new AbortController().signal, workspaceRoot: "/r" }


### PR DESCRIPTION
Three of the four gate-coverage holes left open after #501. The fourth (packages that never typecheck their own tests) is deliberately not here — see the end.

## Every workspace package is linted now, and every directory in it

**Three packages had no `lint` script at all**, so `turbo run lint` skipped them without a word: `@dawn-example/chat-server`, `@dawn-example/memory`, `@dawn-example/research-server`.

**Eleven more had a script whose hand-written path list omitted real code:**

| package | skipped | errors there |
|---|---|---|
| `ag-ui`, `evals`, `sandbox`, `sqlite-storage`, `workspace` | their own `test/` | 25 |
| `apps/web` | `content`, `lib` | 10 |
| `chat-server`, `research-server` | everything | 8 |
| `cli` | `scripts` | 0 |
| `devkit` | `templates` | 1 |
| `research-web` | `e2e` | 0 |
| `config-biome` | its own `biome.json` | 0 |

`pnpm lint` goes **24 tasks → 27**. All 43 diagnostics were safe-fixable; nothing needed a rule suppression.

Two exclusions are deliberate, and I'd rather they be argued with than assumed:

- **`apps/web/public`** — static assets served verbatim, including third-party provider brand marks that `noSvgWithoutTitle` would have us edit.
- **`next-env.d.ts`** — Next rewrites it every build and says so in a comment. I formatted it first and reverted: linting it would churn and re-fail immediately after any build.

### Two guards fired, both correctly

Formatting files that had never been formatted is exactly when pins earn their keep.

**The devkit parity guard.** `examples/research/server` must stay byte-for-byte identical to its `.template` mirrors — and biome skips `.template` as an unknown extension, so the example moved and the copy didn't. Verified both mirrors are plain copies with zero placeholders, then mirrored the formatted content.

**A docs behavior-contract fingerprint.** The API-reference test pins the *token sequence* of the assertion backing each documented claim. Collapsing a multi-line `expect(...)` in `packages/workspace/test/local-exec.test.ts` dropped a trailing comma — a token. Eight pinned files were reformatted and only this one moved, because the fingerprints are whitespace-normalized. The claim is unchanged, so the fingerprint is updated.

## The 5000ms default was wrong for 23 suites

`packages/core/test/render-route-types.test.ts` timed out under a saturated run after passing in isolation moments earlier. Idle, the slowest test in it takes **811ms** — these suites aren't slow, their runtime tracks machine load, because they drive the TypeScript compiler through `src/compiler/typescript-backend.ts`.

Scoped `{ timeout: 30_000 }` to the eight compiler-backed suites in `packages/core`, matching what `packages/cli/test/dev-command.test.ts` already uses for process-spawning tests — rather than raising the default globally and loosening ~500 fast tests to hide a six-file problem. I verified `describe(name, options, fn)` actually propagates before relying on it.

**Then the run verifying that fix found the same defect one package over.** `apps/web`'s four API-reference/nav/sitemap files shell out to Node subprocesses on the same default; 15 more suites annotated.

> Worth knowing before reading a duration as reassurance: **`spawnSync` blocks the event loop, so vitest's timer cannot fire during it.** `api-reference-inventory.test.ts` runs 14.7s against a 5000ms limit and passes. Only tests that `await` ever trip the timeout, so duration is not evidence the limit is adequate.

## `turbo run test` was red on main for two unrelated reasons

Each hid the next. With `apps/web` fixed the run got further and hit `@dawn-example/memory`, which declares `test: vitest run` and ships no test files, so vitest exits 1 with "No test files found". `--passWithNoTests` is what `evals`, `memory`, `inspector` and `workspace` already use. Pre-existing, and CI never hit it — `pnpm test` is a vitest workspace run, not turbo.

## Verification

| gate | result |
|---|---|
| `pnpm lint` | **27/27** (was 24) |
| `pnpm typecheck` | 51/51 |
| `pnpm test` | 4782 passed, 215 skipped, 0 failed |
| `pnpm check:build-cache` | pass |
| `node scripts/check-docs.mjs` | pass |
| `turbo run test --force` | **49/49 — green for the first time** |

That last row is the one that matters for the timeout work: it is the exact command that reproduced the flake, and it took three rounds to get clean because each fix exposed the next thing the previous failure had masked.

## Not here

The fourth hole — **16 packages / 194 test files whose `typecheck` covers only `src/**`**, carrying roughly 150 latent errors concentrated in `core` (64), `ag-ui` (24) and `langchain` (23). The mechanical half has a clean precedent in-repo (`packages/memory`, `postgres-storage`, `memory-pgvector` each ship a `tsconfig.test.json`). The other half is deciding error by error which are drifted types worth fixing properly — when #501 did this for `test/`, its 17 errors included a result type that had drifted from its source, an over-permissive fixture model, and three assertions that would throw `TypeError` instead of failing. That deserves its own review, not a fifth commit here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)