### PR TITLE
test(cli): wait for complete probe files instead of mere existence

### DIFF
--- a/packages/cli/test/helpers/probe-file.ts
+++ b/packages/cli/test/helpers/probe-file.ts
@@ -1,0 +1,121 @@
+import { readFile } from "node:fs/promises"
+
+/**
+ * Probe files are how these suites observe a run that outlives the request that
+ * started it: the fixture route writes a file, the test polls for it.
+ *
+ * `writeFile` is NOT atomic — it opens with O_TRUNC and then writes, awaiting in
+ * between. A reader polling the path can land in that window and read back an
+ * empty or truncated file, which is how `JSON.parse(await waitForFile(...))`
+ * produced an intermittent "Unexpected end of JSON input" in CI.
+ *
+ * Two defenses live here, and both are used:
+ *   - `atomicWriteLines` makes the writer rename a finished temp file onto the
+ *     target, so a reader sees either nothing or the whole body. That removes
+ *     the race at the source.
+ *   - `waitForFile` polls for *complete* content rather than mere existence, so
+ *     a probe writer that has not been converted still cannot hand a caller a
+ *     half-written file.
+ */
+
+export interface WaitForFileOptions {
+  /** Poll interval between attempts. */
+  intervalMs?: number
+  /**
+   * Decides whether the content read so far is the complete payload. Returning
+   * false — or throwing, as `JSON.parse` does on a truncated read — keeps
+   * polling. Defaults to "any non-whitespace content".
+   */
+  isComplete?: (content: string) => boolean
+  /** How long to wait before giving up. */
+  timeoutMs?: number
+  /** Noun used in the timeout error, e.g. "started probe". */
+  what?: string
+}
+
+const hasContent = (content: string): boolean => content.trim().length > 0
+
+/**
+ * Wait for `path` to exist AND to hold complete content, then return it.
+ *
+ * Throws on timeout with an error that distinguishes "never appeared" from
+ * "appeared but never completed", and quotes what was last read.
+ */
+export async function waitForFile(path: string, options: WaitForFileOptions = {}): Promise<string> {
+  const {
+    intervalMs = 25,
+    isComplete = hasContent,
+    timeoutMs = 15_000,
+    what = "probe file",
+  } = options
+  const startedAt = Date.now()
+  let lastContent: string | undefined
+  let lastRejection: unknown
+
+  while (Date.now() - startedAt < timeoutMs) {
+    let content: string | undefined
+    try {
+      content = await readFile(path, "utf8")
+    } catch {
+      // Not written yet — keep polling.
+    }
+    if (content !== undefined) {
+      lastContent = content
+      try {
+        if (isComplete(content)) return content
+        lastRejection = undefined
+      } catch (error) {
+        lastRejection = error
+      }
+    }
+    await new Promise((resolve) => setTimeout(resolve, intervalMs))
+  }
+
+  const waited = Date.now() - startedAt
+  if (lastContent === undefined) {
+    throw new Error(`${what} never appeared: ${path} (waited ${waited}ms)`)
+  }
+  const preview = JSON.stringify(
+    lastContent.length > 200 ? `${lastContent.slice(0, 200)}…` : lastContent,
+  )
+  throw new Error(
+    `${what} never completed: ${path} (waited ${waited}ms, last read ${preview})`,
+    lastRejection === undefined ? undefined : { cause: lastRejection },
+  )
+}
+
+/**
+ * Wait for `path` to hold parseable JSON, then return the parsed value. A
+ * truncated read makes `JSON.parse` throw, which is treated as "not complete
+ * yet" rather than as a test failure.
+ */
+export async function waitForJsonFile<T>(
+  path: string,
+  options: Omit<WaitForFileOptions, "isComplete"> = {},
+): Promise<T> {
+  const content = await waitForFile(path, {
+    ...options,
+    isComplete: (candidate) => {
+      JSON.parse(candidate)
+      return true
+    },
+  })
+  return JSON.parse(content) as T
+}
+
+/**
+ * Source lines for an atomic probe write, to inline into a generated fixture
+ * route. Writes a sibling temp file and renames it onto the target; `rename` is
+ * atomic within a directory, so a concurrent reader never observes a partial
+ * body.
+ *
+ * The emitted code needs `rename` and `writeFile` from `node:fs/promises` in
+ * scope. `pathExpr` is evaluated twice, so pass a plain expression.
+ */
+export function atomicWriteLines(pathExpr: string, bodyExpr: string, indent = "  "): string[] {
+  return [
+    `${indent}const __probeTmp = ${pathExpr} + ".tmp"`,
+    `${indent}await writeFile(__probeTmp, ${bodyExpr})`,
+    `${indent}await rename(__probeTmp, ${pathExpr})`,
+  ]
+}

