### PR TITLE
fix(release): pass the controller's exact candidate shape to final authorization

### DIFF
--- a/scripts/release/recover-v0.8.22-duplicate-drafts.mjs
+++ b/scripts/release/recover-v0.8.22-duplicate-drafts.mjs
@@ -1248,6 +1248,25 @@ export function createProductionRecoveryObserver({
   }
 }
 
+/**
+ * Build the controller's exact candidate shape. `observeProductionCandidate`
+ * and `planRelease` require identity PLUS the CI/publisher policy fields, with
+ * no extra keys — passing bare identity throws "Release candidate is invalid"
+ * only at run time, after both duplicates have already been quarantined.
+ * Mirrors CANDIDATE_POLICY (candidate.mjs) and DEFAULT_CANDIDATE_POLICY
+ * (observe.mjs).
+ */
+export function productionRecoveryCandidate(candidate) {
+  assertRecoveryObserverCandidate(candidate)
+  return Object.freeze({
+    version: candidate.version,
+    commitSha: candidate.commitSha,
+    ciWorkflow: "CI",
+    ciCheck: "validate",
+    publisherWorkflow: ".github/workflows/release.yml",
+  })
+}
+
 export function createNormalProductionRecoveryObserver({ root, token, fileSystem, runGit }) {
   const git = createGitReader({ root, run: runGit })
   const github = createGitHubReader({
@@ -1264,12 +1283,13 @@ export function createNormalProductionRecoveryObserver({ root, token, fileSystem
     fileSystem,
   })
   return async ({ candidate }) => {
+    const productionCandidate = productionRecoveryCandidate(candidate)
     const [managedInventory, marker] = await Promise.all([
       inventory.read({ ref: candidate.commitSha }),
       readCandidateControllerMarker({ git, candidate }),
     ])
     const observed = await observeProductionCandidate({
-      candidate,
+      candidate: productionCandidate,
       inventory: managedInventory,
       marker,
       git,
@@ -1278,7 +1298,7 @@ export function createNormalProductionRecoveryObserver({ root, token, fileSystem
       attestations,
     })
     const plan = planRelease({
-      candidate,
+      candidate: productionCandidate,
       observation: observed.observation,
       mode: "controller",
     })

--- a/scripts/release/test/duplicate-draft-recovery-cli.test.mjs
+++ b/scripts/release/test/duplicate-draft-recovery-cli.test.mjs
@@ -18,6 +18,7 @@ import os from "node:os"
 import path from "node:path"
 import test from "node:test"
 import { promisify } from "node:util"
+import { planRelease } from "../planner.mjs"
 import * as recoveryCliModule from "../recover-v0.8.22-duplicate-drafts.mjs"
 import {
   parseDuplicateDraftRecoveryCliArguments,
@@ -922,6 +923,43 @@ test("production recovery observer rejects an alternate sole Release ID and a fo
       /candidate|inventory|Release|identity/iu,
     )
     assert.equal(normalCalls, 0)
+  }
+})
+
+test("the production candidate satisfies the real controller planner contract", async () => {
+  // Regression: the observer passed bare {version, commitSha}, which
+  // observeProductionCandidate rejects as "Release candidate is invalid". That
+  // gate runs only AFTER both duplicates are quarantined, so the failure landed
+  // at the worst possible moment and produced no authorization receipt.
+  const candidate = recoveryCliModule.productionRecoveryCandidate({
+    version: "0.8.22",
+    commitSha: "2a80deece2ff958fe7fde8fddeb4f99bed70a1c8",
+  })
+  assert.deepEqual(Object.keys(candidate).sort(), [
+    "ciCheck",
+    "ciWorkflow",
+    "commitSha",
+    "publisherWorkflow",
+    "version",
+  ])
+  assert.equal(candidate.ciWorkflow, "CI")
+  assert.equal(candidate.ciCheck, "validate")
+  assert.equal(candidate.publisherWorkflow, ".github/workflows/release.yml")
+
+  // Prove the shape against the REAL planner rather than a local copy of the
+  // field list: planRelease validates candidates the same way the observer does.
+  const plan = planRelease({
+    candidate,
+    observation: { state: "UNKNOWN", diagnostics: [], conflicts: [] },
+    mode: "controller",
+  })
+  assert.equal(typeof plan.state, "string")
+
+  for (const invalid of [
+    { version: "0.8.22", commitSha: "2a80deece2ff958fe7fde8fddeb4f99bed70a1c8", extra: 1 },
+    { version: "0.8.22" },
+  ]) {
+    assert.throws(() => recoveryCliModule.productionRecoveryCandidate(invalid))
   }
 })
 


### PR DESCRIPTION
## Status first: the recovery itself worked

Both duplicates are now **quarantined**. `379991871` is the only marker-backed candidate for v0.8.22.

| Release | Assets | Body | Marker | State |
| --- | ---: | --- | --- | --- |
| `379991871` canonical | 45 | `5fe9fcab…` unchanged | PRESENT | untouched |
| `379982100` duplicate | 47 | recovery notice, 615 B | absent | `quarantined` |
| `379986168` duplicate | 47 | recovery notice, 615 B | absent | `quarantined` |

Each duplicate carries its original-body archive (9,684 B, digest matches) and its recovery receipt. No Release, tag, asset, or npm version was deleted; the canonical draft is byte-identical to before.

## The defect

`apply` completed every mutation and then failed at the **final authorization check** with `Release candidate is invalid`, writing no authorization receipt.

`observeProductionCandidate` and `planRelease` require the controller's full candidate shape — `version`, `commitSha`, `ciWorkflow`, `ciCheck`, `publisherWorkflow`, with no extra keys. The recovery observer passed bare `{version, commitSha}`.

Because that gate runs *after* both duplicates are mutated, the failure landed at the worst possible moment: the recovery had succeeded, but the run could not certify it.

## Fix

Build the candidate through an exported helper mirroring `CANDIDATE_POLICY` (candidate.mjs) and `DEFAULT_CANDIDATE_POLICY` (observe.mjs). The test proves the shape against the **real planner** rather than a local copy of the field list, so it cannot drift.

## This was predicted

Reviewer 3 on #534 found exactly this: making `createNormalProductionRecoveryObserver` throw left all 28 CLI tests green, because every observer test injected an override. It was reported as a coverage gap, and I judged the blast radius acceptable — "the operator does the manual verification the runbook already mandates."

The blast radius assessment was right; the classification was wrong. It was a defect, not just missing coverage, and it cost a stalled run at the least convenient point.

## Verification

Against the live repository the final observation now returns exactly what the design requires:

```json
{
  "state": "CANDIDATE_ESCROWED",
  "disposition": "would-transition",
  "nextTransition": "publish-npm-packages",
  "conflicts": [],
  "diagnostics": [],
  "releaseId": 379991871
}
```

Release-controller suite 2,058/2,058; lint clean.

After merge, `apply` re-runs to produce the authorization receipt. Both duplicates are already quarantined, so it performs **no mutation** and records each as `preexisting-quarantined` with `priorFenceObservations: null`.

Please let `CI / validate` go green before merging — `--reviewed-commit` re-derives that check from GitHub and will refuse the commit otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)