### PR TITLE
ci: run pack and harness verification in parallel with validate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,8 @@ jobs:
 
   validate:
     runs-on: ubuntu-latest
-    # A fully green validate run takes ~26 minutes; 30 left no margin for slow runners.
+    # A fully green validate run took ~26 minutes before pack/harness verification
+    # moved to their own jobs; 30 left no margin for slow runners.
     timeout-minutes: 45
 
     steps:
@@ -120,11 +121,73 @@ jobs:
       - name: Docs Check
         run: node scripts/check-docs.mjs
 
+  # Pack and harness verification used to run at the tail of `validate`,
+  # serialising ~16 minutes behind the source tests. They only need a built
+  # tree, so each rebuilds (~1.5 min) and runs in parallel with `validate`,
+  # which stays the release controller's required check.
+  pack-smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+        with:
+          version: 10.33.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          # Node 24 — Dawn's floor is the active LTS line (node:sqlite
+          # unflagged, npm >= 11 bundled). Matches release.yml and engines.
+          node-version: 24.17.0
+          cache: pnpm
+
+      - name: Install
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        run: pnpm build
+
       - name: Pack Check
         run: pnpm pack:check
 
       - name: TypeScript Tooling Pack Smoke
         run: pnpm verify:typescript-tooling-pack
+
+  harness-verify:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+        with:
+          version: 10.33.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          # Node 24 — Dawn's floor is the active LTS line (node:sqlite
+          # unflagged, npm >= 11 bundled). Matches release.yml and engines.
+          node-version: 24.17.0
+          cache: pnpm
+
+      - name: Install
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        run: pnpm build
 
       - name: Harness Coordinator Self-Test
         run: pnpm verify:harness:self-test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ permissions:
 jobs:
   detect:
     runs-on: ubuntu-24.04
-    timeout-minutes: 20
+    timeout-minutes: 60
     permissions:
       actions: read
       attestations: read

--- a/scripts/release/abandonment-workflow-policy.json
+++ b/scripts/release/abandonment-workflow-policy.json
@@ -5,12 +5,12 @@
     {
       "id": "disabled-2026-08-28",
       "mode": "disabled",
-      "canonicalSha256": "7f6ab574ac0a87a3e7c5e5a8dbc25750c968840b7a186dee8aa510d756e26957"
+      "canonicalSha256": "88edb276d49081637ebc3a4d716a8031cd845b4f95a529ae2d48f9d514b86b61"
     },
     {
       "id": "protected-2026-08-28",
       "mode": "protected",
-      "canonicalSha256": "493dcc25c88baf9b1652a579d57c7b5d227ad885360a8257cc0caf4cb114d75e"
+      "canonicalSha256": "fb3b5129ad23e41bcf7140378092774fbe8952385dea9d7dd760755bb8146682"
     }
   ]
 }

