### PR TITLE
test: typecheck the tests in @dawn-ai/permissions

### DIFF
--- a/packages/permissions/package.json
+++ b/packages/permissions/package.json
@@ -35,9 +35,9 @@
   },
   "scripts": {
     "build": "tsc -b tsconfig.json",
-    "lint": "biome check --config-path ../config-biome/biome.json package.json src test tsconfig.json tsconfig.contracts.json vitest.config.ts",
+    "lint": "biome check --config-path ../config-biome/biome.json package.json src test tsconfig.json tsconfig.contracts.json tsconfig.test.json vitest.config.ts",
     "test": "vitest --run --config vitest.config.ts --passWithNoTests",
-    "typecheck": "tsc --noEmit && tsc -p tsconfig.contracts.json"
+    "typecheck": "tsc --noEmit && tsc -p tsconfig.contracts.json && tsc -p tsconfig.test.json"
   },
   "dependencies": {
     "@dawn-ai/sdk": "workspace:*"

--- a/packages/permissions/tsconfig.test.json
+++ b/packages/permissions/tsconfig.test.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "allowImportingTsExtensions": true,
+    "noEmit": true,
+    "rootDir": ".",
+    "tsBuildInfoFile": "dist/tsconfig.test.tsbuildinfo"
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx", "test/**/*.ts", "test/**/*.tsx"]
+}


### PR DESCRIPTION
Continues the hole-3 sweep from #505: most packages compile only `src/**`, so their own tests are never type-checked.

- `@dawn-ai/permissions`: four plain test suites were outside the compiler's scope (only `*.contract.ts` was covered, via `tsconfig.contracts.json`). They compile clean, so this is pure coverage — a `tsconfig.test.json` matching the established pattern, appended to `typecheck`, and listed in the package's lint file set.
- `@dawn-ai/inspector` was also flagged by the survey but is **already covered**: its main tsconfig includes `test/**` (32 files), `tsconfig.e2e.json` covers `e2e/**` (22 files), and the only exclusion is `test/fixtures` — fixture mini-apps, one deliberately broken, that must not typecheck. No change needed.

Verified: `pnpm run typecheck`, `pnpm run lint`, and `pnpm test` (50/50) in the package.

Remaining in the sweep: `langchain` (~20 errors), `sdk` (~29), `core` (~51) — coming as follow-up PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)