### PR TITLE
fix(release): bind repository id explicitly

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,9 @@ concurrency:
   queue: max
   cancel-in-progress: false
 
+env:
+  GITHUB_REPOSITORY_ID: ${{ github.repository_id }}
+
 permissions:
   contents: read
 

--- a/docs/superpowers/plans/2026-08-31-release-repository-id-recovery.md
+++ b/docs/superpowers/plans/2026-08-31-release-repository-id-recovery.md
@@ -1,0 +1,216 @@
+# Release Repository-ID Recovery Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Explicitly bind the trusted GitHub repository ID into the release workflow, then safely complete the immutable v0.8.22 provenance release with the existing controller CLI.
+
+**Architecture:** Keep the GitHub reader's strict repository-ID pagination validation unchanged. Add one workflow-level environment binding sourced from the GitHub Actions context, prove the binding with a workflow-contract test, and use the merged controller plus immutable artifacts from failed run `33418085547` for the one-time escrow recovery.
+
+**Tech Stack:** GitHub Actions YAML, Node.js 24, `node:test`, Dawn's release controller CLI, GitHub CLI, npm trusted publishing and GitHub artifact attestations.
+
+---
+
+### Task 1: Pin the repository identity at the workflow boundary
+
+**Files:**
+- Modify: `scripts/release/test/workflow-contracts.test.mjs`
+- Modify: `.github/workflows/release.yml`
+
+- [ ] **Step 1: Write the failing workflow-contract assertion**
+
+In `release.yml has exact triggers and one repository-global non-cancelling queue`, add:
+
+```js
+assert.deepEqual(workflow.env, {
+  GITHUB_REPOSITORY_ID: workflowExpression("github.repository_id"),
+})
+```
+
+- [ ] **Step 2: Run the focused test and verify it fails**
+
+Run:
+
+```bash
+PATH=/Users/blove/.nvm/versions/node/v24.19.0/bin:$PATH \
+  node --test --test-name-pattern='repository-global non-cancelling queue' \
+  scripts/release/test/workflow-contracts.test.mjs
+```
+
+Expected: FAIL because `workflow.env` is currently absent.
+
+- [ ] **Step 3: Add the minimal workflow binding**
+
+Add this top-level block to `.github/workflows/release.yml`:
+
+```yaml
+env:
+  GITHUB_REPOSITORY_ID: ${{ github.repository_id }}
+```
+
+Do not modify the GitHub adapter, accept arbitrary repository-ID URLs, or add a fallback value.
+
+- [ ] **Step 4: Run the focused test and verify it passes**
+
+Run the Step 2 command again.
+
+Expected: PASS.
+
+- [ ] **Step 5: Run focused release verification**
+
+Run:
+
+```bash
+PATH=/Users/blove/.nvm/versions/node/v24.19.0/bin:$PATH \
+  node --test scripts/release/test/workflow-contracts.test.mjs
+PATH=/Users/blove/.nvm/versions/node/v24.19.0/bin:$PATH \
+  pnpm test:release-controller
+PATH=/Users/blove/.nvm/versions/node/v24.19.0/bin:$PATH \
+  pnpm lint
+```
+
+Expected: all pass.
+
+- [ ] **Step 6: Commit the implementation**
+
+```bash
+git add .github/workflows/release.yml scripts/release/test/workflow-contracts.test.mjs
+git commit -m "fix(release): bind repository id explicitly"
+```
+
+### Task 2: Validate and merge the permanent fix
+
+**Files:**
+- Verify: repository-wide gates only
+
+- [ ] **Step 1: Run the local Definition of Done**
+
+Run:
+
+```bash
+PATH=/Users/blove/.nvm/versions/node/v24.19.0/bin:$PATH \
+  DAWN_REQUIRE_DOCKER=1 pnpm ci:validate
+```
+
+Expected: all required gates pass. If a disposable-port collision occurs, diagnose it and rerun only after proving it environmental.
+
+- [ ] **Step 2: Push the branch and open a PR**
+
+```bash
+git push -u origin blove/fix-release-repository-id-boundary
+gh pr create --base main --head blove/fix-release-repository-id-boundary \
+  --title "fix(release): bind repository id explicitly" \
+  --body-file <prepared-pr-body>
+```
+
+- [ ] **Step 3: Request and process GitHub Copilot review**
+
+Request Copilot review through GitHub, inspect every comment, and apply feedback only after technical verification. The independent external reviewer remains waived per user instruction.
+
+- [ ] **Step 4: Require exact-head CI**
+
+Record the PR head SHA. Require all substantive checks for that exact SHA, including validation, release-controller coverage, dependency security, real Vercel, CopilotKit v2, sandbox, storage, charts, and CodeQL. Treat only the previously waived no-credit reviewer lane as non-blocking.
+
+- [ ] **Step 5: Merge with exact-head protection**
+
+Re-read the PR head immediately before merge and merge only if it equals the reviewed and validated SHA.
+
+### Task 3: Reconfirm the v0.8.22 recovery preconditions
+
+**Files:**
+- Read: `/tmp/dawn-escrow-diagnose.f0sK9L/runtime/candidate.json`
+- Read: `/tmp/dawn-escrow-diagnose.f0sK9L/runtime/release-record.json`
+- Read: `/tmp/dawn-escrow-diagnose.f0sK9L/runtime/payload/*`
+- Read: `/tmp/dawn-escrow-diagnose.f0sK9L/attestation/attestation-set.json`
+- Read: `/tmp/dawn-escrow-diagnose.f0sK9L/attestation/bundles/*`
+
+- [ ] **Step 1: Re-download immutable artifacts by exact run and artifact name if needed**
+
+Use `gh run download 33418085547` for the exact runtime and attestation artifacts. Reject duplicate or unexpected files.
+
+- [ ] **Step 2: Reconfirm external absence and identity**
+
+Verify all of the following with read-only commands:
+
+- `v0.8.22` still peels to `2a80deece2ff958fe7fde8fddeb4f99bed70a1c8`;
+- no GitHub Release exists at tag `v0.8.22`;
+- every manifest package version `0.8.22` is absent from npm;
+- run `33418085547` is the attestation-set run and contains the expected artifacts;
+- no `publish-npm` job has started for any candidate run.
+
+- [ ] **Step 3: Repeat the guarded real-adapter diagnostic**
+
+Invoke `runReleaseCli(["escrow", ...])` with real GitHub/npm readers and the real attestation verifier, but replace all five writer methods with a function that throws `DIAGNOSTIC_MUTATION_BOUNDARY_REACHED` before mutation. Supply repository ID `1210070282`.
+
+Expected: all checks and all 22 provenance subjects pass, ending only at the guarded writer boundary.
+
+### Task 4: Escrow the immutable candidate with the existing CLI
+
+**Files:**
+- Runtime input: immutable artifacts listed in Task 3
+- Production mutation: draft GitHub Release `v0.8.22`
+
+- [ ] **Step 1: Run the escrow transition once**
+
+From the merged controller checkout, run:
+
+```bash
+GITHUB_TOKEN="$(gh auth token)" \
+GITHUB_REPOSITORY=cacheplane/dawnai \
+GITHUB_REPOSITORY_ID=1210070282 \
+PATH=/Users/blove/.nvm/versions/node/v24.19.0/bin:$PATH \
+node scripts/release/cli.mjs escrow \
+  --candidate /tmp/dawn-escrow-diagnose.f0sK9L/runtime/candidate.json \
+  --record /tmp/dawn-escrow-diagnose.f0sK9L/runtime/release-record.json \
+  --artifact-dir /tmp/dawn-escrow-diagnose.f0sK9L/runtime/payload \
+  --attestation-set /tmp/dawn-escrow-diagnose.f0sK9L/attestation/attestation-set.json \
+  --attestation-bundles-dir /tmp/dawn-escrow-diagnose.f0sK9L/attestation/bundles
+```
+
+Expected: `ESCROWED` result for one draft Release. Never print the token.
+
+- [ ] **Step 2: Verify escrow independently**
+
+Read the `v0.8.22` Release by exact tag and confirm:
+
+- it is draft and mutable;
+- its target/tag identity matches the candidate;
+- its managed marker phase is `ESCROWED`;
+- the base asset set is exact and every digest matches the release record, payload, attestation set, and bundles.
+
+Stop if any field or digest is ambiguous.
+
+### Task 5: Resume provenance publication and verify production
+
+**Files:**
+- Production workflow: `.github/workflows/release.yml` at tag `v0.8.22`
+
+- [ ] **Step 1: Dispatch exact tagged reconciliation**
+
+Dispatch `.github/workflows/release.yml` at ref `v0.8.22` with exact inputs:
+
+```text
+version=0.8.22
+commitSha=2a80deece2ff958fe7fde8fddeb4f99bed70a1c8
+operation=reconcile
+```
+
+- [ ] **Step 2: Observe the workflow through completion**
+
+Require the exact tagged run to complete npm trusted publication, reconciliation, all five published-artifact smoke lanes, independent audit, and final GitHub Release publication. Do not retry blindly after any failure; diagnose the first failed transition.
+
+- [ ] **Step 3: Verify published packages and provenance**
+
+For every package in the sealed manifest, confirm exact version `0.8.22`, integrity/tarball digest, npm provenance, and expected latest-tag behavior.
+
+- [ ] **Step 4: Verify the final GitHub Release**
+
+Confirm the final Release is published, immutable where supported, points to the exact candidate tag/SHA, has the final controller marker, and exposes the exact audited asset set.
+
+- [ ] **Step 5: Run full production smoke verification**
+
+Verify the production Vercel deployment remains tied to the approved candidate content, run the repository's production SEO/link verification, and run the browser smoke against `https://dawnai.org`.
+
+- [ ] **Step 6: Record final evidence**
+
+Report the merged fix PR and SHA, exact release run ID, npm version/provenance results, smoke/audit conclusions, GitHub Release URL, Vercel deployment evidence, and production browser result.
+

