### PR TITLE
fix(release): bind canonical GitHub pagination

### DIFF
--- a/scripts/release/adapters/github.mjs
+++ b/scripts/release/adapters/github.mjs
@@ -35,6 +35,7 @@ const MAX_GITHUB_TOKEN_BYTES = 4_096
 export function createGitHubReader({
   owner,
   repo,
+  repositoryId,
   token,
   apiOrigin = API_ORIGIN,
   fetchImpl = fetch,
@@ -46,6 +47,7 @@ export function createGitHubReader({
 }) {
   assertIdentity(owner, OWNER_PATTERN, "GitHub owner", MAX_GITHUB_OWNER_BYTES)
   assertIdentity(repo, REPOSITORY_PATTERN, "GitHub repository", MAX_GITHUB_REPOSITORY_BYTES)
+  const normalizedRepositoryId = repositoryId === undefined ? null : normalizeId(repositoryId)
   assertInputByteLength(token, MAX_GITHUB_TOKEN_BYTES, "GitHub token")
   if (
     token !== undefined &&
@@ -69,6 +71,8 @@ export function createGitHubReader({
   const context = {
     base,
     apiOrigin: normalizedApiOrigin,
+    repositoryId: normalizedRepositoryId,
+    repositoryPath: new URL(base).pathname,
     http,
     token: token ?? null,
     timeoutMs: timeoutMs ?? DEFAULT_HTTP_TIMEOUT_MS,
@@ -377,6 +381,8 @@ async function readPaginated(
       initialUrl,
       cursorPagination,
       context.apiOrigin,
+      context.repositoryPath,
+      context.repositoryId,
     )
     if (nextUrl === null) {
       return failure("ERROR", operation, result.httpStatus, "UNSAFE_PAGINATION_URL")
@@ -543,21 +549,41 @@ function requestHeaders(token, accept) {
   }
 }
 
-function normalizeNextUrl(value, initialValue, cursorPagination, apiOrigin) {
+function normalizeNextUrl(
+  value,
+  initialValue,
+  cursorPagination,
+  apiOrigin,
+  repositoryPath,
+  repositoryId,
+) {
   try {
     const url = new URL(value)
     const initial = new URL(initialValue)
-    return url.origin === apiOrigin &&
-      url.username === "" &&
-      url.password === "" &&
-      url.hash === "" &&
-      url.pathname === initial.pathname &&
-      paginationQueryMatches(url.searchParams, initial.searchParams, cursorPagination)
-      ? url.href
-      : null
+    if (
+      url.origin !== apiOrigin ||
+      url.username !== "" ||
+      url.password !== "" ||
+      url.hash !== "" ||
+      !paginationPathMatches(url.pathname, initial.pathname, repositoryPath, repositoryId) ||
+      !paginationQueryMatches(url.searchParams, initial.searchParams, cursorPagination)
+    ) {
+      return null
+    }
+    url.pathname = initial.pathname
+    return url.href
   } catch {
     return null
   }
+}
+
+function paginationPathMatches(actual, initial, repositoryPath, repositoryId) {
+  if (actual === initial) return true
+  if (repositoryId === null || !initial.startsWith(`${repositoryPath}/`)) {
+    return false
+  }
+  const endpointSuffix = initial.slice(repositoryPath.length)
+  return actual === `/repositories/${repositoryId}${endpointSuffix}`
 }
 
 function normalizeApiOrigin(value) {

--- a/scripts/release/artifact-store.mjs
+++ b/scripts/release/artifact-store.mjs
@@ -111,6 +111,9 @@ export async function runArtifactStoreCli(
   const metadataReader = createGitHubReader({
     owner: repository.owner,
     repo: repository.repo,
+    ...(environment.GITHUB_REPOSITORY_ID === undefined
+      ? {}
+      : { repositoryId: environment.GITHUB_REPOSITORY_ID }),
     token,
     apiOrigin,
     fetchImpl,
@@ -118,6 +121,9 @@ export async function runArtifactStoreCli(
   const binaryReader = createGitHubReader({
     owner: repository.owner,
     repo: repository.repo,
+    ...(environment.GITHUB_REPOSITORY_ID === undefined
+      ? {}
+      : { repositoryId: environment.GITHUB_REPOSITORY_ID }),
     token,
     apiOrigin,
     fetchImpl,

--- a/scripts/release/cli.mjs
+++ b/scripts/release/cli.mjs
@@ -1769,6 +1769,7 @@ function snapshotEnvironment(environment) {
   for (const name of [
     "GITHUB_TOKEN",
     "GITHUB_REPOSITORY",
+    "GITHUB_REPOSITORY_ID",
     "GITHUB_REF",
     "GITHUB_SHA",
     "GITHUB_RUN_ID",
@@ -1920,6 +1921,9 @@ async function requireGitHub(runtime) {
   )({
     owner: "cacheplane",
     repo: "dawnai",
+    ...(runtime.environment.GITHUB_REPOSITORY_ID === undefined
+      ? {}
+      : { repositoryId: runtime.environment.GITHUB_REPOSITORY_ID }),
     token,
   })
   const writer = moduleFunction(
@@ -1985,6 +1989,9 @@ async function requireProductionGitHub(runtime) {
   )({
     owner: "cacheplane",
     repo: "dawnai",
+    ...(runtime.environment.GITHUB_REPOSITORY_ID === undefined
+      ? {}
+      : { repositoryId: runtime.environment.GITHUB_REPOSITORY_ID }),
     token,
   })
 }

--- a/scripts/release/independent-audit-coordinator.mjs
+++ b/scripts/release/independent-audit-coordinator.mjs
@@ -326,9 +326,10 @@ async function main() {
   const repository = environmentValue(process.env, "GITHUB_REPOSITORY")
   if (repository !== REPOSITORY) throw new TypeError("Independent audit repository is invalid")
   const token = environmentValue(process.env, "GITHUB_TOKEN")
+  const repositoryId = environmentValue(process.env, "GITHUB_REPOSITORY_ID")
   const defaultBranch = environmentValue(process.env, "GITHUB_DEFAULT_BRANCH")
   const [owner, repo] = repository.split("/")
-  const reader = createGitHubReader({ owner, repo, token })
+  const reader = createGitHubReader({ owner, repo, repositoryId, token })
   const writer = createGitHubWriter({ owner, repo, token, reader })
   const result = await coordinateIndependentAudit({
     eventName: environmentValue(process.env, "GITHUB_EVENT_NAME"),

--- a/scripts/release/independent-audit.mjs
+++ b/scripts/release/independent-audit.mjs
@@ -656,6 +656,7 @@ export async function createIndependentAuditRuntime(input, overrides = {}) {
     throw new TypeError("Independent audit runtime identity is invalid")
   }
   const token = environmentString(environment, "GITHUB_TOKEN")
+  const repositoryId = environmentString(environment, "GITHUB_REPOSITORY_ID")
   if (token.length > 4_096 || /[\r\n]/u.test(token)) {
     throw new TypeError("Independent audit GitHub token is invalid")
   }
@@ -693,6 +694,7 @@ export async function createIndependentAuditRuntime(input, overrides = {}) {
   const github = dependencies.createGitHubReader({
     owner: "cacheplane",
     repo: "dawnai",
+    repositoryId,
     token,
     maxResponseBytes: RELEASE_PAYLOAD_LIMITS.actionsArchiveBytes,
   })

--- a/scripts/release/shadow-reconcile.mjs
+++ b/scripts/release/shadow-reconcile.mjs
@@ -73,6 +73,7 @@ export async function runShadowReconcile({
     const github = createGitHubReader({
       owner,
       repo,
+      ...(env.GITHUB_REPOSITORY_ID === undefined ? {} : { repositoryId: env.GITHUB_REPOSITORY_ID }),
       ...(token === undefined || token === "" ? {} : { token }),
     })
     const inventoryReader = {

--- a/scripts/release/test/controller.test.mjs
+++ b/scripts/release/test/controller.test.mjs
@@ -1687,7 +1687,10 @@ test("GitHub-mutating routes lazily construct the production boundary from the e
     ],
     {
       cwd: directory,
-      environment: Object.freeze({ GITHUB_TOKEN: "exact-test-token" }),
+      environment: Object.freeze({
+        GITHUB_REPOSITORY_ID: "1210070282",
+        GITHUB_TOKEN: "exact-test-token",
+      }),
       importModule,
     },
   )
@@ -1696,6 +1699,7 @@ test("GitHub-mutating routes lazily construct the production boundary from the e
   assert.deepEqual(readerCall, {
     owner: "cacheplane",
     repo: "dawnai",
+    repositoryId: "1210070282",
     token: "exact-test-token",
   })
   assert.deepEqual(writerCall, {

--- a/scripts/release/test/fixtures/release-script-hashes.json
+++ b/scripts/release/test/fixtures/release-script-hashes.json
@@ -8,7 +8,7 @@
       "sha256": "465beffc12678ec5bd6d6e5ef6dc4f4c9cc1d76e622b4ed27c35dd231f2e0dda"
     },
     "scripts/release/adapters/github.mjs": {
-      "sha256": "60bf49eb6f62d60ea9f9101d351e787c62084fab96329a763b95dd4b2bd163e3"
+      "sha256": "c91a81df9a2ca263f66855f398d6c0a4660396a54c4bc4ff080238c15e0fca5c"
     },
     "scripts/release/adapters/http.mjs": {
       "sha256": "86e03a6cd1536bd57983c27256694bb281d83dfc7efd09181a299b7f351f9510"
@@ -17,16 +17,16 @@
       "sha256": "35239dcccb293f19064692af1fc1d9aacc8441e00f3e6ff5db4c819b7bf8b955"
     },
     "scripts/release/artifact-store.mjs": {
-      "sha256": "9b3c7342c6eca611ff62a9df472f016539a4e860c9770938b1654b1374530a92"
+      "sha256": "09b5423224b2d76c6cba6de616a1fabae0f5d0efc126e68c3ed3f8de7c82f924"
     },
     "scripts/release/cli.mjs": {
-      "sha256": "72f9e356d4a166870133995d4e776fc3186a3ea95ef3bc79f0fa732c170a423c"
+      "sha256": "027c3e84b07ccc2f40011a536dd8661e04b3b5df7fc78477b463f333411b73fa"
     },
     "scripts/release/independent-audit-coordinator.mjs": {
-      "sha256": "49c4b3e046b223eae9b864b3f2ad38cbc688bd5daffdde99263c05325b8b6dae"
+      "sha256": "29803cd7d46310091d1f723f1ca7c821242127f6127c118dc95ed94db7a3efa7"
     },
     "scripts/release/independent-audit.mjs": {
-      "sha256": "89681d8ab3ae07f52b81ceb9457886c2c1062ffd748b0770b71dbd610c2e6b02"
+      "sha256": "df75a31d6aa7c01a58583fa41eb4041ba4b4322a273c4b739f8e4eb6ffcd3eff"
     },
     "scripts/release/limits.mjs": {
       "sha256": "6ace39d22cdf5dbedff3b14b444c00cd3102082f8ef733ee458d0e6b52f1982f"

--- a/scripts/release/test/github-adapter.test.mjs
+++ b/scripts/release/test/github-adapter.test.mjs
@@ -9,6 +9,7 @@ const REPO = "dawn"
 const TOKEN = "github_secret_token"
 const SHA = "0123456789abcdef0123456789abcdef01234567"
 const BASE = "https://api.github.com/repos/dawn-ai/dawn"
+const REPOSITORY_ID = "1210070282"
 const ALLOWED_METHODS = [
   "downloadActionsArtifact",
   "downloadReleaseAsset",
@@ -785,6 +786,46 @@ test("GitHub pagination preserves exact endpoint and fixed filters", async () =>
   }
 })
 
+test("GitHub pagination follows only the exact bound numeric-repository route", async () => {
+  const canonicalNext = `https://api.github.com/repositories/${REPOSITORY_ID}/releases?per_page=100&page=2`
+  const recording = recordingFetch([
+    jsonResponse([{ id: 2, name: "second" }], 200, linkHeader(canonicalNext)),
+    jsonResponse([{ id: 1, name: "first" }]),
+  ])
+
+  const result = await createGitHubReader({
+    owner: OWNER,
+    repo: REPO,
+    repositoryId: REPOSITORY_ID,
+    fetchImpl: recording.fetchImpl,
+  }).listReleases()
+
+  assert.deepEqual(result.value, [
+    { id: 1, name: "first" },
+    { id: 2, name: "second" },
+  ])
+  assert.deepEqual(
+    recording.calls.map(({ url }) => url),
+    [`${BASE}/releases?per_page=100`, `${BASE}/releases?per_page=100&page=2`],
+  )
+
+  for (const repositoryId of [undefined, "999"]) {
+    const github = createGitHubReader({
+      owner: OWNER,
+      repo: REPO,
+      ...(repositoryId === undefined ? {} : { repositoryId }),
+      fetchImpl: async () =>
+        jsonResponse([{ id: 2, name: "second" }], 200, linkHeader(canonicalNext)),
+    })
+    assert.deepEqual(await github.listReleases(), {
+      status: "ERROR",
+      operation: "releases",
+      httpStatus: 200,
+      code: "UNSAFE_PAGINATION_URL",
+    })
+  }
+})
+
 test("GitHub pagination enforces total page and record limits", async () => {
   const next = `${BASE}/git/matching-refs/tags/?per_page=100&page=2`
   const pageLimited = createGitHubReader({
@@ -1005,6 +1046,12 @@ test("GitHub validates repository identity and every dynamic argument before fet
       createGitHubReader({ owner: OWNER, repo: REPO, token: "bad\ntoken", fetchImpl: assert.fail }),
     /token/u,
   )
+  for (const repositoryId of [0, "0", "01", "not-an-id"]) {
+    assert.throws(
+      () => createGitHubReader({ owner: OWNER, repo: REPO, repositoryId, fetchImpl: assert.fail }),
+      /ID/u,
+    )
+  }
 
   const github = createGitHubReader({ owner: OWNER, repo: REPO, fetchImpl: assert.fail })
   assert.throws(() => github.getCommitCheckRuns({ commitSha: "main" }), /commit SHA/u)

--- a/scripts/release/test/independent-audit.test.mjs
+++ b/scripts/release/test/independent-audit.test.mjs
@@ -46,6 +46,7 @@ function argv(overrides = {}) {
 function environment(overrides = {}) {
   return {
     GITHUB_REPOSITORY: "cacheplane/dawnai",
+    GITHUB_REPOSITORY_ID: "1210070282",
     GITHUB_EVENT_NAME: "workflow_dispatch",
     GITHUB_WORKFLOW_REF: `cacheplane/dawnai/.github/workflows/published-artifact-verify.yml@refs/tags/v${VERSION}`,
     GITHUB_REF: `refs/tags/v${VERSION}`,
@@ -233,6 +234,7 @@ test("constructs only bounded read-only production boundaries and never a writer
       {
         owner: "cacheplane",
         repo: "dawnai",
+        repositoryId: "1210070282",
         token,
         maxResponseBytes: RELEASE_PAYLOAD_LIMITS.actionsArchiveBytes,
       },


### PR DESCRIPTION
## Summary

- accept GitHub's canonical numeric-repository pagination route only when it matches the exact `GITHUB_REPOSITORY_ID`
- rewrite accepted next-page requests to the original named repository route, preserving the existing endpoint/query/cycle bounds
- propagate the repository ID through every release-controller GitHub reader and pin the changed release scripts
- retain fail-closed behavior for missing, malformed, or mismatched repository IDs

## Why

The guarded no-candidate release reconciliation failed before any mutation because GitHub returned a canonical Link header under `/repositories/1210070282/...` while the release adapter only accepted `/repos/cacheplane/dawnai/...`.

## Verification

- `DAWN_REQUIRE_DOCKER=1 pnpm ci:validate` (exit 0)
- harness: framework/runtime/smoke = 3 passed, 0 failed
- live production adapter: 473 releases read, status `PRESENT`
- regression tests cover exact numeric binding plus missing/wrong/invalid IDs
