### PR TITLE
test: typecheck the tests in eight more packages

### DIFF
--- a/.changeset/ag-ui-rxjs-align.md
+++ b/.changeset/ag-ui-rxjs-align.md
@@ -1,0 +1,12 @@
+---
+"@dawn-ai/ag-ui": patch
+---
+
+Align the rxjs devDependency with the one `@ag-ui/client` actually uses.
+
+`@ag-ui/client` and its middleware siblings pin rxjs to exactly `7.8.1`, while
+this package's test-only devDependency asked for `7.8.2`. Two copies of rxjs
+meant two nominally distinct `Observable` declarations, so a test consuming a
+stream produced by `@ag-ui/client` could not describe it in types. rxjs is used
+only by the conformance test here; matching the version the objects come from is
+the point of the pin.

--- a/apps/web/app/components/docs/api-reference.ts
+++ b/apps/web/app/components/docs/api-reference.ts
@@ -569,7 +569,7 @@ export const API_BEHAVIOR_CONTRACTS = [
           "resolveGate prefers gate, then threshold sugar, then informational",
         ],
         assertionFingerprint:
-          'expect ( gate . perScorer ( ) ( report ) . passed ) . toBe ( false )\nexpect ( gate . perScorer ( ) ( { ... report , byScorer : [ { scorer : "informational" , mean : 0 } ] , } ) . passed , ) . toBe ( true )\nexpect ( resolveGate ( { name : "e" , dataset : [ ] , scorers : [ ] , gate : gate . mean ( 0.9 ) } ) ( report ) . passed , ) . toBe ( false )\nexpect ( resolveGate ( { name : "e" , dataset : [ ] , scorers : [ ] , threshold : 0.7 } ) ( report ) . passed , ) . toBe ( true )\nexpect ( resolveGate ( { name : "e" , dataset : [ ] , scorers : [ ] } ) ( report ) . passed ) . toBe ( true )',
+          'expect ( gate . perScorer ( ) ( report ) . passed ) . toBe ( false )\nexpect ( gate . perScorer ( ) ( { ... report , byScorer : [ { scorer : "informational" , mean : 0 } ] , } ) . passed , ) . toBe ( true )\nexpect ( resolveGate ( { gate : gate . mean ( 0.9 ) } ) ( report ) . passed ) . toBe ( false )\nexpect ( resolveGate ( { threshold : 0.7 } ) ( report ) . passed ) . toBe ( true )\nexpect ( resolveGate ( { } ) ( report ) . passed ) . toBe ( true )',
       },
     ],
   },

--- a/packages/ag-ui/package.json
+++ b/packages/ag-ui/package.json
@@ -42,7 +42,7 @@
     "build": "node -e \"const fs = require('node:fs'); const path = require('node:path'); if (fs.existsSync('dist')) for (const entry of fs.readdirSync('dist', { withFileTypes: true })) if (entry.isFile() && /^(?:encode|run-input|translate)\\./.test(entry.name)) fs.rmSync(path.join('dist', entry.name))\" && tsc -b tsconfig.json && node -e \"const fs = require('node:fs'); fs.mkdirSync('dist/react', { recursive: true }); fs.copyFileSync('src/react/styles.css', 'dist/react/styles.css')\"",
     "lint": "biome check --config-path ../config-biome/biome.json package.json src test tsconfig.json vitest.config.ts",
     "test": "vitest --run --config vitest.config.ts --passWithNoTests",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit && tsc -p tsconfig.test.json"
   },
   "dependencies": {
     "@ag-ui/core": "0.0.57",
@@ -70,6 +70,6 @@
     "@types/react-dom": "19.2.4",
     "react": "19.2.8",
     "react-dom": "19.2.8",
-    "rxjs": "7.8.2"
+    "rxjs": "7.8.1"
   }
 }

--- a/packages/ag-ui/test/interrupts.test.ts
+++ b/packages/ag-ui/test/interrupts.test.ts
@@ -124,6 +124,7 @@ describe("fromAguiResume", () => {
     const [resume] = fromAguiResume([
       { interruptId: "perm-1", status: "resolved", payload: undefined },
     ])
+    if (!resume) throw new Error("expected fromAguiResume to return one entry")
     expect(resume).toEqual({ interruptId: "perm-1", status: "resolved", payload: undefined })
     expect(Object.hasOwn(resume, "payload")).toBe(true)
   })