--- a/scripts/release/cli.mjs
+++ b/scripts/release/cli.mjs
@@ -346,8 +346,9 @@ async function runObserve(options, runtime) {
     const ci = await waitForRequiredCi({
       sha: selection.candidate.commitSha,
       github,
-      attempts: 61,
-      delayMs: 10_000,
+      // 100 x 30 s = 50 min: must exceed ci.yml's 45-minute validate budget plus queueing.
+      attempts: 100,
+      delayMs: 30_000,
       delay: runtime.wait ?? defaultWait,
     })
     if (ci.status !== "success") {

--- a/scripts/release/test/fixtures/release-script-hashes.json
+++ b/scripts/release/test/fixtures/release-script-hashes.json
@@ -20,7 +20,7 @@
       "sha256": "1b1e17298068211d5e47ac6adfe74e996b1faee91a567385d694704e3ba2de54"
     },
     "scripts/release/cli.mjs": {
-      "sha256": "9672a6f16ad7f45f43b565f43ae3142e818e273a0020fad3a2599d4e0b237830"
+      "sha256": "1fd4b5e19b1936109e5b687cdcffd98fcc70caf91e5e5f136f5d5e8fcfb12975"
     },
     "scripts/release/independent-audit-coordinator.mjs": {
       "sha256": "a72f438f776f9ca26914c2ec51dd75de8f3b6c7d85ae8b11f2cc51c651e10d53"

--- a/scripts/release/test/fixtures/release-workflow-disabled.yml
+++ b/scripts/release/test/fixtures/release-workflow-disabled.yml
@@ -38,7 +38,7 @@ permissions:
 jobs:
   detect:
     runs-on: ubuntu-24.04
-    timeout-minutes: 20
+    timeout-minutes: 60
     permissions:
       actions: read
       attestations: read

--- a/scripts/release/test/fixtures/release-workflow-protected.yml
+++ b/scripts/release/test/fixtures/release-workflow-protected.yml
@@ -43,7 +43,7 @@ permissions:
 jobs:
   detect:
     runs-on: ubuntu-24.04
-    timeout-minutes: 20
+    timeout-minutes: 60
     permissions:
       actions: read
       attestations: read

--- a/scripts/release/test/fixtures/workflow-entrypoints.json
+++ b/scripts/release/test/fixtures/workflow-entrypoints.json
@@ -2689,7 +2689,7 @@
               "contents": "write"
             },
             "runs-on": "ubuntu-24.04",
-            "timeout-minutes": 20
+            "timeout-minutes": 60
           },
           "steps": [
             {

--- a/scripts/release/test/fixtures/workflow-entrypoints.json
+++ b/scripts/release/test/fixtures/workflow-entrypoints.json
@@ -447,6 +447,102 @@
         },
         {
           "classification": "safe",
+          "id": "harness-verify",
+          "descriptor": {
+            "runs-on": "ubuntu-latest",
+            "timeout-minutes": 30
+          },
+          "steps": [
+            {
+              "classification": "safe",
+              "descriptor": {
+                "name": "Checkout",
+                "uses": "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1",
+                "with": {
+                  "fetch-depth": 0
+                }
+              }
+            },
+            {
+              "classification": "safe",
+              "descriptor": {
+                "name": "Setup pnpm",
+                "uses": "pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271",
+                "with": {
+                  "version": "10.33.0"
+                }
+              }
+            },
+            {
+              "classification": "safe",
+              "descriptor": {
+                "name": "Setup Node.js",
+                "uses": "actions/setup-node@820762786026740c76f36085b0efc47a31fe5020",
+                "with": {
+                  "cache": "pnpm",
+                  "node-version": "24.17.0"
+                }
+              }
+            },
+            {
+              "classification": "safe",
+              "descriptor": {
+                "name": "Install",
+                "run": "pnpm install --frozen-lockfile"
+              }
+            },
+            {
+              "classification": "safe",
+              "descriptor": {
+                "name": "Build",
+                "run": "pnpm build"
+              }
+            },
+            {
+              "classification": "safe",
+              "descriptor": {
+                "name": "Harness Coordinator Self-Test",
+                "run": "pnpm verify:harness:self-test"
+              }
+            },
+            {
+              "classification": "safe",
+              "descriptor": {
+                "name": "Framework Verification",
+                "run": "pnpm verify:harness:framework"
+              }
+            },
+            {
+              "classification": "safe",
+              "descriptor": {
+                "name": "Runtime Contract Verification",
+                "run": "pnpm verify:harness:runtime"
+              }
+            },
+            {
+              "classification": "safe",
+              "descriptor": {
+                "name": "Smoke Harness Verification",
+                "run": "pnpm verify:harness:smoke"
+              }
+            },
+            {
+              "classification": "safe",
+              "descriptor": {
+                "if": "failure()",
+                "name": "Upload Harness Artifacts",
+                "uses": "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a",
+                "with": {
+                  "name": "harness-artifacts",
+                  "path": "artifacts/testing/",
+                  "retention-days": 7
+                }
+              }
+            }
+          ]
+        },
+        {
+          "classification": "safe",
           "id": "inspector-e2e",
           "descriptor": {
             "runs-on": "ubuntu-latest",
@@ -574,6 +670,75 @@
                 "id": "classify",
                 "name": "Classify metadata-only change",
                 "run": "set -eu\nMETADATA_ONLY=\"$(node scripts/ci-scope.mjs --event pull_request --base \"$BASE_SHA\" --head \"$HEAD_SHA\")\"\ncase \"$METADATA_ONLY\" in\n  true|false) ;;\n  *) echo \"Malformed metadata-only scope output\" >&2; exit 1 ;;\nesac\nprintf 'metadata_only=%s\\n' \"$METADATA_ONLY\" >> \"$GITHUB_OUTPUT\"\n"
+              }
+            }
+          ]
+        },
+        {
+          "classification": "safe",
+          "id": "pack-smoke",
+          "descriptor": {
+            "runs-on": "ubuntu-latest",
+            "timeout-minutes": 30
+          },
+          "steps": [
+            {
+              "classification": "safe",
+              "descriptor": {
+                "name": "Checkout",
+                "uses": "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1",
+                "with": {
+                  "fetch-depth": 0
+                }
+              }
+            },
+            {
+              "classification": "safe",
+              "descriptor": {
+                "name": "Setup pnpm",
+                "uses": "pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271",
+                "with": {
+                  "version": "10.33.0"
+                }
+              }
+            },
+            {
+              "classification": "safe",
+              "descriptor": {
+                "name": "Setup Node.js",
+                "uses": "actions/setup-node@820762786026740c76f36085b0efc47a31fe5020",
+                "with": {
+                  "cache": "pnpm",
+                  "node-version": "24.17.0"
+                }
+              }
+            },
+            {
+              "classification": "safe",
+              "descriptor": {
+                "name": "Install",
+                "run": "pnpm install --frozen-lockfile"
+              }
+            },
+            {
+              "classification": "safe",
+              "descriptor": {
+                "name": "Build",
+                "run": "pnpm build"
+              }
+            },
+            {
+              "classification": "safe",
+              "descriptor": {
+                "name": "Pack Check",
+                "run": "pnpm pack:check"
+              }
+            },
+            {
+              "classification": "safe",
+              "descriptor": {
+                "name": "TypeScript Tooling Pack Smoke",
+                "run": "pnpm verify:typescript-tooling-pack"
               }
             }
           ]
@@ -1340,61 +1505,6 @@
               "descriptor": {
                 "name": "Docs Check",
                 "run": "node scripts/check-docs.mjs"
-              }
-            },
-            {
-              "classification": "safe",
-              "descriptor": {
-                "name": "Pack Check",
-                "run": "pnpm pack:check"
-              }
-            },
-            {
-              "classification": "safe",
-              "descriptor": {
-                "name": "TypeScript Tooling Pack Smoke",
-                "run": "pnpm verify:typescript-tooling-pack"
-              }
-            },
-            {
-              "classification": "safe",
-              "descriptor": {
-                "name": "Harness Coordinator Self-Test",
-                "run": "pnpm verify:harness:self-test"
-              }
-            },
-            {
-              "classification": "safe",
-              "descriptor": {
-                "name": "Framework Verification",
-                "run": "pnpm verify:harness:framework"
-              }
-            },
-            {
-              "classification": "safe",
-              "descriptor": {
-                "name": "Runtime Contract Verification",
-                "run": "pnpm verify:harness:runtime"
-              }
-            },
-            {
-              "classification": "safe",
-              "descriptor": {
-                "name": "Smoke Harness Verification",
-                "run": "pnpm verify:harness:smoke"
-              }
-            },
-            {
-              "classification": "safe",
-              "descriptor": {
-                "if": "failure()",
-                "name": "Upload Harness Artifacts",
-                "uses": "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a",
-                "with": {
-                  "name": "harness-artifacts",
-                  "path": "artifacts/testing/",
-                  "retention-days": 7
-                }
               }
             }
           ]

