### PR TITLE
release: adjudicate the smoke gate for a published candidate that cannot finish

### DIFF
--- a/docs/superpowers/runbooks/2026-09-04-smoke-gate-adjudication.md
+++ b/docs/superpowers/runbooks/2026-09-04-smoke-gate-adjudication.md
@@ -1,0 +1,88 @@
+# Smoke gate adjudication
+
+How to close out a candidate whose packages published correctly but whose own
+smoke lanes cannot pass.
+
+## When this applies
+
+All of the following must be true. If any is false, do not adjudicate.
+
+1. The candidate's packages are published and correct, with npm provenance that
+   verifies against the candidate commit.
+2. One or more required smoke lanes fail **deterministically**, and the cause is
+   a defect in the candidate's own smoke scripts rather than evidence about the
+   published packages.
+3. The defect cannot be fixed in place. Every release job except `detect` checks
+   out `candidate_sha`, so a fix merged to main reaches only the *next*
+   candidate.
+4. The tag cannot be moved, because `validateExactPublishedPackageEvidence`
+   rejects a candidate whose commit disagrees with the published provenance.
+
+If the packages did not publish, this is not the tool. A pre-publication
+candidate is abandoned instead (`ABANDONED_PREPUBLICATION`).
+
+## Why an adjudication is needed at all
+
+The controller selects the oldest **incomplete** candidate, and only
+`NO_CANDIDATE`, `SUPERSEDED_NOOP`, `AUDIT_COMPLETE` and
+`ABANDONED_PREPUBLICATION` are terminal. A published candidate stuck at the
+smoke gate is therefore re-selected forever, and no later version can be
+released. Cutting a newer version does **not** supersede it.
+
+## What the record does and does not do
+
+- It records that an operator reviewed the lane outcomes and adjudicated the
+  **smoke gate only**, for one exactly-named candidate.
+- It never asserts that the lanes passed. Each lane carries its real outcome
+  (`passed`, `failed`, `flaked`) and the reason.
+- The **audit gate stays live**. Adjudication moves the candidate to
+  `SMOKES_COMPLETE`; the release audit still has to run and verify.
+- It only advances a candidate whose packages actually published
+  (`evidence.npm.complete`).
+
+## Writing one
+
+Create `scripts/release/smoke-adjudications/v<version>.json`. Every field is
+required, and the record is rejected outright if anything is unexpected.
+
+- `version`, `commitSha`, `manifestSha256` — the exact candidate. All three must
+  match the observed candidate or the record does nothing.
+- `adjudicatedLanes` — every required lane, with its true outcome and a detail
+  explaining it. Missing or extra lanes void the record, so a lane added later
+  is never silently waived.
+- `authority` — `mode` is always `operator-adjudication`; record the operator and
+  the commit whose evidence was reviewed.
+- `remediation` — the commit that fixes the defect, and what it changed.
+- `reason` — why this candidate cannot finish without adjudication.
+
+Then re-run the release. `detect` reads the record from the controller ref,
+`smokeAdjudicationApplies` binds it to the candidate, and the state advances.
+
+## Failure modes it is built to refuse
+
+A record that is absent, unreadable, malformed, filed under the wrong version,
+carrying unknown fields, or naming a different version, commit, manifest or lane
+set has **no effect**. Every one of these leaves the smoke gate shut. This is
+deliberate: the failure mode of an adjudication must be "the release stays
+stuck", never "the gate opens wider than intended".
+
+## Pin coverage
+
+The controller state machine this relies on — `observe.mjs`, `evidence.mjs`,
+`state.mjs`, `observation-schema.mjs` and `smoke-adjudication.mjs` — is content
+pinned, so a change to the adjudication path fails
+`pnpm test:release-controller` until the reviewed fixture is regenerated in the
+same commit. That coverage came from the import-closure pinning added alongside
+this mechanism; before it, only scripts named directly on workflow command lines
+were pinned, and this module would not have been.
+
+The adjudication **records** are not pinned by that gate, because they are data
+rather than executed code. A record is instead constrained by its own schema and
+by exact binding to one candidate: the strongest review point is the pull request
+that adds the record.
+
+## History
+
+First used for v0.8.24 (2026-09-04). Its `storage` and `runtime-targets` lanes
+carried defects fixed on main in `2689ef8d`, which could not reach the frozen
+candidate `88c01c4a`. All 21 packages had already published correctly.

--- a/scripts/release/evidence.mjs
+++ b/scripts/release/evidence.mjs
@@ -5,6 +5,7 @@ import {
   observationStructureIsValid,
 } from "./observation-schema.mjs"
 import { compareSemver, isExactSemver } from "./semver.mjs"
+import { smokeAdjudicationApplies } from "./smoke-adjudication.mjs"
 
 const SHA256_PATTERN = /^[0-9a-f]{64}$/u
 
@@ -67,7 +68,12 @@ function invalidEvidence(conflicts) {
       latestNewer: false,
       ambiguous: false,
     }),
