### PR TITLE
release: wait out registry tarball propagation before failing a publish

### DIFF
--- a/scripts/release/publisher.mjs
+++ b/scripts/release/publisher.mjs
@@ -45,6 +45,24 @@ const POLL_DELAY_MS = 2_000
 const PUBLISH_COMMAND_TIMEOUT_MS = 5 * 60_000
 const EXPECTED_REPOSITORY = "https://github.com/cacheplane/dawnai"
 
+// Registry tarball propagation budget. npm can accept a publish, expose the exact
+// version metadata (integrity, dist-tags, provenance) and still serve 404 for the
+// tarball URL for minutes: run 33896070181 accepted @dawn-ai/ag-ui@0.8.24 at 16:40:52Z
+// and the tarball stayed 404 until ~16:46Z, which the former fixed 20 × 2 s window
+// turned into an NPM_PARTIAL stop. Only the "metadata present, tarball 404" class waits
+// on this budget: the first TARBALL_FAST_POLL_ATTEMPTS polls keep the 2 s cadence, later
+// polls back off to TARBALL_SLOW_POLL_DELAY_MS, and the wait ends with the existing
+// "could not be verified" failure once TARBALL_CONVERGENCE_DEADLINE_MS has elapsed for
+// that package. Every definitive conflict (identity, integrity, dist-tag, fetched bytes)
+// and every non-404 tarball outcome still fails on the first observation. The
+// per-package budget is deliberately larger than PUBLISHER_OVERALL_TIMEOUT_MS / 21: the
+// overall deadline (which release.yml's 30-minute publish-npm job encloses) stays the
+// binding bound, so a run absorbs one or two full-length lags and otherwise stops
+// resumably rather than serializing 21 worst cases.
+const TARBALL_FAST_POLL_ATTEMPTS = 10
+const TARBALL_SLOW_POLL_DELAY_MS = 10_000
+export const TARBALL_CONVERGENCE_DEADLINE_MS = 10 * 60_000
+
 export const PUBLISHER_OVERALL_TIMEOUT_MS = 25 * 60_000
 
 export const PUBLISHER_SPARSE_FILES = Object.freeze([
@@ -83,6 +101,7 @@ export async function publishManifestSerially({
   publishTarball,
   poll,
   log,
+  now = Date.now,
 }) {
   const identity = validateCandidate(candidate)
   const sealedManifest = validateSealedReleaseManifest(manifest, { candidate: identity })
@@ -92,6 +111,7 @@ export async function publishManifestSerially({
   assertFunction(publishTarball, "publishTarball")
   assertFunction(poll, "poll")
   assertFunction(log, "log")
+  assertFunction(now, "now")
 
   const initial = []
   let candidateStarted = false
@@ -105,7 +125,7 @@ export async function publishManifestSerially({
       candidate: identity,
       downloadRegistryTarball,
     })
-    candidateStarted ||= analyzed.status === "present"
+    candidateStarted ||= isPublished(analyzed)
     initial.push(analyzed)
   }
   const initialLatest = newerLatest(initial, identity.version)
@@ -118,7 +138,7 @@ export async function publishManifestSerially({
   for (let index = 0; index < sealedManifest.packages.length; index += 1) {
     const entry = sealedManifest.packages[index]
     let state = initial[index]
-    if (state.status === "present") {
+    if (isPublished(state)) {
       candidateStarted = true
       await waitUntilVerified({
         entry,
@@ -127,6 +147,8 @@ export async function publishManifestSerially({
         downloadRegistryTarball,
         verifyPackage,
         poll,
+        log,
+        now,
       })
       log({ event: "package-verified", name: entry.name })
       continue
@@ -140,7 +162,7 @@ export async function publishManifestSerially({
       candidate: identity,
       downloadRegistryTarball,
     })
-    if (state.status === "present") {
+    if (isPublished(state)) {
       candidateStarted = true
       await waitUntilVerified({
         entry,
@@ -149,6 +171,8 @@ export async function publishManifestSerially({
         downloadRegistryTarball,
         verifyPackage,
         poll,
+        log,
+        now,
       })
       log({ event: "package-recovered", name: entry.name })
       continue
@@ -170,6 +194,8 @@ export async function publishManifestSerially({
         downloadRegistryTarball,
         verifyPackage,
         poll,
+        log,
+        now,
       })
       log({ event: "package-recovered", name: entry.name })
       continue
@@ -185,6 +211,8 @@ export async function publishManifestSerially({
       downloadRegistryTarball,
       verifyPackage,
       poll,
+      log,
+      now,
     })
   }
 
@@ -292,6 +320,7 @@ export async function runPublisherCli(argv, options = {}) {
         auditVerifierFactory,
         poll: options.poll ?? productionPoll,
         log: options.log ?? productionLog,
+        now: options.now ?? Date.now,
         environment,
         deadline,
       }),
@@ -308,7 +337,7 @@ export async function runPublisherCli(argv, options = {}) {
 
 async function runPublisherCliWithinDeadline(
   argv,
-  { fileSystem, npmReader, runNpm, auditVerifierFactory, poll, log, environment, deadline },
+  { fileSystem, npmReader, runNpm, auditVerifierFactory, poll, log, now, environment, deadline },
 ) {
   const input = parsePublisherArguments(argv)
   const paths = Object.fromEntries(
@@ -391,6 +420,7 @@ async function runPublisherCliWithinDeadline(
       publishTarball,
       poll: (request) => deadline.race(poll({ ...request, signal: deadline.signal })),
       log,
+      now,
     })
     await writeCanonicalReport({
       fileSystem,
@@ -417,8 +447,14 @@ async function waitUntilVerified({
   downloadRegistryTarball,
   verifyPackage,
   poll,
+  log,
+  now,
 }) {
-  for (let attempt = 1; attempt <= MAX_POLL_ATTEMPTS; attempt += 1) {
+  let attempt = 0
+  let convergenceAttempts = 0
+  let tarballPending = null
+  for (;;) {
+    attempt += 1
     const metadata = await observeMetadata(observeRegistry, entry.name)
     const latest = metadata.metadata.latest
     if (latest !== null && compareSemver(latest, candidate.version) > 0) {
@@ -432,14 +468,42 @@ async function waitUntilVerified({
       candidate,
       downloadRegistryTarball,
     })
+    if (analyzed.status === "tarball-pending") {
+      tarballPending ??= { startedAt: now(), attempts: 0 }
+      tarballPending.attempts += 1
+      const elapsedMs = Math.max(0, now() - tarballPending.startedAt)
+      const delayMs =
+        tarballPending.attempts <= TARBALL_FAST_POLL_ATTEMPTS
+          ? POLL_DELAY_MS
+          : TARBALL_SLOW_POLL_DELAY_MS
+      log({
+        event: "registry-tarball-pending",
+        name: entry.name,
+        attempt: tarballPending.attempts,
+        elapsedMs,
+        delayMs,
+        deadlineMs: TARBALL_CONVERGENCE_DEADLINE_MS,
+        httpStatus: analyzed.download.httpStatus,
+      })
+      if (elapsedMs >= TARBALL_CONVERGENCE_DEADLINE_MS) {
+        throw new Error(`npm registry tarball could not be verified for ${entry.name}`)
+      }
+      await poll({ name: entry.name, attempt, delayMs })
+      continue
+    }
     if (analyzed.status === "present" && registryReady(analyzed, candidate)) {
       const audit = await observeNpmAudit(verifyPackage, entry, candidate)
       if (audit.status === "verified") return { ...analyzed, audit, ready: true }
     }
-    if (attempt < MAX_POLL_ATTEMPTS)
-      await poll({ name: entry.name, attempt, delayMs: POLL_DELAY_MS })
+    convergenceAttempts += 1
+    if (convergenceAttempts >= MAX_POLL_ATTEMPTS) break
+    await poll({ name: entry.name, attempt, delayMs: POLL_DELAY_MS })
   }
   throw new Error(`npm registry did not converge for ${entry.name}`)
+}
+
+function isPublished(analyzed) {
+  return analyzed.status === "present" || analyzed.status === "tarball-pending"
 }
 
 async function sweepLatest({ manifest, observeRegistry }) {
@@ -500,6 +564,9 @@ async function analyzeVersion({ entry, metadata, version, downloadRegistryTarbal
     throw new Error(`npm package identity or integrity conflicts for ${entry.name}`)
   }
   const download = await downloadRegistryTarball({ tarballUrl: packageRecord.tarballUrl })
+  if (isTarballPending(download)) {
+    return { status: "tarball-pending", entry, metadata, package: packageRecord, download }
+  }
   if (
     download?.status !== "PRESENT" ||
     download.operation !== "package-tarball" ||
@@ -518,6 +585,18 @@ async function analyzeVersion({ entry, metadata, version, downloadRegistryTarbal
     package: packageRecord,
     tarball,
   }
+}
+
+// The npm adapter classifies a tarball 404 as AMBIGUOUS/HTTP_404 (a binary body carries
+// no registry error code) rather than ABSENT; both shapes mean "not propagated yet".
+function isTarballPending(download) {
+  return (
+    download !== null &&
+    typeof download === "object" &&
+    download.operation === "package-tarball" &&
+    download.httpStatus === 404 &&
+    (download.status === "ABSENT" || download.status === "AMBIGUOUS")
+  )
 }
 
 function registryReady(analyzed, candidate) {

--- a/scripts/release/test/fixtures/release-script-hashes.json
+++ b/scripts/release/test/fixtures/release-script-hashes.json
@@ -50,7 +50,7 @@
       "sha256": "bdc06e4902b3e853e858166240e3dd1e068061c3ec69f74cad33f1ae122c7e1b"
     },
     "scripts/release/publisher.mjs": {
-      "sha256": "929c3597880569fdfa2eea79efb6e34fadf83f2be6800333ce40c80671c31763"
+      "sha256": "455f8b647b6458eb3830c30b4ac05dab4cb24a2d713098614cacbee0cfc7516c"
     },
     "scripts/release/release-record.mjs": {
       "sha256": "f841a2b615cef19cf913a4f89665c10c428446f97314de6c27c1785e47a51170"

--- a/scripts/release/test/publisher.test.mjs
+++ b/scripts/release/test/publisher.test.mjs
@@ -32,6 +32,7 @@ import {
   parsePublisherArguments,
   publishManifestSerially,
   runPublisherCli,
+  TARBALL_CONVERGENCE_DEADLINE_MS,
 } from "../publisher.mjs"
 import { canonicalReleaseRecordBytes } from "../release-record.mjs"
 import { EXACT_NPM_PROVENANCE_CERTIFICATE } from "./fixtures/npm-audit-certificates.mjs"
@@ -115,6 +116,93 @@ test("polls delayed exact metadata, signature, provenance, and latest before adv
   assert.deepEqual(fixture.publishCalls, [CANONICAL_RELEASE_PACKAGE_ORDER[0]])
   assert.ok(fixture.pollCalls.length >= 4)
   assert.ok(fixture.pollCalls.every(({ name }) => name === CANONICAL_RELEASE_PACKAGE_ORDER[0]))
+})
+
+test("a published tarball that 404s during propagation is polled at 2 s then 10 s until it arrives", async () => {
+  const first = CANONICAL_RELEASE_PACKAGE_ORDER[0]
+  const pendingReads = 12
+  const fixture = publisherFixture({ tarballPending: { index: 0, reads: pendingReads } })
+  const started = Date.now()
+
+  const result = await publishManifestSerially(fixture.inputs)
+
+  assert.equal(result.status, "NPM_COMPLETE")
+  assert.deepEqual(fixture.publishCalls, CANONICAL_RELEASE_PACKAGE_ORDER)
+  const convergenceDownloads = fixture.downloadCalls.filter((name) => name === first)
+  // pendingReads 404s, one 200 during convergence, and one 200 in the final sweep.
+  assert.equal(convergenceDownloads.length, pendingReads + 2)
+  const pending = fixture.logs.filter(({ event }) => event === "registry-tarball-pending")
+  assert.equal(pending.length, pendingReads)
+  assert.deepEqual(
+    pending.map(({ name, attempt, elapsedMs, delayMs }) => ({ name, attempt, elapsedMs, delayMs })),
+    Array.from({ length: pendingReads }, (_value, index) => ({
+      name: first,
+      attempt: index + 1,
+      elapsedMs: index < 10 ? index * 2_000 : 20_000 + (index - 10) * 10_000,
+      delayMs: index < 10 ? 2_000 : 10_000,
+    })),
+  )
+  assert.ok(pending.every((event) => event.deadlineMs === TARBALL_CONVERGENCE_DEADLINE_MS))
+  assert.deepEqual(
+    fixture.pollCalls.map(({ delayMs }) => delayMs),
+    [...Array(10).fill(2_000), 10_000, 10_000],
+  )
+  assert.ok(
+    fixture.logs.some(({ event, name }) => event === "package-publish-accepted" && name === first),
+  )
+  assert.ok(Date.now() - started < 5_000, "the fake poll must not sleep for real")
+})
+
+test("a tarball that never propagates fails after the ten-minute convergence deadline", async () => {
+  const first = CANONICAL_RELEASE_PACKAGE_ORDER[0]
+  const fixture = publisherFixture({ tarballPending: { index: 0, reads: Infinity } })
+  const started = Date.now()
+
+  await assert.rejects(
+    publishManifestSerially(fixture.inputs),
+    new RegExp(`npm registry tarball could not be verified for ${first}`, "u"),
+  )
+
+  assert.deepEqual(fixture.publishCalls, [first])
+  // 10 × 2 s + 58 × 10 s = 600 s: the 69th observation sees the deadline elapsed.
+  assert.equal(TARBALL_CONVERGENCE_DEADLINE_MS, 10 * 60_000)
+  assert.equal(fixture.downloadCalls.filter((name) => name === first).length, 69)
+  const pending = fixture.logs.filter(({ event }) => event === "registry-tarball-pending")
+  assert.equal(pending.length, 69)
+  assert.equal(pending.at(-1).attempt, 69)
+  assert.equal(pending.at(-1).elapsedMs, TARBALL_CONVERGENCE_DEADLINE_MS)
+  assert.equal(fixture.pollCalls.length, 68)
+  assert.ok(fixture.pollCalls.every(({ name }) => name === first))
+  assert.ok(Date.now() - started < 5_000, "the fake poll must not sleep for real")
+})
+
+test("a fetched tarball with mismatched bytes fails on the first download without polling", async () => {
+  const first = CANONICAL_RELEASE_PACKAGE_ORDER[0]
+  const fixture = publisherFixture({ corruptRegistryIndex: 0 })
+
+  await assert.rejects(
+    publishManifestSerially(fixture.inputs),
+    /registry tarball|digest|bytes.*match/iu,
+  )
+
+  assert.deepEqual(fixture.publishCalls, [first])
+  assert.deepEqual(fixture.downloadCalls, [first])
+  assert.deepEqual(fixture.pollCalls, [])
+  assert.ok(!fixture.logs.some(({ event }) => event === "registry-tarball-pending"))
+})
+
+test("an integrity mismatch fails immediately before any tarball download or poll", async () => {
+  const first = CANONICAL_RELEASE_PACKAGE_ORDER[0]
+  const fixture = publisherFixture({ integrityMismatchIndex: 0 })
+
+  await assert.rejects(
+    publishManifestSerially(fixture.inputs),
+    new RegExp(`identity or integrity conflicts for ${first}`, "u"),
+  )
+
+  assert.deepEqual(fixture.publishCalls, [first])
+  assert.deepEqual(fixture.downloadCalls, [])
+  assert.deepEqual(fixture.pollCalls, [])
 })
 
 test("raw npm signature records never satisfy publication verification", async () => {
@@ -1361,9 +1449,13 @@ function publisherFixture(overrides = {}) {
   const observeCalls = []
   const pollCalls = []
   const verifyCalls = []
+  const downloadCalls = []
+  const logs = []
   const events = []
   const metadataReads = new Map()
   const versionReads = new Map()
+  const tarballReads = new Map()
+  const clock = { now: 0 }
   const newerAfterVersionRecheck = new Set()
   let failureEnabled = true
   let activePublishes = 0
@@ -1435,12 +1527,30 @@ function publisherFixture(overrides = {}) {
       state.ready,
       overrides.corruptRegistryIndex === index,
       overrides.rawSignatureIndex === index,
+      overrides.integrityMismatchIndex === index,
     )
   }
   const downloadRegistryTarball = async ({ tarballUrl }) => {
     const entry = manifest.packages.find((candidate) => registryUrl(candidate) === tarballUrl)
     if (entry === undefined) throw new Error("unknown fixture tarball URL")
     const index = manifest.packages.indexOf(entry)
+    downloadCalls.push(entry.name)
+    const reads = (tarballReads.get(entry.name) ?? 0) + 1
+    tarballReads.set(entry.name, reads)
+    if (
+      overrides.tarballPending !== undefined &&
+      overrides.tarballPending.index === index &&
+      reads <= overrides.tarballPending.reads
+    ) {
+      // The production npm adapter classifies a tarball 404 (binary body, no registry
+      // code) as AMBIGUOUS/HTTP_404, never ABSENT (run 33896070181).
+      return {
+        status: "AMBIGUOUS",
+        operation: "package-tarball",
+        httpStatus: 404,
+        code: "HTTP_404",
+      }
+    }
     const bytes =
       overrides.corruptRegistryIndex === index ? Buffer.from("corrupt") : tarballBytes(entry.name)
     return tarballDownload(entry, bytes)
@@ -1460,8 +1570,9 @@ function publisherFixture(overrides = {}) {
       activePublishes -= 1
     }
   }
-  const poll = async ({ name, attempt }) => {
-    pollCalls.push({ name, attempt })
+  const poll = async ({ name, attempt, delayMs }) => {
+    pollCalls.push({ name, attempt, delayMs })
+    clock.now += delayMs
     const state = present.get(name)
     if (state !== undefined && state.ready < 4) state.ready += 1
   }
@@ -1488,13 +1599,18 @@ function publisherFixture(overrides = {}) {
       verifyPackage,
       publishTarball,
       poll,
-      log() {},
+      now: () => clock.now,
+      log(event) {
+        logs.push(event)
+      },
     },
     npmReader,
     publishCalls,
     observeCalls,
     pollCalls,
     verifyCalls,
+    downloadCalls,
+    logs,
     events,
     concurrentPublishes,
     disableFailure() {
@@ -1700,7 +1816,7 @@ function publisherProvenanceEnvironment() {
   }
 }
 
-function registryObservation(entry, ready, corrupt, rawSignature) {
+function registryObservation(entry, ready, corrupt, rawSignature, integrityMismatch = false) {
   const bytes = corrupt ? Buffer.from("corrupt") : tarballBytes(entry.name)
   return {
     status: "PRESENT",
@@ -1712,7 +1828,9 @@ function registryObservation(entry, ready, corrupt, rawSignature) {
       version: entry.version,
       tarballUrl: registryUrl(entry),
       shasum: createHash("sha1").update(bytes).digest("hex"),
-      integrity: entry.npmIntegrity,
+      integrity: integrityMismatch
+        ? `sha512-${Buffer.alloc(64, 1).toString("base64")}`
+        : entry.npmIntegrity,
       signatures: ready >= 2 ? [{ keyid: "SHA256:key", sig: "signature" }] : [],
       ...(rawSignature
         ? {}

--- a/scripts/release/test/workflow-contracts.test.mjs
+++ b/scripts/release/test/workflow-contracts.test.mjs
@@ -65,8 +65,13 @@ const SCRIPT_PIN_PATH = path.join(ROOT, SCRIPT_PIN_FIXTURE)
 // headroom; diagnostic run 33894039805 measured ~3 s per call) and proves the other 21
 // subjects locally instead of 22 sequential calls; INVALID results now carry a sanitized
 // reason that reaches the thrown escrow error.
+// Repinned for the registry tarball convergence window (scripts/release/publisher.mjs):
+// a published package whose exact metadata is present but whose tarball URL still 404s
+// is polled at 2 s × 10 then 10 s up to a ten-minute per-package deadline instead of the
+// former 20 × 2 s window (run 33896070181: @dawn-ai/ag-ui@0.8.24 accepted 16:40:52Z,
+// tarball 404 until ~16:46Z); every definitive conflict still fails on first sight.
 const STARTING_SCRIPT_PIN_SHA256 =
-  "d707a6bc94fcfd0b050b46f1c5a9b5c829b342929556d51481aeece66434aaee"
+  "cbc0007d9543cbff2e2f0c0de384842a1a4c4e8a483436975cb1b21ad55aa6a9"
 const SHA256_HEX = /^[0-9a-f]{64}$/u
 const workflowExpression = (value) => `\${{ ${value} }}`
 const SCRIPT_REFERENCE = /(?:^|[\s;&|"'(])(scripts\/[\w.-]+(?:\/[\w.-]+)*)/gu


### PR DESCRIPTION
## Defect

Run [33896070181](https://github.com/cacheplane/dawnai/actions/runs/33896070181) (v0.8.24, job `publish-npm`) stopped in `NPM_PARTIAL` after `@dawn-ai/ag-ui@0.8.24`. npm accepted the publish at 16:40:52Z with correct version metadata, integrity, dist-tags and provenance, but the tarball URL returned `404 {"error":"Not found"}` from both registry hosts until ~16:46Z (about 5.5 minutes; npm status showed no incident). `scripts/release/publisher.mjs` converged on a fixed `20 × 2 s` (~40 s) window and treated every non-PRESENT tarball download as "npm registry tarball could not be verified", so a normal propagation lag became a hard stop and manual reconcile rounds.

## Change

- `analyzeVersion` classifies tarball outcomes: a `package-tarball` 404 (the npm adapter reports it as `AMBIGUOUS`/`HTTP_404`, never `ABSENT`, since a binary body has no registry code) becomes a `tarball-pending` analysis; `PRESENT` with mismatched bytes, and every non-404 outcome, still throw on the first observation. Identity/integrity/dist-tag checks still run before any download.
- `waitUntilVerified` polls the pending class at 2 s for the first 10 attempts, then 10 s, up to a documented per-package `TARBALL_CONVERGENCE_DEADLINE_MS = 10 min` on an injected `now` clock (`Date.now` in production, seam on `runPublisherCli` options), then raises the existing "could not be verified" error. The non-tarball convergence budget keeps its 20-attempt bound.
- A structured `registry-tarball-pending` event (`name`, `attempt`, `elapsedMs`, `delayMs`, `deadlineMs`, `httpStatus`) is logged per pending observation. Existing events are unchanged.

## Deadline arithmetic

`PUBLISHER_OVERALL_TIMEOUT_MS` stays 25 min; `release.yml`'s `publish-npm` job stays `timeout-minutes: 30` (not edited). 21 × 10 min = 210 min cannot fit any job timeout, and 25 min / 21 ≈ 71 s per package would not have covered the observed 5.5 min lag. The per-package budget is therefore intentionally larger than the even split: the overall deadline is the binding bound, one or two full-length lags fit in a run, and beyond that the run stops resumably (`resume-npm-publish`) rather than serializing 21 worst cases. A propagation lag is registry-wide, so a run that hits several full-length lags is an npm incident, not a controller condition to absorb.

## Tests

`scripts/release/test/publisher.test.mjs`: (a) 12 × 404 then 200 → publish proceeds, exact `2 s × 10, 10 s × 2` cadence, N+1 convergence downloads, exact event stream; (b) never-propagating tarball → fails with the existing message at the 69th observation when the fake clock reaches 10 min, publish stops after the first package; (c) bytes mismatch → fails on the first download, no poll, no pending event; (d) integrity mismatch → fails before any download. The fixture's fake `poll` advances a fake clock, so nothing sleeps. Mutation: making the 404 branch fail-fast turns (a) and (b) red.

`publisher.mjs` is content-pinned: `release-script-hashes.json` and `STARTING_SCRIPT_PIN_SHA256` are repinned. `blove/release-attestation-verify-once` (#558) had already merged into main before this branch was cut, so its repin is included in the base and no fixture conflict is expected.

## Verification

- `pnpm test:release-controller`: 2365 pass / 0 fail
- `node --test scripts/release/test/workflow-contracts.test.mjs`: 123 pass / 0 fail
- `biome check --config-path packages/config-biome/biome.json` on the four changed files: clean

No changeset: `scripts/release/**` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
