### PR TITLE
release: fix the three smoke-lane defects that blocked the 0.8.24 publish

### DIFF
--- a/scripts/published-artifacts.test.mjs
+++ b/scripts/published-artifacts.test.mjs
@@ -8,7 +8,6 @@ import { afterEach, describe, it } from "node:test"
 import { fileURLToPath } from "node:url"
 
 import { parse } from "yaml"
-
 import {
   assertCleanDependencySpecs,
   assertInstalledCoreResolution,
@@ -45,6 +44,7 @@ import {
   runPublishedArtifactVerify,
 } from "./published-artifact-verify.mjs"
 import { CANONICAL_RELEASE_PACKAGE_ORDER, canonicalManifestBytes } from "./release/manifest.mjs"
+import { assertStrictSmokeCommandOptions } from "./release/smoke-process-runner.mjs"
 import { parseSmokeResult, REQUIRED_RELEASE_SMOKE_LANES } from "./release/smoke-result.mjs"
 
 const {
@@ -3515,7 +3515,10 @@ function fakeStrictRunner(runCommand = async () => ({ stdout: "", stderr: "" }))
     async probe() {
       return { adapter: "systemd-cgroup-v2", imageOS: "ubuntu24", imageVersion: "test" }
     },
-    runCommand,
+    async runCommand(command, args, options = {}) {
+      assertStrictSmokeCommandOptions(options)
+      return await runCommand(command, args, options)
+    },
   }
 }
 

--- a/scripts/release/smoke-process-runner.mjs
+++ b/scripts/release/smoke-process-runner.mjs
@@ -70,6 +70,41 @@ export function strictContainmentReceiptDetail(environment = process.env) {
   return `strict systemd/cgroup-v2 containment available (ImageOS=${imageOS}, ImageVersion=${imageVersion})`
 }
 
+export const STRICT_SMOKE_COMMAND_OPTION_FIELDS = Object.freeze([
+  "acceptedExitCodes",
+  "cwd",
+  "env",
+  "maxOutputBytes",
+  "signal",
+  "timeoutMs",
+])
+
+const STRICT_SMOKE_COMMAND_OPTION_FIELD_SET = new Set(STRICT_SMOKE_COMMAND_OPTION_FIELDS)
+
+export function pickStrictSmokeCommandOptions(options = {}) {
+  if (options === null || Array.isArray(options) || typeof options !== "object") {
+    throw new TypeError("Strict smoke command options are invalid")
+  }
+  const picked = {}
+  for (const field of STRICT_SMOKE_COMMAND_OPTION_FIELDS) {
+    if (options[field] !== undefined) picked[field] = options[field]
+  }
+  return picked
+}
+
+export function assertStrictSmokeCommandOptions(options) {
+  if (options === null || Array.isArray(options) || typeof options !== "object") {
+    throw new TypeError("Strict smoke command options are invalid")
+  }
+  if (
+    Reflect.ownKeys(options).some(
+      (key) => typeof key !== "string" || !STRICT_SMOKE_COMMAND_OPTION_FIELD_SET.has(key),
+    )
+  ) {
+    throw new TypeError("Strict smoke command options contain an unexpected field")
+  }
+}
+
 function normalizeInvocation(command, args, options) {
   if (
     typeof command !== "string" ||
@@ -92,20 +127,7 @@ function normalizeInvocation(command, args, options) {
     }
     return value
   })
