### PR TITLE
test(web): let the api-reference changeset pin survive its own release

### DIFF
--- a/apps/web/app/components/docs/api-reference.test.ts
+++ b/apps/web/app/components/docs/api-reference.test.ts
@@ -1037,7 +1037,11 @@ describe("published manifest address inventory", { timeout: 30_000 }, () => {
 })
 
 describe("package catalog", { timeout: 30_000 }, () => {
-  it("pins the exact twelve-package patch changeset", () => {
+  // `changeset version` deletes this changeset when the release is cut, and the
+  // Version PR runs this suite against the versioned tree — so on a release commit
+  // the file is legitimately gone and there is no pending bump list left to pin.
+  // Reading it unconditionally made the release, and only the release, red.
+  it.skipIf(!existsSync(CHANGESET_PATH))("pins the exact twelve-package patch changeset", () => {
     const source = readFileSync(CHANGESET_PATH, "utf8")
     const entries = [...source.matchAll(/^"([^"]+)": (\w+)$/gm)].map((match) => [
       match[1],


### PR DESCRIPTION
Unblocks the 0.8.22 release. The Version PR [#512](https://github.com/cacheplane/dawnai/pull/512) failed the required `validate` check with:

```
Error: ENOENT: no such file or directory, open '.../.changeset/api-reference-coverage.md'
 ❯ app/components/docs/api-reference.test.ts:1041:20
```

4789 tests passed; this one failed.

## Why it can only fail on a release

`changeset version` deletes every consumed changeset, and the Version PR runs the full suite against that versioned tree. `api-reference.test.ts` reads one specific changeset file unconditionally, so the single commit where it cannot pass is the release commit — the one where the file has done its job and been removed.

The test landed on 2026-08-18 in `bedad77d` ("docs: complete API reference coverage"), after 0.8.21 shipped on 2026-08-10. No release had exercised it before now, which is why CI has been green on every ordinary PR including the one that introduced it.

It is the only test in the repo that reads a specific changeset file — I checked for the class, not just the instance:

```
grep -rn '\.changeset/[a-z0-9-]*\.md' --include='*.ts' --include='*.tsx' --include='*.mjs' --include='*.js'
→ api-reference.test.ts:22 only
```

## The change

`it.skipIf(!existsSync(CHANGESET_PATH))`. The assertion pins a *pending* bump list; once the changeset is consumed there is no pending list left to guard, so absence is the released state rather than a defect. It reports as skipped rather than silently passing, and `existsSync` was already imported.

## Verification

Reproduced the failure locally first by hiding the changeset exactly as `changeset version` does, then confirmed both states:

| condition | result |
|---|---|
| changeset absent (release commit) | exit 0 — 29 passed, **1 skipped** |
| changeset present (ordinary PR) | exit 0 — 30 passed |

`web lint` 0, `web typecheck` 0, `check-docs` 0, `check-changesets` 0 (no user-facing change, so no changeset).

## After this merges

The push to main re-runs Release, which regenerates #512 against the fixed tree. That regeneration does not publish — publishing happens only when the Version PR itself merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
