### PR TITLE
fix(release): confirm npm version absence via packument

### DIFF
--- a/docs/superpowers/plans/2026-08-31-npm-version-absence.md
+++ b/docs/superpowers/plans/2026-08-31-npm-version-absence.md
@@ -1,0 +1,49 @@
+# Npm Exact-Version Absence Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let the release controller prove an unpublished npm version absent without trusting a fragile error-body shape.
+
+**Architecture:** Keep the exact-version request as the first observation. On HTTP 404, confirm absence through a second bounded install-v1 packument read whose package and version-map identities are validated before emitting the existing canonical `E404` absence envelope.
+
+**Tech Stack:** Node.js 24.19.0, Node test runner, npm registry HTTP adapter, pnpm 10.33.0.
+
+---
+
+### Task 1: Reproduce the production response
+
+**Files:**
+- Modify: `scripts/release/test/npm-adapter.test.mjs`
+
+- [x] Add a test whose exact-version response is HTTP 404 with a JSON string,
+      followed by a valid install-v1 packument that omits the requested version.
+- [x] Require two exact requests and the canonical `ABSENT`/404/`E404` envelope.
+- [x] Run `node --test scripts/release/test/npm-adapter.test.mjs` and confirm the
+      new test fails because the current adapter returns `AMBIGUOUS` after one read.
+
+### Task 2: Implement the two-read proof
+
+**Files:**
+- Modify: `scripts/release/adapters/npm.mjs`
+- Modify: `scripts/release/test/npm-adapter.test.mjs`
+
+- [x] Route every exact-version HTTP 404 through a bounded package-metadata read.
+- [x] Validate the exact package identity and complete `versions` mapping.
+- [x] Return canonical absence only when the requested version key is absent.
+- [x] Add fail-closed tests for malformed metadata, package-level 404, and a
+      packument that conflicts by containing the requested version.
+- [x] Run the npm adapter test file and confirm all cases pass.
+
+### Task 3: Verify and deliver the controller fix
+
+**Files:**
+- Modify the adapter, its unit and integration tests, the release rehearsal, the
+  audited release-script hash fixture, and these design/plan documents.
+
+- [x] Run focused release adapter, observation, planner, workflow, and controller tests.
+- [x] Run `DAWN_REQUIRE_DOCKER=1 pnpm ci:validate`.
+- [ ] Commit, push, open a PR, require exact-head CI and Copilot review, then merge
+      with a head guard.
+- [ ] Dispatch `reconcile` for version `0.8.22` and commit
+      `2a80deece2ff958fe7fde8fddeb4f99bed70a1c8`; do not create a replacement
+      candidate or publish locally.

--- a/docs/superpowers/specs/2026-08-31-npm-version-absence-design.md
+++ b/docs/superpowers/specs/2026-08-31-npm-version-absence-design.md
@@ -1,0 +1,43 @@
+# Npm Exact-Version Absence Design
+
+## Problem
+
+The release controller currently accepts an unpublished npm version only when
+the exact-version endpoint returns HTTP 404 with a JSON object containing
+`code: "E404"`. The production npm registry instead returns HTTP 404 with a
+JSON string such as `"version not found: 0.8.22"`. The adapter therefore marks
+every genuinely unpublished package as ambiguous and prevents a new release
+from starting.
+
+Matching that human-readable string or treating every 404 as absence would be
+fragile or unsafe. A 404 alone cannot distinguish a missing version from an
+authorization, proxy, or registry inconsistency.
+
+## Design
+
+For every exact-version 404, the npm adapter performs a second bounded read of
+the package's install-v1 packument. It accepts absence only when the packument:
+
+- is a successful structured response from the already trusted registry origin;
+- has the exact requested package identity;
+- contains a well-formed `versions` mapping whose keys and embedded identities
+  agree; and
+- does not contain the requested version.
+
+The adapter then returns the controller's existing canonical exact-absence
+envelope (`ABSENT`, HTTP 404, `E404`). It does not expose or match npm error
+text. Network failures, authentication failures, missing or malformed package
+metadata, and disagreement between the two reads remain fail-closed.
+
+The controller, planner, workflow, and release candidate identity do not
+change. After this fix reaches `main`, the release workflow can reconcile the
+original `0.8.22` candidate at commit
+`2a80deece2ff958fe7fde8fddeb4f99bed70a1c8`.
+
+## Verification
+
+Tests reproduce npm's real string-body 404, prove the second request and
+canonical absence result, and cover malformed metadata, missing package
+metadata, and a conflicting packument that already contains the version. The
+focused adapter and controller suites run before the full repository validation
+and exact-head CI/review gates.

