### PR TITLE
test(release): make one-target deletion retry clock deterministic

### DIFF
--- a/scripts/release/test/duplicate-draft-consolidation.test.mjs
+++ b/scripts/release/test/duplicate-draft-consolidation.test.mjs
@@ -3604,6 +3604,17 @@ async function oneDeletionFixture(t, options) {
   const authorityTime = new Date(
     Math.max(Date.now(), Date.parse(journal.record.updatedAt) + 1_000),
   ).toISOString()
+  // The retry freshness clock read by the plain dependencies. Every fresh
+  // authority capture stamps its npm inventory `freshAuthorityAdvanceMs`
+  // (default one second) past the journal head, which can sit ahead of the
+  // real clock on a fast run; a frozen clock sixty seconds past the seed
+  // authority is always at or after that inventory and never crosses the
+  // 120 s MAXIMUM_RETRY_NPM_AGE_MS boundary, so the outcome cannot depend on
+  // wall-clock speed. Tests that exercise the stale-retry path build their own
+  // timeline with `dependenciesWithWallClockTimeline`.
+  const retryClockTimeline = Object.freeze(
+    Array.from({ length: 16 }, () => new Date(Date.parse(authorityTime) + 60_000).toISOString()),
+  )
   const targetEvidence = proposal.record.releases.find(({ id }) => id === targetReleaseId)
   const authority = deletionAuthorityFixture({
     proposal,
@@ -3932,6 +3943,7 @@ async function oneDeletionFixture(t, options) {
         assert.equal(signal instanceof AbortSignal, true)
         waits.push(milliseconds)
       }),
+      wallClockTimeline: retryClockTimeline,
     }),
     dependenciesWithFault(faultAt) {
       return Object.freeze({
@@ -3945,6 +3957,7 @@ async function oneDeletionFixture(t, options) {
           waits.push(milliseconds)
         }),
         faultAt,
+        wallClockTimeline: retryClockTimeline,
       })
     },
     dependenciesWithTimeline(monotonicTimeline) {
@@ -3959,6 +3972,7 @@ async function oneDeletionFixture(t, options) {
           waits.push(milliseconds)
         }),
         monotonicTimeline,
+        wallClockTimeline: retryClockTimeline,
       })
     },
     dependenciesWithWallClockTimeline(wallClockTimeline, faultAt) {


### PR DESCRIPTION
## Summary

Fixes the flaky release-controller test `one-target deletion stops on third ambiguity and never mints a fourth writer permit` (CI run 33885603361 on main 88c01c4a: `assert.equal(deleteEvents, 3)` reported actual 2 in a 980 ms run; green everywhere else).

## Mechanism

- `oneDeletionFixture` stamps every fresh delete authority after the first at `journal.updatedAt + freshAuthorityAdvanceMs` (default 1 s), including `npmInventory.completedAt`.
- The journal head is the previous event's `recordedAt`, which the controller takes from the real clock, so that `completedAt` sits ~1 s in the future.
- The plain fixture `dependencies` passed no `wallClockTimeline`, so `deletionWallClock` fell back to the real clock and `retryNpmInventoryIsStale` saw a negative age and threw `Retry freshness clock precedes the prior npm inventory` whenever the run reached the second freshness check in under a second. Two DELETEs instead of three.
- Forcing the race with `freshAuthorityAdvanceMs: 5_000` reproduced the exact inner error and the 2-vs-3 assertion deterministically; the same forced test passes with this change.

## Fix (test infrastructure only)

The plain `dependencies`, `dependenciesWithFault`, and `dependenciesWithTimeline` builders now inject a frozen `wallClockTimeline` pinned sixty seconds past the fixture's seed authority: always at or after any fresh inventory the fixture stamps, never past the 120 s `MAXIMUM_RETRY_NPM_AGE_MS` boundary. The stale-retry tests keep their own timelines via `dependenciesWithWallClockTimeline`. No production file changed; no assertion loosened.

## Verification

- `node --test scripts/release/test/duplicate-draft-consolidation.test.mjs` x5: 154/154 each run
- `pnpm test:release-controller`: 2331 pass, 0 fail
- biome check on the test file: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
