### PR TITLE
release: print a sanitized failure detail next to the CLI error code

### DIFF
--- a/scripts/release/cli.mjs
+++ b/scripts/release/cli.mjs
@@ -2860,6 +2860,17 @@ function usageError() {
   )
 }
 
+const FAILURE_DETAIL_MAX_LENGTH = 512
+const FAILURE_DETAIL_MAX_CAUSES = 3
+const FAILURE_DETAIL_REDACTIONS = Object.freeze([
+  /gh[pous]_[A-Za-z0-9]{20,}/gu,
+  /github_pat_[A-Za-z0-9_]{20,}/gu,
+  /npm_[A-Za-z0-9]{20,}/gu,
+  /Bearer\s+\S+/gu,
+  /authorization:\s*\S+(?:\s+\S+)?/giu,
+  /[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}/gu,
+])
+
 const executedPath =
   process.argv[1] === undefined ? null : pathToFileURL(path.resolve(process.argv[1])).href
 if (executedPath === import.meta.url) {
@@ -2867,6 +2878,7 @@ if (executedPath === import.meta.url) {
     await runReleaseCli(process.argv.slice(2))
   } catch (error) {
     process.stderr.write(`release CLI failed: ${safeCode(error)}\n`)
+    process.stderr.write(`release CLI failure detail: ${safeDetail(error)}\n`)
     process.exitCode = 1
   }
 }
