### PR TITLE
docs(release): let the cutover runbook verify a quarantine from an earlier recovery commit

### DIFF
--- a/docs/superpowers/runbooks/2026-08-09-release-integrity-cutover.md
+++ b/docs/superpowers/runbooks/2026-08-09-release-integrity-cutover.md
@@ -352,7 +352,9 @@ done
 test ! -e /node_modules
 test ! -L /node_modules
 test -z "$(git status --porcelain=v1 --untracked-files=all)"
-git status --ignored --porcelain=v1 --untracked-files=all | node -e '
+# Collapsed mode on purpose: `--untracked-files=all` expands every ignored
+# tree into its files, so no line could ever end in `node_modules/`.
+git status --ignored --porcelain=v1 | node -e '
   let input = ""
   process.stdin.setEncoding("utf8")
   process.stdin.on("data", (chunk) => { input += chunk })
@@ -686,7 +688,13 @@ module's canonical evidence parser; independently validates canonical final
 authorization and duplicate recovery receipt JSON; checks list/numeric-ID
 correlation, body/tag/draft state, exact 45/47 asset counts and digests; hashes
 the downloaded evidence assets; and rechecks every candidate run attempt's
-`publish-npm` job. Its output is a credential-free mode-`0600` verification
+`publish-npm` job. Each duplicate's stored receipt names the reviewed commit
+that performed its quarantine, which may predate `RECOVERY_SHA` when the
+recovery surface was fixed between attempts; the verifier rebuilds the expected
+receipt and notice around that commit with every other field pinned to the
+evidence, exactly as `classifyDuplicateDraft` does, and the shell then
+requires that commit to be a merge commit that is an ancestor of
+`RECOVERY_SHA`. Its output is a credential-free mode-`0600` verification
 receipt.
 
 ```zsh
@@ -700,6 +708,8 @@ import { createHash } from "node:crypto"
 import { readFileSync, statSync } from "node:fs"
 import {
   canonicalDuplicateDraftEvidence,
+  canonicalRecoveryNotice,
+  canonicalRecoveryReceipt,
   parseDuplicateDraftEvidence,
 } from "./scripts/release/duplicate-draft-recovery.mjs"
 import { parseReleaseMarker } from "./scripts/release/metadata.mjs"
@@ -831,8 +841,47 @@ for (const [index, releaseId] of expectedIds.entries()) {
   if (release.id !== releaseId || release.tag_name !== expected.tagName || release.name !== "Dawn v0.8.22" || release.draft !== true || release.prerelease !== false || release.immutable !== false || release.target_commitish !== "main") throw new Error(`Release ${releaseId} mutable draft metadata is not exact`)
   if (index === 0) {
     if (release.body !== expected.body || assets.length !== 45) throw new Error("Canonical Release body or asset count changed")
-  } else if (release.body !== expected.noticeBytes || release.body.includes("DAWN_RELEASE_CONTROLLER_MARKER") || assets.length !== 47) {
-    throw new Error(`Duplicate Release ${releaseId} is not quarantined`)
+  }
+  let recoveryCommit = null
+  let expectedReceipt = null
+  if (index > 0) {
+    // The stored receipt records the commit that PERFORMED the quarantine,
+    // which may be an earlier reviewed recovery commit than RECOVERY_SHA.
+    // Mirror `classifyDuplicateDraft`: rebuild the expected receipt and notice
+    // around that commit with every other field still pinned to the evidence.
+    const receiptAsset = assets.find((asset) => asset.name === expected.receiptAssetName)
+    if (!receiptAsset || !Number.isSafeInteger(receiptAsset.id)) throw new Error(`Duplicate Release ${releaseId} recovery receipt asset is absent`)
+    const storedPath = `${verifyDir}/release-${releaseId}-asset-${receiptAsset.id}.bin`
+    requirePrivate(storedPath)
+    let stored
+    try {
+      stored = JSON.parse(new TextDecoder("utf-8", { fatal: true }).decode(readFileSync(storedPath)))
+    } catch {
+      throw new Error(`Duplicate Release ${releaseId} stored receipt is not JSON`)
+    }
+    if (!stored || typeof stored !== "object" || Array.isArray(stored) || typeof stored.recoveryCommit !== "string" || !/^[0-9a-f]{40}$/u.test(stored.recoveryCommit)) {
+      throw new Error(`Duplicate Release ${releaseId} stored receipt names no recovery commit`)
+    }
+    recoveryCommit = stored.recoveryCommit
+    const { schemaVersion, ...pinned } = JSON.parse(expected.receiptBytes)
+    if (schemaVersion !== 1) throw new Error("Evidence recovery receipt schema is not exact")
+    expectedReceipt = canonicalRecoveryReceipt({ ...pinned, recoveryCommit })
+    const expectedNotice = canonicalRecoveryNotice({
+      repository: pinned.repository,
+      version: pinned.version,
+      canonicalReleaseId: pinned.canonicalReleaseId,
+      duplicateReleaseId: releaseId,
+      originalBodySha256: expected.originalBodySha256,
+      archiveAssetName: expected.archiveAssetName,
+      receiptAssetName: expected.receiptAssetName,
+      receiptSha256: sha256(expectedReceipt),
+    }).toString("utf8")
+    if (recoveryCommit === pinned.recoveryCommit && (expectedNotice !== expected.noticeBytes || !expectedReceipt.equals(Buffer.from(expected.receiptBytes, "utf8")))) {
+      throw new Error("Rebuilt recovery expectations diverge from the evidence")
+    }
+    if (release.body !== expectedNotice || release.body.includes("DAWN_RELEASE_CONTROLLER_MARKER") || assets.length !== 47) {
+      throw new Error(`Duplicate Release ${releaseId} is not quarantined`)
+    }
   }
   const ids = new Set()
   const names = new Set()
@@ -850,7 +899,7 @@ for (const [index, releaseId] of expectedIds.entries()) {
   if (index > 0) {
     for (const item of [
       { name: expected.archiveAssetName, sha256: expected.originalBodySha256, bytes: Buffer.from(evidence.releases.canonical.body, "utf8") },
-      { name: expected.receiptAssetName, sha256: expected.receiptSha256, bytes: Buffer.from(expected.receiptBytes, "utf8") },
+      { name: expected.receiptAssetName, sha256: sha256(expectedReceipt), bytes: expectedReceipt },
     ]) {
       const live = assets.find((asset) => asset.name === item.name)
       if (!live || live.digest !== `sha256:${item.sha256}`) throw new Error(`Release ${releaseId} recovery asset metadata changed`)
@@ -865,7 +914,7 @@ for (const [index, releaseId] of expectedIds.entries()) {
       recoveryAssets.push({ id: live.id, name: live.name, size: live.size, sha256: item.sha256 })
     }
   }
-  findings.push({ releaseId, tagName: release.tag_name, name: release.name, targetCommitish: release.target_commitish, draft: release.draft, prerelease: release.prerelease, immutable: release.immutable, bodySha256: sha256(Buffer.from(release.body, "utf8")), assetCount: assets.length, recoveryAssets })
+  findings.push({ releaseId, tagName: release.tag_name, name: release.name, targetCommitish: release.target_commitish, draft: release.draft, prerelease: release.prerelease, immutable: release.immutable, bodySha256: sha256(Buffer.from(release.body, "utf8")), assetCount: assets.length, recoveryCommit, recoveryAssets })
 }
 
 const runs = objectPages(`${verifyDir}/release-run-pages.json`, "workflow_runs")
@@ -897,6 +946,16 @@ const report = {
 process.stdout.write(canonicalBytes(report))
 NODE
 chmod 0600 "$VERIFY_DIR/independent-verification.json"
+env -u NODE_OPTIONS -u NODE_PATH node -e '
+  const report = JSON.parse(require("node:fs").readFileSync(process.argv[1], "utf8"))
+  const commits = report.releases.filter((release) => release.recoveryAssets.length > 0).map((release) => release.recoveryCommit)
+  if (commits.length !== 2 || commits.some((commit) => !/^[0-9a-f]{40}$/u.test(commit))) throw new Error("Recovery commits are not exact")
+  process.stdout.write(`${commits.join("\n")}\n`)
+' "$VERIFY_DIR/independent-verification.json" | while IFS= read -r recovery_commit; do
+  printf '%s\n' "$recovery_commit" | grep -Eq '^[0-9a-f]{40}$'
+  git merge-base --is-ancestor "$recovery_commit" "$RECOVERY_SHA"
+  test "$(git rev-list --parents --max-count=1 "$recovery_commit" | wc -w | tr -d ' ')" -eq 3
+done
 shasum -a 256 "$CAPTURE_PATH" "$APPLY_PATH" "$VERIFY_DIR/independent-verification.json"
 ```
 
