### PR TITLE
test(k8s-compat): pin the infrastructure chart floor instead of a literal version

### DIFF
--- a/scripts/check-docs.mjs
+++ b/scripts/check-docs.mjs
@@ -3327,9 +3327,24 @@ const sandboxInfraChartSource = readFileSync(
   "utf8",
 )
 const sandboxInfraChart = parseYaml(sandboxInfraChartSource)
-if (sandboxInfraChart?.version !== "0.1.4") {
+// The documentation patch first shipped in chart 0.1.4. Version Packages bumps
+// the chart patch on every release, so require a floor rather than a literal.
+const SANDBOX_INFRA_DOCS_PATCH_FLOOR = [0, 1, 4]
+const sandboxInfraChartVersion =
+  typeof sandboxInfraChart?.version === "string" &&
+  /^\d+\.\d+\.\d+$/u.test(sandboxInfraChart.version)
+    ? sandboxInfraChart.version.split(".").map((part) => Number.parseInt(part, 10))
+    : null
+const sandboxInfraChartAtFloor =
+  sandboxInfraChartVersion !== null &&
+  sandboxInfraChartVersion.reduce(
+    (order, part, index) =>
+      order !== 0 ? order : Math.sign(part - SANDBOX_INFRA_DOCS_PATCH_FLOOR[index]),
+    0,
+  ) >= 0
+if (!sandboxInfraChartAtFloor) {
   failures.push(
-    `charts/dawn-sandbox-infra/Chart.yaml must publish the documentation patch as version 0.1.4; found ${sandboxInfraChart?.version ?? "missing"}`,
+    `charts/dawn-sandbox-infra/Chart.yaml must publish the documentation patch as version 0.1.4 or later; found ${sandboxInfraChart?.version ?? "missing"}`,
   )
 }
 const canonicalKubernetesSandboxUrl = "https://dawnai.org/docs/sandbox/kubernetes"

--- a/test/k8s-compat/docs-policy.test.ts
+++ b/test/k8s-compat/docs-policy.test.ts
@@ -293,8 +293,18 @@ function makesUnsupportedCompatibilityClaim(source: string): boolean {
   return namesManagedKubernetes && !isManagedKubernetesBoundary(text)
 }
 
+function compareChartVersions(left: string, right: string): number {
+  const parts = (value: string) => value.split(".").map((part) => Number.parseInt(part, 10))
+  const [leftParts, rightParts] = [parts(left), parts(right)]
+  for (let index = 0; index < 3; index += 1) {
+    const difference = (leftParts[index] ?? 0) - (rightParts[index] ?? 0)
+    if (difference !== 0) return difference
+  }
+  return 0
+}
+
 describe("Kubernetes compatibility documentation policy", () => {
-  test("publishes the infrastructure documentation patch as chart 0.1.4", async () => {
+  test("ships the infrastructure documentation patch at chart 0.1.4 or later", async () => {
     const { dawnAppChart, sandboxInfraChart } = await loadDocumentation()
     const infrastructureMetadata = parse(sandboxInfraChart) as {
       readonly version?: unknown
@@ -302,7 +312,13 @@ describe("Kubernetes compatibility documentation policy", () => {
     }
     const applicationMetadata = parse(dawnAppChart) as { readonly appVersion?: unknown }
 
-    expect(infrastructureMetadata.version).toBe("0.1.4")
+    // The documentation patch first shipped in chart 0.1.4. Version Packages
+    // bumps the chart patch on every release, so pin a floor, not a literal.
+    expect(infrastructureMetadata.version).toMatch(/^\d+\.\d+\.\d+$/)
+    expect(
+      compareChartVersions(infrastructureMetadata.version as string, "0.1.4"),
+      "infrastructure chart must not regress below the documentation patch",
+    ).toBeGreaterThanOrEqual(0)
     expect(infrastructureMetadata.appVersion).toBe(applicationMetadata.appVersion)
   })
 


### PR DESCRIPTION
`test/k8s-compat/docs-policy.test.ts` asserted `charts/dawn-sandbox-infra` at exactly `0.1.4`. Version Packages bumps the chart patch on every release, so the v0.8.23 merge (1397fd2b, CI run 33844258370) turned `validate` red with no product change. The test now asserts a semver shape and a `0.1.4` floor (the release that carried the documentation patch); the `appVersion` parity assertion is unchanged.

This unblocks the v0.8.23 release: the controller requires a green `CI / validate` on the candidate commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)