### PR TITLE
Skip infrastructure lanes for generated metadata-only changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,39 @@ permissions:
   contents: read
 
 jobs:
+  metadata_scope:
+    name: metadata-scope
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      metadata_only: ${{ steps.classify.outputs.metadata_only }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24.17.0
+
+      - name: Classify metadata-only change
+        id: classify
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -eu
+          METADATA_ONLY="$(node scripts/ci-scope.mjs --event pull_request --base "$BASE_SHA" --head "$HEAD_SHA")"
+          case "$METADATA_ONLY" in
+            true|false) ;;
+            *) echo "Malformed metadata-only scope output" >&2; exit 1 ;;
+          esac
+          printf 'metadata_only=%s\n' "$METADATA_ONLY" >> "$GITHUB_OUTPUT"
+
   changesets:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
@@ -645,6 +678,8 @@ jobs:
             | kubeconform -strict -summary -ignore-missing-schemas
 
   sandbox-k8s:
+    needs: metadata_scope
+    if: ${{ always() && (github.event_name != 'pull_request' || needs.metadata_scope.result != 'success' || needs.metadata_scope.outputs.metadata_only != 'true') }}
     runs-on: ubuntu-latest
     timeout-minutes: 35
     env:
@@ -736,6 +771,8 @@ jobs:
     # sandbox-k8s's kind+Calico setup; adds a Verdaccio-published image build and
     # both Helm charts (cross-namespace: app in dawn-app, sandboxes in
     # dawn-sandboxes). Determinism comes from a baked aimock (no model key).
