### PR TITLE
Fix release observer runtime bootstrap

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,10 +56,18 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86
+        with:
+          version: 10.33.0
+
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
         with:
           node-version: 24.19.0
+
+      - name: Install observer runtime dependency
+        run: '"$PNPM_HOME/pnpm" install --filter . --frozen-lockfile --ignore-scripts'
 
       - name: Seal the production event
         env:

--- a/scripts/release/abandonment-workflow-policy.json
+++ b/scripts/release/abandonment-workflow-policy.json
@@ -5,12 +5,12 @@
     {
       "id": "disabled-2026-08-28",
       "mode": "disabled",
-      "canonicalSha256": "83670374ee707284002a8627675393d5fef3fef7866f307e85eab106529e5272"
+      "canonicalSha256": "5977a3ee83fa9469b4117baf33aee736193777f032742ad59daaa8077b7cde61"
     },
     {
       "id": "protected-2026-08-28",
       "mode": "protected",
-      "canonicalSha256": "00b0bb1a0ab822515c5f5d90fa209a81e4fd56486352c032fe05d152f21d1bef"
+      "canonicalSha256": "1df78b4af9b824883bd70d0d41e2029aa3eafeae6b4d9c7e03536dc3628d1abf"
     }
   ]
 }

--- a/scripts/release/test/fixtures/release-workflow-disabled.yml
+++ b/scripts/release/test/fixtures/release-workflow-disabled.yml
@@ -56,10 +56,18 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86
+        with:
+          version: 10.33.0
+
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
         with:
           node-version: 24.19.0
+
+      - name: Install observer runtime dependency
+        run: '"$PNPM_HOME/pnpm" install --filter . --frozen-lockfile --ignore-scripts'
 
       - name: Seal the production event
         env:

--- a/scripts/release/test/fixtures/release-workflow-protected.yml
+++ b/scripts/release/test/fixtures/release-workflow-protected.yml
@@ -61,10 +61,18 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86
+        with:
+          version: 10.33.0
+
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
         with:
           node-version: 24.19.0
+
+      - name: Install observer runtime dependency
+        run: '"$PNPM_HOME/pnpm" install --filter . --frozen-lockfile --ignore-scripts'
 
       - name: Seal the production event
         env:

