### PR TITLE
test(release): arm the descendant kill clock only once the descendant exists

### DIFF
--- a/scripts/release/test/process-runner.test.mjs
+++ b/scripts/release/test/process-runner.test.mjs
@@ -1,6 +1,8 @@
 import assert from "node:assert/strict"
+import { spawn } from "node:child_process"
 import { EventEmitter } from "node:events"
-import { mkdtemp, readFile, rm } from "node:fs/promises"
+import { readFileSync } from "node:fs"
+import { mkdtemp, rm } from "node:fs/promises"
 import os from "node:os"
 import path from "node:path"
 import { PassThrough } from "node:stream"
@@ -10,6 +12,11 @@ import {
   createReleasePreparationRunner,
   PREPARATION_OVERALL_TIMEOUT_MS,
 } from "../process-runner.mjs"
+
+const DESCENDANT_POLL_MS = 20
+// Process-tree teardown on a saturated CI runner legitimately outlasts the old 2s budget.
+const DESCENDANT_EXIT_TIMEOUT_MS = 10_000
+const DESCENDANT_READY_TIMEOUT_MS = 15_000
 
 test("the production runner deadline stays inside the 30-minute workflow ceiling", () => {
   assert.equal(PREPARATION_OVERALL_TIMEOUT_MS, 25 * 60_000)
@@ -115,24 +122,44 @@ test("the production preparation runner accepts only explicitly allowed nonzero 
 
 test("the production preparation runner terminates descendants on timeout", {
   skip: process.platform === "win32",
+  timeout: 30_000,
 }, async (t) => {
   const temporary = await mkdtemp(path.join(os.tmpdir(), "dawn-runner-tree-"))
   t.after(() => rm(temporary, { recursive: true, force: true }))
   const pidPath = path.join(temporary, "descendant.pid")
+  // The helper renames a fully written temporary file into place so the runner can never
+  // observe a half-written pid, however the termination signal interleaves with the write.
   const source = [
     "const { spawn } = require('node:child_process')",
-    "const { writeFileSync } = require('node:fs')",
+    "const { renameSync, writeFileSync } = require('node:fs')",
     "const child = spawn(process.execPath, ['-e', 'setInterval(() => {}, 1000)'], { stdio: 'ignore' })",
-    `writeFileSync(${JSON.stringify(pidPath)}, String(child.pid))`,
+    `writeFileSync(${JSON.stringify(`${pidPath}.tmp`)}, String(child.pid))`,
+    `renameSync(${JSON.stringify(`${pidPath}.tmp`)}, ${JSON.stringify(pidPath)})`,
     "setInterval(() => {}, 1000)",
   ].join(";")
+  let descendantPid
   const run = createReleasePreparationRunner({
     commandTimeoutMs: 100,
     overallTimeoutMs: 2_000,
+    spawnImpl(command, args, options) {
+      const child = spawn(command, args, options)
+      // The runner arms its deadline as soon as this returns, so the descendant has to
+      // exist first. Otherwise the 100ms budget races helper startup instead of proving
+      // that termination reaches the whole process tree, and a loaded machine kills the
+      // helper before it ever records its child.
+      try {
+        descendantPid = awaitDescendantPid(pidPath)
+      } catch (error) {
+        // The runner only ever cleans up a child it was handed, so a wrapper that throws
+        // owns the tree it already started; leaking it would hang the test run.
+        killProcessGroup(child)
+        throw error
+      }
+      return child
+    },
   })
 
   await assert.rejects(run(process.execPath, ["-e", source], { cwd: temporary }), /timed out/iu)
-  const descendantPid = Number(await readFile(pidPath, "utf8"))
   await waitForProcessExit(descendantPid)
 })
 
@@ -158,8 +185,64 @@ test("the production preparation runner uses taskkill for a Windows process tree
   assert.deepEqual(taskkills, [{ pid: 4242, timeoutMs: 2_000 }])
 })
 
+test("descendant pid readiness rejects every incomplete file", () => {
+  for (const incomplete of [
+    "",
+    " ",
+    "\n",
+    "0",
+    "-1",
+    "01",
+    "1\n",
+    "not-a-pid",
+    "9007199254740992",
+  ]) {
+    assert.equal(
+      readDescendantPid("unused", () => incomplete),
+      null,
+      `expected ${JSON.stringify(incomplete)} to read as an incomplete pid`,
+    )
+  }
+  assert.equal(
+    readDescendantPid("unused", () => "12345"),
+    12345,
+  )
+
+  const missing = Object.assign(new Error("missing"), { code: "ENOENT" })
+  assert.equal(
+    readDescendantPid("unused", () => {
+      throw missing
+    }),
+    null,
+  )
+  const denied = Object.assign(new Error("denied"), { code: "EACCES" })
+  assert.throws(
+    () =>
+      readDescendantPid("unused", () => {
+        throw denied
+      }),
+    (error) => error === denied,
+  )
+})
+
+test("waiting on a descendant rejects a pid that was never recorded", async () => {
+  // Signal 0 addressed to pid 0 targets the caller's own process group, which always
+  // exists, so an unvalidated pid would poll until its deadline and then report the
+  // descendant as a survivor. Every invalid pid has to fail as what it is instead.
+  for (const invalid of [0, -1, Number.NaN, 1.5]) {
+    await assert.rejects(waitForProcessExit(invalid), (error) => {
+      assert.match(error.message, /is not a recorded descendant pid/u)
+      assert.doesNotMatch(error.message, /survived/u)
+      return true
+    })
+  }
+})
+
 async function waitForProcessExit(pid) {
-  const deadline = Date.now() + 2_000
+  if (!Number.isSafeInteger(pid) || pid < 1) {
+    throw new Error(`${pid} is not a recorded descendant pid`)
+  }
+  const deadline = Date.now() + DESCENDANT_EXIT_TIMEOUT_MS
   while (Date.now() < deadline) {
     try {
       process.kill(pid, 0)
@@ -167,7 +250,44 @@ async function waitForProcessExit(pid) {
       if (error?.code === "ESRCH") return
       throw error
     }
-    await new Promise((resolve) => setTimeout(resolve, 20))
+    await new Promise((resolve) => setTimeout(resolve, DESCENDANT_POLL_MS))
   }
   assert.fail(`descendant process ${pid} survived the runner timeout`)
+}
+
+// Blocks the caller until the helper has recorded a complete pid. This runs inside
+// spawnImpl, before the runner starts its own clock, so waiting here costs the command
+// deadline nothing and no amount of load can turn a slow helper into a phantom survivor.
+function awaitDescendantPid(target, timeoutMs = DESCENDANT_READY_TIMEOUT_MS) {
+  const deadline = Date.now() + timeoutMs
+  const idle = new Int32Array(new SharedArrayBuffer(4))
+  for (;;) {
+    const pid = readDescendantPid(target)
+    if (pid !== null) return pid
+    if (Date.now() >= deadline) {
+      throw new Error(`Descendant pid was not recorded in ${target} within ${timeoutMs}ms`)
+    }
+    Atomics.wait(idle, 0, 0, DESCENDANT_POLL_MS)
+  }
+}
+
+function killProcessGroup(child) {
+  if (!Number.isSafeInteger(child?.pid) || child.pid < 1) return
+  try {
+    process.kill(-child.pid, "SIGKILL")
+  } catch (error) {
+    if (error?.code !== "ESRCH") throw error
+  }
+}
+
+function readDescendantPid(target, read = readFileSync) {
+  try {
+    const source = read(target, "utf8")
+    if (!/^[1-9]\d*$/u.test(source)) return null
+    const pid = Number(source)
+    return Number.isSafeInteger(pid) ? pid : null
+  } catch (error) {
+    if (error?.code === "ENOENT") return null
+    throw error
+  }
 }


### PR DESCRIPTION
## The failure

`validate` intermittently failed the process-tree termination test ([run 33908878661](https://github.com/cacheplane/dawnai/actions/runs/33908878661)), on a PR that added only a markdown changeset:

```
✖ the production preparation runner terminates descendants on timeout (2165ms)
  AssertionError: descendant process 0 survived the runner timeout
```

## Root cause

The reported chain is real, and I confirmed every link:

1. `writeFileSync` opens with `O_TRUNC` before writing, so a kill landing in that window leaves the file present but empty.
2. `Number("")` is `0`.
3. **Signal 0 addressed to pid 0 targets the caller's own process group**, which always exists — so the poll loop could never observe `ESRCH` and always fell through to the survivor assertion. (`Number.parseInt("", 10)` is `NaN`, which is why `published-artifacts.test.mjs`, which uses `parseInt`, never showed this symptom.)

But that is the rare mode, not the cause. **The test armed the runner's 100 ms kill clock before the helper existed.** Helper startup — node boot, spawn, pid write — is ~50 ms idle and routinely exceeds 100 ms under load, so the kill landed either *before* the write (`ENOENT`, the wide window) or *inside* the truncate→write gap (empty file, the narrow one). Under synthetic load the original fails **16 of 25 runs, every failure `ENOENT`**.

This matters: validating the pid alone would not have de-flaked the test. If the helper is killed before writing, the file never appears and no amount of polling helps — it would only have converted a rare confusing flake into a common clearly-labelled one.

## The fix

Gate the clock on readiness instead. `spawnImpl` performs the real spawn, then blocks synchronously (`Atomics.wait` — a real sleep, not a spin) until the pid file holds a complete pid. The runner arms its timer the moment `spawnImpl` returns, so waiting there costs the command deadline nothing and races nothing.

A wrapper that throws **owns the tree it already started** — the runner only cleans up a child it was handed. An early version of this got that wrong, leaked the helper and hung the run; it now kills the group before rethrowing. That path fails in 476 ms with `[cause]: Descendant pid was not recorded in … within 300ms`.

Defense in depth behind that:

- the helper renames a finished temp file into place, so a partial read is impossible at the source;
- pid reads are validated against the `readPublisherDescendantPid` idiom already in `publisher.test.mjs`;
- `waitForProcessExit` rejects pid < 1 outright rather than probing the process group;
- its exit budget goes from 2 s to 10 s, since teardown under CI load can legitimately exceed 2 s.

Two guard tests cover the readiness parsing and the invalid-pid rejection. The latter was written first and fails against the old helper at 2002 ms with the exact CI message.

## Verification

Reproduced the mechanism rather than relying on a green run. Interleaved A/B under identical 50-way CPU oversubscription, pass/fail read from exit codes:

| | original | fixed |
|---|---|---|
| descendant test, 25 runs | 9 pass / 16 fail | 25 / 0 |
| descendant test, 60 runs | — | **60 / 0** |
| full file, 30 runs | 5 / 25 | 28 / 2 |

No leaked helper processes after any run. No measurable runtime cost. Test-only change — `scripts/release/process-runner.mjs` (which *is* content-pinned) is untouched.

## Two things deliberately left alone

- **The 2 residual full-file failures are different, untouched tests.** `enforces one overall deadline` and `accepts only explicitly allowed nonzero exits` give a bare `node -e ""` a 1000 ms budget and do fail under that same synthetic load. They hold ~20× headroom on a real runner against the ~2× this test had, which is why only this one reached CI. Worth a follow-up if we want the file hardened; widening a flake fix to chase them seemed wrong.
- **The helper cannot be shared with the `probe-file.ts` one added in #564.** Same bug class, but that helper is TypeScript inside `packages/cli`, and `scripts/` runs plain `.mjs` under `node --test` with no transpile step. A `scripts/release/test/support/` equivalent would still be worth extracting — the pattern is copied across `process-runner.test.mjs`, `publisher.test.mjs`, `published-artifacts.test.mjs` and `smoke-process-runner.test.mjs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)