### PR TITLE
chore(release): add a patch changeset to re-cut the unpublished 0.8.23 bump

### DIFF
--- a/.changeset/recut-release-after-unpublished-candidate.md
+++ b/.changeset/recut-release-after-unpublished-candidate.md
@@ -1,0 +1,5 @@
+---
+"@dawn-ai/cli": patch
+---
+
+Cut a new patch release. The previous version bump was never tagged or published: its merge commit failed CI on a literal chart-version pin in the Kubernetes documentation checks, and the release controller binds a candidate to the commit that introduced its version. The pin is now a floor, so this bump can be released. No runtime behavior changes.


### PR DESCRIPTION
The 0.8.23 Version Packages merge (1397fd2b) fails `CI / validate` permanently: its tree carries the literal `0.1.4` chart pin that #550 turned into a floor, and the release controller binds candidate 0.8.23 to the commit that introduced the version (verified by a local `observe` run at main 1369196f: `candidate.commitSha = 1397fd2b`, `REQUIRED_CI_FAILED`). Later fix commits do not move the candidate.

No tag, draft Release, or npm publication was created for 0.8.23. This changeset makes `version-pr.yml` open a Version Packages PR for the next patch; merging that PR is the explicit release decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)