### PR TITLE
docs(changeset): correct the pending release notes

### DIFF
--- a/.changeset/ag-ui-activity-design-system.md
+++ b/.changeset/ag-ui-activity-design-system.md
@@ -10,7 +10,5 @@ replace a todo or tool row outright. Cards render structured-but-unstyled when
 the stylesheet is not imported, and every rule that styles an element is
 scoped so the sheet cannot affect the rest of your app.
 
-The cards' previous inline styles are gone. Existing consumers who upgrade
-without importing the new stylesheet will see bare, unstyled cards — add
-`import "@dawn-ai/ag-ui/react/styles.css"` to keep the appearance they
-already had.
+The stylesheet is the only styling the cards carry, so importing it is the
+difference between the default look and bare markup.

--- a/.changeset/ag-ui-activity-snapshots.md
+++ b/.changeset/ag-ui-activity-snapshots.md
@@ -7,5 +7,5 @@
 Expose Dawn planning and subagent progress as bounded standard AG-UI activity
 snapshots. The research web example renders plan checklists and delegated-work
 status from those snapshots, which exclude child prose, prompts, tool inputs,
-tool outputs, and final child answers. The generated research starter now points
-users to that activity-aware web recipe.
+tool outputs, and final child answers. The generated research starter renders these
+activities in the web client it ships.

--- a/.changeset/ag-ui-ladder-gaps.md
+++ b/.changeset/ag-ui-ladder-gaps.md
@@ -37,8 +37,7 @@ Four details worth knowing about the resulting surface:
   them at values that are themselves theme-aware, so a half-overridden palette
   does not mix with the package's.
 
-The package README documents this precisely. `classNames`
-entries are appended to the package defaults and never substituted, but the
-stylesheet is unlayered, so an appended class only takes effect on a property the
-sheet leaves unset on that element. The docs now say which properties those are
-and which remain rung-4 work.
+`classNames` entries are appended to the package defaults and never
+substituted, but the stylesheet is unlayered, so an appended class only takes
+effect on a property the sheet leaves unset on that element. The README says
+which properties those are and which remain rung-4 work.

--- a/.changeset/ag-ui-ladder-gaps.md
+++ b/.changeset/ag-ui-ladder-gaps.md
@@ -21,28 +21,23 @@ wrapper, and `marker` targets the disclosure triangle, which is now a real
 `aria-hidden` span instead of a `::before` — so it can be restyled, and its glyph
 no longer lands in the summary's accessible name.
 
-Four narrow behaviour changes, three of which fail silently rather than erroring:
+Four details worth knowing about the resulting surface:
 
-- `classNames.section` no longer reaches the checklist wrapper. It now applies
-  only to a card's labelled region, which means it is inert on
-  `PlanActivityCard` and on a standalone `ActivityChecklist`. Pass
-  `classNames.checklist` for the wrapper. This is the point of the change: one
-  key used to land on two nested elements, so anything box-like drew twice.
-- CSS written against `.dawn-activity__header::before` or against
-  `.dawn-activity__section` as the checklist wrapper stops applying. The marker
-  is `.dawn-activity__marker`; the wrapper is `.dawn-activity__checklist`.
-- A `<summary>` element's `textContent` now includes the marker glyph, which
-  generated content never contributed. A snapshot or text assertion over a card
-  header can flip.
-- A plain `:root` palette override now wins in dark mode and under
-  `data-dawn-theme` as well as in light, where the package's own dark rules used
-  to outrank it. That is the gap being closed, and it changes rendering: a
-  PARTIAL override that previously lost to the package's dark palette now leaks
-  through. Set palette tokens as a set, or point them at values that are
-  themselves theme-aware. Note the README's own rung-1 example was such an
-  override, and is corrected here for the same reason.
+- `classNames.section` targets a card's labelled region only, so it is inert on
+  `PlanActivityCard` and on a standalone `ActivityChecklist`. Use
+  `classNames.checklist` for the checklist wrapper. Keeping them separate means
+  one key cannot land on two nested elements and draw a box twice.
+- The disclosure marker is `.dawn-activity__marker` and the checklist wrapper is
+  `.dawn-activity__checklist`.
+- Because the marker is a real element rather than generated content, its glyph
+  is part of a `<summary>`'s `textContent`. Text assertions over a card header
+  should expect it.
+- A partial `:root` palette override applies in dark mode and under
+  `data-dawn-theme`, not only in light. Set palette tokens as a set, or point
+  them at values that are themselves theme-aware, so a half-overridden palette
+  does not mix with the package's.
 
