### PR TITLE
fix(devkit): leave CopilotKit telemetry off in a scaffolded app

### DIFF
--- a/.changeset/copilotkit-telemetry-off-by-default.md
+++ b/.changeset/copilotkit-telemetry-off-by-default.md
@@ -1,0 +1,20 @@
+---
+"@dawn-ai/devkit": patch
+"create-dawn-ai-app": patch
+---
+
+Leave CopilotKit telemetry off in a scaffolded app.
+
+CopilotKit's runtime reports usage by default, so `npm run build` on a freshly
+generated app POSTed to `https://telemetry.copilotkit.ai/ingest` while Next
+collected page data — before the author had written a line of code. The
+generated `web/next.config.mjs` now sets `COPILOTKIT_TELEMETRY_DISABLED` unless
+the environment already says otherwise, so opting back in is still one variable
+away.
+
+The placement is the fix, not a detail. CopilotKit builds its telemetry client
+at module scope and reads the environment inside that constructor, and ESM
+evaluates imports before the importing module's body — so setting this in the
+route handler that imports the runtime would look correct and change nothing.
+`next.config.mjs` is the first module Next evaluates, for `next build`,
+`next dev` and `next start` alike.

--- a/examples/chat/web/next.config.mjs
+++ b/examples/chat/web/next.config.mjs
@@ -1,3 +1,14 @@
+// CopilotKit's runtime builds a telemetry client at module scope and decides
+// whether to send from `process.env` inside that constructor. ESM evaluates
+// imports before the importing module's body, so setting this in the route
+// handler would be too late — it has to be in place before anything imports
+// `@copilotkit/runtime`, and `next.config.mjs` is the first thing Next
+// evaluates for both `next build` and `next dev`/`next start`.
+//
+// Without it, a bare `next build` POSTs to https://telemetry.copilotkit.ai/ingest
+// while collecting page data. `??=` so anyone who wants it on can still opt in.
+process.env.COPILOTKIT_TELEMETRY_DISABLED ??= "true"
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   agentRules: false,

--- a/examples/research/web/next.config.mjs
+++ b/examples/research/web/next.config.mjs
@@ -1,3 +1,14 @@
+// CopilotKit's runtime builds a telemetry client at module scope and decides
+// whether to send from `process.env` inside that constructor. ESM evaluates
+// imports before the importing module's body, so setting this in the route
+// handler would be too late — it has to be in place before anything imports
+// `@copilotkit/runtime`, and `next.config.mjs` is the first thing Next
+// evaluates for both `next build` and `next dev`/`next start`.
+//
+// Without it, a bare `next build` POSTs to https://telemetry.copilotkit.ai/ingest
+// while collecting page data. `??=` so anyone who wants it on can still opt in.
+process.env.COPILOTKIT_TELEMETRY_DISABLED ??= "true"
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   agentRules: false,

--- a/packages/devkit/templates/app-research/web/next.config.mjs
+++ b/packages/devkit/templates/app-research/web/next.config.mjs
@@ -1,3 +1,14 @@
+// CopilotKit's runtime builds a telemetry client at module scope and decides
+// whether to send from `process.env` inside that constructor. ESM evaluates
+// imports before the importing module's body, so setting this in the route
+// handler would be too late — it has to be in place before anything imports
+// `@copilotkit/runtime`, and `next.config.mjs` is the first thing Next
+// evaluates for both `next build` and `next dev`/`next start`.
+//
+// Without it, a bare `next build` POSTs to https://telemetry.copilotkit.ai/ingest
+// while collecting page data. `??=` so anyone who wants it on can still opt in.
+process.env.COPILOTKIT_TELEMETRY_DISABLED ??= "true"
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   agentRules: false,

--- a/packages/devkit/test/template-telemetry-off.test.ts
+++ b/packages/devkit/test/template-telemetry-off.test.ts
@@ -1,0 +1,40 @@
+import { readFileSync } from "node:fs"
+import { fileURLToPath } from "node:url"
+import { describe, expect, it } from "vitest"
+
+/**
+ * CopilotKit's runtime is on by default and a bare `next build` of a generated
+ * app POSTs to https://telemetry.copilotkit.ai/ingest while collecting page
+ * data. A scaffold should not phone home before its author has written a line
+ * of code, so the template turns it off.
+ *
+ * The assertion is on `next.config.mjs` specifically, and that placement is the
+ * whole substance of the fix rather than a detail. CopilotKit constructs its
+ * telemetry client at module scope and reads `process.env` inside that
+ * constructor, so anything that runs after `@copilotkit/runtime` is imported —
+ * including the route handler that imports it — is too late to matter. Setting
+ * it there would look right, pass review, and send the request anyway.
+ * `next.config.mjs` is the first module Next evaluates for `next build`,
+ * `next dev` and `next start` alike.
+ *
+ * `??=` rather than `=` so a user who genuinely wants telemetry can opt back in
+ * through the environment.
+ */
+const templateConfig = (relativePath: string): string =>
+  readFileSync(fileURLToPath(new URL(`../templates/${relativePath}`, import.meta.url)), "utf8")
+
+describe("scaffolded web app leaves CopilotKit telemetry off", () => {
+  it("disables it in next.config.mjs, before anything imports the runtime", () => {
+    const config = templateConfig("app-research/web/next.config.mjs")
+
+    expect(config).toContain('process.env.COPILOTKIT_TELEMETRY_DISABLED ??= "true"')
+  })
+
+  it("sets it before the config object, not after", () => {
+    const config = templateConfig("app-research/web/next.config.mjs")
+
+    expect(config.indexOf("COPILOTKIT_TELEMETRY_DISABLED")).toBeLessThan(
+      config.indexOf("const nextConfig"),
+    )
+  })
+})

