### PR TITLE
release: harden failure detail redaction and surface writer HTTP status

### DIFF
--- a/scripts/release/adapters/github-write.mjs
+++ b/scripts/release/adapters/github-write.mjs
@@ -51,7 +51,7 @@ const FAILURE_SNIPPET_REDACTIONS = Object.freeze([
   /npm_[A-Za-z0-9]{20,}/gu,
   /Bearer\s+\S+/giu,
   /authorization:\s*\S+(?:\s+\S+)?/giu,
-  /(?<![A-Za-z0-9_.-])[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}/gu,
+  /(?<![A-Za-z0-9_-])[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}/gu,
 ])
 
 export function composeGitHubEffects({ reader, writer }) {

--- a/scripts/release/adapters/github-write.mjs
+++ b/scripts/release/adapters/github-write.mjs
@@ -39,6 +39,20 @@ const MAX_TIMEOUT_MS = 300_000
 const DEFAULT_TIMEOUT_MS = 15_000
 const MAX_RESPONSE_BYTES = 4 * 1024 * 1024
 const MAX_JSON_REQUEST_BYTES = 4 * 1024 * 1024
+// Failure detail carried on a writer Error: the HTTP status plus a short sanitized snippet of
+// the response body. Two v0.8.24 escrow failures at the draft POST were undiagnosable because
+// the status was discarded. Never the headers, never the token. The redaction set mirrors
+// `safeDetail` in ../cli.mjs (which must not be imported here: cli.mjs imports this adapter).
+const FAILURE_SNIPPET_MAX_LENGTH = 200
+const FAILURE_SNIPPET_MAX_INPUT_LENGTH = 4096
+const FAILURE_SNIPPET_REDACTIONS = Object.freeze([
+  /gh[pous]_[A-Za-z0-9]{20,}/gu,
+  /github_pat_[A-Za-z0-9_]{20,}/gu,
+  /npm_[A-Za-z0-9]{20,}/gu,
+  /Bearer\s+\S+/giu,
+  /authorization:\s*\S+(?:\s+\S+)?/giu,
+  /(?<![A-Za-z0-9_.-])[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}/gu,
+])
 
 export function composeGitHubEffects({ reader, writer }) {
   if (
@@ -160,7 +174,7 @@ export function createGitHubWriter({
         },
       })
       if (![201, 422].includes(response.httpStatus)) {
-        throw new Error("GitHub draft creation did not return HTTP 201")
+        throw new Error(writeFailureMessage("GitHub draft creation", response))
       }
       let releaseId
       let status
@@ -169,7 +183,14 @@ export function createGitHubWriter({
         status = "created"
       } else {
         const raced = await findReleaseByTag(context, args)
-        if (raced === null) throw new Error("GitHub draft creation race could not be reconciled")
+        if (raced === null) {
+          throw new Error(
+            writeFailureMessage(
+              "GitHub draft creation race could not be reconciled: no Release matches the tag and the POST",
+              response,
+            ),
+          )
+        }
         releaseId = raced.id
         status = "existing"
       }
@@ -214,8 +235,9 @@ export function createGitHubWriter({
         apiVersion: RELEASE_API_VERSION,
         body: { name: args.title, body: args.body },
       })
-      if (response.httpStatus !== 200)
-        throw new Error("GitHub draft update did not return HTTP 200")
+      if (response.httpStatus !== 200) {
+        throw new Error(writeFailureMessage("GitHub draft update", response))
+      }
       const updated = await readRelease(context, releaseId)
       assertDraftIdentity(updated, args, { title: args.title, body: args.body })
       await verifyAnnotatedTag(context, args.tag, args.targetSha)
@@ -251,7 +273,7 @@ export function createGitHubWriter({
         maxRequestBytes: args.maximumBytes,
       })
       if (![201, 422].includes(response.httpStatus)) {
-        throw new Error("GitHub Release asset upload did not return HTTP 201")
+        throw new Error(writeFailureMessage("GitHub Release asset upload", response))
       }
       assets = await readAssets(context, releaseId)
       existing = findOneAsset(assets, args.name)
@@ -295,8 +317,9 @@ export function createGitHubWriter({
         apiVersion: RELEASE_API_VERSION,
         body: { tag_name: args.tag, draft: false },
       })
-      if (response.httpStatus !== 200)
-        throw new Error("Release publication did not return HTTP 200")
+      if (response.httpStatus !== 200) {
+        throw new Error(writeFailureMessage("Release publication", response))
+      }
       const published = await readRelease(context, releaseId)
       assertPublishedIdentity(published, args)
       if (published.body !== current.body || published.name !== current.name) {
@@ -322,7 +345,12 @@ export function createGitHubWriter({
         body: requestBody,
       })
       if (response.httpStatus !== 200) {
-        throw new Error("GitHub workflow dispatch requires the direct HTTP 200 run receipt")
+        throw new Error(
+          writeFailureMessage(
+            "GitHub workflow dispatch requires the direct HTTP 200 run receipt but",
+            response,
+          ),
+        )
       }
       const receipt = snapshotJson(response.body)
       if (
@@ -701,7 +729,9 @@ async function requestJson(
       })
     } catch (error) {
       throw new Error(
-        controller.signal.aborted ? "GitHub write timed out" : "GitHub write failed",
+        controller.signal.aborted
+          ? `GitHub write timed out after ${context.timeoutMs} ms (${method})`
+          : `GitHub write failed (${method})`,
         {
           cause: error,
         },
@@ -724,11 +754,25 @@ async function requestJson(
         controller.signal,
       )
     } catch (error) {
-      if (controller.signal.aborted) throw new Error("GitHub write timed out", { cause: error })
+      if (controller.signal.aborted) {
+        throw new Error(
+          `GitHub write timed out after ${context.timeoutMs} ms reading the ${method} response`,
+          { cause: error },
+        )
+      }
       throw error
     }
-    if (responseBytes.length === 0) return { httpStatus: status, body: null }
     const responseContentType = response.headers?.get?.("content-type")
+    if (status < 200 || status >= 300) {
+      // A failed write's body is never consumed as data; it is only summarized for the operator,
+      // so the JSON content-type contract below does not apply to it.
+      return {
+        httpStatus: status,
+        body: null,
+        detail: describeFailureBody(responseBytes, responseContentType),
+      }
+    }
+    if (responseBytes.length === 0) return { httpStatus: status, body: null, detail: null }
     if (
       typeof responseContentType !== "string" ||
       !/^application\/(?:[A-Za-z0-9!#$&^_.+-]+\+)?json(?:\s*;|\s*$)/iu.test(responseContentType)
@@ -741,10 +785,61 @@ async function requestJson(
     } catch (error) {
       throw new Error("GitHub write response JSON is malformed", { cause: error })
     }
-    return { httpStatus: status, body: snapshotJson(parsed) }
+    return { httpStatus: status, body: snapshotJson(parsed), detail: null }
   } finally {
     clearTimeout(timeout)
   }
+}
+
+function writeFailureMessage(prefix, response) {
+  const head = `${prefix} returned HTTP ${response.httpStatus}`
+  return response.detail === null ? head : `${head}: ${response.detail}`
+}
+
+function describeFailureBody(bytes, contentType) {
+  if (bytes.length === 0) return null
+  // The body is already bounded by maxResponseBytes; decode leniently so a truncated or
+  // non-UTF-8 error page still yields a glimpse instead of a second failure.
+  const text = new TextDecoder("utf-8", { fatal: false }).decode(bytes)
+  let raw = text
+  if (typeof contentType === "string" && /json/iu.test(contentType)) {
+    try {
+      const parsed = JSON.parse(text)
+      const parts = []
+      if (isRecord(parsed)) {
+        if (typeof parsed.message === "string") parts.push(parsed.message)
+        if (parsed.errors !== undefined) parts.push(`errors=${JSON.stringify(parsed.errors)}`)
+      }
+      if (parts.length > 0) raw = parts.join(" ")
+    } catch {
+      // Fall through to the text snippet: a malformed error body is still worth a glimpse.
+    }
+  }
+  return sanitizeFailureSnippet(raw)
+}
+
+function sanitizeFailureSnippet(value) {
+  let snippet = Array.from(value.slice(0, FAILURE_SNIPPET_MAX_INPUT_LENGTH), (character) => {
+    const codePoint = character.codePointAt(0)
+    return codePoint < 0x20 ||
+      (codePoint >= 0x7f && codePoint <= 0x9f) ||
+      codePoint === 0x2028 ||
+      codePoint === 0x2029
+      ? " "
+      : character
+  }).join("")
+  snippet = snippet.replace(/https?:\/\/[^\s?#]*\?\S*/gu, (token) =>
+    token.slice(0, token.indexOf("?")),
+  )
+  for (const pattern of FAILURE_SNIPPET_REDACTIONS) {
+    snippet = snippet.replace(pattern, "[redacted]")
+  }
+  snippet = snippet.replace(/\s+/gu, " ").trim()
+  if (snippet.length === 0) return null
+  if (snippet.length > FAILURE_SNIPPET_MAX_LENGTH) {
+    snippet = `${snippet.slice(0, FAILURE_SNIPPET_MAX_LENGTH - 1)}\u2026`
+  }
+  return snippet
 }
 
 async function readBoundedResponse(stream, maximum, signal) {

--- a/scripts/release/artifact-store.mjs
+++ b/scripts/release/artifact-store.mjs
@@ -47,7 +47,7 @@ const ATTESTATION_REASON_REDACTIONS = Object.freeze([
   /npm_[A-Za-z0-9]{20,}/gu,
   /Bearer\s+\S+/gu,
   /authorization:\s*\S+(?:\s+\S+)?/giu,
-  /[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}/gu,
+  /(?<![A-Za-z0-9_-])[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}/gu,
 ])
 
 // Declared before the CLI entrypoint below: this module runs `runArtifactStoreCli` during its

--- a/scripts/release/cli.mjs
+++ b/scripts/release/cli.mjs
@@ -2861,14 +2861,19 @@ function usageError() {
 }
 
 const FAILURE_DETAIL_MAX_LENGTH = 512
+// The joined message chain is cut here before any redaction regex runs, so a pathological
+// message (a megabyte of one repeated character) costs a bounded amount of matching work.
+const FAILURE_DETAIL_MAX_INPUT_LENGTH = 4096
 const FAILURE_DETAIL_MAX_CAUSES = 3
 const FAILURE_DETAIL_REDACTIONS = Object.freeze([
   /gh[pous]_[A-Za-z0-9]{20,}/gu,
   /github_pat_[A-Za-z0-9_]{20,}/gu,
   /npm_[A-Za-z0-9]{20,}/gu,
-  /Bearer\s+\S+/gu,
+  /Bearer\s+\S+/giu,
   /authorization:\s*\S+(?:\s+\S+)?/giu,
-  /[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}/gu,
+  // JWT-like: anchored so the match can only start at the beginning of a token run; the
+  // unanchored form retried every offset of a long unbroken run (quadratic, 80k chars ~10 s).
+  /(?<![A-Za-z0-9_.-])[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}/gu,
 ])
 
 const executedPath =
@@ -2897,6 +2902,16 @@ function safeCode(error) {
  * detail is derived from the error message chain only: never a stack, never a body.
  */
 export function safeDetail(error) {
+  // A hostile error (a throwing `message` getter, a Proxy that traps every get) must not turn
+  // the failure report itself into a second crash: the placeholder is the only fallback.
+  try {
+    return unsafeDetail(error)
+  } catch {
+    return "(no message)"
+  }
+}
+
+function unsafeDetail(error) {
   const messages = []
   let current = error
   for (
@@ -2905,10 +2920,13 @@ export function safeDetail(error) {
     depth += 1
   ) {
     const message = current?.message
-    messages.push(typeof message === "string" && message.length > 0 ? message : "(no message)")
+    messages.push(
+      typeof message === "string" && message.trim().length > 0 ? message : "(no message)",
+    )
     current = current !== null && typeof current === "object" ? current.cause : undefined
   }
-  let detail = Array.from(messages.join(" <- "), (character) =>
+  const joined = messages.join(" <- ").slice(0, FAILURE_DETAIL_MAX_INPUT_LENGTH)
+  let detail = Array.from(joined, (character) =>
     isControlCharacter(character) ? " " : character,
   ).join("")
   detail = detail.replace(/https?:\/\/[^\s?#]*\?\S*/gu, (token) =>
@@ -2918,6 +2936,7 @@ export function safeDetail(error) {
     detail = detail.replace(pattern, "[redacted]")
   }
   detail = detail.replace(/\s+/gu, " ").trim()
+  if (detail.length === 0) return "(no message)"
   if (detail.length > FAILURE_DETAIL_MAX_LENGTH) {
     detail = `${detail.slice(0, FAILURE_DETAIL_MAX_LENGTH - 1)}\u2026`
   }

--- a/scripts/release/cli.mjs
+++ b/scripts/release/cli.mjs
@@ -2873,7 +2873,9 @@ const FAILURE_DETAIL_REDACTIONS = Object.freeze([
   /authorization:\s*\S+(?:\s+\S+)?/giu,
   // JWT-like: anchored so the match can only start at the beginning of a token run; the
   // unanchored form retried every offset of a long unbroken run (quadratic, 80k chars ~10 s).
-  /(?<![A-Za-z0-9_.-])[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}/gu,
+  // The lookbehind deliberately admits a preceding dot: `v1.<jwt>` and `id.<jwt>` are real
+  // shapes and must still redact.
+  /(?<![A-Za-z0-9_-])[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}/gu,
 ])
 
 const executedPath =
@@ -2925,7 +2927,12 @@ function unsafeDetail(error) {
     )
     current = current !== null && typeof current === "object" ? current.cause : undefined
   }
-  const joined = messages.join(" <- ").slice(0, FAILURE_DETAIL_MAX_INPUT_LENGTH)
+  let joined = messages.join(" <- ")
+  if (joined.length > FAILURE_DETAIL_MAX_INPUT_LENGTH) {
+    // Drop the token the cut landed inside, so a credential split at the boundary can never
+    // surface as a short fragment the redaction patterns no longer recognize.
+    joined = joined.slice(0, FAILURE_DETAIL_MAX_INPUT_LENGTH).replace(/(?<=\s)\S+$/u, "")
+  }
   let detail = Array.from(joined, (character) =>
     isControlCharacter(character) ? " " : character,
   ).join("")

--- a/scripts/release/test/artifact-store.test.mjs
+++ b/scripts/release/test/artifact-store.test.mjs
@@ -918,6 +918,27 @@ test("attestation verification failures report the exit code, signal, and redact
   assert.equal(timeoutResult.reason.includes(leaked), false)
   assert.equal(timeoutResult.reason.includes("ghp_"), false)
 
+  const jwt =
+    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4ifQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
+  const dotted = createCliAttestationVerifier({
+    repository: "cacheplane/dawnai",
+    token: "token",
+    async runGh() {
+      throw Object.assign(new Error("Command failed"), {
+        code: 1,
+        signal: null,
+        stderr: `bundle rejected: v1.${jwt} via registry.npmjs.org`,
+      })
+    },
+  })
+  const dottedResult = await dotted.verify({ source: "escrow", ...escrow.input })
+  assert.equal(dottedResult.status, "INVALID")
+  assert.equal(
+    dottedResult.reason.includes("eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4ifQ"),
+    false,
+  )
+  assert.match(dottedResult.reason, /v1\.\[redacted\] via registry\.npmjs\.org/u)
+
   const failed = createCliAttestationVerifier({
     repository: "cacheplane/dawnai",
     token: "token",

--- a/scripts/release/test/cli-failure-detail.test.mjs
+++ b/scripts/release/test/cli-failure-detail.test.mjs
@@ -127,6 +127,95 @@ test("safeDetail redacts credentials that straddle a stripped newline", () => {
   assert.ok(!detail.includes("ghp_abcdefghijklmnopqrstuvwxyz0123456789"))
 })
 
+const JWT =
+  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4ifQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
+const JWT_PAYLOAD = "eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4ifQ"
+
+test("safeDetail bounds its work on a one-million-character message", () => {
+  const error = new Error("q".repeat(1_000_000))
+  const started = performance.now()
+  const detail = safeDetail(error)
+  const elapsed = performance.now() - started
+  assert.ok(elapsed < 200, `safeDetail took ${elapsed.toFixed(1)} ms on a 1M-char message`)
+  assert.equal(detail.length, 512)
+  assert.equal(detail.at(-1), "…")
+  assert.ok(detail.startsWith("qqqq"))
+})
+
+for (const [label, message] of [
+  ["at the start of the message", `${JWT} rejected`],
+  ["after an equals sign", `request failed: token=${JWT} rejected`],
+  ["after a Bearer scheme", `request failed: Bearer ${JWT} rejected`],
+  ["after a colon", `request failed: authorization:${JWT} rejected`],
+  ["inside quotes", `request failed: "${JWT}" rejected`],
+  ["after a slash", `request failed: https://example.test/${JWT} rejected`],
+]) {
+  test(`safeDetail redacts a JWT ${label}`, () => {
+    const detail = safeDetail(new Error(message))
+    assert.ok(!detail.includes(JWT_PAYLOAD), `JWT leaked ${label}: ${detail}`)
+    assert.ok(detail.includes("[redacted]"), `JWT not marked redacted ${label}: ${detail}`)
+    assert.ok(detail.startsWith("request failed: ") || detail.startsWith("[redacted]"), detail)
+  })
+}
+
+test("safeDetail leaves dotted identifiers shorter than a JWT segment alone", () => {
+  const detail = safeDetail(new Error("resolved @dawn-ai/core@0.8.24 from registry.npmjs.org"))
+  assert.equal(detail, "resolved @dawn-ai/core@0.8.24 from registry.npmjs.org")
+})
+
+test("safeDetail redacts a lowercase bearer scheme", () => {
+  const detail = safeDetail(
+    new Error("request failed with bearer sk-live-topsecretvalue in the header"),
+  )
+  assert.ok(!detail.includes("sk-live-topsecretvalue"), detail)
+  assert.equal(detail, "request failed with [redacted] in the header")
+  assert.equal(
+    safeDetail(new Error("BEARER sk-live-topsecretvalue rejected")),
+    "[redacted] rejected",
+  )
+})
+
+test("safeDetail returns the placeholder when reading the error throws", () => {
+  const throwingGetter = {
+    get message() {
+      throw new Error("getter exploded")
+    },
+  }
+  assert.equal(safeDetail(throwingGetter), "(no message)")
+
+  const hostileProxy = new Proxy(
+    {},
+    {
+      get() {
+        throw new Error("proxy trap exploded")
+      },
+      has() {
+        throw new Error("proxy trap exploded")
+      },
+    },
+  )
+  assert.equal(safeDetail(hostileProxy), "(no message)")
+
+  const throwingCause = new Error("outer", {
+    cause: new Proxy(
+      {},
+      {
+        get() {
+          throw new Error("cause trap exploded")
+        },
+      },
+    ),
+  })
+  assert.equal(safeDetail(throwingCause), "(no message)")
+})
+
+test("safeDetail substitutes the placeholder for whitespace-only messages", () => {
+  assert.equal(safeDetail(new Error("   ")), "(no message)")
+  assert.equal(safeDetail(new Error("\t\r\n")), "(no message)")
+  assert.equal(safeDetail(new Error("\u0000\u001b\u0085")), "(no message)")
+  assert.equal(safeDetail({ message: "outer", cause: { message: "  " } }), "outer <- (no message)")
+})
+
 test("the CLI entrypoint prints the code line first and a sanitized detail line second", async () => {
   const token = "ghp_notarealtoken_000000000000000000000000"
   const result = await execFile(

--- a/scripts/release/test/cli-failure-detail.test.mjs
+++ b/scripts/release/test/cli-failure-detail.test.mjs
@@ -149,6 +149,10 @@ for (const [label, message] of [
   ["after a colon", `request failed: authorization:${JWT} rejected`],
   ["inside quotes", `request failed: "${JWT}" rejected`],
   ["after a slash", `request failed: https://example.test/${JWT} rejected`],
+  ["after a short dotted prefix", `request failed: v1.${JWT} rejected`],
+  ["after an id. prefix inside JSON", `request failed: {"id.${JWT}":1} rejected`],
+  ["after a hyphenated dotted prefix", `request failed: ab-cd.${JWT} rejected`],
+  ["inside a dotted URL path", `request failed: https://h.test/v1.${JWT} rejected`],
 ]) {
   test(`safeDetail redacts a JWT ${label}`, () => {
     const detail = safeDetail(new Error(message))
@@ -207,6 +211,14 @@ test("safeDetail returns the placeholder when reading the error throws", () => {
     ),
   })
   assert.equal(safeDetail(throwingCause), "(no message)")
+})
+
+test("safeDetail never emits a credential fragment split by the input cap", () => {
+  const detail = safeDetail(new Error(`${" ".repeat(4080)}ghp_${"A".repeat(30)} trailing`))
+  assert.ok(!detail.includes("ghp_"), detail)
+  assert.equal(detail, "(no message)")
+  const kept = safeDetail(new Error(`prefix ${" ".repeat(4070)}ghp_${"A".repeat(30)}`))
+  assert.equal(kept, "prefix")
 })
 
 test("safeDetail substitutes the placeholder for whitespace-only messages", () => {

--- a/scripts/release/test/fixtures/release-script-hashes.json
+++ b/scripts/release/test/fixtures/release-script-hashes.json
@@ -17,10 +17,10 @@
       "sha256": "3e171b1bc9aa79080d58087327ea2014b856ba5e6329f33de1a0a5f1b18c05d1"
     },
     "scripts/release/artifact-store.mjs": {
-      "sha256": "69b3cd1a6c1314dbafe8fb1905bd95a4b7cafb834e40ae258b1fd981fcbe2e4a"
+      "sha256": "7626952c3dace863a1cd933b1a6686e3816a6e054e06742c5d5ea8cf57dfc487"
     },
     "scripts/release/cli.mjs": {
-      "sha256": "d64c318ecfec99c21419bb30e2f32ded3247e2c43a6cd2dc19bc79d9f0cc76ab"
+      "sha256": "a532fb5d18d74786a67761fe98626019a9b467f404b9a6c92083d76957bc569f"
     },
     "scripts/release/independent-audit-coordinator.mjs": {
       "sha256": "a72f438f776f9ca26914c2ec51dd75de8f3b6c7d85ae8b11f2cc51c651e10d53"

--- a/scripts/release/test/fixtures/release-script-hashes.json
+++ b/scripts/release/test/fixtures/release-script-hashes.json
@@ -20,7 +20,7 @@
       "sha256": "69b3cd1a6c1314dbafe8fb1905bd95a4b7cafb834e40ae258b1fd981fcbe2e4a"
     },
     "scripts/release/cli.mjs": {
-      "sha256": "7c7efc77a4d8269e607b09596a148519e50a6d9a51412f43013880a00d9c9329"
+      "sha256": "d64c318ecfec99c21419bb30e2f32ded3247e2c43a6cd2dc19bc79d9f0cc76ab"
     },
     "scripts/release/independent-audit-coordinator.mjs": {
       "sha256": "a72f438f776f9ca26914c2ec51dd75de8f3b6c7d85ae8b11f2cc51c651e10d53"

--- a/scripts/release/test/github-write.test.mjs
+++ b/scripts/release/test/github-write.test.mjs
@@ -779,6 +779,9 @@ test("writer failure detail redacts credentials and query strings from the respo
     "bearer sk-live-topsecretvalue",
     "authorization: Basic dXNlcjpwYXNz",
     jwt,
+    `v1.${jwt}`,
+    `{"id.${jwt}":1}`,
+    `https://h.test/v1.${jwt}`,
   ]
   const writer = draftWriter(async () =>
     jsonResponse(
@@ -802,8 +805,11 @@ test("writer failure detail redacts credentials and query strings from the respo
   ]) {
     assert.ok(!error.message.includes(leak), `leaked ${leak}: ${error.message}`)
   }
-  assert.equal((error.message.match(/\[redacted\]/gu) ?? []).length, 6, error.message)
-  assert.ok(error.message.includes("https://api.github.com/x"))
+  assert.equal((error.message.match(/\[redacted\]/gu) ?? []).length, 9, error.message)
+  assert.match(
+    error.message,
+    /\| https:\/\/h\.test\/v1\.\[redacted\] see https:\/\/api\.github\.com\/x$/u,
+  )
 })
 
 test("writer failure detail bounds a 10 KB body to a 200-character snippet", async () => {

--- a/scripts/release/test/github-write.test.mjs
+++ b/scripts/release/test/github-write.test.mjs
@@ -691,6 +691,261 @@ test("writer bounds response time, content type, redirects, and output bytes", a
   await assert.rejects(dispatch(oversized), /byte limit/iu)
 })
 
+const DRAFT_INPUT = { tag: TAG, targetSha: SHA, title: `Dawn v${VERSION}`, body: "candidate body" }
+const FAKE_TOKEN = `ghp_${"A".repeat(30)}`
+
+function draftWriter(fetchImpl, options = {}) {
+  return createGitHubWriter({
+    owner: OWNER,
+    repo: REPO,
+    reader: exactReader({ releases: [], release: draftRelease("candidate body") }),
+    fetchImpl,
+    ...options,
+  })
+}
+
+async function rejection(promise) {
+  return promise.then(
+    () => assert.fail("the writer call must reject"),
+    (reason) => reason,
+  )
+}
+
+test("draft creation failures carry the HTTP status and the sanitized GitHub message", async () => {
+  const writer = draftWriter(
+    async () => jsonResponse({ message: "Resource not accessible by integration" }, 403),
+    { token: FAKE_TOKEN },
+  )
+  const error = await rejection(writer.createDraftRelease(DRAFT_INPUT))
+  assert.equal(
+    error.message,
+    "GitHub draft creation returned HTTP 403: Resource not accessible by integration",
+  )
+  assert.ok(!error.message.includes(FAKE_TOKEN))
+  assert.ok(!error.message.includes("Authorization"))
+})
+
+test("draft creation failures include structured GitHub errors and survive non-JSON bodies", async () => {
+  const validation = draftWriter(async () =>
+    jsonResponse(
+      {
+        message: "Validation Failed",
+        errors: [{ resource: "Release", code: "custom", field: "tag_name" }],
+        documentation_url: "https://docs.github.com/rest/releases/releases#create-a-release",
+      },
+      400,
+    ),
+  )
+  assert.equal(
+    (await rejection(validation.createDraftRelease(DRAFT_INPUT))).message,
+    'GitHub draft creation returned HTTP 400: Validation Failed errors=[{"resource":"Release","code":"custom","field":"tag_name"}]',
+  )
+
+  const html = draftWriter(
+    async () =>
+      new Response("<html>\n<body>  Bad Gateway\u0000 </body>\n</html>", {
+        status: 502,
+        headers: { "content-type": "text/html" },
+      }),
+  )
+  assert.equal(
+    (await rejection(html.createDraftRelease(DRAFT_INPUT))).message,
+    "GitHub draft creation returned HTTP 502: <html> <body> Bad Gateway </body> </html>",
+  )
+
+  const empty = draftWriter(async () => new Response(null, { status: 500 }))
+  assert.equal(
+    (await rejection(empty.createDraftRelease(DRAFT_INPUT))).message,
+    "GitHub draft creation returned HTTP 500",
+  )
+
+  const malformedJson = draftWriter(
+    async () =>
+      new Response("{not json", { status: 503, headers: { "content-type": "application/json" } }),
+  )
+  assert.equal(
+    (await rejection(malformedJson.createDraftRelease(DRAFT_INPUT))).message,
+    "GitHub draft creation returned HTTP 503: {not json",
+  )
+})
+
+test("writer failure detail redacts credentials and query strings from the response body", async () => {
+  const jwt =
+    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4ifQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
+  const secrets = [
+    FAKE_TOKEN,
+    `github_pat_${"B".repeat(40)}`,
+    `npm_${"C".repeat(36)}`,
+    "bearer sk-live-topsecretvalue",
+    "authorization: Basic dXNlcjpwYXNz",
+    jwt,
+  ]
+  const writer = draftWriter(async () =>
+    jsonResponse(
+      {
+        message: `Bad credentials ${secrets.join(" | ")} see https://api.github.com/x?access_token=leaky`,
+      },
+      401,
+    ),
+  )
+  const error = await rejection(writer.createDraftRelease(DRAFT_INPUT))
+  assert.ok(error.message.startsWith("GitHub draft creation returned HTTP 401: Bad credentials "))
+  for (const leak of [
+    "A".repeat(30),
+    "B".repeat(40),
+    "C".repeat(36),
+    "sk-live-topsecretvalue",
+    "dXNlcjpwYXNz",
+    "eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4ifQ",
+    "access_token",
+    "leaky",
+  ]) {
+    assert.ok(!error.message.includes(leak), `leaked ${leak}: ${error.message}`)
+  }
+  assert.equal((error.message.match(/\[redacted\]/gu) ?? []).length, 6, error.message)
+  assert.ok(error.message.includes("https://api.github.com/x"))
+})
+
+test("writer failure detail bounds a 10 KB body to a 200-character snippet", async () => {
+  const filler = "x".repeat(10 * 1024)
+  const jsonWriter = draftWriter(async () => jsonResponse({ message: filler }, 500))
+  const jsonError = await rejection(jsonWriter.createDraftRelease(DRAFT_INPUT))
+  const jsonPrefix = "GitHub draft creation returned HTTP 500: "
+  assert.ok(jsonError.message.startsWith(jsonPrefix))
+  const jsonSnippet = jsonError.message.slice(jsonPrefix.length)
+  assert.equal(jsonSnippet.length, 200)
+  assert.equal(jsonSnippet.at(-1), "…")
+
+  const textWriter = draftWriter(
+    async () =>
+      new Response(`gateway ${filler}`, { status: 504, headers: { "content-type": "text/plain" } }),
+  )
+  const textError = await rejection(textWriter.createDraftRelease(DRAFT_INPUT))
+  const textSnippet = textError.message.slice("GitHub draft creation returned HTTP 504: ".length)
+  assert.equal(textSnippet.length, 200)
+  assert.ok(textSnippet.startsWith("gateway xxxx"))
+  assert.equal(textSnippet.at(-1), "…")
+})
+
+test("an unreconciled 422 draft race reports the status and GitHub's explanation", async () => {
+  const writer = draftWriter(async () =>
+    jsonResponse({ message: "Validation Failed", errors: [{ code: "already_exists" }] }, 422),
+  )
+  assert.equal(
+    (await rejection(writer.createDraftRelease(DRAFT_INPUT))).message,
+    'GitHub draft creation race could not be reconciled: no Release matches the tag and the POST returned HTTP 422: Validation Failed errors=[{"code":"already_exists"}]',
+  )
+})
+
+test("draft update, asset upload, publication, and dispatch failures carry the HTTP status", async () => {
+  const forbidden = async () =>
+    jsonResponse({ message: "Resource not accessible by integration" }, 403)
+  const detail = "returned HTTP 403: Resource not accessible by integration"
+
+  const updateWriter = createGitHubWriter({
+    owner: OWNER,
+    repo: REPO,
+    reader: exactReader({ release: draftRelease("old body") }),
+    fetchImpl: forbidden,
+  })
+  assert.equal(
+    (
+      await rejection(
+        updateWriter.updateDraftReleaseIfCurrent({
+          releaseId: 7,
+          tag: TAG,
+          targetSha: SHA,
+          expectedBodySha256: releaseBodySha256("old body"),
+          title: `Dawn v${VERSION}`,
+          body: "new body",
+        }),
+      )
+    ).message,
+    `GitHub draft update ${detail}`,
+  )
+
+  const bytes = Buffer.from("exact asset")
+  const uploadWriter = createGitHubWriter({
+    owner: OWNER,
+    repo: REPO,
+    reader: exactReader({ release: draftRelease("body"), assets: [], downloads: new Map() }),
+    fetchImpl: forbidden,
+  })
+  assert.equal(
+    (
+      await rejection(
+        uploadWriter.uploadAssetIfAbsentAndEqual({
+          releaseId: 7,
+          tag: TAG,
+          targetSha: SHA,
+          name: "manifest.json",
+          bytes,
+          sha256: sha256(bytes),
+        }),
+      )
+    ).message,
+    `GitHub Release asset upload ${detail}`,
+  )
+
+  const fixture = verifiedPublicationFixture()
+  const publishWriter = createGitHubWriter({
+    owner: OWNER,
+    repo: REPO,
+    reader: exactReader({
+      release: draftRelease(fixture.body),
+      assets: fixture.assets.map((asset, index) => ({ id: index + 1, name: asset.name })),
+      downloads: new Map(fixture.assets.map((asset, index) => [index + 1, asset.bytes])),
+    }),
+    fetchImpl: forbidden,
+  })
+  assert.equal(
+    (
+      await rejection(
+        publishWriter.publishReleaseIfCurrent({
+          releaseId: 7,
+          tag: TAG,
+          targetSha: SHA,
+          expectedBodySha256: releaseBodySha256(fixture.body),
+          assets: fixture.assets.map(({ name, digest }) => ({ name, sha256: digest })),
+        }),
+      )
+    ).message,
+    `Release publication ${detail}`,
+  )
+
+  const dispatchWriter = createGitHubWriter({
+    owner: OWNER,
+    repo: REPO,
+    reader: exactReader(),
+    fetchImpl: async () => jsonResponse({ message: "Not Found" }, 404),
+  })
+  assert.equal(
+    (
+      await rejection(
+        dispatchWriter.dispatchWorkflowAtRef({
+          workflow: ".github/workflows/release.yml",
+          ref: TAG,
+          inputs: {},
+        }),
+      )
+    ).message,
+    "GitHub workflow dispatch requires the direct HTTP 200 run receipt but returned HTTP 404: Not Found",
+  )
+})
+
+test("writer timeouts report the configured budget without headers or the token", async () => {
+  const writer = draftWriter(
+    (_url, init) =>
+      new Promise((_resolve, reject) => {
+        init.signal.addEventListener("abort", () => reject(new Error("aborted")), { once: true })
+      }),
+    { timeoutMs: 5, token: FAKE_TOKEN },
+  )
+  const error = await rejection(writer.createDraftRelease(DRAFT_INPUT))
+  assert.equal(error.message, "GitHub write timed out after 5 ms (POST)")
+  assert.ok(!error.message.includes(FAKE_TOKEN))
+})
+
 test("publication binds the exact tag and requires an exact immutable unchanged re-read", async () => {
   const fixture = verifiedPublicationFixture()
   const calls = []

--- a/scripts/release/test/workflow-contracts.test.mjs
+++ b/scripts/release/test/workflow-contracts.test.mjs
@@ -70,8 +70,12 @@ const SCRIPT_PIN_PATH = path.join(ROOT, SCRIPT_PIN_FIXTURE)
 // is polled at 2 s × 10 then 10 s up to a ten-minute per-package deadline instead of the
 // former 20 × 2 s window (run 33896070181: @dawn-ai/ag-ui@0.8.24 accepted 16:40:52Z,
 // tarball 404 until ~16:46Z); every definitive conflict still fails on first sight.
+// Repinned for failure-detail hardening (scripts/release/cli.mjs): safeDetail caps its input
+// at 4096 chars before redaction, anchors the JWT pattern (the unanchored form was quadratic),
+// matches Bearer case-insensitively, and falls back to the placeholder when the error itself
+// throws or its message is whitespace-only.
 const STARTING_SCRIPT_PIN_SHA256 =
-  "cbc0007d9543cbff2e2f0c0de384842a1a4c4e8a483436975cb1b21ad55aa6a9"
+  "510d9aa41d273458c82f64e7470c18582d7ad04bb1f392078822eafb513986fe"
 const SHA256_HEX = /^[0-9a-f]{64}$/u
 const workflowExpression = (value) => `\${{ ${value} }}`
 const SCRIPT_REFERENCE = /(?:^|[\s;&|"'(])(scripts\/[\w.-]+(?:\/[\w.-]+)*)/gu

--- a/scripts/release/test/workflow-contracts.test.mjs
+++ b/scripts/release/test/workflow-contracts.test.mjs
@@ -73,9 +73,10 @@ const SCRIPT_PIN_PATH = path.join(ROOT, SCRIPT_PIN_FIXTURE)
 // Repinned for failure-detail hardening (scripts/release/cli.mjs): safeDetail caps its input
 // at 4096 chars before redaction, anchors the JWT pattern (the unanchored form was quadratic),
 // matches Bearer case-insensitively, and falls back to the placeholder when the error itself
-// throws or its message is whitespace-only.
+// throws or its message is whitespace-only. The same anchored JWT pattern (lookbehind
+// without a dot, so v1.<jwt> still redacts) is applied to artifact-store.mjs for consistency.
 const STARTING_SCRIPT_PIN_SHA256 =
-  "510d9aa41d273458c82f64e7470c18582d7ad04bb1f392078822eafb513986fe"
+  "5a539c58d49ad0b6305de6ca4bcebed48497cf254c833533fc78eca950265072"
 const SHA256_HEX = /^[0-9a-f]{64}$/u
 const workflowExpression = (value) => `\${{ ${value} }}`
 const SCRIPT_REFERENCE = /(?:^|[\s;&|"'(])(scripts\/[\w.-]+(?:\/[\w.-]+)*)/gu


### PR DESCRIPTION
## Summary

Small hardening change in the release controller, in two parts.

### Part A — `safeDetail` (review findings on #556)

`scripts/release/cli.mjs`

- **F1** The JWT-like redaction regex was quadratic on long unbroken `[A-Za-z0-9_-]` runs (80k chars ≈ 10 s). It is now anchored with the lookbehind `(?<![A-Za-z0-9_-])` so a match can only start at the beginning of a token run, and the joined message chain is capped at 4096 chars **before** any regex pass. After the cut, the trailing partial token is dropped so a credential split at the boundary never surfaces as a fragment. (Review fix: the first cut of this PR had a dot in the lookbehind, which let `v1.<jwt>`, `id.<jwt>` inside JSON, `ab-cd.<jwt>`, and dotted URL paths escape; the dot is gone in all three copies and each shape is now a test case.)
- **F2** `Bearer\s+\S+` is now case-insensitive (`bearer`, `BEARER`).
- **F3** The body is wrapped in try/catch: a throwing `message` getter or a Proxy that traps every get yields `(no message)` instead of crashing the failure report.
- **F4** Whitespace-only (or control-char-only) messages yield `(no message)`.

### Part B — writer errors carry the HTTP status

`scripts/release/adapters/github-write.mjs`

Two v0.8.24 escrow failures at the draft POST were undiagnosable because the status was discarded (`GitHub draft creation did not return HTTP 201`). Non-2xx writes now throw with the status and a sanitized ≤200-char snippet of the response body's JSON `message`/`errors` (or its text), e.g.

```
GitHub draft creation returned HTTP 403: Resource not accessible by integration
```

Covers draft creation (including the unreconciled 422 race), draft update, asset upload, publication, and workflow dispatch; timeouts now report the budget and method. Headers and the token never reach the message. The snippet sanitizer is a local copy of the six credential patterns + control-char strip + URL query strip, because `cli.mjs` imports this adapter (importing `safeDetail` back would be a cycle).

For non-2xx responses `requestJson` no longer enforces the JSON content-type contract (the body is only summarized, never consumed as data), so a `text/html` 502 from a proxy now surfaces as `HTTP 502: <html> ... Bad Gateway ...` instead of `response content type is not JSON`. The same applies to 422: a 422 whose body is non-JSON or malformed now proceeds to race reconciliation (the existing-draft lookup) instead of throwing on the content type; if reconciliation finds nothing, the error carries `HTTP 422` plus the body snippet.

### `scripts/release/artifact-store.mjs`

The local redactor added by #558 still carried the original unanchored JWT pattern. Its input is capped at 2 KiB so it was not a hang risk, but it is switched to the same anchored form for consistency, with a `v1.<jwt>` redaction test in `artifact-store.test.mjs`.

## Tests

- `pnpm test:release-controller`: **2384 pass, 0 fail** (2360 baseline + 24 new: 17 in `cli-failure-detail.test.mjs`, 7 in `github-write.test.mjs`; `artifact-store.test.mjs` gains assertions inside an existing test).
- `node --test scripts/release/test/workflow-contracts.test.mjs`: 123 pass.
- biome check with the repo config: clean (no `--write`).
- New coverage: 1,000,000-char message returns in < 200 ms (measured ≈ 0.4 ms); JWT redacted at start / after `=` / after `Bearer ` / after `:` / in quotes / after `/` / after `v1.` / after `id.` in JSON / after `ab-cd.` / in a dotted URL path; cap-boundary fragment never emitted; lowercase `bearer`; throwing getter, hostile Proxy, throwing `cause`; whitespace-only; 403 JSON → `HTTP 403` + message; `ghp_`+30 → `[redacted]` (all six patterns + query string); 10 KB JSON and text bodies → 200-char snippet; 422 race detail; update/upload/publish/dispatch 403/404; timeout message with a token configured.

## Mutation check

- Revert the JWT regex to the unanchored form **with the 4096 cap kept**: the timing test stays **green** — the cap alone bounds the work (4096² is too cheap to observe). The cap and the anchor are independent defenses.
- Revert the regex **and** remove the cap: quadratic confirmed on the mutated build — 10k chars 163 ms, 20k 693 ms, 40k 2721 ms (4× per doubling); the 1M-char test would not finish, so it goes red. Restored afterwards; the committed tree is the anchored + capped form.
- Put the dot back in the lookbehind (in cli.mjs and github-write.mjs): **5 tests go red** (the four dotted-prefix `safeDetail` cases and the writer redaction test). Restored.
- Timing on the fixed build: 1M `q` chars 0.3 ms; 1M chars of 25-char dotted runs 0.3 ms; `@dawn-ai/core@0.8.24 from registry.npmjs.org` untouched.

## CodeQL

The `js/incomplete-url-substring-sanitization` alert on the writer redaction test (`error.message.includes("https://api.github.com/x")`) is replaced by an anchored `assert.match(..., /... see https:\/\/api\.github\.com\/x$/u)`.

## Pins

`scripts/release/cli.mjs` and `scripts/release/artifact-store.mjs` are content-pinned: both entries in `release-script-hashes.json` and `STARTING_SCRIPT_PIN_SHA256` in `workflow-contracts.test.mjs` are recomputed. `github-write.mjs` is not in the pin fixture (only final-owner workflow entrypoints are), so it needs no repin.

**Rebased onto main after #559 merged** (publisher.mjs repinned the same fixture): main's publisher.mjs entry is kept byte-for-byte, only the cli.mjs and artifact-store.mjs entries change, and `STARTING_SCRIPT_PIN_SHA256` is recomputed from the merged fixture. Post-rebase: `pnpm test:release-controller` 2388/2388, contracts 123/123, biome clean.

No changeset: release tooling only, nothing published changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