-The README's rung-2 description is corrected as part of this. `classNames`
+The package README documents this precisely. `classNames`
 entries are appended to the package defaults and never substituted, but the
 stylesheet is unlayered, so an appended class only takes effect on a property the
 sheet leaves unset on that element. The docs now say which properties those are

--- a/.changeset/api-reference-coverage.md
+++ b/.changeset/api-reference-coverage.md
@@ -13,4 +13,6 @@
 "@dawn-ai/vite-plugin": patch
 ---
 
-Publish complete API reference coverage and concise canonical package entrypoints.
+Documentation only: every public export of this package now has an API reference
+page on dawnai.org, and the package README leads with a concise entrypoint. No
+runtime behavior changed.

--- a/.changeset/api-reference-platform.md
+++ b/.changeset/api-reference-platform.md
@@ -10,4 +10,6 @@
 "@dawn-ai/testing": patch
 ---
 
-Publish canonical package API references and concise npm entrypoints. The CLI documentation bundle now discovers every registered detailed API page.
+Documentation only: this package gains a canonical API reference on dawnai.org
+and a concise npm entrypoint. No runtime behavior changed. (`dawn docs` also
+now discovers every registered detailed API page.)

--- a/.changeset/bright-docs-cache.md
+++ b/.changeset/bright-docs-cache.md
@@ -2,4 +2,5 @@
 "@dawn-ai/cli": patch
 ---
 
-Invalidate and restore the CLI's bundled documentation correctly through the Turbo build cache.
+Fix a case where `dawn docs` could serve a stale bundled documentation set after
+an upgrade.

--- a/.changeset/edge-quickstart-manifest.md
+++ b/.changeset/edge-quickstart-manifest.md
@@ -7,7 +7,7 @@
 `providerPackages` is not exported from `@dawn-ai/cli/fetch`.**
 
 Two errata against the docs and changelog that shipped with the `hono` build
-target. The bundled CLI docs (`packages/cli/docs/`) carry the fixes.
+target. `dawn docs` carries the fixes.
 
 - **The `@dawn-ai/cli/fetch` snippet under *Edge runtimes* imported
   `./.dawn/build/modules.mjs`.** That is the `node` target's manifest: it reaches

--- a/.changeset/inspector-browse-orchestration.md
+++ b/.changeset/inspector-browse-orchestration.md
@@ -37,10 +37,5 @@ polling as before.
   prefix answer client-side — otherwise the total and the rows would describe
   different sets.
 
-Column sorting is off in the browse view for now: sorting a server-selected window
-locally presents the wrong sample, not merely the wrong order. It returns with
-server-side ordering.
-
 `useMemoryBrowse` also arbitrates load-more against the poll cadence and keeps a
-separate failure slot for it, but nothing in this release asks for one — the
-control arrives with server-side paging.
+separate failure slot for it.

--- a/.changeset/inspector-column-filters.md
+++ b/.changeset/inspector-column-filters.md
@@ -11,10 +11,9 @@ single-choice, could not express.
 Filtering stays server-side: the funnels only decide the query, which sends the
 filter repeated (`?status=candidate&status=superseded`). Narrowing only the rows
 already loaded would quietly answer a different question, since the list is one
-page of a larger store. For the same reason only status and kind carry funnels —
-the other columns are not translated into the query, and a control that filtered
-the current page would mislead. Content is what search is for; namespace is what
-the facet rail scopes, with real counts.
+page of a larger store. Status and kind lead here; the remaining columns gain
+funnels once the query mapping can express them, which the server-authority entry
+in this release adds.
 
 `is none of` is resolved against the column's options rather than needing
 negation downstream, and a filter that matches nothing now says "No memories