--- a/docs/superpowers/plans/2026-08-31-release-repository-id-recovery.md
+++ b/docs/superpowers/plans/2026-08-31-release-repository-id-recovery.md
@@ -15,6 +15,10 @@
 **Files:**
 - Modify: `scripts/release/test/workflow-contracts.test.mjs`
 - Modify: `.github/workflows/release.yml`
+- Modify: `scripts/release/test/fixtures/release-workflow-disabled.yml`
+- Modify: `scripts/release/test/fixtures/release-workflow-protected.yml`
+- Modify: `scripts/release/test/fixtures/workflow-entrypoints.json`
+- Modify: `scripts/release/abandonment-workflow-policy.json`
 
 - [ ] **Step 1: Write the failing workflow-contract assertion**
 
@@ -49,6 +53,10 @@ env:
 
 Do not modify the GitHub adapter, accept arbitrary repository-ID URLs, or add a fallback value.
 
+Apply the identical workflow change to both reviewed abandonment fixtures,
+refresh their exact canonical policy digests, and add the resulting top-level
+`env` descriptor to the audited workflow-entrypoint fixture.
+
 - [ ] **Step 4: Run the focused test and verify it passes**
 
 Run the Step 2 command again.
@@ -73,7 +81,12 @@ Expected: all pass.
 - [ ] **Step 6: Commit the implementation**
 
 ```bash
-git add .github/workflows/release.yml scripts/release/test/workflow-contracts.test.mjs
+git add .github/workflows/release.yml \
+  scripts/release/test/workflow-contracts.test.mjs \
+  scripts/release/test/fixtures/release-workflow-disabled.yml \
+  scripts/release/test/fixtures/release-workflow-protected.yml \
+  scripts/release/abandonment-workflow-policy.json \
+  scripts/release/test/fixtures/workflow-entrypoints.json
 git commit -m "fix(release): bind repository id explicitly"
 ```
 