@@ -2876,6 +2888,50 @@ function safeCode(error) {
   return typeof code === "string" && /^[A-Z0-9_]{1,128}$/u.test(code)
     ? code
     : "INVALID_RELEASE_COMMAND"
+}
+
+/**
+ * One operator-facing line describing why the CLI failed. Most controller failures are
+ * plain Errors without a code, so `release CLI failed: INVALID_RELEASE_COMMAND` alone hides
+ * the actual reason (run 33889526426 failed in escrow with exactly that masked line). The
+ * detail is derived from the error message chain only: never a stack, never a body.
+ */
+export function safeDetail(error) {
+  const messages = []
+  let current = error
+  for (
+    let depth = 0;
+    depth <= FAILURE_DETAIL_MAX_CAUSES && (depth === 0 || current !== undefined);
+    depth += 1
+  ) {
+    const message = current?.message
+    messages.push(typeof message === "string" && message.length > 0 ? message : "(no message)")
+    current = current !== null && typeof current === "object" ? current.cause : undefined
+  }
+  let detail = Array.from(messages.join(" <- "), (character) =>
+    isControlCharacter(character) ? " " : character,
+  ).join("")
+  detail = detail.replace(/https?:\/\/[^\s?#]*\?\S*/gu, (token) =>
+    token.slice(0, token.indexOf("?")),
+  )
+  for (const pattern of FAILURE_DETAIL_REDACTIONS) {
+    detail = detail.replace(pattern, "[redacted]")
+  }
+  detail = detail.replace(/\s+/gu, " ").trim()
+  if (detail.length > FAILURE_DETAIL_MAX_LENGTH) {
+    detail = `${detail.slice(0, FAILURE_DETAIL_MAX_LENGTH - 1)}\u2026`
+  }
+  return detail
+}
+
+function isControlCharacter(character) {
+  const codePoint = character.codePointAt(0)
+  return (
+    codePoint < 0x20 ||
+    (codePoint >= 0x7f && codePoint <= 0x9f) ||
+    codePoint === 0x2028 ||
+    codePoint === 0x2029
+  )
 }
 
 function safeObservationFailure(error, fallback) {

--- a/scripts/release/test/cli-failure-detail.test.mjs
+++ b/scripts/release/test/cli-failure-detail.test.mjs
@@ -1,0 +1,149 @@
+import assert from "node:assert/strict"
+import { execFile as execFileCallback } from "node:child_process"
+import path from "node:path"
+import test from "node:test"
+import { fileURLToPath } from "node:url"
+import { promisify } from "node:util"
+
+import { safeDetail } from "../cli.mjs"
+
+const execFile = promisify(execFileCallback)
+const CLI_PATH = fileURLToPath(new URL("../cli.mjs", import.meta.url))
+const ROOT = path.resolve(path.dirname(CLI_PATH), "..", "..")
+
+test("safeDetail reports a plain Error message", () => {
+  assert.equal(
+    safeDetail(new Error("GitHub draft creation did not return HTTP 201")),
+    "GitHub draft creation did not return HTTP 201",
+  )
+})
+
+test("safeDetail reports the message of a coded error without the code", () => {
+  const error = Object.assign(new Error("Attestation bundle verification failed"), {
+    code: "ATTESTATION_INVALID",
+  })
+  assert.equal(safeDetail(error), "Attestation bundle verification failed")
+})
+
+test("safeDetail joins up to three nested causes and ignores deeper ones", () => {
+  const error = new Error("escrow failed", {
+    cause: new Error("npm view failed", {
+      cause: new Error("socket hang up", {
+        cause: new Error("third cause", { cause: new Error("fourth cause is dropped") }),
+      }),
+    }),
+  })
+  assert.equal(
+    safeDetail(error),
+    "escrow failed <- npm view failed <- socket hang up <- third cause",
+  )
+})
+
+test("safeDetail substitutes a placeholder for non-string and empty messages", () => {
+  assert.equal(safeDetail(undefined), "(no message)")
+  assert.equal(safeDetail(null), "(no message)")
+  assert.equal(safeDetail("a thrown string"), "(no message)")
+  assert.equal(safeDetail({ message: 42 }), "(no message)")
+  assert.equal(safeDetail(new Error("")), "(no message)")
+  assert.equal(
+    safeDetail({ message: "outer", cause: { message: ["not", "a", "string"] } }),
+    "outer <- (no message)",
+  )
+})
+
+test("safeDetail strips newlines and control characters and collapses whitespace", () => {
+  const error = new Error(
+    "line one\r\nline two\ttabbed nul\u0000\u001b[31mansi\u0085nel\u2028ls   spaced ",
+  )
+  const detail = safeDetail(error)
+  assert.equal(detail, "line one line two tabbed nul [31mansi nel ls spaced")
+  for (const character of detail) {
+    const codePoint = character.codePointAt(0)
+    assert.ok(codePoint >= 0x20 && codePoint !== 0x7f && codePoint !== 0x85, `control ${codePoint}`)
+  }
+})
+
+test("safeDetail truncates to 512 characters", () => {
+  const detail = safeDetail(new Error("x".repeat(2000)))
+  assert.equal(detail.length, 512)
+  assert.equal(detail.at(-1), "…")
+  assert.equal(safeDetail(new Error("y".repeat(512))).length, 512)
+})
+
+test("safeDetail never includes a stack trace", () => {
+  const error = new Error("boom")
+  assert.ok(typeof error.stack === "string" && error.stack.includes("cli-failure-detail.test.mjs"))
+  assert.doesNotMatch(safeDetail(error), /cli-failure-detail\.test\.mjs|\bat\s/u)
+})
+
+test("safeDetail strips query strings from URLs", () => {
+  const detail = safeDetail(
+    new Error(
+      "GET https://api.github.com/repos/o/r/releases?per_page=100&token=secretvalue failed; see https://example.test/path#frag?not-a-query",
+    ),
+  )
+  assert.doesNotMatch(detail, /secretvalue|per_page/u)
+  assert.ok(detail.includes("https://api.github.com/repos/o/r/releases failed"))
+  assert.ok(detail.includes("https://example.test/path#frag?not-a-query"))
+})
+
+const CREDENTIAL_CASES = [
+  ["ghp token", "ghp_abcdefghijklmnopqrstuvwxyz0123456789"],
+  ["gho token", "gho_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123"],
+  ["ghu token", "ghu_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123"],
+  ["ghs token", "ghs_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123"],
+  ["fine-grained PAT", "github_pat_11ABCDEFG0123456789_abcdefghijklmnopqrstuvwxyz"],
+  ["npm token", "npm_abcdefghijklmnopqrstuvwxyz0123456789"],
+  ["bearer scheme", "Bearer sk-live-topsecretvalue", "sk-live-topsecretvalue"],
+  ["authorization header", "authorization: Basic dXNlcjpwYXNz", "dXNlcjpwYXNz"],
+  ["Authorization header, mixed case", "AUTHORIZATION:token123456", "token123456"],
+  [
+    "JWT",
+    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4ifQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",
+    "eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4ifQ",
+  ],
+]
+
+for (const [label, secret, mustBeAbsent = secret] of CREDENTIAL_CASES) {
+  test(`safeDetail redacts a ${label}`, () => {
+    const detail = safeDetail(new Error(`request failed with ${secret} in the header`))
+    assert.ok(!detail.includes(mustBeAbsent), `${label} leaked: ${detail}`)
+    assert.ok(detail.includes("[redacted]"), `${label} not marked redacted: ${detail}`)
+    assert.ok(detail.startsWith("request failed with "))
+  })
+}
+
+test("safeDetail redacts credentials inside nested causes", () => {
+  const error = new Error("escrow failed", {
+    cause: new Error("token ghp_abcdefghijklmnopqrstuvwxyz0123456789 rejected"),
+  })
+  const detail = safeDetail(error)
+  assert.ok(!detail.includes("ghp_abcdefghijklmnopqrstuvwxyz0123456789"))
+  assert.equal(detail, "escrow failed <- token [redacted] rejected")
+})
+
+test("safeDetail redacts credentials that straddle a stripped newline", () => {
+  const detail = safeDetail(new Error("Bearer\nghp_abcdefghijklmnopqrstuvwxyz0123456789 rejected"))
+  assert.ok(!detail.includes("ghp_abcdefghijklmnopqrstuvwxyz0123456789"))
+})
+
+test("the CLI entrypoint prints the code line first and a sanitized detail line second", async () => {
+  const token = "ghp_notarealtoken_000000000000000000000000"
+  const result = await execFile(
+    process.execPath,
+    [CLI_PATH, "escrow", "--candidate", path.join(ROOT, "does-not-exist", "candidate.json")],
+    { cwd: ROOT, env: { ...process.env, GITHUB_TOKEN: token }, encoding: "utf8" },
+  ).then(
+    () => assert.fail("the CLI must exit non-zero"),
+    (error) => error,
+  )
+  assert.equal(result.code, 1)
+  const lines = result.stderr.split("\n").filter((line) => line.length > 0)
+  assert.equal(lines.length, 2, result.stderr)
+  assert.match(lines[0], /^release CLI failed: [A-Z0-9_]{1,128}$/u)
+  assert.match(lines[1], /^release CLI failure detail: \S.*$/u)
+  assert.ok(lines[1].length <= "release CLI failure detail: ".length + 512)
+  assert.ok(!result.stderr.includes(token))
+  assert.ok(!result.stderr.includes("notarealtoken"))
+  assert.doesNotMatch(result.stderr, /\n\s+at /u)
+})

--- a/scripts/release/test/fixtures/release-script-hashes.json
+++ b/scripts/release/test/fixtures/release-script-hashes.json
@@ -20,7 +20,7 @@
       "sha256": "1b1e17298068211d5e47ac6adfe74e996b1faee91a567385d694704e3ba2de54"
     },
     "scripts/release/cli.mjs": {
-      "sha256": "1fd4b5e19b1936109e5b687cdcffd98fcc70caf91e5e5f136f5d5e8fcfb12975"
+      "sha256": "7c7efc77a4d8269e607b09596a148519e50a6d9a51412f43013880a00d9c9329"
     },
     "scripts/release/independent-audit-coordinator.mjs": {
       "sha256": "a72f438f776f9ca26914c2ec51dd75de8f3b6c7d85ae8b11f2cc51c651e10d53"

--- a/scripts/release/test/workflow-contracts.test.mjs
+++ b/scripts/release/test/workflow-contracts.test.mjs
@@ -57,8 +57,11 @@ const SCRIPT_PIN_PATH = path.join(ROOT, SCRIPT_PIN_FIXTURE)
 // the v0.8.22 terminal recovery record names the operator login its token acts as.
 // Repinned for the observe CI wait (scripts/release/cli.mjs): detect now waits the full
 // ci.yml validate budget (100 x 30 s) instead of timing out after 10 minutes.
+// Repinned for the sanitized failure detail line (scripts/release/cli.mjs): the entrypoint
+// now prints `release CLI failure detail: ...` after the unchanged code line (run
+// 33889526426 failed in escrow with only the masked INVALID_RELEASE_COMMAND).
 const STARTING_SCRIPT_PIN_SHA256 =
-  "f81e46ace20c56b9a0c988006507e705e28d9fb5300d0a90b75fff66252023ec"
+  "3607d3ce78dd5da379599deffc30e95aa05bb1931367c0e2874e2a1067fa447f"
 const SHA256_HEX = /^[0-9a-f]{64}$/u
 const workflowExpression = (value) => `\${{ ${value} }}`
 const SCRIPT_REFERENCE = /(?:^|[\s;&|"'(])(scripts\/[\w.-]+(?:\/[\w.-]+)*)/gu


### PR DESCRIPTION
## Problem

`scripts/release/cli.mjs` caught every error from `runReleaseCli` and printed only `release CLI failed: <code>`. Most controller failures are plain `Error`s with no code, so production logs showed only the fallback `INVALID_RELEASE_COMMAND`. The v0.8.24 tagged run 33889526426 failed in `escrow` with exactly that masked line and cost an hour of local reproduction.

## Change

- The entrypoint prints one additional stderr line, `release CLI failure detail: <message>`, after the unchanged `release CLI failed: <code>` line. Exit code unchanged.
- New pure helper `safeDetail(error)` next to `safeCode`: message plus up to 3 nested `cause` messages joined by ` <- `; non-string/empty messages become `(no message)`; control characters and newlines replaced, whitespace collapsed, truncated to 512 chars; URL query strings stripped; credential shapes (`gh[pous]_…`, `github_pat_…`, `npm_…`, `Bearer …`, `authorization: …`, JWT-like) replaced with `[redacted]`. Never a stack, never a body.
- 21 tests in `scripts/release/test/cli-failure-detail.test.mjs`: plain/coded errors, nested causes, control stripping, truncation, no-stack, URL query stripping, every redaction pattern, and an integration test that spawns the CLI and asserts both stderr lines with no token substring.
- `cli.mjs` is content-pinned: its sha256 in `release-script-hashes.json` and the fixture pin `STARTING_SCRIPT_PIN_SHA256` are updated. `release.yml` and its fixtures are untouched.

## Verification

- `pnpm test:release-controller`: 2352/2352 green.
- `node --test scripts/release/test/workflow-contracts.test.mjs`: 122/122 green.
- Biome clean on all changed files.
- Mutation: disabling the redaction loop reds all 12 redaction tests; restored to green.
- Manual: `GITHUB_TOKEN=ghp_notarealtoken_… node scripts/release/cli.mjs escrow --candidate /nonexistent` prints the code line, then the detail line, and the token substring is absent from stderr.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