--- a/.changeset/inspector-column-filters.md
+++ b/.changeset/inspector-column-filters.md
@@ -11,9 +11,10 @@ single-choice, could not express.
 Filtering stays server-side: the funnels only decide the query, which sends the
 filter repeated (`?status=candidate&status=superseded`). Narrowing only the rows
 already loaded would quietly answer a different question, since the list is one
-page of a larger store. Status and kind lead here; the remaining columns gain
-funnels once the query mapping can express them, which the server-authority entry
-in this release adds.
+page of a larger store. Every column's funnel therefore maps to a server
+predicate; a control that could only narrow the rows already on screen would
+mislead. Content is also what search is for, and namespace is what the facet
+rail scopes, with real counts.
 
 `is none of` is resolved against the column's options rather than needing
 negation downstream, and a filter that matches nothing now says "No memories

--- a/.changeset/orchestration-correlation.md
+++ b/.changeset/orchestration-correlation.md
@@ -8,5 +8,5 @@ Carry the model's tool-call ID from a tool execution into the capability
 stream: `StreamTransformerInput` gains an optional `toolCallId`, and the
 planning capability echoes it as `tool_call_id` on `plan_update`. Child
 capability events keep their subagent's tool-call ID internal. This is the
-correlation groundwork for presenting built-in orchestration work once; no
-emitted AG-UI event changes yet.
+correlation plumbing behind presenting built-in orchestration work once; the
+presentation change that consumes it ships in this same release.

--- a/.changeset/scaffold-ui-signposts.md
+++ b/.changeset/scaffold-ui-signposts.md
@@ -4,6 +4,5 @@
 ---
 
 Point new users at a UI after scaffolding. The research template's next steps
-now name `npx dawn inspect` (the Inspector the template already installs) and
-link the web UI recipe, and the basic template no longer points at a README it
-does not ship.
+name `npx dawn inspect` (the Inspector the template already installs), and the
+basic template no longer points at a README it does not ship.

--- a/.changeset/scenario-tool-mocking.md
+++ b/.changeset/scenario-tool-mocking.md
@@ -7,6 +7,11 @@
 "@dawn-ai/vite-plugin": patch
 ---
 
+**Breaking:** scenario files must default export `scenarios("<route>")` from
+`@dawn-ai/sdk/testing`. A plain default-exported array now throws
+`RunScenarioLoadError` at load; wrap the array in `scenarios("/route")` to
+migrate.
+
 Add route-scoped fluent `dawn test` scenarios with generated application-tool
 types, invocation-local in-process tool mocks, and declarative mock call
 assertions. Scenario files now use `scenarios("/route")`; plain default-exported

--- a/.changeset/scenario-tool-mocking.md
+++ b/.changeset/scenario-tool-mocking.md
@@ -14,5 +14,4 @@ migrate.
 
 Add route-scoped fluent `dawn test` scenarios with generated application-tool
 types, invocation-local in-process tool mocks, and declarative mock call
-assertions. Scenario files now use `scenarios("/route")`; plain default-exported
-arrays are no longer supported.
+assertions.

--- a/.changeset/steady-research-starter.md
+++ b/.changeset/steady-research-starter.md
@@ -3,4 +3,6 @@
 "create-dawn-ai-app": patch
 ---
 
-Keep the default research scaffold aligned with the dogfooded example, add a coherent npm lifecycle and environment handoff, and verify packaged AG-UI activation through the built artifact.
+The research scaffold gains a complete npm lifecycle (`install` → `verify` →
+`dev`) and an explicit `.env` handoff, and its AG-UI wiring is checked against
+the packaged build.

--- a/.changeset/testing-harness-mode-cleanup.md
+++ b/.changeset/testing-harness-mode-cleanup.md
@@ -2,7 +2,9 @@
 "@dawn-ai/testing": patch
 ---
 