--- a/packages/ag-ui/tsconfig.test.json
+++ b/packages/ag-ui/tsconfig.test.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "allowImportingTsExtensions": true,
+    "noEmit": true,
+    "rootDir": ".",
+    "tsBuildInfoFile": "dist/tsconfig.test.tsbuildinfo"
+  },
+  "include": [
+    "src/**/*.ts",
+    "src/**/*.tsx",
+    "test/**/*.ts",
+    "test/**/*.tsx"
+  ]
+}

--- a/packages/devkit/package.json
+++ b/packages/devkit/package.json
@@ -34,7 +34,7 @@
     "build": "tsc -b tsconfig.json",
     "lint": "biome check --config-path ../config-biome/biome.json --css-parse-tailwind-directives=true package.json src test templates tsconfig.json vitest.config.ts",
     "test": "vitest --run --config vitest.config.ts",
-    "typecheck": "tsc --noEmit -p tsconfig.json"
+    "typecheck": "tsc --noEmit -p tsconfig.json && tsc -p tsconfig.test.json"
   },
   "devDependencies": {
     "@dawn-ai/config-typescript": "workspace:*",

--- a/packages/devkit/tsconfig.test.json
+++ b/packages/devkit/tsconfig.test.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "allowImportingTsExtensions": true,
+    "noEmit": true,
+    "rootDir": ".",
+    "tsBuildInfoFile": "dist/tsconfig.test.tsbuildinfo"
+  },
+  "include": [
+    "src/**/*.ts",
+    "src/**/*.tsx",
+    "test/**/*.ts",
+    "test/**/*.tsx"
+  ]
+}

--- a/packages/evals/package.json
+++ b/packages/evals/package.json
@@ -33,7 +33,7 @@
     "build": "tsc -b tsconfig.json",
     "lint": "biome check --config-path ../config-biome/biome.json package.json src test tsconfig.json vitest.config.ts",
     "test": "vitest --run --config vitest.config.ts --passWithNoTests",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit && tsc -p tsconfig.test.json"
   },
   "peerDependencies": {
     "@dawn-ai/testing": "workspace:*"

--- a/packages/evals/test/gate.test.ts
+++ b/packages/evals/test/gate.test.ts
@@ -45,12 +45,8 @@ describe("gate policies", () => {
     expect(gate.any(gate.mean(0.9), gate.everyCase(0.5))(report).passed).toBe(true)
   })
   it("resolveGate prefers gate, then threshold sugar, then informational", () => {
-    expect(
-      resolveGate({ gate: gate.mean(0.9) })(report).passed,
-    ).toBe(false)
-    expect(
-      resolveGate({ threshold: 0.7 })(report).passed,
-    ).toBe(true)
+    expect(resolveGate({ gate: gate.mean(0.9) })(report).passed).toBe(false)
+    expect(resolveGate({ threshold: 0.7 })(report).passed).toBe(true)
     expect(resolveGate({})(report).passed).toBe(true) // informational
   })
 })

--- a/packages/evals/test/gate.test.ts
+++ b/packages/evals/test/gate.test.ts
@@ -46,11 +46,11 @@ describe("gate policies", () => {
   })
   it("resolveGate prefers gate, then threshold sugar, then informational", () => {
     expect(
-      resolveGate({ name: "e", dataset: [], scorers: [], gate: gate.mean(0.9) })(report).passed,
+      resolveGate({ gate: gate.mean(0.9) })(report).passed,
     ).toBe(false)
     expect(
-      resolveGate({ name: "e", dataset: [], scorers: [], threshold: 0.7 })(report).passed,
+      resolveGate({ threshold: 0.7 })(report).passed,
     ).toBe(true)
-    expect(resolveGate({ name: "e", dataset: [], scorers: [] })(report).passed).toBe(true) // informational
+    expect(resolveGate({})(report).passed).toBe(true) // informational
   })
 })

--- a/packages/evals/test/llm-judge.test.ts
+++ b/packages/evals/test/llm-judge.test.ts
@@ -8,6 +8,7 @@ function run(finalMessage: string): AgentRunResult {
     finalMessage,
     messages: [],
     toolCalls: [],
+    toolResults: [],
     tokens: [],
     state: {},
     threadId: "t",
@@ -20,9 +21,13 @@ function run(finalMessage: string): AgentRunResult {
   }
 }
 
