### PR TITLE
test(cli): make a native Vercel deploy failure diagnosable

### DIFF
--- a/packages/cli/test/helpers/vercel-native-fixture.ts
+++ b/packages/cli/test/helpers/vercel-native-fixture.ts
@@ -3206,9 +3206,82 @@ export async function runNativeDeployAttempt(options: {
     projectId: options.projectId,
   })
   await options.persistDeploymentBinding(binding)
-  const ready = await options.boundary.inspect(deployment)
+  let ready: Awaited<ReturnType<typeof options.boundary.inspect>>
+  try {
+    ready = await options.boundary.inspect(deployment)
+  } catch (cause) {
+    // The lane's cleanup deletes this deployment the moment the attempt fails;
+    // afterwards the API answers not_found and the failure reason is gone for
+    // good. Read the deployment's terminal state now, best-effort, and carry
+    // it on the thrown error so the uploaded diagnostics say WHY the build
+    // failed, not just that a deployment id existed and was DELETED.
+    throw new Error(
+      `native Vercel deployment ${deployment.deploymentId} failed before readiness; ` +
+        `state captured before cleanup: ${await captureNativeDeploymentState(
+          options.apiClient,
+          options.orgId,
+          deployment.deploymentId,
+        )}`,
+      { cause },
+    )
+  }
   await options.persistStage?.("readiness", ready)
   return { attempt, binding, commandEvidence, config, ...deployment, ...ready }
+}
+
+/**
+ * Best-effort read of a deployment's terminal state for failure diagnostics.
+ * Extracts only the short, non-sensitive status fields from the deployment
+ * read — never the full body — because this string travels on an Error
+ * message, ahead of writeDiagnostic's redaction.
+ */
+async function captureNativeDeploymentState(
+  apiClient: NativeVercelApiClient,
+  orgId: string,
+  deploymentId: string,
+): Promise<string> {
+  try {
+    const response = await apiClient.request(
+      "GET",
+      `/v13/deployments/${encodeURIComponent(deploymentId)}?teamId=${encodeURIComponent(orgId)}`,
+    )
+    const body =
+      typeof response.body === "object" && response.body !== null
+        ? (response.body as Record<string, unknown>)
+        : {}
+    const field = (name: string): string | undefined => {
+      const value = body[name]
+      return typeof value === "string" ? value : undefined
+    }
+    return JSON.stringify({
+      status: response.status,
+      readyState: field("readyState"),
+      errorCode: field("errorCode"),
+      errorMessage: field("errorMessage"),
+      errorStep: field("errorStep"),
+    })
+  } catch {
+    return "unavailable (deployment state read failed)"
+  }
+}
+
+/**
+ * Render an error's cause chain as one readable block for a diagnostic file.
+ * Messages only — stacks stay in the test runner's own output.
+ */
+function flattenNativeFailureChain(failure: unknown): string {
+  const lines: string[] = []
+  let current: unknown = failure
+  for (let depth = 0; depth < 10 && current !== undefined && current !== null; depth += 1) {
+    if (current instanceof Error) {
+      lines.push(current.message)
+      current = current.cause
+      continue
+    }
+    lines.push(String(current))
+    break
+  }
+  return lines.length > 0 ? lines.join("\ncaused by: ") : "unknown failure"
 }
 
 export function parseNativeVercelProjectBinding(
@@ -5847,8 +5920,21 @@ export async function prepareNativeFixtureDeployment<
   let deployment: Deployment
   try {
     deployment = await options.deploy()
-  } catch {
-    throw new Error(`native Vercel ${options.kind} deploy attempt failed`)
+  } catch (cause) {
+    // Persist the real failure before rethrowing: the lane's cleanup deletes
+    // the deployment as soon as this attempt fails, after which the Vercel API
+    // returns not_found and the reason is unrecoverable. Every message on this
+    // chain is either fixture-authored or already redacted at its source, and
+    // writeDiagnostic redacts again before anything reaches the artifact.
+    try {
+      await options.writeDiagnostic(
+        `${options.kind}-deploy-failure.log`,
+        `${flattenNativeFailureChain(cause)}\n`,
+      )
+    } catch {
+      // Diagnostic persistence must never mask the deploy failure itself.
+    }
+    throw new Error(`native Vercel ${options.kind} deploy attempt failed`, { cause })
   }
   assertDeploymentId(deployment.deploymentId)
   canonicalizeVercelOrigin(deployment.canonicalOrigin)
@@ -6007,10 +6093,12 @@ interface NativeCleanupAttemptRecord {
 
 const NATIVE_DIAGNOSTIC_NAMES = new Set([
   "prebuilt-build.log",
+  "prebuilt-deploy-failure.log",
   "prebuilt-events.json",
   "prebuilt-local-build.log",
   "prebuilt-runtime.jsonl",
   "source-build.log",
+  "source-deploy-failure.log",
   "source-events.json",
   "source-runtime.jsonl",
 ])

--- a/packages/cli/test/vercel-native-lane.test.ts
+++ b/packages/cli/test/vercel-native-lane.test.ts
@@ -2230,6 +2230,102 @@ describe("pinned vercel boundary", () => {
     ])
   })
 