-Remove the unsupported `mode` property from `createAgentHarness()` options. The
+**Breaking for callers that passed it, though it had no effect:** remove the
+unsupported `mode` property from `createAgentHarness()` options — a call site
+that set it stops type-checking, and should simply drop the property. The
 harness remains the in-process testing API; use the existing
 `createAgentProtocolInjector()` or `createSubprocessApp()` factory when testing
 those execution boundaries.

--- a/.changeset/thread-access-hook.md
+++ b/.changeset/thread-access-hook.md
@@ -42,6 +42,4 @@ without booting a server, and `createAgentProtocolInjector` accepts a
 `threadAccess` policy.
 
 The run endpoints — `/runs/stream`, `/runs/wait`, `/resume` and `/agui` — plus
-`GET /threads/:thread_id/pending_interrupts` are gated on this policy too; see
-the entry covering them for the ordering consequences and the `ThreadOperation`
-addition.
+`GET /threads/:thread_id/pending_interrupts` are gated on this policy too.

--- a/.changeset/thread-access-resuming.md
+++ b/.changeset/thread-access-resuming.md
@@ -5,8 +5,8 @@
 ---
 
 Add `resuming` to `ThreadAccessRequest`: a required boolean that is `true` when
-the request carries a resume credential and will continue a parked turn. It is
-additive — an existing policy compiles and behaves exactly as before.
+the request carries a resume credential and will continue a parked turn. A policy that ignores it behaves the same
+for resumed and ordinary turns.
 
 A policy that wants resumes treated differently from ordinary turns — step-up
 auth, a second approver, extra logging — should check `req.resuming` rather than

--- a/.changeset/thread-access-resuming.md
+++ b/.changeset/thread-access-resuming.md
@@ -5,8 +5,8 @@
 ---
 
 Add `resuming` to `ThreadAccessRequest`: a required boolean that is `true` when
-the request carries a resume credential and will continue a parked turn. A policy that ignores it behaves the same
-for resumed and ordinary turns.
+the request carries a resume credential and will continue a parked turn. A
+policy that ignores it behaves the same for resumed and ordinary turns.
 
 A policy that wants resumes treated differently from ordinary turns — step-up
 auth, a second approver, extra logging — should check `req.resuming` rather than

--- a/.changeset/thread-access-run-endpoints.md
+++ b/.changeset/thread-access-run-endpoints.md
@@ -6,20 +6,18 @@
 
 Thread access now authorizes the run endpoints and the pending-interrupts read.
 
-Two things to check before upgrading.
+Two things to know about the shipped surface.
 
-**`ThreadOperation` gains a tenth member, `"thread.pending_interrupts"`.** The
-addition is source-compatible everywhere except an exhaustive `switch` or
-mapped type over the union, which stops compiling until it handles the new
-member. It arrives under `action: "read"`.
+**`ThreadOperation` includes `"thread.pending_interrupts"`**, under
+`action: "read"`. An exhaustive `switch` or mapped type over the union must
+handle every member.
 
-**A policy written against the five endpoints of the previous release will now
-be invoked on five more.** `POST /threads/:id/runs/stream`, `/runs/wait`,
-`/resume`, `POST /agui/:routeId` and `GET /threads/:id/pending_interrupts` are
-gated on the thread-access axis. The migration hazard is a policy whose
-`fallback` returns a bare `{ allow: false }`, or denies any operation it does
-not recognize: it will start denying traffic it permitted before, on endpoints
-that previously answered to route middleware alone. Read your `fallback` before
+**Ten endpoints are gated on the thread-access axis**, including
+`POST /threads/:id/runs/stream`, `/runs/wait`, `/resume`,
+`POST /agui/:routeId` and `GET /threads/:id/pending_interrupts`. The hazard to
+watch is a policy whose `fallback` returns a bare `{ allow: false }`, or denies
+any operation it does not recognize: it denies these endpoints too, where route
+middleware alone used to decide. Read your `fallback` before
 upgrading. A `run.*` operation on a thread that exists arrives under
 `action: "update"`; on a thread id with no row yet, `run.stream`, `run.wait` and
 `run.agui` arrive under `action: "create"` — see the companion note on stamping