+// Typed with the arguments `llmJudge` actually calls it with, not `() =>`.
+// Inferred from a zero-arg lambda, `mock.calls[0]` is the empty tuple and
+// reading `[1]` off it is a type error over a value that is really there —
+// which is how the assertion below came to cast an argument it already knew.
 function fakeFetch(content: string) {
   return vi.fn(
-    async () =>
+    async (_input: string, _init: RequestInit) =>
       new Response(JSON.stringify({ choices: [{ message: { content } }] }), { status: 200 }),
   )
 }
@@ -40,7 +45,7 @@ describe("llmJudge", () => {
     expect(v.score).toBe(0.8)
     expect(v.reason).toBe("close enough")
     // criteria interpolated + output included in the user message sent to the model
-    const body = JSON.parse((fetchImpl.mock.calls[0]![1] as RequestInit).body as string)
+    const body = JSON.parse(fetchImpl.mock.calls[0]![1].body as string)
     expect(JSON.stringify(body.messages)).toContain("hello")
   })
   it("scores 0 with a reason when the verdict is unparseable", async () => {

--- a/packages/evals/test/run-eval.test.ts
+++ b/packages/evals/test/run-eval.test.ts
@@ -9,6 +9,7 @@ function run(finalMessage: string, toolCalls: AgentRunResult["toolCalls"] = []):
     finalMessage,
     messages: [],
     toolCalls,
+    toolResults: [],
     tokens: [],
     state: {},
     threadId: "t",

--- a/packages/evals/test/scorers.test.ts
+++ b/packages/evals/test/scorers.test.ts
@@ -34,6 +34,7 @@ function run(partial: Partial<AgentRunResult>): AgentRunResult {
     finalMessage: "",
     messages: [],
     toolCalls: [],
+    toolResults: [],
     tokens: [],
     state: {},
     threadId: "t",

--- a/packages/evals/tsconfig.test.json
+++ b/packages/evals/tsconfig.test.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "allowImportingTsExtensions": true,
+    "noEmit": true,
+    "rootDir": ".",
+    "tsBuildInfoFile": "dist/tsconfig.test.tsbuildinfo"
+  },
+  "include": [
+    "src/**/*.ts",
+    "src/**/*.tsx",
+    "test/**/*.ts",
+    "test/**/*.tsx"
+  ]
+}

--- a/packages/langgraph/package.json
+++ b/packages/langgraph/package.json
@@ -41,7 +41,7 @@
     "build": "tsc -b tsconfig.json",
     "lint": "biome check --config-path ../config-biome/biome.json package.json src test tsconfig.json vitest.config.ts",
     "test": "vitest --run --config vitest.config.ts",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit && tsc -p tsconfig.test.json"
   },
   "dependencies": {
     "@dawn-ai/sdk": "workspace:*"

--- a/packages/langgraph/tsconfig.test.json
+++ b/packages/langgraph/tsconfig.test.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "allowImportingTsExtensions": true,
+    "noEmit": true,
+    "rootDir": ".",
+    "tsBuildInfoFile": "dist/tsconfig.test.tsbuildinfo"
+  },
+  "include": [
+    "src/**/*.ts",
+    "src/**/*.tsx",
+    "test/**/*.ts",
+    "test/**/*.tsx"
+  ]
+}

--- a/packages/sandbox/package.json
+++ b/packages/sandbox/package.json
@@ -37,7 +37,7 @@
     "build": "tsc -b tsconfig.json",
     "lint": "biome check --config-path ../config-biome/biome.json package.json src test tsconfig.json vitest.config.ts",
     "test": "vitest --run --config vitest.config.ts --passWithNoTests",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit && tsc -p tsconfig.test.json"
   },
   "dependencies": {
     "@dawn-ai/sdk": "workspace:*",

--- a/packages/sandbox/tsconfig.test.json
+++ b/packages/sandbox/tsconfig.test.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "allowImportingTsExtensions": true,
+    "noEmit": true,
+    "rootDir": ".",
+    "tsBuildInfoFile": "dist/tsconfig.test.tsbuildinfo"
+  },
+  "include": [
+    "src/**/*.ts",
+    "src/**/*.tsx",
+    "test/**/*.ts",
+    "test/**/*.tsx"
+  ]
+}

