### PR TITLE
feat(release): let the draft-reading release jobs see draft Releases

### DIFF
--- a/.github/workflows/published-artifact-verify.yml
+++ b/.github/workflows/published-artifact-verify.yml
@@ -32,7 +32,8 @@ jobs:
     timeout-minutes: 5
     permissions:
       actions: write
-      contents: read
+      # contents: write — the only scope that exposes draft Releases to GITHUB_TOKEN (spec 2026-09-04-controller-draft-visibility).
+      contents: write
     outputs:
       mode: ${{ steps.route.outputs.mode }}
     steps:
@@ -73,7 +74,8 @@ jobs:
       actions: read
       attestations: read
       checks: read
-      contents: read
+      # contents: write — the only scope that exposes draft Releases to GITHUB_TOKEN (spec 2026-09-04-controller-draft-visibility).
+      contents: write
     steps:
       - name: Checkout exact candidate
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,8 @@ jobs:
       actions: read
       attestations: read
       checks: read
-      contents: read
+      # contents: write — the only scope that exposes draft Releases to GITHUB_TOKEN (spec 2026-09-04-controller-draft-visibility).
+      contents: write
     outputs:
       candidate_sha: ${{ steps.observe.outputs.candidate_sha }}
       candidate_version: ${{ steps.observe.outputs.candidate_version }}
@@ -1087,7 +1088,8 @@ jobs:
     timeout-minutes: 10
     permissions:
       actions: write
-      contents: read
+      # contents: write — the only scope that exposes draft Releases to GITHUB_TOKEN (spec 2026-09-04-controller-draft-visibility).
+      contents: write
     outputs:
       dispatch_artifact_id: ${{ steps.receipt.outputs.artifact-id }}
     steps:

--- a/docs/superpowers/plans/2026-09-04-controller-draft-visibility.md
+++ b/docs/superpowers/plans/2026-09-04-controller-draft-visibility.md
@@ -1,0 +1,30 @@
+# Controller Draft Visibility Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give the four draft-reading release jobs `contents: write` so the controller can observe its own escrow, and pin the write set in the contract tests.
+
+**Architecture:** Two YAML permission edits and one contract-test file. No script changes. Spec: `docs/superpowers/specs/2026-09-04-controller-draft-visibility-design.md`.
+
+**Tech Stack:** GitHub Actions YAML, `node:test` (`scripts/release/test/workflow-contracts.test.mjs`), Node 24, biome.
+
+---
+
+### Task 1: Pin the write set in the contract tests (red first)
+
+**Files:** Modify `scripts/release/test/workflow-contracts.test.mjs`.
+
+- [ ] Add a test `"only the enumerated jobs hold contents: write"` that parses both workflows (use the file's `readRequiredWorkflow`) and asserts the exact sets: release.yml → `["correlate-audit","detect","dispatch-audit","escrow","publish-release","reconcile-npm","reconcile-smokes","record-audit-dispatch","tag"]`; published-artifact-verify.yml → `["coordinate","verify-draft"]`. Sort before comparing.
+- [ ] Add a helper `assertContentsWriteOnly(job)`: `job.permissions.contents === "write"`, every other permission value is `"read"`, and `permissions["id-token"] !== "write"`. Use it for `detect` (replacing `assertNoWriteOrOidc(detect)` at ~L865), `dispatch-audit` (replacing the `notEqual(...contents, "write")` at ~L1207 with `assertContentsWriteOnly` and keeping `actions === "write"` — NOTE: dispatch-audit legitimately holds `actions: write`, so for that job the helper must allow `actions: write` explicitly: give the helper an `allowedWrites` parameter defaulting to `[]`), `coordinate` (~L1310; it holds `actions: write`), and `verify-draft` (~L1732 currently `deepEqual(job.permissions, { contents: "read" })` → `{ contents: "write" }` plus whatever it already has).
+- [ ] Run `node --test scripts/release/test/workflow-contracts.test.mjs` → the new enumeration test and the four updated assertions FAIL against the current YAML.
+
+### Task 2: Grant the permission
+
+**Files:** Modify `.github/workflows/release.yml` (`detect`, `dispatch-audit`) and `.github/workflows/published-artifact-verify.yml` (`coordinate`, `verify-draft`): `contents: read` → `contents: write` in each job's `permissions` block only. Add a one-line YAML comment above each: `# contents: write — the only scope that exposes draft Releases to GITHUB_TOKEN (spec 2026-09-04-controller-draft-visibility).`
+
+- [ ] Run the contract test file → all pass. Run `pnpm test:release-controller` → exit 0. Run `node scripts/check-docs.mjs`.
+- [ ] Commit `feat(release): let the draft-reading release jobs see draft Releases`.
+
+### Task 3: PR
+
+- [ ] Push; open a PR with the spec's Problem and Accepted trade-off sections; `gh pr merge --auto --merge`.

--- a/docs/superpowers/specs/2026-09-04-controller-draft-visibility-design.md
+++ b/docs/superpowers/specs/2026-09-04-controller-draft-visibility-design.md
@@ -1,0 +1,104 @@
+# Controller Draft Visibility Design
+
+## Status
+
+Approved design, 2026-09-04. Sub-project A of the v0.8.22 unblock; prerequisite
+for the v0.8.23 release.
+
+## Problem
+
+GitHub lists draft Releases only to callers with push access. In Actions, the
+`GITHUB_TOKEN` at `contents: read` receives HTTP 403 for a draft by ID and lists
+no drafts (probe run 33780657483, 2026-09-03). The release controller escrows
+every candidate as a draft Release and then observes it, but four jobs that
+read drafts run with `contents: read`:
+
+- `release.yml` `detect` (the production observer, `cli.mjs observe`)
+- `release.yml` `dispatch-audit` (`cli.mjs dispatch-audit`)
+- `published-artifact-verify.yml` `coordinate` (lists Releases and reads a
+  draft by tag through `independent-audit-coordinator.mjs`)
+- `published-artifact-verify.yml` `verify-draft` (`independent-audit.mjs`)
+
+Consequently the v0.8.22 reconcile runs on 2026-09-03 observed the escrow as
+absent and skipped every publishing job. Job permissions live in the workflow
+file at the immutable candidate tag, so this must merge to `main` before the
+v0.8.23 tag is created; the controller creates that tag from `main`.
+
+`publish-npm` and the five smoke jobs do not read the Release (they consume
+Actions artifacts and npm), and every other draft-touching job already has
+`contents: write`.
+
+## Goals
+
+- Every job that reads a draft Release can see it.
+- The set of jobs holding `contents: write` is enumerated and pinned by the
+  workflow-contract tests so it cannot grow silently.
+- No job gains `id-token: write` or any other write scope it does not have.
+
+## Non-goals
+
+- Changing any script, adapter, or observer behavior.
+- Restoring abandonment or altering the audit workflow's dispatch contract.
+- Retrofitting the v0.8.22 tag (it is terminal by the reviewed record).
+
+## Design
+
+Grant `contents: write` to exactly the four jobs above. Nothing else changes in
+either workflow.
+
+### The observer invariant
+
+The contract tests asserted that `detect`, `prepare`, `hydrate`, and every
+smoke job hold no write permission at all (`assertNoWriteOrOidc`). GitHub
+offers no read-only scope that exposes drafts, so the invariant for `detect`
+becomes: `contents: write` is the only write scope, `id-token` is not `write`,
+and the job's steps invoke only the observer (already asserted step by step).
+`prepare`, `hydrate`, and the smokes keep the strict no-write assertion. The
+same relaxed shape applies to `dispatch-audit`, `coordinate`, and
+`verify-draft`, each of which keeps its existing step-level assertions.
+
+### Accepted trade-off
+
+A job running reviewed scripts from `main` with a write-capable token could, if
+a script regressed, mutate a Release. The controller's writers already run
+under that token in `escrow`, `reconcile-npm`, `reconcile-smokes`,
+`record-audit-dispatch`, `correlate-audit`, and `publish-release`; this widens
+exposure to four more jobs but to no new code paths, and the adapters' innermost
+per-call-site guards are unchanged. This is preferred over an external token
+with push access, which would introduce a long-lived credential.
+
+## Testing
+
+`scripts/release/test/workflow-contracts.test.mjs`:
+
+- `detect`, `dispatch-audit`, `coordinate`, `verify-draft`: assert
+  `permissions.contents === "write"`, no other write scope, `id-token` not
+  `write`.
+- A new enumeration test: the exact set of jobs with `contents: write` in
+  `release.yml` is `{tag, escrow, reconcile-npm, reconcile-smokes,
+  record-audit-dispatch, correlate-audit, publish-release, detect,
+  dispatch-audit}` and in `published-artifact-verify.yml` is `{coordinate,
+  verify-draft}`; any other job with `contents: write` fails.
+- Existing strict assertions for `prepare`, `hydrate`, `publish-npm`, and the
+  smokes are unchanged.
+
+## Release sequence
+
+1. Merge this change on green `validate`.
+2. Run the runbook's pre-enable checks and a read-only `observe` from `main`:
+   v0.8.22 must read `ABANDONED_PREPUBLICATION`; no other candidate pending;
+   release.yml `disabled_manually`; zero nonterminal Release runs.
+3. Enable `release.yml`.
+4. Merge Version Packages PR #525 (v0.8.23). The push to `main` runs the
+   controller, which creates the annotated `v0.8.23` tag (carrying this
+   workflow) and dispatches at the tag.
+5. Watch the tagged run through escrow, publish-npm, the five smokes,
+   reconcile, the independent audit, and publish-release. Stop at the first
+   failed transition and preserve evidence.
+
+## Success criteria
+
+- The v0.8.23 tagged run's `detect` observes its own escrow draft
+  (`CANDIDATE_ESCROWED`) on the run after `escrow`, and the run proceeds to
+  `publish-npm`.
+- No job outside the enumerated set holds `contents: write`.

--- a/scripts/release/abandonment-workflow-policy.json
+++ b/scripts/release/abandonment-workflow-policy.json
@@ -5,12 +5,12 @@
     {
       "id": "disabled-2026-08-28",
       "mode": "disabled",
-      "canonicalSha256": "18677ab818fc1cf834cd0c3c7f1219883c00421a9452305a411f758e8102dbea"
+      "canonicalSha256": "7f6ab574ac0a87a3e7c5e5a8dbc25750c968840b7a186dee8aa510d756e26957"
     },
     {
       "id": "protected-2026-08-28",
       "mode": "protected",
-      "canonicalSha256": "d8fabd2297e2ebc23d472a1dfa1a0f73a9d96ce2a5d72994494fe24e0ab631db"
+      "canonicalSha256": "493dcc25c88baf9b1652a579d57c7b5d227ad885360a8257cc0caf4cb114d75e"
     }
   ]
 }

