### PR TITLE
release: find the auditable draft by listing releases, not by tag

### DIFF
--- a/scripts/release/independent-audit-coordinator.mjs
+++ b/scripts/release/independent-audit-coordinator.mjs
@@ -40,14 +40,9 @@ export async function coordinateIndependentAudit(input) {
     if (invocation.sha !== invocation.inputs.commitSha) {
       throw new Error("Exact-tag audit SHA does not match its candidate input")
     }
-    const release = await readReleaseByTag(
-      invocation.github.reader,
-      `v${invocation.inputs.version}`,
-    )
-    const managed = parseManagedRelease(release, {
+    const managed = await readAuditableManagedRelease(invocation.github.reader, {
       defaultBranch: invocation.defaultBranch,
       expected: invocation.inputs,
-      allowDraft: true,
     })
     await verifyAnnotatedTag(invocation.github.reader, managed)
     return Object.freeze({ mode: managed.mode, ...managedIdentity(managed) })
@@ -79,6 +74,40 @@ export async function coordinateIndependentAudit(input) {
   )
   assertDispatchReceipt(receipt)
   return Object.freeze({ mode: "relayed", ...identity })
+}
+
+/**
+ * Find the managed Release for an exact candidate.
+ *
+ * A managed draft carries no resolvable `tag_name` — GitHub names it
+ * `untagged-<id>` until it is published — so `GET /releases/tags/{tag}` cannot
+ * see it and returns 404. The draft is instead identified by its marker, which
+ * `parseManagedRelease` already reads. Listing is paginated and covers drafts
+ * and published releases alike.
+ *
+ * Candidates are narrowed by exact release name before parsing, so a malformed
+ * release for this very version fails loudly instead of being skipped, and more
+ * than one match is an error rather than a silent pick: a duplicated draft is
+ * the hazard that stranded v0.8.22.
+ */
+async function readAuditableManagedRelease(reader, { defaultBranch, expected }) {
+  const releases = await readEnvelopeValue(reader.listReleases(), "releases")
+  if (!Array.isArray(releases)) throw new Error("GitHub Release list is malformed")
+  const name = `Dawn v${expected.version}`
+  const matches = releases.filter(
+    (release) =>
+      release !== null &&
+      typeof release === "object" &&
+      !Array.isArray(release) &&
+      release.name === name,
+  )
+  if (matches.length === 0) {
+    throw new Error(`No managed Release named ${name} was found`)
+  }
+  if (matches.length > 1) {
+    throw new Error(`Managed Release ${name} is duplicated`)
+  }
+  return parseManagedRelease(matches[0], { defaultBranch, expected, allowDraft: true })
 }
 
 async function discoverLatestPublishedRelease(reader, defaultBranch) {

--- a/scripts/release/test/fixtures/release-script-hashes.json
+++ b/scripts/release/test/fixtures/release-script-hashes.json
@@ -77,7 +77,7 @@
       "sha256": "427419a41951adb53720470d80f1defca030f8eb9289dae50c704f332e5f9ac0"
     },
     "scripts/release/independent-audit-coordinator.mjs": {
-      "sha256": "a72f438f776f9ca26914c2ec51dd75de8f3b6c7d85ae8b11f2cc51c651e10d53"
+      "sha256": "5045bb1d81504a25379d791408deebf50057b05c50eae29aca06a94ece444f63"
     },
     "scripts/release/independent-audit.mjs": {
       "sha256": "32746a3162b0fbf97990e3ad01952a4f581fa92ece87aaf8252a9a7fa4a68dd8"

--- a/scripts/release/test/independent-audit-coordinator.test.mjs
+++ b/scripts/release/test/independent-audit-coordinator.test.mjs
@@ -174,12 +174,13 @@ function githubBoundary({ releases, calls, refType = "tag", tagTargetSha }) {
         return present("releases", releases)
       },
       async getReleaseByTag({ tag }) {
-        return present(
-          "release",
-          releases.find(
-            (release) => release.tag_name === tag || parseReleaseMarker(release.body).tag === tag,
-          ),
-        )
+        // Real GitHub resolves a Release by tag only once it is published: a draft
+        // carries an opaque `untagged-<id>` name and 404s here however its marker
+        // reads. Matching a draft's marker tag would make this fake more capable
+        // than the API it stands in for, which is exactly how a coordinator that
+        // could not observe its own draft reached production.
+        const found = releases.find((release) => release.draft !== true && release.tag_name === tag)
+        return found === undefined ? absent("release") : present("release", found)
       },
       async getRef({ ref }) {
         selectedTag = ref.replace(/^tags\//u, "")
@@ -215,4 +216,8 @@ function githubBoundary({ releases, calls, refType = "tag", tagTargetSha }) {
 
 function present(operation, value) {
   return { status: "PRESENT", operation, httpStatus: 200, code: null, value }
+}
+
+function absent(operation) {
+  return { status: "ABSENT", operation, httpStatus: 404, code: "NOT_FOUND", value: null }
 }

--- a/scripts/release/test/workflow-contracts.test.mjs
+++ b/scripts/release/test/workflow-contracts.test.mjs
@@ -93,7 +93,7 @@ const SCRIPT_PIN_PATH = path.join(ROOT, SCRIPT_PIN_FIXTURE)
 // environment and the abandonment environment. It is declared in RELEASE_DATA_FILES and anchored
 // to those readers, so the declaration fails as a stale pin if they stop naming it.
 const STARTING_SCRIPT_PIN_SHA256 =
-  "fb2b8f444e43553779db4f36435f68d8278e14a84debda1be4c1b837306232c7"
+  "8009b5b7f7cc4aed302b134ad9b9eab117fbf75a478a653b1c8ad66c21ec2f49"
 const SHA256_HEX = /^[0-9a-f]{64}$/u
 const workflowExpression = (value) => `\${{ ${value} }}`
 const SCRIPT_REFERENCE = /(?:^|[\s;&|"'(])(scripts\/[\w.-]+(?:\/[\w.-]+)*)/gu


### PR DESCRIPTION
## The bug

The independent audit coordinator resolved the candidate's Release with `GET /releases/tags/{tag}` and then parsed it with `allowDraft: true`. **Those two cannot both hold.** A managed draft carries an opaque `untagged-<id>` name until it is published, so get-release-by-tag 404s on it regardless of what its marker says — and the coordinator threw before `allowDraft` was ever consulted:

```
GitHub release observation is not exact
```

Confirmed in production: v0.8.24's release is `untagged-a4a022eb7414255884bc` (`draft=true`), and `GET /releases/tags/v0.8.24` returns 404.

## Why nothing caught it

**Nothing had ever exercised this path.** v0.8.24 is the first candidate to reach `dispatch-release-audit` at all — v0.8.22 was abandoned before publication and v0.8.23 was never cut. The audit had only ever run against *published* releases discovered by listing.

**And the test fake hid it.** `getReleaseByTag` in the coordinator's test matched a draft on `parseReleaseMarker(release.body).tag`, which real GitHub cannot do. The fake was strictly more capable than the API it stands in for, so the draft-audit path passed in tests and 404'd in production — the same fake-vs-real shape mismatch as the strict smoke runner in #561.

## The fix

Find the draft the way a draft *can* be found: list releases (paginated, and covers drafts), narrow to the exact release name, parse that one strictly. `parseManagedRelease` already reads a draft's identity from its marker, so **only the lookup changed**.

Two deliberate properties:

- Candidates are narrowed **by name before parsing**, so a malformed release for this very version fails loudly instead of being silently skipped.
- **More than one match is an error**, not a silent pick — a duplicated draft is precisely the hazard that stranded v0.8.22.

## The fake now matches reality

`getReleaseByTag` in the test returns `ABSENT` for a draft, like GitHub does. **With that change alone, the old coordinator fails the draft-audit test** — verified by reverting the fix and re-running:

```
✖ an exact annotated tag routes mutable draft and published immutable audits separately
ℹ pass 5   ℹ fail 1
```

With the fix: 6/6.

## Verification

- Coordinator tests **6/6**; workflow contracts + coordinator **143/143**.
- Content pin updated for `independent-audit-coordinator.mjs` (now covered by #566's import closure).

## Context

This unblocks v0.8.24, which #567 advanced past the smoke gate. The audit gate was deliberately left live there, and this is the next real gate it hit. `publish-release` after it has also never run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)