### PR TITLE
release: verify the attestation anchor once and prove subject membership locally

### DIFF
--- a/scripts/release/artifact-store.mjs
+++ b/scripts/release/artifact-store.mjs
@@ -32,6 +32,32 @@ const ZIP_LOCAL_SIGNATURE = 0x04034b50
 const ZIP_CENTRAL_SIGNATURE = 0x02014b50
 const ZIP_END_SIGNATURE = 0x06054b50
 const execFileAsync = promisify(execFile)
+/**
+ * Every `gh attestation verify` child gets this budget. A runner diagnostic (run 33894039805)
+ * measured ~3 s per call under GITHUB_TOKEN, so 180 s is headroom, not a fix: the v0.8.24
+ * attest (63 s) and escrow (71 s) job times were 22 sequential calls, and the escrow failures
+ * on runs 33889526426 and 33892398216 were not this timeout. Escrow now makes one call.
+ */
+const ATTESTATION_VERIFY_TIMEOUT_MS = 180_000
+const ATTESTATION_REASON_STDERR_BYTES = 2 * 1024
+const ATTESTATION_REASON_MAX_LENGTH = 2 * 1024 + 128
+const ATTESTATION_REASON_REDACTIONS = Object.freeze([
+  /gh[pous]_[A-Za-z0-9]{20,}/gu,
+  /github_pat_[A-Za-z0-9_]{20,}/gu,
+  /npm_[A-Za-z0-9]{20,}/gu,
+  /Bearer\s+\S+/gu,
+  /authorization:\s*\S+(?:\s+\S+)?/giu,
+  /[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}/gu,
+])
+
+// Declared before the CLI entrypoint below: this module runs `runArtifactStoreCli` during its
+// own evaluation when executed directly, so anything the verifier needs must already exist.
+class AttestationVerificationFailure extends Error {
+  constructor(reason) {
+    super(reason)
+    this.name = "AttestationVerificationFailure"
+  }
+}
 const VERIFIED_MATERIALIZATIONS = new WeakMap()
 
 export const ARTIFACT_STORE_SPARSE_FILES = Object.freeze([
@@ -491,7 +517,11 @@ function validateActionsMetadata(value, record) {
 
 function validateAttestationResult(value, subjects) {
   if (value?.status !== "VERIFIED" || !Array.isArray(value.subjects)) {
-    throw new Error("GitHub attestation verification did not succeed")
+    const reason =
+      typeof value?.reason === "string" && value.reason.length > 0
+        ? `: ${sanitizeReasonText(value.reason)}`
+        : ""
+    throw new Error(`GitHub attestation verification did not succeed${reason}`)
   }
   const normalized = value.subjects.map((subject) => {
     if (
@@ -801,6 +831,20 @@ function isAllowedLaterReceipt(name, size) {
   }
 }
 
+/**
+ * Verifies release attestations with the gh CLI.
+ *
+ * Escrow mode runs `gh attestation verify --bundle` ONCE, for the first file (the anchor),
+ * which proves the signature, the Sigstore chain, the signer workflow, and the source
+ * ref/digest of the multi-subject bundle. Every other file is then proved a member of that
+ * verified statement locally: its sha256 and name must appear among the statement subjects,
+ * the statement must carry exactly as many subjects as the input, and every per-file bundle
+ * must be byte-identical to the anchor (the escrow set replicates one bundle 22 times). This
+ * turns 22 network verifications into 1.
+ *
+ * Actions mode has no bundle to prove membership against (gh fetches each subject's
+ * attestation from the API by digest), so it stays online per file with the same budget.
+ */
 export function createCliAttestationVerifier({
   repository,
   token,
@@ -809,21 +853,20 @@ export function createCliAttestationVerifier({
 }) {
   return {
     async verify({ source, record, subjects, files, bundles }) {
-      if (!Array.isArray(files) || files.length !== subjects.length) {
-        return { status: "INVALID", subjects: [] }
+      if (!Array.isArray(subjects) || !Array.isArray(files) || files.length !== subjects.length) {
+        return invalidAttestationResult("attestation subject and file counts differ")
       }
+      if (files.length === 0) return invalidAttestationResult("no attestation subjects to verify")
       const bundlesByName = new Map(
         Array.isArray(bundles) ? bundles.map((bundle) => [bundle.name, bundle]) : [],
       )
       const directory = await fileSystem.mkdtemp(path.join(os.tmpdir(), "dawn-attest-"))
       try {
-        for (const file of files) {
+        const verifyOnline = async (file, bundle) => {
           const target = path.join(directory, file.name)
           await fileSystem.writeFile(target, file.bytes, { flag: "wx" })
           let bundlePath
-          if (source === "escrow") {
-            const bundle = bundlesByName.get(`${file.name}.intoto.jsonl`)
-            if (bundle === undefined) return { status: "INVALID", subjects: [] }
+          if (bundle !== undefined) {
             bundlePath = path.join(directory, bundle.name)
             await fileSystem.writeFile(bundlePath, bundle.bytes, { flag: "wx" })
           }
@@ -834,20 +877,177 @@ export function createCliAttestationVerifier({
             record,
             ...(bundlePath === undefined ? {} : { bundlePath }),
           })
-          await runGh(args, {
-            env: { ...process.env, GH_TOKEN: token },
-            timeout: 60_000,
-            killSignal: "SIGKILL",
-          })
+          try {
+            await runGh(args, {
+              env: { ...process.env, GH_TOKEN: token },
+              timeout: ATTESTATION_VERIFY_TIMEOUT_MS,
+              killSignal: "SIGKILL",
+            })
+          } catch (error) {
+            throw new AttestationVerificationFailure(describeGhFailure(file.name, error))
+          }
         }
-      } catch {
-        return { status: "INVALID", subjects: [] }
+        if (source === "escrow") {
+          const anchorFile = files[0]
+          const anchorBundle = bundlesByName.get(`${anchorFile.name}.intoto.jsonl`)
+          if (anchorBundle === undefined) {
+            throw new AttestationVerificationFailure(
+              `attestation bundle for ${anchorFile.name} is missing`,
+            )
+          }
+          await verifyOnline(anchorFile, anchorBundle)
+          proveSubjectMembership({ anchorBundle, bundlesByName, subjects, files })
+        } else {
+          for (const file of files) await verifyOnline(file, undefined)
+        }
+      } catch (error) {
+        return invalidAttestationResult(
+          error instanceof AttestationVerificationFailure
+            ? error.message
+            : `attestation verification threw: ${sanitizeReasonText(String(error?.message ?? error))}`,
+        )
       } finally {
         await fileSystem.rm(directory, { recursive: true, force: true })
       }
       return { status: "VERIFIED", subjects }
     },
   }
+}
+
+function invalidAttestationResult(reason) {
+  return { status: "INVALID", subjects: [], reason: sanitizeReasonText(reason) }
+}
+
+/**
+ * Proves every input file is a subject of the gh-verified anchor statement. The anchor
+ * bundle is one JSON line whose DSSE payload is a base64 in-toto statement with
+ * `subject[] = { name, digest: { sha256 } }`.
+ */
+function proveSubjectMembership({ anchorBundle, bundlesByName, subjects, files }) {
+  const anchorBytes = Buffer.from(anchorBundle.bytes)
+  const statementSubjects = parseAnchorStatementSubjects(anchorBytes)
+  if (statementSubjects.length !== subjects.length) {
+    throw new AttestationVerificationFailure(
+      `anchor attestation lists ${statementSubjects.length} subjects but ${subjects.length} were expected`,
+    )
+  }
+  const attested = new Set(statementSubjects.map(({ name, sha256 }) => `${name}:${sha256}`))
+  for (const [index, file] of files.entries()) {
+    const bundle = bundlesByName.get(`${file.name}.intoto.jsonl`)
+    if (bundle === undefined) {
+      throw new AttestationVerificationFailure(`attestation bundle for ${file.name} is missing`)
+    }
+    if (!Buffer.from(bundle.bytes).equals(anchorBytes)) {
+      throw new AttestationVerificationFailure(
+        `attestation bundle for ${file.name} is not byte-identical to the verified anchor`,
+      )
+    }
+    const sha256 = createHash("sha256").update(file.bytes).digest("hex")
+    const subject = subjects[index]
+    if (subject?.name !== file.name || subject.sha256 !== sha256) {
+      throw new AttestationVerificationFailure(
+        `subject ${index} does not describe file ${file.name} (${sha256})`,
+      )
+    }
+    if (!attested.has(`${file.name}:${sha256}`)) {
+      throw new AttestationVerificationFailure(
+        `${file.name} (${sha256}) is not attested by the verified anchor`,
+      )
+    }
+  }
+}
+
+function parseAnchorStatementSubjects(bytes) {
+  let statement
+  try {
+    const source = new TextDecoder("utf-8", { fatal: true }).decode(bytes)
+    const bundle = JSON.parse(source)
+    const envelope = bundle?.dsseEnvelope
+    if (
+      envelope === null ||
+      typeof envelope !== "object" ||
+      envelope.payloadType !== "application/vnd.in-toto+json" ||
+      typeof envelope.payload !== "string"
+    ) {
+      throw new Error("bundle is not one DSSE in-toto envelope")
+    }
+    const payload = Buffer.from(envelope.payload, "base64")
+    if (payload.length === 0 || payload.toString("base64") !== envelope.payload) {
+      throw new Error("bundle payload is not canonical base64")
+    }
+    statement = JSON.parse(new TextDecoder("utf-8", { fatal: true }).decode(payload))
+  } catch (error) {
+    throw new AttestationVerificationFailure(
+      `anchor attestation bundle is unreadable: ${sanitizeReasonText(String(error?.message ?? error))}`,
+    )
+  }
+  if (!Array.isArray(statement?.subject)) {
+    throw new AttestationVerificationFailure("anchor attestation statement has no subject list")
+  }
+  return statement.subject.map((subject, index) => {
+    const name = subject?.name
+    const sha256 = subject?.digest?.sha256
+    if (typeof name !== "string" || !SHA256_PATTERN.test(sha256)) {
+      throw new AttestationVerificationFailure(
+        `anchor attestation subject ${index} is missing a name or sha256 digest`,
+      )
+    }
+    return { name, sha256 }
+  })
+}
+
+function describeGhFailure(fileName, error) {
+  const parts = [`gh attestation verify ${fileName}:`]
+  const signal = typeof error?.signal === "string" ? error.signal : null
+  const code = error?.code
+  if (signal !== null) {
+    parts.push(
+      `signal ${signal}${
+        signal === "SIGKILL" || error?.killed === true
+          ? ` (timed out after ${ATTESTATION_VERIFY_TIMEOUT_MS}ms)`
+          : ""
+      }`,
+    )
+  } else if (Number.isInteger(code)) {
+    parts.push(`exit code ${code}`)
+  } else if (typeof code === "string") {
+    parts.push(`error ${code}`)
+  } else {
+    parts.push("failed without an exit code")
+  }
+  const stderr = error?.stderr
+  const stderrBytes =
+    typeof stderr === "string"
+      ? Buffer.from(stderr, "utf8")
+      : Buffer.isBuffer(stderr)
+        ? stderr
+        : null
+  if (stderrBytes !== null && stderrBytes.length > 0) {
+    parts.push(
+      `stderr: ${stderrBytes.subarray(0, ATTESTATION_REASON_STDERR_BYTES).toString("utf8")}`,
+    )
+  } else if (typeof error?.message === "string" && error.message.length > 0) {
+    parts.push(error.message)
+  }
+  return parts.join(" ")
+}
+
+/** Redacts credential shapes, strips control characters, collapses whitespace, and bounds length. */
+function sanitizeReasonText(value) {
+  let text = typeof value === "string" ? value : String(value)
+  text = Array.from(text, (character) => {
+    const codePoint = character.codePointAt(0)
+    return codePoint < 0x20 || (codePoint >= 0x7f && codePoint <= 0x9f) ? " " : character
+  }).join("")
+  text = text.replace(/https?:\/\/[^\s?#]*\?\S*/gu, (token) => token.slice(0, token.indexOf("?")))
+  for (const pattern of ATTESTATION_REASON_REDACTIONS) {
+    text = text.replace(pattern, "[redacted]")
+  }
+  text = text.replace(/\s+/gu, " ").trim()
+  if (text.length > ATTESTATION_REASON_MAX_LENGTH) {
+    text = `${text.slice(0, ATTESTATION_REASON_MAX_LENGTH - 1)}…`
+  }
+  return text.length === 0 ? "(no reason)" : text
 }
 
 export function buildAttestationVerificationArguments({

--- a/scripts/release/duplicate-draft-consolidation-adapters.mjs
+++ b/scripts/release/duplicate-draft-consolidation-adapters.mjs
@@ -2351,13 +2351,20 @@ function normalizeAttestationResult(value) {
   } catch {
     throw new TypeError("Attestation evidence is malformed")
   }
+  // An INVALID result may carry the verifier's sanitized `reason` (gh exit code, signal, and
+  // redacted stderr); VERIFIED results never do.
+  const hasReason = isPlainRecord(snapshot) && Object.hasOwn(snapshot, "reason")
   if (
     !isPlainRecord(snapshot) ||
-    !hasExactKeys(snapshot, ["status", "subjects"]) ||
+    !hasExactKeys(
+      snapshot,
+      hasReason ? ["status", "subjects", "reason"] : ["status", "subjects"],
+    ) ||
     !["VERIFIED", "INVALID"].includes(snapshot.status) ||
     !Array.isArray(snapshot.subjects) ||
     snapshot.subjects.length > 22 ||
-    (snapshot.status === "INVALID" && snapshot.subjects.length !== 0)
+    (snapshot.status === "INVALID" && snapshot.subjects.length !== 0) ||
+    (hasReason && (snapshot.status !== "INVALID" || !safeBoundedString(snapshot.reason, 4_096)))
   ) {
     throw new TypeError("Attestation evidence is malformed")
   }
@@ -2375,7 +2382,11 @@ function normalizeAttestationResult(value) {
     names.add(subject.name)
     return { name: subject.name, sha256: subject.sha256 }
   })
-  return deepFreeze({ status: snapshot.status, subjects })
+  return deepFreeze({
+    status: snapshot.status,
+    subjects,
+    ...(hasReason ? { reason: snapshot.reason } : {}),
+  })
 }
 
 function containsProxy(value, seen = new Set()) {

--- a/scripts/release/metadata.mjs
+++ b/scripts/release/metadata.mjs
@@ -1859,11 +1859,21 @@ async function verifyAttestationBundles({
       }),
     )
   } catch (error) {
-    throw new Error("Attestation bundle verification failed", { cause: error })
+    throw new Error(
+      `Attestation bundle verification failed: ${attestationFailureReason(error?.message)}`,
+      { cause: error },
+    )
+  }
+  if (!isRecord(result) || result.status !== "VERIFIED") {
+    // The verifier reports why gh (or the local membership proof) rejected the escrow:
+    // exit code, signal/timeout, and redacted stderr. Run 33889526426 failed here with only
+    // the bare "Attestation bundle verification failed" line.
+    throw new Error(
+      `Attestation bundle verification failed: ${attestationFailureReason(result?.reason)}`,
+    )
   }
   if (
     !hasExactFields(result, ["status", "subjects"]) ||
-    result.status !== "VERIFIED" ||
     !Array.isArray(result.subjects) ||
     result.subjects.length !== subjects.length ||
     result.subjects.some(
@@ -1875,6 +1885,33 @@ async function verifyAttestationBundles({
   ) {
     throw new Error("Attestation bundle verification did not prove all 22 subjects")
   }
+}
+
+const ATTESTATION_FAILURE_REASON_MAX_LENGTH = 2 * 1024 + 128
+const ATTESTATION_FAILURE_REASON_REDACTIONS = Object.freeze([
+  /gh[pous]_[A-Za-z0-9]{20,}/gu,
+  /github_pat_[A-Za-z0-9_]{20,}/gu,
+  /npm_[A-Za-z0-9]{20,}/gu,
+  /Bearer\s+\S+/gu,
+  /authorization:\s*\S+(?:\s+\S+)?/giu,
+  /[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}/gu,
+])
+
+/** Bounds and re-redacts a verifier-supplied reason before it reaches an Error message. */
+function attestationFailureReason(value) {
+  if (typeof value !== "string") return "(no reason)"
+  let text = Array.from(value, (character) => {
+    const codePoint = character.codePointAt(0)
+    return codePoint < 0x20 || (codePoint >= 0x7f && codePoint <= 0x9f) ? " " : character
+  }).join("")
+  for (const pattern of ATTESTATION_FAILURE_REASON_REDACTIONS) {
+    text = text.replace(pattern, "[redacted]")
+  }
+  text = text.replace(/\s+/gu, " ").trim()
+  if (text.length > ATTESTATION_FAILURE_REASON_MAX_LENGTH) {
+    text = `${text.slice(0, ATTESTATION_FAILURE_REASON_MAX_LENGTH - 1)}…`
+  }
+  return text.length === 0 ? "(no reason)" : text
 }
 
 function validateMultiSubjectAttestationBundle(bytes, { manifest, attestationSet = null }) {

--- a/scripts/release/test/artifact-store.test.mjs
+++ b/scripts/release/test/artifact-store.test.mjs
@@ -727,7 +727,7 @@ test("attestation verification binds the signer, tag, commit, repository, predic
   )
 })
 
-test("the CLI attestation verifier bounds every gh child process", async () => {
+test("the CLI attestation verifier keeps the Actions path online per file with the larger budget", async () => {
   const calls = []
   const verifier = createCliAttestationVerifier({
     repository: "cacheplane/dawnai",
@@ -736,19 +736,205 @@ test("the CLI attestation verifier bounds every gh child process", async () => {
       calls.push({ args, options })
     },
   })
-  const subject = { name: "manifest.json", sha256: "b".repeat(64) }
+  const subjects = [
+    { name: "manifest.json", sha256: "b".repeat(64) },
+    { name: "dawn-ai-core-0.8.22.tgz", sha256: "c".repeat(64) },
+  ]
   const result = await verifier.verify({
     source: "actions",
     record: artifactFixture().record,
-    subjects: [subject],
-    files: [{ name: subject.name, bytes: Buffer.from("manifest") }],
+    subjects,
+    files: subjects.map((subject) => ({ name: subject.name, bytes: Buffer.from(subject.name) })),
     bundles: [],
   })
 
-  assert.equal(result.status, "VERIFIED")
+  assert.deepEqual(result, { status: "VERIFIED", subjects })
+  assert.equal(calls.length, 2)
+  for (const call of calls) {
+    assert.equal(call.options.timeout, 180_000)
+    assert.equal(call.options.killSignal, "SIGKILL")
+    assert.equal(call.args.includes("--bundle"), false)
+  }
+})
+
+test("escrow verification runs gh once for the anchor and proves the other 21 subjects locally", async () => {
+  const escrow = escrowVerificationFixture()
+  const calls = []
+  const verifier = createCliAttestationVerifier({
+    repository: "cacheplane/dawnai",
+    token: "token",
+    async runGh(args, options) {
+      calls.push({ args, options })
+    },
+  })
+
+  const result = await verifier.verify({ source: "escrow", ...escrow.input })
+
+  assert.deepEqual(result, { status: "VERIFIED", subjects: escrow.input.subjects })
+  assert.equal(escrow.input.files.length, 22)
   assert.equal(calls.length, 1)
-  assert.equal(calls[0].options.timeout, 60_000)
+  assert.equal(calls[0].options.timeout, 180_000)
   assert.equal(calls[0].options.killSignal, "SIGKILL")
+  assert.equal(path.basename(calls[0].args[2]), "manifest.json")
+  assert.equal(path.basename(calls[0].args.at(-1)), "manifest.json.intoto.jsonl")
+  assert.equal(calls[0].options.env.GH_TOKEN, "token")
+})
+
+test("escrow verification rejects a file whose digest is absent from the anchor's subjects", async () => {
+  const escrow = escrowVerificationFixture()
+  const files = escrow.input.files.map((file, index) =>
+    index === 7 ? { name: file.name, bytes: Buffer.from("tampered tarball") } : file,
+  )
+  const subjects = files.map((file) => ({
+    name: file.name,
+    sha256: createHash("sha256").update(file.bytes).digest("hex"),
+  }))
+  const verifier = createCliAttestationVerifier({
+    repository: "cacheplane/dawnai",
+    token: "token",
+    async runGh() {},
+  })
+
+  const result = await verifier.verify({ source: "escrow", ...escrow.input, files, subjects })
+
+  assert.equal(result.status, "INVALID")
+  assert.deepEqual(result.subjects, [])
+  assert.match(result.reason, /not attested/u)
+  assert.ok(result.reason.includes(files[7].name))
+
+  const inconsistent = await verifier.verify({ source: "escrow", ...escrow.input, files })
+  assert.equal(inconsistent.status, "INVALID")
+  assert.match(inconsistent.reason, /subject 7 does not describe file/u)
+})
+
+test("escrow verification rejects an anchor whose subject count differs from the input", async () => {
+  const escrow = escrowVerificationFixture({ statementSubjectCount: 23 })
+  const verifier = createCliAttestationVerifier({
+    repository: "cacheplane/dawnai",
+    token: "token",
+    async runGh() {},
+  })
+
+  const result = await verifier.verify({ source: "escrow", ...escrow.input })
+
+  assert.equal(result.status, "INVALID")
+  assert.deepEqual(result.subjects, [])
+  assert.match(result.reason, /23 subjects .*22/u)
+})
+
+test("escrow verification rejects an anchor subject whose name does not match the file", async () => {
+  const escrow = escrowVerificationFixture({ renameStatementSubject: 3 })
+  const verifier = createCliAttestationVerifier({
+    repository: "cacheplane/dawnai",
+    token: "token",
+    async runGh() {},
+  })
+
+  const result = await verifier.verify({ source: "escrow", ...escrow.input })
+
+  assert.equal(result.status, "INVALID")
+  assert.deepEqual(result.subjects, [])
+  assert.match(result.reason, /not attested/u)
+})
+
+test("escrow verification stays INVALID when gh rejects a tampered anchor bundle", async () => {
+  const escrow = escrowVerificationFixture()
+  const tamperedStatement = JSON.parse(
+    Buffer.from(
+      JSON.parse(escrow.input.bundles[0].bytes.toString("utf8")).dsseEnvelope.payload,
+      "base64",
+    ).toString("utf8"),
+  )
+  tamperedStatement.predicate.runDetails.metadata.invocationId = "https://example.invalid/run"
+  const tamperedBundle = multiSubjectBundleBytes(escrow.input.files, {
+    statement: tamperedStatement,
+  })
+  const bundles = escrow.input.bundles.map(({ name }) => ({
+    name,
+    bytes: Buffer.from(tamperedBundle),
+  }))
+  let invoked = 0
+  const verifier = createCliAttestationVerifier({
+    repository: "cacheplane/dawnai",
+    token: "token",
+    async runGh() {
+      invoked += 1
+      throw Object.assign(new Error("Command failed: gh attestation verify"), {
+        code: 1,
+        signal: null,
+        stderr: "✗ Sigstore verification failed: signature does not match payload\n",
+      })
+    },
+  })
+
+  const result = await verifier.verify({ source: "escrow", ...escrow.input, bundles })
+
+  assert.equal(invoked, 1)
+  assert.equal(result.status, "INVALID")
+  assert.deepEqual(result.subjects, [])
+  assert.match(result.reason, /exit code 1/u)
+  assert.match(result.reason, /signature does not match payload/u)
+})
+
+test("escrow verification rejects a bundle that is not byte-identical to the anchor", async () => {
+  const escrow = escrowVerificationFixture()
+  const bundles = escrow.input.bundles.map((bundle, index) =>
+    index === 5 ? { name: bundle.name, bytes: Buffer.from("different bundle") } : bundle,
+  )
+  const verifier = createCliAttestationVerifier({
+    repository: "cacheplane/dawnai",
+    token: "token",
+    async runGh() {},
+  })
+
+  const result = await verifier.verify({ source: "escrow", ...escrow.input, bundles })
+
+  assert.equal(result.status, "INVALID")
+  assert.match(result.reason, /anchor/u)
+})
+
+test("attestation verification failures report the exit code, signal, and redacted stderr", async () => {
+  const escrow = escrowVerificationFixture()
+  const leaked = `ghp_${"A".repeat(30)}`
+  const timedOut = createCliAttestationVerifier({
+    repository: "cacheplane/dawnai",
+    token: leaked,
+    async runGh() {
+      throw Object.assign(new Error("spawnSync gh SIGKILL"), {
+        killed: true,
+        code: null,
+        signal: "SIGKILL",
+        stdout: "",
+        stderr: `Loading trusted root from Sigstore TUF repository... token ${leaked}\n`,
+      })
+    },
+  })
+  const timeoutResult = await timedOut.verify({ source: "escrow", ...escrow.input })
+  assert.equal(timeoutResult.status, "INVALID")
+  assert.deepEqual(timeoutResult.subjects, [])
+  assert.match(timeoutResult.reason, /signal SIGKILL/u)
+  assert.match(timeoutResult.reason, /timed out after 180000ms/u)
+  assert.match(timeoutResult.reason, /\[redacted\]/u)
+  assert.equal(timeoutResult.reason.includes(leaked), false)
+  assert.equal(timeoutResult.reason.includes("ghp_"), false)
+
+  const failed = createCliAttestationVerifier({
+    repository: "cacheplane/dawnai",
+    token: "token",
+    async runGh() {
+      throw Object.assign(new Error("Command failed"), {
+        code: 2,
+        signal: null,
+        stderr: `${"x".repeat(5_000)}\u0007Bearer secret-value`,
+      })
+    },
+  })
+  const failedResult = await failed.verify({ source: "actions", ...escrow.input, bundles: [] })
+  assert.equal(failedResult.status, "INVALID")
+  assert.match(failedResult.reason, /exit code 2/u)
+  assert.ok(failedResult.reason.length <= 2_048 + 128)
+  assert.equal(failedResult.reason.includes("\u0007"), false)
+  assert.equal(failedResult.reason.includes("secret-value"), false)
 })
 
 test("artifact metadata and extracted files reject accessors without invoking them", async () => {
@@ -1041,4 +1227,70 @@ function storedZip(files) {
   end.writeUInt32LE(centralSize, 12)
   end.writeUInt32LE(centralOffset, 16)
   return Buffer.concat([...locals, ...centrals, end])
+}
+
+function escrowVerificationFixture({ statementSubjectCount, renameStatementSubject } = {}) {
+  const names = [
+    "manifest.json",
+    ...CANONICAL_RELEASE_PACKAGE_ORDER.map((name) => filenameFor(name)),
+  ]
+  const files = names.map((name) => ({ name, bytes: Buffer.from(`escrow-bytes:${name}`) }))
+  const subjects = files.map((file) => ({
+    name: file.name,
+    sha256: createHash("sha256").update(file.bytes).digest("hex"),
+  }))
+  let statementSubjects = subjects.map((subject) => ({
+    name: subject.name,
+    digest: { sha256: subject.sha256 },
+  }))
+  if (statementSubjectCount !== undefined) {
+    statementSubjects = Array.from({ length: statementSubjectCount }, (_, index) =>
+      index < statementSubjects.length
+        ? statementSubjects[index]
+        : { name: `extra-${index}.tgz`, digest: { sha256: "d".repeat(64) } },
+    )
+  }
+  if (renameStatementSubject !== undefined) {
+    statementSubjects = statementSubjects.map((subject, index) =>
+      index === renameStatementSubject ? { ...subject, name: "renamed.tgz" } : subject,
+    )
+  }
+  const bundleBytes = multiSubjectBundleBytes(files, { subjects: statementSubjects })
+  const bundles = files.map((file) => ({
+    name: `${file.name}.intoto.jsonl`,
+    bytes: Buffer.from(bundleBytes),
+  }))
+  return { input: { record: artifactFixture().record, subjects, files, bundles } }
+}
+
+function multiSubjectBundleBytes(files, { subjects, statement } = {}) {
+  const resolvedStatement = statement ?? {
+    _type: "https://in-toto.io/Statement/v1",
+    subject:
+      subjects ??
+      files.map((file) => ({
+        name: file.name,
+        digest: { sha256: createHash("sha256").update(file.bytes).digest("hex") },
+      })),
+    predicateType: "https://slsa.dev/provenance/v1",
+    predicate: {
+      runDetails: {
+        metadata: {
+          invocationId: "https://github.com/cacheplane/dawnai/actions/runs/1/attempts/1",
+        },
+      },
+    },
+  }
+  return Buffer.from(
+    `${JSON.stringify({
+      mediaType: "application/vnd.dev.sigstore.bundle.v0.3+json",
+      dsseEnvelope: {
+        payloadType: "application/vnd.in-toto+json",
+        payload: Buffer.from(JSON.stringify(resolvedStatement), "utf8").toString("base64"),
+        signatures: [{ sig: Buffer.from("signature", "utf8").toString("base64") }],
+      },
+      verificationMaterial: {},
+    })}\n`,
+    "utf8",
+  )
 }

--- a/scripts/release/test/duplicate-draft-consolidation-adapters.test.mjs
+++ b/scripts/release/test/duplicate-draft-consolidation-adapters.test.mjs
@@ -1427,12 +1427,32 @@ test("delegated npm and attestation results reject hostile mutable evidence", as
   await assert.rejects(adapters.attestations.verify({}), /attestation|evidence|malformed/iu)
   assert.equal(invoked, 0)
 
+  for (const invalid of [
+    { status: "INVALID", subjects: [] },
+    { status: "INVALID", subjects: [], reason: "gh attestation verify manifest.json: exit code 1" },
+  ]) {
+    const invalidWithReason = await createDuplicateDraftConsolidationAdapters({
+      cwd: "/workspace",
+      token: TOKEN,
+      dependencies: {
+        fetchImpl: assert.fail,
+        run: commandRunner([]),
+        createCliAttestationVerifier: () => ({ verify: async () => invalid }),
+      },
+    })
+    assert.deepEqual(await invalidWithReason.attestations.verify({}), invalid)
+  }
+
   for (const result of [
     { status: "VERIFIED", subjects: [], extra: true },
     {
       status: "VERIFIED",
       subjects: [{ name: "manifest.json", sha256: "A".repeat(64) }],
     },
+    { status: "VERIFIED", subjects: [], reason: "verified results carry no reason" },
+    { status: "INVALID", subjects: [], reason: { nested: true } },
+    { status: "INVALID", subjects: [], reason: "x".repeat(4_097) },
+    { status: "INVALID", subjects: [], reason: "control\u0007character" },
     new Proxy({ status: "INVALID", subjects: [] }, {}),
   ]) {
     const hostile = await createDuplicateDraftConsolidationAdapters({

--- a/scripts/release/test/fixtures/release-script-hashes.json
+++ b/scripts/release/test/fixtures/release-script-hashes.json
@@ -17,7 +17,7 @@
       "sha256": "3e171b1bc9aa79080d58087327ea2014b856ba5e6329f33de1a0a5f1b18c05d1"
     },
     "scripts/release/artifact-store.mjs": {
-      "sha256": "1b1e17298068211d5e47ac6adfe74e996b1faee91a567385d694704e3ba2de54"
+      "sha256": "69b3cd1a6c1314dbafe8fb1905bd95a4b7cafb834e40ae258b1fd981fcbe2e4a"
     },
     "scripts/release/cli.mjs": {
       "sha256": "7c7efc77a4d8269e607b09596a148519e50a6d9a51412f43013880a00d9c9329"
@@ -35,7 +35,7 @@
       "sha256": "1a931c3056826e489894f67474287b81d6518c9076abbc779ad387697b61b4a9"
     },
     "scripts/release/metadata.mjs": {
-      "sha256": "15e739bbe95a683e0254d79e7a3dfefdb5bbd7f7e18cf96545c38a09ee132be1"
+      "sha256": "1b3e9cc2e5eb187309565e46bd5ecdc2cb2d6578288a9c05a58a120dfef2020e"
     },
     "scripts/release/npm-audit.mjs": {
       "sha256": "308b723105b9549a2740456eaedf2f272c0885fdc5c530f9bfb3aa0e49314111"

--- a/scripts/release/test/metadata.test.mjs
+++ b/scripts/release/test/metadata.test.mjs
@@ -302,6 +302,72 @@ test("escrow invokes the bounded verifier for all 22 bundles before any Release 
   assert.equal(alternateRepository.uploadCount + alternateRepository.updateCount, 0)
 })
 
+test("escrow surfaces the verifier's sanitized reason when attestation verification fails", async () => {
+  const fixture = releaseFixture()
+  const reason = "gh attestation verify manifest.json: signal SIGKILL (timed out after 180000ms)"
+  const invalid = Object.freeze({
+    async verify() {
+      return { status: "INVALID", subjects: [], reason }
+    },
+  })
+  await assert.rejects(
+    escrowCandidate({
+      candidate: CANDIDATE,
+      record: fixture.record,
+      artifact: fixture.artifact,
+      attestationSet: fixture.attestationSet,
+      bundles: fixture.bundles,
+      publicationState: publicationState(fixture),
+      attestations: invalid,
+      github: inMemoryGitHub().github,
+    }),
+    (error) =>
+      error instanceof Error &&
+      error.message === `Attestation bundle verification failed: ${reason}`,
+  )
+
+  const throwing = Object.freeze({
+    async verify() {
+      throw new Error("gh binary is missing")
+    },
+  })
+  await assert.rejects(
+    escrowCandidate({
+      candidate: CANDIDATE,
+      record: fixture.record,
+      artifact: fixture.artifact,
+      attestationSet: fixture.attestationSet,
+      bundles: fixture.bundles,
+      publicationState: publicationState(fixture),
+      attestations: throwing,
+      github: inMemoryGitHub().github,
+    }),
+    (error) =>
+      error instanceof Error &&
+      error.message === "Attestation bundle verification failed: gh binary is missing" &&
+      error.cause instanceof Error,
+  )
+
+  const malformedReason = Object.freeze({
+    async verify() {
+      return { status: "INVALID", subjects: [], reason: { nested: true } }
+    },
+  })
+  await assert.rejects(
+    escrowCandidate({
+      candidate: CANDIDATE,
+      record: fixture.record,
+      artifact: fixture.artifact,
+      attestationSet: fixture.attestationSet,
+      bundles: fixture.bundles,
+      publicationState: publicationState(fixture),
+      attestations: malformedReason,
+      github: inMemoryGitHub().github,
+    }),
+    /Attestation bundle verification failed: \(no reason\)/u,
+  )
+})
+
 test("publication state proves all job attempts and exact package absence before escrow", () => {
   const fixture = releaseFixture()
   const state = publicationState(fixture)

--- a/scripts/release/test/publisher.test.mjs
+++ b/scripts/release/test/publisher.test.mjs
@@ -758,7 +758,9 @@ test("the exact sparse production sequence resolves Actions and expired escrow i
       ),
     )
     const ghCalls = commands.filter(({ command }) => command === "gh")
-    assert.equal(ghCalls.length, 22)
+    // Actions mode stays online per file; escrow verifies the anchor bundle once and proves
+    // the remaining 21 subjects locally against that verified statement.
+    assert.equal(ghCalls.length, scenario === "escrow" ? 1 : 22)
     assert.ok(
       ghCalls.every(
         ({ args }) =>
@@ -913,9 +915,11 @@ async function sparseProductionFixture(t) {
   for (const file of [
     { name: "release-record.json", bytes: canonicalReleaseRecordBytes(record) },
     ...artifactFiles,
+    // The escrow replicates one multi-subject bundle per file; the verifier proves every
+    // file's membership in this statement locally after gh verifies the anchor once.
     ...artifactFiles.map((file) => ({
       name: `${file.name}.intoto.jsonl`,
-      bytes: Buffer.from(`bundle:${file.name}`),
+      bytes: multiSubjectBundleBytes(artifactFiles),
     })),
   ]) {
     escrowAssets.push({
@@ -1771,4 +1775,34 @@ function tarballBytes(name) {
 
 function tarballStem(name) {
   return name.startsWith("@") ? name.slice(1).replaceAll("/", "-") : name
+}
+
+function multiSubjectBundleBytes(files) {
+  const statement = {
+    _type: "https://in-toto.io/Statement/v1",
+    subject: files.map((file) => ({
+      name: file.name,
+      digest: { sha256: createHash("sha256").update(file.bytes).digest("hex") },
+    })),
+    predicateType: "https://slsa.dev/provenance/v1",
+    predicate: {
+      runDetails: {
+        metadata: {
+          invocationId: "https://github.com/cacheplane/dawnai/actions/runs/1/attempts/1",
+        },
+      },
+    },
+  }
+  return Buffer.from(
+    `${JSON.stringify({
+      mediaType: "application/vnd.dev.sigstore.bundle.v0.3+json",
+      dsseEnvelope: {
+        payloadType: "application/vnd.in-toto+json",
+        payload: Buffer.from(JSON.stringify(statement), "utf8").toString("base64"),
+        signatures: [{ sig: Buffer.from("signature", "utf8").toString("base64") }],
+      },
+      verificationMaterial: {},
+    })}\n`,
+    "utf8",
+  )
 }

--- a/scripts/release/test/workflow-contracts.test.mjs
+++ b/scripts/release/test/workflow-contracts.test.mjs
@@ -60,8 +60,13 @@ const SCRIPT_PIN_PATH = path.join(ROOT, SCRIPT_PIN_FIXTURE)
 // Repinned for the sanitized failure detail line (scripts/release/cli.mjs): the entrypoint
 // now prints `release CLI failure detail: ...` after the unchanged code line (run
 // 33889526426 failed in escrow with only the masked INVALID_RELEASE_COMMAND).
+// Repinned for the verify-once attestation verifier (scripts/release/artifact-store.mjs and
+// metadata.mjs): escrow runs `gh attestation verify --bundle` once for the anchor (180 s
+// headroom; diagnostic run 33894039805 measured ~3 s per call) and proves the other 21
+// subjects locally instead of 22 sequential calls; INVALID results now carry a sanitized
+// reason that reaches the thrown escrow error.
 const STARTING_SCRIPT_PIN_SHA256 =
-  "3607d3ce78dd5da379599deffc30e95aa05bb1931367c0e2874e2a1067fa447f"
+  "d707a6bc94fcfd0b050b46f1c5a9b5c829b342929556d51481aeece66434aaee"
 const SHA256_HEX = /^[0-9a-f]{64}$/u
 const workflowExpression = (value) => `\${{ ${value} }}`
 const SCRIPT_REFERENCE = /(?:^|[\s;&|"'(])(scripts\/[\w.-]+(?:\/[\w.-]+)*)/gu


### PR DESCRIPTION
## Summary

Efficiency and observability change to the release controller's CLI attestation verifier (`scripts/release/artifact-store.mjs`). Not the root cause of the v0.8.24 escrow failures on runs 33889526426 and 33892398216: a runner diagnostic (run 33894039805) measured `gh attestation verify` at ~3 s per file under `GITHUB_TOKEN`, so the attest job's 63 s and the escrow job's 71 s were simply 22 sequential network verifications (~4 s per call locally with a PAT). Those failures did not hit the verifier timeout.

**Verify the anchor once, prove membership locally (escrow mode).** `metadata.mjs` already asserts that all 22 escrow bundles are byte-identical to one multi-subject anchor bundle. The verifier now runs `gh attestation verify --bundle` ONCE for the first file, which proves the signature, the Sigstore chain, the signer workflow, and the source ref/digest. The remaining 21 files are proved members of that verified statement locally: decode the anchor's DSSE payload into the in-toto statement, require the subject count to equal the input count, require every file's `sha256(bytes)` and name among the subjects, require each input subject to describe its file, and require every per-file bundle to be byte-identical to the anchor. Any mismatch is INVALID. 22 network calls become 1 (~66 s to ~3 s per job).

**Actions mode stays per-file.** `loadVerifiedReleaseArtifact` uses Actions mode when the artifact has not expired (the hydrate/attestation-output path). There is no bundle to prove membership against; `gh` fetches each subject's attestation from the API by digest, so that path keeps one online verification per file. Both modes use an explicit 180 s per-call budget (headroom; SIGKILL kept) instead of 60 s.

**Surface the failure reason.** The bare `catch {}` is replaced. INVALID results carry a sanitized `reason`: gh's exit code or signal (with the budget on SIGKILL) plus the first 2 KiB of stderr, with control characters stripped and credential shapes (`ghp_`/`gho_`/`ghu_`/`ghs_`, `github_pat_`, `npm_`, Bearer, authorization headers, JWT-shaped strings) replaced by `[redacted]`; local membership failures name the offending file and digest. `metadata.mjs` includes the reason in the thrown escrow error (`Attestation bundle verification failed: <reason>`) after re-sanitizing it. `metadata.mjs` assigns no error codes, so the message-only convention is kept. The duplicate-draft consolidation adapter accepts the optional bounded `reason` on INVALID evidence only.

**Temporal dead zone caught by the sparse production sequence.** `artifact-store.mjs` runs `runArtifactStoreCli` during its own evaluation when executed directly, so the verifier's constants and failure class are declared above that entrypoint.

## Tests

- Escrow verifier proves 22 subjects with exactly one `gh` call; a digest absent from the anchor, a subject-count mismatch (23 vs 22), a renamed subject, a non-identical per-file bundle, and a `gh`-rejected tampered bundle are each INVALID.
- Timeout/SIGKILL and non-zero exits yield a redacted reason (a `ghp_` + 30-char token in stderr becomes `[redacted]`; control characters and a `Bearer` value never reach the reason).
- Actions mode stays per-file with the 180 s budget and no `--bundle`.
- `metadata.mjs` escrow error carries the reason (returned reason, thrown cause, and a malformed non-string reason).
- Consolidation adapter accepts `reason` on INVALID; rejects it on VERIFIED, non-string, oversized, or with control characters.
- Sparse production fixture ships a real multi-subject bundle and expects 1 `gh` call in escrow versus 22 in Actions.
- Mutation check: forcing membership to always pass turns the digest-absent and renamed-subject tests red (2 failures); restored.
- `pnpm test:release-controller`: 2360/2360. `node --test scripts/release/test/workflow-contracts.test.mjs`: 122/122. Biome check clean on all nine changed files.
- `artifact-store.mjs` and `metadata.mjs` repinned in `release-script-hashes.json`; `STARTING_SCRIPT_PIN_SHA256` updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
