### PR TITLE
Fix immutable draft release identity and align CopilotKit v2

### DIFF
--- a/.changeset/calm-cats-align.md
+++ b/.changeset/calm-cats-align.md
@@ -1,0 +1,7 @@
+---
+"@dawn-ai/ag-ui": patch
+"@dawn-ai/cli": patch
+"@dawn-ai/devkit": patch
+---
+
+Align the CopilotKit v2 examples, research scaffold, and Dawn AG-UI runtime on CopilotKit 1.70 and AG-UI 0.0.59.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -560,12 +560,15 @@ jobs:
             scripts/release/artifact-store.mjs
             scripts/release/limits.mjs
             scripts/release/manifest.mjs
+            scripts/release/metadata.mjs
             scripts/release/npm-audit.mjs
             scripts/release/npm-evidence.mjs
             scripts/release/process-runner.mjs
             scripts/release/publisher.mjs
             scripts/release/release-record.mjs
             scripts/release/semver.mjs
+            scripts/release/smoke-result.mjs
+            scripts/release/terminal-records.mjs
             scripts/release/topology.mjs
 
       - name: Setup Node.js

--- a/docs/superpowers/plans/2026-08-31-immutable-draft-release-identity.md
+++ b/docs/superpowers/plans/2026-08-31-immutable-draft-release-identity.md
@@ -1,0 +1,429 @@
+# Immutable Draft Release Identity Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make Dawn's release controller safely reconcile GitHub drafts whose temporary `tag_name` is not the requested release tag, then bind and verify the exact tag during immutable publication.
+
+**Architecture:** Add one canonical marker-backed draft selector beside `parseReleaseMarker`, and use it only in paths that may observe mutable managed drafts. Split the GitHub writer's draft and published identity assertions so draft mutations rely on Release ID, canonical metadata, and independent annotated-tag verification, while publication explicitly sends and then re-verifies the exact tag. Published-release consumers retain exact `tag_name` matching.
+
+**Tech Stack:** Node.js 24, ESM JavaScript, `node:test`, GitHub REST API adapters, canonical Dawn release markers, pnpm 10.
+
+---
+
+## File Map
+
+- `scripts/release/metadata.mjs`: owns canonical marker parsing, marker-backed draft selection, escrow discovery, and mutable draft validation.
+- `scripts/release/adapters/github-write.mjs`: owns GitHub mutation boundaries, distinct draft/published identity assertions, creation race reconciliation, and explicit publication tag binding.
+- `scripts/release/observe.mjs`: production observation of marker-backed pre-publication drafts.
+- `scripts/release/candidate.mjs`: active managed-candidate discovery from marker-backed drafts.
+- `scripts/release/audit.mjs`: audit transitions that operate on a mutable draft.
+- `scripts/release/independent-audit.mjs`: independent audit verification of the managed draft before final publication.
+- `scripts/release/independent-audit-coordinator.mjs`: selection of the marker-backed draft for exact-tag and default-branch audit runs.
+- `scripts/release/artifact-store.mjs`: release-side attestation resolution while the Release remains a draft.
+- `scripts/release/abandonment.mjs`: fail-closed discovery and validation of a prepublication candidate draft.
+- `scripts/release/abandonment-handoff.mjs`: recovery-context discovery of a marker-backed draft.
+- `scripts/release/test/*.test.mjs`: focused regression tests for each affected boundary.
+- `scripts/release/test/support/release-rehearsal-github.mjs`: realistic fake GitHub behavior that gives drafts temporary tag identities and binds the requested tag at publication.
+
+### Task 1: Define canonical marker-backed draft selection
+
+**Files:**
+- Modify: `scripts/release/metadata.mjs`
+- Modify: `scripts/release/test/metadata.test.mjs`
+
+- [ ] **Step 1: Write failing discovery and ambiguity tests**
+
+Add a test fixture whose Release has:
+
+```js
+{
+  id: 7,
+  tag_name: "untagged-opaque",
+  target_commitish: "main",
+  name: `Dawn v${VERSION}`,
+  body: canonicalReleaseBody({ marker, manifest }),
+  draft: true,
+  prerelease: false,
+  immutable: false,
+}
+```
+
+Assert that escrow resumes this exact `ATTACHING` draft instead of calling
+`createDraftRelease`. Add a second marker-bearing draft and assert the operation
+fails with the existing duplicate-managed-Release ambiguity before mutation.
+
+- [ ] **Step 2: Run the focused test and verify RED**
+
+Run:
+
+```bash
+PATH=/Users/blove/.nvm/versions/node/v24.19.0/bin:$PATH node --test --test-name-pattern='temporary tag|duplicate managed Releases' scripts/release/test/metadata.test.mjs
+```
+
+Expected: FAIL because `findManagedRelease` only compares `tag_name`.
+
+- [ ] **Step 3: Add the canonical selector**
+
+Export a small predicate beside `parseReleaseMarker`:
+
+```js
+export function isManagedReleaseForTag(release, tag) {
+  if (!isRecord(release) || typeof release.tag_name !== "string") return false
+  if (release.tag_name === tag) return true
+  if (
+    release.draft !== true ||
+    release.immutable !== false ||
+    typeof release.body !== "string"
+  ) {
+    return false
+  }
+  try {
+    return parseReleaseMarker(release.body).tag === tag
+  } catch {
+    return false
+  }
+}
+```
+
+Use it in `findManagedRelease`. Remove `tag_name` from
+`assertMutableCandidateRelease`; continue requiring the exact title,
+`target_commitish`, prerelease state, body, draft state, immutable state, marker,
+and independently verified annotated tag.
+
+- [ ] **Step 4: Run the focused metadata tests and verify GREEN**
+
+Run:
+
+```bash
+PATH=/Users/blove/.nvm/versions/node/v24.19.0/bin:$PATH node --test scripts/release/test/metadata.test.mjs
+```
+
+Expected: all metadata tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/release/metadata.mjs scripts/release/test/metadata.test.mjs
+git commit -m "fix(release): identify drafts by canonical marker"
+```
+
+### Task 2: Separate GitHub draft identity from published tag identity
+
+**Files:**
+- Modify: `scripts/release/adapters/github-write.mjs`
+- Modify: `scripts/release/test/github-write.test.mjs`
+
+- [ ] **Step 1: Write failing writer tests**
+
+Cover three behaviors:
+
+1. POST creates a draft whose subsequent GET reports a temporary `tag_name`, and
+   creation still returns the created Release ID.
+2. Update and asset upload accept that same mutable draft while annotated-tag
+   verification remains before and after the mutation.
+3. Publication PATCH contains both fields and the immutable re-read must expose
+   the exact requested tag:
+
+```js
+assert.deepEqual(JSON.parse(publishRequest.body), {
+  tag_name: TAG,
+  draft: false,
+})
+```
+
+Also assert an immutable re-read with a temporary tag fails.
+
+- [ ] **Step 2: Run the writer tests and verify RED**
+
+Run:
+
+```bash
+PATH=/Users/blove/.nvm/versions/node/v24.19.0/bin:$PATH node --test scripts/release/test/github-write.test.mjs
+```
+
+Expected: FAIL at `assertReleaseIdentity` and because publication omits
+`tag_name`.
+
+- [ ] **Step 3: Implement distinct assertions and draft discovery**
+
+Refactor to these responsibilities:
+
+```js
+function assertReleaseMetadata(release, args) {
+  if (
+    positiveId(release.id, "Release ID") !==
+      positiveId(args.releaseId ?? release.id, "Release ID") ||
+    release.target_commitish !== "main" ||
+    release.prerelease !== false ||
+    typeof release.tag_name !== "string" ||
+    typeof release.name !== "string" ||
+    typeof release.body !== "string" ||
+    typeof release.draft !== "boolean" ||
+    typeof release.immutable !== "boolean"
+  ) {
+    throw new Error("GitHub Release identity or metadata is malformed")
+  }
+}
+
+function assertDraftIdentity(release, args, expected = {}) {
+  assertReleaseMetadata(release, args)
+  if (release.draft !== true || release.immutable !== false) {
+    throw new Error("GitHub Release is not the expected mutable draft")
+  }
+  // Retain exact title/body compare-and-swap checks.
+}
+
+function assertPublishedIdentity(release, args) {
+  assertReleaseMetadata(release, args)
+  if (release.tag_name !== args.tag || release.draft !== false || release.immutable !== true) {
+    throw new Error("GitHub published Release identity is malformed")
+  }
+}
+```
+
+For creation/race discovery, accept an exact tag match or a mutable draft with
+the exact requested title and canonical body. Preserve duplicate ambiguity.
+Change publication to:
+
+```js
+body: { tag_name: args.tag, draft: false }
+```
+
+Use `assertDraftIdentity` before publication and
+`assertPublishedIdentity` after publication or for an existing published
+Release.
+
+- [ ] **Step 4: Run writer tests and verify GREEN**
+
+Run:
+
+```bash
+PATH=/Users/blove/.nvm/versions/node/v24.19.0/bin:$PATH node --test scripts/release/test/github-write.test.mjs
+```
+
+Expected: all writer tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/release/adapters/github-write.mjs scripts/release/test/github-write.test.mjs
+git commit -m "fix(release): bind draft tag at publication"
+```
+
+### Task 3: Migrate every prepublication reader to marker-backed selection
+
+**Files:**
+- Modify: `scripts/release/observe.mjs`
+- Modify: `scripts/release/candidate.mjs`
+- Modify: `scripts/release/audit.mjs`
+- Modify: `scripts/release/independent-audit.mjs`
+- Modify: `scripts/release/independent-audit-coordinator.mjs`
+- Modify: `scripts/release/artifact-store.mjs`
+- Modify: `scripts/release/abandonment.mjs`
+- Modify: `scripts/release/abandonment-handoff.mjs`
+- Modify: corresponding files under `scripts/release/test/`
+
+- [ ] **Step 1: Add failing temporary-draft tests at each selection boundary**
+
+In each existing fixture, change the managed prepublication Release from
+`tag_name: v<version>` to `tag_name: "untagged-opaque"` while retaining its
+canonical marker. Assert the same candidate, escrow, audit, or abandonment
+result is selected. Add one malformed-marker case and one duplicate-marker case
+to prove unrelated temporary drafts are ignored and conflicts fail closed.
+
+Do not change fixtures for paths that explicitly require a published Release;
+those must continue to use `tag_name: v<version>`.
+
+- [ ] **Step 2: Run affected tests and verify RED**
+
+Run:
+
+```bash
+PATH=/Users/blove/.nvm/versions/node/v24.19.0/bin:$PATH node --test \
+  scripts/release/test/observe-production.test.mjs \
+  scripts/release/test/candidate.test.mjs \
+  scripts/release/test/audit.test.mjs \
+  scripts/release/test/independent-audit.test.mjs \
+  scripts/release/test/independent-audit-coordinator.test.mjs \
+  scripts/release/test/artifact-store.test.mjs \
+  scripts/release/test/abandonment.test.mjs \
+  scripts/release/test/abandonment-handoff.test.mjs
+```
+
+Expected: failures where exact `tag_name` filters miss the managed draft.
+
+- [ ] **Step 3: Use the shared selector only for mutable managed state**
+
+Import `isManagedReleaseForTag` from `metadata.mjs` and replace exact filters in
+prepublication discovery:
+
+```js
+const matches = releases.filter((release) => isManagedReleaseForTag(release, tag))
+```
+
+Remove `tag_name` equality from validators that have already selected a mutable
+draft by its exact canonical marker; retain their title, commit, phase, body,
+asset, and annotated-tag checks. Retain explicit
+`release.tag_name === tag` checks in final publication, immutable-release
+verification, release-integrity audit results, and any other path whose
+contract requires a published Release.
+
+- [ ] **Step 4: Run the affected test set and verify GREEN**
+
+Run the command from Step 2.
+
+Expected: all affected tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/release/observe.mjs scripts/release/candidate.mjs \
+  scripts/release/audit.mjs scripts/release/independent-audit.mjs \
+  scripts/release/independent-audit-coordinator.mjs \
+  scripts/release/artifact-store.mjs scripts/release/abandonment.mjs \
+  scripts/release/abandonment-handoff.mjs scripts/release/test
+git commit -m "fix(release): observe marker-backed drafts"
+```
+
+### Task 4: Make the full release rehearsal reproduce GitHub semantics
+
+**Files:**
+- Modify: `scripts/release/test/support/release-rehearsal-github.mjs`
+- Modify: `scripts/release/test/support/release-rehearsal.mjs`
+- Modify: `scripts/release/test/rehearsal.test.mjs`
+- Modify: `scripts/release/test/rehearsal-controller.test.mjs`
+
+- [ ] **Step 1: Change the fake to expose temporary draft identity**
+
+Make draft creation store an opaque temporary `tag_name` while preserving the
+requested tag separately inside the fake's expected publication state. On the
+publication PATCH, require `tag_name` and assign it to the Release before
+returning `draft: false, immutable: true`.
+
+- [ ] **Step 2: Run the rehearsal and verify RED**
+
+Run the owning test file found by:
+
+```bash
+rg -l 'release-rehearsal-github' scripts/release/test
+```
+
+Expected: FAIL until all release phases use marker-backed draft discovery and
+publication binds the tag.
+
+- [ ] **Step 3: Complete the fake and assertions**
+
+Assert the rehearsal crosses:
+
+```text
+ATTACHING -> ESCROWED -> NPM_COMPLETE -> SMOKES_COMPLETE
+-> AUDIT_DISPATCHED -> AUDIT_VERIFIED -> immutable publication
+```
+
+with a temporary tag throughout the draft phases and the exact tag only after
+publication.
+
+- [ ] **Step 4: Run the rehearsal and verify GREEN**
+
+Run the owning test plus `github-write.test.mjs` and `metadata.test.mjs`.
+
+Expected: all pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/release/test/support/release-rehearsal-github.mjs scripts/release/test
+git commit -m "test(release): rehearse temporary draft identity"
+```
+
+### Task 5: Validate, review, and merge the permanent fix
+
+**Files:**
+- Modify only files needed to fix failures attributable to this change.
+
+- [ ] **Step 1: Run focused and full controller verification**
+
+```bash
+PATH=/Users/blove/.nvm/versions/node/v24.19.0/bin:$PATH pnpm lint
+PATH=/Users/blove/.nvm/versions/node/v24.19.0/bin:$PATH pnpm test:release-controller
+```
+
+Expected: lint exits 0 and all release-controller tests pass.
+
+- [ ] **Step 2: Run the repository Definition of Done**
+
+```bash
+DAWN_REQUIRE_DOCKER=1 PATH=/Users/blove/.nvm/versions/node/v24.19.0/bin:$PATH pnpm ci:validate
+```
+
+Expected: all AGENTS.md gates pass. If a loaded concurrent harness produces a
+transport-only failure, repeat only that exact harness in isolation and retain
+both outputs as evidence.
+
+- [ ] **Step 3: Push and open the PR**
+
+Push `blove/fix-immutable-draft-identity`, open a PR describing the live
+GitHub behavior and safe partial-draft recovery, and require exact-head CI.
+
+- [ ] **Step 4: Request GitHub Copilot review**
+
+Request Copilot on the exact PR head. Resolve technically valid feedback with
+`superpowers:receiving-code-review`; do not add an independent human/agent
+reviewer because the user waived it.
+
+- [ ] **Step 5: Merge only the exact reviewed head**
+
+Require all substantive checks, the real Vercel lanes, and Copilot review.
+Treat the known no-credit reviewer lane as waived. Merge with
+`--match-head-commit` and verify the exact head is an ancestor of `origin/main`.
+
+### Task 6: Converge v0.8.22 and complete provenance publication
+
+**Files:**
+- No source changes expected.
+- Existing recovery inputs: `/tmp/dawn-escrow-diagnose.f0sK9L/`
+- Existing draft: GitHub Release ID `379991871`
+
+- [ ] **Step 1: Re-run read-only preconditions**
+
+Verify the annotated tag object still peels to
+`2a80deece2ff958fe7fde8fddeb4f99bed70a1c8`, Release `379991871` is a mutable
+`ATTACHING` draft with exactly 45 assets, all v0.8.22 npm versions remain absent,
+and no publish job has started.
+
+- [ ] **Step 2: Run the fixed escrow CLI**
+
+```bash
+GITHUB_TOKEN="$(gh auth token)" \
+GITHUB_REPOSITORY=cacheplane/dawnai \
+GITHUB_REPOSITORY_ID=1210070282 \
+PATH=/Users/blove/.nvm/versions/node/v24.19.0/bin:$PATH \
+node scripts/release/cli.mjs escrow \
+  --candidate /tmp/dawn-escrow-diagnose.f0sK9L/runtime/candidate.json \
+  --record /tmp/dawn-escrow-diagnose.f0sK9L/runtime/release-record.json \
+  --artifact-dir /tmp/dawn-escrow-diagnose.f0sK9L/runtime/payload \
+  --attestation-set /tmp/dawn-escrow-diagnose.f0sK9L/attestation/attestation-set.json \
+  --attestation-bundles-dir /tmp/dawn-escrow-diagnose.f0sK9L/attestation/bundles
+```
+
+Expected: exit 0; the existing draft remains Release `379991871`, retains the
+exact 45 assets, and advances to `ESCROWED` without replacing assets.
+
+- [ ] **Step 3: Dispatch the exact tagged reconciliation workflow**
+
+Dispatch `.github/workflows/release.yml` at `v0.8.22` with version `0.8.22`,
+candidate commit `2a80deece2ff958fe7fde8fddeb4f99bed70a1c8`, and operation `reconcile`.
+Observe the exact run rather than retrying generically on failure.
+
+- [ ] **Step 4: Verify each irreversible boundary**
+
+Confirm npm trusted publishing produces provenance for all 21 packages, smoke
+receipts cover every required lane, the independent audit succeeds, the GitHub
+Release publishes with exact tag `v0.8.22` and `immutable: true`, and no asset or
+marker drift occurs.
+
+- [ ] **Step 5: Run full production smoke verification**
+
+Verify package installation, scaffolding, runtime targets, storage, metadata,
+CopilotKit v2 examples, the real Vercel deployment, dawnai.org production
+content, SEO URLs, and browser smoke. Report exact run/deployment/release IDs.

--- a/docs/superpowers/specs/2026-08-31-immutable-draft-release-identity-design.md
+++ b/docs/superpowers/specs/2026-08-31-immutable-draft-release-identity-design.md
@@ -1,0 +1,132 @@
+# Immutable Draft Release Identity Design
+
+## Problem
+
+Dawn's release controller assumes that a GitHub draft Release created for
+`v<version>` will continue to report that value in `tag_name`. GitHub does not
+provide that invariant. A draft can be represented by a temporary
+`untagged-<opaque>` identity until publication, including when the requested
+annotated tag already exists. The v0.8.22 recovery demonstrated the behavior:
+GitHub accepted the draft, all 45 base assets converged, and a later re-read
+reported the temporary tag identity. The controller rejected the otherwise
+valid draft and intentionally left its marker at `ATTACHING`.
+
+The requested release tag remains an independently verifiable annotated Git
+object throughout this process. The problem is the controller treating the
+draft Release's temporary `tag_name` as that tag's identity.
+
+## Goals
+
+- Model GitHub drafts without depending on an opaque temporary tag name.
+- Preserve exact annotated-tag verification before and after every mutation.
+- Reconcile the existing v0.8.22 `ATTACHING` draft without recreating or
+  replacing its 45 assets.
+- Bind the exact requested tag during publication and require exact tag
+  identity on the immutable published Release.
+- Keep duplicate or conflicting drafts fail-closed.
+
+## Non-goals
+
+- Matching or interpreting GitHub's `untagged-*` naming convention.
+- Disabling GitHub release immutability.
+- Adding compatibility overrides, retries based on error strings, or a
+  v0.8.22-only recovery path.
+- Weakening artifact, provenance, publication-history, or npm checks.
+
+## Identity Model
+
+### Mutable draft
+
+A managed mutable draft is identified by:
+
+1. its positive GitHub Release ID;
+2. `draft: true` and `immutable: false`;
+3. the canonical Dawn release marker embedded in its body, whose exact tag,
+   version, candidate commit, phase, and digests match the candidate;
+4. the expected title, `target_commitish`, and prerelease state; and
+5. an independently verified annotated Git ref whose tag object peels to the
+   exact candidate commit.
+
+The draft's `tag_name` remains validated as data but is not an identity field.
+The controller does not inspect, match, or persist GitHub's temporary value.
+
+Draft discovery accepts either a published-style exact `tag_name` match or a
+draft whose canonical marker names the exact requested tag. More than one
+matching Release is ambiguous and blocks all mutation.
+
+### Published Release
+
+Publication sends the exact requested `tag_name` together with `draft: false`.
+After GitHub publishes the Release, the controller requires:
+
+- `tag_name` equals `v<version>` exactly;
+- `draft: false` and `immutable: true`;
+- the Release ID, title, body, and asset set are unchanged; and
+- the annotated tag still peels to the candidate commit.
+
+Published Releases continue to use exact tag identity in observers, audit
+coordination, and final verification.
+
+## Component Changes
+
+### GitHub writer boundary
+
+Split draft and published identity assertions. Draft reads require stable
+Release metadata but do not equate `tag_name` with the requested tag. Published
+reads retain that exact check. Draft creation and race reconciliation discover
+an existing draft by the exact canonical body and title as well as by an exact
+published tag match. Publication explicitly includes `tag_name` in the PATCH.
+
+### Release metadata controller
+
+Discover managed drafts by parsing their canonical marker. Ignore unrelated or
+unparseable drafts, but treat multiple candidate matches as ambiguous. The
+existing marker and asset validation remains authoritative after discovery.
+
+### Production observation and release phases
+
+Any path that must observe a pre-publication managed Release selects a draft by
+its canonical marker rather than by temporary `tag_name`. Paths that require a
+published Release continue to require the exact tag. This distinction applies
+to escrow, npm reconciliation, smoke reconciliation, audit coordination,
+abandonment safety, and production observation.
+
+## Recovery Flow
+
+After the fix is merged, the controller re-runs escrow against Release
+`379991871`. It discovers the draft from the exact v0.8.22 marker, re-reads and
+verifies all 45 existing assets, and advances the marker from `ATTACHING` to
+`ESCROWED`. No asset is replaced and no draft is recreated. The tagged
+provenance workflow can then continue npm trusted publishing, release smokes,
+independent audit, and final immutable publication.
+
+## Error Handling
+
+- Missing, malformed, or conflicting markers block mutation.
+- Duplicate candidate drafts or a draft plus a conflicting published Release
+  block mutation.
+- An annotated tag that is missing, lightweight, moved, or peels to another
+  commit blocks mutation.
+- Publication that does not bind the exact tag or become immutable is rejected
+  on re-read.
+- Existing compare-and-swap checks for body and asset digests remain unchanged.
+
+## Testing
+
+Regression tests must fail against the current implementation and cover:
+
+- creation re-reads where GitHub changes a draft's `tag_name` to an opaque
+  temporary value;
+- convergence of an existing `ATTACHING` draft discovered by marker;
+- duplicate marker-bearing drafts failing closed;
+- update and asset upload operations accepting only the marker-authorized
+  mutable draft;
+- publication sending the exact tag and requiring it on the immutable re-read;
+- production observation and each pre-publication phase finding marker-backed
+  drafts while published-release paths retain exact tag checks; and
+- unchanged rejection of moved tags, malformed markers, conflicting metadata,
+  and non-immutable publication.
+
+Focused release-controller tests run first, followed by lint, the full release
+controller suite, and the repository Definition of Done. GitHub Copilot reviews
+the exact PR head before merge.

