### PR TITLE
release: cut 0.8.25 so the repaired release automation runs end to end

### DIFF
--- a/.changeset/olive-pugs-repeat.md
+++ b/.changeset/olive-pugs-repeat.md
@@ -1,0 +1,15 @@
+---
+"@dawn-ai/cli": patch
+---
+
+Re-cut the release so the repaired release automation runs end to end.
+
+There are no functional changes to any package in this version: the published
+0.8.24 packages and these are built from the same sources. 0.8.24 published
+correctly, but its release ceremony could not finish because two defects in
+that candidate's own smoke lanes made them fail on every attempt, and every
+release job outside the controller runs from the frozen candidate commit, so
+the fixes could not reach it.
+
+This version is the first candidate to carry the repaired publish retry and
+smoke lanes, which is what proves them.


### PR DESCRIPTION
Adds one `patch` changeset to re-cut the release from repaired main.

## Why

v0.8.24 published all 21 packages correctly and they are fine — both defects that stalled it were in the release smoke lanes, not in the product. But its ceremony cannot finish:

- Two deterministic defects live in **that candidate's own** smoke lanes (a strict-runner option leak that killed the storage probes, and a `graphAdapter` assertion that asserted the wrong shape). They fail identically on every re-dispatch.
- **Every release job except `detect` checks out the frozen `candidate_sha`.** The candidate `88c01c4a` is the Version Packages merge and predates #553–#559 by ~1,500 lines, so none of today's fixes ever applied to it — and #561 cannot reach it either.
- **Moving the tag is not an escape hatch.** `validateExactPublishedPackageEvidence` throws when `provenance.commitSha !== candidate.commitSha`, and all 21 published packages carry npm provenance attesting `88c01c4a`. A moved tag would fail metadata verification for every package.

So the repaired tooling can only be exercised by a new candidate.

## What this contains

No package source changes — `git diff 88c01c4a origin/main -- packages/` is empty. This version's purpose is to be the first candidate carrying the repaired publish retry (#559) and smoke lanes (#561), which is what proves them. Nine days of release-tooling work is currently unvalidated for exactly the freeze reason above.

## Checks done

- `changeset status` confirms **patch** for the fixed group and nothing at minor or major — a `minor` in a 0.x fixed group would jump to 1.0.0.
- `node scripts/check-docs.mjs` passes, so the changeset text carries no banned phrase into the generated CHANGELOG (a banned phrase in a changeset has reddened a release run before).
- No new packages, so no npm OIDC bootstrap is needed — all 21 already exist at 0.8.24.

## After merge

The Version Packages PR bumps all 21 to 0.8.25. That PR gets no checks (bot token), so it needs an admin merge, and the post-merge Release run must be verified rather than assumed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)