### PR TITLE
fix(release): recognize a quarantine performed by an earlier recovery commit

### DIFF
--- a/scripts/release/duplicate-draft-recovery.mjs
+++ b/scripts/release/duplicate-draft-recovery.mjs
@@ -724,6 +724,22 @@ export function classifyDuplicateDraft(value, expected) {
   }
   const recoveryReceiptBytes = canonicalRecoveryReceipt(recoveryReceiptInput)
   const recoveryReceiptSha256 = sha256Bytes(recoveryReceiptBytes)
+  // A stored receipt records the commit that PERFORMED the quarantine. That is
+  // history, not a function of the current run: re-capturing from a later
+  // reviewed commit (say after fixing the recovery surface) must still
+  // recognize it. Rebuild the expected receipt around the stored commit, with
+  // every other field still pinned to the current expectations.
+  const expectedReceiptFor = (storedBytes) => {
+    const storedCommit = storedRecoveryCommit(storedBytes)
+    if (storedCommit === null || storedCommit === recoveryReceiptInput.recoveryCommit) {
+      return { bytes: recoveryReceiptBytes, sha256: recoveryReceiptSha256 }
+    }
+    const bytes = canonicalRecoveryReceipt({
+      ...recoveryReceiptInput,
+      recoveryCommit: storedCommit,
+    })
+    return { bytes, sha256: sha256Bytes(bytes) }
+  }
   const expectedAssetNames = new Set(originalAssets.map((asset) => asset.name))
   for (const asset of assets) {
     if (
@@ -742,6 +758,7 @@ export function classifyDuplicateDraft(value, expected) {
     throw new Error("Duplicate Release original asset namespace changed")
   }
   const evidence = assets.slice(originalAssets.length)
+  let observedReceiptSha256 = null
   const notice =
     evidenceKinds.length === 2 && snapshot.marker === null
       ? parseCanonicalNotice(
@@ -763,15 +780,19 @@ export function classifyDuplicateDraft(value, expected) {
       ) {
         throw new Error("Duplicate Release original-body archive is not exact")
       }
-    } else if (
-      asset.name !== receiptAssetName ||
-      asset.sha256 !== recoveryReceiptSha256 ||
-      asset.size !== recoveryReceiptBytes.byteLength ||
-      typeof asset.bytes !== "string" ||
-      asset.bytes !== recoveryReceiptBytes.toString("utf8") ||
-      (notice !== null && asset.sha256 !== notice.receiptSha256)
-    ) {
-      throw new Error("Duplicate Release recovery receipt asset is not exact")
+    } else {
+      const expectedReceipt = expectedReceiptFor(asset.bytes)
+      observedReceiptSha256 = expectedReceipt.sha256
+      if (
+        asset.name !== receiptAssetName ||
+        asset.sha256 !== expectedReceipt.sha256 ||
+        asset.size !== expectedReceipt.bytes.byteLength ||
+        typeof asset.bytes !== "string" ||
+        asset.bytes !== expectedReceipt.bytes.toString("utf8") ||
+        (notice !== null && asset.sha256 !== notice.receiptSha256)
+      ) {
+        throw new Error("Duplicate Release recovery receipt asset is not exact")
+      }
     }
   }
 
@@ -783,7 +804,24 @@ export function classifyDuplicateDraft(value, expected) {
     }
   }
   if (evidenceKinds.length === 2 && snapshot.marker === null) {
-    if (snapshot.body !== requirements.recoveryNotice || !isCanonicalNotice(snapshot.body)) {
+    // The notice binds the receipt digest, which is itself derived from the
+    // commit that performed the quarantine. Rebuild the expected notice around
+    // the receipt actually stored so a later reviewed commit still recognizes
+    // an existing quarantine; every other notice field stays pinned.
+    const expectedNotice =
+      observedReceiptSha256 === null
+        ? requirements.recoveryNotice
+        : canonicalRecoveryNotice({
+            repository: DUPLICATE_DRAFT_RECOVERY_POLICY.repository,
+            version: DUPLICATE_DRAFT_RECOVERY_POLICY.version,
+            canonicalReleaseId: DUPLICATE_DRAFT_RECOVERY_POLICY.canonicalReleaseId,
+            duplicateReleaseId: requirements.releaseId,
+            originalBodySha256: requirements.originalBodySha256,
+            archiveAssetName: bodyAssetName,
+            receiptAssetName,
+            receiptSha256: observedReceiptSha256,
+          }).toString("utf8")
+    if (snapshot.body !== expectedNotice || !isCanonicalNotice(snapshot.body)) {
       throw new Error("Duplicate Release recovery notice is malformed")
     }
     return "quarantined"
@@ -2293,6 +2331,26 @@ export function sameAssetSet(left, right) {
         .sort((a, b) => (a < b ? -1 : a > b ? 1 : 0)),
     )
   return key(left) === key(right)
+}
+
+/**
+ * Read the `recoveryCommit` recorded in a stored receipt, or null when the
+ * bytes are absent or not a well-formed receipt. Only a syntactically valid
+ * commit SHA is accepted; every other receipt field remains pinned by the
+ * caller, so a tampered receipt still fails the byte comparison.
+ */
+function storedRecoveryCommit(bytes) {
+  if (typeof bytes !== "string") return null
+  let parsed
+  try {
+    parsed = JSON.parse(bytes)
+  } catch {
+    return null
+  }
+  if (!isRecord(parsed)) return null
+  const descriptor = Object.getOwnPropertyDescriptor(parsed, "recoveryCommit")
+  const value = descriptor?.value
+  return typeof value === "string" && /^[0-9a-f]{40}$/u.test(value) ? value : null
 }
 
 function assetSetSha256(assets) {

--- a/scripts/release/test/duplicate-draft-recovery.test.mjs
+++ b/scripts/release/test/duplicate-draft-recovery.test.mjs
@@ -291,6 +291,69 @@ test("classifies each exact resumable duplicate state", () => {
   }
 })
 
+test("recognizes a quarantine performed by an earlier recovery commit", () => {
+  // Regression: the receipt records the commit that PERFORMED the quarantine,
+  // and the notice binds that receipt's digest. Rebuilding both from the
+  // CURRENT reviewed commit made an existing quarantine unclassifiable the
+  // moment the recovery surface itself was fixed and re-merged — the state was
+  // correct in production but permanently unreadable.
+  const releaseId = POLICY.duplicates[0].releaseId
+  const expected = expectedFor(releaseId)
+  const historicalCommit = "a".repeat(40)
+  assert.notEqual(historicalCommit, expected.recoveryReceipt.recoveryCommit)
+
+  const historicalReceiptBytes = canonicalRecoveryReceipt({
+    ...expected.recoveryReceipt,
+    recoveryCommit: historicalCommit,
+  })
+  const historicalReceiptSha256 = createHash("sha256").update(historicalReceiptBytes).digest("hex")
+  const historicalNotice = canonicalRecoveryNotice({
+    repository: POLICY.repository,
+    version: POLICY.version,
+    canonicalReleaseId: POLICY.canonicalReleaseId,
+    duplicateReleaseId: releaseId,
+    originalBodySha256: expected.originalBodySha256,
+    archiveAssetName: originalBodyAssetName(releaseId, expected.originalBodySha256),
+    receiptAssetName: recoveryReceiptAssetName(releaseId),
+    receiptSha256: historicalReceiptSha256,
+  }).toString("utf8")
+
+  const observed = snapshot(
+    {
+      quarantined: true,
+      evidenceAssets: ["body", "receipt"],
+      receiptBytes: historicalReceiptBytes.toString("utf8"),
+      receiptSha256: historicalReceiptSha256,
+      body: historicalNotice,
+    },
+    releaseId,
+  )
+  assert.equal(classifyDuplicateDraft(observed, expected), "quarantined")
+
+  // A receipt that differs in anything but the recovery commit is still exact.
+  const tampered = canonicalRecoveryReceipt({
+    ...expected.recoveryReceipt,
+    recoveryCommit: historicalCommit,
+    canonicalReleaseId: POLICY.canonicalReleaseId,
+  })
+  assert.equal(tampered.toString("utf8"), historicalReceiptBytes.toString("utf8"))
+  assert.throws(() =>
+    classifyDuplicateDraft(
+      snapshot(
+        {
+          quarantined: true,
+          evidenceAssets: ["body", "receipt"],
+          receiptBytes: historicalReceiptBytes.toString("utf8"),
+          receiptSha256: "b".repeat(64),
+          body: historicalNotice,
+        },
+        releaseId,
+      ),
+      expected,
+    ),
+  )
+})
+
 test("compares original asset namespaces without conflating cross-Release asset IDs", () => {
   const expected = expectedFor()
   const duplicate = snapshot()


### PR DESCRIPTION
## The problem

Both duplicates **are** quarantined in production and the canonical draft is the only marker-backed candidate. But `capture` could no longer classify that state:

```
CAPTURE_EVIDENCE_CONFLICT
  → "Duplicate Release recovery receipt asset is not exact"
  → "Duplicate Release recovery notice is malformed"
```

The recovery receipt records the commit that **performed** the quarantine (`a647da21`), and the notice binds that receipt's digest. Both were rebuilt from the **current** reviewed commit and compared byte-for-byte. So the moment the recovery surface itself was fixed and re-merged — which is exactly what #537 and #538 did — an already-quarantined state became permanently unreadable.

The state in production was correct. Only the reader disagreed.

This is precisely the failure shape the design exists to exclude: a correct partial state that no recognized transition can resume. Left unfixed, the recovery could never be certified, because certifying it requires re-reading it from a newer commit than the one that wrote it.

## Fix

Treat the recorded commit as history, not as a function of the current run:

- the stored receipt's `recoveryCommit` is accepted when it is a well-formed SHA;
- the expected receipt is rebuilt around that commit;
- the expected notice is rebuilt around the resulting receipt digest.

Every other field of both records stays pinned. A receipt or notice differing in anything else — repository, version, candidate, Release IDs, body digest, base-asset digest, archive asset — still fails byte comparison. The test asserts both directions, including that a wrong receipt digest is still rejected.

## Verification

Against the live repository, from a reviewed commit **two merges later** than the one that performed the quarantine:

```
FULL CAPTURE OK; duplicates: [ 'quarantined', 'quarantined' ]
```

Release-controller suite 2,059/2,059; lint clean.

## Production state (unchanged by this PR)

| Release | Assets | Body | Marker |
| --- | ---: | --- | --- |
| `379991871` canonical | 45 | `5fe9fcab…` unchanged | PRESENT |
| `379982100` | 47 | recovery notice | absent |
| `379986168` | 47 | recovery notice | absent |

After merge, `apply` runs once more purely to emit the authorization receipt. Both duplicates are already quarantined, so it performs **no mutation** and records each as `preexisting-quarantined` with `priorFenceObservations: null`.

Please let `CI / validate` go green before merging — `--reviewed-commit` re-derives that check and will refuse the commit otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)