### PR TITLE
fix(release): request Actions artifact archives with the documented JSON media type

### DIFF
--- a/scripts/release/adapters/github.mjs
+++ b/scripts/release/adapters/github.mjs
@@ -151,6 +151,8 @@ export function createGitHubReader({
       return readBinary(context, {
         url: `${base}/releases/assets/${id}`,
         operation: "release-asset-download",
+        // Release assets return their bytes (via one signed redirect) only for this media type.
+        accept: "application/octet-stream",
         ...(limit === null ? {} : { maximumBytes: limit }),
       })
     },
@@ -236,6 +238,9 @@ export function createGitHubReader({
       return readBinary(context, {
         url: `${base}/actions/artifacts/${id}/zip`,
         operation: "actions-artifact-download",
+        // The artifact archive endpoint answers 302 to the documented JSON media type and,
+        // since 2026-09-03, HTTP 415 to application/octet-stream (observed in production).
+        accept: JSON_ACCEPT,
         ...(limit === null ? {} : { maximumBytes: limit }),
       })
     },
@@ -418,7 +423,7 @@ async function readJson(context, { url, operation, requestBudget = {} }) {
   }
 }
 
-async function readBinary(context, { url, operation, maximumBytes }) {
+async function readBinary(context, { url, operation, maximumBytes, accept }) {
   const budget = createOperationBudget(context, maximumBytes)
   const firstRequest = remainingRequestBudget(budget)
   if (firstRequest === null) {
@@ -426,7 +431,7 @@ async function readBinary(context, { url, operation, maximumBytes }) {
   }
   const result = await context.http.getBinary({
     url,
-    headers: requestHeaders(context.token, "application/octet-stream"),
+    headers: requestHeaders(context.token, accept),
     ...firstRequest,
   })
   if (result.code === "RESPONSE_TOO_LARGE") {

--- a/scripts/release/test/fixtures/release-script-hashes.json
+++ b/scripts/release/test/fixtures/release-script-hashes.json
@@ -8,7 +8,7 @@
       "sha256": "465beffc12678ec5bd6d6e5ef6dc4f4c9cc1d76e622b4ed27c35dd231f2e0dda"
     },
     "scripts/release/adapters/github.mjs": {
-      "sha256": "c91a81df9a2ca263f66855f398d6c0a4660396a54c4bc4ff080238c15e0fca5c"
+      "sha256": "00d507ac49a810092b78fbd65445aca3bde7b96cb50fda7202791593a22cfe53"
     },
     "scripts/release/adapters/http.mjs": {
       "sha256": "86e03a6cd1536bd57983c27256694bb281d83dfc7efd09181a299b7f351f9510"

--- a/scripts/release/test/github-adapter.test.mjs
+++ b/scripts/release/test/github-adapter.test.mjs
@@ -410,7 +410,7 @@ test("GitHub download methods return JSON-safe base64 without exposing response 
     calls.map(({ url, init }) => [url, init.method, init.headers.Accept]),
     [
       [`${BASE}/releases/assets/7`, "GET", "application/octet-stream"],
-      [`${BASE}/actions/artifacts/8/zip`, "GET", "application/octet-stream"],
+      [`${BASE}/actions/artifacts/8/zip`, "GET", "application/vnd.github+json"],
     ],
   )
 })
@@ -446,7 +446,7 @@ test("GitHub downloads follow one approved signed redirect without forwarding AP
       {
         url: `${BASE}/actions/artifacts/8/zip`,
         headers: {
-          Accept: "application/octet-stream",
+          Accept: "application/vnd.github+json",
           Authorization: `Bearer ${TOKEN}`,
           "X-GitHub-Api-Version": "2022-11-28",
         },

--- a/scripts/release/test/workflow-contracts.test.mjs
+++ b/scripts/release/test/workflow-contracts.test.mjs
@@ -45,9 +45,12 @@ const EXECUTABLE_ALLOWLIST = JSON.parse(
 )
 const SCRIPT_PIN_FIXTURE = "scripts/release/test/fixtures/release-script-hashes.json"
 const SCRIPT_PIN_PATH = path.join(ROOT, SCRIPT_PIN_FIXTURE)
-// Exact fixture bytes at Task 11's starting HEAD e5cf1986c0f2cb2f55b891a7c92fa7291289dfdb.
+// Exact fixture bytes after the reviewed artifact-download Accept fix
+// (scripts/release/adapters/github.mjs; GitHub began answering HTTP 415 to
+// application/octet-stream on the artifact zip endpoint on 2026-09-03).
+// Previously pinned at Task 11's starting HEAD e5cf1986c0f2cb2f55b891a7c92fa7291289dfdb.
 const STARTING_SCRIPT_PIN_SHA256 =
-  "b6d939f6ad17ffa011f600fda31792716c73baf5a7cd4e3540dfbe30c75d727c"
+  "1d0c67a4da9dd7fc33b8a8938dd672ae215a5db9cd8ace27756a72a0d5531f1f"
 const SHA256_HEX = /^[0-9a-f]{64}$/u
 const workflowExpression = (value) => `\${{ ${value} }}`
 const SCRIPT_REFERENCE = /(?:^|[\s;&|"'(])(scripts\/[\w.-]+(?:\/[\w.-]+)*)/gu


### PR DESCRIPTION
## Summary

The first v0.8.22 reconcile dispatch after the duplicate-draft recovery ([run 33764298343](https://github.com/cacheplane/dawnai/actions/runs/33764298343)) failed at `detect`. The production observation came back ambiguous with `HTTP_415` on `actions-artifact-download` and a consequent `ACTIONS_ARTIFACT_DIGEST_MISMATCH`, so the controller blocked (`CANDIDATE_TAGGED` / `blocked`) and mutated nothing. `publish-npm` never started and the canonical draft is unchanged.

Reproduced outside Actions through the same adapter: since 2026-09-03, `GET /repos/{owner}/{repo}/actions/artifacts/{id}/zip` answers **HTTP 415** to `Accept: application/octet-stream` and only issues its 302 to the signed archive URL for `Accept: application/vnd.github+json`, which is the media type [GitHub's documentation](https://docs.github.com/en/rest/actions/artifacts) shows for this endpoint. The adapter used octet-stream for every binary read. Release asset downloads still require octet-stream, so `readBinary` now takes the Accept value per call site.

`detect` checks out the default branch, so this fix takes effect on the next dispatch without touching the immutable `v0.8.22` tag.

## Changes

- `scripts/release/adapters/github.mjs`: `readBinary({ accept })`; artifact archives send `application/vnd.github+json`, Release assets keep `application/octet-stream`. Redirect handling, signed-URL allowlist, and credential stripping are unchanged.
- `scripts/release/test/github-adapter.test.mjs`: the two header expectations for the artifact endpoint.
- `scripts/release/test/fixtures/release-script-hashes.json`: the adapter's content pin, as the pin test instructs.
- `scripts/release/test/workflow-contracts.test.mjs`: the fixture-bytes pin that guarded the consolidation work, moved with a comment explaining why.

## Verification

- Live, through the patched adapter: both v0.8.22 escrow artifacts (13,474,661 and 447 bytes) download with digests matching GitHub's `digest` field, and a Release receipt asset still downloads byte-exact via octet-stream.
- `pnpm test:release-controller`: 2175/2175.
- biome clean on all four files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
