### PR TITLE
test(k8s-compat): give the helm-rendered Role parity test a real timeout

### DIFF
--- a/test/k8s-compat/chart-rbac.test.ts
+++ b/test/k8s-compat/chart-rbac.test.ts
@@ -84,5 +84,8 @@ describe("dawn-orchestrator Role parity", () => {
         [...REQUIRED_KUBE_PERMISSIONS].sort((a, b) => key(a).localeCompare(key(b))),
       )
     },
+    // `helm template` takes ~2s on a loaded CI runner and has exceeded the 5s
+    // default twice in a row; give the external render a real budget.
+    30_000,
   )
 })


### PR DESCRIPTION
## Summary

`test/k8s-compat/chart-rbac.test.ts` shells out to `helm template`, which takes about 2 seconds on a loaded CI runner (2145 ms and 2045 ms on the last two green `validate` runs). It ran under Vitest's 5 second default and timed out on two consecutive `validate` attempts for #541, a change confined to `scripts/release`, while passing locally in about 140 ms. This gives the external render a 30 second budget.

## Verification

- `pnpm exec vitest run test/k8s-compat/chart-rbac.test.ts` passes locally with helm present.
- biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