--- a/packages/sqlite-storage/package.json
+++ b/packages/sqlite-storage/package.json
@@ -33,7 +33,7 @@
     "build": "tsc -b tsconfig.json",
     "lint": "biome check --config-path ../config-biome/biome.json package.json src test tsconfig.json vitest.config.ts",
     "test": "vitest --run --config vitest.config.ts --passWithNoTests",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit && tsc -p tsconfig.test.json"
   },
   "peerDependencies": {
     "@langchain/core": "^1.2.4",

--- a/packages/sqlite-storage/test/checkpointer.test.ts
+++ b/packages/sqlite-storage/test/checkpointer.test.ts
@@ -185,7 +185,9 @@ describe("DawnSqliteSaver", () => {
 
     // Pending writes must also round-trip correctly
     expect(tuple!.pendingWrites).toHaveLength(1)
-    const [taskId, channel, value] = tuple!.pendingWrites![0]
+    const pendingWrite = tuple!.pendingWrites?.[0]
+    if (!pendingWrite) throw new Error("expected exactly one pending write to round-trip")
+    const [taskId, channel, value] = pendingWrite
     expect(taskId).toBe("tools-task-1")
     expect(channel).toBe("__interrupt__")
     expect((value as Record<string, unknown>).id).toBe("test-interrupt")

--- a/packages/sqlite-storage/tsconfig.test.json
+++ b/packages/sqlite-storage/tsconfig.test.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "allowImportingTsExtensions": true,
+    "noEmit": true,
+    "rootDir": ".",
+    "tsBuildInfoFile": "dist/tsconfig.test.tsbuildinfo"
+  },
+  "include": [
+    "src/**/*.ts",
+    "src/**/*.tsx",
+    "test/**/*.ts",
+    "test/**/*.tsx"
+  ]
+}

--- a/packages/vite-plugin/package.json
+++ b/packages/vite-plugin/package.json
@@ -33,7 +33,7 @@
     "build": "tsc -b tsconfig.json",
     "lint": "biome check --config-path ../config-biome/biome.json package.json src test tsconfig.json vitest.config.ts",
     "test": "vitest --run --config vitest.config.ts",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit && tsc -p tsconfig.test.json"
   },
   "dependencies": {
     "@dawn-ai/core": "workspace:*"

--- a/packages/vite-plugin/tsconfig.test.json
+++ b/packages/vite-plugin/tsconfig.test.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "allowImportingTsExtensions": true,
+    "noEmit": true,
+    "rootDir": ".",
+    "tsBuildInfoFile": "dist/tsconfig.test.tsbuildinfo"
+  },
+  "include": [
+    "src/**/*.ts",
+    "src/**/*.tsx",
+    "test/**/*.ts",
+    "test/**/*.tsx"
+  ]
+}

--- a/packages/workspace/package.json
+++ b/packages/workspace/package.json
@@ -37,7 +37,7 @@
     "build": "tsc -b tsconfig.json",
     "lint": "biome check --config-path ../config-biome/biome.json package.json src test tsconfig.json vitest.config.ts",
     "test": "vitest --run --config vitest.config.ts --passWithNoTests",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit && tsc -p tsconfig.test.json"
   },
   "dependencies": {
     "@dawn-ai/sdk": "workspace:*"

--- a/packages/workspace/tsconfig.test.json
+++ b/packages/workspace/tsconfig.test.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "allowImportingTsExtensions": true,
+    "noEmit": true,
+    "rootDir": ".",
+    "tsBuildInfoFile": "dist/tsconfig.test.tsbuildinfo"
+  },
+  "include": [
+    "src/**/*.ts",
+    "src/**/*.tsx",
+    "test/**/*.ts",
+    "test/**/*.tsx"
+  ]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -400,8 +400,8 @@ importers:
         specifier: 19.2.8
         version: 19.2.8(react@19.2.8)
       rxjs:
-        specifier: 7.8.2
-        version: 7.8.2
+        specifier: 7.8.1
+        version: 7.8.1
 
   packages/cli:
     dependencies:
@@ -7947,9 +7947,6 @@ packages:
   rxjs@7.8.1:
     resolution: {integrity: sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==}
 
-  rxjs@7.8.2:
-    resolution: {integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==}
-
   sade@1.8.1:
     resolution: {integrity: sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==}
     engines: {node: '>=6'}
@@ -9662,7 +9659,7 @@ snapshots:
       '@slack/bolt': 4.7.3(@types/express@5.0.6)
       '@slack/types': 2.22.0
       '@slack/web-api': 7.19.0
-      rxjs: 7.8.2
+      rxjs: 7.8.1
       zod: 3.25.76
       zod-to-json-schema: 3.25.2(zod@3.25.76)
     transitivePeerDependencies:
@@ -9685,7 +9682,7 @@ snapshots:
       '@microsoft/agents-activity': 1.7.2
       '@microsoft/agents-hosting': 1.7.2(@opentelemetry/api@1.9.1)
       express: 4.22.2