+    needs: metadata_scope
+    if: ${{ always() && (github.event_name != 'pull_request' || needs.metadata_scope.result != 'success' || needs.metadata_scope.outputs.metadata_only != 'true') }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
@@ -894,6 +931,8 @@ jobs:
     # host daemon, then tears it down. Mirrors sandbox-docker's host-Docker setup;
     # adds a Verdaccio-published image build (same mechanism as sandbox-k8s-e2e).
     # Determinism comes from a baked aimock (no model key).
+    needs: metadata_scope
+    if: ${{ always() && (github.event_name != 'pull_request' || needs.metadata_scope.result != 'success' || needs.metadata_scope.outputs.metadata_only != 'true') }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
@@ -974,6 +1013,8 @@ jobs:
           docker network rm dawn-smoke-net || true
 
   chart-apply-smoke:
+    needs: metadata_scope
+    if: ${{ always() && (github.event_name != 'pull_request' || needs.metadata_scope.result != 'success' || needs.metadata_scope.outputs.metadata_only != 'true') }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     env:

--- a/scripts/ci-scope.d.mts
+++ b/scripts/ci-scope.d.mts
@@ -1,0 +1,18 @@
+export const METADATA_ONLY_PATHS: readonly string[]
+
+export interface GitCommandResult {
+  readonly stdout: Buffer
+}
+
+export type GitCommandRunner = (file: string, args: readonly string[]) => Promise<GitCommandResult>
+
+export interface MetadataOnlyScopeRequest {
+  readonly event: unknown
+  readonly base?: unknown
+  readonly head?: unknown
+}
+
+export function classifyMetadataOnlyScope(
+  request: MetadataOnlyScopeRequest,
+  runCommand?: GitCommandRunner,
+): Promise<boolean>

--- a/scripts/ci-scope.mjs
+++ b/scripts/ci-scope.mjs
@@ -1,0 +1,115 @@
+import { execFileSync } from "node:child_process"
+import { pathToFileURL } from "node:url"
+import { TextDecoder } from "node:util"
+
+export const METADATA_ONLY_PATHS = Object.freeze(["apps/web/app/seo/lastmod.generated.json"])
+
+const COMMIT_SHA_PATTERN = /^[0-9a-f]{40}$/
+const METADATA_ONLY_PATH_SET = new Set(METADATA_ONLY_PATHS)
+
+function expectCommitSha(value, name) {
+  if (typeof value !== "string" || !COMMIT_SHA_PATTERN.test(value)) {
+    throw new Error(`Pull-request ${name} SHA must be exactly 40 lowercase hexadecimal characters`)
+  }
+  return value
+}
+
+function parseNulDelimitedPaths(output) {
+  if (output.length === 0) return []
+  if (output[output.length - 1] !== 0) {
+    throw new Error("Malformed NUL-delimited Git diff output: missing final NUL byte")
+  }
+
+  const decoder = new TextDecoder("utf-8", { fatal: true, ignoreBOM: true })
+  const paths = []
+  let start = 0
+  for (let index = 0; index < output.length; index += 1) {
+    if (output[index] !== 0) continue
+    if (index === start) {
+      throw new Error("Malformed NUL-delimited Git diff output: empty filename")
+    }
+    try {
+      paths.push(decoder.decode(output.subarray(start, index)))
+    } catch (cause) {
+      throw new Error("Malformed Git diff filename: expected valid UTF-8", { cause })
+    }
+    start = index + 1
+  }
+  return paths
+}
+
+async function runGitCommand(file, args) {
+  return {
+    stdout: execFileSync(file, args, {
+      encoding: "buffer",
+      maxBuffer: 32 * 1_024 * 1_024,
+      timeout: 30_000,
+    }),
+  }
+}
+
+export async function classifyMetadataOnlyScope(request, runCommand = runGitCommand) {
+  if (request.event === "push") return false
+  if (request.event !== "pull_request") {
+    throw new Error(`Unknown CI scope event mode: ${String(request.event)}`)
+  }
+
+  const base = expectCommitSha(request.base, "base")
+  const head = expectCommitSha(request.head, "head")
+  await runCommand("git", ["cat-file", "-e", `${base}^{commit}`])
+  await runCommand("git", ["cat-file", "-e", `${head}^{commit}`])
+  const { stdout } = await runCommand("git", [
+    "diff",
+    "--merge-base",
+    "--no-renames",
+    "--name-only",
+    "-z",
+    base,
+    head,
+  ])
+  if (!Buffer.isBuffer(stdout)) {
+    throw new Error("Malformed Git diff output: expected a Buffer")
+  }
+
+  const paths = parseNulDelimitedPaths(stdout)
+  return paths.length > 0 && paths.every((path) => METADATA_ONLY_PATH_SET.has(path))
+}
+
+function parseCliArgs(argv) {
+  const flags = new Map()
+  for (let index = 0; index < argv.length; index += 2) {
+    const flag = argv[index]
+    const value = argv[index + 1]
+    if (flag === undefined || !["--event", "--base", "--head"].includes(flag)) {
+      throw new Error(`Unknown flag: ${String(flag)}`)
+    }
+    if (value === undefined || value.length === 0 || value.startsWith("--")) {
+      throw new Error(`Missing value for flag: ${flag}`)
+    }
+    if (flags.has(flag)) throw new Error(`Duplicate flag: ${flag}`)
+    flags.set(flag, value)
+  }
+
+  const event = flags.get("--event")
+  if (event === undefined) throw new Error("Missing required flag: --event")
+  if (event === "push" && (flags.has("--base") || flags.has("--head"))) {
+    throw new Error("push scope does not accept pull-request SHA flags")
+  }
+  return {
+    event,
+    ...(flags.has("--base") ? { base: flags.get("--base") } : {}),
+    ...(flags.has("--head") ? { head: flags.get("--head") } : {}),
+  }
+}
+
+const entrypoint = process.argv[1]
+if (entrypoint !== undefined && import.meta.url === pathToFileURL(entrypoint).href) {
+  classifyMetadataOnlyScope(parseCliArgs(process.argv.slice(2)))
+    .then((metadataOnly) => process.stdout.write(`${String(metadataOnly)}\n`))
+    .catch((error) => {
+      process.stderr.write(
+        `${error instanceof Error ? (error.stack ?? error.message) : String(error)}\n`,
+      )
+      process.exitCode = 1
+    })
+}

--- a/scripts/release/test/fixtures/workflow-entrypoints.json
+++ b/scripts/release/test/fixtures/workflow-entrypoints.json
@@ -98,6 +98,8 @@
             "env": {
               "DAWN_TEST_K8S_CONTEXT": "kind-dawn-chart-apply"
             },
+            "if": "${{ always() && (github.event_name != 'pull_request' || needs.metadata_scope.result != 'success' || needs.metadata_scope.outputs.metadata_only != 'true') }}",
+            "needs": "metadata_scope",
             "runs-on": "ubuntu-latest",
             "timeout-minutes": 15
           },
@@ -531,6 +533,53 @@
         },
         {
           "classification": "safe",
+          "id": "metadata_scope",
+          "descriptor": {
+            "if": "github.event_name == 'pull_request'",
+            "name": "metadata-scope",
+            "outputs": {
+              "metadata_only": "${{ steps.classify.outputs.metadata_only }}"
+            },
+            "runs-on": "ubuntu-latest",
+            "timeout-minutes": 5
+          },
+          "steps": [
+            {
+              "classification": "safe",
+              "descriptor": {
+                "name": "Checkout",
+                "uses": "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1",
+                "with": {
+                  "fetch-depth": 0
+                }
+              }
+            },
+            {
+              "classification": "safe",
+              "descriptor": {
+                "name": "Setup Node.js",
+                "uses": "actions/setup-node@820762786026740c76f36085b0efc47a31fe5020",
+                "with": {
+                  "node-version": "24.17.0"
+                }
+              }
+            },
+            {
+              "classification": "safe",
+              "descriptor": {
+                "env": {
+                  "BASE_SHA": "${{ github.event.pull_request.base.sha }}",
+                  "HEAD_SHA": "${{ github.event.pull_request.head.sha }}"
+                },
+                "id": "classify",
+                "name": "Classify metadata-only change",
+                "run": "set -eu\nMETADATA_ONLY=\"$(node scripts/ci-scope.mjs --event pull_request --base \"$BASE_SHA\" --head \"$HEAD_SHA\")\"\ncase \"$METADATA_ONLY\" in\n  true|false) ;;\n  *) echo \"Malformed metadata-only scope output\" >&2; exit 1 ;;\nesac\nprintf 'metadata_only=%s\\n' \"$METADATA_ONLY\" >> \"$GITHUB_OUTPUT\"\n"
+              }
+            }
+          ]
+        },
+        {
+          "classification": "safe",
           "id": "pgvector-docker",
           "descriptor": {
             "runs-on": "ubuntu-latest",
@@ -727,6 +776,8 @@
             "env": {
               "DAWN_TEST_SMOKE_E2E": "1"
             },
+            "if": "${{ always() && (github.event_name != 'pull_request' || needs.metadata_scope.result != 'success' || needs.metadata_scope.outputs.metadata_only != 'true') }}",
+            "needs": "metadata_scope",
             "runs-on": "ubuntu-latest",
             "timeout-minutes": 30
           },
@@ -811,6 +862,8 @@
             "env": {
               "DAWN_TEST_K8S_CONTEXT": "kind-dawn-k8s-canonical"
             },
+            "if": "${{ always() && (github.event_name != 'pull_request' || needs.metadata_scope.result != 'success' || needs.metadata_scope.outputs.metadata_only != 'true') }}",
+            "needs": "metadata_scope",
             "runs-on": "ubuntu-latest",
             "timeout-minutes": 35
           },
@@ -943,6 +996,8 @@
               "DAWN_TEST_SMOKE_E2E": "1",
               "KIND_CLUSTER": "dawn-smoke"
             },