-  if (options === null || Array.isArray(options) || typeof options !== "object") {
-    throw new TypeError("Strict smoke command options are invalid")
-  }
-  const allowed = new Set([
-    "acceptedExitCodes",
-    "cwd",
-    "env",
-    "maxOutputBytes",
-    "signal",
-    "timeoutMs",
-  ])
-  if (Reflect.ownKeys(options).some((key) => typeof key !== "string" || !allowed.has(key))) {
-    throw new TypeError("Strict smoke command options contain an unexpected field")
-  }
+  assertStrictSmokeCommandOptions(options)
   const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS
   if (!Number.isSafeInteger(timeoutMs) || timeoutMs < 1 || timeoutMs > MAX_TIMEOUT_MS) {
     throw new TypeError("Strict smoke command timeout is outside its bound")

--- a/scripts/release/smoke-result.mjs
+++ b/scripts/release/smoke-result.mjs
@@ -678,6 +678,7 @@ export function formatSmokeError(error) {
   let detail
   try {
     detail = error instanceof Error ? error.message : String(error)
+    detail = appendAggregatedCauses(detail, error)
   } catch {
     detail = "Smoke operation failed with an unprintable error"
   }
@@ -687,6 +688,19 @@ export function formatSmokeError(error) {
   detail = replaceControlCharacters(detail)
   detail = detail.replace(/\s+/gu, " ").trim()
   return truncateUtf8(detail || "Smoke operation failed", 4_096)
+}
+
+function appendAggregatedCauses(detail, error, depth = 0) {
+  if (depth >= 4 || !(error instanceof AggregateError) || !Array.isArray(error.errors)) {
+    return detail
+  }
+  const causes = []
+  for (const cause of error.errors.slice(0, 8)) {
+    let text = cause instanceof Error ? cause.message : String(cause)
+    text = appendAggregatedCauses(text, cause, depth + 1)
+    if (text) causes.push(text)
+  }
+  return causes.length === 0 ? detail : `${detail}: ${causes.join("; ")}`
 }
 
 function replaceControlCharacters(value) {

--- a/scripts/release/smoke/published-harness.mjs
+++ b/scripts/release/smoke/published-harness.mjs
@@ -29,6 +29,7 @@ import {
 import { parseNpmAuditSignatures as parseVerifiedNpmAuditSignatures } from "../npm-audit.mjs"
 import {
   createStrictSmokeProcessRunner,
+  pickStrictSmokeCommandOptions,
   strictContainmentReceiptDetail,
 } from "../smoke-process-runner.mjs"
 import { executeSmokeLane, parseSmokeLaneArgs } from "../smoke-result.mjs"
@@ -332,7 +333,7 @@ for (const [name, value] of Object.entries(surfaces[lane])) {
 
 function productionCommandOptions(options = {}) {
   return {
-    ...options,
+    ...pickStrictSmokeCommandOptions(options),
     env: publicNpmEnvironment({ home: options.cwd ?? process.cwd(), extra: options.env }),
     timeoutMs: COMMAND_TIMEOUT_MS,
     maxOutputBytes: options.maxOutputBytes ?? COMMAND_OUTPUT_BYTES,

--- a/scripts/release/smoke/runtime-targets.mjs
+++ b/scripts/release/smoke/runtime-targets.mjs
@@ -7,6 +7,7 @@ import { pathToFileURL } from "node:url"
 import { makeTempDir, publicNpmEnvironment, removeDir } from "../../lib/published-artifacts.mjs"
 import {
   createStrictSmokeProcessRunner,
+  pickStrictSmokeCommandOptions,
   strictContainmentReceiptDetail,
 } from "../smoke-process-runner.mjs"
 import { executeSmokeLane, parseSmokeLaneArgs } from "../smoke-result.mjs"
@@ -110,8 +111,19 @@ import { discoverRoutes } from "@dawn-ai/core/node"
 import { graphAdapter } from "@dawn-ai/langgraph"
 import { toAguiEvents } from "@dawn-ai/ag-ui"
 
-for (const [name, value] of Object.entries({ agent, discoverRoutes, graphAdapter, toAguiEvents })) {
+for (const [name, value] of Object.entries({ agent, discoverRoutes, toAguiEvents })) {
   assert.equal(typeof value, "function", name + " must be a function")
+}
+
+assert.equal(typeof graphAdapter, "object", "graphAdapter must be a backend adapter object")
+assert.notEqual(graphAdapter, null, "graphAdapter must be a backend adapter object")
+assert.equal(graphAdapter.kind, "graph", "graphAdapter must declare the graph backend kind")
+for (const method of ["execute", "stream"]) {
+  assert.equal(
+    typeof graphAdapter[method],
+    "function",
+    "graphAdapter." + method + " must be a function",
+  )
 }
 `
 }
@@ -135,7 +147,7 @@ assert.deepEqual(edgeSurface(), ["function", "function"])
 
 function productionCommandOptions(options = {}) {
   return {
-    ...options,
+    ...pickStrictSmokeCommandOptions(options),
     env: publicNpmEnvironment({ home: options.cwd ?? process.cwd(), extra: options.env }),
     timeoutMs: COMMAND_TIMEOUT_MS,
     maxOutputBytes: COMMAND_OUTPUT_BYTES,

--- a/scripts/release/smoke/scaffold.mjs
+++ b/scripts/release/smoke/scaffold.mjs
@@ -7,6 +7,7 @@ import { pathToFileURL } from "node:url"
 import { makeTempDir, publicNpmEnvironment, removeDir } from "../../lib/published-artifacts.mjs"
 import {
   createStrictSmokeProcessRunner,
+  pickStrictSmokeCommandOptions,
   strictContainmentReceiptDetail,
 } from "../smoke-process-runner.mjs"
 import { executeSmokeLane, parseSmokeLaneArgs } from "../smoke-result.mjs"
@@ -123,7 +124,7 @@ export async function verifyExactScaffold(root, version) {
 
 function productionCommandOptions(options = {}) {
   return {
-    ...options,
+    ...pickStrictSmokeCommandOptions(options),
     env: publicNpmEnvironment({ home: options.cwd ?? process.cwd(), extra: options.env }),
     timeoutMs: COMMAND_TIMEOUT_MS,
     maxOutputBytes: COMMAND_OUTPUT_BYTES,

--- a/scripts/release/smoke/storage.mjs
+++ b/scripts/release/smoke/storage.mjs
@@ -13,6 +13,7 @@ import {
 } from "../../published-artifact-smoke.mjs"
 import {
   createStrictSmokeProcessRunner,
+  pickStrictSmokeCommandOptions,
   strictContainmentReceiptDetail,
 } from "../smoke-process-runner.mjs"
 import { executeSmokeLane, parseSmokeLaneArgs } from "../smoke-result.mjs"
@@ -231,7 +232,7 @@ try {
 
 function productionCommandOptions(options = {}) {
   return {
-    ...options,
+    ...pickStrictSmokeCommandOptions(options),
     env: publicNpmEnvironment({
       home: options.cwd ?? process.cwd(),
       extra: options.env,

--- a/scripts/release/test/fixtures/release-script-hashes.json
+++ b/scripts/release/test/fixtures/release-script-hashes.json
@@ -59,19 +59,19 @@
       "sha256": "fee872a1dddfa280cf0efe608525cad6d9f42d8d647a9ccf2ef9be1b7c41a06a"
     },
     "scripts/release/smoke-result.mjs": {
-      "sha256": "d86a5cc1ccb9bafa45451ae4186b7d2a8573eba03cbf127efe0843712c9cd21e"
+      "sha256": "b6ab2832f862bd628529528ab95d462708cc84d832d935163e48abe029e2af21"
     },
     "scripts/release/smoke/published-harness.mjs": {
-      "sha256": "48cec31768f1df81f29876f3630c9d721a4af1b606740d3502c9c02b0473c041"
+      "sha256": "763afad7c1a2fcf2501d246164fa221aedebf494d8a0ffe9484adb482f4c1a42"
     },
     "scripts/release/smoke/runtime-targets.mjs": {
-      "sha256": "8828d0c774ae927aaf32e7a806cb0618cc67912c8f526e3300fae6b6e0b8e237"
+      "sha256": "e82aebe4c25805b7c60e7ec64af72f8c4b922a3aeddd1c9afbff48e6bdf8294d"
     },
     "scripts/release/smoke/scaffold.mjs": {
-      "sha256": "948e0e51b372244839cebe358d5370874ef134ee7226a365c127577ae0f670ac"
+      "sha256": "a8809c7be496ce59e3dddecc7f893135800dab4fefce823a5112ebd72dba3b52"
     },
     "scripts/release/smoke/storage.mjs": {
-      "sha256": "448dbbca39890ef849ed5658931b0e2a193693354ed87d6c109f0f7e0d6270a7"
+      "sha256": "be07add60b15362476e45f5705b9f6fcdb44d0b005ee277a6538cae07f189798"
     },
     "scripts/release/terminal-records.mjs": {
       "sha256": "17151da8acf77431decd76ea3b78af41243b7e5a92cb572427c8aa8196af61d1"

--- a/scripts/release/test/published-harness-smoke.test.mjs
+++ b/scripts/release/test/published-harness-smoke.test.mjs
@@ -1,7 +1,6 @@
 import assert from "node:assert/strict"
 import { createHash } from "node:crypto"
 import test from "node:test"
-
 import { CANONICAL_RELEASE_PACKAGE_ORDER, canonicalManifestBytes } from "../manifest.mjs"
 import {
   cleanupDockerSandboxResources,
@@ -9,6 +8,7 @@ import {
   runPublishedHarnessSmoke,
   validateNpmAuditSignatures,
 } from "../smoke/published-harness.mjs"
+import { assertStrictSmokeCommandOptions } from "../smoke-process-runner.mjs"
 import { parseSmokeResult } from "../smoke-result.mjs"
 import { EXACT_NPM_PROVENANCE_CERTIFICATE } from "./fixtures/npm-audit-certificates.mjs"
 
@@ -559,7 +559,10 @@ function fakeStrictRunner(runCommand) {
     async probe() {
       return { adapter: "systemd-cgroup-v2", imageOS: "ubuntu24", imageVersion: "test" }
     },
-    runCommand,
+    async runCommand(command, args, options = {}) {
+      assertStrictSmokeCommandOptions(options)
+      return await runCommand(command, args, options)
+    },
   }
 }
 

--- a/scripts/release/test/runtime-targets-smoke.test.mjs
+++ b/scripts/release/test/runtime-targets-smoke.test.mjs
@@ -1,6 +1,12 @@
 import assert from "node:assert/strict"
+import { execFile } from "node:child_process"
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
 import test from "node:test"
-import { runRuntimeTargetsSmoke } from "../smoke/runtime-targets.mjs"
+import { promisify } from "node:util"
+import { nodeRuntimeProbeSource, runRuntimeTargetsSmoke } from "../smoke/runtime-targets.mjs"
+import { assertStrictSmokeCommandOptions } from "../smoke-process-runner.mjs"
 import { parseSmokeResult } from "../smoke-result.mjs"
 
 const options = Object.freeze({
@@ -8,6 +14,66 @@ const options = Object.freeze({
   commitSha: "a".repeat(40),
   manifestSha256: "b".repeat(64),
   result: "/results/runtime-targets.json",
+})
+
+const execFileAsync = promisify(execFile)
+
+async function writeStubPackage(root, name, source, exportsMap) {
+  const dir = join(root, "node_modules", ...name.split("/"))
+  await mkdir(dir, { recursive: true })
+  await writeFile(
+    join(dir, "package.json"),
+    JSON.stringify({ name, version: "0.0.0", type: "module", exports: exportsMap }),
+    "utf8",
+  )
+  await writeFile(join(dir, "index.js"), source, "utf8")
+}
+
+async function runNodeRuntimeProbe(graphAdapterSource) {
+  const root = await mkdtemp(join(tmpdir(), "dawn-runtime-probe-"))
+  try {
+    await writeFile(join(root, "package.json"), JSON.stringify({ type: "module" }), "utf8")
+    await writeStubPackage(root, "@dawn-ai/sdk", "export const agent = () => {}", "./index.js")
+    await writeStubPackage(root, "@dawn-ai/ag-ui", "export const toAguiEvents = () => {}", {
+      ".": "./index.js",
+    })
+    await writeStubPackage(root, "@dawn-ai/core", "export const discoverRoutes = () => {}", {
+      "./node": "./index.js",
+    })
+    await writeStubPackage(root, "@dawn-ai/langgraph", graphAdapterSource, "./index.js")
+    await writeFile(join(root, "node-runtime.mjs"), nodeRuntimeProbeSource(), "utf8")
+    await execFileAsync(process.execPath, ["node-runtime.mjs"], { cwd: root })
+    return { ok: true, stderr: "" }
+  } catch (error) {
+    return { ok: false, stderr: String(error.stderr ?? error.message) }
+  } finally {
+    await rm(root, { recursive: true, force: true })
+  }
+}
+
+test("node runtime probe accepts the shipped backend-adapter shape of graphAdapter", async () => {
+  const shipped = await runNodeRuntimeProbe(
+    'export const graphAdapter = { kind: "graph", execute: async () => {}, stream: async function* () {} }',
+  )
+  assert.equal(shipped.ok, true, shipped.stderr)
+})
+
+test("node runtime probe rejects a graphAdapter that loses its backend-adapter contract", async () => {
+  const asFunction = await runNodeRuntimeProbe("export const graphAdapter = () => {}")
+  assert.equal(asFunction.ok, false)
+  assert.match(asFunction.stderr, /graphAdapter must be a backend adapter object/u)
+
+  const wrongKind = await runNodeRuntimeProbe(
+    'export const graphAdapter = { kind: "workflow", execute: async () => {}, stream: async function* () {} }',
+  )
+  assert.equal(wrongKind.ok, false)
+  assert.match(wrongKind.stderr, /graphAdapter must declare the graph backend kind/u)
+
+  const missingStream = await runNodeRuntimeProbe(
+    'export const graphAdapter = { kind: "graph", execute: async () => {} }',
+  )
+  assert.equal(missingStream.ok, false)
+  assert.match(missingStream.stderr, /graphAdapter\.stream must be a function/u)
 })
 
 test("installs exact public packages and runs Node plus edge-target bundle/import probes", async () => {
@@ -110,7 +176,10 @@ function fakeStrictRunner(runCommand) {
     async probe() {
       return { adapter: "systemd-cgroup-v2", imageOS: "ubuntu24", imageVersion: "test" }
     },
-    runCommand,
+    async runCommand(command, args, options = {}) {
+      assertStrictSmokeCommandOptions(options)
+      return await runCommand(command, args, options)
+    },
   }
 }
 

--- a/scripts/release/test/scaffold-smoke.test.mjs
+++ b/scripts/release/test/scaffold-smoke.test.mjs
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict"
 import test from "node:test"
 import { runScaffoldSmoke } from "../smoke/scaffold.mjs"
+import { assertStrictSmokeCommandOptions } from "../smoke-process-runner.mjs"
 import { parseSmokeResult } from "../smoke-result.mjs"
 
 const options = Object.freeze({
@@ -109,7 +110,10 @@ function fakeStrictRunner(runCommand) {
     async probe() {
       return { adapter: "systemd-cgroup-v2", imageOS: "ubuntu24", imageVersion: "test" }
     },
-    runCommand,
+    async runCommand(command, args, options = {}) {
+      assertStrictSmokeCommandOptions(options)
+      return await runCommand(command, args, options)
+    },
   }
 }
 

--- a/scripts/release/test/smoke-result.test.mjs
+++ b/scripts/release/test/smoke-result.test.mjs
@@ -10,6 +10,7 @@ import {
   canonicalSmokeResultBytes,
   correlateSmokeResults,
   executeSmokeLane,
+  formatSmokeError,
   parseSmokeLaneArgs,
   parseSmokeResult,
   REQUIRED_RELEASE_SMOKE_LANES,
@@ -447,6 +448,32 @@ test("bounds and redacts multibyte failure details so the receipt is always writ
   assert.equal(receipt.conclusion, "failure")
   assert.equal(Buffer.byteLength(receipt.checks[0].detail, "utf8") <= 4_096, true)
   assert.doesNotMatch(receipt.checks[0].detail, /super_secret/u)
+})
+
+test("failure detail surfaces aggregated workload and cleanup causes", () => {
+  const detail = formatSmokeError(
+    new AggregateError(
+      [new Error("tar extraction failed"), new Error("cgroup cleanup failed")],
+      "Contained smoke workload and cleanup did not both succeed",
+    ),
+  )
+  assert.match(detail, /Contained smoke workload and cleanup did not both succeed/u)
+  assert.match(detail, /tar extraction failed/u)
+  assert.match(detail, /cgroup cleanup failed/u)
+})
+
+test("aggregated failure detail stays redacted, bounded, and non-recursive", () => {
+  const nested = new AggregateError(
+    [new AggregateError([new Error("npm_super_secret_token leaked")], "inner")],
+    "outer",
+  )
+  const detail = formatSmokeError(nested)
+  assert.doesNotMatch(detail, /super_secret/u)
+  assert.equal(Buffer.byteLength(detail, "utf8") <= 4_096, true)
+
+  const cyclic = new AggregateError([new Error("boom")], "cyclic")
+  cyclic.errors.push(cyclic)
+  assert.match(formatSmokeError(cyclic), /boom/u)
 })
 
 function sequenceClock(...timestamps) {

--- a/scripts/release/test/storage-smoke.test.mjs
+++ b/scripts/release/test/storage-smoke.test.mjs
@@ -1,4 +1,7 @@
 import assert from "node:assert/strict"
+import { mkdtemp, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
 import test from "node:test"
 import {
   cleanupStorageContainer,
@@ -6,6 +9,10 @@ import {
   startDisposableDatabase,
   storageDockerIdentities,
 } from "../smoke/storage.mjs"
+import {
+  assertStrictSmokeCommandOptions,
+  STRICT_SMOKE_COMMAND_OPTION_FIELDS,
+} from "../smoke-process-runner.mjs"
 import { parseSmokeResult } from "../smoke-result.mjs"
 
 const options = Object.freeze({
@@ -280,12 +287,55 @@ function clock() {
   return () => values.shift() ?? new Date("2026-08-25T12:00:01.000Z")
 }
 
+test("storage runtime probes reach the strict runner with only contract option fields", async (t) => {
+  const seen = []
+  let receipt
+  const probeRoot = await mkdtemp(join(tmpdir(), "dawn-storage-smoke-"))
+  t.after(async () => {
+    await rm(probeRoot, { recursive: true, force: true })
+  })
+  await runStorageSmoke(options, {
+    env: releaseEnv("602", "1"),
+    now: clock(),
+    randomUUID: () => "123e4567-e89b-42d3-a456-426614174000",
+    async makeTempDir() {
+      return probeRoot
+    },
+    async removeDir() {},
+    strictRunner: fakeStrictRunner(async (command, args, runOptions) => {
+      seen.push({ command, args, fields: Object.keys(runOptions).sort() })
+      return { stdout: "", stderr: "" }
+    }),
+    async startDatabase({ kind }) {
+      return `postgres://postgres:postgres@127.0.0.1/${kind}`
+    },
+    async stopContainer() {},
+    async writeFile(_path, bytes) {
+      receipt = parseSmokeResult(bytes)
+    },
+    async mkdir() {},
+  })
+
+  assert.equal(receipt.conclusion, "success")
+  const probes = seen.filter((entry) => entry.command === "node")
+  assert.ok(probes.length >= 2, "both storage runtime probes must run through the strict runner")
+  for (const probe of probes) {
+    assert.deepEqual(
+      probe.fields.filter((field) => !STRICT_SMOKE_COMMAND_OPTION_FIELDS.includes(field)),
+      [],
+    )
+  }
+})
+
 function fakeStrictRunner(runCommand) {
   return {
     async probe() {
       return { adapter: "systemd-cgroup-v2", imageOS: "ubuntu24", imageVersion: "test" }
     },
-    runCommand,
+    async runCommand(command, args, options = {}) {
+      assertStrictSmokeCommandOptions(options)
+      return await runCommand(command, args, options)
+    },
   }
 }
 

--- a/scripts/release/test/workflow-contracts.test.mjs
+++ b/scripts/release/test/workflow-contracts.test.mjs
@@ -75,8 +75,12 @@ const SCRIPT_PIN_PATH = path.join(ROOT, SCRIPT_PIN_FIXTURE)
 // matches Bearer case-insensitively, and falls back to the placeholder when the error itself
 // throws or its message is whitespace-only. The same anchored JWT pattern (lookbehind
 // without a dot, so v1.<jwt> still redacts) is applied to artifact-store.mjs for consistency.
+// Repinned for the smoke-lane fixes: every lane now picks only strict-runner contract fields
+// at its boundary (an includeOpenAi leak killed the 0.8.24 storage probes), the runtime-target
+// probe asserts graphAdapter's real BackendAdapter shape instead of typeof "function", and
+// formatSmokeError flattens AggregateError causes so a masked containment failure names itself.
 const STARTING_SCRIPT_PIN_SHA256 =
-  "5a539c58d49ad0b6305de6ca4bcebed48497cf254c833533fc78eca950265072"
+  "faeb5a309eb86de93e30c26a2e052d8d2d24bc2dfbd1e5e964b2b187a5e0bdb0"
 const SHA256_HEX = /^[0-9a-f]{64}$/u
 const workflowExpression = (value) => `\${{ ${value} }}`
 const SCRIPT_REFERENCE = /(?:^|[\s;&|"'(])(scripts\/[\w.-]+(?:\/[\w.-]+)*)/gu


### PR DESCRIPTION
## What happened

Publishing for v0.8.24 finished — all 21 packages are on npm — and the release reached the smoke lanes for the first time. Four of five lanes failed. Three failures are defects in the lanes themselves; the published packages are fine.

| Lane | Check | Cause |
|---|---|---|
| storage | `pgvector-runtime` | real defect — option leak (fixed here) |
| runtime-targets | `node-runtime` | real defect — wrong assertion (fixed here) |
| metadata | `package:@dawn-ai/workspace` | cause was masked (diagnosability fixed here) |
| published-harness | `docker-pid-recovery` | known sandbox fork-bomb flake |
| scaffold | — | passed |

## The three fixes

**1. Storage — `includeOpenAi` leaked into the strict runner.** `runRuntimeSmoke` passes `includeOpenAi` as a *command option*. The legacy runner accepts it; the strict systemd runner rejects any field outside its allowlist, so every storage runtime probe died with `Strict smoke command options contain an unexpected field`.

The leak was systemic, not one call site: all four lanes' `productionCommandOptions` spread raw caller options straight into the strict runner. The option contract is now exported from the runner and each lane picks only contract fields at the boundary. Env correctness is preserved — `publicNpmEnvironment` already spreads `options.env`, which carries `OPENAI_API_KEY` when a probe asks for it.

Dropping unknown fields at the boundary (rather than throwing) is deliberate: the lane adapter's job is to translate a shared probe API into strict-runner options, and throwing would reproduce the exact production failure.

**2. Runtime targets — the probe asserted the wrong shape.** It asserted `typeof graphAdapter === "function"`, but `graphAdapter` has always been a `BackendAdapter` object (`createLangGraphAdapter` returns an object literal). Verified against the published `@dawn-ai/langgraph@0.8.24`:

```
typeof: object   kind: graph   execute: function   stream: function
```

The probe now asserts the real contract. The old assertion was wrong in both directions — it would have passed a bare function and failed the shipped object — so the new test proves both.

**3. Diagnosability — `AggregateError` causes were discarded.** `formatSmokeError` read only `error.message`, so an `AggregateError` surfaced as `Contained smoke workload and cleanup did not both succeed` with every underlying cause dropped. That is precisely what masked the metadata lane failure on `@dawn-ai/workspace`. Causes are now flattened into the detail, bounded and redacted like any other detail, with a depth cap so a cyclic aggregate terminates.

## Why the tests missed all of this

All five `fakeStrictRunner` copies ignored their `options` argument entirely, so the real runner's allowlist was never exercised — a fake that did not match the shape of the real adapter. Each fake now enforces the same contract the real runner does, and a new storage test drives the **real** pgvector probe path end to end.

## Verification

- The new storage test fails against the pre-fix lane and passes after — confirmed by reverting the fix and re-running.
- `node --test --test-concurrency=1 scripts/published-artifacts.test.mjs scripts/release/test/*.test.mjs` → **2370 passed, 0 failed**.
- Release-integrity content pins updated for every changed pinned script, plus the fixture's own pin.
- Lint clean on `scripts` (formatting scoped to touched files only).

## Not addressed here

- **published-harness `docker-pid-recovery`** is the known sandbox fork-bomb flake (`notStrictEqual` with two identical container ids). Left for the re-run rather than papered over.
- **metadata `@dawn-ai/workspace`** — only 1 of 21 packages, and consistent with registry convergence lag on a late-published package. Fix 3 means a recurrence will now name its actual cause instead of hiding it.
- The content-pin set covers only scripts named on workflow command lines, not the modules they import, so files like `smoke-process-runner.mjs` execute during a release unpinned. Real gap, but widening the pin set is a release-integrity design change that deserves its own review — filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)