### PR TITLE
fix(release): recognize current tagged workflow attempt

### DIFF
--- a/scripts/release/cli.mjs
+++ b/scripts/release/cli.mjs
@@ -366,6 +366,10 @@ async function runObserve(options, runtime) {
     }
   }
   const npmAuditFactory = await requireNpmAuditFactory(runtime)
+  const currentPublisherRun = currentPublisherRunFromEnvironment(
+    runtime.environment,
+    selection.candidate,
+  )
   const observer = {
     async observe() {
       if (resolutionFailure !== null || selection.candidate === null) {
@@ -385,6 +389,7 @@ async function runObserve(options, runtime) {
           npmAuditFactory,
           attestations,
           includeRecovery: true,
+          ...(currentPublisherRun === null ? {} : { currentPublisherRun }),
         })
         observationDiagnostics = normalizeObservationDiagnostics(result.diagnostics)
         observationRecovery = snapshotCliData(result.recovery, "production recovery evidence")
@@ -1799,6 +1804,28 @@ function projectEnvironment(environment, names) {
     result[name] = descriptor.value
   }
   return Object.freeze(result)
+}
+
+function currentPublisherRunFromEnvironment(environment, candidate) {
+  if (candidate === null) return null
+  const projected = projectEnvironment(environment, [
+    "GITHUB_REF",
+    "GITHUB_SHA",
+    "GITHUB_RUN_ID",
+    "GITHUB_RUN_ATTEMPT",
+  ])
+  if (
+    projected.GITHUB_REF !== `refs/tags/v${candidate.version}` ||
+    projected.GITHUB_SHA !== candidate.commitSha
+  ) {
+    return null
+  }
+  return Object.freeze({
+    runId: environmentPositiveInteger(projected, "GITHUB_RUN_ID"),
+    runAttempt: environmentPositiveInteger(projected, "GITHUB_RUN_ATTEMPT"),
+    ref: projected.GITHUB_REF,
+    sha: projected.GITHUB_SHA,
+  })
 }
 
 function environmentPositiveInteger(environment, name) {

--- a/scripts/release/cli.mjs
+++ b/scripts/release/cli.mjs
@@ -1820,12 +1820,22 @@ function currentPublisherRunFromEnvironment(environment, candidate) {
   ) {
     return null
   }
+  const runId = optionalEnvironmentPositiveInteger(projected, "GITHUB_RUN_ID")
+  const runAttempt = optionalEnvironmentPositiveInteger(projected, "GITHUB_RUN_ATTEMPT")
+  if (runId === null || runAttempt === null) return null
   return Object.freeze({
-    runId: environmentPositiveInteger(projected, "GITHUB_RUN_ID"),
-    runAttempt: environmentPositiveInteger(projected, "GITHUB_RUN_ATTEMPT"),
+    runId,
+    runAttempt,
     ref: projected.GITHUB_REF,
     sha: projected.GITHUB_SHA,
   })
+}
+
+function optionalEnvironmentPositiveInteger(environment, name) {
+  const value = environment[name]
+  if (typeof value !== "string" || !DECIMAL_ID_PATTERN.test(value)) return null
+  const parsed = Number(value)
+  return Number.isSafeInteger(parsed) && parsed >= 1 ? parsed : null
 }
 
 function environmentPositiveInteger(environment, name) {

--- a/scripts/release/observe.mjs
+++ b/scripts/release/observe.mjs
@@ -330,11 +330,13 @@ export async function observeProductionCandidate({
   npmAuditFactory,
   attestations,
   includeRecovery = false,
+  currentPublisherRun = null,
 }) {
   if (typeof includeRecovery !== "boolean") {
     throw new TypeError("Production recovery inclusion flag is invalid")
   }
   const identity = normalizeCandidate(candidate)
+  const currentRun = normalizeCurrentPublisherRun(currentPublisherRun, identity)
   const managedInventory = normalizeProductionInventory(inventory, identity)
   normalizeControllerMarker(marker)
   assertMethods(git, ["resolveTag"], "Git reader")
@@ -584,6 +586,7 @@ export async function observeProductionCandidate({
     candidate: identity,
     github,
     diagnostics,
+    currentPublisherRun: currentRun,
   })
   if (publicationHistory.ambiguous) {
     registryPackages = registryPackages.map((pkg) => ambiguousRegistryPackage(pkg.name))
@@ -4093,7 +4096,13 @@ function normalizeEnvelope(value, options, diagnostics) {
   return result
 }
 
-async function observeProductionPublicationHistory({ result, candidate, github, diagnostics }) {
+async function observeProductionPublicationHistory({
+  result,
+  candidate,
+  github,
+  diagnostics,
+  currentPublisherRun,
+}) {
   if (result.status !== "PRESENT" || !Array.isArray(result.value)) {
     return { started: false, ambiguous: true }
   }
@@ -4133,7 +4142,12 @@ async function observeProductionPublicationHistory({ result, candidate, github, 
     }
     runIds.add(value.id)
     if (value.head_branch === `v${candidate.version}`) {
-      runs.push({ id: value.id, runAttempt: value.run_attempt })
+      runs.push({
+        id: value.id,
+        runAttempt: value.run_attempt,
+        status: value.status,
+        conclusion: value.conclusion,
+      })
     }
   }
 
@@ -4145,7 +4159,14 @@ async function observeProductionPublicationHistory({ result, candidate, github, 
       payloadKey: "value",
       diagnostics,
     })
-    const jobs = normalizePublisherJobs(jobsResult, run.runAttempt)
+    const jobs = normalizePublisherJobs(jobsResult, run.runAttempt, {
+      allowCurrentAttemptWithoutPublisherJob:
+        currentPublisherRun !== null &&
+        run.id === currentPublisherRun.runId &&
+        run.runAttempt === currentPublisherRun.runAttempt &&
+        run.status === "in_progress" &&
+        run.conclusion === null,
+    })
     if (jobs === null) {
       addDiagnostic(
         diagnostics,
@@ -4161,7 +4182,11 @@ async function observeProductionPublicationHistory({ result, candidate, github, 
   return { started, ambiguous: false }
 }
 
-function normalizePublisherJobs(result, currentAttempt) {
+function normalizePublisherJobs(
+  result,
+  currentAttempt,
+  { allowCurrentAttemptWithoutPublisherJob = false } = {},
+) {
   if (
     result.status !== "PRESENT" ||
     !Array.isArray(result.value) ||
@@ -4230,9 +4255,29 @@ function normalizePublisherJobs(result, currentAttempt) {
     return null
   }
   for (let attempt = 1; attempt <= currentAttempt; attempt += 1) {
-    if (publisherJobsByAttempt.get(attempt) !== 1) return null
+    const publisherJobs = publisherJobsByAttempt.get(attempt) ?? 0
+    if (
+      publisherJobs !== 1 &&
+      !(allowCurrentAttemptWithoutPublisherJob && attempt === currentAttempt && publisherJobs === 0)
+    ) {
+      return null
+    }
   }
   return jobs
+}
+
+function normalizeCurrentPublisherRun(value, candidate) {
+  if (value === null || value === undefined) return null
+  if (
+    !hasExactKeys(value, ["runId", "runAttempt", "ref", "sha"]) ||
+    !isPositiveSafeInteger(value.runId) ||
+    !isPositiveSafeInteger(value.runAttempt) ||
+    value.ref !== `refs/tags/v${candidate.version}` ||
+    value.sha !== candidate.commitSha
+  ) {
+    throw new TypeError("Current publisher run identity is invalid")
+  }
+  return snapshotJson(value)
 }
 
 function publisherJobObservedStarted(job) {

--- a/scripts/release/test/fixtures/release-script-hashes.json
+++ b/scripts/release/test/fixtures/release-script-hashes.json
@@ -20,7 +20,7 @@
       "sha256": "09b5423224b2d76c6cba6de616a1fabae0f5d0efc126e68c3ed3f8de7c82f924"
     },
     "scripts/release/cli.mjs": {
-      "sha256": "027c3e84b07ccc2f40011a536dd8661e04b3b5df7fc78477b463f333411b73fa"
+      "sha256": "0b4ef4fa1c7eb24120c11ac77571c0700ca9d379096148a2295a6a1c73927d08"
     },
     "scripts/release/independent-audit-coordinator.mjs": {
       "sha256": "29803cd7d46310091d1f723f1ca7c821242127f6127c118dc95ed94db7a3efa7"

--- a/scripts/release/test/fixtures/release-script-hashes.json
+++ b/scripts/release/test/fixtures/release-script-hashes.json
@@ -20,7 +20,7 @@
       "sha256": "09b5423224b2d76c6cba6de616a1fabae0f5d0efc126e68c3ed3f8de7c82f924"
     },
     "scripts/release/cli.mjs": {
-      "sha256": "0b4ef4fa1c7eb24120c11ac77571c0700ca9d379096148a2295a6a1c73927d08"
+      "sha256": "7d78f62482a472a7380987353a5d895c84c9da97600643ff2aead40c7904b2c8"
     },
     "scripts/release/independent-audit-coordinator.mjs": {
       "sha256": "29803cd7d46310091d1f723f1ca7c821242127f6127c118dc95ed94db7a3efa7"

--- a/scripts/release/test/observe-production.test.mjs
+++ b/scripts/release/test/observe-production.test.mjs
@@ -629,6 +629,68 @@ test("production publication history ignores the branch coordinator and schedule
   assert.equal(observation.registry.mutationStarted, false)
 })
 
+test("production publication history permits only the current exact-tag detect before publish materializes", async () => {
+  const currentRun = {
+    id: 40,
+    name: "Release",
+    path: ".github/workflows/release.yml",
+    head_sha: COMMIT_SHA,
+    head_branch: `v${VERSION}`,
+    status: "in_progress",
+    conclusion: null,
+    run_attempt: 1,
+  }
+  const github = githubReader({
+    async listWorkflowRuns({ workflow }) {
+      return present("workflow-runs", workflow === "ci.yml" ? ciRuns() : [currentRun])
+    },
+    async listActionsRunJobs({ runId }) {
+      assert.equal(runId, currentRun.id)
+      return present("actions-run-jobs", [
+        {
+          id: 401,
+          runAttempt: 1,
+          name: "detect",
+          status: "in_progress",
+          conclusion: null,
+          startedAt: "2026-08-31T15:44:39.000Z",
+          completedAt: null,
+        },
+      ])
+    },
+  })
+
+  const blocked = await observeProductionCandidate({
+    candidate: candidate(),
+    inventory: inventory(),
+    marker: MARKER,
+    git: gitReader(),
+    github,
+    npm: npmReader(),
+    attestations: attestationVerifier([]),
+  })
+  assert.ok(blocked.diagnostics.some((entry) => entry.code === "PUBLISHER_JOB_HISTORY_INVALID"))
+
+  const current = await observeProductionCandidate({
+    candidate: candidate(),
+    inventory: inventory(),
+    marker: MARKER,
+    git: gitReader(),
+    github,
+    npm: npmReader(),
+    attestations: attestationVerifier([]),
+    currentPublisherRun: {
+      runId: currentRun.id,
+      runAttempt: currentRun.run_attempt,
+      ref: `refs/tags/v${VERSION}`,
+      sha: COMMIT_SHA,
+    },
+  })
+  assert.deepEqual(current.diagnostics, [])
+  assert.equal(current.observation.registry.publishJobStarted, false)
+  assert.equal(current.observation.registry.mutationStarted, false)
+})
+
 test("production observation binds a prepared artifact to its exact run and release record", async () => {
   const prepared = preparedArtifactFixture()
   const github = githubReader({
@@ -2762,6 +2824,75 @@ test("observe CLI resolves the immutable candidate, runs the dry one-transition 
         "",
       ].join("\n"),
     )
+  } finally {
+    await rm(directory, { recursive: true, force: true })
+  }
+})
+
+test("observe CLI identifies its exact current tag attempt before downstream jobs materialize", async () => {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "dawn-observe-current-run-"))
+  try {
+    const eventPath = path.join(directory, "event.json")
+    const reportPath = path.join(directory, "report.json")
+    const outputPath = path.join(directory, "github-output")
+    await Promise.all([
+      writeFile(
+        eventPath,
+        `${JSON.stringify({ inputs: { version: VERSION, commitSha: COMMIT_SHA } })}\n`,
+      ),
+      writeFile(outputPath, ""),
+    ])
+    const dependencies = cliCandidateDependencies(directory)
+    const base = githubReader()
+    dependencies.githubReader = {
+      ...base,
+      async listWorkflowRuns(input) {
+        if (input.workflow === "ci.yml") return base.listWorkflowRuns(input)
+        return present("workflow-runs", [
+          {
+            id: 40,
+            name: "Release",
+            path: ".github/workflows/release.yml",
+            head_sha: COMMIT_SHA,
+            head_branch: `v${VERSION}`,
+            status: "in_progress",
+            conclusion: null,
+            run_attempt: 1,
+          },
+        ])
+      },
+      async listActionsRunJobs(input) {
+        if (Number(input.runId) === 40) {
+          return present("actions-run-jobs", [
+            {
+              id: 401,
+              runAttempt: 1,
+              name: "detect",
+              status: "in_progress",
+              conclusion: null,
+              startedAt: "2026-08-31T15:44:39.000Z",
+              completedAt: null,
+            },
+          ])
+        }
+        return base.listActionsRunJobs(input)
+      },
+    }
+    dependencies.environment = {
+      GITHUB_REF: `refs/tags/v${VERSION}`,
+      GITHUB_SHA: COMMIT_SHA,
+      GITHUB_RUN_ID: "40",
+      GITHUB_RUN_ATTEMPT: "1",
+    }
+
+    const result = await runReleaseCli(
+      ["observe", "--event", eventPath, "--report", reportPath, "--github-output", outputPath],
+      dependencies,
+    )
+
+    assert.deepEqual(result.diagnostics, [])
+    assert.equal(result.before.plan.state, "CANDIDATE_TAGGED")
+    assert.equal(result.before.plan.nextTransition, "prepare-artifacts")
   } finally {
     await rm(directory, { recursive: true, force: true })
   }

--- a/scripts/release/test/observe-production.test.mjs
+++ b/scripts/release/test/observe-production.test.mjs
@@ -2893,6 +2893,29 @@ test("observe CLI identifies its exact current tag attempt before downstream job
     assert.deepEqual(result.diagnostics, [])
     assert.equal(result.before.plan.state, "CANDIDATE_TAGGED")
     assert.equal(result.before.plan.nextTransition, "prepare-artifacts")
+
+    for (const environment of [
+      {
+        GITHUB_REF: `refs/tags/v${VERSION}`,
+        GITHUB_SHA: COMMIT_SHA,
+        GITHUB_RUN_ATTEMPT: "1",
+      },
+      {
+        GITHUB_REF: `refs/tags/v${VERSION}`,
+        GITHUB_SHA: COMMIT_SHA,
+        GITHUB_RUN_ID: "not-a-run-id",
+        GITHUB_RUN_ATTEMPT: "1",
+      },
+    ]) {
+      dependencies.environment = environment
+      await rm(reportPath, { force: true })
+      const blocked = await runReleaseCli(
+        ["observe", "--event", eventPath, "--report", reportPath, "--github-output", outputPath],
+        dependencies,
+      )
+      assert.ok(blocked.diagnostics.some((entry) => entry.code === "PUBLISHER_JOB_HISTORY_INVALID"))
+      assert.equal(blocked.before.plan.disposition, "blocked")
+    }
   } finally {
     await rm(directory, { recursive: true, force: true })
   }


### PR DESCRIPTION
## Summary

- bind the current publisher attempt only from exact trusted Actions tag/SHA/run environment
- allow that one in-progress detect job to observe history before GitHub materializes `publish-npm`
- preserve fail-closed validation for prior, completed, and unrelated attempts

## Production evidence

The existing v0.8.22 tag relay run 33410175329 stopped safely in `detect` with `PUBLISHER_JOB_HISTORY_INVALID`; every downstream job was skipped and no publication mutation began. GitHub had not yet materialized the downstream `publish-npm` job while `detect` inspected its own run.

## Verification

- `pnpm lint`
- `node --test scripts/release/test/observe-production.test.mjs` (64/64)
- `pnpm test:release-controller` (1314/1314)
- workflow contract tests (61/61)
- `DAWN_REQUIRE_DOCKER=1 pnpm ci:validate` (all gates passed except one disposable runtime port race after framework passed)
- clean Node 24.19.0 `pnpm verify:harness:runtime` rerun (1/1 passed)
- release CLI content-pin hash recomputed and verified