### PR TITLE
fix(release): partition recovery evidence assets by name, not position

### DIFF
--- a/scripts/release/duplicate-draft-recovery-adapters.mjs
+++ b/scripts/release/duplicate-draft-recovery-adapters.mjs
@@ -2101,8 +2101,13 @@ async function normalizeReleaseSnapshot({
     fail("RELEASE_MALFORMED", "Release snapshot is malformed")
   }
   const marker = releaseMarker(raw.body)
+  // GitHub lists assets sorted by name, and a recovery evidence asset's name
+  // interleaves with the base assets rather than following them. Partition by
+  // name so the downstream "first 45 are base, the rest are evidence" contract
+  // is true by construction, whatever order the listing arrives in.
+  const baseAssets = []
+  const evidenceEntries = []
   const assets = []
-  const evidenceAssets = []
   const assetIds = new Set()
   const assetNames = new Set()
   for (const rawAsset of rawAssets) {
@@ -2168,10 +2173,17 @@ async function normalizeReleaseSnapshot({
       } else {
         normalized.bytes = bytes.toString("utf8")
       }
-      evidenceAssets.push(kind)
+      evidenceEntries.push({ kind, asset: normalized })
+      continue
     }
-    assets.push(normalized)
+    baseAssets.push(normalized)
   }
+  evidenceEntries.sort(
+    (left, right) =>
+      EVIDENCE_KIND_ORDER.indexOf(left.kind) - EVIDENCE_KIND_ORDER.indexOf(right.kind),
+  )
+  assets.push(...baseAssets, ...evidenceEntries.map((entry) => entry.asset))
+  const evidenceAssets = evidenceEntries.map((entry) => entry.kind)
   return deepFreeze({
     releaseId,
     tagName: raw.tag_name,
@@ -2186,6 +2198,8 @@ async function normalizeReleaseSnapshot({
     ...(releaseId === DUPLICATE_DRAFT_RECOVERY_POLICY.canonicalReleaseId ? {} : { evidenceAssets }),
   })
 }
+
+const EVIDENCE_KIND_ORDER = Object.freeze(["body", "receipt"])
 
 function recoveryEvidenceKind(name, releaseId) {
   const prefix = `dawn-v${DUPLICATE_DRAFT_RECOVERY_POLICY.version}-duplicate-${releaseId}-`

--- a/scripts/release/test/duplicate-draft-recovery-adapters.test.mjs
+++ b/scripts/release/test/duplicate-draft-recovery-adapters.test.mjs
@@ -2015,6 +2015,58 @@ test("release snapshots read complete assets and required recovery bytes through
   assert.equal(Object.hasOwn(snapshot.assets[1], "bytes"), false)
 })
 
+test("release snapshot partitions evidence assets that sort among the base assets", async () => {
+  // Regression: GitHub lists assets by name, and the archive asset's name sorts
+  // BETWEEN base assets (in production it precedes `release-record.json`). The
+  // snapshot previously assumed the first 45 entries were base assets, so the
+  // first upload pushed a base asset out of the base window and made the very
+  // next read unclassifiable.
+  const releaseId = DUPLICATE_ID
+  const originalBody = "canonical body\n"
+  const archiveBytes = Buffer.from(originalBody, "utf8")
+  const archiveSha = createHash("sha256").update(archiveBytes).digest("hex")
+  const archiveName = `dawn-v0.8.22-duplicate-${releaseId}-original-body-${archiveSha}.txt`
+  const trailingBase = "release-record.json"
+  assert.ok(archiveName < trailingBase, "fixture must interleave the archive before a base asset")
+
+  const reader = createDuplicateDraftRecoveryReader({
+    root: "/workspace",
+    run: async () => `${REVIEWED_COMMIT}\n`,
+    fetchImpl: async (url) => {
+      if (url === `${BASE}/releases/${releaseId}`) {
+        return jsonResponse(releaseFixture({ releaseId, body: originalBody }))
+      }
+      if (url === `${BASE}/releases/${releaseId}/assets?per_page=100`) {
+        // Name-sorted, exactly as GitHub returns it.
+        return jsonResponse([
+          asset(1, "aaa-base.tgz", Buffer.from("base-one")),
+          asset(2, archiveName, archiveBytes),
+          asset(3, trailingBase, Buffer.from("base-two")),
+        ])
+      }
+      if (url === `${BASE}/releases/assets/2`) {
+        return binaryResponse(new Uint8Array(), 302, {
+          location: "https://objects.githubusercontent.com/recovery-archive",
+        })
+      }
+      if (url === "https://objects.githubusercontent.com/recovery-archive") {
+        return binaryResponse(archiveBytes)
+      }
+      assert.fail(`unexpected URL ${url}`)
+    },
+  })
+
+  const snapshot = await reader.readReleaseSnapshot(releaseId, {
+    expectedOriginalBody: originalBody,
+  })
+  assert.deepEqual(snapshot.evidenceAssets, ["body"])
+  assert.deepEqual(
+    snapshot.assets.map(({ name }) => name),
+    ["aaa-base.tgz", trailingBase, archiveName],
+    "base assets keep listing order and evidence assets follow them",
+  )
+})
+
 test("release capture rejects canonical and duplicate title drift", async () => {
   for (const releaseId of [379991871, DUPLICATE_ID, SECOND_DUPLICATE_ID]) {
     const reader = createDuplicateDraftRecoveryReader({


### PR DESCRIPTION
## What happened

A real `apply` run against production uploaded the first archive asset **successfully**, then reported `MUTATION_OUTCOME_AMBIGUOUS`. The next `capture` could not classify the resulting state at all (`CAPTURE_EVIDENCE_CONFLICT`), so resume was blocked.

Current production state — safe, and now correctly recognized as `body-archived`:

| Release | Assets | Body | State |
| --- | ---: | --- | --- |
| `379991871` canonical | 45 | unchanged `5fe9fcab…` | untouched |
| `379982100` duplicate | **46** | unchanged `5fe9fcab…` | `body-archived` |
| `379986168` duplicate | 45 | unchanged `5fe9fcab…` | `untouched` |

The uploaded asset is byte-correct (9,684 bytes, digest matches the original body). Nothing was lost or corrupted, and no body was rewritten.

## Root cause

GitHub lists release assets **sorted by name**, and a recovery evidence asset's name *interleaves* with the base assets rather than following them. In production:

```
dawn-v0.8.22-duplicate-379982100-original-body-<sha>.txt   ← uploaded asset
release-record.json                                        ← sorts AFTER it
```

The snapshot assumed the first 45 listed assets were the base set and anything beyond was evidence. So the very first upload pushed `release-record.json` out of the base window and pulled the archive into it. That broke the post-upload verification — **which is why the outcome was ambiguous even though the upload succeeded** — and then made the state unclassifiable on the next read.

One root cause, two symptoms.

## Fix

Partition by name: base assets first in listing order, evidence assets after them in canonical kind order. The downstream *"first 45 are base, the rest are evidence"* contract becomes true by construction, whatever order the listing arrives in.

## Why the tests missed it

The existing fixture listed its evidence asset **last** (`base.tgz`, then `dawn-v0.8.22-…`), which is the one arrangement where the positional assumption holds. The new test interleaves the archive between two base assets exactly as production does, and asserts the partition explicitly.

This was predicted. Reviewer 2 on #534 flagged that evidence assets were "required strictly at positions 45/46" and that the recovery code was "strictly tighter than the controller," noting any deviation would be an unrecoverable conflict. I recorded it as Minor and moved on. It was a blocker, and it fired in a partial production state.

## Verification

Against the live repository, capture now classifies the real partial state:

```
FULL CAPTURE OK; duplicates: [ 'body-archived', 'untouched' ]
```

Release-controller suite 2,057/2,057; lint clean. The operator edit freeze on `379982100`/`379986168` remains in force until resume completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)