--- a/scripts/release/test/fixtures/workflow-safe-executables.json
+++ b/scripts/release/test/fixtures/workflow-safe-executables.json
@@ -150,56 +150,136 @@
       },
       {
         "classification": "safe",
-        "job": "validate",
-        "stepIndex": 12,
+        "job": "pack-smoke",
+        "stepIndex": 0,
+        "step": "Checkout",
+        "kind": "step-uses",
+        "value": "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1"
+      },
+      {
+        "classification": "safe",
+        "job": "pack-smoke",
+        "stepIndex": 1,
+        "step": "Setup pnpm",
+        "kind": "step-uses",
+        "value": "pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271"
+      },
+      {
+        "classification": "safe",
+        "job": "pack-smoke",
+        "stepIndex": 2,
+        "step": "Setup Node.js",
+        "kind": "step-uses",
+        "value": "actions/setup-node@820762786026740c76f36085b0efc47a31fe5020"
+      },
+      {
+        "classification": "safe",
+        "job": "pack-smoke",
+        "stepIndex": 3,
+        "step": "Install",
+        "kind": "run",
+        "value": "pnpm install --frozen-lockfile"
+      },
+      {
+        "classification": "safe",
+        "job": "pack-smoke",
+        "stepIndex": 4,
+        "step": "Build",
+        "kind": "run",
+        "value": "pnpm build"
+      },
+      {
+        "classification": "safe",
+        "job": "pack-smoke",
+        "stepIndex": 5,
         "step": "Pack Check",
         "kind": "run",
         "value": "pnpm pack:check"
       },
       {
         "classification": "safe",
-        "job": "validate",
-        "stepIndex": 13,
+        "job": "pack-smoke",
+        "stepIndex": 6,
         "step": "TypeScript Tooling Pack Smoke",
         "kind": "run",
         "value": "pnpm verify:typescript-tooling-pack"
       },
       {
         "classification": "safe",
-        "job": "validate",
-        "stepIndex": 14,
+        "job": "harness-verify",
+        "stepIndex": 0,
+        "step": "Checkout",
+        "kind": "step-uses",
+        "value": "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1"
+      },
+      {
+        "classification": "safe",
+        "job": "harness-verify",
+        "stepIndex": 1,
+        "step": "Setup pnpm",
+        "kind": "step-uses",
+        "value": "pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271"
+      },
+      {
+        "classification": "safe",
+        "job": "harness-verify",
+        "stepIndex": 2,
+        "step": "Setup Node.js",
+        "kind": "step-uses",
+        "value": "actions/setup-node@820762786026740c76f36085b0efc47a31fe5020"
+      },
+      {
+        "classification": "safe",
+        "job": "harness-verify",
+        "stepIndex": 3,
+        "step": "Install",
+        "kind": "run",
+        "value": "pnpm install --frozen-lockfile"
+      },
+      {
+        "classification": "safe",
+        "job": "harness-verify",
+        "stepIndex": 4,
+        "step": "Build",
+        "kind": "run",
+        "value": "pnpm build"
+      },
+      {
+        "classification": "safe",
+        "job": "harness-verify",
+        "stepIndex": 5,
         "step": "Harness Coordinator Self-Test",
         "kind": "run",
         "value": "pnpm verify:harness:self-test"
       },
       {
         "classification": "safe",
-        "job": "validate",
-        "stepIndex": 15,
+        "job": "harness-verify",
+        "stepIndex": 6,
         "step": "Framework Verification",
         "kind": "run",
         "value": "pnpm verify:harness:framework"
       },
       {
         "classification": "safe",
-        "job": "validate",
-        "stepIndex": 16,
+        "job": "harness-verify",
+        "stepIndex": 7,
         "step": "Runtime Contract Verification",
         "kind": "run",
         "value": "pnpm verify:harness:runtime"
       },
       {
         "classification": "safe",
-        "job": "validate",
-        "stepIndex": 17,
+        "job": "harness-verify",
+        "stepIndex": 8,
         "step": "Smoke Harness Verification",
         "kind": "run",
         "value": "pnpm verify:harness:smoke"
       },
       {
         "classification": "safe",
-        "job": "validate",
-        "stepIndex": 18,
+        "job": "harness-verify",
+        "stepIndex": 9,
         "step": "Upload Harness Artifacts",
         "kind": "step-uses",
         "value": "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a"

--- a/scripts/release/test/observe-production.test.mjs
+++ b/scripts/release/test/observe-production.test.mjs
@@ -3076,7 +3076,7 @@ test("observe CLI waits within a fixed budget for the exact main CI before autho
     )
 
     assert.equal(result.before.plan.nextTransition, "prepare-artifacts")
-    assert.deepEqual(delays, [10_000])
+    assert.deepEqual(delays, [30_000])
     assert.ok(checkReads >= 3, "CI is polled to success and then independently re-observed")
     assert.ok(workflowReads >= 3, "the exact workflow/check-suite correlation is re-observed")
   } finally {

--- a/scripts/release/test/workflow-contracts.test.mjs
+++ b/scripts/release/test/workflow-contracts.test.mjs
@@ -55,8 +55,10 @@ const SCRIPT_PIN_PATH = path.join(ROOT, SCRIPT_PIN_FIXTURE)
 // post-publication-audit.mjs each now pass the ref their own job checks out).
 // Repinned for getAuthenticatedUser on the GitHub reader (scripts/release/adapters/github.mjs):
 // the v0.8.22 terminal recovery record names the operator login its token acts as.
+// Repinned for the observe CI wait (scripts/release/cli.mjs): detect now waits the full
+// ci.yml validate budget (100 x 30 s) instead of timing out after 10 minutes.
 const STARTING_SCRIPT_PIN_SHA256 =
-  "23b0a9057c4f8051049e4ebd71f40c8844cca4ce9f562b6f40c5d82e066fbdb0"
+  "f81e46ace20c56b9a0c988006507e705e28d9fb5300d0a90b75fff66252023ec"
 const SHA256_HEX = /^[0-9a-f]{64}$/u
 const workflowExpression = (value) => `\${{ ${value} }}`
 const SCRIPT_REFERENCE = /(?:^|[\s;&|"'(])(scripts\/[\w.-]+(?:\/[\w.-]+)*)/gu


### PR DESCRIPTION
## Summary

On green CI run 33851172726 (main `1369196f`), `validate` took **34 min serial** while the next-longest lane took 15. Its tail was pure verification that only needs a built tree:

| Step | Duration |
|---|---|
| Framework Verification | 6m36 |
| TypeScript Tooling Pack Smoke | 5m12 |
| Runtime Contract Verification | 2m36 |
| Smoke Harness Verification | 1m05 |
| Pack Check | 0m45 |

This PR moves those steps (plus `Harness Coordinator Self-Test` and the failure-only `Upload Harness Artifacts`) into two new jobs that run **in parallel** with `validate`:

- **`pack-smoke`** (timeout 30): Pack Check, TypeScript Tooling Pack Smoke
- **`harness-verify`** (timeout 30): Harness Coordinator Self-Test, Framework Verification, Runtime Contract Verification, Smoke Harness Verification, Upload Harness Artifacts (`if: failure()`)

Each new job carries the same Checkout / Setup pnpm / Setup Node.js / Install / Build prelude (identical pinned action SHAs). No `needs:` among the three. Every moved step keeps its `name:` and `run:` byte-identical. `validate` keeps its name (the release controller's required check — `classifyRequiredCi` in `scripts/release/candidate.mjs` keys on check name `validate` plus overall CI run success, unchanged) and its 45-minute budget. Permissions stay `contents: read`.

Expected critical path: **~20 min**, at the cost of two extra ~1.5-min builds.

No env was replicated: `scripts/harness-report.mjs`, `pack-check.mjs`, and `typescript-tooling-pack-smoke.mjs` read no environment variables, and `DAWN_REQUIRE_DOCKER` belongs only to `Source Tests`, which stays in `validate`.

## Fixtures

`scripts/release/test/fixtures/workflow-entrypoints.json` and `workflow-safe-executables.json` (which pin ci.yml job descriptors and executables) are updated in lockstep, edited textually.

## Verification

- `node --test scripts/release/test/workflow-contracts.test.mjs`: 122/122
- `pnpm test:release-controller`: 2331/2331
- YAML parses with the repo's `yaml` dependency; both fixtures parse as JSON; biome clean
- **Mutation**: adding a bogus `run: echo x` step to `harness-verify` fails exactly `every workflow executable entrypoint matches the readable audited allowlist`; restored

## Stacking

Stacked on #553 (`blove/release-detect-ci-wait`) so the shared workflow fixtures merge cleanly. **Merge after #553.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