@@ -213,4 +226,3 @@ Verify the production Vercel deployment remains tied to the approved candidate c
 - [ ] **Step 6: Record final evidence**
 
 Report the merged fix PR and SHA, exact release run ID, npm version/provenance results, smoke/audit conclusions, GitHub Release URL, Vercel deployment evidence, and production browser result.
-

--- a/docs/superpowers/specs/2026-08-31-release-repository-id-recovery-design.md
+++ b/docs/superpowers/specs/2026-08-31-release-repository-id-recovery-design.md
@@ -1,0 +1,105 @@
+# Release Repository-ID Recovery Design
+
+## Context
+
+The v0.8.22 provenance release reached the `escrow` job and stopped before any
+GitHub Release or npm mutation. GitHub's Releases endpoint returned its next
+page in canonical repository-ID form:
+
+```text
+/repositories/1210070282/releases?per_page=100&page=2
+```
+
+The release reader already accepts that form when initialized with the exact
+repository ID. The job did not provide `GITHUB_REPOSITORY_ID` to the CLI, so
+the reader correctly rejected the otherwise valid next-page URL as
+`UNSAFE_PAGINATION_URL`.
+
+The v0.8.22 tag and candidate commit are immutable. Its tagged workflow cannot
+consume a workflow-only fix merged later on `main` for downstream jobs that
+checkout the exact candidate.
+
+## Decision
+
+Keep strict pagination validation and explicitly bind the trusted GitHub
+Actions `github.repository_id` context into the release controller's
+environment. Do not loosen URL validation, add an override, or special-case an
+error string.
+
+For the already-tagged v0.8.22 candidate, use the existing release CLI with:
+
+- the exact candidate, release record, payload, attestation set, and bundles
+  downloaded by immutable artifact ID from the failed tagged run;
+- the authenticated GitHub and npm adapters;
+- the exact repository ID returned by GitHub for `cacheplane/dawnai`;
+- the existing writer and attestation verifier without bypasses or mocks.
+
+This one-time CLI execution performs only the `escrow` transition. npm
+publication, provenance publication, smoke lanes, audit, and final Release
+publication remain owned by the tagged GitHub Actions workflow.
+
+## Alternatives Rejected
+
+### Trust any repository-ID pagination path
+
+Following any `/repositories/<id>/...` link from GitHub would remove the
+runtime dependency on a known ID, but it weakens the existing repository
+identity check. The exact repository ID is available from the Actions context,
+so relaxing this boundary is unnecessary.
+
+### Replace enumeration with the exact-tag Release endpoint
+
+An exact-tag lookup is efficient, but the current reader intentionally treats
+HTTP 404 as ambiguous because absence and hidden resources cannot be
+distinguished generally. Changing those semantics expands the security design
+well beyond this production failure.
+
+### Move or recreate the v0.8.22 tag
+
+Changing the tag target would invalidate the approved candidate identity and
+its existing CI and provenance evidence. The tag remains untouched.
+
+## Permanent Workflow Change
+
+Every release-controller CLI step that may construct the production GitHub
+reader will receive:
+
+```yaml
+env:
+  GITHUB_REPOSITORY_ID: ${{ github.repository_id }}
+```
+
+The CLI continues to validate the value as a positive decimal ID and continues
+to require the pagination suffix to match the original repository endpoint.
+No adapter behavior changes.
+
+Workflow contract tests will prove that the repository ID is explicitly wired
+into all relevant release entrypoints, preventing a future runner-environment
+change from silently removing it.
+
+## Recovery Flow
+
+1. Reconfirm that v0.8.22 is absent from npm and that no `v0.8.22` GitHub
+   Release exists.
+2. Run a guarded dry diagnostic with the real readers and attestation verifier
+   and a writer that stops before mutation.
+3. Run the existing `escrow` CLI once with the production writer and exact
+   repository ID.
+4. Verify the draft Release marker and exact asset inventory independently
+   through read-only API calls.
+5. Dispatch the exact tagged workflow for v0.8.22 reconciliation.
+6. Observe npm publication, all published-artifact smoke lanes, independent
+   audit, and final Release publication to completion.
+7. Verify exact npm versions, provenance, GitHub Release identity/assets,
+   production documentation, and the production browser smoke.
+
+If any check is ambiguous, stop before the next mutation. The controller's
+existing idempotency and compare-and-swap checks remain authoritative.
+
+## Verification
+
+The permanent change must pass focused workflow-contract tests, release
+controller tests, lint, and the repository Definition of Done. The recovery
+must preserve evidence from the exact candidate SHA
+`2a80deece2ff958fe7fde8fddeb4f99bed70a1c8` and tag `v0.8.22`.
+