-    smokes: Object.freeze({ complete: false, anyPassed: false, ambiguous: false }),
+    smokes: Object.freeze({
+      complete: false,
+      anyPassed: false,
+      ambiguous: false,
+      adjudicated: false,
+    }),
     audit: Object.freeze({
       dispatched: false,
       complete: false,
@@ -666,11 +672,19 @@ function analyzeNpm(candidate, observation, packageByName, conflicts) {
 }
 
 function analyzeSmokes(candidate, observation, manifestSha256, conflicts) {
+  // An adjudication only ever satisfies the gate for the exact candidate it
+  // names; it never asserts that the lanes passed. See smoke-adjudication.mjs.
+  const adjudicated = smokeAdjudicationApplies(observation.smokeAdjudication ?? null, {
+    commitSha: candidate.commitSha,
+    manifestSha256,
+    requiredLanes: observation.requiredSmokeLanes,
+    version: candidate.version,
+  })
   const lanes = observation.requiredSmokeLanes
   const results = Array.isArray(observation.smokes) ? observation.smokes : []
   if (!Array.isArray(lanes)) {
     conflicts.add("required-smoke-lanes-missing")
-    return Object.freeze({ complete: false, anyPassed: false, ambiguous: false })
+    return Object.freeze({ complete: false, anyPassed: false, ambiguous: false, adjudicated })
   }
   if (lanes.length === 0) conflicts.add("required-smoke-lanes-empty")
   if (new Set(lanes).size !== lanes.length) conflicts.add("required-smoke-lane-duplicate")
@@ -718,6 +732,7 @@ function analyzeSmokes(candidate, observation, manifestSha256, conflicts) {
     complete,
     anyPassed: results.some((result) => result.status === "passed"),
     ambiguous,
+    adjudicated,
   })
 }
 

--- a/scripts/release/observation-schema.mjs
+++ b/scripts/release/observation-schema.mjs
@@ -1,6 +1,7 @@
 import { createHash } from "node:crypto"
 import { canonicalReleaseBody, parseSmokeReleaseAssetName } from "./metadata.mjs"
 import { isExactSemver, parseSemver } from "./semver.mjs"
+import { SMOKE_ADJUDICATION_RECORD_FIELDS } from "./smoke-adjudication.mjs"
 
 const PLANNER_FIELDS = Object.freeze(["candidate", "observation", "mode"])
 const CANDIDATE_FIELDS = Object.freeze([
@@ -46,6 +47,7 @@ const OBSERVATION_FIELDS = Object.freeze([
   "smokes",
   "audit",
   "abandonment",
+  "smokeAdjudication",
 ])
 const SMOKE_FIELDS = Object.freeze([
   "name",
@@ -65,6 +67,11 @@ const AUDIT_FIELDS = Object.freeze([
   "runAttempt",
   "conclusion",
 ])
+
+function smokeAdjudicationShapeValid(value) {
+  if (value === undefined || value === null) return true
+  return hasExactFields(value, SMOKE_ADJUDICATION_RECORD_FIELDS)
+}
 
 export function snapshotPlannerInput(input) {
   assertPlannerRoot(input)
@@ -88,7 +95,12 @@ export function snapshotReleaseInput(candidate, observation) {
 export function findObservationSchemaConflicts(observation) {
   const conflicts = new Set()
   if (!isRecord(observation)) return ["observation-schema-invalid"]
-  if (!hasExactFields(observation, OBSERVATION_FIELDS, ["requiredSmokeLanes"])) {
+  if (
+    !hasExactFields(observation, OBSERVATION_FIELDS, ["requiredSmokeLanes", "smokeAdjudication"])
+  ) {
+    conflicts.add("observation-schema-invalid")
+  }
+  if (!smokeAdjudicationShapeValid(observation.smokeAdjudication)) {
     conflicts.add("observation-schema-invalid")
   }
   const structurallyValid =

--- a/scripts/release/observe.mjs
+++ b/scripts/release/observe.mjs
@@ -31,6 +31,7 @@ import {
   releaseRecordSha256,
 } from "./release-record.mjs"
 import { compareSemver, isExactSemver, parseSemver } from "./semver.mjs"
+import { readSmokeAdjudication } from "./smoke-adjudication.mjs"
 import {
   aggregateSmokeResults,
   canonicalAggregateSmokeResultBytes,
@@ -397,6 +398,25 @@ export async function observeProductionCandidate({
       error instanceof TypeError ? "TERMINAL_RECORD_INVALID" : "TERMINAL_RECORD_UNREADABLE",
     )
   }
+  let smokeAdjudication = null
+  try {
+    smokeAdjudication = await readSmokeAdjudication({
+      git,
+      ref: terminalRecordRef,
+      version: identity.version,
+    })
+  } catch (error) {
+    // A present-but-unreadable adjudication must never widen into a waiver: leave it null so the
+    // smoke gate stays shut, and record why an operator's record did not take effect.
+    smokeAdjudication = null
+    addDiagnostic(
+      diagnostics,
+      "git",
+      "smoke-adjudication",
+      "AMBIGUOUS",
+      error instanceof TypeError ? "SMOKE_ADJUDICATION_INVALID" : "SMOKE_ADJUDICATION_UNREADABLE",
+    )
+  }
   if (
     committedTerminalRecord !== null &&
     !terminalRecordBindsCandidate(committedTerminalRecord, identity)
@@ -686,6 +706,7 @@ export async function observeProductionCandidate({
         : pendingProductionSmokeObservations(identity, artifacts.manifestSha256),
     audit: releaseState.audit,
     abandonment,
+    smokeAdjudication,
   }
   diagnostics.sort(compareDiagnostics)
   const result = { observation, diagnostics }

--- a/scripts/release/smoke-adjudication.mjs
+++ b/scripts/release/smoke-adjudication.mjs
@@ -1,0 +1,203 @@
+// Operator adjudication of the release smoke gate for a single, exactly-pinned
+// candidate.
+//
+// This exists for one failure mode: a candidate whose packages published
+// correctly but whose own frozen smoke lanes cannot pass, because every release
+// job outside the controller checks out the candidate commit. A defect in that
+// commit's smoke scripts reproduces identically on every re-dispatch, and the
+// published packages' npm provenance binds them to that commit, so the tag
+// cannot be moved to pick up a fix. Without an adjudication the candidate can
+// never reach a terminal state, and no later version can be released.
+//
+// The record NEVER claims the smokes passed. It records that an operator
+// reviewed the lane outcomes and adjudicated the gate, and it is bound to one
+// version, one commit and one manifest digest, so it cannot apply to any other
+// candidate.
+
+const SHA256 = /^[0-9a-f]{64}$/u
+const SHA1 = /^[0-9a-f]{40}$/u
+const EXACT_SEMVER = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/u
+
+export const SMOKE_ADJUDICATION_RECORD_FIELDS = Object.freeze([
+  "adjudicatedLanes",
+  "authority",
+  "commitSha",
+  "kind",
+  "manifestSha256",
+  "reason",
+  "remediation",
+  "schemaVersion",
+  "version",
+])
+const LANE_FIELDS = Object.freeze(["detail", "name", "outcome"])
+const AUTHORITY_FIELDS = Object.freeze(["capturedAt", "mode", "operator", "reviewedCommit"])
+const LANE_OUTCOMES = Object.freeze(["passed", "failed", "flaked"])
+const REMEDIATION_FIELDS = Object.freeze(["fixCommitSha", "summary"])
+
+function isPlainObject(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+}
+
+function hasExactFields(value, fields) {
+  if (!isPlainObject(value)) return false
+  const keys = Reflect.ownKeys(value)
+  if (keys.some((key) => typeof key !== "string")) return false
+  return keys.length === fields.length && fields.every((field) => keys.includes(field))
+}
+
+function boundedText(value, max) {
+  return typeof value === "string" && value.length > 0 && value.length <= max
+}
+
+/**
+ * Parse a smoke adjudication record. Throws on anything unexpected: an
+ * adjudication that cannot be fully understood must never take effect.
+ */
+export function parseSmokeAdjudication(value) {
+  if (!hasExactFields(value, SMOKE_ADJUDICATION_RECORD_FIELDS)) {
+    throw new TypeError("Smoke adjudication record fields are invalid")
+  }
+  if (value.schemaVersion !== 1) {
+    throw new TypeError("Smoke adjudication schema version is unsupported")
+  }
+  if (value.kind !== "smoke-gate-adjudicated") {
+    throw new TypeError("Smoke adjudication kind is unsupported")
+  }
+  if (typeof value.version !== "string" || !EXACT_SEMVER.test(value.version)) {
+    throw new TypeError("Smoke adjudication version must be exact SemVer")
+  }
+  if (typeof value.commitSha !== "string" || !SHA1.test(value.commitSha)) {
+    throw new TypeError("Smoke adjudication commit is invalid")
+  }
+  if (typeof value.manifestSha256 !== "string" || !SHA256.test(value.manifestSha256)) {
+    throw new TypeError("Smoke adjudication manifest digest is invalid")
+  }
+  if (!boundedText(value.reason, 2_048)) {
+    throw new TypeError("Smoke adjudication reason is required")
+  }
+  if (!hasExactFields(value.authority, AUTHORITY_FIELDS)) {
+    throw new TypeError("Smoke adjudication authority is invalid")
+  }
+  if (value.authority.mode !== "operator-adjudication") {
+    throw new TypeError("Smoke adjudication authority mode is unsupported")
+  }
+  if (!boundedText(value.authority.operator, 256)) {
+    throw new TypeError("Smoke adjudication operator is required")
+  }
+  if (
+    typeof value.authority.reviewedCommit !== "string" ||
+    !SHA1.test(value.authority.reviewedCommit)
+  ) {
+    throw new TypeError("Smoke adjudication reviewed commit is invalid")
+  }
+  if (
+    typeof value.authority.capturedAt !== "string" ||
+    Number.isNaN(Date.parse(value.authority.capturedAt))
+  ) {
+    throw new TypeError("Smoke adjudication capture time is invalid")
+  }
+  if (!hasExactFields(value.remediation, REMEDIATION_FIELDS)) {
+    throw new TypeError("Smoke adjudication remediation is invalid")
+  }
+  if (
+    typeof value.remediation.fixCommitSha !== "string" ||
+    !SHA1.test(value.remediation.fixCommitSha)
+  ) {
+    throw new TypeError("Smoke adjudication remediation commit is invalid")
+  }
+  if (!boundedText(value.remediation.summary, 2_048)) {
+    throw new TypeError("Smoke adjudication remediation summary is required")
+  }
+  if (!Array.isArray(value.adjudicatedLanes) || value.adjudicatedLanes.length === 0) {
+    throw new TypeError("Smoke adjudication must record every lane outcome")
+  }
+  const names = new Set()
+  for (const lane of value.adjudicatedLanes) {
+    if (!hasExactFields(lane, LANE_FIELDS)) {
+      throw new TypeError("Smoke adjudication lane fields are invalid")
+    }
+    if (!boundedText(lane.name, 128)) throw new TypeError("Smoke adjudication lane name is invalid")
+    if (names.has(lane.name)) throw new TypeError("Smoke adjudication lane is duplicated")
+    names.add(lane.name)
+    if (!LANE_OUTCOMES.includes(lane.outcome)) {
+      throw new TypeError("Smoke adjudication lane outcome is unsupported")
+    }
+    if (!boundedText(lane.detail, 2_048)) {
+      throw new TypeError("Smoke adjudication lane detail is required")
+    }
+  }
+  return Object.freeze({
+    adjudicatedLanes: Object.freeze(
+      value.adjudicatedLanes.map((lane) =>
+        Object.freeze({ detail: lane.detail, name: lane.name, outcome: lane.outcome }),
+      ),
+    ),
+    authority: Object.freeze({ ...value.authority }),
+    commitSha: value.commitSha,
+    kind: value.kind,
+    manifestSha256: value.manifestSha256,
+    reason: value.reason,
+    remediation: Object.freeze({ ...value.remediation }),
+    schemaVersion: value.schemaVersion,
+    version: value.version,
+  })
+}
+
+/**
+ * An adjudication applies only to the exact candidate it names. Every identity
+ * field must match, and the required lanes must be covered exactly, so a record
+ * can never be inherited by a later candidate or widened after review.
+ */
+export function smokeAdjudicationApplies(record, candidate) {
+  if (record === null || record === undefined) return false
+  if (!isPlainObject(candidate)) return false
+  const { commitSha, manifestSha256, requiredLanes, version } = candidate
+  if (record.version !== version) return false
+  if (record.commitSha !== commitSha) return false
+  if (record.manifestSha256 !== manifestSha256) return false
+  if (!Array.isArray(requiredLanes) || requiredLanes.length === 0) return false
+  const adjudicated = new Set(record.adjudicatedLanes.map((lane) => lane.name))
+  if (adjudicated.size !== requiredLanes.length) return false
+  return requiredLanes.every((lane) => adjudicated.has(lane))
+}
+
+export function smokeAdjudicationPath(version) {
+  if (typeof version !== "string" || !EXACT_SEMVER.test(version)) {
+    throw new TypeError("Smoke adjudication version must be exact SemVer")
+  }
+  return `scripts/release/smoke-adjudications/v${version}.json`
+}
+
+/**
+ * Read the adjudication for one version from git at an explicit ref, mirroring
+ * how terminal records are read. Absence is normal and yields null; a record
+ * that exists but cannot be validated throws, so a damaged or tampered
+ * adjudication fails closed instead of silently waiving the gate.
+ */
+export async function readSmokeAdjudication({ git, ref, version }) {
+  if (typeof git?.listTree !== "function" || typeof git?.showFile !== "function") {
+    throw new TypeError("Smoke adjudication git reader is invalid")
+  }
+  if (typeof ref !== "string" || ref.length === 0) {
+    throw new TypeError("Smoke adjudication ref is invalid")
+  }
+  const path = smokeAdjudicationPath(version)
+  const tree = await git.listTree({ ref })
+  if (typeof tree !== "string") throw new TypeError("Smoke adjudication tree listing is invalid")
+  const paths = new Set(tree.split("\n").filter((line) => line.length > 0))
+  if (!paths.has(path)) return null
+  const text = await git.showFile({ ref, path })
+  if (typeof text !== "string") throw new TypeError("Smoke adjudication contents are invalid")
+  let parsed
+  try {
+    parsed = parseSmokeAdjudication(JSON.parse(text))
+  } catch (error) {
+    throw new TypeError(`Smoke adjudication ${path} is invalid: ${error.message}`, { cause: error })
+  }
+  // The path names the version, so a record whose own identity disagrees with it is filed under a
+  // version it does not describe; binding them here keeps callers from trusting the path alone.
+  if (parsed.version !== version) {
+    throw new TypeError(`Smoke adjudication ${path} names another version`)
+  }
+  return parsed
+}

--- a/scripts/release/smoke-adjudications/v0.8.24.json
+++ b/scripts/release/smoke-adjudications/v0.8.24.json
@@ -1,0 +1,45 @@
+{
+  "adjudicatedLanes": [
+    {
+      "detail": "Passed in release run 33913051310 after the registry served the attestation for the last-published package; the earlier failure was convergence lag, not a defect.",
+      "name": "metadata",
+      "outcome": "passed"
+    },
+    {
+      "detail": "Failed in release run 33913051310 on the known sandbox fork-bomb flake: the PID-exhausted keeper assertion compares two identical container ids under notStrictEqual. A flake in the lane, not evidence about the published packages.",
+      "name": "published-harness",
+      "outcome": "flaked"
+    },
+    {
+      "detail": "Failed deterministically: the candidate's node runtime probe asserts typeof graphAdapter === \"function\", but graphAdapter is and always has been a BackendAdapter object exposing kind \"graph\" with execute and stream. Verified directly against the published @dawn-ai/langgraph@0.8.24. The probe is wrong; the package is correct.",
+      "name": "runtime-targets",
+      "outcome": "failed"
+    },
+    {
+      "detail": "Passed in release run 33913051310, exercising the published scaffolder end to end: create, install, typecheck, build and run.",
+      "name": "scaffold",
+      "outcome": "passed"
+    },
+    {
+      "detail": "Failed deterministically: runRuntimeSmoke passes includeOpenAi as a command option, which the candidate's strict systemd runner rejects as a field outside its allowlist, so both storage runtime probes died before touching the published packages. A defect in the lane's own plumbing.",
+      "name": "storage",
+      "outcome": "failed"
+    }
+  ],
+  "authority": {
+    "capturedAt": "2026-09-04T20:30:00.000Z",
+    "mode": "operator-adjudication",
+    "operator": "blove",
+    "reviewedCommit": "f3766a9eac7de7c0df42a5424df73117a69ae26a"
+  },
+  "commitSha": "88c01c4afd59866fc0ea4c8f3b8444439a01c8ea",
+  "kind": "smoke-gate-adjudicated",
+  "manifestSha256": "68e45c7d302147f387c4cd68586a4e6411ea6a7c7889f6e2edc32a0793696e5c",
+  "reason": "All 21 packages published correctly at 0.8.24 with valid npm provenance, and reconcile-npm succeeded. Two of the five smoke lanes carry defects in the candidate's own scripts, and every release job outside the controller checks out the candidate commit, so those lanes fail identically on every re-dispatch. The published packages' provenance binds them to this commit, so the tag cannot be moved to pick up the fix. Without this adjudication the candidate can never reach a terminal state and no later version can be released. Only the smoke gate is adjudicated: the release audit still runs.",
+  "remediation": {
+    "fixCommitSha": "2689ef8d260b089bbb2ed105b165e625409d8701",
+    "summary": "Both lane defects are fixed on main: every lane now passes only strict-runner contract fields at its boundary, and the runtime-target probe asserts the real BackendAdapter contract. The fixes reach the next candidate, which is where they are proven."
+  },
+  "schemaVersion": 1,
+  "version": "0.8.24"
+}

--- a/scripts/release/state.mjs
+++ b/scripts/release/state.mjs
@@ -114,6 +114,12 @@ function classifySnapshot(observation, evidence) {
   if (evidence.assets.smokesReconciled && evidence.smokes.complete) {
     return ReleaseState.SMOKES_COMPLETE
   }
+  // A candidate whose own frozen smoke lanes cannot pass is adjudicated by an
+  // operator record bound to that exact candidate. The audit gate below stays
+  // live: only the smoke gate is adjudicated, and only for the named candidate.
+  if (evidence.smokes.adjudicated && evidence.npm.complete) {
+    return ReleaseState.SMOKES_COMPLETE
+  }
   if (evidence.assets.npmReconciled && evidence.npm.complete) {
     return ReleaseState.RELEASE_DRAFT_COMPLETE
   }

--- a/scripts/release/test/fixtures/release-script-hashes.json
+++ b/scripts/release/test/fixtures/release-script-hashes.json
@@ -71,7 +71,7 @@
       "sha256": "01fed2681f86b452ec5f2323190e0cbfdce2ce265c62c185ca802464f3e8a2fb"
     },
     "scripts/release/evidence.mjs": {
-      "sha256": "4c509c699fe8bd2fc9dd46468e849eb0d05e8206d43e1d3debc7c2fdb1a1836f"
+      "sha256": "d75eca0a21c2ecef2b0041f4aa3a4c3b0052c329820f8a96b1be9845a379405d"
     },
     "scripts/release/fixture-io.mjs": {
       "sha256": "427419a41951adb53720470d80f1defca030f8eb9289dae50c704f332e5f9ac0"
@@ -101,10 +101,10 @@
       "sha256": "fc14058dcf57fd3252cf758d8f58ee2795a5d5f210f41231a794018b17366b74"
     },
     "scripts/release/observation-schema.mjs": {
-      "sha256": "168c24767b3b891e769e4b1447942a0786f9da1965db8d13b2fd82c540edd74b"
+      "sha256": "fc3847533cbf01b8fa2420f484680a7576b8b2b4edf4d6f41f56df925f4914c3"
     },
     "scripts/release/observe.mjs": {
-      "sha256": "ed3a23d3ac333ae17a9637a347d4b34c5fe9db178586157f66809b5e8216424a"
+      "sha256": "1c19385a438555a0715aacbf0b2ef616cce81a6cc4906dbe44cc8562c6d51c8f"
     },
     "scripts/release/planner.mjs": {
       "sha256": "c68760ef160b100ad20233fe7c3608e381b976158b248ff6ee3bceccf3023d0f"
@@ -129,6 +129,9 @@
     },
     "scripts/release/semver.mjs": {
       "sha256": "fee872a1dddfa280cf0efe608525cad6d9f42d8d647a9ccf2ef9be1b7c41a06a"
+    },
+    "scripts/release/smoke-adjudication.mjs": {
+      "sha256": "3cbcdaab65d37a970043338b04341fc6ebf2ecafb1f3dda5709aa329e72390e6"
     },
     "scripts/release/smoke-command-shim.mjs": {
       "sha256": "ee2691f7b31b03ecd1b2501b74d72f7491f92350cb0fc74d5251ab812f64dc04"
@@ -158,7 +161,7 @@
       "sha256": "be07add60b15362476e45f5705b9f6fcdb44d0b005ee277a6538cae07f189798"
     },
     "scripts/release/state.mjs": {
-      "sha256": "15aba66d4234bd11db65c11dbaf8efa3825c6660f7a024cbb67c714120780863"
+      "sha256": "81e852b5c9d1dd6f34ab0cceb28002b7917f364e749e1a0e1b2ddff4e35c2479"
     },
     "scripts/release/terminal-record-store.mjs": {
       "sha256": "cd5561d0dfb8e959ae180f851791b26b7611e2252c6cb4ac4a6718bdeab0225a"

--- a/scripts/release/test/smoke-adjudication.test.mjs
+++ b/scripts/release/test/smoke-adjudication.test.mjs
@@ -1,0 +1,317 @@
+import assert from "node:assert/strict"
+import { readFile } from "node:fs/promises"
+import test from "node:test"
+import {
+  parseSmokeAdjudication,
+  readSmokeAdjudication,
+  smokeAdjudicationApplies,
+  smokeAdjudicationPath,
+} from "../smoke-adjudication.mjs"
+import { REQUIRED_RELEASE_SMOKE_LANES } from "../smoke-result.mjs"
+
+const COMMIT = "88c01c4afd59866fc0ea4c8f3b8444439a01c8ea"
+const FIX_COMMIT = "2689ef8d260b089bbb2ed105b165e625409d8701"
+const REVIEWED = "f3766a9e" + "0".repeat(32)
+const MANIFEST = "68e45c7d302147f387c4cd68586a4e6411ea6a7c7889f6e2edc32a0793696e5c"
+const LANES = ["metadata", "published-harness", "runtime-targets", "scaffold", "storage"]
+
+function record(overrides = {}) {
+  return {
+    adjudicatedLanes: LANES.map((name) => ({
+      detail: `${name} outcome reviewed by the operator`,
+      name,
+      outcome: name === "scaffold" || name === "metadata" ? "passed" : "failed",
+    })),
+    authority: {
+      capturedAt: "2026-09-04T20:00:00.000Z",
+      mode: "operator-adjudication",
+      operator: "blove",
+      reviewedCommit: REVIEWED,
+    },
+    commitSha: COMMIT,
+    kind: "smoke-gate-adjudicated",
+    manifestSha256: MANIFEST,
+    reason: "The candidate's own smoke lanes carry defects that cannot be fixed in place.",
+    remediation: {
+      fixCommitSha: FIX_COMMIT,
+      summary: "Lane defects fixed on main; they reach the next candidate, not this one.",
+    },
+    schemaVersion: 1,
+    version: "0.8.24",
+    ...overrides,
+  }
+}
+
+const candidate = Object.freeze({
+  commitSha: COMMIT,
+  manifestSha256: MANIFEST,
+  requiredLanes: LANES,
+  version: "0.8.24",
+})
+
+test("an exact adjudication parses and applies to the candidate it names", () => {
+  const parsed = parseSmokeAdjudication(record())
+  assert.equal(parsed.version, "0.8.24")
+  assert.equal(smokeAdjudicationApplies(parsed, candidate), true)
+  assert.equal(smokeAdjudicationPath("0.8.24"), "scripts/release/smoke-adjudications/v0.8.24.json")
+})
+
+test("the record never claims the failing lanes passed", () => {
+  const parsed = parseSmokeAdjudication(record())
+  const failed = parsed.adjudicatedLanes.filter((lane) => lane.outcome !== "passed")
+  assert.deepEqual(failed.map((lane) => lane.name).sort(), [
+    "published-harness",
+    "runtime-targets",
+    "storage",
+  ])
+})
+
+test("an adjudication never applies to a different candidate", () => {
+  const parsed = parseSmokeAdjudication(record())
+  for (const drift of [
+    { ...candidate, version: "0.8.25" },
+    { ...candidate, commitSha: "a".repeat(40) },
+    { ...candidate, manifestSha256: "b".repeat(64) },
+  ]) {
+    assert.equal(smokeAdjudicationApplies(parsed, drift), false)
+  }
+})
+
+test("an adjudication never applies when the required lanes are not covered exactly", () => {
+  const parsed = parseSmokeAdjudication(record())
+  assert.equal(
+    smokeAdjudicationApplies(parsed, { ...candidate, requiredLanes: [...LANES, "extra-lane"] }),
+    false,
+    "a newly required lane must not be waived by an older adjudication",
+  )
+  assert.equal(
+    smokeAdjudicationApplies(parsed, { ...candidate, requiredLanes: LANES.slice(0, 4) }),
+    false,
+  )
+  for (const empty of [[], null, undefined]) {
+    assert.equal(smokeAdjudicationApplies(parsed, { ...candidate, requiredLanes: empty }), false)
+  }
+})
+
+test("a missing or malformed adjudication never applies", () => {
+  for (const absent of [null, undefined]) {
+    assert.equal(smokeAdjudicationApplies(absent, candidate), false)
+  }
+  assert.equal(smokeAdjudicationApplies(parseSmokeAdjudication(record()), null), false)
+})
+
+test("parsing rejects every unbound, widened, or unattributed record", () => {
+  const cases = [
+    [{ version: "0.8" }, /exact SemVer/u],
+    [{ version: "v0.8.24" }, /exact SemVer/u],
+    [{ commitSha: "88c01c4a" }, /commit is invalid/u],
+    [{ manifestSha256: "not-a-digest" }, /manifest digest is invalid/u],
+    [{ kind: "smokes-passed" }, /kind is unsupported/u],
+    [{ schemaVersion: 2 }, /schema version is unsupported/u],
+    [{ reason: "" }, /reason is required/u],
+    [{ adjudicatedLanes: [] }, /every lane outcome/u],
+    [{ authority: { ...record().authority, mode: "automatic" } }, /authority mode is unsupported/u],
+    [{ authority: { ...record().authority, operator: "" } }, /operator is required/u],
+    [
+      { authority: { ...record().authority, reviewedCommit: "nope" } },
+      /reviewed commit is invalid/u,
+    ],
+    [{ remediation: { fixCommitSha: "nope", summary: "s" } }, /remediation commit is invalid/u],
+  ]
+  for (const [overrides, pattern] of cases) {
+    assert.throws(() => parseSmokeAdjudication(record(overrides)), pattern)
+  }
+})
+
+test("parsing rejects unknown, missing, and duplicated fields rather than ignoring them", () => {
+  const extra = record()
+  extra.autoApprove = true
+  assert.throws(() => parseSmokeAdjudication(extra), /record fields are invalid/u)
+
+  const missing = record()
+  delete missing.reason
+  assert.throws(() => parseSmokeAdjudication(missing), /record fields are invalid/u)
+
+  const duplicated = record({
+    adjudicatedLanes: [
+      { detail: "d", name: "storage", outcome: "failed" },
+      { detail: "d", name: "storage", outcome: "passed" },
+    ],
+  })
+  assert.throws(() => parseSmokeAdjudication(duplicated), /lane is duplicated/u)
+
+  const badOutcome = record({
+    adjudicatedLanes: [{ detail: "d", name: "storage", outcome: "waived" }],
+  })
+  assert.throws(() => parseSmokeAdjudication(badOutcome), /lane outcome is unsupported/u)
+})
+
+test("parsing rejects non-objects and prototype-polluting shapes", () => {
+  for (const value of [null, undefined, [], "record", 7]) {
+    assert.throws(() => parseSmokeAdjudication(value), /record fields are invalid/u)
+  }
+  const polluted = JSON.parse('{"__proto__": {"admin": true}}')
+  assert.throws(() => parseSmokeAdjudication(polluted), /record fields are invalid/u)
+})
+
+test("the parsed record is frozen so no caller can widen it after review", () => {
+  const parsed = parseSmokeAdjudication(record())
+  assert.throws(() => {
+    parsed.commitSha = "a".repeat(40)
+  }, TypeError)
+  assert.throws(() => {
+    parsed.adjudicatedLanes.push({ detail: "d", name: "new", outcome: "passed" })
+  }, TypeError)
+})
+
+test("the adjudication path is derived from the version and rejects traversal", () => {
+  for (const bad of ["../../etc/passwd", "0.8.24/../0.8.25", "", "latest"]) {
+    assert.throws(() => smokeAdjudicationPath(bad), /exact SemVer/u)
+  }
+})
+
+test("the shipped 0.8.24 record applies to its own candidate and to no other", async () => {
+  const source = await readFile(
+    new URL("../smoke-adjudications/v0.8.24.json", import.meta.url),
+    "utf8",
+  )
+  const shipped = parseSmokeAdjudication(JSON.parse(source))
+  const real = {
+    commitSha: "88c01c4afd59866fc0ea4c8f3b8444439a01c8ea",
+    manifestSha256: "68e45c7d302147f387c4cd68586a4e6411ea6a7c7889f6e2edc32a0793696e5c",
+    requiredLanes: [...REQUIRED_RELEASE_SMOKE_LANES],
+    version: "0.8.24",
+  }
+  assert.equal(smokeAdjudicationApplies(shipped, real), true)
+  assert.equal(
+    smokeAdjudicationApplies(shipped, {
+      ...real,
+      commitSha: "f3766a9eac7de7c0df42a5424df73117a69ae26a",
+      version: "0.8.25",
+    }),
+    false,
+    "the 0.8.24 adjudication must never waive the smoke gate for 0.8.25",
+  )
+  assert.equal(
+    shipped.adjudicatedLanes.every((lane) => lane.detail.length > 40),
+    true,
+    "every adjudicated lane must record why it was adjudicated",
+  )
+})
+
+test("reading an adjudication fails closed on damage and on a misfiled version", async () => {
+  const path = "scripts/release/smoke-adjudications/v0.8.24.json"
+  const tree = `${path}\nscripts/release/state.mjs`
+  const valid = await readFile(
+    new URL("../smoke-adjudications/v0.8.24.json", import.meta.url),
+    "utf8",
+  )
+
+  const present = await readSmokeAdjudication({
+    git: {
+      async listTree() {
+        return tree
+      },
+      async showFile() {
+        return valid
+      },
+    },
+    ref: "main",
+    version: "0.8.24",
+  })
+  assert.equal(present.version, "0.8.24")
+
+  assert.equal(
+    await readSmokeAdjudication({
+      git: {
+        async listTree() {
+          return "scripts/release/state.mjs"
+        },
+        async showFile() {
+          throw new Error("must not read")
+        },
+      },
+      ref: "main",
+      version: "0.8.24",
+    }),
+    null,
+    "an absent adjudication is normal and waives nothing",
+  )
+
+  await assert.rejects(
+    readSmokeAdjudication({
+      git: {
+        async listTree() {
+          return tree
+        },
+        async showFile() {
+          return "{ not json"
+        },
+      },
+      ref: "main",
+      version: "0.8.24",
+    }),
+    /is invalid/u,
+  )
+
+  await assert.rejects(
+    readSmokeAdjudication({
+      git: {
+        async listTree() {
+          return "scripts/release/smoke-adjudications/v0.8.25.json"
+        },
+        async showFile() {
+          return valid
+        },
+      },
+      ref: "main",
+      version: "0.8.25",
+    }),
+    /names another version/u,
+    "a record filed under the wrong version must never be trusted by its path",
+  )
+
+  for (const bad of [
+    { git: {}, ref: "main", version: "0.8.24" },
+    {
+      git: {
+        async listTree() {
+          return ""
+        },
+        async showFile() {
+          return ""
+        },
+      },
+      ref: "",
+      version: "0.8.24",
+    },
+  ]) {
+    await assert.rejects(readSmokeAdjudication(bad), /invalid/u)
+  }
+})
+
+test("an adjudication advances the smoke gate only for a candidate whose packages published", () => {
+  const base = { complete: false, anyPassed: false, ambiguous: false }
+  const assets = { smokesReconciled: false, npmReconciled: true }
+
+  assert.equal(
+    smokeGateState({ smokes: { ...base, adjudicated: true }, npm: { complete: true }, assets }),
+    "SMOKES_COMPLETE",
+  )
+  assert.equal(
+    smokeGateState({ smokes: { ...base, adjudicated: true }, npm: { complete: false }, assets }),
+    "not-advanced",
+    "an adjudication must never advance a candidate that never published",
+  )
+  assert.equal(
+    smokeGateState({ smokes: { ...base, adjudicated: false }, npm: { complete: true }, assets }),
+    "not-advanced",
+  )
+})
+
+// Mirrors the ordering in state.mjs classifySnapshot so the guard is asserted directly.
+function smokeGateState(evidence) {
+  if (evidence.assets.smokesReconciled && evidence.smokes.complete) return "SMOKES_COMPLETE"
+  if (evidence.smokes.adjudicated && evidence.npm.complete) return "SMOKES_COMPLETE"
+  return "not-advanced"
+}

--- a/scripts/release/test/workflow-contracts.test.mjs
+++ b/scripts/release/test/workflow-contracts.test.mjs
@@ -93,7 +93,7 @@ const SCRIPT_PIN_PATH = path.join(ROOT, SCRIPT_PIN_FIXTURE)
 // environment and the abandonment environment. It is declared in RELEASE_DATA_FILES and anchored
 // to those readers, so the declaration fails as a stale pin if they stop naming it.
 const STARTING_SCRIPT_PIN_SHA256 =
-  "4a583c0ad48fd33c9fb0ba206f76a40ef6c60d43466805740fd58e30e99a70db"
+  "fb2b8f444e43553779db4f36435f68d8278e14a84debda1be4c1b837306232c7"
 const SHA256_HEX = /^[0-9a-f]{64}$/u
 const workflowExpression = (value) => `\${{ ${value} }}`
 const SCRIPT_REFERENCE = /(?:^|[\s;&|"'(])(scripts\/[\w.-]+(?:\/[\w.-]+)*)/gu


### PR DESCRIPTION
> **Do not merge yet.** Merging this completes 0.8.24, which immediately lets 0.8.25 tag and release. Brian asked to hold that until the in-flight test-flake fixes land.

## The deadlock

v0.8.24 published all 21 packages correctly — valid npm provenance, `reconcile-npm` succeeded. It then stalled at the smoke gate and **cannot leave it**:

- Two of five required lanes fail **deterministically** on defects in the candidate's own smoke scripts (`storage`: an `includeOpenAi` option leak into the strict runner; `runtime-targets`: asserting `typeof graphAdapter === "function"` when it is a `BackendAdapter` object).
- Every release job except `detect` checks out `candidate_sha`, so the fixes in `2689ef8d` reach only the *next* candidate.
- The tag cannot be moved: `validateExactPublishedPackageEvidence` throws when provenance commit ≠ candidate commit, and all 21 published packages attest `88c01c4a`.

The controller selects the oldest **incomplete** candidate, and only `NO_CANDIDATE`, `SUPERSEDED_NOOP`, `AUDIT_COMPLETE`, `ABANDONED_PREPUBLICATION` are terminal. So 0.8.24 is re-selected forever and **no later version can be released** — cutting 0.8.25 does not supersede it (verified: the controller re-dispatched v0.8.24 after #563 merged, and no v0.8.25 tag was created).

Abandonment does not fit: the packages are live, so `ABANDONED_PREPUBLICATION` would be false.

## What this adds

A git-resident adjudication at `scripts/release/smoke-adjudications/v<version>.json`, read by `detect` from the controller ref and bound to one exact candidate.

**It is deliberately narrow:**

| Property | How |
|---|---|
| Bound to one candidate | version **and** commit sha **and** manifest digest must all match |
| Never claims lanes passed | each lane records its real outcome (`passed`/`failed`/`flaked`) + reason |
| Only the smoke gate | advances to `SMOKES_COMPLETE`; **the audit still runs** |
| Only a published candidate | gate also requires `evidence.npm.complete` |
| Cannot be widened after review | parsed records are frozen; a newly-required lane voids coverage |
| Fails closed | absent, unreadable, malformed, misfiled, unknown fields, prototype pollution → **no effect** |

The failure mode is always "the release stays stuck", never "the gate opens wider than intended".

## Verification

- **13 adversarial tests** in `scripts/release/test/smoke-adjudication.test.mjs`.
- Verified with **real values** that the 0.8.24 record applies to `88c01c4a` and does **not** apply to 0.8.25.
- Full release suite: **2405/2406 pass**. The single failure is a pre-existing process-tree flake (`terminates the full descendant tree`) that fails on an ENOENT reading `grandchild.pid`; it passes in isolation (2/2) and this branch does not touch `published-artifact-smoke.mjs`.

## Please read closely

No automated review is available (Anthropic org credits are at zero), and this is a gate bypass. The two places most worth your eyes:

1. `scripts/release/state.mjs` — the added branch and its ordering relative to the real smoke gate.
2. The `reason` and per-lane `detail` fields in `scripts/release/smoke-adjudications/v0.8.24.json` — this is the permanent audit record of why 0.8.24 was let through.

## Pin coverage (updated)

This PR is now rebased on #566, which closes the import-closure gap it originally exposed. The closure walker **automatically caught the new module** and refused the build until it was pinned:

```
Release workflow reaches a repository script with no content pin:
  scripts/release/smoke-adjudication.mjs
A pinned release entrypoint imports it, so it executes during a release
and its bytes must be pinned too.
```

All five changed files are now content-pinned — `observe.mjs`, `evidence.mjs`, `state.mjs`, `observation-schema.mjs` and `smoke-adjudication.mjs` — so this bypass **is** covered by the release-integrity review gate. The runbook's "Known gap" section is stale in this respect and should be read against #566.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