--- a/scripts/release/test/fixtures/release-workflow-disabled.yml
+++ b/scripts/release/test/fixtures/release-workflow-disabled.yml
@@ -43,7 +43,8 @@ jobs:
       actions: read
       attestations: read
       checks: read
-      contents: read
+      # contents: write — the only scope that exposes draft Releases to GITHUB_TOKEN (spec 2026-09-04-controller-draft-visibility).
+      contents: write
     outputs:
       candidate_sha: ${{ steps.observe.outputs.candidate_sha }}
       candidate_version: ${{ steps.observe.outputs.candidate_version }}
@@ -1087,7 +1088,8 @@ jobs:
     timeout-minutes: 10
     permissions:
       actions: write
-      contents: read
+      # contents: write — the only scope that exposes draft Releases to GITHUB_TOKEN (spec 2026-09-04-controller-draft-visibility).
+      contents: write
     outputs:
       dispatch_artifact_id: ${{ steps.receipt.outputs.artifact-id }}
     steps:

--- a/scripts/release/test/fixtures/release-workflow-protected.yml
+++ b/scripts/release/test/fixtures/release-workflow-protected.yml
@@ -48,7 +48,8 @@ jobs:
       actions: read
       attestations: read
       checks: read
-      contents: read
+      # contents: write — the only scope that exposes draft Releases to GITHUB_TOKEN (spec 2026-09-04-controller-draft-visibility).
+      contents: write
     outputs:
       candidate_sha: ${{ steps.observe.outputs.candidate_sha }}
       candidate_version: ${{ steps.observe.outputs.candidate_version }}
@@ -1111,7 +1112,8 @@ jobs:
     timeout-minutes: 10
     permissions:
       actions: write
-      contents: read
+      # contents: write — the only scope that exposes draft Releases to GITHUB_TOKEN (spec 2026-09-04-controller-draft-visibility).
+      contents: write
     outputs:
       dispatch_artifact_id: ${{ steps.receipt.outputs.artifact-id }}
     steps:

--- a/scripts/release/test/fixtures/workflow-entrypoints.json
+++ b/scripts/release/test/fixtures/workflow-entrypoints.json
@@ -2190,7 +2190,7 @@
             },
             "permissions": {
               "actions": "write",
-              "contents": "read"
+              "contents": "write"
             },
             "runs-on": "ubuntu-24.04",
             "timeout-minutes": 5
@@ -2245,7 +2245,7 @@
               "actions": "read",
               "attestations": "read",
               "checks": "read",
-              "contents": "read"
+              "contents": "write"
             },
             "runs-on": "ubuntu-24.04",
             "timeout-minutes": 30
@@ -2686,7 +2686,7 @@
               "actions": "read",
               "attestations": "read",
               "checks": "read",
-              "contents": "read"
+              "contents": "write"
             },
             "runs-on": "ubuntu-24.04",
             "timeout-minutes": 20
@@ -2790,7 +2790,7 @@
             },
             "permissions": {
               "actions": "write",
-              "contents": "read"
+              "contents": "write"
             },
             "runs-on": "ubuntu-24.04",
             "timeout-minutes": 10

--- a/scripts/release/test/workflow-contracts.test.mjs
+++ b/scripts/release/test/workflow-contracts.test.mjs
@@ -858,11 +858,29 @@ test("final release workflows pin every action and the exact Node, pnpm, and npm
   assert.ok(npmChecks > 0, "the exact npm runtime must be asserted before release verification")
 })
 
