### PR TITLE
test: typecheck the tests in langchain, sdk, and core — hole 3 closed

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -39,9 +39,9 @@
   },
   "scripts": {
     "build": "tsc -b tsconfig.json",
-    "lint": "biome check --config-path ../config-biome/biome.json package.json src test tsconfig.json vitest.config.ts",
+    "lint": "biome check --config-path ../config-biome/biome.json package.json src test tsconfig.json tsconfig.test.json vitest.config.ts",
     "test": "vitest --run --config vitest.config.ts",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit && tsc -p tsconfig.test.json"
   },
   "dependencies": {
     "@dawn-ai/permissions": "workspace:*",

--- a/packages/core/test/capabilities/memory.test.ts
+++ b/packages/core/test/capabilities/memory.test.ts
@@ -40,7 +40,7 @@ const baseCtx = (store: any) => ({
     store,
     namespace: "ws=a|route=/r",
     writes: "candidate" as const,
-    defined: { kind: "semantic", scope: ["route"], identity: ["subject", "predicate"] },
+    defined: { kind: "semantic" as const, scope: ["route"], identity: ["subject", "predicate"] },
     validate: (data: unknown) => ({ ok: true as const, value: data as Record<string, unknown> }),
     now: () => "2026-01-01T00:00:00.000Z",
   },

--- a/packages/core/test/capabilities/permission-gate.test.ts
+++ b/packages/core/test/capabilities/permission-gate.test.ts
@@ -361,7 +361,7 @@ describe("wrapToolWithApproval", () => {
       name: "deployProd",
       description: "deploys",
       filePath: "/app/src/app/ops/tools/deployProd.ts",
-      run: async (input: unknown) => `deployed:${JSON.stringify(input)}`,
+      run: async (input: unknown, _context: unknown) => `deployed:${JSON.stringify(input)}`,
     }
     const wrapped = wrapToolWithApproval(tool, permissions)
     expect(wrapped.name).toBe("deployProd")
@@ -381,7 +381,7 @@ describe("wrapToolWithApproval", () => {
     const wrapped = wrapToolWithApproval(
       {
         name: "deployProd",
-        run: async () => {
+        run: async (_input: unknown, _context: unknown) => {
           ran = true
           return "deployed"
         },
@@ -400,7 +400,10 @@ describe("wrapToolWithApproval", () => {
       mode: "non-interactive",
     })
     await permissions.load()
-    const wrapped = wrapToolWithApproval({ name: "x", run: async () => "ran" }, permissions)
+    const wrapped = wrapToolWithApproval(
+      { name: "x", run: async (_input: unknown, _context: unknown) => "ran" },
+      permissions,
+    )
     expect(String(await wrapped.run({}, { signal }))).toMatch(/fail-closed/)
   })
 
@@ -412,7 +415,7 @@ describe("wrapToolWithApproval", () => {
     })
     await permissions.load()
     const wrapped = wrapToolWithApproval(
-      { name: "deployProd", run: async () => "ran" },
+      { name: "deployProd", run: async (_input: unknown, _context: unknown) => "ran" },
       permissions,
     )
     const result = String(await wrapped.run({}, { signal }))
@@ -436,7 +439,7 @@ describe("wrapToolWithConstraint", () => {
   it("allows (runs the real tool) when the predicate returns true", async () => {
     const tool = {
       name: "deployProd",
-      run: async (i: unknown) => `ran:${JSON.stringify(i)}`,
+      run: async (i: unknown, _context: unknown) => `ran:${JSON.stringify(i)}`,
     }
     const wrapped = wrapToolWithConstraint(tool, () => true, undefined, "/ops#agent")
     expect(await wrapped.run({ env: "staging" }, runCtx)).toBe('ran:{"env":"staging"}')
@@ -446,7 +449,7 @@ describe("wrapToolWithConstraint", () => {
     let ran = false
     const tool = {
       name: "deployProd",
-      run: async () => {
+      run: async (_input: unknown, _context: unknown) => {
         ran = true
         return "ran"
       },
@@ -466,10 +469,10 @@ describe("wrapToolWithConstraint", () => {
     let seen: {
       toolName?: string
       routeId?: string
-      threadId?: string
+      threadId?: string | undefined
       params?: unknown
     } = {}
-    const tool = { name: "deployProd", run: async () => "ran" }
+    const tool = { name: "deployProd", run: async (_input: unknown, _context: unknown) => "ran" }
     const wrapped = wrapToolWithConstraint(
       tool,
       (_args, ctx) => {
@@ -497,7 +500,7 @@ describe("wrapToolWithConstraint", () => {
     let ran = false
     const tool = {
       name: "deployProd",
-      run: async () => {
+      run: async (_input: unknown, _context: unknown) => {
         ran = true
         return "ran"
       },
@@ -516,7 +519,7 @@ describe("wrapToolWithConstraint", () => {
   })
 
   it("awaits an async predicate", async () => {
-    const tool = { name: "deployProd", run: async () => "ran" }
+    const tool = { name: "deployProd", run: async (_input: unknown, _context: unknown) => "ran" }
     const wrapped = wrapToolWithConstraint(
       tool,
       async () => await Promise.resolve("async denied"),
@@ -533,7 +536,10 @@ describe("wrapToolWithConstraint", () => {
       mode: "interactive",
     })
     await permissions.load()
-    const tool = { name: "deployProd", run: async () => "deployed" }
+    const tool = {
+      name: "deployProd",
+      run: async (_input: unknown, _context: unknown) => "deployed",
+    }
     const wrapped = wrapToolWithConstraint(
       tool,
       () => ({ approve: true }),
@@ -553,7 +559,7 @@ describe("wrapToolWithConstraint", () => {
     let ran = false
     const tool = {
       name: "deployProd",
-      run: async () => {
+      run: async (_input: unknown, _context: unknown) => {
         ran = true
         return "deployed"
       },
@@ -574,7 +580,7 @@ describe("wrapToolWithConstraint", () => {
       let ran = false
       const tool = {
         name: "deployProd",
-        run: async () => {
+        run: async (_input: unknown, _context: unknown) => {
           ran = true
           return "ran"
         },

--- a/packages/core/test/capabilities/subagents-static.test.ts
+++ b/packages/core/test/capabilities/subagents-static.test.ts
@@ -14,7 +14,7 @@ function childRoute(): RouteDefinition {
     kind: "agent",
     pathname: "/chat/subagents/helper",
     routeDir: `${parentRouteDir}/subagents/helper`,
-    segments: ["chat", "subagents", "helper"],
+    segments: ["chat", "subagents", "helper"].map((raw) => ({ kind: "static" as const, raw })),
   }
 }
 

--- a/packages/core/test/capabilities/workspace-fs.test.ts
+++ b/packages/core/test/capabilities/workspace-fs.test.ts
@@ -59,6 +59,7 @@ describe("createWorkspaceFs", () => {
       readFile: async () => "x",
       writeFile: async () => ({ bytesWritten: 1 }),
       listDir: async () => [],
+      realPath: async (path: string) => path,
     }
     const fs = createWorkspaceFs({
       workspaceRoot,

--- a/packages/core/test/compiler-route-analysis.test.ts
+++ b/packages/core/test/compiler-route-analysis.test.ts
@@ -48,7 +48,7 @@ function compileScenarioDeclaration(options: {
         kind: "workflow",
         entryFile: join(options.routeDir, "index.ts"),
         routeDir: options.routeDir,
-        segments: [{ kind: "static", value: options.pathname.slice(1) }],
+        segments: [{ kind: "static", raw: options.pathname.slice(1) }],
       },
     ],
   }

--- a/packages/core/test/discover-routes.test.ts
+++ b/packages/core/test/discover-routes.test.ts
@@ -59,7 +59,7 @@ describe("discoverRoutes", () => {
 
     const manifest = await discoverRoutes({ appRoot })
 
-    expect(manifest.routes[0].kind).toBe("graph")
+    expect(manifest.routes[0]?.kind).toBe("graph")
   })
 
   it("throws when index.ts exports both workflow and graph", async () => {
@@ -89,7 +89,7 @@ describe("discoverRoutes", () => {
 
     const manifest = await discoverRoutes({ appRoot })
 
-    expect(manifest.routes[0].pathname).toBe("/hello")
+    expect(manifest.routes[0]?.pathname).toBe("/hello")
   })
 
   it("preserves dynamic segments in pathnames", async () => {
@@ -99,8 +99,8 @@ describe("discoverRoutes", () => {
 
     const manifest = await discoverRoutes({ appRoot })
 
-    expect(manifest.routes[0].pathname).toBe("/hello/[tenant]")
-    expect(manifest.routes[0].segments).toEqual([
+    expect(manifest.routes[0]?.pathname).toBe("/hello/[tenant]")
+    expect(manifest.routes[0]?.segments).toEqual([
       { kind: "static", raw: "hello" },
       { kind: "dynamic", name: "tenant", raw: "[tenant]" },
     ])

--- a/packages/core/test/extract-tool-schema.test.ts
+++ b/packages/core/test/extract-tool-schema.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { afterEach, beforeEach, describe, expect, test } from "vitest"
 
-import { extractToolSchemasForRoute } from "../src/typegen/extract-tool-schema"
+import { extractToolSchemasForRoute } from "../src/typegen/extract-tool-schema.js"
 
 let tempDir: string
 

--- a/packages/core/test/extract-tool-types.test.ts
+++ b/packages/core/test/extract-tool-types.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { afterEach, beforeEach, describe, expect, test } from "vitest"
 
-import { extractToolTypesForRoute } from "../src/typegen/extract-tool-types"
+import { extractToolTypesForRoute } from "../src/typegen/extract-tool-types.js"
 
 let tempDir: string
 

--- a/packages/core/test/integration-dx-improvements.test.ts
+++ b/packages/core/test/integration-dx-improvements.test.ts
@@ -4,7 +4,7 @@ import { join } from "node:path"
 import { afterEach, beforeEach, describe, expect, test } from "vitest"
 
 import { extractToolArtifactsForRoute } from "../src/compiler/index.ts"
-import { extractToolSchemasForRoute } from "../src/typegen/extract-tool-schema"
+import { extractToolSchemasForRoute } from "../src/typegen/extract-tool-schema.js"
 
 let tempDir: string
 
@@ -48,6 +48,7 @@ export default async (input: {
 
     expect(schemas).toHaveLength(1)
     const [schema] = schemas
+    if (!schema) throw new Error("Expected one extracted tool schema")
 
     expect(schema.name).toBe("search")
     expect(schema.description).toBe("Searches the knowledge base for relevant documents.")

--- a/packages/core/test/nested-tool-inputs-integration.test.ts
+++ b/packages/core/test/nested-tool-inputs-integration.test.ts
@@ -3,8 +3,8 @@ import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { afterEach, beforeEach, describe, expect, test } from "vitest"
 
-import { extractToolSchemasForRoute } from "../src/typegen/extract-tool-schema"
-import { extractToolTypesForRoute } from "../src/typegen/extract-tool-types"
+import { extractToolSchemasForRoute } from "../src/typegen/extract-tool-schema.js"
+import { extractToolTypesForRoute } from "../src/typegen/extract-tool-types.js"
 
 // End-to-end coverage that a single tool with a deeply nested input flows
 // consistently through BOTH real extractors: the JSON-Schema path (what the

--- a/packages/core/test/render-route-types.test.ts
+++ b/packages/core/test/render-route-types.test.ts
@@ -3,11 +3,11 @@ import { fileURLToPath } from "node:url"
 import ts from "typescript"
 import { describe, expect, test } from "vitest"
 
-import { renderDawnTypes, renderRouteTypes } from "../src/typegen/render-route-types"
+import { renderDawnTypes, renderRouteTypes } from "../src/typegen/render-route-types.js"
 import { renderScenarioTypes, SCENARIO_TYPES_FILE } from "../src/typegen/render-scenario-types.ts"
-import { type RouteStateFields, renderStateTypes } from "../src/typegen/render-state-types"
-import { renderToolTypes } from "../src/typegen/render-tool-types"
-import type { RouteManifest, RouteSegment, RouteToolTypes } from "../src/types"
+import { type RouteStateFields, renderStateTypes } from "../src/typegen/render-state-types.js"
+import { renderToolTypes } from "../src/typegen/render-tool-types.js"
+import type { RouteManifest, RouteSegment, RouteToolTypes } from "../src/types.js"
 
 const MANIFEST_SNAPSHOT_PATH = fileURLToPath(
   new URL("../../../test/fixtures/contracts/manifest.snap.json", import.meta.url),
@@ -101,8 +101,8 @@ describe("renderDawnTypes", { timeout: 30_000 }, () => {
           entryFile: "/tmp/example-app/hello/[tenant].tsx",
           routeDir: "/tmp/example-app/hello/[tenant]",
           segments: [
-            { kind: "static", value: "hello" },
-            { kind: "dynamic", name: "tenant" },
+            { kind: "static", raw: "hello" },
+            { kind: "dynamic", name: "tenant", raw: "[tenant]" },
           ],
         },
       ],
@@ -110,7 +110,9 @@ describe("renderDawnTypes", { timeout: 30_000 }, () => {
     const toolTypes: RouteToolTypes[] = [
       {
         pathname: "/hello/[tenant]",
-        tools: [{ name: "greet", inputType: "{ tenant: string }", outputType: "string" }],
+        tools: [
+          { name: "greet", description: "", inputType: "{ tenant: string }", outputType: "string" },
+        ],
       },
     ]
 
@@ -135,7 +137,7 @@ describe("renderDawnTypes", { timeout: 30_000 }, () => {
           kind: "workflow",
           entryFile: "/tmp/example-app/hello.tsx",
           routeDir: "/tmp/example-app/hello",
-          segments: [{ kind: "static", value: "hello" }],
+          segments: [{ kind: "static", raw: "hello" }],
         },
       ],
     }
@@ -146,7 +148,9 @@ describe("renderDawnTypes", { timeout: 30_000 }, () => {
     const toolTypes: RouteToolTypes[] = [
       {
         pathname: "/hello",
-        tools: [{ name: "status", inputType: "void", outputType: '"ready" | "done"' }],
+        tools: [
+          { name: "status", description: "", inputType: "void", outputType: '"ready" | "done"' },
+        ],
       },
     ]
     const output = renderDawnTypes(manifest, toolTypes, stateTypes)
@@ -172,14 +176,14 @@ describe("renderDawnTypes", { timeout: 30_000 }, () => {
           kind: "workflow",
           entryFile: "/tmp/example-app/hello.tsx",
           routeDir: "/tmp/example-app/hello",
-          segments: [{ kind: "static", value: "hello" }],
+          segments: [{ kind: "static", raw: "hello" }],
         },
       ],
     }
     const output = renderDawnTypes(manifest, [
       {
         pathname: "/hello",
-        tools: [{ name: "greet", inputType: "void", outputType: "string" }],
+        tools: [{ name: "greet", description: "", inputType: "void", outputType: "string" }],
       },
     ])
     const expected = ["DawnRouteParams", "DawnRoutePath", "DawnRouteTools", "RouteTools"]
@@ -208,8 +212,8 @@ describe("renderDawnTypes", { timeout: 30_000 }, () => {
           entryFile: "/tmp/example-app/hello/[tenant].tsx",
           routeDir: "/tmp/example-app/hello/[tenant]",
           segments: [
-            { kind: "static", value: "hello" },
-            { kind: "dynamic", name: "tenant" },
+            { kind: "static", raw: "hello" },
+            { kind: "dynamic", name: "tenant", raw: "[tenant]" },
           ],
         },
       ],
@@ -221,6 +225,7 @@ describe("renderDawnTypes", { timeout: 30_000 }, () => {
         tools: [
           {
             name: "greet",
+            description: "",
             inputType: "{ readonly tenant: string; }",
             outputType: "{ greeting: string; }",
           },
@@ -288,8 +293,8 @@ describe("renderDawnTypes", { timeout: 30_000 }, () => {
           entryFile: "/tmp/example-app/hello/[tenant].tsx",
           routeDir: "/tmp/example-app/hello/[tenant]",
           segments: [
-            { kind: "static", value: "hello" },
-            { kind: "dynamic", name: "tenant" },
+            { kind: "static", raw: "hello" },
+            { kind: "dynamic", name: "tenant", raw: "[tenant]" },
           ],
         },
       ],
@@ -325,8 +330,8 @@ describe("renderDawnTypes", { timeout: 30_000 }, () => {
           entryFile: "/tmp/example-app/hello/[tenant].tsx",
           routeDir: "/tmp/example-app/hello/[tenant]",
           segments: [
-            { kind: "static", value: "hello" },
-            { kind: "dynamic", name: "tenant" },
+            { kind: "static", raw: "hello" },
+            { kind: "dynamic", name: "tenant", raw: "[tenant]" },
           ],
         },
       ],
@@ -351,8 +356,8 @@ describe("renderScenarioTypes", { timeout: 30_000 }, () => {
           entryFile: "/tmp/example-app/hello/[tenant].tsx",
           routeDir: "/tmp/example-app/hello/[tenant]",
           segments: [
-            { kind: "static", value: "hello" },
-            { kind: "dynamic", name: "tenant" },
+            { kind: "static", raw: "hello" },
+            { kind: "dynamic", name: "tenant", raw: "[tenant]" },
           ],
         },
       ],
@@ -397,7 +402,7 @@ describe("renderScenarioTypes", { timeout: 30_000 }, () => {
           kind: "workflow",
           entryFile: "/tmp/example-app/without-tools.tsx",
           routeDir: "/tmp/example-app/without-tools",
-          segments: [{ kind: "static", value: "without-tools" }],
+          segments: [{ kind: "static", raw: "without-tools" }],
         },
         {
           id: "/ping",
@@ -405,7 +410,7 @@ describe("renderScenarioTypes", { timeout: 30_000 }, () => {
           kind: "workflow",
           entryFile: "/tmp/example-app/ping.tsx",
           routeDir: "/tmp/example-app/ping",
-          segments: [{ kind: "static", value: "ping" }],
+          segments: [{ kind: "static", raw: "ping" }],
         },
       ],
     }

--- a/packages/core/test/render-state-types.test.ts
+++ b/packages/core/test/render-state-types.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "vitest"
 
-import { renderStateTypes } from "../src/typegen/render-state-types"
+import { renderStateTypes } from "../src/typegen/render-state-types.js"
 
 describe("renderStateTypes", () => {
   test("renders empty interface when no routes have state", () => {

--- a/packages/core/test/render-tool-types.test.ts
+++ b/packages/core/test/render-tool-types.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "vitest"
 
-import { renderToolTypes } from "../src/typegen/render-tool-types"
-import type { RouteToolTypes } from "../src/types"
+import { renderToolTypes } from "../src/typegen/render-tool-types.js"
+import type { RouteToolTypes } from "../src/types.js"
 
 describe("renderToolTypes", () => {
   test("empty routeTools renders empty interface", () => {
@@ -21,6 +21,7 @@ describe("renderToolTypes", () => {
         tools: [
           {
             name: "greet",
+            description: "",
             inputType: "{ readonly tenant: string; }",
             outputType: "{ greeting: string; }",
           },
@@ -48,11 +49,13 @@ describe("renderToolTypes", () => {
         tools: [
           {
             name: "getUser",
+            description: "",
             inputType: "{ id: string }",
             outputType: "{ name: string }",
           },
           {
             name: "listUsers",
+            description: "",
             inputType: "void",
             outputType: "{ users: string[] }",
           },
@@ -81,6 +84,7 @@ describe("renderToolTypes", () => {
         tools: [
           {
             name: "ping",
+            description: "",
             inputType: "void",
             outputType: "{ pong: boolean }",
           },
@@ -112,6 +116,7 @@ describe("renderToolTypes", () => {
         tools: [
           {
             name: "doThing",
+            description: "",
             inputType: "{ x: number }",
             outputType: "{ result: number }",
           },
@@ -137,7 +142,7 @@ describe("renderToolTypes", () => {
       { pathname: "/without-tools", tools: [] },
       {
         pathname: "/ping",
-        tools: [{ name: "ping", inputType: "void", outputType: "string" }],
+        tools: [{ name: "ping", description: "", inputType: "void", outputType: "string" }],
       },
     ])
 
@@ -152,6 +157,7 @@ describe("renderToolTypes", () => {
         tools: [
           {
             name: "toolA",
+            description: "",
             inputType: "string",
             outputType: "number",
           },
@@ -162,6 +168,7 @@ describe("renderToolTypes", () => {
         tools: [
           {
             name: "toolB",
+            description: "",
             inputType: "void",
             outputType: "boolean",
           },

--- a/packages/core/test/resolve-state-fields.test.ts
+++ b/packages/core/test/resolve-state-fields.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "vitest"
 
-import { resolveStateFields } from "../src/state/resolve-state-fields"
+import { resolveStateFields } from "../src/state/resolve-state-fields.js"
 
 describe("resolveStateFields", () => {
   test("infers append reducer for array defaults", () => {

--- a/packages/core/test/subagents/policy.test.ts
+++ b/packages/core/test/subagents/policy.test.ts
@@ -354,6 +354,7 @@ describe("resolveGuardedSubagent", () => {
         message:
           "[DAWN_E3002] Subagent delegation constraint check failed. The subagent was not started.",
       })
+      if (result.ok) throw new Error("Expected a denied delegation result")
       expect(result.message).not.toContain(secret.message)
       expect(warn).not.toHaveBeenCalled()
       expect(resolve).not.toHaveBeenCalled()
@@ -491,7 +492,7 @@ describe("resolveGuardedSubagent", () => {
           action: "constrain",
           predicate: async () => {
             controller.abort()
-            return true
+            return true as const
           },
         }),
       ],
@@ -532,7 +533,7 @@ describe("resolveGuardedSubagent", () => {
           action: "constrain",
           predicate: async () => {
             order.push("policy")
-            return true
+            return true as const
           },
         }),
       ],

--- a/packages/core/test/subagents/registry.test.ts
+++ b/packages/core/test/subagents/registry.test.ts
@@ -15,7 +15,10 @@ function route(id: string, routeDir: string): RouteDefinition {
     kind: "agent",
     entryFile: `${routeDir}/index.ts`,
     routeDir,
-    segments: id.split("/").filter(Boolean),
+    segments: id
+      .split("/")
+      .filter(Boolean)
+      .map((raw) => ({ kind: "static" as const, raw })),
   }
 }
 

--- a/packages/core/tsconfig.test.json
+++ b/packages/core/tsconfig.test.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "allowImportingTsExtensions": true,
+    "noEmit": true,
+    "rootDir": ".",
+    "tsBuildInfoFile": "dist/tsconfig.test.tsbuildinfo"
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx", "test/**/*.ts", "test/**/*.tsx"]
+}

--- a/packages/langchain/package.json
+++ b/packages/langchain/package.json
@@ -39,9 +39,9 @@
   },
   "scripts": {
     "build": "tsc -b tsconfig.json",
-    "lint": "biome check --config-path ../config-biome/biome.json package.json src test tsconfig.json vitest.config.ts",
+    "lint": "biome check --config-path ../config-biome/biome.json package.json src test tsconfig.json tsconfig.test.json vitest.config.ts",
     "test": "vitest --run --config vitest.config.ts",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit && tsc -p tsconfig.test.json"
   },
   "dependencies": {
     "@dawn-ai/core": "workspace:*",

--- a/packages/langchain/test/agent-adapter-interrupt.test.ts
+++ b/packages/langchain/test/agent-adapter-interrupt.test.ts
@@ -376,7 +376,6 @@ describe("streamAgent — interrupt propagation", () => {
         name: "task",
         description: "Delegate.",
         schema: z.object({ subagent: z.string(), input: z.string() }),
-        run: () => "placeholder",
       },
       async () => ({
         ok: true,
@@ -450,7 +449,7 @@ describe("streamAgent — interrupt propagation", () => {
     })) {
       resumed.push(chunk)
     }
-    const output = resumed.findLast(({ type }) => type === "done")?.data as {
+    const output = resumed.filter(({ type }) => type === "done").at(-1)?.data as {
       messages?: Array<{ content?: unknown }>
     }
     expect(output.messages?.at(-1)?.content).toBe("approved:once")

--- a/packages/langchain/test/logical-identity-graph.test.ts
+++ b/packages/langchain/test/logical-identity-graph.test.ts
@@ -56,11 +56,15 @@ interface RawEvent {
   readonly data: any
 }
 
-async function collectRawEvents(graph: {
-  streamEvents: (input: unknown, options: Record<string, unknown>) => AsyncIterable<unknown>
-}): Promise<RawEvent[]> {
+async function collectRawEvents(graph: object): Promise<RawEvent[]> {
+  // createReactAgent's streamEvents signature is generic over its input, which
+  // makes it contravariantly incompatible with any concrete parameter type;
+  // the adapter under test makes this same structural cast internally.
+  const streamable = graph as {
+    streamEvents: (input: unknown, options: Record<string, unknown>) => AsyncIterable<unknown>
+  }
   const events: RawEvent[] = []
-  for await (const event of graph.streamEvents(
+  for await (const event of streamable.streamEvents(
     { messages: [{ role: "user", content: "go" }] },
     { version: "v2", configurable: { thread_id: "spike-thread" } },
   )) {

--- a/packages/langchain/test/planning.test.ts
+++ b/packages/langchain/test/planning.test.ts
@@ -123,6 +123,7 @@ describe("planning capability — state mutation end-to-end", () => {
       const result = await applyCapabilities(registry, routeDir, {
         routeManifest: { appRoot: routeDir, routes: [] },
         descriptor: undefined,
+        appRoot: routeDir,
         markerFs: nodeMarkerFs,
       })
       const writeTodos = result.contributions[0]?.contribution.tools?.[0]

--- a/packages/langchain/test/state-adapter.test.ts
+++ b/packages/langchain/test/state-adapter.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "vitest"
 
-import { materializeStateSchema } from "../src/state-adapter"
+import { materializeStateSchema } from "../src/state-adapter.js"
 
 describe("materializeStateSchema", () => {
   test("produces an annotation root with messages + custom fields", () => {

--- a/packages/langchain/test/subagent-tool-bridge.test.ts
+++ b/packages/langchain/test/subagent-tool-bridge.test.ts
@@ -4,6 +4,7 @@ import {
   Annotation,
   Command,
   END,
+  type Interrupt,
   interrupt,
   isGraphInterrupt,
   MemorySaver,
@@ -49,7 +50,7 @@ describe("convertSubagentTaskToLangChain", () => {
     const resolver = vi.fn<SubagentResolver>(async () => allowedChild(child))
     const tool = convertSubagentTaskToLangChain(taskPlaceholder, resolver)
     const signal = new AbortController().signal
-    const callbacks = []
+    const callbacks: RunnableConfig["callbacks"] = []
     const tags = ["live-parent"]
     const parentStack = [{ callId: "outer", name: "planner", routeId: "/planner" }]
     const config = {
@@ -264,7 +265,7 @@ describe("convertSubagentTaskToLangChain", () => {
         result: await tool.func({ subagent: "researcher", input: "Cancel" }, undefined, {
           ...config,
           toolCall: { id: "task-cancel" },
-        }),
+        } as RunnableConfig),
       }))
       .addEdge(START, "dispatch")
       .addEdge("dispatch", END)
@@ -315,7 +316,9 @@ describe("convertSubagentTaskToLangChain", () => {
       .addEdge("tools", END)
       .compile({ checkpointer: saver })
     const config = { configurable: { thread_id: "root-thread" } }
-    const first = await root.invoke(
+    // `__interrupt__` is real on an interrupted invoke's return value, but the
+    // graph's static state type does not carry it.
+    const first = (await root.invoke(
       {
         messages: [
           new AIMessage({
@@ -332,7 +335,7 @@ describe("convertSubagentTaskToLangChain", () => {
         ],
       },
       config,
-    )
+    )) as { __interrupt__?: Interrupt[] }
     const interruptId = first.__interrupt__?.[0]?.id
     expect(interruptId).toEqual(expect.any(String))
 
@@ -384,7 +387,7 @@ describe("convertSubagentTaskToLangChain", () => {
       .compile({ checkpointer: saver })
     const config = { configurable: { thread_id: "parallel-root" } }
 
-    const first = await root.invoke({}, config)
+    const first = (await root.invoke({}, config)) as { __interrupt__?: Interrupt[] }
     const interruptIds = first.__interrupt__?.map(({ id }) => id) ?? []
     expect(interruptIds).toHaveLength(2)
     expect(new Set(interruptIds).size).toBe(2)

--- a/packages/langchain/test/summarization-hook.test.ts
+++ b/packages/langchain/test/summarization-hook.test.ts
@@ -1,6 +1,6 @@
 import { AIMessage, HumanMessage, SystemMessage } from "@langchain/core/messages"
 import { describe, expect, it, vi } from "vitest"
-import { buildSummarizationHook } from "../src/summarization/hook.js"
+import { buildSummarizationHook, type SummarizeFn } from "../src/summarization/hook.js"
 
 const H = (c: string) => new HumanMessage(c)
 const A = (c: string) => new AIMessage(c)
@@ -36,14 +36,12 @@ describe("buildSummarizationHook", () => {
   })
 
   it("incrementally folds only the newly-aged delta (previousSummary + delta)", async () => {
-    const summarize = vi.fn(async () => "S2")
+    const summarize = vi.fn<SummarizeFn>(async () => "S2")
     const hook = makeHook({ maxTokens: 5, keepRecentTurns: 1, summarize })
     const msgs = [H("u1"), A("a1"), H("u2"), A("a2"), H("u3"), A("a3")]
     await hook({ messages: msgs, runningSummary: { summary: "S1", coveredCount: 2 } })
-    const arg = summarize.mock.calls[0]?.[0] as {
-      previousSummary?: string
-      messages: Array<{ content: string }>
-    }
+    const arg = summarize.mock.calls[0]?.[0]
+    if (!arg) throw new Error("summarize was never called")
     expect(arg.previousSummary).toBe("S1")
     expect(arg.messages.map((m) => m.content)).toEqual(["u2", "a2"]) // delta only (toSummarize=[u1,a1,u2,a2], minus covered 2)
   })

--- a/packages/langchain/test/tool-converter.test.ts
+++ b/packages/langchain/test/tool-converter.test.ts
@@ -384,7 +384,9 @@ describe("convertToolToLangChain — {result, state} wrapped returns", () => {
 
 describe("convertToolToLangChain — config.configurable forwarding", () => {
   it("forwards thread_id and route params from config.configurable into the tool run context", async () => {
-    let seen: { threadId?: string; params?: Record<string, string> } | undefined
+    let seen:
+      | { threadId: string | undefined; params: Record<string, string> | undefined }
+      | undefined
     const tool = {
       name: "probe",
       run: (_input: unknown, ctx: { threadId?: string; params?: Record<string, string> }) => {

--- a/packages/langchain/tsconfig.test.json
+++ b/packages/langchain/tsconfig.test.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "allowImportingTsExtensions": true,
+    "noEmit": true,
+    "rootDir": ".",
+    "tsBuildInfoFile": "dist/tsconfig.test.tsbuildinfo"
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx", "test/**/*.ts", "test/**/*.tsx"]
+}

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -39,9 +39,9 @@
   },
   "scripts": {
     "build": "tsc -b tsconfig.json",
-    "lint": "biome check --config-path ../config-biome/biome.json package.json src test tsconfig.json tsconfig.contracts.json vitest.config.ts",
+    "lint": "biome check --config-path ../config-biome/biome.json package.json src test tsconfig.json tsconfig.contracts.json tsconfig.test.json vitest.config.ts",
     "test": "vitest --run --config vitest.config.ts",
-    "typecheck": "tsc --noEmit && tsc -p tsconfig.contracts.json"
+    "typecheck": "tsc --noEmit && tsc -p tsconfig.contracts.json && tsc -p tsconfig.test.json"
   },
   "peerDependencies": {
     "zod": "^4.0.0"

--- a/packages/sdk/test/errors.test.ts
+++ b/packages/sdk/test/errors.test.ts
@@ -1,12 +1,18 @@
 import { describe, expect, it } from "vitest"
 
-import { DAWN_ERRORS, type DawnErrorCode, describeError, errorDocsUrl } from "../src/errors.js"
+import {
+  DAWN_ERRORS,
+  type DawnErrorCode,
+  type DawnErrorDescriptor,
+  describeError,
+  errorDocsUrl,
+} from "../src/errors.js"
 
 const CODE_RE = /^DAWN_E\d{4}$/
 const DOCS_PATH_RE = /^\/docs\/[a-z0-9-]+(#[a-z0-9-]+)?$/
 
 describe("DAWN_ERRORS registry", () => {
-  const entries = Object.entries(DAWN_ERRORS)
+  const entries: Array<[string, DawnErrorDescriptor]> = Object.entries(DAWN_ERRORS)
 
   it("has at least the wired families", () => {
     expect(entries.length).toBeGreaterThanOrEqual(10)
@@ -82,7 +88,9 @@ describe("errorDocsUrl", () => {
   })
 
   it("returns undefined for a code without a docsPath", () => {
-    const codeWithoutDocs = Object.values(DAWN_ERRORS).find((d) => d.docsPath === undefined)
+    const codeWithoutDocs = Object.values(DAWN_ERRORS).find(
+      (d: DawnErrorDescriptor) => d.docsPath === undefined,
+    )
     expect(codeWithoutDocs).toBeDefined()
     if (codeWithoutDocs) {
       expect(errorDocsUrl(codeWithoutDocs.code as DawnErrorCode)).toBeUndefined()

--- a/packages/sdk/test/runtime-context.test.ts
+++ b/packages/sdk/test/runtime-context.test.ts
@@ -1,5 +1,12 @@
-import type { RuntimeContext, RuntimeTool } from "@dawn-ai/sdk"
+import type { RuntimeContext, RuntimeTool, WorkspaceFs } from "@dawn-ai/sdk"
 import { describe, expect, expectTypeOf, test } from "vitest"
+
+const stubWorkspaceFs: WorkspaceFs = {
+  readFile: async () => "",
+  readBinaryFile: async () => new Uint8Array(),
+  writeFile: async () => ({ bytesWritten: 0 }),
+  listDir: async () => [],
+}
 
 describe("@dawn-ai/sdk runtime-context type surface", () => {
   test("runtime-context types are exported from the package root", () => {
@@ -10,6 +17,7 @@ describe("@dawn-ai/sdk runtime-context type surface", () => {
     expectTypeOf<RuntimeContext<Tools>>().toEqualTypeOf<{
       readonly signal: AbortSignal
       readonly tools: Tools
+      readonly fs: WorkspaceFs
     }>()
   })
 
@@ -28,6 +36,7 @@ describe("@dawn-ai/sdk runtime-context type surface", () => {
         tools: {
           lookupCustomer: async ({ id }) => ({ id }),
         },
+        fs: stubWorkspaceFs,
       },
     )
 

--- a/packages/sdk/test/scenario-builder.test.ts
+++ b/packages/sdk/test/scenario-builder.test.ts
@@ -7,7 +7,7 @@ declare module "../src/testing/index.js" {
     "/research": {
       readonly tools: {
         readonly ping: () => Promise<string>
-        readonly searchWeb: (input: { readonly query: string }) => Promise<{
+        readonly searchWeb: (input: { readonly query: string; readonly limit: number }) => Promise<{
           readonly results: readonly string[]
         }>
       }
@@ -94,8 +94,24 @@ describe("scenarios", () => {
   })
 
   test("rejects incomplete and conflicting states at runtime", () => {
-    // biome-ignore lint/suspicious/noExplicitAny: this test deliberately bypasses the public type states.
-    type UnsafeBuilder = Record<string, (...args: any[]) => any>
+    // Deliberately bypasses the public staged builder types so each guard can
+    // be violated at runtime; every method is total so the calls typecheck.
+    interface UnsafeCall {
+      called(): UnsafeCall
+      calledOnce(): UnsafeCall
+      notCalled(): UnsafeCall
+      withArgs(args: unknown): UnsafeCall
+    }
+    interface UnsafeBuilder {
+      input(value: unknown): UnsafeBuilder
+      server(url: string): UnsafeBuilder
+      mockTool(name: string, impl: (input: never) => unknown): UnsafeBuilder
+      expectPassed(): UnsafeBuilder
+      expectFailed(): UnsafeBuilder
+      expectError(expectation: unknown): UnsafeBuilder
+      expectOutput(output: unknown): UnsafeBuilder
+      expectTool(name: string, expect: (call: UnsafeCall) => unknown): UnsafeBuilder
+    }
 
     const suite = scenarios("/research") as unknown as {
       scenario(name: string, configure: (builder: UnsafeBuilder) => UnsafeBuilder): unknown

--- a/packages/sdk/test/scenario-snapshot.test.ts
+++ b/packages/sdk/test/scenario-snapshot.test.ts
@@ -4,6 +4,25 @@ import { describe, expect, test, vi } from "vitest"
 
 import { createScenarioSnapshotter } from "../src/testing/scenario-snapshot.js"
 
+// The ES2022 lib carries no WebAssembly declarations (they live in lib.dom),
+// and this suite feature-detects the global at runtime anyway — declare only
+// the narrow slice it touches.
+declare global {
+  var WebAssembly: {
+    readonly Module: (new (
+      bytes: Uint8Array,
+    ) => object) & {
+      exports(module: object): unknown[]
+    }
+    readonly Memory: new (descriptor: { initial: number }) => object
+    readonly Table: new (descriptor: { element: string; initial: number }) => object
+    readonly Global: new (
+      descriptor: { mutable: boolean; value: string },
+      value?: unknown,
+    ) => object
+  }
+}
+
 describe("createScenarioSnapshotter", () => {
   test("preserves all array data properties and cycles", () => {
     const marker = Symbol("marker")

--- a/packages/sdk/tsconfig.test.json
+++ b/packages/sdk/tsconfig.test.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "allowImportingTsExtensions": true,
+    "noEmit": true,
+    "rootDir": ".",
+    "tsBuildInfoFile": "dist/tsconfig.test.tsbuildinfo"
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx", "test/**/*.ts", "test/**/*.tsx"]
+}


### PR DESCRIPTION
Finishes the hole-3 sweep (#505, #507): after this, **every package's tests are type-checked**. Three commits, one per package, each with the full defect breakdown in its message.

- `@dawn-ai/langchain` (20 errors): a fixture prop the type never had, ES2023 `findLast` under the ES2022 lib, a contravariantly-unsatisfiable helper signature (now the same structural cast the adapter makes internally), missing required `appRoot` in context literals, `__interrupt__` reads off invoke results whose static type doesn't carry it, a no-arg-typed `vi.fn` mock whose calls tuple hid a cast, and two `exactOptionalPropertyTypes` violations.
- `@dawn-ai/sdk` (29 errors): the DAWN_ERRORS union vs its descriptor interface, a type-surface test that predated `RuntimeContext.fs`, two **disagreeing module augmentations of the same RouteScenarioMap key** across test files (program-wide, so they must be identical), a `Record<string, fn>` escape hatch that `noUncheckedIndexedAccess` makes uncallable, and `WebAssembly` having no declaration in any node lib (narrow ambient declaration matching the suite's runtime feature-detect).
- `@dawn-ai/core` (51 errors → 72 once 13 extensionless imports resolved and exposed the files behind them): stale `RouteSegment`/`ExtractedToolType` fixtures, a `defined.kind` widened to `string`, fake tools whose zero-arg `run` propagated into the wrapped tool's own call signature, unnarrowed index accesses, `boolean` where `DelegationVerdict` wants literal `true`, a backend fixture missing required `realPath`, and a destructure that would have surfaced a regression as a TypeError instead of the assertion meant to catch it.

Verified: repo `pnpm lint` 27/27, `pnpm typecheck` 51/51 tasks, `node scripts/check-docs.mjs` clean, and the full CI test path (`pnpm test`) green — 4782 passed / 217 skipped — plus each package's own suite (221 / 110 / 506).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