@@ -914,7 +973,8 @@ Require all of the following before releasing the edit freeze:
   exact-tag candidate;
 - each original-body archive downloads byte-for-byte to the canonical original
   body, and each duplicate recovery receipt asset is canonical with the
-  recorded Release ID, asset ID, size, and SHA-256;
+  recorded Release ID, asset ID, size, and SHA-256, and names as its recovery
+  commit a merge commit that is an ancestor of `RECOVERY_SHA`;
 - the local final authorization receipt is canonical, credential-free,
   `atomic: false`, and scope-exact; each duplicate is honestly either
   `performed`, with this invocation's exact `preWriteFence` and


### PR DESCRIPTION
## Summary

Running the v0.8.22 duplicate-draft recovery runbook verbatim from a clean clone at the merged #539 commit surfaced two defects in the runbook's own embedded scripts. Both are fixed here; no code changes.

1. **Impossible post-install gate.** The "ignored paths are exclusively `node_modules` trees" check piped `git status --ignored --porcelain=v1 --untracked-files=all` into a regex requiring every line to end in `node_modules/`. Under `--untracked-files=all` git expands every ignored tree into its individual files, so the gate can never pass (117k lines on a real checkout, none matching). Collapsed mode lists the ignored directories themselves and the existing regex then does what it was meant to.

2. **Verifier rejected a quarantine performed by an earlier recovery commit.** The independent verifier compared each duplicate's live body and receipt asset against `noticeBytes` / `receiptBytes` derived for `RECOVERY_SHA`. The stored receipt records the commit that *performed* the quarantine (the #537 merge in production), so after #539 the command classified both duplicates as `quarantined` and emitted the final authorization receipt, but the runbook verifier threw `Duplicate Release 379982100 is not quarantined`. The verifier now rebuilds the expected receipt and notice around the stored receipt's `recoveryCommit` with every other field pinned to the evidence, exactly as `classifyDuplicateDraft` does after #539, reports that commit in the verification receipt, and the shell requires it to be a merge commit that is an ancestor of `RECOVERY_SHA`.

## Verification

- Corrected verifier run over the preserved attempt-01 capture, apply receipt, and downloads: passes, with both duplicates naming `a647da21` (#537 merge) as the recovery commit.
- Mutation test: a fabricated but internally consistent recovery commit (receipt, digest, and notice all rewritten) is accepted by the node verifier, as designed, and rejected by the shell ancestry gate.
- `node scripts/check-docs.mjs` passes; `scripts/check-changesets.mjs` reports no user-facing change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