--- a/scripts/release/test/fixtures/workflow-entrypoints.json
+++ b/scripts/release/test/fixtures/workflow-entrypoints.json
@@ -2358,11 +2358,28 @@
             {
               "classification": "safe",
               "descriptor": {
+                "name": "Setup pnpm",
+                "uses": "pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86",
+                "with": {
+                  "version": "10.33.0"
+                }
+              }
+            },
+            {
+              "classification": "safe",
+              "descriptor": {
                 "name": "Setup Node.js",
                 "uses": "actions/setup-node@820762786026740c76f36085b0efc47a31fe5020",
                 "with": {
                   "node-version": "24.19.0"
                 }
+              }
+            },
+            {
+              "classification": "safe",
+              "descriptor": {
+                "name": "Install observer runtime dependency",
+                "run": "\"$PNPM_HOME/pnpm\" install --filter . --frozen-lockfile --ignore-scripts"
               }
             },
             {

--- a/scripts/release/test/fixtures/workflow-safe-executables.json
+++ b/scripts/release/test/fixtures/workflow-safe-executables.json
@@ -1492,6 +1492,14 @@
         "classification": "safe",
         "job": "detect",
         "stepIndex": 1,
+        "step": "Setup pnpm",
+        "kind": "step-uses",
+        "value": "pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86"
+      },
+      {
+        "classification": "safe",
+        "job": "detect",
+        "stepIndex": 2,
         "step": "Setup Node.js",
         "kind": "step-uses",
         "value": "actions/setup-node@820762786026740c76f36085b0efc47a31fe5020"
@@ -1499,7 +1507,15 @@
       {
         "classification": "safe",
         "job": "detect",
-        "stepIndex": 2,
+        "stepIndex": 3,
+        "step": "Install observer runtime dependency",
+        "kind": "run",
+        "value": "\"$PNPM_HOME/pnpm\" install --filter . --frozen-lockfile --ignore-scripts"
+      },
+      {
+        "classification": "safe",
+        "job": "detect",
+        "stepIndex": 4,
         "step": "Seal the production event",
         "kind": "run",
         "value": "if [[ \"$GITHUB_EVENT_NAME\" == \"workflow_dispatch\" ]]; then\n  node -e 'require(\"node:fs\").writeFileSync(process.argv[1], JSON.stringify({inputs:{version:process.env.VERSION,commitSha:process.env.COMMIT_SHA}}))' \"$RUNNER_TEMP/release-event.json\"\nelse\n  cp \"$GITHUB_EVENT_PATH\" \"$RUNNER_TEMP/release-event.json\"\nfi\n"
@@ -1507,7 +1523,7 @@
       {
         "classification": "safe",
         "job": "detect",
-        "stepIndex": 3,
+        "stepIndex": 5,
         "step": "Observe one production transition",
         "kind": "run",
         "value": "node scripts/release/cli.mjs observe \\\n  --event \"$RUNNER_TEMP/release-event.json\" \\\n  --report \"$RUNNER_TEMP/production-observation.json\" \\\n  --github-output \"$GITHUB_OUTPUT\"\n"
@@ -1515,7 +1531,7 @@
       {
         "classification": "safe",
         "job": "detect",
-        "stepIndex": 4,
+        "stepIndex": 6,
         "step": "Preserve production observation",
         "kind": "step-uses",
         "value": "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a"
@@ -1523,7 +1539,7 @@
       {
         "classification": "safe",
         "job": "detect",
-        "stepIndex": 5,
+        "stepIndex": 7,
         "step": "Require a non-ambiguous route",
         "kind": "run",
         "value": "test \"$DISPOSITION\" != \"blocked\""

--- a/scripts/release/test/workflow-contracts.test.mjs
+++ b/scripts/release/test/workflow-contracts.test.mjs
@@ -233,7 +233,19 @@ test("detect invokes the sole production observer and exports only validated con
   assert.deepEqual(normalizeNeeds(detect.needs), [])
   assertNoWriteOrOidc(detect)
   assert.equal(detect.permissions?.checks, "read")
+  const checkout = onlyStepUsing(detect, ACTIONS.checkout)
+  const pnpm = onlyStepUsing(detect, ACTIONS.pnpm)
+  const node = onlyStepUsing(detect, ACTIONS.node)
+  const install = onlyRunStepMatching(
+    detect,
+    /^"\$PNPM_HOME\/pnpm" install --filter \. --frozen-lockfile --ignore-scripts$/u,
+  )
   const observe = onlyRunStepMatching(detect, /node scripts\/release\/cli\.mjs observe\b/u)
+  assert.deepEqual(pnpm.with, { version: "10.33.0" })
+  assert.ok(detect.steps.indexOf(checkout) < detect.steps.indexOf(pnpm))
+  assert.ok(detect.steps.indexOf(pnpm) < detect.steps.indexOf(node))
+  assert.ok(detect.steps.indexOf(node) < detect.steps.indexOf(install))
+  assert.ok(detect.steps.indexOf(install) < detect.steps.indexOf(observe))
   assert.equal(observe.id, "observe")
   assert.equal(observe["continue-on-error"], undefined)
   assertCommandFlags(observe.run, "node scripts/release/cli.mjs observe", [
@@ -263,7 +275,6 @@ test("detect invokes the sole production observer and exports only validated con
   assert.equal(countMatches(source, /scripts\/release\/cli\.mjs observe\b/gu), 1)
   assert.doesNotMatch(source, /release:shadow|shadow-reconcile|release-shadow/iu)
 
-  const checkout = onlyStepUsing(detect, ACTIONS.checkout)
   assert.equal(checkout.with?.ref, workflowExpression("github.event.repository.default_branch"))
   assert.equal(checkout.with?.["fetch-depth"], 0)
   assert.equal(checkout.with?.["persist-credentials"], false)


### PR DESCRIPTION
Summary:
- install the pinned root runtime dependency closure before the Release detect job runs
- keep the install frozen, root-only, and script-disabled
- bind the bootstrap in release workflow contracts and reviewed workflow variants

Production evidence:
- scheduled run 33312693977 failed read-only detection with ERR_MODULE_NOT_FOUND for yaml
- every mutation job was skipped
- version 0.8.22 remains absent for all 21 fixed-group packages

Validation:
- DAWN_REQUIRE_DOCKER=1 pnpm ci:validate
- source tests: 4792 passed, 215 skipped
- release controller: 1307 passed
- harness: framework, runtime, and smoke passed with zero skips