### PR TITLE
test(cli): fix the vercel-native readiness wait at its real bound

### DIFF
--- a/packages/cli/test/helpers/vercel-native-fixture.ts
+++ b/packages/cli/test/helpers/vercel-native-fixture.ts
@@ -2663,7 +2663,20 @@ export interface NativeDeployCommandEvidence {
   readonly prebuiltFlagCount: 0 | 1
 }
 
-const NATIVE_VERCEL_CHILD_TIMEOUT_MS = 120_000
+/**
+ * Budget for the Vercel CLI invocations whose duration is bounded by their own
+ * work: `--version`, `deploy --no-wait` (upload, then return), and the log reads.
+ */
+export const NATIVE_VERCEL_CHILD_TIMEOUT_MS = 120_000
+/**
+ * Budget for the readiness wait alone. `vercel inspect --wait` blocks until the
+ * deployment reaches a terminal state, so its duration is set by Vercel's build
+ * queue rather than by this fixture — the shorter budget above turns a slow queue
+ * into a lane failure. The lane waits twice (source, then prebuilt), and the lane
+ * test pins both waits inside the gated test's own timeout so a blown budget still
+ * reports through the lane's diagnostics rather than as a bare vitest timeout.
+ */
+export const NATIVE_VERCEL_READINESS_TIMEOUT_MS = 600_000
 const NATIVE_VERCEL_API_TIMEOUT_MS = 30_000
 
 function pathIsInsideOrEqual(parent: string, candidate: string): boolean {
@@ -2808,18 +2821,21 @@ export async function createNativePinnedVercelBoundary(
 
   const run = async (
     label: string,
-    request: Omit<NativeVercelChildRequest, "executable" | "timeoutMs">,
+    request: Omit<NativeVercelChildRequest, "executable" | "timeoutMs"> & {
+      readonly timeoutMs?: number
+    },
     validateSuccessStderr?: (stderr: string) => void,
   ): Promise<NativeLocalCommandResult> => {
+    const timeoutMs = request.timeoutMs ?? NATIVE_VERCEL_CHILD_TIMEOUT_MS
     let result: NativeLocalCommandResult
     try {
-      result = await options.runChild({
-        ...request,
-        executable: cliPath,
-        timeoutMs: NATIVE_VERCEL_CHILD_TIMEOUT_MS,
-      })
-    } catch {
-      throw new Error(`${label} child transport failed`)
+      result = await options.runChild({ ...request, executable: cliPath, timeoutMs })
+    } catch (cause) {
+      // The child runner's own message is the only thing separating a blown budget
+      // from a spawn failure or a killed process, and the lane writes its
+      // deploy-failure diagnostic from this chain. Every message the runner can
+      // produce is fixture-authored, so none of them can carry a secret.
+      throw new Error(`${label} child transport failed under its ${timeoutMs}ms budget`, { cause })
     }
     if (result.exitCode !== 0) throw protectedChildError(result, label, redactor)
     if (validateSuccessStderr) validateSuccessStderr(result.stderr)
@@ -2919,6 +2935,7 @@ export async function createNativePinnedVercelBoundary(
         ],
         cwd: options.jobRoot,
         env: credentialEnv(false),
+        timeoutMs: NATIVE_VERCEL_READINESS_TIMEOUT_MS,
       })
       return parseNativeVercelInspectReceipt(result.stdout, {
         canonicalOrigin: expectedOrigin,

--- a/packages/cli/test/helpers/vercel-native-fixture.ts
+++ b/packages/cli/test/helpers/vercel-native-fixture.ts
@@ -2669,14 +2669,24 @@ export interface NativeDeployCommandEvidence {
  */
 export const NATIVE_VERCEL_CHILD_TIMEOUT_MS = 120_000
 /**
- * Budget for the readiness wait alone. `vercel inspect --wait` blocks until the
- * deployment reaches a terminal state, so its duration is set by Vercel's build
- * queue rather than by this fixture — the shorter budget above turns a slow queue
- * into a lane failure. The lane waits twice (source, then prebuilt), and the lane
- * test pins both waits inside the gated test's own timeout so a blown budget still
- * reports through the lane's diagnostics rather than as a bare vitest timeout.
+ * How long the readiness wait asks the Vercel CLI to block for. `vercel inspect
+ * --wait` defaults to `--timeout 3m`, and on expiry it does NOT fail: it warns
+ * "stopped waiting after ...", stops polling, and returns `exitCode(readyState)`,
+ * which is 0 for BUILDING and QUEUED. So the CLI's own cap — not the child budget
+ * below — is what actually bounds the wait, and overrunning it surfaces as a
+ * not-ready receipt rather than as an error. Passing this explicitly is the only
+ * way to raise that bound.
  */
-export const NATIVE_VERCEL_READINESS_TIMEOUT_MS = 600_000
+export const NATIVE_VERCEL_READINESS_CLI_TIMEOUT_MS = 300_000
+/**
+ * Backstop budget for the readiness child. Strictly above the CLI timeout above so
+ * the CLI always reports first, with a payload naming the state it reached; this
+ * deadline fires only if the CLI itself stops making progress. The lane waits twice
+ * (source, then prebuilt) and the lane test pins both inside the gated test's own
+ * timeout, so a blown budget still reports through the lane's diagnostics rather
+ * than as a bare vitest timeout.
+ */
+export const NATIVE_VERCEL_READINESS_TIMEOUT_MS = 360_000
 const NATIVE_VERCEL_API_TIMEOUT_MS = 30_000
 
 function pathIsInsideOrEqual(parent: string, candidate: string): boolean {
@@ -2928,6 +2938,8 @@ export async function createNativePinnedVercelBoundary(
           "--scope",
           options.orgId,
           "--wait",
+          "--timeout",
+          `${NATIVE_VERCEL_READINESS_CLI_TIMEOUT_MS}ms`,
           "--json",
           "--non-interactive",
           "--global-config",
@@ -3448,10 +3460,19 @@ export function parseNativeVercelInspectReceipt(
   if (
     receipt.id !== expected.deploymentId ||
     typeof receipt.url !== "string" ||
-    canonicalizeVercelOrigin(receipt.url) !== expectedOrigin ||
-    receipt.readyState !== "READY"
+    canonicalizeVercelOrigin(receipt.url) !== expectedOrigin
   ) {
-    throw new Error("native Vercel inspect receipt does not match the ready deployment")
+    throw new Error("native Vercel inspect receipt does not match the deployment under test")
+  }
+  if (receipt.readyState !== "READY") {
+    // `vercel inspect --wait` exits 0 with the deployment still BUILDING or QUEUED
+    // once it gives up waiting, so this branch — not a thrown child error — is the
+    // shape an overrun readiness wait takes. Name the state: it is what separates
+    // "Vercel was still building" from "Vercel failed the build", and the two have
+    // opposite fixes. readyState is a short status enum, never a credential.
+    const state =
+      typeof receipt.readyState === "string" ? receipt.readyState.slice(0, 32) : "unknown"
+    throw new Error(`native Vercel inspect receipt is not ready: readyState=${state}`)
   }
   for (const field of [
     "error",

--- a/packages/cli/test/vercel-native-lane.test.ts
+++ b/packages/cli/test/vercel-native-lane.test.ts
@@ -58,6 +58,7 @@ import {
   deriveNativeAttemptEvidence,
   NATIVE_DIRECT_DAWN_DEPENDENCIES,
   NATIVE_VERCEL_CHILD_TIMEOUT_MS,
+  NATIVE_VERCEL_READINESS_CLI_TIMEOUT_MS,
   NATIVE_VERCEL_READINESS_TIMEOUT_MS,
   type NativeAttemptEvidence,
   type NativeLocalCommandRequest,
@@ -1680,6 +1681,8 @@ describe("pinned vercel boundary", () => {
       "--scope",
       "team_Test123",
       "--wait",
+      "--timeout",
+      `${NATIVE_VERCEL_READINESS_CLI_TIMEOUT_MS}ms`,
       "--json",
       "--non-interactive",
       "--global-config",
@@ -2453,12 +2456,40 @@ describe("readiness budget", () => {
       NATIVE_VERCEL_CHILD_TIMEOUT_MS,
     )
     expect(NATIVE_VERCEL_READINESS_TIMEOUT_MS).toBeGreaterThan(NATIVE_VERCEL_CHILD_TIMEOUT_MS)
+
+    // The child deadline is only a backstop. `vercel inspect --wait` enforces its own
+    // `--timeout` (default 3m) and on expiry exits 0 with a still-building payload —
+    // so without this flag the child budget is unreachable and raising it buys nothing.
+    const inspectArgs = requests.find((request) => request.args.includes("--wait"))?.args ?? []
+    expect(inspectArgs).toContain("--timeout")
+    expect(inspectArgs[inspectArgs.indexOf("--timeout") + 1]).toBe(
+      `${NATIVE_VERCEL_READINESS_CLI_TIMEOUT_MS}ms`,
+    )
+    expect(NATIVE_VERCEL_READINESS_CLI_TIMEOUT_MS).toBeLessThan(NATIVE_VERCEL_READINESS_TIMEOUT_MS)
+  })
+
+  test("names the state a not-ready inspect receipt reached", () => {
+    // The overrun path exits 0 with BUILDING, so this message is the only place the
+    // lane can say why readiness ended. A bare "does not match" would read the same
+    // as a wrong deployment id.
+    expect(() =>
+      parseNativeVercelInspectReceipt(
+        '{"id":"dpl_Source123","url":"dawn-source-abc.vercel.app","readyState":"BUILDING"}',
+        {
+          canonicalOrigin: "https://dawn-source-abc.vercel.app",
+          deploymentId: "dpl_Source123",
+        },
+      ),
+    ).toThrow(/readyState=BUILDING/)
   })
 
   test("keeps both readiness waits inside the gated test's own timeout", () => {
     // A budget at or above the test timeout would surface as a bare vitest timeout,
     // losing the lane's diagnostics — the very evidence the budget exists to produce.
-    // The lane waits twice: once for source, once for prebuilt.
+    // This bounds the readiness waits only, not the whole lane: the other steps carry
+    // their own budgets. Both waits count — the orchestration stops at the first
+    // FAILING kind, but source can finish slowly and successfully before prebuilt
+    // overruns, so a failing run can still spend two full caps.
     expect(2 * NATIVE_VERCEL_READINESS_TIMEOUT_MS).toBeLessThan(NATIVE_VERCEL_GATED_TEST_TIMEOUT_MS)
   })
 

--- a/packages/cli/test/vercel-native-lane.test.ts
+++ b/packages/cli/test/vercel-native-lane.test.ts
@@ -57,6 +57,8 @@ import {
   deriveDawnPackageClosure,
   deriveNativeAttemptEvidence,
   NATIVE_DIRECT_DAWN_DEPENDENCIES,
+  NATIVE_VERCEL_CHILD_TIMEOUT_MS,
+  NATIVE_VERCEL_READINESS_TIMEOUT_MS,
   type NativeAttemptEvidence,
   type NativeLocalCommandRequest,
   type NativePackedArtifact,
@@ -2362,6 +2364,128 @@ describe("pinned vercel boundary", () => {
       /method/,
     )
     expect(JSON.stringify(requests)).not.toContain("postgres://")
+  })
+})
+
+describe("readiness budget", () => {
+  const makeReadinessBoundary = async (
+    runChild: (request: NativeVercelChildRequest) => Promise<{
+      readonly exitCode: number
+      readonly stderr: string
+      readonly stdout: string
+    }>,
+  ): Promise<{
+    readonly boundary: Awaited<ReturnType<typeof createNativePinnedVercelBoundary>>
+    readonly fixtureRoot: string
+  }> => {
+    const jobRoot = await realpath(await makeTempDir())
+    const fixtureRoot = join(jobRoot, "source")
+    const prebuiltRoot = join(jobRoot, "prebuilt")
+    const globalConfigDir = join(jobRoot, "global-config")
+    await mkdir(fixtureRoot)
+    await mkdir(prebuiltRoot)
+    await mkdir(globalConfigDir, { mode: 0o700 })
+    await writeFile(join(fixtureRoot, "vercel.json"), '{"fluid":true}\n', "utf8")
+    const boundary = await createNativePinnedVercelBoundary({
+      cliPackageRoot,
+      databaseUrl: "postgres://native-secret",
+      fixtureRoots: [fixtureRoot, prebuiltRoot],
+      globalConfigDir,
+      jobRoot,
+      orgId: "team_Test123",
+      parentEnv: { PATH: process.env.PATH },
+      projectId: "prj_Test456",
+      releaseCredential: "private-release-value",
+      runChild,
+      token: "vercel-token-secret",
+    })
+    return { boundary, fixtureRoot }
+  }
+
+  test("gives the readiness wait its own budget and leaves the bounded commands alone", async () => {
+    const requests: NativeVercelChildRequest[] = []
+    const { boundary, fixtureRoot } = await makeReadinessBoundary(async (request) => {
+      requests.push(request)
+      if (request.args[0] === "--version") {
+        return { exitCode: 0, stderr: pinnedVercelVersionStderr, stdout: "58.9.0\n" }
+      }
+      if (request.args[0] === "inspect") {
+        return {
+          exitCode: 0,
+          stderr: "",
+          stdout:
+            '{"id":"dpl_Source123","url":"dawn-source-abc.vercel.app","readyState":"READY"}\n',
+        }
+      }
+      return {
+        exitCode: 0,
+        stderr: "",
+        stdout: '{"id":"dpl_Source123","url":"dawn-source-abc.vercel.app"}\n',
+      }
+    })
+
+    await boundary.assertVersion()
+    await boundary.deploy({
+      fixtureRoot,
+      kind: "source",
+      localConfigPath: join(fixtureRoot, "vercel.json"),
+      marker: `vclrun_${"a".repeat(32)}`,
+    })
+    await boundary.inspect({
+      canonicalOrigin: "https://dawn-source-abc.vercel.app",
+      deploymentId: "dpl_Source123",
+    })
+
+    const budgetFor = (predicate: (request: NativeVercelChildRequest) => boolean): number => {
+      const match = requests.find(predicate)
+      if (!match) throw new Error("expected a matching child request")
+      return match.timeoutMs
+    }
+    // `inspect --wait` blocks on Vercel's build queue; the others are bounded by
+    // their own work and must not silently inherit the longer budget.
+    expect(budgetFor((request) => request.args.includes("--wait"))).toBe(
+      NATIVE_VERCEL_READINESS_TIMEOUT_MS,
+    )
+    expect(budgetFor((request) => request.args[0] === "--version")).toBe(
+      NATIVE_VERCEL_CHILD_TIMEOUT_MS,
+    )
+    expect(budgetFor((request) => request.args[0] === "deploy")).toBe(
+      NATIVE_VERCEL_CHILD_TIMEOUT_MS,
+    )
+    expect(NATIVE_VERCEL_READINESS_TIMEOUT_MS).toBeGreaterThan(NATIVE_VERCEL_CHILD_TIMEOUT_MS)
+  })
+
+  test("keeps both readiness waits inside the gated test's own timeout", () => {
+    // A budget at or above the test timeout would surface as a bare vitest timeout,
+    // losing the lane's diagnostics — the very evidence the budget exists to produce.
+    // The lane waits twice: once for source, once for prebuilt.
+    expect(2 * NATIVE_VERCEL_READINESS_TIMEOUT_MS).toBeLessThan(NATIVE_VERCEL_GATED_TEST_TIMEOUT_MS)
+  })
+
+  test("carries the child runner's own failure as the cause of a transport failure", async () => {
+    const { boundary } = await makeReadinessBoundary(async (request) => {
+      if (request.args[0] === "--version") {
+        return { exitCode: 0, stderr: pinnedVercelVersionStderr, stdout: "58.9.0\n" }
+      }
+      throw new Error("native child timeout deadline exceeded")
+    })
+    await boundary.assertVersion()
+    const caught = await boundary
+      .inspect({
+        canonicalOrigin: "https://dawn-source-abc.vercel.app",
+        deploymentId: "dpl_Source123",
+      })
+      .then(
+        () => undefined,
+        (error: unknown) => error,
+      )
+    expect(caught).toBeInstanceOf(Error)
+    // Without the cause the lane cannot tell "we ran out of budget" from "Vercel
+    // rejected the deployment" — the two have opposite fixes.
+    expect((caught as Error).message).toContain(String(NATIVE_VERCEL_READINESS_TIMEOUT_MS))
+    expect(((caught as Error).cause as Error).message).toBe(
+      "native child timeout deadline exceeded",
+    )
   })
 })
 


### PR DESCRIPTION
Fixes the `vercel-native` flake at its actual bound. Test-only — `packages/cli/test/**`, no shipped code, no changeset (the gate agrees).

## Where the failure is

Localized from the `vercel-native-diagnostics` artifact of the red run on [#508](https://github.com/cacheplane/dawnai/pull/508) (run 33083282984), not guessed:

- `cleanup-manifest.json` shows the prebuilt attempt reached **both** `deploymentReceipt` and `binding` (with `ownerIdMatched`/`projectIdMatched`/`createdAt`). So it got past `boundary.deploy()`, past the `/v13/deployments` read returning 200, past `parseNativeVercelDeploymentBinding`, past `persistDeploymentBinding`.
- The artifact has `prebuilt-local-build.log` but no `prebuilt-build.log`, `prebuilt-events.json`, or `prebuilt-runtime.jsonl`; `receipt.partial.json` has no prebuilt entry.
- In `runNativeDeployAttempt` exactly one step follows `persistDeploymentBinding`: `await options.boundary.inspect(deployment)`.
- The prebuilt deployment was created at 14:42:06.773Z; the test threw ~182s later. The **source** deployment in the same run went from created to its logs query in ~17s.

The readiness wait is the failing step, and its duration is set by Vercel's build queue rather than by the fixture.

## What actually bounded it

Not our child deadline. `vercel inspect --wait` enforces its own `--timeout`, default `3m`, and on expiry it does **not** fail. From the pinned 58.9.0 (`commands-bulk.js`):

- `:45830` `ms(flags["--timeout"] ?? "3m")`
- `:45907-45910` warns `stopped waiting after ...`, aborts, `break` — no throw
- `:45926` `return exitCode(deployment.readyState)`, and `exitCode` (`:46065`) returns 1 only for `ERROR`/`CANCELED`

So a still-`BUILDING` deployment makes the CLI exit **0**. The first commit here raised only the child budget; that moved the effective ceiling 120s → 180s and made an overrun surface as a not-ready receipt rather than a thrown error — bypassing the `{ cause }` chain in exactly the case it was added for. Review caught it; the second commit is the real fix.

## The change

- **`inspect` passes `--timeout` explicitly** (`NATIVE_VERCEL_READINESS_CLI_TIMEOUT_MS`, 300_000), so the ceiling is ours to set. Verified `ms("300000ms") === 300000` against the bundled `ms@2.1.1`, and against the real binary: a bogus value is rejected at the same gate with `Invalid timeout`.
- **The child deadline becomes a backstop** (`NATIVE_VERCEL_READINESS_TIMEOUT_MS`, 360_000), strictly above the CLI cap, so the CLI always reports first with a payload naming the state; the deadline fires only if the CLI stops making progress. The other commands (`--version`, `deploy`, `logs`, `inspect --logs`) keep the 120s budget — none can block on the build queue.
- **`run()` preserves the child error** as `{ cause }` and names the applied budget. This was the same bare `catch` [#509](https://github.com/cacheplane/dawnai/pull/509) fixed one layer up, still present on the one path separating "we ran out of budget" from "Vercel rejected the deployment".
- **The receipt parser separates "not ready" from "wrong deployment"** and names the state (`readyState=BUILDING`). Since the overrun path exits 0, this branch — not a thrown child error — is the shape an overrun takes. The CLI's warning goes to stderr and the JSON to stdout, so the single-JSON-document parse still holds.

## Verification

Lane suite **297 passed / 1 skipped** (293 on `main` — four new tests). Full CLI suite 1607 passed. `typecheck` 0, `lint` 0, root `lint` 0, `check-docs` 0.

Each new assertion was mutation-tested: dropping `--timeout`, dropping the `ms` suffix, raising the CLI cap above the backstop, reverting the parse split, and reverting `{ cause }` each fail a specific test.

## What this does not claim

It does not prove the mechanism of the one observed failure — the discriminating evidence was destroyed by the bare `catch` being fixed here, and the deployment was deleted by the lane's own cleanup before it could be read. What is proven is the bound that applied and that it was unrelated to the work being waited on. If it recurs, `<kind>-deploy-failure.log` and the `readyState=` message now say which of the two it was.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
