### PR TITLE
test(inspector): typecheck its own tests

### DIFF
--- a/packages/inspector/package.json
+++ b/packages/inspector/package.json
@@ -4,7 +4,7 @@
   "private": false,
   "type": "module",
   "license": "MIT",
-  "description": "Dawn runtime inspector — browser UI for inspecting a Dawn app (memory panel).",
+  "description": "Dawn runtime inspector \u2014 browser UI for inspecting a Dawn app (memory panel).",
   "homepage": "https://github.com/cacheplane/dawnai/tree/main/packages/inspector#readme",
   "repository": {
     "type": "git",
@@ -30,10 +30,10 @@
   "scripts": {
     "build": "next build && node scripts/post-build.mjs",
     "dev": "next dev",
-    "lint": "biome check --config-path ../config-biome/biome.json package.json next.config.ts postcss.config.mjs vitest.config.ts vitest.components.config.ts vitest.e2e.config.ts src app scripts test e2e playwright.config.ts tsconfig.json tsconfig.e2e.json",
+    "lint": "biome check --config-path ../config-biome/biome.json package.json next.config.ts postcss.config.mjs vitest.config.ts vitest.components.config.ts vitest.e2e.config.ts src app scripts test e2e playwright.config.ts tsconfig.json tsconfig.e2e.json tsconfig.test.json",
     "test": "vitest --run --config vitest.config.ts --passWithNoTests",
     "test:e2e": "playwright test --config playwright.config.ts",
-    "typecheck": "tsc --noEmit && tsc --noEmit -p tsconfig.e2e.json"
+    "typecheck": "tsc --noEmit && tsc --noEmit -p tsconfig.e2e.json && tsc -p tsconfig.test.json"
   },
   "dependencies": {
     "@dawn-ai/core": "workspace:*",

--- a/packages/inspector/tsconfig.test.json
+++ b/packages/inspector/tsconfig.test.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "allowImportingTsExtensions": true,
+    "noEmit": true,
+    "rootDir": ".",
+    "tsBuildInfoFile": "dist/tsconfig.test.tsbuildinfo"
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx", "test/**/*.ts", "test/**/*.tsx"]
+}


### PR DESCRIPTION
The last package whose `typecheck` compiled only `src/**`. Its **31 test files** were never type-checked.

They compile clean once in scope, so this is coverage with nothing to fix — `tsconfig.test.json` matching the one every other package now carries, plus the lint script picking the new file up alongside the tsconfigs it already covers.

**With this, every workspace package that has tests type-checks them.** The sweep that started with the root `test/` tree in #501 is closed.

## Verification

| gate | result |
|---|---|
| `pnpm lint` | 27/27 |
| `pnpm typecheck` | 51/51 |
| `pnpm test` | 5586 passed, 218 skipped, 0 failed |
| `node scripts/check-docs.mjs` | pass |

`tsc --listFiles` confirms the 31 test files are actually in scope rather than silently skipped, and an injected `TS2322` in a test file is caught by the equivalent config — the configs check, they don't just pass.

## Note for reviewers

`permissions`, `sdk`, `langchain` and `core` already landed their own `tsconfig.test.json` on main while this was in flight, so they are deliberately untouched here. This PR is `inspector` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)