--- a/scripts/release/abandonment-workflow-policy.json
+++ b/scripts/release/abandonment-workflow-policy.json
@@ -5,12 +5,12 @@
     {
       "id": "disabled-2026-08-28",
       "mode": "disabled",
-      "canonicalSha256": "5977a3ee83fa9469b4117baf33aee736193777f032742ad59daaa8077b7cde61"
+      "canonicalSha256": "4c4a666d03964c4d3e9f76eb2753b5e2728827d80eb7185c59501894deecc448"
     },
     {
       "id": "protected-2026-08-28",
       "mode": "protected",
-      "canonicalSha256": "1df78b4af9b824883bd70d0d41e2029aa3eafeae6b4d9c7e03536dc3628d1abf"
+      "canonicalSha256": "ffc8fc51bfd0e430967e33d93633b83da5bb229b051fa165426062bdc94249de"
     }
   ]
 }

--- a/scripts/release/test/fixtures/release-workflow-disabled.yml
+++ b/scripts/release/test/fixtures/release-workflow-disabled.yml
@@ -29,6 +29,9 @@ concurrency:
   queue: max
   cancel-in-progress: false
 
+env:
+  GITHUB_REPOSITORY_ID: ${{ github.repository_id }}
+
 permissions:
   contents: read
 

--- a/scripts/release/test/fixtures/release-workflow-protected.yml
+++ b/scripts/release/test/fixtures/release-workflow-protected.yml
@@ -34,6 +34,9 @@ concurrency:
   queue: max
   cancel-in-progress: false
 