+  test("captures the deployment's terminal state before cleanup when readiness fails", async () => {
+    const coordinates = {
+      githubJob: "vercel-native",
+      githubRepositoryId: "123456",
+      githubRunAttempt: "2",
+      githubRunId: "987654",
+      kind: "source" as const,
+      logicalAttemptIndex: "0",
+    }
+    const attemptStartMs = 1_800_000_000_000
+    const inspectFailure = new Error("native Vercel deployment inspect failed with exit 1")
+    let marker = ""
+    let apiCall = 0
+    const failure = await runNativeDeployAttempt({
+      apiClient: {
+        request: async (_method, path) => {
+          apiCall += 1
+          if (apiCall === 1) {
+            return {
+              body: { id: "prj_Test456", accountId: "team_Test123", rootDirectory: null },
+              status: 200,
+            }
+          }
+          expect(path).toContain("/v13/deployments/dpl_Source123")
+          if (apiCall === 2) {
+            return {
+              body: {
+                id: "dpl_Source123",
+                url: "dawn-source-abc.vercel.app",
+                projectId: "prj_Test456",
+                ownerId: "team_Test123",
+                createdAt: attemptStartMs,
+                target: null,
+                meta: { dawnVercelRun: marker },
+              },
+              status: 200,
+            }
+          }
+          // The capture read runs after inspect fails, before the lane's
+          // cleanup can delete the deployment.
+          return {
+            body: {
+              id: "dpl_Source123",
+              readyState: "ERROR",
+              errorCode: "BUILD_FAILED",
+              errorMessage: "Command exited with 1",
+            },
+            status: 200,
+          }
+        },
+      },
+      attemptStartMs,
+      boundary: {
+        assertVersion: async () => {},
+        deploy: async (request) => {
+          marker = request.marker
+          return {
+            canonicalOrigin: "https://dawn-source-abc.vercel.app",
+            commandEvidence: {
+              command: "deploy" as const,
+              positionalPathAbsent: true as const,
+              prebuiltFlagCount: 0 as const,
+            },
+            deploymentId: "dpl_Source123",
+          }
+        },
+        inspect: async () => {
+          throw inspectFailure
+        },
+      },
+      coordinates,
+      fixtureRoot: "/unused/source",
+      localConfigPath: "/unused/source/vercel.json",
+      orgId: "team_Test123",
+      persistAttempt: async () => {},
+      persistDeploymentBinding: async () => {},
+      persistDeploymentReceipt: async () => {},
+      projectId: "prj_Test456",
+      readConfigEvidence: async () => ({ fluid: true, sha256: "a".repeat(64) }),
+    }).then(
+      () => {
+        throw new Error("expected the deploy attempt to fail")
+      },
+      (error: unknown) => error,
+    )
+
+    expect(failure).toBeInstanceOf(Error)
+    const error = failure as Error
+    expect(error.message).toContain("dpl_Source123 failed before readiness")
+    expect(error.message).toContain('"readyState":"ERROR"')
+    expect(error.message).toContain('"errorCode":"BUILD_FAILED"')
+    expect(error.message).toContain('"errorMessage":"Command exited with 1"')
+    expect(error.cause).toBe(inspectFailure)
+    expect(apiCall).toBe(3)
+  })
+
   test("uses only the fixed Vercel API origin and authorization header", async () => {
     const requests: NativeVercelApiRequest[] = []
     const client = createNativeVercelApiClient({
@@ -6901,6 +6997,60 @@ describe("native orchestration and evidence closure", () => {
       "prebuilt-black-box",
       "prebuilt-reconcile",
     ])
+  })
+
+  test("persists the real deploy failure as a diagnostic and preserves its cause", async () => {
+    const fixture = await makeUploadFixture("source")
+    const deployFailure = new Error(
+      "native Vercel deployment dpl_Source123 failed before readiness; state captured before cleanup: " +
+        '{"status":200,"readyState":"ERROR","errorCode":"BUILD_FAILED"}',
+      { cause: new Error("native Vercel deployment inspect failed with exit 1") },
+    )
+    const diagnostics: Record<string, string> = {}
+    const failure = await runNativeDeploymentKind({
+      deployAttempt: async () => {
+        throw deployFailure
+      },
+      expectedTarballs: fixture.expectedTarballs,
+      fixtureRoot: fixture.root,
+      inspectBuildLogs: async () => {
+        throw new Error("build logs must not be inspected for a failed deploy")
+      },
+      kind: "source",
+      orgId: "team_Test123",
+      parentEnv: {},
+      projectId: "prj_Test456",
+      protectedValues,
+      reconcile: async () => {
+        throw new Error("reconciliation must not run for a failed deploy")
+      },
+      runBlackBox: async () => {
+        throw new Error("black box must not run for a failed deploy")
+      },
+      runBuildChild: async () => {
+        throw new Error("local build must not run for a source deploy")
+      },
+      validateOutput: async () => {},
+      writeDiagnostic: async (name, contents) => {
+        diagnostics[name] = contents
+      },
+    }).then(
+      () => {
+        throw new Error("expected the deployment kind to fail")
+      },
+      (error: unknown) => error,
+    )
+
+    expect(failure).toBeInstanceOf(Error)
+    const error = failure as Error
+    expect(error.message).toBe("native Vercel source deploy attempt failed")
+    expect(error.cause).toBe(deployFailure)
+    expect(Object.keys(diagnostics)).toEqual(["source-deploy-failure.log"])
+    expect(diagnostics["source-deploy-failure.log"]).toBe(
+      "native Vercel deployment dpl_Source123 failed before readiness; " +
+        'state captured before cleanup: {"status":200,"readyState":"ERROR","errorCode":"BUILD_FAILED"}\n' +
+        "caused by: native Vercel deployment inspect failed with exit 1\n",
+    )
   })
 
   test.each(["empty", "mismatched", "cardinality"] as const)(


### PR DESCRIPTION
The `vercel-native` lane flakes against live Vercel (one red run on `main` after #504, green on re-run), and diagnosing it took far longer than it should have. The root cause of the *diagnosis* pain: `runNativeDeploymentKind`'s deploy catch was a bare `catch` with no binding — the real Vercel error was discarded, the uploaded diagnostics contained only a deployment id and a `DELETED` cleanup record, and querying the API afterwards returns `not_found` because the lane's own cleanup had already deleted the deployment.

Three changes, none affecting the success path:

- **Preserve the cause.** The deploy catch rethrows with `{ cause }` and writes the flattened message chain to a new `<kind>-deploy-failure.log` diagnostic (allow-listed and redacted like every other diagnostic). Every message on that chain is fixture-authored or already redacted at its source (`protectedChildError`).
- **Capture the deployment's terminal state before cleanup tears it down.** When the readiness inspect fails, `runNativeDeployAttempt` reads the deployment once more and carries `status`/`readyState`/`errorCode`/`errorMessage`/`errorStep` (never the full body) on the thrown error. Best-effort, and scoped to the inspect step so the existing persist-failure and non-200 short-circuit pins are untouched.
- **Two new pins** covering both behaviors, including that the original inspect error survives as the `cause` and that the diagnostic is the only one written for a failed deploy.

Verified: `vercel-native-lane.test.ts` 293 passed / 1 skipped (was 291/1), cli `typecheck` and `lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)