### PR TITLE
release: let detect wait the full CI budget before observing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ permissions:
 jobs:
   detect:
     runs-on: ubuntu-24.04
-    timeout-minutes: 20
+    timeout-minutes: 60
     permissions:
       actions: read
       attestations: read

--- a/scripts/release/abandonment-workflow-policy.json
+++ b/scripts/release/abandonment-workflow-policy.json
@@ -5,12 +5,12 @@
     {
       "id": "disabled-2026-08-28",
       "mode": "disabled",
-      "canonicalSha256": "7f6ab574ac0a87a3e7c5e5a8dbc25750c968840b7a186dee8aa510d756e26957"
+      "canonicalSha256": "88edb276d49081637ebc3a4d716a8031cd845b4f95a529ae2d48f9d514b86b61"
     },
     {
       "id": "protected-2026-08-28",
       "mode": "protected",
-      "canonicalSha256": "493dcc25c88baf9b1652a579d57c7b5d227ad885360a8257cc0caf4cb114d75e"
+      "canonicalSha256": "fb3b5129ad23e41bcf7140378092774fbe8952385dea9d7dd760755bb8146682"
     }
   ]
 }

--- a/scripts/release/cli.mjs
+++ b/scripts/release/cli.mjs
@@ -346,8 +346,9 @@ async function runObserve(options, runtime) {
     const ci = await waitForRequiredCi({
       sha: selection.candidate.commitSha,
       github,
-      attempts: 61,
-      delayMs: 10_000,
+      // 100 x 30 s = 50 min: must exceed ci.yml's 45-minute validate budget plus queueing.
+      attempts: 100,
+      delayMs: 30_000,
       delay: runtime.wait ?? defaultWait,
     })
     if (ci.status !== "success") {

--- a/scripts/release/test/fixtures/release-script-hashes.json
+++ b/scripts/release/test/fixtures/release-script-hashes.json
@@ -20,7 +20,7 @@
       "sha256": "1b1e17298068211d5e47ac6adfe74e996b1faee91a567385d694704e3ba2de54"
     },
     "scripts/release/cli.mjs": {
-      "sha256": "9672a6f16ad7f45f43b565f43ae3142e818e273a0020fad3a2599d4e0b237830"
+      "sha256": "1fd4b5e19b1936109e5b687cdcffd98fcc70caf91e5e5f136f5d5e8fcfb12975"
     },
     "scripts/release/independent-audit-coordinator.mjs": {
       "sha256": "a72f438f776f9ca26914c2ec51dd75de8f3b6c7d85ae8b11f2cc51c651e10d53"

--- a/scripts/release/test/fixtures/release-workflow-disabled.yml
+++ b/scripts/release/test/fixtures/release-workflow-disabled.yml
@@ -38,7 +38,7 @@ permissions:
 jobs:
   detect:
     runs-on: ubuntu-24.04
-    timeout-minutes: 20
+    timeout-minutes: 60
     permissions:
       actions: read
       attestations: read

--- a/scripts/release/test/fixtures/release-workflow-protected.yml
+++ b/scripts/release/test/fixtures/release-workflow-protected.yml
@@ -43,7 +43,7 @@ permissions:
 jobs:
   detect:
     runs-on: ubuntu-24.04
-    timeout-minutes: 20
+    timeout-minutes: 60
     permissions:
       actions: read
       attestations: read

--- a/scripts/release/test/fixtures/workflow-entrypoints.json
+++ b/scripts/release/test/fixtures/workflow-entrypoints.json
@@ -2689,7 +2689,7 @@
               "contents": "write"
             },
             "runs-on": "ubuntu-24.04",
-            "timeout-minutes": 20
+            "timeout-minutes": 60
           },
           "steps": [
             {

--- a/scripts/release/test/observe-production.test.mjs
+++ b/scripts/release/test/observe-production.test.mjs
@@ -3076,7 +3076,7 @@ test("observe CLI waits within a fixed budget for the exact main CI before autho
     )
 
     assert.equal(result.before.plan.nextTransition, "prepare-artifacts")
-    assert.deepEqual(delays, [10_000])
+    assert.deepEqual(delays, [30_000])
     assert.ok(checkReads >= 3, "CI is polled to success and then independently re-observed")
     assert.ok(workflowReads >= 3, "the exact workflow/check-suite correlation is re-observed")
   } finally {

--- a/scripts/release/test/workflow-contracts.test.mjs
+++ b/scripts/release/test/workflow-contracts.test.mjs
@@ -55,8 +55,10 @@ const SCRIPT_PIN_PATH = path.join(ROOT, SCRIPT_PIN_FIXTURE)
 // post-publication-audit.mjs each now pass the ref their own job checks out).
 // Repinned for getAuthenticatedUser on the GitHub reader (scripts/release/adapters/github.mjs):
 // the v0.8.22 terminal recovery record names the operator login its token acts as.
+// Repinned for the observe CI wait (scripts/release/cli.mjs): detect now waits the full
+// ci.yml validate budget (100 x 30 s) instead of timing out after 10 minutes.
 const STARTING_SCRIPT_PIN_SHA256 =
-  "23b0a9057c4f8051049e4ebd71f40c8844cca4ce9f562b6f40c5d82e066fbdb0"
+  "f81e46ace20c56b9a0c988006507e705e28d9fb5300d0a90b75fff66252023ec"
 const SHA256_HEX = /^[0-9a-f]{64}$/u
 const workflowExpression = (value) => `\${{ ${value} }}`
 const SCRIPT_REFERENCE = /(?:^|[\s;&|"'(])(scripts\/[\w.-]+(?:\/[\w.-]+)*)/gu


### PR DESCRIPTION
## Problem

The push-triggered `detect` job runs `cli.mjs observe`, whose required-CI wait was 61 × 10 s (~10 minutes). A green `CI / validate` on the candidate commit takes ~26 minutes (ci.yml budgets 45), so every push-triggered release run blocked with `REQUIRED_CI_TIMEOUT` and an operator had to `gh run rerun --failed` once CI turned green (runs 33844258382 and 33851172545 — three times today).

## Change

- `scripts/release/cli.mjs`: observe CI wait → `attempts: 100, delayMs: 30_000` (50-minute ceiling, within `waitForRequiredCi`'s caps). The independent-audit poller (181 × 10 s) is untouched.
- `.github/workflows/release.yml`: `detect` `timeout-minutes: 20` → `60`. Nothing else in the workflow changes.
- Lockstep pins: `release-workflow-disabled.yml` (byte-identical to live), `release-workflow-protected.yml` (`detect` job only), both `abandonment-workflow-policy.json` canonical digests, the `workflow-entrypoints.json` `detect` descriptor, the `cli.mjs` hash in `release-script-hashes.json`, and `STARTING_SCRIPT_PIN_SHA256`.
- `observe-production.test.mjs`: the observe CLI test now expects a 30 s poll delay.

## Verification

- `pnpm test:release-controller`: 2331/2331 pass.
- `node --test workflow-contracts.test.mjs candidate.test.mjs`: 176/176 pass.
- `cmp release.yml release-workflow-disabled.yml`: identical.
- Mutation: reverting only the live `release.yml` edit turns `release.yml makes workflow abandonment unreachable` and `every workflow executable entrypoint matches the readable audited allowlist` red; restored.
- biome check on changed files: clean.

No changeset: workflow/controller/tests only, no package change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