+env:
+  GITHUB_REPOSITORY_ID: ${{ github.repository_id }}
+
 permissions:
   contents: read
 

--- a/scripts/release/test/fixtures/workflow-entrypoints.json
+++ b/scripts/release/test/fixtures/workflow-entrypoints.json
@@ -2077,6 +2077,9 @@
           "group": "dawn-release-controller",
           "queue": "max"
         },
+        "env": {
+          "GITHUB_REPOSITORY_ID": "${{ github.repository_id }}"
+        },
         "name": "Release",
         "on": {
           "push": {

--- a/scripts/release/test/workflow-contracts.test.mjs
+++ b/scripts/release/test/workflow-contracts.test.mjs
@@ -167,6 +167,9 @@ test("version-pr.yml is version-only and uses only RELEASE_GITHUB_TOKEN", async 
 
 test("release.yml has exact triggers and one repository-global non-cancelling queue", async () => {
   const { workflow } = await readRequiredWorkflow("release.yml")
+  assert.deepEqual(workflow.env, {
+    GITHUB_REPOSITORY_ID: workflowExpression("github.repository_id"),
+  })
   assert.deepEqual(Object.keys(workflow.on).sort(), ["push", "schedule", "workflow_dispatch"])
   assert.deepEqual(workflow.on.push, { branches: ["main"] })
   assert.ok(Array.isArray(workflow.on.schedule) && workflow.on.schedule.length === 1)


### PR DESCRIPTION
## Summary

- bind the exact GitHub repository ID into every release-controller job through the workflow environment
- preserve strict repository-ID pagination validation without adapter fallbacks or error-string matching
- refresh the reviewed workflow fixtures, canonical abandonment policy digests, and audited workflow descriptor
- document the v0.8.22 recovery design and implementation plan

## Root cause

GitHub canonicalized Releases pagination from the owner/name route to the repository-ID route. The reader already validates and supports that route when initialized with the repository ID, but the tagged escrow job did not receive the ID and failed closed with UNSAFE_PAGINATION_URL before any mutation.

## Verification

- focused regression red then green
- workflow and abandonment security suites: 81/81
- release controller: 1314/1314
- source tests: 4791 passed, 216 skipped
- lint, build, typecheck, release inventory, chart sync, docs, pack check, TypeScript tooling packed-consumer smoke, framework harness, runtime harness, and smoke harness passed
- shared-host timing and dev-server restart races were reproduced only under concurrent harness load and passed on isolated rerun

## Release recovery

The immutable v0.8.22 candidate remains unchanged. After this fix merges, the existing CLI will escrow the already-attested candidate once with the exact repository ID; npm trusted publication, published-artifact smokes, independent audit, and final Release publication remain in GitHub Actions.