--- a/packages/cli/test/pending-interrupts-endpoint.test.ts
+++ b/packages/cli/test/pending-interrupts-endpoint.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { dirname, join } from "node:path"
 import type { ThreadAccessPolicy } from "@dawn-ai/sdk"
@@ -17,6 +17,7 @@ import { createAimock } from "../../testing/dist/aimock-runner.js"
 import { script } from "../../testing/dist/fixture-builder.js"
 import { createRuntimeFetchHandler } from "../src/lib/dev/runtime-fetch-handler.js"
 import { terminalStatus } from "../src/lib/dev/terminal-status.js"
+import { atomicWriteLines, waitForFile } from "./helpers/probe-file.js"
 
 const cleanup: Array<() => Promise<void> | void> = []
 
@@ -35,12 +36,14 @@ const ECHO_ROUTE = ["export const graph = async () => ({ ok: true })", ""].join(
  * run slot until a release file appears, so a cancel can land mid-run. It
  * deliberately ignores ctx.signal and self-releases after 15s. */
 const BLOCKING_ROUTE = [
-  'import { readFile, writeFile } from "node:fs/promises"',
+  'import { readFile, rename, writeFile } from "node:fs/promises"',
   "export const graph = async (",
   "  input: { startedFile?: string; releaseFile?: string } | undefined,",
   "  _ctx: { signal: AbortSignal },",
   ") => {",
-  "  if (input?.startedFile) await writeFile(input.startedFile, 'started')",
+  "  if (input?.startedFile) {",
+  ...atomicWriteLines("input.startedFile", "'started'", "    "),
+  "  }",
   "  const deadline = Date.now() + 15000",
   "  while (Date.now() < deadline) {",
   "    if (!input?.releaseFile) break",
@@ -82,13 +85,13 @@ const BROKEN_AGENT_ROUTE = [
  * /runs/wait turn is durably parked but has not returned yet. Routine app code:
  * a slow sibling tool call is what any real agent turn looks like. */
 const SLOW_PING_TOOL = [
-  'import { readFile, writeFile } from "node:fs/promises"',
+  'import { readFile, rename, writeFile } from "node:fs/promises"',
   "/** Ping a host, slowly. */",
   "export default async function slowPing(input: {",
   "  startedFile: string",
   "  releaseFile: string",
   "}): Promise<string> {",
-  "  await writeFile(input.startedFile, 'started')",
+  ...atomicWriteLines("input.startedFile", "'started'"),
   "  const deadline = Date.now() + 15000",
   "  while (Date.now() < deadline) {",
   "    try { await readFile(input.releaseFile, 'utf8'); break } catch {}",
@@ -772,7 +775,7 @@ describe("GET /threads/:thread_id/pending_interrupts — gating", () => {
     // running, and the permission interrupt is already DURABLE in the
     // checkpoint. The second is the attacker's oracle — everything the endpoint
     // would hand over already exists at this instant.
-    await waitForFile(startedFile)
+    await waitForFile(startedFile, { what: "started probe" })
     await waitForParkedWrite(saver, threadId)
 
     // Both of these are ungated today, which is what makes the window
@@ -856,7 +859,7 @@ describe("GET /threads/:thread_id/pending_interrupts — gating", () => {
     const streamPromise = handler.fetch(
       parkRunRequest(threadId, "deploy to staging", { "x-admin": "1" }),
     )
-    await waitForFile(startedFile)
+    await waitForFile(startedFile, { what: "started probe" })
 
     // Every settle path ends in updateMetadata, which is a documented NO-OP for
     // a missing row — not an error. So deleting the row here used to let the
@@ -943,18 +946,6 @@ async function threadStatus(handler: Handler, threadId: string): Promise<string>
   return ((await response.json()) as { status: string }).status
 }
 
-async function waitForFile(path: string, timeoutMs = 15_000): Promise<string> {
-  const startedAt = Date.now()
-  while (Date.now() - startedAt < timeoutMs) {
-    try {
-      return await readFile(path, "utf8")
-    } catch {
-      await new Promise((resolve) => setTimeout(resolve, 25))
-    }
-  }
-  throw new Error(`probe file never appeared: ${path}`)
-}
-
 // ---------------------------------------------------------------------------
 // "interrupted" is deliberately overloaded: cancelled OR parked. The
 // discriminator is pending_interrupts — non-empty means the agent is waiting
@@ -987,7 +978,7 @@ describe("thread status after a parked or cancelled turn", () => {
     const runResponse = await handler.fetch(
       runStreamRequest(threadId, "/blocking#graph", { releaseFile, startedFile }),
     )
-    await waitForFile(startedFile)
+    await waitForFile(startedFile, { what: "started probe" })
     expect((await handler.fetch(cancelRequest(threadId))).status).toBe(200)
     await drain(runResponse)
 

--- a/packages/cli/test/request-stores.test.ts
+++ b/packages/cli/test/request-stores.test.ts
@@ -1,10 +1,9 @@
-import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { dirname, join } from "node:path"
 import type { ThreadsStore } from "@dawn-ai/sqlite-storage"
 import { MemorySaver } from "@langchain/langgraph"
 import { afterEach, describe, expect, it, vi } from "vitest"
-
 import { createRuntimeFetchHandler, isEventStream } from "../src/lib/dev/runtime-fetch-core.js"
 import { createRuntimeFetchHandler as createNodeRuntimeFetchHandler } from "../src/lib/dev/runtime-fetch-handler.js"
 import type { RequestStores } from "../src/lib/dev/runtime-server.js"
@@ -16,6 +15,7 @@ import {
   memoryThreadsStore,
   simpleScript,
 } from "./helpers/fetch-entry-fixture.js"
+import { atomicWriteLines, waitForFile } from "./helpers/probe-file.js"
 import {
   buildStaticModulesForFixture,
   cleanup,
@@ -269,12 +269,14 @@ describe("per-request stores", () => {
 
 /** Blocks until `releaseFile` exists; the paths arrive as route input. */
 const BLOCKING_ROUTE = [
-  'import { readFile, writeFile } from "node:fs/promises"',
+  'import { readFile, rename, writeFile } from "node:fs/promises"',
   "export const graph = async (",
   "  input: { startedFile?: string; releaseFile?: string } | undefined,",
   "  _ctx: { signal: AbortSignal },",
   ") => {",
-  "  if (input?.startedFile) await writeFile(input.startedFile, 'started')",
+  "  if (input?.startedFile) {",
+  ...atomicWriteLines("input.startedFile", "'started'", "    "),
+  "  }",
   "  const deadline = Date.now() + 15000",
   "  while (Date.now() < deadline) {",
   "    if (!input?.releaseFile) break",
@@ -293,9 +295,9 @@ const BLOCKING_ROUTE = [
  */
 function blockingRouteWithLiterals(startedFile: string, releaseFile: string): string {
   return [
-    'import { readFile, writeFile } from "node:fs/promises"',
+    'import { readFile, rename, writeFile } from "node:fs/promises"',
     "export const graph = async () => {",
-    `  await writeFile(${JSON.stringify(startedFile)}, 'started')`,
+    ...atomicWriteLines(JSON.stringify(startedFile), "'started'"),
     "  const deadline = Date.now() + 15000",
     "  while (Date.now() < deadline) {",
     `    try { await readFile(${JSON.stringify(releaseFile)}, 'utf8'); break } catch {}`,
@@ -318,19 +320,6 @@ function deferred(): { promise: Promise<void>; resolve: () => void } {
 /** One macrotask, so a promise chain that was already settled can run. */
 function tick(): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, 10))
-}
-
-async function waitForFile(path: string, timeoutMs = 15_000): Promise<void> {
-  const startedAt = Date.now()
-  while (Date.now() - startedAt < timeoutMs) {
-    try {
-      await readFile(path, "utf8")
-      return
-    } catch {
-      await new Promise((resolve) => setTimeout(resolve, 25))
-    }
-  }
-  throw new Error(`probe file never appeared: ${path}`)
 }
 
 async function waitUntil(predicate: () => boolean, what: string, timeoutMs = 15_000) {
@@ -435,7 +424,7 @@ describe("per-request stores outlive the response when the run does", () => {
         method: "POST",
       }),
     )
-    await waitForFile(startedFile)
+    await waitForFile(startedFile, { what: "started probe" })
 
     const cancelResponse = await handler.fetch(
       new Request(`http://localhost/threads/${threadId}/cancel`, { method: "POST" }),

--- a/packages/cli/test/runtime-fetch-parity.test.ts
+++ b/packages/cli/test/runtime-fetch-parity.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises"
 import type { IncomingMessage } from "node:http"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
@@ -14,6 +14,7 @@ import { createRunRegistry } from "../src/lib/dev/run-registry.js"
 import { createRuntimeFetchHandler } from "../src/lib/dev/runtime-fetch-handler.js"
 import type { RuntimeRegistry } from "../src/lib/dev/runtime-registry.js"
 import { statusResponse } from "../src/lib/dev/status-response.js"
+import { atomicWriteLines, waitForFile, waitForJsonFile } from "./helpers/probe-file.js"
 
 const cleanup: Array<() => Promise<void> | void> = []
 
@@ -172,14 +173,18 @@ async function fixtureApp(): Promise<string> {
     // A slow non-agent route that records, at completion, whether its run
     // signal was aborted — the probe for disconnect-abort behavior.
     "src/app/noop/index.ts": [
-      'import { writeFile } from "node:fs/promises"',
+      'import { rename, writeFile } from "node:fs/promises"',
       "export const graph = async (",
       "  input: { probeFile?: string } | undefined,",
       "  ctx: { signal: AbortSignal },",
       ") => {",
       "  await new Promise((resolve) => setTimeout(resolve, 150))",
       "  if (input?.probeFile) {",
-      "    await writeFile(input.probeFile, JSON.stringify({ aborted: ctx.signal.aborted }))",
+      ...atomicWriteLines(
+        "input.probeFile",
+        "JSON.stringify({ aborted: ctx.signal.aborted })",
+        "    ",
+      ),
       "  }",
       "  return { ok: true }",
       "}",
@@ -205,18 +210,6 @@ function streamRequest(threadId: string, probeFile?: string): Request {
   })
 }
 
-async function waitForFile(path: string, timeoutMs = 15_000): Promise<string> {
-  const startedAt = Date.now()
-  while (Date.now() - startedAt < timeoutMs) {
-    try {
-      return await readFile(path, "utf8")
-    } catch {
-      await new Promise((resolve) => setTimeout(resolve, 25))
-    }
-  }
-  throw new Error(`probe file never appeared: ${path}`)
-}
-
 describe("runtime fetch handler parity", () => {
   // Not merely legacy parity: continuing on disconnect is the documented
   // decision for the durable AP surface. Explicit stop is POST /threads/:id/cancel.
@@ -238,9 +231,9 @@ describe("runtime fetch handler parity", () => {
     expect(handler.state.activeRequests).toBe(0)
 
     // ...but the run itself keeps going and completes un-aborted.
-    const probe = JSON.parse(await waitForFile(probeFile)) as {
-      aborted: boolean
-    }
+    const probe = await waitForJsonFile<{ aborted: boolean }>(probeFile, {
+      what: "disconnect probe",
+    })
     expect(probe.aborted).toBe(false)
 
     // With no active requests, close() resolves promptly.
@@ -260,7 +253,7 @@ describe("runtime fetch handler parity", () => {
 
     // Wait for the run to finish so shutdown has no background work — the
     // body is still entirely unread, so the in-flight slot is still held.
-    await waitForFile(probeFile)
+    await waitForFile(probeFile, { what: "unread probe" })
     expect(handler.state.activeRequests).toBe(1)
 
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {})


### PR DESCRIPTION
## Problem

The `validate` lane intermittently fails with:

```
FAIL @dawn-ai/cli test/runtime-fetch-parity.test.ts > runtime fetch handler parity > AP stream: client disconnect does not abort the run (deliberate)
SyntaxError: Unexpected end of JSON input
 ❯ test/runtime-fetch-parity.test.ts:241:24
```

Seen on 2026-09-04 in run 33905118173 (1 failed of 5841). A flake, not a regression.

`waitForFile` returned as soon as `readFile` succeeded. `writeFile` is **not** atomic — it opens with `O_TRUNC` and then writes, awaiting in between — so a poller could land in that window, read `""`, and hand it to `JSON.parse`.

## Fix

Both ends, in one shared helper (`test/helpers/probe-file.ts`) that the **three** near-duplicate copies of `waitForFile` now import — there was a third copy in `pending-interrupts-endpoint.test.ts` beyond the two originally spotted.

**Writer (removes the race at its source).** `atomicWriteLines()` emits `write temp → rename onto target` into the generated fixture routes. `rename` is atomic within a directory, so a reader sees either nothing or the whole body. Applied to all four probe writers.

**Reader (defence in depth).** `waitForFile` polls for *complete* content rather than existence. It accepts an `isComplete` predicate; returning false — or throwing, as `JSON.parse` does on a truncated read — keeps polling, still bounded by the timeout. `waitForJsonFile<T>` wraps that and returns the parsed value, so callers no longer parse the string themselves. On timeout the error distinguishes *never appeared* from *never completed*, quotes the last read, and attaches the parse failure as `cause`.

## Verification

The mechanism was reproduced rather than only observed to stop failing. Against a writer that creates the file and writes its body 150ms later:

```
OLD helper + JSON.parse  : THREW: SyntaxError: Unexpected end of JSON input   ← the CI error, exactly
NEW waitForJsonFile      : {"aborted":false}
ATOMIC write + new helper: {"aborted":false}
TIMEOUT (absent)         : disconnect probe never appeared: …/nope.json (waited 210ms)
TIMEOUT (incomplete)     : disconnect probe never completed: …/stuck.json (waited 219ms, last read "") | cause: SyntaxError
```

On Node 24:

- affected test **25/25** green
- all three modified files **20/20** green (1000 test executions)
- full CLI suite `1611 passed | 3 skipped`, exit 0
- `typecheck` clean; `lint` clean (8 warnings, all pre-existing, none in the touched files)

No changeset: test-only, ships nothing.

## Noted, not addressed here

A **separate** flake surface turned up while verifying. One full-suite run showed 20 failures across 6 files (`dev-command`, `vercel-target`, `typegen-command`, `build-targets`, `check-command`, `vercel-native-lane`). None reference anything changed here, they pass in isolation, and a **pristine-baseline full run also failed** (5 tests, a different file) — the failing set varies run to run on identical code, with slow runs at 271s vs 114s. That is load-induced timeout flakiness, likely a second independent source of intermittent `validate` reds, and wants its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)