--- a/examples/chat/web/app/page.tsx
+++ b/examples/chat/web/app/page.tsx
@@ -4,7 +4,7 @@ import { dawnActivityRenderers } from "@dawn-ai/ag-ui/react"
 import { DemoSuggestions } from "./components/DemoSuggestions"
 import { PermissionInterrupt } from "./components/PermissionInterrupt"
 
-// Notes (verified against installed @copilotkit/react-core@1.68.3 types):
+// Notes (verified against installed @copilotkit/react-core@1.70.0 types):
 // - Use the `CopilotKit` wrapper (not bare `CopilotKitProvider`) per CopilotKit's own v2
 //   guidance: it adds the error boundary, toasts, and threads provider around the context.
 //   Its props are a superset of CopilotKitProviderProps (so `runtimeUrl` applies).

--- a/examples/chat/web/package.json
+++ b/examples/chat/web/package.json
@@ -12,9 +12,9 @@
     "typecheck": "tsc -p . --noEmit"
   },
   "dependencies": {
-    "@ag-ui/client": "0.0.57",
-    "@copilotkit/react-core": "^1.68.3",
-    "@copilotkit/runtime": "^1.68.3",
+    "@ag-ui/client": "0.0.59",
+    "@copilotkit/react-core": "^1.70.0",
+    "@copilotkit/runtime": "^1.70.0",
     "@dawn-ai/ag-ui": "workspace:*",
     "next": "16.3.0",
     "react": "19.2.8",

--- a/examples/research/web/app/components/AppShell.tsx
+++ b/examples/research/web/app/components/AppShell.tsx
@@ -376,7 +376,7 @@ export function AppShell({
   // like it would apply and does not. `copilotkit.connectAgent()` asks the
   // runtime to replay a thread's historic events, but the only two callers of
   // it live inside `<CopilotChat>`, which this app does not mount, and
-  // `useAgent`'s own thread effect does exactly one thing in 1.68.3:
+  // `useAgent`'s own thread effect does exactly one thing in 1.70.0:
   // `agent.threadId = resolvedThreadId`. Verified live: switching away from a
   // three-message thread and back leaves it empty and fires no network request
   // at all. The server holds that history and this client has to ask for it

--- a/examples/research/web/app/components/MemoryPanel.test.tsx
+++ b/examples/research/web/app/components/MemoryPanel.test.tsx
@@ -528,7 +528,7 @@ describe("memory panel container", () => {
  * - the proxy route itself. Which paths are legal is `proxy-allowlist.test.ts`,
  *   and what the Dawn server does with an approve is `@dawn-ai/memory`'s.
  * - the real `AgentSubscriber` contract. The fake agent's `subscribe` accepts
- *   an `onRunFinishedEvent` because `@ag-ui/client@0.0.57` defines one; that
+ *   an `onRunFinishedEvent` because `@ag-ui/client@0.0.59` defines one; that
  *   the installed client actually calls it is a typecheck-and-live-run fact,
  *   not something these tests observe.
  * - anything visual. Whether three clamped candidates plus the thread list fit

--- a/examples/research/web/app/components/MemoryPanel.tsx
+++ b/examples/research/web/app/components/MemoryPanel.tsx
@@ -298,7 +298,7 @@ function readApproveOutcome(body: unknown): string | null {
  * one because `remember()` lands during a run, so a memory proposed in the
  * answer you are reading should be reviewable without a reload.
  * `onRunFinishedEvent` is a distinct `AgentSubscriber` callback in the
- * installed `@ag-ui/client@0.0.57`, and a finished run is the first moment the
+ * installed `@ag-ui/client@0.0.59`, and a finished run is the first moment the
  * write is certainly in the store.
  */
 export function MemoryPanel() {

--- a/examples/research/web/app/components/ToolCallCard.tsx
+++ b/examples/research/web/app/components/ToolCallCard.tsx
@@ -1,7 +1,7 @@
 "use client"
 import { useRenderTool } from "@copilotkit/react-core/v2"
 
-// CopilotKit 1.68.3 V2 notes (verified against the installed
+// CopilotKit 1.70.0 V2 notes (verified against the installed
 // @copilotkit/react-core types under
 // node_modules/@copilotkit/react-core/dist; the bundled `.d.mts` filenames
 // carry content hashes that change between releases, so none is cited here):
@@ -13,7 +13,7 @@ import { useRenderTool } from "@copilotkit/react-core/v2"
 // - Wildcard registration: pass `{ name: "*", render, agentId? }` — the "*"
 //   renderer is the fallback when no exact tool-name renderer is registered.
 // - The public wildcard overload currently types `render` props as `any`; it
-//   does not statically enforce field names or status values. The 1.68.3 V2
+//   does not statically enforce field names or status values. The 1.70.0 V2
 //   runtime/default renderer passes
 //   `{ name, toolCallId, parameters, status, result }`, where current status
 //   values are `"inProgress"`, `"executing"`, and `"complete"`, and `result`

--- a/examples/research/web/app/lib/transcript.ts
+++ b/examples/research/web/app/lib/transcript.ts
@@ -8,10 +8,9 @@
  * function is the only way to test them without a live agent.
  *
  * The message shapes are declared structurally rather than imported from
- * `@ag-ui/core`. Two copies of that package are installed — the app depends on
- * `@ag-ui/client@0.0.57`, `@copilotkit/react-core` on its own — and the union
- * below is a supertype of the real one, so `agent.messages` assigns to it
- * whichever copy the hook's types come from. Verified against
+ * `@ag-ui/core`. That keeps this pure transcript module decoupled from the
+ * transport package while the union below remains a supertype of the real
+ * message shape. Verified against
  * `MessageSchema` in `@ag-ui/core`: the seven roles are user, assistant, tool,
  * activity, reasoning, system and developer.
  */

--- a/examples/research/web/app/page.tsx
+++ b/examples/research/web/app/page.tsx
@@ -11,7 +11,7 @@ import {
   type WorkbenchThread,
 } from "./lib/thread-source"
 
-// Notes (verified against installed @copilotkit/react-core@1.68.3 types — see
+// Notes (verified against installed @copilotkit/react-core@1.70.0 types — see
 // examples/chat/web/app/page.tsx for the original investigation):
 // - Use the `CopilotKit` wrapper (not bare `CopilotKitProvider`) per CopilotKit's own v2
 //   guidance: it adds the error boundary, toasts, and threads provider around the context.

--- a/examples/research/web/package.json
+++ b/examples/research/web/package.json
@@ -13,9 +13,9 @@
     "typecheck": "tsc -p . --noEmit"
   },
   "dependencies": {
-    "@ag-ui/client": "0.0.57",
-    "@copilotkit/react-core": "^1.68.3",
-    "@copilotkit/runtime": "^1.68.3",
+    "@ag-ui/client": "0.0.59",
+    "@copilotkit/react-core": "^1.70.0",
+    "@copilotkit/runtime": "^1.70.0",
     "@dawn-ai/ag-ui": "workspace:*",
     "@tailwindcss/postcss": "^4.3.3",
     "next": "16.3.0",

--- a/packages/ag-ui/package.json
+++ b/packages/ag-ui/package.json
@@ -45,8 +45,8 @@
     "typecheck": "tsc --noEmit && tsc -p tsconfig.test.json"
   },
   "dependencies": {
-    "@ag-ui/core": "0.0.57",
-    "@ag-ui/encoder": "0.0.57",
+    "@ag-ui/core": "0.0.59",
+    "@ag-ui/encoder": "0.0.59",
     "zod": "^4.4.3"
   },
   "peerDependencies": {
@@ -62,8 +62,8 @@
     }
   },
   "devDependencies": {
-    "@ag-ui/client": "0.0.57",
-    "@copilotkit/react-core": "^1.68.3",
+    "@ag-ui/client": "0.0.59",
+    "@copilotkit/react-core": "^1.70.0",
     "@dawn-ai/config-typescript": "workspace:*",
     "@types/node": "26.1.2",
     "@types/react": "19.2.18",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -53,7 +53,7 @@
     "typecheck": "tsc -p tsconfig.json"
   },
   "dependencies": {
-    "@ag-ui/core": "0.0.57",
+    "@ag-ui/core": "0.0.59",
     "@dawn-ai/ag-ui": "workspace:*",
     "@dawn-ai/core": "workspace:*",
     "@dawn-ai/langchain": "workspace:*",

--- a/packages/devkit/templates/app-research/web/app/components/AppShell.tsx
+++ b/packages/devkit/templates/app-research/web/app/components/AppShell.tsx
@@ -376,7 +376,7 @@ export function AppShell({
   // like it would apply and does not. `copilotkit.connectAgent()` asks the
   // runtime to replay a thread's historic events, but the only two callers of
   // it live inside `<CopilotChat>`, which this app does not mount, and
-  // `useAgent`'s own thread effect does exactly one thing in 1.68.3:
+  // `useAgent`'s own thread effect does exactly one thing in 1.70.0:
   // `agent.threadId = resolvedThreadId`. Verified live: switching away from a
   // three-message thread and back leaves it empty and fires no network request
   // at all. The server holds that history and this client has to ask for it

--- a/packages/devkit/templates/app-research/web/app/components/MemoryPanel.test.tsx.template
+++ b/packages/devkit/templates/app-research/web/app/components/MemoryPanel.test.tsx.template
@@ -528,7 +528,7 @@ describe("memory panel container", () => {
  * - the proxy route itself. Which paths are legal is `proxy-allowlist.test.ts`,
  *   and what the Dawn server does with an approve is `@dawn-ai/memory`'s.
  * - the real `AgentSubscriber` contract. The fake agent's `subscribe` accepts
- *   an `onRunFinishedEvent` because `@ag-ui/client@0.0.57` defines one; that
+ *   an `onRunFinishedEvent` because `@ag-ui/client@0.0.59` defines one; that
  *   the installed client actually calls it is a typecheck-and-live-run fact,
  *   not something these tests observe.
  * - anything visual. Whether three clamped candidates plus the thread list fit

--- a/packages/devkit/templates/app-research/web/app/components/MemoryPanel.tsx
+++ b/packages/devkit/templates/app-research/web/app/components/MemoryPanel.tsx
@@ -298,7 +298,7 @@ function readApproveOutcome(body: unknown): string | null {
  * one because `remember()` lands during a run, so a memory proposed in the
  * answer you are reading should be reviewable without a reload.
  * `onRunFinishedEvent` is a distinct `AgentSubscriber` callback in the
- * installed `@ag-ui/client@0.0.57`, and a finished run is the first moment the
+ * installed `@ag-ui/client@0.0.59`, and a finished run is the first moment the
  * write is certainly in the store.
  */
 export function MemoryPanel() {

--- a/packages/devkit/templates/app-research/web/app/components/ToolCallCard.tsx
+++ b/packages/devkit/templates/app-research/web/app/components/ToolCallCard.tsx
@@ -1,7 +1,7 @@
 "use client"
 import { useRenderTool } from "@copilotkit/react-core/v2"
 
-// CopilotKit 1.68.3 V2 notes (verified against the installed
+// CopilotKit 1.70.0 V2 notes (verified against the installed
 // @copilotkit/react-core types under
 // node_modules/@copilotkit/react-core/dist; the bundled `.d.mts` filenames
 // carry content hashes that change between releases, so none is cited here):
@@ -13,7 +13,7 @@ import { useRenderTool } from "@copilotkit/react-core/v2"
 // - Wildcard registration: pass `{ name: "*", render, agentId? }` — the "*"
 //   renderer is the fallback when no exact tool-name renderer is registered.
 // - The public wildcard overload currently types `render` props as `any`; it
-//   does not statically enforce field names or status values. The 1.68.3 V2
+//   does not statically enforce field names or status values. The 1.70.0 V2
 //   runtime/default renderer passes
 //   `{ name, toolCallId, parameters, status, result }`, where current status
 //   values are `"inProgress"`, `"executing"`, and `"complete"`, and `result`

--- a/packages/devkit/templates/app-research/web/app/lib/transcript.ts
+++ b/packages/devkit/templates/app-research/web/app/lib/transcript.ts
@@ -8,10 +8,9 @@
  * function is the only way to test them without a live agent.
  *
  * The message shapes are declared structurally rather than imported from
- * `@ag-ui/core`. Two copies of that package are installed — the app depends on
- * `@ag-ui/client@0.0.57`, `@copilotkit/react-core` on its own — and the union
- * below is a supertype of the real one, so `agent.messages` assigns to it
- * whichever copy the hook's types come from. Verified against
+ * `@ag-ui/core`. That keeps this pure transcript module decoupled from the
+ * transport package while the union below remains a supertype of the real
+ * message shape. Verified against
  * `MessageSchema` in `@ag-ui/core`: the seven roles are user, assistant, tool,
  * activity, reasoning, system and developer.
  */

--- a/packages/devkit/templates/app-research/web/app/page.tsx
+++ b/packages/devkit/templates/app-research/web/app/page.tsx
@@ -11,7 +11,7 @@ import {
   type WorkbenchThread,
 } from "./lib/thread-source"
 
-// Notes (verified against installed @copilotkit/react-core@1.68.3 types — see
+// Notes (verified against installed @copilotkit/react-core@1.70.0 types — see
 // examples/chat/web/app/page.tsx for the original investigation):
 // - Use the `CopilotKit` wrapper (not bare `CopilotKitProvider`) per CopilotKit's own v2
 //   guidance: it adds the error boundary, toasts, and threads provider around the context.

--- a/packages/devkit/templates/app-research/web/package.json.template
+++ b/packages/devkit/templates/app-research/web/package.json.template
@@ -11,9 +11,9 @@
     "typecheck": "tsc -p . --noEmit"
   },
   "dependencies": {
-    "@ag-ui/client": "0.0.57",
-    "@copilotkit/react-core": "^1.68.3",
-    "@copilotkit/runtime": "^1.68.3",
+    "@ag-ui/client": "0.0.59",
+    "@copilotkit/react-core": "^1.70.0",
+    "@copilotkit/runtime": "^1.70.0",
     "@dawn-ai/ag-ui": "{{dawnAgUiSpecifier}}",
     "@tailwindcss/postcss": "^4.3.3",
     "next": "16.3.0",

--- a/packages/devkit/test/template-copilotkit-dependencies.test.ts
+++ b/packages/devkit/test/template-copilotkit-dependencies.test.ts
@@ -1,0 +1,23 @@
+import { readFileSync } from "node:fs"
+import { fileURLToPath } from "node:url"
+import { describe, expect, it } from "vitest"
+
+interface WebManifest {
+  readonly dependencies?: Readonly<Record<string, string>>
+}
+
+const manifestPath = fileURLToPath(
+  new URL("../templates/app-research/web/package.json.template", import.meta.url),
+)
+
+describe("research web template dependency alignment", () => {
+  it("generates a CopilotKit v2 app on the reviewed AG-UI dependency family", () => {
+    const manifest = JSON.parse(readFileSync(manifestPath, "utf8")) as WebManifest
+
+    expect(manifest.dependencies).toMatchObject({
+      "@ag-ui/client": "0.0.59",
+      "@copilotkit/react-core": "^1.70.0",
+      "@copilotkit/runtime": "^1.70.0",
+    })
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -191,14 +191,14 @@ importers:
   examples/chat/web:
     dependencies:
       '@ag-ui/client':
-        specifier: 0.0.57
-        version: 0.0.57
+        specifier: 0.0.59
+        version: 0.0.59
       '@copilotkit/react-core':
-        specifier: ^1.68.3
-        version: 1.68.3(@types/mdast@4.0.4)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(graphql@16.14.2)(micromark-util-types@2.0.2)(micromark@4.0.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(zod@4.4.3)
+        specifier: ^1.70.0
+        version: 1.70.0(@types/mdast@4.0.4)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(graphql@16.14.2)(micromark-util-types@2.0.2)(micromark@4.0.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(zod@4.4.3)
       '@copilotkit/runtime':
-        specifier: ^1.68.3
-        version: 1.68.3(@anthropic-ai/sdk@0.115.0(zod@4.4.3))(@cfworker/json-schema@4.1.1)(@langchain/core@1.2.5(@opentelemetry/api@1.9.1)(openai@6.45.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0))(@langchain/langgraph-sdk@1.9.28(@langchain/core@1.2.5(@opentelemetry/api@1.9.1)(openai@6.45.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@langchain/openai@1.5.6(@langchain/core@1.2.5(@opentelemetry/api@1.9.1)(openai@6.45.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0))(ws@8.21.0))(@opentelemetry/api@1.9.1)(@types/express@5.0.6)(langchain@1.5.2(@langchain/core@1.2.5(@opentelemetry/api@1.9.1)(openai@6.45.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0))(@opentelemetry/api@1.9.1)(openai@6.45.0(ws@8.21.0)(zod@4.4.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(ws@8.21.0))(openai@6.45.0(ws@8.21.0)(zod@4.4.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10)
+        specifier: ^1.70.0
+        version: 1.70.0(@anthropic-ai/sdk@0.115.0(zod@4.4.3))(@cfworker/json-schema@4.1.1)(@langchain/core@1.2.5(@opentelemetry/api@1.9.1)(openai@6.45.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0))(@langchain/langgraph-sdk@1.9.28(@langchain/core@1.2.5(@opentelemetry/api@1.9.1)(openai@6.45.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@langchain/openai@1.5.6(@langchain/core@1.2.5(@opentelemetry/api@1.9.1)(openai@6.45.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0))(ws@8.21.0))(@opentelemetry/api@1.9.1)(langchain@1.5.2(@langchain/core@1.2.5(@opentelemetry/api@1.9.1)(openai@6.45.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0))(@opentelemetry/api@1.9.1)(openai@6.45.0(ws@8.21.0)(zod@4.4.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(ws@8.21.0))(openai@6.45.0(ws@8.21.0)(zod@4.4.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10)
       '@dawn-ai/ag-ui':
         specifier: workspace:*
         version: link:../../../packages/ag-ui
@@ -314,14 +314,14 @@ importers:
   examples/research/web:
     dependencies:
       '@ag-ui/client':
-        specifier: 0.0.57
-        version: 0.0.57
+        specifier: 0.0.59
+        version: 0.0.59
       '@copilotkit/react-core':
-        specifier: ^1.68.3
-        version: 1.68.3(@types/mdast@4.0.4)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(graphql@16.14.2)(micromark-util-types@2.0.2)(micromark@4.0.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(zod@4.4.3)
+        specifier: ^1.70.0
+        version: 1.70.0(@types/mdast@4.0.4)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(graphql@16.14.2)(micromark-util-types@2.0.2)(micromark@4.0.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(zod@4.4.3)
       '@copilotkit/runtime':
-        specifier: ^1.68.3
-        version: 1.68.3(@anthropic-ai/sdk@0.115.0(zod@4.4.3))(@cfworker/json-schema@4.1.1)(@langchain/core@1.2.5(@opentelemetry/api@1.9.1)(openai@6.45.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0))(@langchain/langgraph-sdk@1.9.28(@langchain/core@1.2.5(@opentelemetry/api@1.9.1)(openai@6.45.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@langchain/openai@1.5.6(@langchain/core@1.2.5(@opentelemetry/api@1.9.1)(openai@6.45.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0))(ws@8.21.0))(@opentelemetry/api@1.9.1)(@types/express@5.0.6)(langchain@1.5.2(@langchain/core@1.2.5(@opentelemetry/api@1.9.1)(openai@6.45.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0))(@opentelemetry/api@1.9.1)(openai@6.45.0(ws@8.21.0)(zod@4.4.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(ws@8.21.0))(openai@6.45.0(ws@8.21.0)(zod@4.4.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10)
+        specifier: ^1.70.0
+        version: 1.70.0(@anthropic-ai/sdk@0.115.0(zod@4.4.3))(@cfworker/json-schema@4.1.1)(@langchain/core@1.2.5(@opentelemetry/api@1.9.1)(openai@6.45.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0))(@langchain/langgraph-sdk@1.9.28(@langchain/core@1.2.5(@opentelemetry/api@1.9.1)(openai@6.45.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@langchain/openai@1.5.6(@langchain/core@1.2.5(@opentelemetry/api@1.9.1)(openai@6.45.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0))(ws@8.21.0))(@opentelemetry/api@1.9.1)(langchain@1.5.2(@langchain/core@1.2.5(@opentelemetry/api@1.9.1)(openai@6.45.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0))(@opentelemetry/api@1.9.1)(openai@6.45.0(ws@8.21.0)(zod@4.4.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(ws@8.21.0))(openai@6.45.0(ws@8.21.0)(zod@4.4.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10)
       '@dawn-ai/ag-ui':
         specifier: workspace:*
         version: link:../../../packages/ag-ui
@@ -366,21 +366,21 @@ importers:
   packages/ag-ui:
     dependencies:
       '@ag-ui/core':
-        specifier: 0.0.57
-        version: 0.0.57
+        specifier: 0.0.59
+        version: 0.0.59
       '@ag-ui/encoder':
-        specifier: 0.0.57
-        version: 0.0.57
+        specifier: 0.0.59
+        version: 0.0.59
       zod:
         specifier: ^4.4.3
         version: 4.4.3
     devDependencies:
       '@ag-ui/client':
-        specifier: 0.0.57
-        version: 0.0.57
+        specifier: 0.0.59
+        version: 0.0.59
       '@copilotkit/react-core':
-        specifier: ^1.68.3
-        version: 1.68.3(@types/mdast@4.0.4)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(graphql@16.14.2)(micromark-util-types@2.0.2)(micromark@4.0.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(zod@4.4.3)
+        specifier: ^1.70.0
+        version: 1.70.0(@types/mdast@4.0.4)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(graphql@16.14.2)(micromark-util-types@2.0.2)(micromark@4.0.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(zod@4.4.3)
       '@dawn-ai/config-typescript':
         specifier: workspace:*
         version: link:../config-typescript
@@ -406,8 +406,8 @@ importers:
   packages/cli:
     dependencies:
       '@ag-ui/core':
-        specifier: 0.0.57
-        version: 0.0.57
+        specifier: 0.0.59
+        version: 0.0.59
       '@dawn-ai/ag-ui':
         specifier: workspace:*
         version: link:../ag-ui
@@ -981,17 +981,26 @@ packages:
   '@ag-ui/client@0.0.57':
     resolution: {integrity: sha512-Xap2alG9Z0/j5kb3x4D7oTpe2sw1dfrC9rgJJr2NZu5vKcm8dzIPNd31mF2B4zS3BKqYIu245yxKPhEtT30MHw==}
 
+  '@ag-ui/client@0.0.59':
+    resolution: {integrity: sha512-d7++r8sBAq6z9G/D/WKrMznQ1Mdvew14pCqOVATReFIvl06mCi1BPqTwmos3zCDGAIiSgcvxc/8m472rYQgFFQ==}
+
   '@ag-ui/core@0.0.54':
     resolution: {integrity: sha512-Ilx31OvRQaZfU7jSArGqz06JZKOsAt8zWiCPJljyp9zR6Tzl18oyfx8o6FsuGfAktGRe50GI9SCCxNXXysZwtA==}
 
   '@ag-ui/core@0.0.57':
     resolution: {integrity: sha512-gho1OWjNE6E3Rl7ZEZ1wr2CEpUHjLFU0FqzCZZk439TicLu+BfLCMkMokB07bMGlRmbJ60hM6LW60iOVauCx+Q==}
 
+  '@ag-ui/core@0.0.59':
+    resolution: {integrity: sha512-hDgy4ipTqXieT8YG8Mr917Y+FD/f11VK1GefZ5CwTDCuNqS/oTwjJ5l/DZkicThgS8hQW/Y7wPylPBMBJ8BkUg==}
+
   '@ag-ui/encoder@0.0.54':
     resolution: {integrity: sha512-0dPuE/eAeBRBDj/OOj5AW8SoP1r0dufmoOdrtKgmf+dlbVXKSNkDDHGrrvIWFPxwvPTWhHeN6wnsVUayWpUsGg==}
 
   '@ag-ui/encoder@0.0.57':
     resolution: {integrity: sha512-ifD9NctR4xyPDR58xF9GK1bj/S8oECFkTeDfuYD8tXdbcOstIJ2TOqU2zhiCKnw7Vw+zR9Qv3TbsM9E7Gi9X3Q==}
+
+  '@ag-ui/encoder@0.0.59':
+    resolution: {integrity: sha512-wQCzBsStyZMm8nzhTdTx1G0B1C8yv5rbzZLnz1ka/l5LcJEsK3KTounU8CR9l+7QtcpOUUDJKd0xAbyI6gNcSw==}
 
   '@ag-ui/langgraph@0.0.42':
     resolution: {integrity: sha512-dXasEbGQFJcasdoy5khYyDHZHYoD1/i7hioaP8cejfw+Dss4tLvN8ndzD6c5j0hmANaKscekl+zkF7UQq3sI9w==}
@@ -1014,6 +1023,9 @@ packages:
 
   '@ag-ui/proto@0.0.57':
     resolution: {integrity: sha512-pPENOZt0P6ibH8sCTgq05wLYXi5t3P9B5r/1bWYehXjUxtyOdnukSlWM++SsCIwUXsQdm/b3aBgGjEeTF7RenA==}
+
+  '@ag-ui/proto@0.0.59':
+    resolution: {integrity: sha512-X+uvDaegLEHw5kJu8tv2eSqHH8ouat+JCfFokGV1uuMquY8qCEQSlGsM7xzexwX9fujuxgHOWumg5kJDqa0+RA==}
 
   '@ai-sdk/anthropic@2.0.85':
     resolution: {integrity: sha512-ozfPUXb5cnXyFWXyY0hRFi8fudgNDr+FAuP2J1HTRhPjkTHTSFLbPSVRXEXCVoJhfl1IboF+xNDZs35nOHDU7w==}
@@ -1397,8 +1409,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@copilotkit/a2ui-renderer@1.68.3':
-    resolution: {integrity: sha512-rnD94CIJtLAGDmrJCjwJAFtAUwgNXRt+Ril+rf4hUdUxcYgCNvV43RYOenahbYAF+M9GBrBe+9zWlkLfjtUIig==}
+  '@copilotkit/a2ui-renderer@1.70.0':
+    resolution: {integrity: sha512-4tbiQMciQ9rv6BoggPunr2HrQYuoOs0c6evKDzBsl2yOdgRwEq//YuCRebTZCA6+HlF9lMP69Rniz5FtY6CDfw==}
     peerDependencies:
       react: ^18 || ^19 || ^19.0.0-rc
       react-dom: ^18 || ^19 || ^19.0.0-rc
@@ -1445,23 +1457,27 @@ packages:
     resolution: {integrity: sha512-HcMX5/QwYGsEBLqZUxCeTqhCPaihtCq1Fjm6xUygX6WVrdbqtalKWuRQNFCwvzB0YMYvnNNZLRYcp37PprJq9A==}
     engines: {node: '>=18'}
 
+  '@copilotkit/core@1.70.0':
+    resolution: {integrity: sha512-l9hABFMzQZlDHCcDygO9wG8GCOp4gvk7asSfb1Enp0wP7YPwJ1ir5hmyPSKzWvuUoNPZGMu9Ohkr3yv76gQ4GA==}
+    engines: {node: '>=18'}
+
   '@copilotkit/license-verifier@0.5.0':
     resolution: {integrity: sha512-vrwKtIpYwF0FT9ZoYASH8owa2cGV0dhDvJGaCRaRMStwDxpc6DRdydKkhx8cWZXyBRxEYcq/Vygv4JvevhQQdQ==}
 
-  '@copilotkit/react-core@1.68.3':
-    resolution: {integrity: sha512-CRlwG7VeDmUofAvlOzw+RI/3+vCPR6NJD66MxUtBTMmHhPaEEahXSBSBqwLJ9MwLSCO+83J1dTLeTuGmWivDjg==}
+  '@copilotkit/react-core@1.70.0':
+    resolution: {integrity: sha512-/xj/AWKB5vCvKw6zDRRpHsDP+QxTnRm/Ste5v0HuEUqErMGfu4MwXXA88kQzg8PPof5+Ty7/NXmavrVB64YCcQ==}
     peerDependencies:
       react: ^18 || ^19 || ^19.0.0-rc
       react-dom: ^18 || ^19 || ^19.0.0-rc
       zod: '>=3.0.0'
 
-  '@copilotkit/runtime-client-gql@1.68.3':
-    resolution: {integrity: sha512-GJRdcVU7Z3RDd8N6RDgMFi9M0QidU8UxWnns4d40UhriZxXN51jeGnw8E21P5DLtF41wfyn39gfK2SRvnm/jCQ==}
+  '@copilotkit/runtime-client-gql@1.70.0':
+    resolution: {integrity: sha512-RGm+0FTE78DmF0eEVV2uQzM89E5t2mWpAUcL3x6SqKPvV+50l6l99PcSNwJgBQ87vFgZGbK1GaFh7YDhJHfisQ==}
     peerDependencies:
       react: ^18 || ^19 || ^19.0.0-rc
 
-  '@copilotkit/runtime@1.68.3':
-    resolution: {integrity: sha512-BOgYbRIXOXLcgiW+OISuMrzxXyXN0Ghk1xuHbd8XPTtgTl82NGBnv8XHHfxsMolta3SVAUaIkcphaUlw2439MQ==}
+  '@copilotkit/runtime@1.70.0':
+    resolution: {integrity: sha512-6azGv1V2ndwPu/A1D33i7KUOQLW+LPDGyIfg+ypaqQxPGI20iJG1phnmcjNC2VWT5o5eyGfMBslmaaZb7XnjHQ==}
     peerDependencies:
       '@anthropic-ai/sdk': '>=0.57.0'
       '@langchain/aws': '>=0.1.9'
@@ -1498,14 +1514,19 @@ packages:
     peerDependencies:
       '@ag-ui/core': '>=0.0.48'
 
-  '@copilotkit/web-components@1.68.3':
-    resolution: {integrity: sha512-7pj1HXhk2DG/1jdvpJmJIQxmxWsl3RRdme9ganf7HWKn5COLlTp7k+mkgk+1s3iKaAno2snGuWdyGa7xNQDR1g==}
+  '@copilotkit/shared@1.70.0':
+    resolution: {integrity: sha512-RuZ6ZaaLu2aXcbJskKsz//ZkGsqTCtb7DqvKrWVmklZkBbel0VWRMsvhfvh93gLH2WwFBsjLmVpNEondh0AFsA==}
+    peerDependencies:
+      '@ag-ui/core': '>=0.0.48'
+
+  '@copilotkit/web-components@1.70.0':
+    resolution: {integrity: sha512-mwl8FSkTNr0pta3JlBujhkAT7ccCiKQ9KfUZMePXrDpp7K9Zu4nMl4yd97fCSye06jxllE8ZDETJSXCBhVi5PA==}
     engines: {node: '>=18'}
     peerDependencies:
       lit: ^3.3.2
 
-  '@copilotkit/web-inspector@1.68.3':
-    resolution: {integrity: sha512-VJtKeNEA86FV1jrwVeXvoV3F8Iors9BclV5t7rfGduCw67rxVgl4wWydeOLqiJ/Jlm9F+nDywN3zPSJjjspjaQ==}
+  '@copilotkit/web-inspector@1.70.0':
+    resolution: {integrity: sha512-LIq2nAdV7H0ZlzXI/7LXPwml7oVUInRNtqVrG3Ho4NyT/sUVd423zGZrmK636xsLa/IDHiTqNu9XhVV0lauynA==}
     engines: {node: '>=18'}
 
   '@cspotcode/source-map-support@0.8.1':
@@ -2659,16 +2680,8 @@ packages:
     peerDependencies:
       '@langchain/core': ^1.0.0
 
-  '@lit-labs/react@2.1.3':
-    resolution: {integrity: sha512-OD9h2JynerBQUMNzb563jiVpxfvPF0HjQkKY2mx0lpVYvD7F+rtJpOGz6ek+6ufMidV3i+MPT9SX62OKWHFrQg==}
-
   '@lit-labs/ssr-dom-shim@1.6.0':
     resolution: {integrity: sha512-VHb0ALPMTlgKjM6yIxxoQNnpKyUKLD04VzeQdsiXkMqkvYlAHxq9glGLmgbb889/1GsohSOAjvQYoiBppXFqrQ==}
-
-  '@lit/react@1.0.8':
-    resolution: {integrity: sha512-p2+YcF+JE67SRX3mMlJ1TKCSTsgyOVdAwd/nxp3NuV1+Cb6MWALbN6nT7Ld4tpmYofcE5kcaSY1YBB9erY+6fw==}
-    peerDependencies:
-      '@types/react': 17 || 18 || 19
 
   '@lit/reactive-element@2.1.2':
     resolution: {integrity: sha512-pbCDiVMnne1lYUIaYNN5wrwQXDtHaYtg7YEFPeW+hws6U47WeFvISGUWekPGKWOP1ygrs0ef0o1VJMk1exos5A==}
@@ -3972,6 +3985,9 @@ packages:
   '@types/connect@3.4.38':
     resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
 
+  '@types/cors@2.8.19':
+    resolution: {integrity: sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==}
+
   '@types/d3-array@3.2.2':
     resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
 
@@ -4083,11 +4099,11 @@ packages:
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
-  '@types/express-serve-static-core@5.1.3':
-    resolution: {integrity: sha512-dPfW8NFiOF4wOHc7+N/QSxlY9cfSsenewGbAz8C8U/MULPd/YZ27LvJUIlzaXie7e6Ove9YunJGgC9tbHD2cKw==}
+  '@types/express-serve-static-core@4.19.9':
+    resolution: {integrity: sha512-QP2ESEe/ImWY0HDwNAnK9PvEffUyhLTnWkk7KXzHfyeWAnlrDe1fN77bXl6ia8KT3wPlmA7t9/VPRpnf4Ex9sg==}
 
-  '@types/express@5.0.6':
-    resolution: {integrity: sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==}
+  '@types/express@4.17.25':
+    resolution: {integrity: sha512-dVd04UKsfpINUnK0yBoYHDF3xu7xVH4BuDotC/xGuycx4CgbP48X/KF/586bcObxT0HENHXEU8Nqtu6NR+eKhw==}
 
   '@types/geojson@7946.0.16':
     resolution: {integrity: sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==}
@@ -4124,6 +4140,9 @@ packages:
 
   '@types/mdx@2.0.14':
     resolution: {integrity: sha512-T48PeuJtvLosNTPVhfnIp3i/n3a4g4Bad7YCq5k64D4u7NwDrAotikQ+5+sjtUvBmxCMlbo3dVL+C2dP0rWHzg==}
+
+  '@types/mime@1.3.5':
+    resolution: {integrity: sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==}
 
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
@@ -4175,11 +4194,14 @@ packages:
   '@types/semver@7.7.1':
     resolution: {integrity: sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==}
 
+  '@types/send@0.17.6':
+    resolution: {integrity: sha512-Uqt8rPBE8SY0RK8JB1EzVOIZ32uqy8HwdxCnoCOsYrvnswqmFZ/k+9Ikidlk/ImhsdvBsloHbAlewb2IEBV/Og==}
+
   '@types/send@1.2.1':
     resolution: {integrity: sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==}
 
-  '@types/serve-static@2.2.0':
-    resolution: {integrity: sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==}
+  '@types/serve-static@1.15.10':
+    resolution: {integrity: sha512-tRs1dB+g8Itk72rlSI2ZrW6vZg0YrLI81iQSTkMmOqnqCaNr/8Ek4VwWcN5vZgCYWbg/JJSGBlUaYGAOP73qBw==}
 
   '@types/ssh2-streams@0.1.13':
     resolution: {integrity: sha512-faHyY3brO9oLEA0QlcO8N2wT7R0+1sHWZvQ+y3rMLwdY1ZyS1z0W3t65j9PqT4HmQ6ALzNe7RZlNuCNE0wBSWA==}
@@ -9021,10 +9043,10 @@ snapshots:
       zod: 3.25.76
       zod-to-json-schema: 3.25.2(zod@3.25.76)
 
-  '@ag-ui/a2ui-middleware@0.0.10(@ag-ui/client@0.0.57)(rxjs@7.8.1)':
+  '@ag-ui/a2ui-middleware@0.0.10(@ag-ui/client@0.0.59)(rxjs@7.8.1)':
     dependencies:
       '@ag-ui/a2ui-toolkit': 0.0.4
-      '@ag-ui/client': 0.0.57
+      '@ag-ui/client': 0.0.59
       clarinet: 0.12.6
       rxjs: 7.8.1
 
@@ -9056,11 +9078,28 @@ snapshots:
       uuid: 11.1.1
       zod: 3.25.76
 
+  '@ag-ui/client@0.0.59':
+    dependencies:
+      '@ag-ui/core': 0.0.59
+      '@ag-ui/encoder': 0.0.59
+      '@ag-ui/proto': 0.0.59
+      '@types/uuid': 10.0.0
+      compare-versions: 6.1.1
+      fast-json-patch: 3.1.1
+      rxjs: 7.8.1
+      untruncate-json: 0.0.1
+      uuid: 11.1.1
+      zod: 3.25.76
+
   '@ag-ui/core@0.0.54':
     dependencies:
       zod: 3.25.76
 
   '@ag-ui/core@0.0.57':
+    dependencies:
+      zod: 3.25.76
+
+  '@ag-ui/core@0.0.59':
     dependencies:
       zod: 3.25.76
 
@@ -9074,11 +9113,16 @@ snapshots:
       '@ag-ui/core': 0.0.57
       '@ag-ui/proto': 0.0.57
 
-  '@ag-ui/langgraph@0.0.42(@ag-ui/client@0.0.57)(@ag-ui/core@0.0.57)(@opentelemetry/api@1.9.1)(openai@6.45.0(ws@8.21.0)(zod@4.4.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(ws@8.21.0)':
+  '@ag-ui/encoder@0.0.59':
+    dependencies:
+      '@ag-ui/core': 0.0.59
+      '@ag-ui/proto': 0.0.59
+
+  '@ag-ui/langgraph@0.0.42(@ag-ui/client@0.0.59)(@ag-ui/core@0.0.59)(@opentelemetry/api@1.9.1)(openai@6.45.0(ws@8.21.0)(zod@4.4.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(ws@8.21.0)':
     dependencies:
       '@ag-ui/a2ui-toolkit': 0.0.4
-      '@ag-ui/client': 0.0.57
-      '@ag-ui/core': 0.0.57
+      '@ag-ui/client': 0.0.59
+      '@ag-ui/core': 0.0.59
       '@langchain/core': 1.2.5(@opentelemetry/api@1.9.1)(openai@6.45.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0)
       '@langchain/langgraph-sdk': 1.9.28(@langchain/core@1.2.5(@opentelemetry/api@1.9.1)(openai@6.45.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       langchain: 1.5.2(@langchain/core@1.2.5(@opentelemetry/api@1.9.1)(openai@6.45.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0))(@opentelemetry/api@1.9.1)(openai@6.45.0(ws@8.21.0)(zod@4.4.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(ws@8.21.0)
@@ -9095,9 +9139,9 @@ snapshots:
       - vue
       - ws
 
-  '@ag-ui/mcp-apps-middleware@0.0.3(@ag-ui/client@0.0.57)(@cfworker/json-schema@4.1.1)(zod@3.25.76)':
+  '@ag-ui/mcp-apps-middleware@0.0.3(@ag-ui/client@0.0.59)(@cfworker/json-schema@4.1.1)(zod@3.25.76)':
     dependencies:
-      '@ag-ui/client': 0.0.57
+      '@ag-ui/client': 0.0.59
       '@modelcontextprotocol/sdk': 1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76)
       rxjs: 7.8.1
     transitivePeerDependencies:
@@ -9124,6 +9168,12 @@ snapshots:
   '@ag-ui/proto@0.0.57':
     dependencies:
       '@ag-ui/core': 0.0.57
+      '@bufbuild/protobuf': 2.12.1
+      '@protobuf-ts/protoc': 2.11.1
+
+  '@ag-ui/proto@0.0.59':
+    dependencies:
+      '@ag-ui/core': 0.0.59
       '@bufbuild/protobuf': 2.12.1
       '@protobuf-ts/protoc': 2.11.1
 
@@ -9598,7 +9648,7 @@ snapshots:
   '@cloudflare/workerd-windows-64@1.20260801.1':
     optional: true
 
-  '@copilotkit/a2ui-renderer@1.68.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+  '@copilotkit/a2ui-renderer@1.70.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
       '@a2ui/web_core': 0.10.4
       clsx: 2.1.1
@@ -9619,7 +9669,7 @@ snapshots:
       '@ag-ui/core': 0.0.57
       '@copilotkit/channels-ui': 0.9.0(@ag-ui/core@0.0.57)
       '@copilotkit/core': 1.68.3(@ag-ui/core@0.0.57)(zod@3.25.76)
-      '@copilotkit/shared': 1.68.3(@ag-ui/core@0.0.57)
+      '@copilotkit/shared': 1.70.0(@ag-ui/core@0.0.57)
       zod-to-json-schema: 3.25.2(zod@3.25.76)
     optionalDependencies:
       vitest: 4.1.10(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(@vitest/ui@4.1.10)(jsdom@30.0.1)(vite@6.4.3(@types/node@26.1.2)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.10)(yaml@2.9.0))
@@ -9627,13 +9677,13 @@ snapshots:
       - encoding
       - zod
 
-  '@copilotkit/channels-intelligence@0.9.0(@ag-ui/core@0.0.57)(@opentelemetry/api@1.9.1)(@types/express@5.0.6)(vitest@4.1.10)(zod@3.25.76)':
+  '@copilotkit/channels-intelligence@0.9.0(@ag-ui/core@0.0.59)(@opentelemetry/api@1.9.1)(@types/express@4.17.25)(vitest@4.1.10)(zod@3.25.76)':
     dependencies:
       '@ag-ui/client': 0.0.57
       '@copilotkit/channels-core': 0.9.0(vitest@4.1.10)(zod@3.25.76)
-      '@copilotkit/channels-slack': 0.9.0(@types/express@5.0.6)(vitest@4.1.10)
+      '@copilotkit/channels-slack': 0.9.0(@types/express@4.17.25)(vitest@4.1.10)
       '@copilotkit/channels-teams': 0.9.0(@opentelemetry/api@1.9.1)(vitest@4.1.10)
-      '@copilotkit/channels-ui': 0.9.0(@ag-ui/core@0.0.57)
+      '@copilotkit/channels-ui': 0.9.0(@ag-ui/core@0.0.59)
       phoenix: 1.8.9
     transitivePeerDependencies:
       - '@ag-ui/core'
@@ -9648,15 +9698,15 @@ snapshots:
       - vitest
       - zod
 
-  '@copilotkit/channels-slack@0.9.0(@types/express@5.0.6)(vitest@4.1.10)':
+  '@copilotkit/channels-slack@0.9.0(@types/express@4.17.25)(vitest@4.1.10)':
     dependencies:
       '@ag-ui/client': 0.0.57
       '@ag-ui/core': 0.0.57
       '@copilotkit/channels-core': 0.9.0(vitest@4.1.10)(zod@3.25.76)
       '@copilotkit/channels-ui': 0.9.0(@ag-ui/core@0.0.57)
       '@copilotkit/core': 1.68.3(@ag-ui/core@0.0.57)(zod@3.25.76)
-      '@copilotkit/shared': 1.68.3(@ag-ui/core@0.0.57)
-      '@slack/bolt': 4.7.3(@types/express@5.0.6)
+      '@copilotkit/shared': 1.70.0(@ag-ui/core@0.0.57)
+      '@slack/bolt': 4.7.3(@types/express@4.17.25)
       '@slack/types': 2.22.0
       '@slack/web-api': 7.19.0
       rxjs: 7.8.1
@@ -9678,7 +9728,7 @@ snapshots:
       '@copilotkit/channels-core': 0.9.0(vitest@4.1.10)(zod@3.25.76)
       '@copilotkit/channels-ui': 0.9.0(@ag-ui/core@0.0.57)
       '@copilotkit/core': 1.68.3(@ag-ui/core@0.0.57)(zod@3.25.76)
-      '@copilotkit/shared': 1.68.3(@ag-ui/core@0.0.57)
+      '@copilotkit/shared': 1.70.0(@ag-ui/core@0.0.57)
       '@microsoft/agents-activity': 1.7.2
       '@microsoft/agents-hosting': 1.7.2(@opentelemetry/api@1.9.1)
       express: 4.22.2
@@ -9694,7 +9744,14 @@ snapshots:
 
   '@copilotkit/channels-ui@0.9.0(@ag-ui/core@0.0.57)':
     dependencies:
-      '@copilotkit/shared': 1.68.3(@ag-ui/core@0.0.57)
+      '@copilotkit/shared': 1.70.0(@ag-ui/core@0.0.57)
+    transitivePeerDependencies:
+      - '@ag-ui/core'
+      - encoding
+
+  '@copilotkit/channels-ui@0.9.0(@ag-ui/core@0.0.59)':
+    dependencies:
+      '@copilotkit/shared': 1.70.0(@ag-ui/core@0.0.59)
     transitivePeerDependencies:
       - '@ag-ui/core'
       - encoding
@@ -9712,10 +9769,10 @@ snapshots:
       - encoding
       - zod
 
-  '@copilotkit/core@1.68.3(@ag-ui/core@0.0.57)(zod@4.4.3)':
+  '@copilotkit/core@1.70.0(@ag-ui/core@0.0.59)(zod@4.4.3)':
     dependencies:
-      '@ag-ui/client': 0.0.57
-      '@copilotkit/shared': 1.68.3(@ag-ui/core@0.0.57)
+      '@ag-ui/client': 0.0.59
+      '@copilotkit/shared': 1.70.0(@ag-ui/core@0.0.59)
       '@tanstack/pacer': 0.20.1
       phoenix: 1.8.9
       rxjs: 7.8.1
@@ -9727,18 +9784,17 @@ snapshots:
 
   '@copilotkit/license-verifier@0.5.0': {}
 
-  '@copilotkit/react-core@1.68.3(@types/mdast@4.0.4)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(graphql@16.14.2)(micromark-util-types@2.0.2)(micromark@4.0.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(zod@4.4.3)':
+  '@copilotkit/react-core@1.70.0(@types/mdast@4.0.4)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(graphql@16.14.2)(micromark-util-types@2.0.2)(micromark@4.0.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(zod@4.4.3)':
     dependencies:
-      '@ag-ui/client': 0.0.57
-      '@ag-ui/core': 0.0.57
-      '@copilotkit/a2ui-renderer': 1.68.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      '@copilotkit/core': 1.68.3(@ag-ui/core@0.0.57)(zod@4.4.3)
-      '@copilotkit/runtime-client-gql': 1.68.3(@ag-ui/core@0.0.57)(graphql@16.14.2)(react@19.2.8)
-      '@copilotkit/shared': 1.68.3(@ag-ui/core@0.0.57)
-      '@copilotkit/web-components': 1.68.3(lit@3.3.3)
-      '@copilotkit/web-inspector': 1.68.3(@ag-ui/core@0.0.57)(zod@4.4.3)
+      '@ag-ui/client': 0.0.59
+      '@ag-ui/core': 0.0.59
+      '@copilotkit/a2ui-renderer': 1.70.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@copilotkit/core': 1.70.0(@ag-ui/core@0.0.59)(zod@4.4.3)
+      '@copilotkit/runtime-client-gql': 1.70.0(@ag-ui/core@0.0.59)(graphql@16.14.2)(react@19.2.8)
+      '@copilotkit/shared': 1.70.0(@ag-ui/core@0.0.59)
+      '@copilotkit/web-components': 1.70.0(lit@3.3.3)
+      '@copilotkit/web-inspector': 1.70.0(@ag-ui/core@0.0.59)(zod@4.4.3)
       '@jetbrains/websandbox': 1.3.1
-      '@lit-labs/react': 2.1.3(@types/react@19.2.18)
       '@radix-ui/react-dropdown-menu': 2.1.20(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@radix-ui/react-slot': 1.3.0(@types/react@19.2.18)(react@19.2.8)
       '@radix-ui/react-tooltip': 1.2.12(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -9770,9 +9826,9 @@ snapshots:
       - micromark-util-types
       - supports-color
 
-  '@copilotkit/runtime-client-gql@1.68.3(@ag-ui/core@0.0.57)(graphql@16.14.2)(react@19.2.8)':
+  '@copilotkit/runtime-client-gql@1.70.0(@ag-ui/core@0.0.59)(graphql@16.14.2)(react@19.2.8)':
     dependencies:
-      '@copilotkit/shared': 1.68.3(@ag-ui/core@0.0.57)
+      '@copilotkit/shared': 1.70.0(@ag-ui/core@0.0.59)
       '@urql/core': 5.2.0(graphql@16.14.2)
       react: 19.2.8
       untruncate-json: 0.0.1
@@ -9782,14 +9838,14 @@ snapshots:
       - encoding
       - graphql
 
-  '@copilotkit/runtime@1.68.3(@anthropic-ai/sdk@0.115.0(zod@4.4.3))(@cfworker/json-schema@4.1.1)(@langchain/core@1.2.5(@opentelemetry/api@1.9.1)(openai@6.45.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0))(@langchain/langgraph-sdk@1.9.28(@langchain/core@1.2.5(@opentelemetry/api@1.9.1)(openai@6.45.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@langchain/openai@1.5.6(@langchain/core@1.2.5(@opentelemetry/api@1.9.1)(openai@6.45.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0))(ws@8.21.0))(@opentelemetry/api@1.9.1)(@types/express@5.0.6)(langchain@1.5.2(@langchain/core@1.2.5(@opentelemetry/api@1.9.1)(openai@6.45.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0))(@opentelemetry/api@1.9.1)(openai@6.45.0(ws@8.21.0)(zod@4.4.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(ws@8.21.0))(openai@6.45.0(ws@8.21.0)(zod@4.4.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10)':
+  '@copilotkit/runtime@1.70.0(@anthropic-ai/sdk@0.115.0(zod@4.4.3))(@cfworker/json-schema@4.1.1)(@langchain/core@1.2.5(@opentelemetry/api@1.9.1)(openai@6.45.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0))(@langchain/langgraph-sdk@1.9.28(@langchain/core@1.2.5(@opentelemetry/api@1.9.1)(openai@6.45.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0))(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@langchain/openai@1.5.6(@langchain/core@1.2.5(@opentelemetry/api@1.9.1)(openai@6.45.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0))(ws@8.21.0))(@opentelemetry/api@1.9.1)(langchain@1.5.2(@langchain/core@1.2.5(@opentelemetry/api@1.9.1)(openai@6.45.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0))(@opentelemetry/api@1.9.1)(openai@6.45.0(ws@8.21.0)(zod@4.4.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(ws@8.21.0))(openai@6.45.0(ws@8.21.0)(zod@4.4.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10)':
     dependencies:
-      '@ag-ui/a2ui-middleware': 0.0.10(@ag-ui/client@0.0.57)(rxjs@7.8.1)
-      '@ag-ui/client': 0.0.57
-      '@ag-ui/core': 0.0.57
-      '@ag-ui/encoder': 0.0.57
-      '@ag-ui/langgraph': 0.0.42(@ag-ui/client@0.0.57)(@ag-ui/core@0.0.57)(@opentelemetry/api@1.9.1)(openai@6.45.0(ws@8.21.0)(zod@4.4.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(ws@8.21.0)
-      '@ag-ui/mcp-apps-middleware': 0.0.3(@ag-ui/client@0.0.57)(@cfworker/json-schema@4.1.1)(zod@3.25.76)
+      '@ag-ui/a2ui-middleware': 0.0.10(@ag-ui/client@0.0.59)(rxjs@7.8.1)
+      '@ag-ui/client': 0.0.59
+      '@ag-ui/core': 0.0.59
+      '@ag-ui/encoder': 0.0.59
+      '@ag-ui/langgraph': 0.0.42(@ag-ui/client@0.0.59)(@ag-ui/core@0.0.59)(@opentelemetry/api@1.9.1)(openai@6.45.0(ws@8.21.0)(zod@4.4.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(ws@8.21.0)
+      '@ag-ui/mcp-apps-middleware': 0.0.3(@ag-ui/client@0.0.59)(@cfworker/json-schema@4.1.1)(zod@3.25.76)
       '@ag-ui/mcp-middleware': 0.0.1(@cfworker/json-schema@4.1.1)(rxjs@7.8.1)(zod@3.25.76)
       '@ai-sdk/anthropic': 3.0.95(zod@3.25.76)
       '@ai-sdk/google': 3.0.90(zod@3.25.76)
@@ -9797,9 +9853,9 @@ snapshots:
       '@ai-sdk/mcp': 1.0.60(zod@3.25.76)
       '@ai-sdk/openai': 3.0.82(zod@3.25.76)
       '@copilotkit/channels-core': 0.9.0(vitest@4.1.10)(zod@3.25.76)
-      '@copilotkit/channels-intelligence': 0.9.0(@ag-ui/core@0.0.57)(@opentelemetry/api@1.9.1)(@types/express@5.0.6)(vitest@4.1.10)(zod@3.25.76)
+      '@copilotkit/channels-intelligence': 0.9.0(@ag-ui/core@0.0.59)(@opentelemetry/api@1.9.1)(@types/express@4.17.25)(vitest@4.1.10)(zod@3.25.76)
       '@copilotkit/license-verifier': 0.5.0
-      '@copilotkit/shared': 1.68.3(@ag-ui/core@0.0.57)
+      '@copilotkit/shared': 1.70.0(@ag-ui/core@0.0.59)
       '@graphql-yoga/plugin-defer-stream': 3.21.2(graphql-yoga@5.21.2(graphql@16.14.2))(graphql@16.14.2)
       '@hono/node-server': 1.19.17(hono@4.13.3)
       '@langchain/core': 1.2.5(@opentelemetry/api@1.9.1)(openai@6.45.0(ws@8.21.0)(zod@4.4.3))(ws@8.21.0)
@@ -9807,6 +9863,8 @@ snapshots:
       '@remix-run/node-fetch-server': 0.13.3
       '@scarf/scarf': 1.4.0
       '@segment/analytics-node': 2.3.0
+      '@types/cors': 2.8.19
+      '@types/express': 4.17.25
       ai: 6.0.221(zod@3.25.76)
       clarinet: 0.12.6
       class-transformer: 0.5.1
@@ -9839,7 +9897,6 @@ snapshots:
       - '@opentelemetry/api-logs'
       - '@opentelemetry/exporter-trace-otlp-proto'
       - '@opentelemetry/sdk-trace-base'
-      - '@types/express'
       - bufferutil
       - debug
       - encoding
@@ -9867,15 +9924,47 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  '@copilotkit/web-components@1.68.3(lit@3.3.3)':
+  '@copilotkit/shared@1.70.0(@ag-ui/core@0.0.57)':
+    dependencies:
+      '@ag-ui/client': 0.0.59
+      '@ag-ui/core': 0.0.57
+      '@copilotkit/license-verifier': 0.5.0
+      '@segment/analytics-node': 2.3.0
+      '@standard-schema/spec': 1.1.0
+      chalk: 4.1.2
+      graphql: 16.14.2
+      partial-json: 0.1.7
+      uuid: 11.1.1
+      zod: 3.25.76
+      zod-to-json-schema: 3.25.2(zod@3.25.76)
+    transitivePeerDependencies:
+      - encoding
+
+  '@copilotkit/shared@1.70.0(@ag-ui/core@0.0.59)':
+    dependencies:
+      '@ag-ui/client': 0.0.59
+      '@ag-ui/core': 0.0.59
+      '@copilotkit/license-verifier': 0.5.0
+      '@segment/analytics-node': 2.3.0
+      '@standard-schema/spec': 1.1.0
+      chalk: 4.1.2
+      graphql: 16.14.2
+      partial-json: 0.1.7
+      uuid: 11.1.1
+      zod: 3.25.76
+      zod-to-json-schema: 3.25.2(zod@3.25.76)
+    transitivePeerDependencies:
+      - encoding
+
+  '@copilotkit/web-components@1.70.0(lit@3.3.3)':
     dependencies:
       lit: 3.3.3
 
-  '@copilotkit/web-inspector@1.68.3(@ag-ui/core@0.0.57)(zod@4.4.3)':
+  '@copilotkit/web-inspector@1.70.0(@ag-ui/core@0.0.59)(zod@4.4.3)':
     dependencies:
-      '@ag-ui/client': 0.0.57
-      '@copilotkit/core': 1.68.3(@ag-ui/core@0.0.57)(zod@4.4.3)
-      '@copilotkit/shared': 1.68.3(@ag-ui/core@0.0.57)
+      '@ag-ui/client': 0.0.59
+      '@copilotkit/core': 1.70.0(@ag-ui/core@0.0.59)(zod@4.4.3)
+      '@copilotkit/shared': 1.70.0(@ag-ui/core@0.0.59)
       lit: 3.3.3
       lucide: 0.525.0
       marked: 12.0.2
@@ -10754,17 +10843,7 @@ snapshots:
       - '@smithy/signature-v4'
       - ws
 
-  '@lit-labs/react@2.1.3(@types/react@19.2.18)':
-    dependencies:
-      '@lit/react': 1.0.8(@types/react@19.2.18)
-    transitivePeerDependencies:
-      - '@types/react'
-
   '@lit-labs/ssr-dom-shim@1.6.0': {}
-
-  '@lit/react@1.0.8(@types/react@19.2.18)':
-    dependencies:
-      '@types/react': 19.2.18
 
   '@lit/reactive-element@2.1.2':
     dependencies:
@@ -11658,14 +11737,14 @@ snapshots:
 
   '@sindresorhus/is@8.1.0': {}
 
-  '@slack/bolt@4.7.3(@types/express@5.0.6)':
+  '@slack/bolt@4.7.3(@types/express@4.17.25)':
     dependencies:
       '@slack/logger': 4.0.1
       '@slack/oauth': 3.0.5
       '@slack/socket-mode': 2.0.7
       '@slack/types': 2.22.0
       '@slack/web-api': 7.19.0
-      '@types/express': 5.0.6
+      '@types/express': 4.17.25
       axios: 1.19.0
       express: 5.2.1
       path-to-regexp: 8.4.2
@@ -11921,6 +12000,10 @@ snapshots:
     dependencies:
       '@types/node': 26.1.2
 
+  '@types/cors@2.8.19':
+    dependencies:
+      '@types/node': 26.1.2
+
   '@types/d3-array@3.2.2': {}
 
   '@types/d3-axis@3.0.6':
@@ -12061,18 +12144,19 @@ snapshots:
 
   '@types/estree@1.0.9': {}
 
-  '@types/express-serve-static-core@5.1.3':
+  '@types/express-serve-static-core@4.19.9':
     dependencies:
       '@types/node': 26.1.2
       '@types/qs': 6.15.1
       '@types/range-parser': 1.2.7
       '@types/send': 1.2.1
 
-  '@types/express@5.0.6':
+  '@types/express@4.17.25':
     dependencies:
       '@types/body-parser': 1.19.6
-      '@types/express-serve-static-core': 5.1.3
-      '@types/serve-static': 2.2.0
+      '@types/express-serve-static-core': 4.19.9
+      '@types/qs': 6.15.1
+      '@types/serve-static': 1.15.10
 
   '@types/geojson@7946.0.16': {}
 
@@ -12108,6 +12192,8 @@ snapshots:
       '@types/unist': 3.0.3
 
   '@types/mdx@2.0.14': {}
+
+  '@types/mime@1.3.5': {}
 
   '@types/ms@2.1.0': {}
 
@@ -12162,14 +12248,20 @@ snapshots:
 
   '@types/semver@7.7.1': {}
 
+  '@types/send@0.17.6':
+    dependencies:
+      '@types/mime': 1.3.5
+      '@types/node': 26.1.2
+
   '@types/send@1.2.1':
     dependencies:
       '@types/node': 26.1.2
 
-  '@types/serve-static@2.2.0':
+  '@types/serve-static@1.15.10':
     dependencies:
       '@types/http-errors': 2.0.5
       '@types/node': 26.1.2
+      '@types/send': 0.17.6
 
   '@types/ssh2-streams@0.1.13':
     dependencies:

--- a/scripts/release/abandonment-handoff.mjs
+++ b/scripts/release/abandonment-handoff.mjs
@@ -6,7 +6,7 @@ import {
   parseAbandonmentReleaseBody,
 } from "./abandonment.mjs"
 import { snapshotJson } from "./adapter-normalize.mjs"
-import { parseReleaseMarker, releaseBodySha256 } from "./metadata.mjs"
+import { isManagedReleaseForTag, parseReleaseMarker, releaseBodySha256 } from "./metadata.mjs"
 import {
   classifyProductionEvent as defaultClassifyProductionEvent,
   createProductionInventoryReader as defaultCreateProductionInventoryReader,
@@ -259,7 +259,7 @@ async function captureDurableAbandonmentContext({ candidate, github }) {
       throw new Error("Abandonment recovery GitHub Release identity is malformed or duplicate")
     }
     ids.add(String(release.id))
-    if (release.tag_name === `v${candidate.version}`) matches.push(release)
+    if (isManagedReleaseForTag(release, `v${candidate.version}`)) matches.push(release)
     if (
       release.tag_name.startsWith("v") &&
       isReleaseVersion(release.tag_name.slice(1)) &&
@@ -475,7 +475,7 @@ async function captureExactReleaseContext({
       throw new Error("Abandonment context GitHub Release identity is malformed or duplicate")
     }
     ids.add(String(release.id))
-    if (release.tag_name === `v${candidate.version}`) matches.push(release)
+    if (isManagedReleaseForTag(release, `v${candidate.version}`)) matches.push(release)
     if (release.tag_name.startsWith("v") && isReleaseVersion(release.tag_name.slice(1))) {
       if (compareSemver(release.tag_name.slice(1), candidate.version) > 0) {
         throw new Error("A newer GitHub Release interleaved before abandonment context capture")
@@ -548,7 +548,6 @@ function normalizeDraftRelease(value, candidate, { bodyRequired }) {
     !isRecord(release) ||
     !isPositiveInteger(release.id) ||
     release.name !== `Dawn v${candidate.version}` ||
-    release.tag_name !== `v${candidate.version}` ||
     release.target_commitish !== "main" ||
     release.draft !== true ||
     release.immutable !== false ||
@@ -563,7 +562,7 @@ function normalizeDraftRelease(value, candidate, { bodyRequired }) {
   return {
     id: release.id,
     name: release.name,
-    tag: release.tag_name,
+    tag: `v${candidate.version}`,
     targetCommitish: release.target_commitish,
     draft: release.draft,
     immutable: release.immutable,
@@ -580,7 +579,6 @@ function normalizeRecoveryDraftRelease(value, candidate, { bodyRequired }) {
       `Dawn v${candidate.version}`,
       `Dawn v${candidate.version} (abandoned before publication)`,
     ].includes(release.name) ||
-    release.tag_name !== `v${candidate.version}` ||
     release.target_commitish !== "main" ||
     release.draft !== true ||
     release.immutable !== false ||

--- a/scripts/release/abandonment-workflow-policy.json
+++ b/scripts/release/abandonment-workflow-policy.json
@@ -5,12 +5,12 @@
     {
       "id": "disabled-2026-08-28",
       "mode": "disabled",
-      "canonicalSha256": "4c4a666d03964c4d3e9f76eb2753b5e2728827d80eb7185c59501894deecc448"
+      "canonicalSha256": "18677ab818fc1cf834cd0c3c7f1219883c00421a9452305a411f758e8102dbea"
     },
     {
       "id": "protected-2026-08-28",
       "mode": "protected",
-      "canonicalSha256": "ffc8fc51bfd0e430967e33d93633b83da5bb229b051fa165426062bdc94249de"
+      "canonicalSha256": "d8fabd2297e2ebc23d472a1dfa1a0f73a9d96ce2a5d72994494fe24e0ab631db"
     }
   ]
 }

--- a/scripts/release/abandonment.mjs
+++ b/scripts/release/abandonment.mjs
@@ -6,6 +6,7 @@ import { CANONICAL_RELEASE_PACKAGE_ORDER } from "./manifest.mjs"
 import {
   abandonmentReleaseMarker,
   canonicalReleaseBody,
+  isManagedReleaseForTag,
   parseReleaseMarker,
   releaseBodySha256,
 } from "./metadata.mjs"
@@ -672,7 +673,7 @@ async function reconcileReleaseList({ releases, context, candidate, reader }) {
     }
     if (ids.has(release.id)) throw new Error("GitHub Release identities are duplicate")
     ids.add(release.id)
-    if (release.tag_name === `v${candidate.version}`) matches.push(release)
+    if (isManagedReleaseForTag(release, `v${candidate.version}`)) matches.push(release)
     if (release.tag_name.startsWith("v") && isReleaseVersion(release.tag_name.slice(1))) {
       if (compareSemver(release.tag_name.slice(1), candidate.version) > 0) {
         throw new Error("A newer GitHub Release interleaved before abandonment")
@@ -707,7 +708,9 @@ async function reobserveReleaseBoundary(reader, candidate, expectedRelease) {
       throw new Error("GitHub Release identity is malformed or duplicate")
     }
     ids.add(release.id)
-    if (release.tag_name === `v${candidate.version}`) candidateMatches.push(release)
+    if (isManagedReleaseForTag(release, `v${candidate.version}`)) {
+      candidateMatches.push(release)
+    }
     if (release.tag_name.startsWith("v") && isReleaseVersion(release.tag_name.slice(1))) {
       if (compareSemver(release.tag_name.slice(1), candidate.version) > 0) {
         throw new Error("A newer GitHub Release interleaved before abandonment")
@@ -1131,7 +1134,7 @@ async function readManagedRelease(reader, releaseId) {
 
 function assertDraftRelease(release, candidate) {
   if (
-    release.tag_name !== `v${candidate.version}` ||
+    !isManagedReleaseForTag(release, `v${candidate.version}`) ||
     release.target_commitish !== "main" ||
     release.prerelease !== false ||
     typeof release.name !== "string" ||

--- a/scripts/release/adapters/github-write.mjs
+++ b/scripts/release/adapters/github-write.mjs
@@ -3,6 +3,7 @@ import { createHash, timingSafeEqual } from "node:crypto"
 import { normalizeAdapterEnvelope, snapshotJson } from "../adapter-normalize.mjs"
 import { assertPayloadByteLength, RELEASE_PAYLOAD_LIMITS } from "../limits.mjs"
 import {
+  isManagedReleaseForTag,
   parseReleaseMarker,
   parseSmokeReleaseAssetName,
   preflightPublicationAssetMetadata,
@@ -127,10 +128,17 @@ export function createGitHubWriter({
       validateText(args.title, 512, "Release title")
       validateText(args.body, 1024 * 1024, "Release body")
       await verifyAnnotatedTag(context, args.tag, args.targetSha)
-      const existing = await findReleaseByTag(context, args.tag)
+      const existing = await findReleaseByTag(context, args)
       if (existing !== null) {
         const release = await readRelease(context, existing.id)
-        assertDraftIdentity(release, args, { title: args.title, body: args.body })
+        assertDraftIdentity(
+          release,
+          { ...args, releaseId: existing.id },
+          {
+            title: args.title,
+            body: args.body,
+          },
+        )
         await verifyAnnotatedTag(context, args.tag, args.targetSha)
         return Object.freeze({
           releaseId: release.id,
@@ -160,13 +168,13 @@ export function createGitHubWriter({
         releaseId = positiveId(response.body?.id, "created Release ID")
         status = "created"
       } else {
-        const raced = await findReleaseByTag(context, args.tag)
+        const raced = await findReleaseByTag(context, args)
         if (raced === null) throw new Error("GitHub draft creation race could not be reconciled")
         releaseId = raced.id
         status = "existing"
       }
       const release = await readRelease(context, releaseId)
-      assertDraftIdentity(release, args, { title: args.title, body: args.body })
+      assertDraftIdentity(release, { ...args, releaseId }, { title: args.title, body: args.body })
       await verifyAnnotatedTag(context, args.tag, args.targetSha)
       return Object.freeze({
         releaseId,
@@ -269,7 +277,8 @@ export function createGitHubWriter({
       const expectedAssets = normalizeExpectedAssets(args.assets)
       await verifyAnnotatedTag(context, args.tag, args.targetSha)
       const current = await readRelease(context, releaseId)
-      assertReleaseIdentity(current, args)
+      if (current.draft === true) assertDraftIdentity(current, args)
+      else assertPublishedIdentity(current, args)
       if (releaseBodySha256(current.body) !== args.expectedBodySha256) {
         throw new Error("Release publication body compare-and-swap is stale")
       }
@@ -277,30 +286,20 @@ export function createGitHubWriter({
       validatePublicationMarker(marker, args, expectedAssets)
       await assertExactPublicationAssets(context, releaseId, expectedAssets, marker)
       if (current.draft === false) {
-        if (current.immutable !== true)
-          throw new Error("Published managed Release is not immutable")
         await verifyAnnotatedTag(context, args.tag, args.targetSha)
         return Object.freeze({ releaseId, status: "existing", immutable: true })
-      }
-      if (current.draft !== true || current.immutable !== false) {
-        throw new Error("Release publication requires one mutable draft")
       }
       const response = await requestJson(context, {
         url: `${context.base}/releases/${releaseId}`,
         method: "PATCH",
         apiVersion: RELEASE_API_VERSION,
-        body: { draft: false },
+        body: { tag_name: args.tag, draft: false },
       })
       if (response.httpStatus !== 200)
         throw new Error("Release publication did not return HTTP 200")
       const published = await readRelease(context, releaseId)
-      assertReleaseIdentity(published, args)
-      if (
-        published.draft !== false ||
-        published.immutable !== true ||
-        published.body !== current.body ||
-        published.name !== current.name
-      ) {
+      assertPublishedIdentity(published, args)
+      if (published.body !== current.body || published.name !== current.name) {
         throw new Error("Published Release immutable re-read changed metadata")
       }
       await assertExactPublicationAssets(context, releaseId, expectedAssets, marker)
@@ -370,10 +369,15 @@ async function verifyAnnotatedTag(context, tag, targetSha) {
   }
 }
 
-async function findReleaseByTag(context, tag) {
+async function findReleaseByTag(context, { tag, title, body }) {
   const releases = await readValue(context, "listReleases", {}, "releases")
   if (!Array.isArray(releases)) throw new Error("GitHub Release list is malformed")
-  const matches = releases.filter((release) => isRecord(release) && release.tag_name === tag)
+  const matches = releases.filter(
+    (release) =>
+      isRecord(release) &&
+      (release.tag_name === tag ||
+        (release.name === title && release.body === body && isManagedReleaseForTag(release, tag))),
+  )
   if (matches.length > 1) throw new Error("Duplicate matching GitHub Releases are ambiguous")
   if (matches.length === 0) return null
   return { id: positiveId(matches[0].id, "Release ID") }
@@ -421,7 +425,7 @@ async function readValue(context, method, args, operation) {
 }
 
 function assertDraftIdentity(release, args, expected = {}) {
-  assertReleaseIdentity(release, args)
+  assertCommonReleaseMetadata(release, args)
   if (release.draft !== true || release.immutable !== false) {
     throw new Error("GitHub Release is not the expected mutable draft")
   }
@@ -433,11 +437,17 @@ function assertDraftIdentity(release, args, expected = {}) {
   }
 }
 
-function assertReleaseIdentity(release, args) {
+function assertPublishedIdentity(release, args) {
+  assertCommonReleaseMetadata(release, args)
+  if (release.tag_name !== args.tag || release.draft !== false || release.immutable !== true) {
+    throw new Error("GitHub published Release identity or metadata is malformed")
+  }
+}
+
+function assertCommonReleaseMetadata(release, args) {
   if (
-    positiveId(release.id, "Release ID") !==
-      positiveId(args.releaseId ?? release.id, "Release ID") ||
-    release.tag_name !== args.tag ||
+    positiveId(release.id, "Release ID") !== positiveId(args.releaseId, "Release ID") ||
+    typeof release.tag_name !== "string" ||
     release.target_commitish !== "main" ||
     release.prerelease !== false ||
     typeof release.name !== "string" ||

--- a/scripts/release/artifact-store.mjs
+++ b/scripts/release/artifact-store.mjs
@@ -10,6 +10,7 @@ import { inflateRawSync } from "node:zlib"
 import { createGitHubReader } from "./adapters/github.mjs"
 import { assertPayloadByteLength, RELEASE_PAYLOAD_LIMITS } from "./limits.mjs"
 import { canonicalManifestBytes, parseSealedReleaseManifest } from "./manifest.mjs"
+import { isManagedReleaseForTag } from "./metadata.mjs"
 import { canonicalReleaseRecordBytes, parseReleaseRecord } from "./release-record.mjs"
 
 const METADATA_FIELDS = Object.freeze([
@@ -34,13 +35,18 @@ const execFileAsync = promisify(execFile)
 const VERIFIED_MATERIALIZATIONS = new WeakMap()
 
 export const ARTIFACT_STORE_SPARSE_FILES = Object.freeze([
+  "scripts/release/adapter-normalize.mjs",
   "scripts/release/adapters/github.mjs",
   "scripts/release/adapters/http.mjs",
   "scripts/release/artifact-store.mjs",
   "scripts/release/limits.mjs",
   "scripts/release/manifest.mjs",
+  "scripts/release/metadata.mjs",
+  "scripts/release/npm-evidence.mjs",
   "scripts/release/release-record.mjs",
   "scripts/release/semver.mjs",
+  "scripts/release/smoke-result.mjs",
+  "scripts/release/terminal-records.mjs",
   "scripts/release/topology.mjs",
 ])
 
@@ -648,7 +654,9 @@ export function createArtifactStoreGitHubRuntime({
         }
         const releasesResult = await metadataReader.listReleases()
         if (releasesResult.status !== "PRESENT") return releasesResult
-        const matching = releasesResult.value.filter((release) => release?.tag_name === tag)
+        const matching = releasesResult.value.filter((release) =>
+          isManagedReleaseForTag(release, tag),
+        )
         if (matching.length !== 1) {
           return { status: "ERROR", httpStatus: 200, code: "RELEASE_IDENTITY_CONFLICT" }
         }
@@ -656,6 +664,7 @@ export function createArtifactStoreGitHubRuntime({
         if (
           release.target_commitish !== "main" ||
           release.draft !== true ||
+          release.immutable !== false ||
           release.prerelease !== false ||
           !Number.isSafeInteger(release.id)
         ) {

--- a/scripts/release/audit.mjs
+++ b/scripts/release/audit.mjs
@@ -5,6 +5,7 @@ import { extractActionsArtifactZip } from "./artifact-store.mjs"
 import { RELEASE_PAYLOAD_LIMITS } from "./limits.mjs"
 import {
   canonicalReleaseBody,
+  isManagedReleaseForTag,
   parseReleaseMarker,
   parseSmokeReleaseAssetName,
   preflightAuditDraftAssetMetadata,
@@ -723,11 +724,12 @@ async function verifyAnnotatedCandidateTag(reader, candidate) {
 async function requireDraftRelease(reader, candidate) {
   const releases = await readValue(reader.listReleases({}), "releases")
   if (!Array.isArray(releases)) throw new Error("Managed Release list is malformed")
-  const matches = releases.filter((release) => release?.tag_name === `v${candidate.version}`)
+  const matches = releases.filter((release) =>
+    isManagedReleaseForTag(release, `v${candidate.version}`),
+  )
   if (matches.length !== 1) throw new Error("Managed audit draft is missing or ambiguous")
   const release = await readManagedRelease(reader, positiveId(matches[0].id, "Release ID"))
   if (
-    release.tag_name !== `v${candidate.version}` ||
     release.name !== `Dawn v${candidate.version}` ||
     typeof release.body !== "string" ||
     release.draft !== true ||

--- a/scripts/release/candidate.mjs
+++ b/scripts/release/candidate.mjs
@@ -3,7 +3,7 @@ import { createHash } from "node:crypto"
 import { canonicalAbandonmentBytes, parseAbandonmentReleaseBody } from "./abandonment.mjs"
 import { assertPayloadByteLength, RELEASE_PAYLOAD_LIMITS } from "./limits.mjs"
 import { CANONICAL_RELEASE_PACKAGE_ORDER } from "./manifest.mjs"
-import { canonicalReleaseBody, parseReleaseMarker } from "./metadata.mjs"
+import { canonicalReleaseBody, isManagedReleaseForTag, parseReleaseMarker } from "./metadata.mjs"
 import { planCandidateArbitration } from "./planner.mjs"
 import { releaseRecordSha256 } from "./release-record.mjs"
 import { compareSemver, isExactSemver, parseSemver } from "./semver.mjs"
@@ -392,11 +392,22 @@ async function inspectManagedReleases({
   marker,
   verifyTerminalAbandonment,
 }) {
-  const managed = records.filter((record) => managedVersionFromTag(record?.tag_name) !== null)
+  const managed = []
+  for (const release of records) {
+    const exactTag = managedVersionFromTag(release?.tag_name) === null ? null : release.tag_name
+    const markerTag =
+      exactTag === null
+        ? [...tagsByName.keys()].find((tag) => isManagedReleaseForTag(release, tag))
+        : null
+    const tag = exactTag ?? markerTag
+    if (managedVersionFromTag(tag) !== null && isManagedReleaseForTag(release, tag)) {
+      managed.push({ release, tag })
+    }
+  }
   const seenTags = new Set()
   const releases = []
-  for (const release of managed) {
-    const tag = release.tag_name
+  for (const managedRelease of managed) {
+    const { release, tag } = managedRelease
     if (seenTags.has(tag)) throw new Error(`Managed GitHub Release ${tag} is duplicated`)
     seenTags.add(tag)
     if (!isPositiveId(release.id) || typeof release.draft !== "boolean") {
@@ -526,7 +537,6 @@ function assertExactAuditVerifiedDraft({
   tagIdentity,
 }) {
   if (
-    release.tag_name !== tagIdentity.tag ||
     release.name !== `Dawn v${tagIdentity.version}` ||
     release.target_commitish !== "main" ||
     release.draft !== true ||

--- a/scripts/release/independent-audit-coordinator.mjs
+++ b/scripts/release/independent-audit-coordinator.mjs
@@ -7,7 +7,7 @@ import { pathToFileURL } from "node:url"
 import { normalizeAdapterEnvelope, snapshotJson } from "./adapter-normalize.mjs"
 import { createGitHubReader } from "./adapters/github.mjs"
 import { createGitHubWriter } from "./adapters/github-write.mjs"
-import { canonicalReleaseBody, parseReleaseMarker } from "./metadata.mjs"
+import { canonicalReleaseBody, isManagedReleaseForTag, parseReleaseMarker } from "./metadata.mjs"
 import { compareSemver, isExactSemver, parseSemver } from "./semver.mjs"
 
 const REPOSITORY = "cacheplane/dawnai"
@@ -144,18 +144,7 @@ function parseManagedRelease(value, { defaultBranch, expected, allowDraft }) {
   ) {
     throw new Error("Managed Release identity is malformed")
   }
-  const version = release.tag_name.startsWith("v") ? release.tag_name.slice(1) : ""
-  if (!isReleaseVersion(version) || release.name !== `Dawn v${version}`) {
-    throw new Error("Managed Release version or title is malformed")
-  }
   const marker = parseReleaseMarker(release.body)
-  if (
-    marker.version !== version ||
-    marker.tag !== release.tag_name ||
-    release.body !== canonicalReleaseBody({ marker, manifest: null })
-  ) {
-    throw new Error("Managed Release marker identity is malformed")
-  }
   let mode
   if (release.draft === false && release.immutable === true && marker.phase === "AUDIT_VERIFIED") {
     mode = "published"
@@ -168,6 +157,18 @@ function parseManagedRelease(value, { defaultBranch, expected, allowDraft }) {
     mode = "draft"
   } else {
     throw new Error("Managed Release is not an auditable draft or published immutable release")
+  }
+  const version = mode === "draft" ? marker.version : release.tag_name.slice(1)
+  const tag = `v${version}`
+  if (
+    !isReleaseVersion(version) ||
+    release.name !== `Dawn v${version}` ||
+    marker.version !== version ||
+    marker.tag !== tag ||
+    (mode === "draft" ? !isManagedReleaseForTag(release, tag) : release.tag_name !== tag) ||
+    release.body !== canonicalReleaseBody({ marker, manifest: null })
+  ) {
+    throw new Error("Managed Release marker identity is malformed")
   }
   const identity = {
     version,
@@ -182,7 +183,7 @@ function parseManagedRelease(value, { defaultBranch, expected, allowDraft }) {
   ) {
     throw new Error("Managed Release does not match the exact audit inputs")
   }
-  return Object.freeze({ ...identity, tag: release.tag_name, mode })
+  return Object.freeze({ ...identity, tag, mode })
 }
 
 async function verifyAnnotatedTag(reader, release) {

--- a/scripts/release/independent-audit.mjs
+++ b/scripts/release/independent-audit.mjs
@@ -14,7 +14,12 @@ import { createCliAttestationVerifier } from "./artifact-store.mjs"
 import { readBoundedFixture } from "./fixture-io.mjs"
 import { RELEASE_PAYLOAD_LIMITS } from "./limits.mjs"
 import { CANONICAL_RELEASE_PACKAGE_ORDER } from "./manifest.mjs"
-import { canonicalReleaseBody, MAX_AUDIT_ATTEMPTS, parseReleaseMarker } from "./metadata.mjs"
+import {
+  canonicalReleaseBody,
+  isManagedReleaseForTag,
+  MAX_AUDIT_ATTEMPTS,
+  parseReleaseMarker,
+} from "./metadata.mjs"
 import { createNpmAuditVerifier } from "./npm-audit.mjs"
 import {
   createProductionInventoryReader,
@@ -350,7 +355,7 @@ function parseDispatchRelease(value, candidate, manifestSha256) {
     !isRecord(release) ||
     !isPositiveInteger(release.id) ||
     release.name !== `Dawn v${candidate.version}` ||
-    release.tag_name !== `v${candidate.version}` ||
+    !isManagedReleaseForTag(release, `v${candidate.version}`) ||
     release.target_commitish !== "main" ||
     release.draft !== true ||
     release.immutable !== false ||

--- a/scripts/release/metadata.mjs
+++ b/scripts/release/metadata.mjs
@@ -190,6 +190,31 @@ export function parseReleaseMarker(value) {
   return marker
 }
 
+export function isManagedReleaseForTag(release, tag) {
+  try {
+    if (!isPlainDataObject(release) || typeof tag !== "string") return false
+    const tagName = Object.getOwnPropertyDescriptor(release, "tag_name")
+    if (!isEnumerableData(tagName) || typeof tagName.value !== "string") return false
+    if (tagName.value === tag) return true
+    const draft = Object.getOwnPropertyDescriptor(release, "draft")
+    const immutable = Object.getOwnPropertyDescriptor(release, "immutable")
+    const body = Object.getOwnPropertyDescriptor(release, "body")
+    if (
+      !isEnumerableData(draft) ||
+      draft.value !== true ||
+      !isEnumerableData(immutable) ||
+      immutable.value !== false ||
+      !isEnumerableData(body) ||
+      typeof body.value !== "string"
+    ) {
+      return false
+    }
+    return parseReleaseMarker(body.value).tag === tag
+  } catch {
+    return false
+  }
+}
+
 export function canonicalReleaseBody(input) {
   const source = snapshotJson(input)
   if (!isRecord(source) || !hasExactFields(source, ["marker", "manifest"], ["previousMarker"])) {
@@ -966,7 +991,7 @@ export async function escrowCandidate(input) {
     })
     release = await readManagedRelease(github.reader, positiveId(created.releaseId, "Release ID"))
   }
-  assertMutableCandidateRelease(release, candidate, title)
+  assertMutableCandidateRelease(release, title)
   let marker = parseReleaseMarker(release.body)
   assertEscrowMarkerMatches(marker, desiredMarker, { candidate, manifest })
   if (release.body !== canonicalReleaseBody({ marker, manifest })) {
@@ -2191,7 +2216,7 @@ function bindMethods(value, methods, label) {
 async function findManagedRelease(reader, tag) {
   const releases = await readGitHubValue(reader.listReleases({}), "releases")
   if (!Array.isArray(releases)) throw new Error("GitHub Release list is malformed")
-  const matches = releases.filter((release) => isRecord(release) && release.tag_name === tag)
+  const matches = releases.filter((release) => isManagedReleaseForTag(release, tag))
   if (matches.length > 1) throw new Error("Duplicate managed Releases are ambiguous")
   if (matches.length === 0) return null
   return readManagedRelease(reader, positiveId(matches[0].id, "Release ID"))
@@ -2230,7 +2255,7 @@ async function readManagedRelease(reader, releaseId) {
 async function requireDraftRelease(reader, candidate) {
   const release = await findManagedRelease(reader, `v${candidate.version}`)
   if (release === null) throw new Error("Managed draft Release is missing")
-  assertMutableCandidateRelease(release, candidate, `Dawn v${candidate.version}`)
+  assertMutableCandidateRelease(release, `Dawn v${candidate.version}`)
   return release
 }
 
@@ -2412,9 +2437,8 @@ function addPublicationBytes(current, size, maximum, label) {
   return total
 }
 
-function assertMutableCandidateRelease(release, candidate, title) {
+function assertMutableCandidateRelease(release, title) {
   if (
-    release.tag_name !== `v${candidate.version}` ||
     release.target_commitish !== "main" ||
     release.prerelease !== false ||
     release.name !== title ||

--- a/scripts/release/observe.mjs
+++ b/scripts/release/observe.mjs
@@ -13,6 +13,7 @@ import {
 } from "./manifest.mjs"
 import {
   canonicalReleaseBody,
+  isManagedReleaseForTag,
   MAX_AUDIT_ATTEMPTS,
   MAX_PUBLICATION_ASSETS,
   MAX_SMOKE_ASSETS,
@@ -1669,7 +1670,9 @@ async function mapProductionRelease({
       escrow: { status: "ambiguous", manifestSha256: null, assets: [] },
     })
   }
-  const matches = result.value.filter((release) => release?.tag_name === `v${candidate.version}`)
+  const matches = result.value.filter((release) =>
+    isManagedReleaseForTag(release, `v${candidate.version}`),
+  )
   if (matches.length === 0) {
     return productionReleaseState({
       release: nonPresentRelease("absent"),
@@ -2411,7 +2414,8 @@ function normalizeReleaseIdentity(value, candidate) {
     !isRecord(value) ||
     !isPositiveId(value.id) ||
     !allowedTitles.has(value.name) ||
-    value.tag_name !== `v${candidate.version}` ||
+    (!(value.draft === true && value.immutable === false) &&
+      value.tag_name !== `v${candidate.version}`) ||
     value.target_commitish !== "main" ||
     typeof value.draft !== "boolean" ||
     typeof value.immutable !== "boolean" ||
@@ -3741,10 +3745,12 @@ async function mapRelease(result, inventory, candidate, github, diagnostics, obs
     return ambiguousRelease()
   }
   const tag = release.tag_name
+  const expectedTag = `v${candidate.version}`
   const commitSha = marker.commitSha
+  const mutableDraft = release.draft === true && release.immutable === false
   if (
-    tag !== `v${candidate.version}` ||
-    marker.tag !== tag ||
+    (mutableDraft ? !isManagedReleaseForTag(release, expectedTag) : tag !== expectedTag) ||
+    marker.tag !== expectedTag ||
     marker.version !== candidate.version ||
     commitSha !== candidate.commitSha
   ) {
@@ -3832,7 +3838,7 @@ async function mapRelease(result, inventory, candidate, github, diagnostics, obs
   })
   return {
     status: release.draft === true ? "draft" : "published",
-    tag,
+    tag: expectedTag,
     commitSha,
     immutable: release.immutable,
     bodySha256: sha256(Buffer.from(release.body, "utf8")),

--- a/scripts/release/test/abandonment-handoff.test.mjs
+++ b/scripts/release/test/abandonment-handoff.test.mjs
@@ -492,7 +492,7 @@ function githubReader(raw, calls) {
     },
     async getRelease({ releaseId }) {
       calls.github.push("getRelease")
-      const listed = raw.releases.find(({ tag_name: tagName }) => tagName === `v${VERSION}`)
+      const listed = raw.releases.find((release) => release.id === releaseId)
       assert.equal(releaseId, listed?.id)
       return present("release", raw.release)
     },
@@ -520,10 +520,10 @@ function rawReleaseFixture(observation) {
   const release = {
     id: 901,
     name: `Dawn v${VERSION}`,
-    tag_name: `v${VERSION}`,
+    tag_name: observation.release.status === "published" ? `v${VERSION}` : "untagged-opaque",
     target_commitish: "main",
-    draft: true,
-    immutable: false,
+    draft: observation.release.status !== "published",
+    immutable: observation.release.status === "published",
     prerelease: false,
     body: releaseBody(observation),
   }

--- a/scripts/release/test/abandonment.test.mjs
+++ b/scripts/release/test/abandonment.test.mjs
@@ -894,7 +894,7 @@ function fakeGitHub({
     const body = canonicalReleaseBody({ marker: context.release.marker, manifest: null })
     state.release = {
       id: context.release.releaseId,
-      tag_name: `v${VERSION}`,
+      tag_name: "untagged-opaque",
       target_commitish: "main",
       prerelease: false,
       name: `Dawn v${VERSION}`,
@@ -958,10 +958,11 @@ function fakeGitHub({
   }
   const writer = {
     createDraftRelease: async ({ tag, title, body }) => {
+      assert.equal(tag, `v${VERSION}`)
       if (createStatus === "created") state.mutations.push("create")
       state.release = {
         id: 10,
-        tag_name: tag,
+        tag_name: "untagged-opaque",
         target_commitish: "main",
         prerelease: false,
         name: title,
@@ -969,7 +970,7 @@ function fakeGitHub({
         draft: true,
         immutable: false,
       }
-      state.releases.push({ id: 10, tag_name: tag })
+      state.releases.push({ id: 10, tag_name: state.release.tag_name })
       if (failAfter === "create") throw new Error("Simulated runner loss after create")
       return { releaseId: 10, status: createStatus, bodySha256: releaseBodySha256(body) }
     },

--- a/scripts/release/test/artifact-store.test.mjs
+++ b/scripts/release/test/artifact-store.test.mjs
@@ -18,7 +18,9 @@ import {
 } from "../artifact-store.mjs"
 import { RELEASE_PAYLOAD_LIMITS } from "../limits.mjs"
 import { CANONICAL_RELEASE_PACKAGE_ORDER, canonicalManifestBytes } from "../manifest.mjs"
+import { canonicalReleaseBody } from "../metadata.mjs"
 import { canonicalReleaseRecordBytes } from "../release-record.mjs"
+import { observationForMarker } from "./support/marker-observation.mjs"
 
 const VERSION = "0.8.22"
 const SHA = "a".repeat(40)
@@ -298,13 +300,18 @@ test("the documented four-argument resolver defaults to its built-in ZIP extract
 
 test("the sparse executable dependency allowlist covers its exact local import closure", () => {
   assert.deepEqual(ARTIFACT_STORE_SPARSE_FILES, [
+    "scripts/release/adapter-normalize.mjs",
     "scripts/release/adapters/github.mjs",
     "scripts/release/adapters/http.mjs",
     "scripts/release/artifact-store.mjs",
     "scripts/release/limits.mjs",
     "scripts/release/manifest.mjs",
+    "scripts/release/metadata.mjs",
+    "scripts/release/npm-evidence.mjs",
     "scripts/release/release-record.mjs",
     "scripts/release/semver.mjs",
+    "scripts/release/smoke-result.mjs",
+    "scripts/release/terminal-records.mjs",
     "scripts/release/topology.mjs",
   ])
 })
@@ -355,6 +362,10 @@ test("production escrow accepts GitHub's main target only after exact annotated-
     size: bytes.length,
   }))
   const byId = new Map(assets.map((asset) => [asset.id, contents.get(asset.name)]))
+  const draftBody = canonicalReleaseBody({
+    marker: observationForMarker({ phase: "ESCROWED" }).release.marker,
+    manifest: null,
+  })
   const calls = []
   const runtime = createArtifactStoreGitHubRuntime({
     metadataReader: {
@@ -364,10 +375,21 @@ test("production escrow accepts GitHub's main target only after exact annotated-
           value: [
             {
               id: 44,
-              tag_name: fixture.record.tag,
+              tag_name: "untagged-opaque",
               target_commitish: "main",
               draft: true,
+              immutable: false,
               prerelease: false,
+              body: draftBody,
+            },
+            {
+              id: 45,
+              tag_name: "untagged-unrelated",
+              target_commitish: "main",
+              draft: true,
+              immutable: false,
+              prerelease: false,
+              body: `${draftBody}${draftBody}`,
             },
           ],
         }
@@ -450,6 +472,7 @@ test("production escrow rejects noncanonical targets, lightweight tags, and wron
                 tag_name: fixture.record.tag,
                 target_commitish: variation.target,
                 draft: true,
+                immutable: false,
                 prerelease: false,
               },
             ],
@@ -498,6 +521,7 @@ test("production escrow downloads share one bounded byte budget", async () => {
               tag_name: fixture.record.tag,
               target_commitish: "main",
               draft: true,
+              immutable: false,
               prerelease: false,
             },
           ],
@@ -547,6 +571,7 @@ test("escrow rejects an oversized asset from metadata before downloading it", as
               tag_name: fixture.record.tag,
               target_commitish: "main",
               draft: true,
+              immutable: false,
               prerelease: false,
             },
           ],

--- a/scripts/release/test/audit.test.mjs
+++ b/scripts/release/test/audit.test.mjs
@@ -82,6 +82,13 @@ test("independent dispatch uses the exact tag workflow and direct run receipt", 
 
 test("dispatch recording CASes only an exact mutable SMOKES_COMPLETE draft", async () => {
   const remote = auditRemote()
+  remote.listedReleases.push({
+    id: 8,
+    tag_name: "untagged-unrelated",
+    draft: true,
+    immutable: false,
+    body: `${remote.release.body}${remote.release.body}`,
+  })
   const before = remote.baseSnapshot()
   const recorded = await recordAuditDispatch({
     candidate: CANDIDATE,
@@ -116,6 +123,21 @@ test("dispatch recording CASes only an exact mutable SMOKES_COMPLETE draft", asy
     }),
     /dispatch|phase|conflict/iu,
   )
+})
+
+test("dispatch recording rejects duplicate marker-backed drafts before mutation", async () => {
+  const remote = auditRemote()
+  remote.listedReleases.push({ ...remote.release, id: 8 })
+
+  await assert.rejects(
+    recordAuditDispatch({
+      candidate: CANDIDATE,
+      dispatch: dispatch(501),
+      github: remote.releaseGitHub,
+    }),
+    /missing|ambiguous|duplicate/iu,
+  )
+  assert.equal(remote.updateCount, 0)
 })
 
 test("audit observation parses durable smoke receipts and recomputes their selected aggregate", async () => {
@@ -652,7 +674,7 @@ function auditRemote() {
   const remote = {
     release: {
       id: 7,
-      tag_name: `v${VERSION}`,
+      tag_name: "untagged-opaque",
       target_commitish: "main",
       prerelease: false,
       name: `Dawn v${VERSION}`,
@@ -665,6 +687,7 @@ function auditRemote() {
     updateCount: 0,
     uploadCount: 0,
     publishCount: 0,
+    listedReleases: [{ id: 7 }],
     throwAfterUploadName: null,
     throwAfterUpdate: false,
   }
@@ -691,7 +714,12 @@ function auditRemote() {
       })
     },
     async listReleases() {
-      return present("releases", [{ id: 7, tag_name: `v${VERSION}` }])
+      return present(
+        "releases",
+        remote.listedReleases.map((release) =>
+          release.id === remote.release.id ? { ...remote.release, ...release } : release,
+        ),
+      )
     },
     async getRelease() {
       return present("release", { ...remote.release })

--- a/scripts/release/test/candidate.test.mjs
+++ b/scripts/release/test/candidate.test.mjs
@@ -394,18 +394,84 @@ test("scheduled discovery admits an exact AUDIT_VERIFIED draft for production ob
     commit(SHA_21, "0.8.21", { parent: BASE_SHA, marker: true }),
   ])
   const release = auditVerifiedDraftRelease(21, "0.8.21", SHA_21)
+  release.tag_name = "untagged-opaque"
+  const github = githubFixture({
+    tags: [tagRef("0.8.21", SHA_21)],
+    releases: [release],
+  })
 
   const result = await discoverScheduledCandidate({
     inventory: repository.inventory,
     git: repository.git,
-    github: githubFixture({
-      tags: [tagRef("0.8.21", SHA_21)],
-      releases: [release],
-    }),
+    github,
     marker: ACTIVE_MARKER,
   })
 
   assert.deepEqual(result, selectedCandidate("0.8.21", SHA_21, "CANDIDATE_TAGGED"))
+  assert.deepEqual(
+    github.calls.filter(([operation]) => operation === "listReleaseAssets"),
+    [["listReleaseAssets", release.id]],
+  )
+})
+
+test("scheduled discovery ignores malformed temporary drafts beside a marker-backed candidate", async () => {
+  const repository = repositoryFixture([
+    commit(BASE_SHA, "0.8.20"),
+    commit(SHA_21, "0.8.21", { parent: BASE_SHA, marker: true }),
+  ])
+  const release = auditVerifiedDraftRelease(21, "0.8.21", SHA_21)
+  release.tag_name = "untagged-opaque"
+  const github = githubFixture({
+    tags: [tagRef("0.8.21", SHA_21)],
+    releases: [
+      {
+        id: 99,
+        tag_name: "untagged-unrelated",
+        draft: true,
+        immutable: false,
+        body: `${release.body}${release.body}`,
+        assets: [],
+      },
+      release,
+    ],
+  })
+
+  const result = await discoverScheduledCandidate({
+    inventory: repository.inventory,
+    git: repository.git,
+    github,
+    marker: ACTIVE_MARKER,
+  })
+
+  assert.deepEqual(result, selectedCandidate("0.8.21", SHA_21, "CANDIDATE_TAGGED"))
+  assert.deepEqual(
+    github.calls.filter(([operation]) => operation === "listReleaseAssets"),
+    [["listReleaseAssets", release.id]],
+  )
+})
+
+test("scheduled discovery fails closed on duplicate marker-backed candidate drafts", async () => {
+  const repository = repositoryFixture([
+    commit(BASE_SHA, "0.8.20"),
+    commit(SHA_21, "0.8.21", { parent: BASE_SHA, marker: true }),
+  ])
+  const release = auditVerifiedDraftRelease(21, "0.8.21", SHA_21)
+  release.tag_name = "untagged-opaque"
+  const duplicate = auditVerifiedDraftRelease(22, "0.8.21", SHA_21)
+  duplicate.tag_name = "untagged-conflict"
+
+  await assert.rejects(
+    discoverScheduledCandidate({
+      inventory: repository.inventory,
+      git: repository.git,
+      github: githubFixture({
+        tags: [tagRef("0.8.21", SHA_21)],
+        releases: [release, duplicate],
+      }),
+      marker: ACTIVE_MARKER,
+    }),
+    /duplicated|duplicate|ambiguous/iu,
+  )
 })
 
 test("scheduled discovery rejects successful audit evidence on any inexact draft", async () => {

--- a/scripts/release/test/fixtures/release-script-hashes.json
+++ b/scripts/release/test/fixtures/release-script-hashes.json
@@ -17,22 +17,25 @@
       "sha256": "3e171b1bc9aa79080d58087327ea2014b856ba5e6329f33de1a0a5f1b18c05d1"
     },
     "scripts/release/artifact-store.mjs": {
-      "sha256": "09b5423224b2d76c6cba6de616a1fabae0f5d0efc126e68c3ed3f8de7c82f924"
+      "sha256": "1b1e17298068211d5e47ac6adfe74e996b1faee91a567385d694704e3ba2de54"
     },
     "scripts/release/cli.mjs": {
       "sha256": "7d78f62482a472a7380987353a5d895c84c9da97600643ff2aead40c7904b2c8"
     },
     "scripts/release/independent-audit-coordinator.mjs": {
-      "sha256": "29803cd7d46310091d1f723f1ca7c821242127f6127c118dc95ed94db7a3efa7"
+      "sha256": "a72f438f776f9ca26914c2ec51dd75de8f3b6c7d85ae8b11f2cc51c651e10d53"
     },
     "scripts/release/independent-audit.mjs": {
-      "sha256": "df75a31d6aa7c01a58583fa41eb4041ba4b4322a273c4b739f8e4eb6ffcd3eff"
+      "sha256": "1d18e376e41e12b4d98cf63f79448d485a5cf3ca95abdedbc5045b3f29c6a818"
     },
     "scripts/release/limits.mjs": {
       "sha256": "6ace39d22cdf5dbedff3b14b444c00cd3102082f8ef733ee458d0e6b52f1982f"
     },
     "scripts/release/manifest.mjs": {
       "sha256": "1a931c3056826e489894f67474287b81d6518c9076abbc779ad387697b61b4a9"
+    },
+    "scripts/release/metadata.mjs": {
+      "sha256": "7eb0cfcbccc5ab01a222c3e8c69b645eb6bcc20f23d087a7bdf9f649100feb69"
     },
     "scripts/release/npm-audit.mjs": {
       "sha256": "308b723105b9549a2740456eaedf2f272c0885fdc5c530f9bfb3aa0e49314111"
@@ -55,6 +58,9 @@
     "scripts/release/semver.mjs": {
       "sha256": "fee872a1dddfa280cf0efe608525cad6d9f42d8d647a9ccf2ef9be1b7c41a06a"
     },
+    "scripts/release/smoke-result.mjs": {
+      "sha256": "d86a5cc1ccb9bafa45451ae4186b7d2a8573eba03cbf127efe0843712c9cd21e"
+    },
     "scripts/release/smoke/published-harness.mjs": {
       "sha256": "48cec31768f1df81f29876f3630c9d721a4af1b606740d3502c9c02b0473c041"
     },
@@ -66,6 +72,9 @@
     },
     "scripts/release/smoke/storage.mjs": {
       "sha256": "448dbbca39890ef849ed5658931b0e2a193693354ed87d6c109f0f7e0d6270a7"
+    },
+    "scripts/release/terminal-records.mjs": {
+      "sha256": "17151da8acf77431decd76ea3b78af41243b7e5a92cb572427c8aa8196af61d1"
     },
     "scripts/release/topology.mjs": {
       "sha256": "537ba6f93eeb3411d40371b04ed4d0db380089861a8560a143b50c9c5b2f917e"

--- a/scripts/release/test/fixtures/release-workflow-disabled.yml
+++ b/scripts/release/test/fixtures/release-workflow-disabled.yml
@@ -560,12 +560,15 @@ jobs:
             scripts/release/artifact-store.mjs
             scripts/release/limits.mjs
             scripts/release/manifest.mjs
+            scripts/release/metadata.mjs
             scripts/release/npm-audit.mjs
             scripts/release/npm-evidence.mjs
             scripts/release/process-runner.mjs
             scripts/release/publisher.mjs
             scripts/release/release-record.mjs
             scripts/release/semver.mjs
+            scripts/release/smoke-result.mjs
+            scripts/release/terminal-records.mjs
             scripts/release/topology.mjs
 
       - name: Setup Node.js

--- a/scripts/release/test/fixtures/release-workflow-protected.yml
+++ b/scripts/release/test/fixtures/release-workflow-protected.yml
@@ -584,12 +584,15 @@ jobs:
             scripts/release/artifact-store.mjs
             scripts/release/limits.mjs
             scripts/release/manifest.mjs
+            scripts/release/metadata.mjs
             scripts/release/npm-audit.mjs
             scripts/release/npm-evidence.mjs
             scripts/release/process-runner.mjs
             scripts/release/publisher.mjs
             scripts/release/release-record.mjs
             scripts/release/semver.mjs
+            scripts/release/smoke-result.mjs
+            scripts/release/terminal-records.mjs
             scripts/release/topology.mjs
 
       - name: Setup Node.js

--- a/scripts/release/test/fixtures/workflow-entrypoints.json
+++ b/scripts/release/test/fixtures/workflow-entrypoints.json
@@ -2877,7 +2877,7 @@
                 "with": {
                   "persist-credentials": false,
                   "ref": "${{ needs.detect.outputs.candidate_sha }}",
-                  "sparse-checkout": "scripts/release/adapter-normalize.mjs\nscripts/release/adapters/github.mjs\nscripts/release/adapters/http.mjs\nscripts/release/adapters/npm.mjs\nscripts/release/artifact-store.mjs\nscripts/release/limits.mjs\nscripts/release/manifest.mjs\nscripts/release/npm-audit.mjs\nscripts/release/npm-evidence.mjs\nscripts/release/process-runner.mjs\nscripts/release/publisher.mjs\nscripts/release/release-record.mjs\nscripts/release/semver.mjs\nscripts/release/topology.mjs\n",
+                  "sparse-checkout": "scripts/release/adapter-normalize.mjs\nscripts/release/adapters/github.mjs\nscripts/release/adapters/http.mjs\nscripts/release/adapters/npm.mjs\nscripts/release/artifact-store.mjs\nscripts/release/limits.mjs\nscripts/release/manifest.mjs\nscripts/release/metadata.mjs\nscripts/release/npm-audit.mjs\nscripts/release/npm-evidence.mjs\nscripts/release/process-runner.mjs\nscripts/release/publisher.mjs\nscripts/release/release-record.mjs\nscripts/release/semver.mjs\nscripts/release/smoke-result.mjs\nscripts/release/terminal-records.mjs\nscripts/release/topology.mjs\n",
                   "sparse-checkout-cone-mode": false
                 }
               }

--- a/scripts/release/test/github-write.test.mjs
+++ b/scripts/release/test/github-write.test.mjs
@@ -42,7 +42,7 @@ test("draft creation proves an annotated tag and re-reads the exact created draf
     releases: [],
     release: {
       id: 7,
-      tag_name: TAG,
+      tag_name: "untagged-opaque",
       target_commitish: "main",
       prerelease: false,
       name: `Dawn v${VERSION}`,
@@ -83,6 +83,160 @@ test("draft creation proves an annotated tag and re-reads the exact created draf
     generate_release_notes: false,
   })
   assert.equal(Object.hasOwn(JSON.parse(calls[0].init.body), "target_commitish"), false)
+})
+
+test("draft creation discovers one exact mutable draft despite an opaque temporary tag", async () => {
+  const fixture = verifiedPublicationFixture()
+  const release = { ...draftRelease(fixture.body), tag_name: "untagged-opaque" }
+  const writer = createGitHubWriter({
+    owner: OWNER,
+    repo: REPO,
+    reader: exactReader({ releases: [release], release }),
+    fetchImpl: assert.fail,
+  })
+
+  assert.deepEqual(
+    await writer.createDraftRelease({
+      tag: TAG,
+      targetSha: SHA,
+      title: `Dawn v${VERSION}`,
+      body: fixture.body,
+    }),
+    {
+      releaseId: 7,
+      status: "existing",
+      bodySha256: releaseBodySha256(fixture.body),
+    },
+  )
+})
+
+test("draft creation reconciles one exact opaque-tag race and rejects ambiguous duplicates", async () => {
+  const fixture = verifiedPublicationFixture()
+  const release = { ...draftRelease(fixture.body), tag_name: "untagged-opaque" }
+  let lists = 0
+  const raced = createGitHubWriter({
+    owner: OWNER,
+    repo: REPO,
+    reader: exactReader({
+      releases() {
+        lists += 1
+        return lists === 1 ? [] : [release]
+      },
+      release,
+    }),
+    fetchImpl: async () => jsonResponse({}, 422),
+  })
+
+  assert.deepEqual(
+    await raced.createDraftRelease({
+      tag: TAG,
+      targetSha: SHA,
+      title: `Dawn v${VERSION}`,
+      body: fixture.body,
+    }),
+    {
+      releaseId: 7,
+      status: "existing",
+      bodySha256: releaseBodySha256(fixture.body),
+    },
+  )
+  assert.equal(lists, 2)
+
+  let mutations = 0
+  const duplicate = createGitHubWriter({
+    owner: OWNER,
+    repo: REPO,
+    reader: exactReader({
+      releases: [release, { ...release, id: 8, tag_name: "untagged-other" }],
+      release,
+    }),
+    fetchImpl: async () => {
+      mutations += 1
+      return jsonResponse({}, 201)
+    },
+  })
+  await assert.rejects(
+    duplicate.createDraftRelease({
+      tag: TAG,
+      targetSha: SHA,
+      title: `Dawn v${VERSION}`,
+      body: fixture.body,
+    }),
+    /duplicate|ambiguous/iu,
+  )
+  assert.equal(mutations, 0)
+})
+
+test("draft updates and asset uploads preserve tag verification around opaque-tag mutations", async () => {
+  let updateTagReads = 0
+  let body = "old body"
+  const updateWriter = createGitHubWriter({
+    owner: OWNER,
+    repo: REPO,
+    reader: exactReader({
+      release: () => ({ ...draftRelease(body), tag_name: "untagged-opaque" }),
+      tagTargetSha() {
+        updateTagReads += 1
+        return SHA
+      },
+    }),
+    fetchImpl: async (_url, init) => {
+      body = JSON.parse(init.body).body
+      return jsonResponse({ id: 7 }, 200)
+    },
+  })
+  assert.deepEqual(
+    await updateWriter.updateDraftReleaseIfCurrent({
+      releaseId: 7,
+      tag: TAG,
+      targetSha: SHA,
+      expectedBodySha256: releaseBodySha256("old body"),
+      title: `Dawn v${VERSION}`,
+      body: "new body",
+    }),
+    {
+      releaseId: 7,
+      status: "updated",
+      bodySha256: releaseBodySha256("new body"),
+    },
+  )
+  assert.equal(updateTagReads, 2)
+
+  const bytes = Buffer.from("exact asset")
+  const digest = sha256(bytes)
+  const assets = []
+  const downloads = new Map()
+  let uploadTagReads = 0
+  const uploadWriter = createGitHubWriter({
+    owner: OWNER,
+    repo: REPO,
+    reader: exactReader({
+      release: { ...draftRelease("body"), tag_name: "untagged-opaque" },
+      assets,
+      downloads,
+      tagTargetSha() {
+        uploadTagReads += 1
+        return SHA
+      },
+    }),
+    fetchImpl: async () => {
+      assets.push({ id: 90, name: "manifest.json" })
+      downloads.set(90, bytes)
+      return jsonResponse({ id: 90 }, 201)
+    },
+  })
+  assert.deepEqual(
+    await uploadWriter.uploadAssetIfAbsentAndEqual({
+      releaseId: 7,
+      tag: TAG,
+      targetSha: SHA,
+      name: "manifest.json",
+      bytes,
+      sha256: digest,
+    }),
+    { assetId: 90, status: "uploaded", sha256: digest },
+  )
+  assert.equal(uploadTagReads, 2)
 })
 
 test("writer rejects lightweight tags and stale body CAS without mutation", async () => {
@@ -537,7 +691,7 @@ test("writer bounds response time, content type, redirects, and output bytes", a
   await assert.rejects(dispatch(oversized), /byte limit/iu)
 })
 
-test("publication changes only draft state and requires immutable unchanged re-read", async () => {
+test("publication binds the exact tag and requires an exact immutable unchanged re-read", async () => {
   const fixture = verifiedPublicationFixture()
   const calls = []
   let releaseReads = 0
@@ -546,7 +700,7 @@ test("publication changes only draft state and requires immutable unchanged re-r
       releaseReads += 1
       return {
         id: 7,
-        tag_name: TAG,
+        tag_name: releaseReads === 1 ? "untagged-opaque" : TAG,
         target_commitish: "main",
         prerelease: false,
         name: `Dawn v${VERSION}`,
@@ -578,7 +732,113 @@ test("publication changes only draft state and requires immutable unchanged re-r
   assert.deepEqual(result, { releaseId: 7, status: "published", immutable: true })
   assert.equal(calls.length, 1)
   assert.equal(calls[0].url, `${API_BASE}/releases/7`)
-  assert.deepEqual(JSON.parse(calls[0].init.body), { draft: false })
+  assert.deepEqual(JSON.parse(calls[0].init.body), { tag_name: TAG, draft: false })
+})
+
+test("publication PATCH includes the exact requested tag for an already tagged draft", async () => {
+  const fixture = verifiedPublicationFixture()
+  const calls = []
+  let releaseReads = 0
+  const writer = createGitHubWriter({
+    owner: OWNER,
+    repo: REPO,
+    reader: exactReader({
+      release() {
+        releaseReads += 1
+        return {
+          ...draftRelease(fixture.body),
+          draft: releaseReads === 1,
+          immutable: releaseReads > 1,
+        }
+      },
+      assets: fixture.assets.map((asset, index) => ({ id: index + 1, name: asset.name })),
+      downloads: new Map(fixture.assets.map((asset, index) => [index + 1, asset.bytes])),
+    }),
+    fetchImpl: async (url, init) => {
+      calls.push({ url: String(url), init })
+      return jsonResponse({ id: 7, draft: false }, 200)
+    },
+  })
+
+  await writer.publishReleaseIfCurrent({
+    releaseId: 7,
+    tag: TAG,
+    targetSha: SHA,
+    expectedBodySha256: releaseBodySha256(fixture.body),
+    assets: fixture.assets.map(({ name, digest }) => ({ name, sha256: digest })),
+  })
+
+  assert.equal(calls.length, 1)
+  assert.deepEqual(JSON.parse(calls[0].init.body), { tag_name: TAG, draft: false })
+})
+
+test("publication rejects an immutable re-read that retains the opaque temporary tag", async () => {
+  const fixture = verifiedPublicationFixture()
+  let releaseReads = 0
+  const writer = createGitHubWriter({
+    owner: OWNER,
+    repo: REPO,
+    reader: exactReader({
+      release() {
+        releaseReads += 1
+        return {
+          ...draftRelease(fixture.body),
+          tag_name: "untagged-opaque",
+          draft: releaseReads === 1,
+          immutable: releaseReads > 1,
+        }
+      },
+      assets: fixture.assets.map((asset, index) => ({ id: index + 1, name: asset.name })),
+      downloads: new Map(fixture.assets.map((asset, index) => [index + 1, asset.bytes])),
+    }),
+    fetchImpl: async () => jsonResponse({ id: 7, draft: false }, 200),
+  })
+
+  await assert.rejects(
+    writer.publishReleaseIfCurrent({
+      releaseId: 7,
+      tag: TAG,
+      targetSha: SHA,
+      expectedBodySha256: releaseBodySha256(fixture.body),
+      assets: fixture.assets.map(({ name, digest }) => ({ name, sha256: digest })),
+    }),
+    /identity|metadata|tag/iu,
+  )
+  assert.equal(releaseReads, 2)
+})
+
+test("an existing published Release must expose the exact tag and be immutable", async () => {
+  const fixture = verifiedPublicationFixture()
+  let mutations = 0
+  for (const release of [
+    { ...draftRelease(fixture.body), tag_name: "untagged-opaque", draft: false, immutable: true },
+    { ...draftRelease(fixture.body), draft: false, immutable: false },
+  ]) {
+    const writer = createGitHubWriter({
+      owner: OWNER,
+      repo: REPO,
+      reader: exactReader({
+        release,
+        assets: fixture.assets.map((asset, index) => ({ id: index + 1, name: asset.name })),
+        downloads: new Map(fixture.assets.map((asset, index) => [index + 1, asset.bytes])),
+      }),
+      fetchImpl: async () => {
+        mutations += 1
+        return jsonResponse({}, 200)
+      },
+    })
+    await assert.rejects(
+      writer.publishReleaseIfCurrent({
+        releaseId: 7,
+        tag: TAG,
+        targetSha: SHA,
+        expectedBodySha256: releaseBodySha256(fixture.body),
+        assets: fixture.assets.map(({ name, digest }) => ({ name, sha256: digest })),
+      }),
+      /identity|metadata|immutable/iu,
+    )
+  }
+  assert.equal(mutations, 0)
 })
 
 test("publication rejects a marker whose immutable base digest does not match its assets", async () => {

--- a/scripts/release/test/independent-audit-coordinator.test.mjs
+++ b/scripts/release/test/independent-audit-coordinator.test.mjs
@@ -157,7 +157,7 @@ function managedRelease({ id, version, commitSha, draft = false }) {
   return {
     id,
     name: `Dawn v${version}`,
-    tag_name: `v${version}`,
+    tag_name: draft ? "untagged-opaque" : `v${version}`,
     target_commitish: "main",
     draft,
     immutable: !draft,
@@ -176,7 +176,9 @@ function githubBoundary({ releases, calls, refType = "tag", tagTargetSha }) {
       async getReleaseByTag({ tag }) {
         return present(
           "release",
-          releases.find((release) => release.tag_name === tag),
+          releases.find(
+            (release) => release.tag_name === tag || parseReleaseMarker(release.body).tag === tag,
+          ),
         )
       },
       async getRef({ ref }) {
@@ -184,9 +186,13 @@ function githubBoundary({ releases, calls, refType = "tag", tagTargetSha }) {
         return present("ref", { object: { type: refType, sha: TAG_SHA } })
       },
       async getGitTag() {
-        const release = releases.find((candidate) => candidate.tag_name === selectedTag)
+        const release = releases.find(
+          (candidate) =>
+            candidate.tag_name === selectedTag ||
+            parseReleaseMarker(candidate.body).tag === selectedTag,
+        )
         return present("git-tag", {
-          tag: release.tag_name,
+          tag: selectedTag,
           object: {
             type: "commit",
             sha: tagTargetSha ?? parseReleaseMarker(release.body).commitSha,

--- a/scripts/release/test/independent-audit.test.mjs
+++ b/scripts/release/test/independent-audit.test.mjs
@@ -923,7 +923,7 @@ function draftRelease(marker) {
   return {
     id: 91,
     name: `Dawn v${VERSION}`,
-    tag_name: `v${VERSION}`,
+    tag_name: "untagged-opaque",
     target_commitish: "main",
     draft: true,
     immutable: false,

--- a/scripts/release/test/metadata.test.mjs
+++ b/scripts/release/test/metadata.test.mjs
@@ -7,6 +7,7 @@ import {
   canonicalBaseAssetSet,
   canonicalReleaseBody,
   escrowCandidate,
+  isManagedReleaseForTag,
   parseAttestationSet,
   parsePublicationState,
   parseReleaseMarker,
@@ -86,6 +87,49 @@ test("release bodies contain one canonical exact marker and reject phase-invalid
         manifest: fixture.manifest,
       }),
     /attestation|repository|identity/iu,
+  )
+})
+
+test("managed Release identity accepts exact tags or canonical mutable-draft markers only", () => {
+  const fixture = releaseFixture()
+  const body = canonicalReleaseBody({
+    marker: attachingMarker(fixture),
+    manifest: fixture.manifest,
+  })
+
+  assert.equal(isManagedReleaseForTag({ tag_name: `v${VERSION}` }, `v${VERSION}`), true)
+  assert.equal(
+    isManagedReleaseForTag(
+      { tag_name: "untagged-opaque", draft: true, immutable: false, body },
+      `v${VERSION}`,
+    ),
+    true,
+  )
+  assert.equal(
+    isManagedReleaseForTag(
+      { tag_name: "untagged-opaque", draft: false, immutable: true, body },
+      `v${VERSION}`,
+    ),
+    false,
+  )
+  assert.equal(
+    isManagedReleaseForTag(
+      { tag_name: "untagged-opaque", draft: true, immutable: false, body: "malformed" },
+      `v${VERSION}`,
+    ),
+    false,
+  )
+  assert.equal(
+    isManagedReleaseForTag(
+      Object.defineProperty({}, "tag_name", {
+        enumerable: true,
+        get() {
+          throw new Error("must not execute accessors")
+        },
+      }),
+      `v${VERSION}`,
+    ),
+    false,
   )
 })
 
@@ -452,6 +496,89 @@ test("escrow creates one resumable 45-asset draft and advances its marker only a
   })
   assert.equal(repeated.status, "unchanged")
   assert.equal(remote.uploadCount, 45)
+})
+
+test("escrow resumes the exact attaching draft whose opaque tag is bound by its canonical marker", async () => {
+  const fixture = releaseFixture()
+  const remote = inMemoryGitHub()
+  remote.release = {
+    id: 7,
+    tag_name: "untagged-opaque",
+    target_commitish: "main",
+    prerelease: false,
+    name: `Dawn v${VERSION}`,
+    body: canonicalReleaseBody({ marker: attachingMarker(fixture), manifest: fixture.manifest }),
+    draft: true,
+    immutable: false,
+  }
+
+  const result = await escrowCandidate({
+    candidate: CANDIDATE,
+    record: fixture.record,
+    artifact: fixture.artifact,
+    attestationSet: fixture.attestationSet,
+    bundles: fixture.bundles,
+    publicationState: publicationState(fixture),
+    attestations: verifiedAttestations(fixture),
+    github: remote.github,
+  })
+
+  assert.deepEqual(result, {
+    releaseId: 7,
+    phase: "ESCROWED",
+    status: "escrowed",
+    assetCount: 45,
+    bodySha256: releaseBodySha256(remote.release.body),
+  })
+  assert.equal(remote.createCount, 0)
+  assert.equal(remote.release.tag_name, "untagged-opaque")
+})
+
+test("escrow rejects duplicate marker-bearing drafts before mutation", async () => {
+  const fixture = releaseFixture()
+  const remote = inMemoryGitHub()
+  const body = canonicalReleaseBody({
+    marker: attachingMarker(fixture),
+    manifest: fixture.manifest,
+  })
+  remote.listedReleases = [
+    {
+      id: 7,
+      tag_name: "untagged-opaque-a",
+      target_commitish: "main",
+      prerelease: false,
+      name: `Dawn v${VERSION}`,
+      body,
+      draft: true,
+      immutable: false,
+    },
+    {
+      id: 8,
+      tag_name: "untagged-opaque-b",
+      target_commitish: "main",
+      prerelease: false,
+      name: `Dawn v${VERSION}`,
+      body,
+      draft: true,
+      immutable: false,
+    },
+  ]
+
+  await assert.rejects(
+    escrowCandidate({
+      candidate: CANDIDATE,
+      record: fixture.record,
+      artifact: fixture.artifact,
+      attestationSet: fixture.attestationSet,
+      bundles: fixture.bundles,
+      publicationState: publicationState(fixture),
+      attestations: verifiedAttestations(fixture),
+      github: remote.github,
+    }),
+    /Duplicate managed Releases are ambiguous/u,
+  )
+
+  assert.equal(remote.createCount + remote.uploadCount + remote.updateCount, 0)
 })
 
 test("escrow adopts one different valid concurrent Release bundle and binds its signed replay run", async () => {
@@ -1708,9 +1835,11 @@ function zip(files) {
 function inMemoryGitHub() {
   const remote = {
     release: null,
+    listedReleases: null,
     assets: new Map(),
     nextAssetId: 1,
     uploadCount: 0,
+    createCount: 0,
     updateCount: 0,
     publishCount: 0,
     failAfterUploads: null,
@@ -1746,7 +1875,7 @@ function inMemoryGitHub() {
     async listReleases() {
       return present(
         "releases",
-        remote.release === null ? [] : [{ id: 7, tag_name: `v${VERSION}` }],
+        remote.listedReleases ?? (remote.release === null ? [] : [{ ...remote.release }]),
       )
     },
     async getRelease() {
@@ -1811,6 +1940,7 @@ function inMemoryGitHub() {
   })
   const writer = Object.freeze({
     async createDraftRelease({ tag, title, body }) {
+      remote.createCount += 1
       if (remote.release === null) {
         remote.release = {
           id: 7,

--- a/scripts/release/test/observe-production.test.mjs
+++ b/scripts/release/test/observe-production.test.mjs
@@ -1425,12 +1425,22 @@ test("production observation rejects a retained manifest sealed by a pull-reques
 
 test("production observation partitions and binds the exact draft Release base namespace", async () => {
   const escrow = attestedReleaseFixture()
+  escrow.release.tag_name = "untagged-opaque"
   const github = githubReader({
     async listActionsArtifacts() {
       return present("actions-artifacts", [])
     },
     async listReleases() {
-      return present("releases", [escrow.release])
+      return present("releases", [
+        {
+          id: 999,
+          tag_name: "untagged-unrelated",
+          draft: true,
+          immutable: false,
+          body: `${escrow.release.body}${escrow.release.body}`,
+        },
+        escrow.release,
+      ])
     },
     async getRelease({ releaseId }) {
       assert.equal(releaseId, escrow.release.id)
@@ -1478,6 +1488,38 @@ test("production observation partitions and binds the exact draft Release base n
   assert.equal(plan.state, "CANDIDATE_ESCROWED")
   assert.equal(plan.nextTransition, "publish-npm-packages")
   assert.deepEqual(plan.conflicts, [])
+})
+
+test("production observation fails closed on duplicate marker-backed draft Releases", async () => {
+  const escrow = attestedReleaseFixture()
+  escrow.release.tag_name = "untagged-opaque"
+  const duplicate = { ...escrow.release, id: escrow.release.id + 1 }
+  let exactReads = 0
+  const github = githubReader({
+    async listActionsArtifacts() {
+      return present("actions-artifacts", [])
+    },
+    async listReleases() {
+      return present("releases", [escrow.release, duplicate])
+    },
+    async getRelease() {
+      exactReads += 1
+      throw new Error("ambiguous drafts must fail before an exact Release read")
+    },
+  })
+
+  const { observation, diagnostics } = await observeProductionCandidate({
+    candidate: candidate(),
+    inventory: inventory(),
+    marker: MARKER,
+    git: gitReader(),
+    github,
+    npm: npmReader(),
+  })
+
+  assert.equal(exactReads, 0)
+  assert.equal(observation.release.status, "ambiguous")
+  assert.ok(diagnostics.some((entry) => entry.code === "RELEASE_IDENTITY_AMBIGUOUS"))
 })
 
 test("production observation rejects a retained attestation winner without its exact Actions run", async () => {

--- a/scripts/release/test/process-runner.test.mjs
+++ b/scripts/release/test/process-runner.test.mjs
@@ -50,12 +50,14 @@ test("the production preparation runner enforces a per-command deadline", async 
 })
 
 test("the production preparation runner enforces one overall deadline", async () => {
+  let currentTimeMs = 0
   const run = createReleasePreparationRunner({
     commandTimeoutMs: 1_000,
-    overallTimeoutMs: 80,
+    overallTimeoutMs: 2_000,
+    now: () => currentTimeMs,
   })
   await run(process.execPath, ["-e", ""], { cwd: process.cwd() })
-  await new Promise((resolve) => setTimeout(resolve, 60))
+  currentTimeMs = 2_001
 
   await assert.rejects(
     run(process.execPath, ["-e", "setTimeout(() => {}, 1_000)"], { cwd: process.cwd() }),

--- a/scripts/release/test/publisher.test.mjs
+++ b/scripts/release/test/publisher.test.mjs
@@ -24,6 +24,7 @@ import { pathToFileURL } from "node:url"
 
 import { ARTIFACT_STORE_SPARSE_FILES } from "../artifact-store.mjs"
 import { CANONICAL_RELEASE_PACKAGE_ORDER, canonicalManifestBytes } from "../manifest.mjs"
+import { canonicalReleaseBody } from "../metadata.mjs"
 import { canonicalNpmEvidenceBytes, parseNpmEvidence } from "../npm-evidence.mjs"
 import {
   PUBLISHER_OVERALL_TIMEOUT_MS,
@@ -34,6 +35,7 @@ import {
 } from "../publisher.mjs"
 import { canonicalReleaseRecordBytes } from "../release-record.mjs"
 import { EXACT_NPM_PROVENANCE_CERTIFICATE } from "./fixtures/npm-audit-certificates.mjs"
+import { observationForMarker } from "./support/marker-observation.mjs"
 
 const VERSION = "0.8.22"
 const COMMIT_SHA = "0123456789abcdef0123456789abcdef01234567"
@@ -925,6 +927,10 @@ async function sparseProductionFixture(t) {
     assetId += 1
   }
   assert.equal(escrowAssets.length, 45)
+  const releaseBody = canonicalReleaseBody({
+    marker: observationForMarker({ phase: "ESCROWED" }).release.marker,
+    manifest: null,
+  })
 
   const fixturePath = path.join(harnessRoot, "fixture.json")
   await writeFile(
@@ -932,7 +938,7 @@ async function sparseProductionFixture(t) {
     `${JSON.stringify({
       record,
       archiveBase64: archive.toString("base64"),
-      release: { id: 77, assets: escrowAssets },
+      release: { id: 77, body: releaseBody, assets: escrowAssets },
       npm: {
         packages: npmPackages,
       },
@@ -1113,10 +1119,12 @@ globalThis.fetch = async (input, init = {}) => {
       {
         id: fixture.release.id,
         name: \`Dawn \${fixture.record.tag}\`,
-        tag_name: fixture.record.tag,
+        tag_name: "untagged-opaque",
         target_commitish: "main",
         draft: true,
+        immutable: false,
         prerelease: false,
+        body: fixture.release.body,
       },
     ])
   }

--- a/scripts/release/test/rehearsal.test.mjs
+++ b/scripts/release/test/rehearsal.test.mjs
@@ -458,6 +458,33 @@ test("real escrow transition resumes draft creation and selected 45-asset crash 
   const snapshot = remote.snapshot()
   assert.equal(snapshot.assets.length, 45)
   assert.equal(parseReleaseMarker(snapshot.release.body).phase, "ESCROWED")
+  assert.equal(snapshot.release.name, `Dawn v${fixture.candidate.version}`)
+  assert.notEqual(snapshot.release.tag_name, `v${fixture.candidate.version}`)
+  assert.deepEqual(
+    snapshot.releaseMutations
+      .filter(({ operation }) => operation === "create" || operation === "update")
+      .map(({ phase, tagName, draft, immutable }) => ({ phase, tagName, draft, immutable })),
+    [
+      {
+        phase: "ATTACHING",
+        tagName: snapshot.release.tag_name,
+        draft: true,
+        immutable: false,
+      },
+      {
+        phase: "ESCROWED",
+        tagName: snapshot.release.tag_name,
+        draft: true,
+        immutable: false,
+      },
+    ],
+  )
+  const [listed, read] = await Promise.all([
+    remote.releaseGitHub.reader.listReleases({}),
+    remote.releaseGitHub.reader.getRelease({ releaseId: snapshot.release.id }),
+  ])
+  assert.deepEqual(listed.value, [snapshot.release])
+  assert.deepEqual(read.value, snapshot.release)
   assert.deepEqual(gate.snapshot().remaining, [])
 })
 
@@ -540,6 +567,38 @@ test("real reconciliation, audit retry, publication, and immutable replay surviv
   assert.deepEqual(snapshot.dispatchedRunIds, [501, 502, 503, 504, 505, 506])
   assert.equal(snapshot.release.draft, false)
   assert.equal(snapshot.release.immutable, true)
+  assert.equal(snapshot.release.tag_name, `v${fixture.candidate.version}`)
+  const publication = snapshot.releaseMutations.at(-1)
+  assert.deepEqual(publication, {
+    operation: "publish",
+    phase: "AUDIT_VERIFIED",
+    tagName: `v${fixture.candidate.version}`,
+    draft: false,
+    immutable: true,
+    patch: { tag_name: `v${fixture.candidate.version}`, draft: false },
+  })
+  const mutableMutations = snapshot.releaseMutations.slice(0, -1)
+  const temporaryTagNames = new Set(mutableMutations.map(({ tagName }) => tagName))
+  assert.equal(temporaryTagNames.size, 1)
+  assert.notEqual([...temporaryTagNames][0], `v${fixture.candidate.version}`)
+  assert.equal(
+    mutableMutations.every(({ draft, immutable }) => draft === true && immutable === false),
+    true,
+  )
+  assert.deepEqual(
+    mutableMutations
+      .map(({ phase }) => phase)
+      .filter((phase, index, phases) => phases.indexOf(phase) === index),
+    [
+      "ATTACHING",
+      "ESCROWED",
+      "NPM_COMPLETE",
+      "SMOKES_COMPLETE",
+      "AUDIT_DISPATCHED",
+      "AUDIT_RETRYABLE",
+      "AUDIT_VERIFIED",
+    ],
+  )
   const baseNames = new Set(base.assets.map(({ name }) => name))
   assert.equal(snapshot.assets.filter(({ name }) => baseNames.has(name)).length, 45)
   assert.equal(

--- a/scripts/release/test/support/release-rehearsal-github.mjs
+++ b/scripts/release/test/support/release-rehearsal-github.mjs
@@ -13,6 +13,7 @@ const REPOSITORY = "cacheplane/dawnai"
 const AUDIT_WORKFLOW = ".github/workflows/published-artifact-verify.yml"
 const SHA_PATTERN = /^[0-9a-f]{40}$/u
 const SHA256_PATTERN = /^[0-9a-f]{64}$/u
+const TEMPORARY_DRAFT_TAG = "draft-release-7-4f9a2c6e"
 
 export function createRehearsalArtifactUploadResult({ candidate, artifact }) {
   const identity = validateCandidate(candidate)
@@ -64,6 +65,8 @@ export function createRehearsalGitHub({ candidate, gate, baseAssetNames = [], ta
     nextRunId: 501,
     retryAudit: false,
     release: null,
+    publicationTag: null,
+    releaseMutations: [],
     assets: new Map(),
     nextAssetId: 1,
     prepared: null,
@@ -272,9 +275,10 @@ export function createRehearsalGitHub({ candidate, gate, baseAssetNames = [], ta
       validateReleaseIdentity({ tag, targetSha }, identity)
       return gate.around("draft-create", async () => {
         if (state.release === null) {
+          state.publicationTag = tag
           state.release = {
             id: 7,
-            tag_name: tag,
+            tag_name: TEMPORARY_DRAFT_TAG,
             name: title,
             body,
             draft: true,
@@ -282,11 +286,15 @@ export function createRehearsalGitHub({ candidate, gate, baseAssetNames = [], ta
             target_commitish: "main",
             prerelease: false,
           }
+          recordReleaseMutation(state, "create")
           return {
             releaseId: 7,
             status: "created",
             bodySha256: releaseBodySha256(body),
           }
+        }
+        if (state.publicationTag !== tag) {
+          throw new Error("Release rehearsal requested publication tag changed")
         }
         return {
           releaseId: state.release.id,
@@ -305,6 +313,7 @@ export function createRehearsalGitHub({ candidate, gate, baseAssetNames = [], ta
     }) {
       validateReleaseIdentity({ tag, targetSha }, identity)
       requireReleaseId(state, releaseId)
+      assertTemporaryDraftTag(state, state.release.tag_name)
       if (!state.release.draft || releaseBodySha256(state.release.body) !== expectedBodySha256) {
         throw new Error("Release rehearsal draft compare-and-swap failed")
       }
@@ -312,9 +321,12 @@ export function createRehearsalGitHub({ candidate, gate, baseAssetNames = [], ta
       const next = parseReleaseMarker(body)
       const transition = markerTransition(previous.phase, next.phase)
       const update = async () => {
+        const temporaryTag = state.release.tag_name
         state.release.name = title
         state.release.body = body
+        assertTemporaryDraftTag(state, temporaryTag)
         state.retryAudit = next.phase === "AUDIT_RETRYABLE"
+        recordReleaseMutation(state, "update")
         return {
           releaseId,
           status: "updated",
@@ -326,10 +338,12 @@ export function createRehearsalGitHub({ candidate, gate, baseAssetNames = [], ta
     async uploadAssetIfAbsentAndEqual({ releaseId, tag, targetSha, name, bytes, sha256 }) {
       validateReleaseIdentity({ tag, targetSha }, identity)
       requireReleaseId(state, releaseId)
+      assertTemporaryDraftTag(state, state.release.tag_name)
       const content = Buffer.from(bytes)
       if (digest(content) !== sha256) throw new Error("Release rehearsal asset digest is invalid")
       const transition = assetTransition({ name, content, baseOrdinal })
       const upload = async () => {
+        const temporaryTag = state.release.tag_name
         const existing = state.assets.get(name)
         if (existing !== undefined) {
           if (digest(existing.bytes) !== sha256) {
@@ -340,6 +354,8 @@ export function createRehearsalGitHub({ candidate, gate, baseAssetNames = [], ta
         const asset = { id: state.nextAssetId, bytes: Buffer.from(content) }
         state.nextAssetId += 1
         state.assets.set(name, asset)
+        assertTemporaryDraftTag(state, temporaryTag)
+        recordReleaseMutation(state, "upload")
         return { assetId: asset.id, status: "uploaded", sha256 }
       }
       return transition === null ? upload() : gate.around(transition, upload)
@@ -354,8 +370,9 @@ export function createRehearsalGitHub({ candidate, gate, baseAssetNames = [], ta
         throw new Error("Release rehearsal publication asset set is incomplete")
       }
       return gate.around("release-publication", async () => {
-        state.release.draft = false
-        state.release.immutable = true
+        const patch = { tag_name: tag, draft: false }
+        applyPublicationPatch(state, patch)
+        recordReleaseMutation(state, "publish", patch)
         return { releaseId, status: "published", immutable: true }
       })
     },
@@ -367,7 +384,7 @@ export function createRehearsalGitHub({ candidate, gate, baseAssetNames = [], ta
       if (
         tag !== `v${identity.version}` ||
         state.release === null ||
-        state.release.tag_name !== tag ||
+        !isMutableReleaseForTag(state.release, tag) ||
         state.assets.size !== 45
       ) {
         throw new Error("Release rehearsal escrow is incomplete")
@@ -532,6 +549,7 @@ export function createRehearsalGitHub({ candidate, gate, baseAssetNames = [], ta
         dispatchedRunIds: [...state.dispatchedRunIds],
         retryAudit: state.retryAudit,
         release: state.release === null ? null : cloneRelease(state.release),
+        releaseMutations: state.releaseMutations.map((mutation) => structuredClone(mutation)),
         assets: [...state.assets].map(([name, asset]) => ({
           id: asset.id,
           name,
@@ -581,6 +599,58 @@ function validateReleaseIdentity({ tag, targetSha }, candidate) {
 function requireReleaseId(state, releaseId) {
   if (state.release === null || state.release.id !== releaseId) {
     throw new Error("Release rehearsal GitHub Release identity is invalid")
+  }
+}
+
+function assertTemporaryDraftTag(state, previousTag) {
+  if (
+    state.release === null ||
+    state.release.tag_name !== previousTag ||
+    state.release.tag_name !== TEMPORARY_DRAFT_TAG ||
+    state.release.tag_name === state.publicationTag ||
+    state.release.draft !== true ||
+    state.release.immutable !== false
+  ) {
+    throw new Error("Release rehearsal mutable draft identity changed")
+  }
+}
+
+function applyPublicationPatch(state, patch) {
+  if (
+    state.release === null ||
+    patch === null ||
+    typeof patch !== "object" ||
+    Array.isArray(patch) ||
+    Object.keys(patch).length !== 2 ||
+    patch.tag_name !== state.publicationTag ||
+    patch.draft !== false
+  ) {
+    throw new Error("Release rehearsal publication PATCH is invalid")
+  }
+  assertTemporaryDraftTag(state, state.release.tag_name)
+  state.release.tag_name = patch.tag_name
+  state.release.draft = false
+  state.release.immutable = true
+}
+
+function recordReleaseMutation(state, operation, patch) {
+  if (state.release === null) throw new Error("Release rehearsal mutation has no Release")
+  state.releaseMutations.push({
+    operation,
+    phase: parseReleaseMarker(state.release.body).phase,
+    tagName: state.release.tag_name,
+    draft: state.release.draft,
+    immutable: state.release.immutable,
+    ...(patch === undefined ? {} : { patch: structuredClone(patch) }),
+  })
+}
+
+function isMutableReleaseForTag(release, tag) {
+  if (release.draft !== true || release.immutable !== false) return false
+  try {
+    return parseReleaseMarker(release.body).tag === tag
+  } catch {
+    return false
   }
 }
 

--- a/test/security-dependencies/copilotkit-v2-runtime.test.ts
+++ b/test/security-dependencies/copilotkit-v2-runtime.test.ts
@@ -278,7 +278,7 @@ describe.each(routeCases)(
 
       expect(info.status).toBe(200)
       expect(await info.json()).toMatchObject({
-        version: "1.68.3",
+        version: "1.70.0",
         mode: "sse",
         agents: { default: { name: "default" } },
       })

--- a/test/security-dependencies/dependency-resolution.test.ts
+++ b/test/security-dependencies/dependency-resolution.test.ts
@@ -507,7 +507,7 @@ function providerUtilsRootPathFailure(
     return `${targetIdentity} starts at unexpected importer ${path[0] ?? "<missing>"}`
   }
   const runtimeIndex = path.findIndex((identity) =>
-    isPackageIdentity(identity, "@copilotkit/runtime", (candidate) => candidate === "1.68.3"),
+    isPackageIdentity(identity, "@copilotkit/runtime", (candidate) => candidate === "1.70.0"),
   )
   const vertexIndex = path.findIndex((identity) =>
     isPackageIdentity(
@@ -609,13 +609,13 @@ describe("dependency security graph invariants", () => {
         manifest.dependencies,
         `${manifestPath}.dependencies`,
       )
-      expect(manifestDependencies["@copilotkit/react-core"]).toBe("^1.68.3")
-      expect(manifestDependencies["@copilotkit/runtime"]).toBe("^1.68.3")
-      expect(manifestDependencies["@ag-ui/client"]).toBe("0.0.57")
+      expect(manifestDependencies["@copilotkit/react-core"]).toBe("^1.70.0")
+      expect(manifestDependencies["@copilotkit/runtime"]).toBe("^1.70.0")
+      expect(manifestDependencies["@ag-ui/client"]).toBe("0.0.59")
 
       for (const dependency of ["@copilotkit/react-core", "@copilotkit/runtime"] as const) {
         const owned = importerDependency(workspace, importerName, "dependencies", dependency)
-        expect(owned.specifier).toBe("^1.68.3")
+        expect(owned.specifier).toBe("^1.70.0")
         const target = importerDependencyLocator(
           workspace,
           importerName,
@@ -624,12 +624,12 @@ describe("dependency security graph invariants", () => {
         )
         expect({ name: target.name, version: target.version }).toEqual({
           name: dependency,
-          version: "1.68.3",
+          version: "1.70.0",
         })
       }
       expect(importerDependency(workspace, importerName, "dependencies", "@ag-ui/client")).toEqual({
-        specifier: "0.0.57",
-        version: "0.0.57",
+        specifier: "0.0.59",
+        version: "0.0.59",
       })
       const agUiTarget = importerDependencyLocator(
         workspace,
@@ -639,7 +639,7 @@ describe("dependency security graph invariants", () => {
       )
       expect({ name: agUiTarget.name, version: agUiTarget.version }).toEqual({
         name: "@ag-ui/client",
-        version: "0.0.57",
+        version: "0.0.59",
       })
     }
 
@@ -648,12 +648,18 @@ describe("dependency security graph invariants", () => {
       readFileSync(resolve(repositoryRoot, agUiManifestPath), "utf8"),
       agUiManifestPath,
     )
+    const agUiDependencies = requireStringMap(
+      agUiManifest.dependencies,
+      `${agUiManifestPath}.dependencies`,
+    )
     const agUiDevDependencies = requireStringMap(
       agUiManifest.devDependencies,
       `${agUiManifestPath}.devDependencies`,
     )
-    expect(agUiDevDependencies["@ag-ui/client"]).toBe("0.0.57")
-    expect(agUiDevDependencies["@copilotkit/react-core"]).toBe("^1.68.3")
+    expect(agUiDependencies["@ag-ui/core"]).toBe("0.0.59")
+    expect(agUiDependencies["@ag-ui/encoder"]).toBe("0.0.59")
+    expect(agUiDevDependencies["@ag-ui/client"]).toBe("0.0.59")
+    expect(agUiDevDependencies["@copilotkit/react-core"]).toBe("^1.70.0")
     expect(
       requireStringMap(agUiManifest.peerDependencies, `${agUiManifestPath}.peerDependencies`)[
         "@copilotkit/react-core"
@@ -661,7 +667,7 @@ describe("dependency security graph invariants", () => {
     ).toBe(">=1.66.0")
     expect(
       importerDependency(workspace, "packages/ag-ui", "devDependencies", "@ag-ui/client"),
-    ).toEqual({ specifier: "0.0.57", version: "0.0.57" })
+    ).toEqual({ specifier: "0.0.59", version: "0.0.59" })
     const agUiClientOwner = importerDependencyLocator(
       workspace,
       "packages/ag-ui",
@@ -670,7 +676,7 @@ describe("dependency security graph invariants", () => {
     )
     expect({ name: agUiClientOwner.name, version: agUiClientOwner.version }).toEqual({
       name: "@ag-ui/client",
-      version: "0.0.57",
+      version: "0.0.59",
     })
     const agUiOwner = importerDependency(
       workspace,
@@ -678,7 +684,7 @@ describe("dependency security graph invariants", () => {
       "devDependencies",
       "@copilotkit/react-core",
     )
-    expect(agUiOwner.specifier).toBe("^1.68.3")
+    expect(agUiOwner.specifier).toBe("^1.70.0")
     const agUiReactCoreOwner = importerDependencyLocator(
       workspace,
       "packages/ag-ui",
@@ -687,18 +693,27 @@ describe("dependency security graph invariants", () => {
     )
     expect({ name: agUiReactCoreOwner.name, version: agUiReactCoreOwner.version }).toEqual({
       name: "@copilotkit/react-core",
-      version: "1.68.3",
+      version: "1.70.0",
     })
+
+    const cliManifestPath = "packages/cli/package.json"
+    const cliManifest = parseJsonRecord(
+      readFileSync(resolve(repositoryRoot, cliManifestPath), "utf8"),
+      cliManifestPath,
+    )
+    expect(
+      requireStringMap(cliManifest.dependencies, `${cliManifestPath}.dependencies`)["@ag-ui/core"],
+    ).toBe("0.0.59")
   })
 
-  it("contains only CopilotKit 1.68.3 package identities", () => {
+  it("contains only CopilotKit 1.70.0 package identities", () => {
     const workspace = readWorkspace()
     for (const name of ["@copilotkit/react-core", "@copilotkit/runtime"] as const) {
-      expect(packageVersions(workspace, name)).toEqual(["1.68.3"])
+      expect(packageVersions(workspace, name)).toEqual(["1.70.0"])
     }
   })
 
-  it("keeps direct AG-UI on 0.0.57 and isolates any legacy 0.0.54", () => {
+  it("keeps direct AG-UI on 0.0.59 and isolates any legacy 0.0.54", () => {
     const workspace = readWorkspace()
     const versions = packageVersions(workspace, "@ag-ui/client")
     expect(versions).not.toContain("0.0.58")
@@ -927,7 +942,7 @@ describe("dependency security graph invariants", () => {
 
   it("rejects malformed provider-utils root paths", () => {
     const target = "@ai-sdk/provider-utils@3.0.50(zod@3.25.76)"
-    const runtime = "@copilotkit/runtime@1.68.3(zod@3.25.76)"
+    const runtime = "@copilotkit/runtime@1.70.0(zod@3.25.76)"
     const vertex = "@ai-sdk/google-vertex@3.0.1(zod@3.25.76)"
     expect(
       providerUtilsRootPathFailure(target, ["examples/chat/web", runtime, vertex, target]),
@@ -935,7 +950,7 @@ describe("dependency security graph invariants", () => {
     for (const [label, path] of [
       ["unexpected importer", ["packages/cli", runtime, vertex, target]],
       ["missing runtime", ["examples/chat/web", vertex, target]],
-      ["wrong runtime", ["examples/chat/web", "@copilotkit/runtime@1.68.2", vertex, target]],
+      ["wrong runtime", ["examples/chat/web", "@copilotkit/runtime@1.69.9", vertex, target]],
       ["missing Vertex", ["examples/chat/web", runtime, target]],
       ["wrong Vertex", ["examples/chat/web", runtime, "@ai-sdk/google-vertex@2.9.0", target]],
       ["incorrect ordering", ["examples/chat/web", vertex, runtime, target]],
@@ -962,8 +977,8 @@ describe("dependency security graph invariants", () => {
         "examples/chat/web": {
           dependencies: {
             "@copilotkit/runtime": {
-              specifier: "^1.68.3",
-              version: "1.68.3(zod@3.25.76)",
+              specifier: "^1.70.0",
+              version: "1.70.0(zod@3.25.76)",
             },
           },
         },
@@ -972,7 +987,7 @@ describe("dependency security graph invariants", () => {
       packages: {
         "@ai-sdk/google-vertex@3.0.1": {},
         "@ai-sdk/provider-utils@3.0.50": {},
-        "@copilotkit/runtime@1.68.3": {},
+        "@copilotkit/runtime@1.70.0": {},
       },
       snapshots: {
         "@ai-sdk/google-vertex@3.0.1(zod@3.25.76)": {
@@ -982,7 +997,7 @@ describe("dependency security graph invariants", () => {
         },
         [approvedProvider]: {},
         [orphanProvider]: {},
-        "@copilotkit/runtime@1.68.3(zod@3.25.76)": {
+        "@copilotkit/runtime@1.70.0(zod@3.25.76)": {
           dependencies: {
             "@ai-sdk/google-vertex": "3.0.1(zod@3.25.76)",
           },

--- a/test/security-dependencies/mermaid-browser.spec.ts
+++ b/test/security-dependencies/mermaid-browser.spec.ts
@@ -186,7 +186,7 @@ function resolveAppGraph(appRelativePath: string): AppGraph {
   const appRoot = resolve(repositoryRoot, appRelativePath)
   const appManifestPath = resolve(appRoot, "package.json")
   const appManifest = readManifest(appManifestPath)
-  if (dependencyRange(appManifest, "@copilotkit/react-core") !== "^1.68.3") {
+  if (dependencyRange(appManifest, "@copilotkit/react-core") !== "^1.70.0") {
     throw new Error("example does not declare the reviewed React Core range")
   }
 

--- a/test/security-dependencies/mermaid-rendering.test.ts
+++ b/test/security-dependencies/mermaid-rendering.test.ts
@@ -451,17 +451,17 @@ describe("local Mermaid UI compatibility harness", () => {
       expect(lockUiDependencyChain(importerName)).toEqual({
         dompurify: "3.4.13",
         mermaid: "11.16.1",
-        reactCore: { specifier: "^1.68.3", version: "1.68.3" },
+        reactCore: { specifier: "^1.70.0", version: "1.70.0" },
         streamdown: "1.6.11",
       })
     }
     for (const receipt of receipts) {
       expect(receipt).toMatchObject({
-        appReactCoreRange: "^1.68.3",
+        appReactCoreRange: "^1.70.0",
         dompurify: "3.4.13",
         mermaid: "11.16.1",
         mermaidDompurifyRange: "^3.3.3",
-        reactCore: "1.68.3",
+        reactCore: "1.70.0",
         reactCoreStreamdownRange: "^1.3.0",
         streamdown: "1.6.11",
         streamdownMermaidRange: "^11.11.0",


### PR DESCRIPTION
## Summary

- identify mutable immutable-release drafts by canonical controller marker and Release ID, then bind the exact version tag only during publication
- update every prepublication reader, sparse workflow contract, content pin, and full release rehearsal for opaque draft tags
- align CopilotKit v2 examples and the research scaffold on CopilotKit 1.70 / AG-UI 0.0.59 without overrides or compatibility layers
- make the overall-deadline test deterministic under loaded CI hosts

## Test plan

- `DAWN_REQUIRE_DOCKER=1 pnpm ci:validate`
- full source suite: 4,792 passed, 216 skipped
- release controller: 1,327/1,327 passed
- final harness: framework, runtime, and smoke all passed
- clean generated research scaffold install, typecheck, and production build
- security dependency suite: 356 passed, 1 skipped

## Release context

The private v0.8.22 draft uses GitHub immutable releases temporary tag identity. No npm package was published. After this PR merges, v0.8.22 should be abandoned prepublication and the fixed-group patch changeset should produce the next candidate.