--- a/test/generated/vitest.config.ts
+++ b/test/generated/vitest.config.ts
@@ -5,13 +5,15 @@ export default defineConfig({
     environment: "node",
     // Set on the WORKER, which is how they reach every child this lane spawns:
     // `spawnProcess` builds `{...process.env, ...options.env}` and neither name
-    // is in `GENERATED_APP_UNSET_ENV`. Without them the generated app's
-    // `npm run build` fans out to `next build`, which evaluates the CopilotKit
-    // runtime handler at module scope during "Collecting page data" and fires a
-    // real POST to telemetry.copilotkit.ai — an outbound call from a lane whose
-    // whole claim is that a generated app reaches nothing but the local aimock.
-    // (Whether the SCAFFOLD should default these off is a separate product
-    // question; this only closes the test lane. See the plan's S2.)
+    // is in `GENERATED_APP_UNSET_ENV`.
+    //
+    // The scaffold now turns CopilotKit telemetry off itself, in the generated
+    // app's `next.config.mjs`, so this is no longer what stops the outbound
+    // POST to telemetry.copilotkit.ai during `next build`. It stays as a second
+    // line for anything else in a generated app that reads either name — this
+    // lane's whole claim is that a generated app reaches nothing but the local
+    // aimock. `packages/devkit/test/template-telemetry-off.test.ts` is what
+    // guards the scaffold default.
     env: {
       COPILOTKIT_TELEMETRY_DISABLED: "true",
       DO_NOT_TRACK: "1",


### PR DESCRIPTION
`npm create dawn-ai-app` produced an app that phoned home before its author had written a line of code. A bare `npm run build` POSTs to `https://telemetry.copilotkit.ai/ingest` while Next collects page data.

## Reproduced, not inferred

Intercepting `fetch` during a real `next build` of `examples/research/web`:

```
BEFORE  → OUTBOUND https://telemetry.copilotkit.ai/ingest     (1 call)
AFTER   → (none)
```

## The placement is the fix

CopilotKit's runtime does this:

```js
const telemetry = new TelemetryClient()   // module scope
// constructor: this.telemetryDisabled = telemetryDisabled ?? isTelemetryDisabled()
```

`isTelemetryDisabled()` reads `process.env` right there, and ESM evaluates imports before the importing module's body. **So setting the variable inside the route handler that imports `@copilotkit/runtime` reads as the obvious fix, passes review, and sends the request anyway** — the singleton has already decided by the time that line runs.

`next.config.mjs` is the first module Next evaluates. I verified the ordering rather than trusting it, by writing timestamped markers from both files during a real build:

```
config 1787806037398
config 1787806038175
route  1787806045383 disabled=unset     ← before
route  1787806058024 disabled=true      ← after
```

Two alternatives were ruled out on evidence, not taste:

- **`.env`** — gitignored in every web package (`examples/*/web/.gitignore`, and the root ignores `.env`/`.env.*` except `.env.example`), so it cannot ship in a template.
- **`instrumentation.ts`** — Next's designed "runs before your app" hook, but it does not cover `next build`, which is exactly when the call fires.

`??=` rather than `=`, so anyone who wants telemetry keeps it with one environment variable.

## Guarded

`packages/devkit/test/template-telemetry-off.test.ts` asserts both the setting **and its position** — that it precedes `const nextConfig`. A later reader tidying it next to the runtime import would silently restore the old behaviour, and nothing else in the suite would notice.

## Also

The generated-app test lane already set `COPILOTKIT_TELEMETRY_DISABLED`/`DO_NOT_TRACK` on the worker, with a comment calling the scaffold default "a separate product question". That question is answered now; the override stays as a second line for anything else in a generated app that reads those names, and the comment says so instead.

Applied to `examples/research/web`, `examples/chat/web`, and the scaffold template — byte-for-byte parity between the example and the template still holds.

## Verification

| gate | result |
|---|---|
| `pnpm lint` | 27/27 |
| `pnpm typecheck` | 51/51 |
| `packages/devkit` tests | 45 passed (10 files) |
| `node scripts/check-docs.mjs` | pass |
| `next build`, fetch intercepted | 1 telemetry call → 0 |

Patch changeset for `@dawn-ai/devkit` and `create-dawn-ai-app`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)