@@ -44,15 +42,14 @@ that needed no credential, and reading the `400`/`409` codes as an oracle on a
 guessed `interruptId`/`resumeKey`. A `/pending_interrupts` deny returns the
 handler's own `404 thread_not_found`, indistinguishable from a genuine miss.
 
-`dawn build --target hono` and `--target vercel` now build an app that has a
-policy file, instead of refusing with `DAWN_E1005`. The policy is bundled into
-the static module manifest and runs on those runtimes exactly as it does under
-`dawn dev`. To close the gap that made the refusal necessary, a build that saw a
-policy file stamps that fact into its entry point, and the boot now fails when
-such an entry point is paired with a manifest carrying no thread-access entry —
-a stale manifest would otherwise come up with every thread endpoint open and
-nothing to say so. `--target langsmith` still refuses, permanently: it
-materializes per-route graphs with no Dawn HTTP layer to run a policy in.
+`dawn build --target hono` and `--target vercel` bundle the policy into the
+static module manifest and run it on those runtimes exactly as `dawn dev` does.
+A build that saw a policy file stamps that fact into its entry point, and boot
+fails when such an entry point is paired with a manifest carrying no
+thread-access entry — a stale manifest would otherwise come up with every thread
+endpoint open and nothing to say so. `--target langsmith` refuses with
+`DAWN_E1005`, permanently: it materializes per-route graphs with no Dawn HTTP
+layer to run a policy in.
 
 `create-dawn-app` templates now carry a deny-by-default `src/thread-access.ts`
 and the shared `src/auth.ts` it imports, both as `.example` files that a rename


### PR DESCRIPTION
Corrects the 45 pending changeset bodies before they become the 0.8.22 CHANGELOGs. Changeset text only — 17 files under `.changeset/`, no frontmatter, no code. All bumps stay `patch`.

These accumulated across a long arc where each PR's baseline was the previous PR rather than the last release. Read as a set against `main`, several described a world that will not exist when they publish.

## Two outright contradictions

- **`@dawn-ai/inspector` said "column sorting is off in the browse view for now"** one entry before another shipped five sortable columns. Deleted.
- **`@dawn-ai/cli` claimed hono/vercel builds "previously refused with `DAWN_E1005`"** and offered a migration. Only `--target langsmith` calls `assertNoThreadAccessPolicy`, so that refusal never reached a user. Now states the rule that ships: `--target langsmith` refuses with `DAWN_E1005`, permanently.

## Phantom migrations

`@dawn-ai/ag-ui`'s CHANGELOG has zero `react` entries, and no CHANGELOG anywhere mentions `defineThreadAccess` — both surfaces debut in this release. Several bodies nonetheless told readers how to upgrade from them, or described behaviour as "additive" relative to something no one has. Rewritten to describe the shipped surface.

## Stale claims about the scaffold

Two entries said the scaffold "points users to the web UI recipe". It ships the UI, and three tests assert that link is gone.

## Unlabelled removals

`scenarios("<route>")` and the `mode` option removal are breaking for callers. Both now carry a **Breaking** label and the one-line migration.

## Readability

Six entries were written for someone who had read the PR. `api-reference-coverage.md` was a single sentence spanning 12 packages, two of which shipped nothing. A repo path (`packages/cli/docs/`) is replaced with the `dawn docs` command a reader can actually run.

## Verification

`check-docs` 0, `check-changesets` 0, `check:release-inventory` 0, `pnpm build` 0, `pnpm lint` 0. `release:preflight` shows its single expected FAIL (`github-workflow-active`) — the Release workflow is still disabled, which is step 2 and a separate decision.

97 bump declarations, all `patch` — no `minor` that would force 1.0.0 across the fixed 0.x group. `git diff -U0 origin/main...HEAD -- .changeset/ | grep -E '^[-+]"@dawn-ai|^[-+]"create-dawn'` returns nothing.

## What this does not do

It does not re-enable the Release workflow or touch the Version PR. Merging this invalidates the existing Version PR's generated CHANGELOGs, so the next Release run must regenerate them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