-      rxjs: 7.8.2
+      rxjs: 7.8.1
       zod: 3.25.76
       zod-to-json-schema: 3.25.2(zod@3.25.76)
     transitivePeerDependencies:
@@ -16902,10 +16899,6 @@ snapshots:
   rw@1.3.3: {}
 
   rxjs@7.8.1:
-    dependencies:
-      tslib: 2.8.1
-
-  rxjs@7.8.2:
     dependencies:
       tslib: 2.8.1
 


### PR DESCRIPTION
Most packages here compile only `src/**`, so their own test files are never type-checked. That's 16 packages / 194 test files repo-wide. This covers eight of them; `langchain` and `core` are deliberately left for a separate pass (see the end).

## Getting to a real number first

A naive widening reports 143 errors. Matching the config to how vitest actually resolves — `allowImportingTsExtensions`, since these suites import with explicit `.ts` extensions — drops it to **101**, and reveals that five packages were already clean:

| package | errors |
|---|---|
| langgraph, sandbox, vite-plugin, workspace, devkit | **0** — coverage for free |
| sqlite-storage | 1 |
| evals | 8 |
| ag-ui | 21 |
| *langchain* | *20 — not in this PR* |
| *core* | *51 — not in this PR* |

Each package gets a `tsconfig.test.json` in the shape `memory`, `postgres-storage` and `memory-pgvector` already use.

## ag-ui's 21 errors were one dependency bug

`@ag-ui/client` and its middleware siblings pin rxjs to **exactly `7.8.1`**. This package's test-only devDependency asked for **`7.8.2`**. Two copies of rxjs means two nominally distinct `Observable` declarations, so `lastValueFrom`/`toArray` from our copy could not accept a stream produced by theirs:

```
error TS2345: Argument of type 'OperatorFunction<...>' (rxjs@7.8.2)
  is not assignable to parameter of type 'OperatorFunction<...>' (rxjs@7.8.1)
```

The resulting `unknown` cascaded into 14 implicit-any errors. rxjs appears **nowhere** in `packages/ag-ui/src` — only the conformance test uses it, to consume what `@ag-ui/client` emits. Matching the version those objects come from is the whole point of the pin, so it moves to `7.8.1`. 21 → 1.

## What the other errors were

The same shapes the root `test/` tree turned up in #501, which is the argument for this coverage existing at all:

- **A fixture lying about its type.** `AgentRunResult.toolResults` is required; three `evals` fixtures omitted it and pass today only because nothing in those tests reads it.
- **A mock typed as taking no arguments.** `evals`'s `fakeFetch` was `vi.fn(async () => ...)`, so `mock.calls[0]` was the empty tuple while the code under test really calls it with `(input, init)`. The assertion reached for `[1]` and cast it — over an argument the mock already had. Typed to the real signature, the cast goes.
- **Two destructures that would throw instead of fail.** `sqlite-storage`'s `tuple!.pendingWrites![0]` and `ag-ui`'s `const [resume] = fromAguiResume([...])` followed by `Object.hasOwn(resume, ...)`. Both had an assertion above them that doesn't narrow, so a regression would surface as a `TypeError` from the destructure rather than as the assertion that was meant to catch it.
- **An argument the callee never reads.** `resolveGate` takes `Pick<EvalDefinition, "gate" | "threshold">`; the test passed `name`/`dataset`/`scorers` too.

## The docs contract guard fired, as designed

Trimming those `resolveGate` literals changed the token sequence the API-reference registry pins for the `evals.run-and-gate` claim. The claim is unchanged, so the fingerprint follows the source. `api-reference-inventory.test.ts` back to 252/252.

## Verification

| gate | result |
|---|---|
| `pnpm lint` | 27/27 |
| `pnpm typecheck` | 51/51 |
| `pnpm test` | 4782 passed, 215 skipped, 0 failed |
| `node scripts/check-docs.mjs` | pass |

Patch changeset for `@dawn-ai/ag-ui` (the rxjs pin is a published-package change).

## Not in this PR

`langchain` (20) and `core` (51). langchain's are a genuine mix — a `SubagentTaskPlaceholder` shape that drifted, `__interrupt__` absent from a state type, another empty-tuple mock, `exactOptionalPropertyTypes` violations, a lib-target gap — and each wants its own judgment rather than a bulk edit. Its wiring is reverted here so nothing half-finished ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)