+            "if": "${{ always() && (github.event_name != 'pull_request' || needs.metadata_scope.result != 'success' || needs.metadata_scope.outputs.metadata_only != 'true') }}",
+            "needs": "metadata_scope",
             "runs-on": "ubuntu-latest",
             "timeout-minutes": 30
           },

--- a/scripts/release/test/fixtures/workflow-safe-executables.json
+++ b/scripts/release/test/fixtures/workflow-safe-executables.json
@@ -14,6 +14,30 @@
     "ci.yml": [
       {
         "classification": "safe",
+        "job": "metadata_scope",
+        "stepIndex": 0,
+        "step": "Checkout",
+        "kind": "step-uses",
+        "value": "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1"
+      },
+      {
+        "classification": "safe",
+        "job": "metadata_scope",
+        "stepIndex": 1,
+        "step": "Setup Node.js",
+        "kind": "step-uses",
+        "value": "actions/setup-node@820762786026740c76f36085b0efc47a31fe5020"
+      },
+      {
+        "classification": "safe",
+        "job": "metadata_scope",
+        "stepIndex": 2,
+        "step": "Classify metadata-only change",
+        "kind": "run",
+        "value": "set -eu\nMETADATA_ONLY=\"$(node scripts/ci-scope.mjs --event pull_request --base \"$BASE_SHA\" --head \"$HEAD_SHA\")\"\ncase \"$METADATA_ONLY\" in\n  true|false) ;;\n  *) echo \"Malformed metadata-only scope output\" >&2; exit 1 ;;\nesac\nprintf 'metadata_only=%s\\n' \"$METADATA_ONLY\" >> \"$GITHUB_OUTPUT\"\n"
+      },
+      {
+        "classification": "safe",
         "job": "changesets",
         "stepIndex": 0,
         "step": "Checkout",

--- a/test/k8s-compat/ci-scope.test.ts
+++ b/test/k8s-compat/ci-scope.test.ts
@@ -1,0 +1,245 @@
+import { execFileSync } from "node:child_process"
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { resolve } from "node:path"
+
+import { describe, expect, test } from "vitest"
+import { parse } from "yaml"
+
+import {
+  classifyMetadataOnlyScope,
+  type GitCommandRunner,
+  METADATA_ONLY_PATHS,
+} from "../../scripts/ci-scope.mjs"
+
+const BASE_SHA = "a".repeat(40)
+const HEAD_SHA = "b".repeat(40)
+const repoRoot = resolve(__dirname, "../..")
+const ciWorkflow = parse(readFileSync(resolve(repoRoot, ".github/workflows/ci.yml"), "utf8"))
+
+function commandResult(paths: readonly string[] = []): { readonly stdout: Buffer } {
+  return { stdout: Buffer.from(paths.length === 0 ? "" : `${paths.join("\0")}\0`) }
+}
+
+function githubExpression(expression: string): string {
+  return `\${{ ${expression} }}`
+}
+
+describe("metadata-only CI scope", () => {
+  test("publishes a single exact generated-metadata allowlist", () => {
+    expect(METADATA_ONLY_PATHS).toEqual(["apps/web/app/seo/lastmod.generated.json"])
+    expect(Object.isFrozen(METADATA_ONLY_PATHS)).toBe(true)
+  })
+
+  test("skips infrastructure only when every changed path is generated metadata", async () => {
+    const calls: { readonly file: string; readonly args: readonly string[] }[] = []
+    const runCommand: GitCommandRunner = async (file, args) => {
+      calls.push({ file, args })
+      return args[0] === "diff" ? commandResult(METADATA_ONLY_PATHS) : commandResult()
+    }
+
+    await expect(
+      classifyMetadataOnlyScope(
+        { event: "pull_request", base: BASE_SHA, head: HEAD_SHA },
+        runCommand,
+      ),
+    ).resolves.toBe(true)
+    expect(calls).toEqual([
+      { file: "git", args: ["cat-file", "-e", `${BASE_SHA}^{commit}`] },
+      { file: "git", args: ["cat-file", "-e", `${HEAD_SHA}^{commit}`] },
+      {
+        file: "git",
+        args: ["diff", "--merge-base", "--no-renames", "--name-only", "-z", BASE_SHA, HEAD_SHA],
+      },
+    ])
+  })
+
+  test("includes feature changes already present at the base endpoint", async () => {
+    const temporary = mkdtempSync(resolve(tmpdir(), "dawn-ci-scope-"))
+    const git = (...args: string[]) =>
+      execFileSync("git", args, { cwd: temporary, encoding: "utf8" }).trim()
+    try {
+      git("init", "--initial-branch=main")
+      git("config", "user.name", "CI Scope Test")
+      git("config", "user.email", "ci-scope@example.invalid")
+      writeFileSync(resolve(temporary, "README.md"), "fixture\n")
+      git("add", "README.md")
+      git("commit", "-m", "initial")
+
+      git("checkout", "-b", "feature")
+      mkdirSync(resolve(temporary, "apps/web/app/seo"), { recursive: true })
+      mkdirSync(resolve(temporary, "packages/example"), { recursive: true })
+      writeFileSync(resolve(temporary, METADATA_ONLY_PATHS[0] as string), "{}\n")
+      writeFileSync(resolve(temporary, "packages/example/index.ts"), "export const value = 1\n")
+      git("add", ".")
+      git("commit", "-m", "feature changes")
+      const head = git("rev-parse", "HEAD")
+
+      git("checkout", "main")
+      mkdirSync(resolve(temporary, "packages/example"), { recursive: true })
+      writeFileSync(resolve(temporary, "packages/example/index.ts"), "export const value = 1\n")
+      git("add", ".")
+      git("commit", "-m", "base receives same source change")
+      const base = git("rev-parse", "HEAD")
+
+      const runCommand: GitCommandRunner = async (file, args) => ({
+        stdout: execFileSync(file, [...args], { cwd: temporary, encoding: "buffer" }),
+      })
+      await expect(
+        classifyMetadataOnlyScope({ event: "pull_request", base, head }, runCommand),
+      ).resolves.toBe(false)
+    } finally {
+      rmSync(temporary, { recursive: true, force: true })
+    }
+  })
+
+  test.each([
+    [[]],
+    [["apps/web/app/seo/lastmod.generated.json", "apps/web/app/seo/lastmod.ts"]],
+    [["apps/web/app/seo/lastmod.generated.ts"]],
+    [["./apps/web/app/seo/lastmod.generated.json"]],
+    [["apps\\web\\app\\seo\\lastmod.generated.json"]],
+  ])("runs infrastructure for an empty, mixed, or near-miss diff: %#", async (paths) => {
+    const runCommand: GitCommandRunner = async (_file, args) =>
+      args[0] === "diff" ? commandResult(paths) : commandResult()
+
+    await expect(
+      classifyMetadataOnlyScope(
+        { event: "pull_request", base: BASE_SHA, head: HEAD_SHA },
+        runCommand,
+      ),
+    ).resolves.toBe(false)
+  })
+
+  test("always runs infrastructure for push events without invoking Git", async () => {
+    const calls: unknown[] = []
+    const runCommand: GitCommandRunner = async (file, args) => {
+      calls.push({ file, args })
+      return commandResult()
+    }
+
+    await expect(classifyMetadataOnlyScope({ event: "push" }, runCommand)).resolves.toBe(false)
+    expect(calls).toEqual([])
+  })
+
+  test.each(["", "a".repeat(39), "A".repeat(40), "g".repeat(40)])(
+    "rejects invalid pull-request SHAs before invoking Git: %#",
+    async (base) => {
+      const calls: unknown[] = []
+      const runCommand: GitCommandRunner = async (file, args) => {
+        calls.push({ file, args })
+        return commandResult()
+      }
+
+      await expect(
+        classifyMetadataOnlyScope({ event: "pull_request", base, head: HEAD_SHA }, runCommand),
+      ).rejects.toThrow(/base SHA/)
+      expect(calls).toEqual([])
+    },
+  )
+
+  test("rejects unsupported events without invoking Git", async () => {
+    const calls: unknown[] = []
+    const runCommand: GitCommandRunner = async (file, args) => {
+      calls.push({ file, args })
+      return commandResult()
+    }
+
+    await expect(classifyMetadataOnlyScope({ event: "schedule" }, runCommand)).rejects.toThrow(
+      "Unknown CI scope event mode",
+    )
+    expect(calls).toEqual([])
+  })
+
+  test.each([
+    Buffer.from("apps/web/app/seo/lastmod.generated.json"),
+    Buffer.from("\0"),
+    Buffer.from("apps/web/app/seo/lastmod.generated.json\0\0"),
+    Buffer.from([0xff, 0x00]),
+  ])("rejects malformed Git diff bytes: %#", async (stdout) => {
+    const runCommand: GitCommandRunner = async (_file, args) =>
+      args[0] === "diff" ? { stdout } : commandResult()
+
+    await expect(
+      classifyMetadataOnlyScope(
+        { event: "pull_request", base: BASE_SHA, head: HEAD_SHA },
+        runCommand,
+      ),
+    ).rejects.toThrow(/malformed|UTF-8/i)
+  })
+
+  test("rejects non-buffer diff output and propagates Git failures", async () => {
+    const nonBuffer: GitCommandRunner = async (_file, args) =>
+      args[0] === "diff"
+        ? ({ stdout: "not-a-buffer" } as unknown as { readonly stdout: Buffer })
+        : commandResult()
+    await expect(
+      classifyMetadataOnlyScope(
+        { event: "pull_request", base: BASE_SHA, head: HEAD_SHA },
+        nonBuffer,
+      ),
+    ).rejects.toThrow("expected a Buffer")
+
+    const failure = new Error("git timed out")
+    const rejecting: GitCommandRunner = async () => Promise.reject(failure)
+    await expect(
+      classifyMetadataOnlyScope(
+        { event: "pull_request", base: BASE_SHA, head: HEAD_SHA },
+        rejecting,
+      ),
+    ).rejects.toBe(failure)
+  })
+})
+
+describe("CI workflow metadata scope", () => {
+  test("uses one scope output to skip only the expensive Kubernetes and full-arc jobs", () => {
+    const jobs = ciWorkflow.jobs as Record<string, Record<string, unknown>>
+    const scope = jobs.metadata_scope
+    expect(scope).toBeDefined()
+    expect(scope?.name).toBe("metadata-scope")
+    expect(scope?.if).toBe("github.event_name == 'pull_request'")
+    expect(scope?.outputs).toEqual({
+      metadata_only: githubExpression("steps.classify.outputs.metadata_only"),
+    })
+
+    const steps = scope?.steps as Record<string, unknown>[]
+    expect(steps).toContainEqual({
+      name: "Checkout",
+      uses: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1",
+      with: { "fetch-depth": 0 },
+    })
+    expect(steps).toContainEqual({
+      name: "Setup Node.js",
+      uses: "actions/setup-node@820762786026740c76f36085b0efc47a31fe5020",
+      with: { "node-version": "24.17.0" },
+    })
+    const classify = steps.find((step) => step.name === "Classify metadata-only change")
+    expect(classify?.id).toBe("classify")
+    expect(classify?.env).toEqual({
+      BASE_SHA: githubExpression("github.event.pull_request.base.sha"),
+      HEAD_SHA: githubExpression("github.event.pull_request.head.sha"),
+    })
+    expect(classify?.run).toContain("node scripts/ci-scope.mjs")
+    expect(classify?.run).toContain("Malformed metadata-only scope output")
+
+    const scopedJobs = ["sandbox-k8s", "sandbox-k8s-e2e", "sandbox-docker-e2e", "chart-apply-smoke"]
+    const failOpenCondition = githubExpression(
+      "always() && (github.event_name != 'pull_request' || needs.metadata_scope.result != 'success' || needs.metadata_scope.outputs.metadata_only != 'true')",
+    )
+    for (const id of scopedJobs) {
+      expect(jobs[id]?.needs).toBe("metadata_scope")
+      expect(jobs[id]?.if).toBe(failOpenCondition)
+    }
+
+    expect(
+      Object.entries(jobs)
+        .filter(([, job]) => job.needs === "metadata_scope")
+        .map(([id]) => id)
+        .sort(),
+    ).toEqual([...scopedJobs].sort())
+
+    for (const id of ["validate", "sandbox-docker", "chart-validate", "vercel-native"]) {
+      expect(jobs[id]?.needs).toBeUndefined()
+    }
+  })
+})


### PR DESCRIPTION
## Summary
- classify pull requests with a strict, nonempty generated-metadata allowlist using merge-base Git semantics
- skip only the Kubernetes and full-arc infrastructure jobs for that exact scope, while failing open for pushes and classifier errors
- audit the workflow entrypoints and cover mixed, malformed, and diverged-history cases

## Verification
- `pnpm lint`
- `pnpm typecheck`
- `pnpm exec vitest --run --config test/k8s-compat/vitest.config.ts` (754 tests)
- `pnpm test:release-controller` (1327 tests)
- `node scripts/check-docs.mjs`
- `pnpm check:release-inventory`