--- a/scripts/release/adapters/npm.mjs
+++ b/scripts/release/adapters/npm.mjs
@@ -161,6 +161,9 @@ async function observePackageVersion({ registry, http, name, version, signal }) 
     signal,
   })
   if (versionResult.status !== "PRESENT") {
+    if (versionResult.httpStatus === 404) {
+      return confirmPackageVersionAbsent({ registry, http, name, version, signal })
+    }
     return versionResult
   }
 
@@ -210,6 +213,33 @@ async function observePackageVersion({ registry, http, name, version, signal }) 
       latest: distTags.latest ?? null,
     },
   }
+}
+
+async function confirmPackageVersionAbsent({ registry, http, name, version, signal }) {
+  const metadataResult = await getJson({
+    http,
+    url: new URL(encodeURIComponent(name), registry),
+    operation: "package-metadata",
+    accept: "application/vnd.npm.install-v1+json",
+    signal,
+  })
+  if (metadataResult.status !== "PRESENT") {
+    return failure(
+      metadataResult.status,
+      "package-version",
+      metadataResult.httpStatus,
+      metadataResult.code,
+    )
+  }
+  const packument = normalizePackument(metadataResult.body, name)
+  const versions = normalizePackumentVersions(packument?.versions, name)
+  if (versions === null) {
+    return failure("ERROR", "package-version", metadataResult.httpStatus, "MALFORMED_SCHEMA")
+  }
+  if (versions.has(version)) {
+    return failure("AMBIGUOUS", "package-version", 404, "REGISTRY_VERSION_CONFLICT")
+  }
+  return failure("ABSENT", "package-version", 404, "E404")
 }
 
 async function getJson({ http, url, operation, accept, signal }) {
@@ -283,6 +313,23 @@ function normalizePackument(value, expectedName) {
   return name?.enumerable === true && "value" in name && name.value === expectedName
     ? snapshot
     : null
+}
+
+function normalizePackumentVersions(value, expectedName) {
+  if (!isObject(value)) return null
+  const versions = new Set()
+  for (const [version, document] of Object.entries(value)) {
+    if (
+      !isExactSemver(version) ||
+      !isObject(document) ||
+      document.name !== expectedName ||
+      document.version !== version
+    ) {
+      return null
+    }
+    versions.add(version)
+  }
+  return versions
 }
 
 function normalizeRegistryUrl(value) {

--- a/scripts/release/test/fault-harness.integration.mjs
+++ b/scripts/release/test/fault-harness.integration.mjs
@@ -552,7 +552,12 @@ test("the production npm reader distinguishes exact absence and every determinis
     name: PACKAGE_NAMES[0],
     version: VERSION,
   })
-  assert.equal(delayedMissing.status, "ABSENT")
+  assert.deepEqual(pickClassification(delayedMissing), {
+    status: "AMBIGUOUS",
+    operation: "package-version",
+    httpStatus: 404,
+    code: "REGISTRY_VERSION_CONFLICT",
+  })
   assert.equal(
     (
       await reader.observePackageVersion({
@@ -568,7 +573,7 @@ test("the production npm reader distinguishes exact absence and every determinis
   assertPlannerDisposition({
     exact: delayedMissing,
     latest: visibleLatest,
-    blocked: false,
+    blocked: true,
     candidateVersion: VERSION,
   })
 

--- a/scripts/release/test/fixtures/release-script-hashes.json
+++ b/scripts/release/test/fixtures/release-script-hashes.json
@@ -14,7 +14,7 @@
       "sha256": "86e03a6cd1536bd57983c27256694bb281d83dfc7efd09181a299b7f351f9510"
     },
     "scripts/release/adapters/npm.mjs": {
-      "sha256": "35239dcccb293f19064692af1fc1d9aacc8441e00f3e6ff5db4c819b7bf8b955"
+      "sha256": "3e171b1bc9aa79080d58087327ea2014b856ba5e6329f33de1a0a5f1b18c05d1"
     },
     "scripts/release/artifact-store.mjs": {
       "sha256": "09b5423224b2d76c6cba6de616a1fabae0f5d0efc126e68c3ed3f8de7c82f924"

--- a/scripts/release/test/npm-adapter.test.mjs
+++ b/scripts/release/test/npm-adapter.test.mjs
@@ -240,6 +240,113 @@ test("observePackageMetadata never classifies package-level 404 as exact-version
   })
 })
 
+test("confirms npm's string-body exact-version 404 against the structured packument", async () => {
+  const previousVersion = "0.8.20"
+  const { fetchImpl, calls } = recordingFetch([
+    jsonResponse(`version not found: ${VERSION}`, 404),
+    jsonResponse({
+      name: NAME,
+      "dist-tags": { latest: previousVersion },
+      versions: {
+        [previousVersion]: { name: NAME, version: previousVersion },
+      },
+    }),
+  ])
+
+  const result = await createNpmReader({ fetchImpl }).observePackageVersion({
+    name: NAME,
+    version: VERSION,
+  })
+
+  assert.deepEqual(
+    calls.map(({ url, init }) => ({ url, accept: init.headers.Accept })),
+    [
+      { url: `${REGISTRY}/%40dawn-ai%2Fsdk/0.8.21`, accept: "application/json" },
+      {
+        url: `${REGISTRY}/%40dawn-ai%2Fsdk`,
+        accept: "application/vnd.npm.install-v1+json",
+      },
+    ],
+  )
+  assert.deepEqual(result, {
+    status: "ABSENT",
+    operation: "package-version",
+    httpStatus: 404,
+    code: "E404",
+  })
+})
+
+test("keeps exact-version 404 ambiguous when package metadata is also unavailable", async () => {
+  const { fetchImpl, calls } = recordingFetch([
+    jsonResponse(`version not found: ${VERSION}`, 404),
+    jsonResponse({ code: "E404" }, 404),
+  ])
+
+  const result = await createNpmReader({ fetchImpl }).observePackageVersion({
+    name: NAME,
+    version: VERSION,
+  })
+
+  assert.equal(calls.length, 2)
+  assert.deepEqual(result, {
+    status: "AMBIGUOUS",
+    operation: "package-version",
+    httpStatus: 404,
+    code: "E404",
+  })
+})
+
+test("rejects a malformed packument used to confirm exact-version absence", async () => {
+  const previousVersion = "0.8.20"
+  const { fetchImpl } = recordingFetch([
+    jsonResponse(`version not found: ${VERSION}`, 404),
+    jsonResponse({
+      name: NAME,
+      "dist-tags": { latest: previousVersion },
+      versions: {
+        [previousVersion]: { name: "@dawn-ai/wrong", version: previousVersion },
+      },
+    }),
+  ])
+
+  const result = await createNpmReader({ fetchImpl }).observePackageVersion({
+    name: NAME,
+    version: VERSION,
+  })
+
+  assert.deepEqual(result, {
+    status: "ERROR",
+    operation: "package-version",
+    httpStatus: 200,
+    code: "MALFORMED_SCHEMA",
+  })
+})
+
+test("blocks when the exact-version 404 conflicts with the package version map", async () => {
+  const { fetchImpl } = recordingFetch([
+    jsonResponse(`version not found: ${VERSION}`, 404),
+    jsonResponse({
+      name: NAME,
+      "dist-tags": { latest: VERSION },
+      versions: {
+        [VERSION]: { name: NAME, version: VERSION },
+      },
+    }),
+  ])
+
+  const result = await createNpmReader({ fetchImpl }).observePackageVersion({
+    name: NAME,
+    version: VERSION,
+  })
+
+  assert.deepEqual(result, {
+    status: "AMBIGUOUS",
+    operation: "package-version",
+    httpStatus: 404,
+    code: "REGISTRY_VERSION_CONFLICT",
+  })
+})
+
 test("classifyRegistryResponse treats only exact-version E404 as absence", () => {
   const rows = [
     {
@@ -570,19 +677,26 @@ test("npm rejects malformed injected status and does not trust response ok", asy
     assert.equal(result.code, "MALFORMED_RESPONSE")
   }
 
-  const concealed = createNpmReader({
-    fetchImpl: async () =>
-      responseLike({
-        status: 404,
-        ok: true,
-        body: JSON.stringify({ code: "E404" }),
-        headers: { "content-type": "application/json" },
-      }),
-  })
+  const previousVersion = "0.8.20"
+  const concealedResponses = recordingFetch([
+    responseLike({
+      status: 404,
+      ok: true,
+      body: JSON.stringify({ code: "E404" }),
+      headers: { "content-type": "application/json" },
+    }),
+    jsonResponse({
+      name: NAME,
+      "dist-tags": { latest: previousVersion },
+      versions: { [previousVersion]: { name: NAME, version: previousVersion } },
+    }),
+  ])
+  const concealed = createNpmReader({ fetchImpl: concealedResponses.fetchImpl })
   assert.equal(
     (await concealed.observePackageVersion({ name: NAME, version: VERSION })).status,
     "ABSENT",
   )
+  assert.equal(concealedResponses.calls.length, 2)
 })
 
 function versionDocument() {

--- a/scripts/release/test/rehearsal.test.mjs
+++ b/scripts/release/test/rehearsal.test.mjs
@@ -585,15 +585,14 @@ test("registry harness packs without publishing and exposes one bounded real pub
       return fetch(new URL(`${target.pathname}${target.search}`, harness.proxy.url), options)
     },
   })
+  await harness.publishPreparedTarball({ tarballPath: packed[0].tarballPath })
   harness.proxy.setMode("exact-version-e404")
   assert.equal(
-    (await reader.observePackageVersion({ name: packed[0].name, version: packed[0].version }))
-      .status,
+    (await reader.observePackageVersion({ name: packed[0].name, version: "999.0.0" })).status,
     "ABSENT",
   )
 
   harness.proxy.reset()
-  await harness.publishPreparedTarball({ tarballPath: packed[0].tarballPath })
   const present = await reader.observePackageVersion({
     name: packed[0].name,
     version: packed[0].version,


### PR DESCRIPTION
## Summary

- confirm every npm exact-version 404 with a second bounded install-v1 packument read
- validate the exact package identity and full version map before classifying absence
- fail closed on missing, malformed, or conflicting registry metadata
- update release rehearsal/integration coverage and the audited release-script content pin

## Verification

- `pnpm lint`
- `pnpm test:release-controller` (1,312 passed)
- `node --test scripts/release/test/fault-harness.integration.mjs` (33 passed)
- `DAWN_REQUIRE_DOCKER=1 pnpm ci:validate` (framework/runtime/smoke 3/3 passed)
- live read-only npm adapter check: all 21 `0.8.22` versions classified canonical `ABSENT`/404/`E404`

## Release continuity

After merge, reconcile the existing `0.8.22` candidate at `2a80deece2ff958fe7fde8fddeb4f99bed70a1c8`. Do not create a replacement candidate or publish locally.