+test("only the enumerated jobs hold contents: write", async () => {
+  const { workflow: release } = await readRequiredWorkflow("release.yml")
+  assert.deepEqual(jobsWithContentsWrite(release), [
+    "correlate-audit",
+    "detect",
+    "dispatch-audit",
+    "escrow",
+    "publish-release",
+    "reconcile-npm",
+    "reconcile-smokes",
+    "record-audit-dispatch",
+    "tag",
+  ])
+
+  const { workflow: audit } = await readRequiredWorkflow("published-artifact-verify.yml")
+  assert.deepEqual(jobsWithContentsWrite(audit), ["coordinate", "verify-draft"])
+})
+
 test("detect invokes the sole production observer and exports only validated controller outputs", async () => {
   const { source, workflow } = await readRequiredWorkflow("release.yml")
   const detect = requiredJob(workflow, "detect")
   assert.deepEqual(normalizeNeeds(detect.needs), [])
-  assertNoWriteOrOidc(detect)
+  assertContentsWriteOnly(detect)
   assert.equal(detect.permissions?.checks, "read")
   const checkout = onlyStepUsing(detect, ACTIONS.checkout)
   const pnpm = onlyStepUsing(detect, ACTIONS.pnpm)
@@ -1204,7 +1222,7 @@ test("audit dispatch, receipt recording, correlation, and immutable publication 
   const publish = requiredJob(workflow, "publish-release")
   assert.deepEqual(normalizeNeeds(dispatch.needs), ["detect", "hydrate", "reconcile-smokes", "tag"])
   assert.equal(dispatch.permissions?.actions, "write")
-  assert.notEqual(dispatch.permissions?.contents, "write")
+  assertContentsWriteOnly(dispatch, { allowedWrites: ["actions"] })
   const dispatchStep = onlyRunStepMatching(
     dispatch,
     /node scripts\/release\/cli\.mjs dispatch-audit\b/u,
@@ -1307,7 +1325,7 @@ test("the independent workflow relays default-branch audits and verifies exact t
 
   const coordinator = requiredJob(workflow, "coordinate")
   assert.equal(coordinator.permissions?.actions, "write")
-  assert.notEqual(coordinator.permissions?.contents, "write")
+  assertContentsWriteOnly(coordinator, { allowedWrites: ["actions"] })
   assert.match(coordinator.if, /github\.event\.repository\.default_branch/u)
   const coordinatorCheckout = onlyStepUsing(coordinator, ACTIONS.checkout)
   assert.equal(
@@ -1327,7 +1345,7 @@ test("the independent workflow relays default-branch audits and verifies exact t
   const draft = requiredJob(workflow, "verify-draft")
   assert.equal(draft.name, "verify")
   assert.deepEqual(normalizeNeeds(draft.needs), ["coordinate"])
-  assert.equal(hasWritePermission(draft.permissions), false)
+  assertContentsWriteOnly(draft)
   assert.equal(draft.permissions?.checks, "read")
   assertExactIndependentTagGate(draft, "draft")
   const checkout = onlyStepUsing(draft, ACTIONS.checkout)
@@ -1410,7 +1428,9 @@ test("the independent workflow relays default-branch audits and verifies exact t
     source,
     /runOpenAI|runPgvector|packageSet|return_run_details|list.*workflow.*runs/iu,
   )
-  assert.doesNotMatch(source, /contents\s*:\s*write|gh\s+release|\/releases\/.+(?:PATCH|DELETE)/iu)
+  // contents: write is required for the draft-reading jobs to see draft Releases at all
+  // (spec 2026-09-04-controller-draft-visibility); the enumeration test pins which jobs hold it.
+  assert.doesNotMatch(source, /gh\s+release|\/releases\/.+(?:PATCH|DELETE)/iu)
 })
 
 test("release.yml is the only trusted npm publisher and chart publication remains separate", async () => {
@@ -3314,6 +3334,24 @@ function assertNoWriteOrOidc(job) {
   assert.ok(isRecord(job.permissions), "read-only jobs must declare explicit permissions")
   assert.equal(hasWritePermission(job.permissions), false)
   assert.notEqual(job.permissions["id-token"], "write")
+}
+
+function assertContentsWriteOnly(job, { allowedWrites = [] } = {}) {
+  assert.ok(isRecord(job.permissions), "draft-reading jobs must declare explicit permissions")
+  assert.equal(job.permissions.contents, "write")
+  assert.notEqual(job.permissions["id-token"], "write")
+  const allowed = new Set(["contents", ...allowedWrites])
+  for (const [permission, value] of Object.entries(job.permissions)) {
+    if (allowed.has(permission)) continue
+    assert.equal(value, "read", `${permission} must stay read-only`)
+  }
+}
+
+function jobsWithContentsWrite(workflow) {
+  return Object.entries(workflow.jobs)
+    .filter(([, job]) => isRecord(job.permissions) && job.permissions.contents === "write")
+    .map(([id]) => id)
+    .sort()
 }
 
 function normalizeNeeds(needs) {


### PR DESCRIPTION
## Problem

GitHub lists draft Releases only to callers with push access. In Actions, the
`GITHUB_TOKEN` at `contents: read` receives HTTP 403 for a draft by ID and lists
no drafts (probe run 33780657483, 2026-09-03). The release controller escrows
every candidate as a draft Release and then observes it, but four jobs that
read drafts run with `contents: read`:

- `release.yml` `detect` (the production observer, `cli.mjs observe`)
- `release.yml` `dispatch-audit` (`cli.mjs dispatch-audit`)
- `published-artifact-verify.yml` `coordinate` (lists Releases and reads a
  draft by tag through `independent-audit-coordinator.mjs`)
- `published-artifact-verify.yml` `verify-draft` (`independent-audit.mjs`)

Consequently the v0.8.22 reconcile runs on 2026-09-03 observed the escrow as
absent and skipped every publishing job. Job permissions live in the workflow
file at the immutable candidate tag, so this must merge to `main` before the
v0.8.23 tag is created; the controller creates that tag from `main`.

`publish-npm` and the five smoke jobs do not read the Release (they consume
Actions artifacts and npm), and every other draft-touching job already has
`contents: write`.

## Accepted trade-off

A job running reviewed scripts from `main` with a write-capable token could, if
a script regressed, mutate a Release. The controller's writers already run
under that token in `escrow`, `reconcile-npm`, `reconcile-smokes`,
`record-audit-dispatch`, `correlate-audit`, and `publish-release`; this widens
exposure to four more jobs but to no new code paths, and the adapters' innermost
per-call-site guards are unchanged. This is preferred over an external token
with push access, which would introduce a long-lived credential.

## Testing

`node --test scripts/release/test/workflow-contracts.test.mjs` 122/122 (the new
`only the enumerated jobs hold contents: write` test plus the four updated job
assertions were red against the unchanged YAML, and a reverted single edit turns
the enumeration test red again), `pnpm test:release-controller` 2331/2331 exit 0,
`node scripts/check-docs.mjs` pass, biome clean.
