### PR TITLE
feat(cli): add server.cors, off by default

### DIFF
--- a/.changeset/rotten-donkeys-shout.md
+++ b/.changeset/rotten-donkeys-shout.md
@@ -1,0 +1,41 @@
+---
+"@dawn-ai/cli": patch
+"@dawn-ai/core": patch
+---
+
+Add `server.cors`, off by default.
+
+A Dawn server sends no `Access-Control-*` header unless `dawn.config.ts` sets
+`server.cors`. With the block absent the runtime answers exactly as it did
+before — no header on any response, and `OPTIONS` still falling through the
+route table to its 404. Opening a server to other origins is a deployment
+decision, so nothing is inferred.
+
+```ts
+server: { cors: { origins: ["https://app.example.com"] } }
+```
+
+Set it when a browser client talks to Dawn directly rather than through a
+same-origin proxy. Origins are compared exactly after normalizing case and a
+trailing slash; note that `localhost` and `127.0.0.1` are different origins to
+a browser, so list both if your dev client may be opened at either.
+
+Every response carries the headers, including error responses and the shutdown
+503 — a browser that cannot read a 404 reports an opaque CORS failure instead,
+which is the most confusing way to debug this. A request from an origin that
+is not on the list is still served normally and simply carries no CORS header;
+answering 403 there would break non-browser clients that happen to send an
+`Origin`. A preflight from a disallowed origin does get a 403.
+
+The policy is validated once at boot, so a malformed origin list fails on
+startup rather than on the first cross-origin request. `origins: "*"` combined
+with `credentials: true` is rejected outright: browsers refuse a wildcard
+allow-origin on a credentialed request, so accepting it would produce a server
+that looks configured and fails only in the console.
+
+Defaults for the rest: `credentials` false; `methods` `GET, POST, DELETE,
+OPTIONS`; `headers` echoes the browser's own `Access-Control-Request-Headers`;
+`exposeHeaders` empty; `maxAgeSeconds` 600.
+
+CORS controls which origins a browser will let read a response. It does not
+decide who may call the server — pair it with `defineThreadAccess`.

--- a/apps/web/app/seo/lastmod.generated.json
+++ b/apps/web/app/seo/lastmod.generated.json
@@ -57,9 +57,9 @@
       "recordDigest": "d0e6f710b402ab091c2a142b9b3de8156039f4fac117eed878af7e1ff153c130"
     },
     "/docs/api/core": {
-      "lastModified": "2026-08-12T13:00:08.000Z",
-      "sourceDigest": "b7b195ee1789e29067a9f65402dd9d2c11485b9f918b76b850d9c5df02306be5",
-      "recordDigest": "31d090f8881510eecd52cdbe08f8444c334f36295136af411f804e35ccf12aac"
+      "lastModified": "2026-09-05T04:14:24.132Z",
+      "sourceDigest": "b8a7659186ad4161bd6c175d537f55f45182f7a77db9b3b83bb71a293cc1aca1",
+      "recordDigest": "9fe64df85de747f01005260a0d23a3ec0e55b1f92a311b37811ede85e92e305b"
     },
     "/docs/api/evals": {
       "lastModified": "2026-08-12T12:57:08.000Z",
@@ -137,9 +137,9 @@
       "recordDigest": "ed5d6b70b61f6e75bbbb9c465757131740fe4abdf4b3745b1bdd22649ee8fb03"
     },
     "/docs/configuration": {
-      "lastModified": "2026-08-11T18:35:09.000Z",
-      "sourceDigest": "7533f89c2d1929a543b80b88f39272ee1d37d9700ed140887c4a9bd47bf4e556",
-      "recordDigest": "fa62a074676d2e031248f290497fb51ea55a55a681661aee5a8ddef65ebf8045"
+      "lastModified": "2026-09-05T04:14:24.132Z",
+      "sourceDigest": "80284badafaf462fd6bc72bd39d31fb095555492ad4b265a13eb97c89b7768f4",
+      "recordDigest": "b8fc46792dbd6da810ab7b2d18ebc1cf01a9d4d4d7e3b16b4402b58abbf1249b"
     },
     "/docs/context-management": {
       "lastModified": "2026-08-11T18:35:09.000Z",
@@ -307,9 +307,9 @@
       "recordDigest": "6cd9fb8b4b1a8a78cc48ab11101a3bd5ca6eb946d0e3f4404f1112ea44c5506b"
     },
     "/docs/recipes/research-web-ui": {
-      "lastModified": "2026-08-26T16:03:21.000Z",
-      "sourceDigest": "9aaa4da9f64bc8f720d492478356e59c11acb4b6db4be64384973a036acaa180",
-      "recordDigest": "6427d6e8bc0ad2cbd3568a406beb5b325da7742dd992592d71afbbe2dd79a7ab"
+      "lastModified": "2026-09-05T04:14:24.132Z",
+      "sourceDigest": "8b8babfbfac63a63f3c8ec9336305cfd7eb4ca087a21c8a14185633b103efaeb",
+      "recordDigest": "e676ee59690704cd870a936d026bfadf4daf9e3dc522b9131e5c955e0971f451"
     },
     "/docs/recipes/retry-flaky-tools": {
       "lastModified": "2026-08-12T13:00:08.000Z",

--- a/apps/web/content/docs/api/core.mdx
+++ b/apps/web/content/docs/api/core.mdx
@@ -113,6 +113,7 @@ Importing `/node` registers the disk-backed `dawn.config.ts` loader. The root re
 | `RouteStateFields` | Describe generated state fields for one route. |
 | `renderStateTypes` | Render route state types. |
 | `renderToolTypes` | Render route tool types. |
+| `CorsConfig` | Configure cross-origin access to the runtime. |
 | `DawnConfig` | Configure a Dawn application. |
 | `DiscoveredDawnApp` | Describe a located Dawn application. |
 | `DiscoverRoutesOptions` | Configure route discovery. |

--- a/apps/web/content/docs/configuration.mdx
+++ b/apps/web/content/docs/configuration.mdx
@@ -384,6 +384,61 @@ Retrieval](/docs/memory/retrieval) for ranking, [Episodes](/docs/memory/episodes
 for run history, and [Distillation](/docs/memory/distillation) for explicit
 consolidation and reflection.
 
+### `server.cors`
+
+```ts
+server?: {
+  cors?: {
+    origins: readonly string[] | "*"
+    credentials?: boolean
+    methods?: readonly string[]
+    headers?: readonly string[]
+    exposeHeaders?: readonly string[]
+    maxAgeSeconds?: number
+  }
+}
+```
+
+Absent by default, and absence means **no `Access-Control-*` header on any
+response** — a browser on another origin cannot call `/agui/*`, `/threads/*` or
+`/memory/*`, and `OPTIONS` falls through to the router's 404. Opening a server
+to other origins is a deployment decision, so nothing here is inferred.
+
+Set it when a browser client talks to Dawn directly instead of through a
+same-origin proxy:
+
+```ts
+server: { cors: { origins: ["https://app.example.com"] } }
+```
+
+Origins are compared exactly, after normalizing case and a trailing slash, so
+`"HTTP://LocalHost:3010/"` matches an `Origin: http://localhost:3010`. Note that
+`localhost` and `127.0.0.1` are *different* origins — list both if your dev
+client may be opened at either.
+
+The policy is resolved and validated once at boot, so a malformed origin list
+fails on startup rather than on the first cross-origin request. `origins: "*"`
+with `credentials: true` is rejected outright: browsers refuse a wildcard
+allow-origin on a credentialed request, and accepting it would produce a server
+that looks configured and fails only in the console.
+
+Defaults for the rest: `credentials` false; `methods` `GET, POST, DELETE,
+OPTIONS`; `headers` echoes the browser's own
+`Access-Control-Request-Headers` (so an app can add an auth header without
+changing server config); `exposeHeaders` empty; `maxAgeSeconds` 600.
+
+Two behaviors worth knowing. A request from an origin **not** on the list is
+still served normally — it just carries no CORS header, and the browser is what
+refuses to hand it to the page; answering 403 there would break every
+non-browser client that happens to send an `Origin`. And error responses are
+stamped too, including the shutdown 503, because a cross-origin caller that
+cannot read a 404 sees only an opaque CORS failure.
+
+CORS is not authentication. It controls which origins a browser will let read a
+response; it does not decide who may call the server. Pair it with
+[`defineThreadAccess`](/docs/thread-access).
+
+
 ## Postgres backend
 
 Shared Postgres persistence requires three explicit entries: the checkpointer,

--- a/apps/web/content/docs/configuration.mdx
+++ b/apps/web/content/docs/configuration.mdx
@@ -61,6 +61,14 @@ export default config({
 
   build: { targets: ["node", "langsmith"] },
 
+  // Cross-origin access. Omit and the runtime sends no `Access-Control-*`
+  // header at all, so a browser on another origin cannot call it — the
+  // default, because opening a server to other origins is a deployment
+  // decision. `localhost` and `127.0.0.1` are different origins to a browser.
+  server: {
+    cors: { origins: ["https://app.example.com"] },
+  },
+
   // sandbox: {
   //   provider: dockerSandbox({ image: "node:24-slim" }),
   //   network: { mode: "allow", denylist: ["169.254.169.254"] },
@@ -384,7 +392,7 @@ Retrieval](/docs/memory/retrieval) for ranking, [Episodes](/docs/memory/episodes
 for run history, and [Distillation](/docs/memory/distillation) for explicit
 consolidation and reflection.
 
-### `server.cors`
+### `server`
 
 ```ts
 server?: {

--- a/apps/web/content/docs/recipes/research-web-ui.mdx
+++ b/apps/web/content/docs/recipes/research-web-ui.mdx
@@ -289,7 +289,7 @@ POST /memory/candidates/:id/reject
 ```
 
 The browser cannot call those routes directly unless the server sets
-[`server.cors`](/docs/configuration#servercors); with it absent the Dawn dev server sends no CORS
+[`server.cors`](/docs/configuration#server); with it absent the Dawn dev server sends no CORS
 headers — so the example reaches them through a same-origin catch-all,
 `app/api/dawn/[...path]/route.ts`. That proxy is **allowlisted**, not
 pass-through: `app/lib/proxy-allowlist.ts` is a pure function listing the exact

--- a/apps/web/content/docs/recipes/research-web-ui.mdx
+++ b/apps/web/content/docs/recipes/research-web-ui.mdx
@@ -288,7 +288,8 @@ POST /memory/candidates/:id/approve
 POST /memory/candidates/:id/reject
 ```
 
-The browser cannot call those routes directly — the Dawn dev server sets no CORS
+The browser cannot call those routes directly unless the server sets
+[`server.cors`](/docs/configuration#servercors); with it absent the Dawn dev server sends no CORS
 headers — so the example reaches them through a same-origin catch-all,
 `app/api/dawn/[...path]/route.ts`. That proxy is **allowlisted**, not
 pass-through: `app/lib/proxy-allowlist.ts` is a pure function listing the exact

--- a/examples/research/server/dawn.config.ts
+++ b/examples/research/server/dawn.config.ts
@@ -35,6 +35,21 @@ export default config({
   // Persistence (SQLite checkpointer + Agent Protocol) is on by default — no
   // config needed. Threads survive a restart.
 
+  // --- Capability seam (documented, inactive): cross-origin access ---
+  // Dawn sends no `Access-Control-*` header unless this block exists, and
+  // `web/` deliberately does not need it: its browser client reaches Dawn
+  // through a same-origin Next proxy (`web/app/api/dawn/[...path]/route.ts`),
+  // so Dawn's address never leaves the server.
+  //
+  // Uncomment when a browser talks to Dawn DIRECTLY — a client on another
+  // origin, or one that has dropped the proxy. `localhost` and `127.0.0.1` are
+  // different origins to a browser, so list both if your dev client may be
+  // opened at either. See /docs/configuration#servercors.
+  //
+  // server: {
+  //   cors: { origins: ["http://localhost:3010", "http://127.0.0.1:3010"] },
+  // },
+
   // --- Capability seam: Docker execution sandbox ---
   // Default runs use the local workspace so the bundled corpus works without
   // Docker. Run `npm run test:sandbox:docker` to dogfood the same scaffold with

--- a/examples/research/web/app/api/dawn/[...path]/route.ts
+++ b/examples/research/web/app/api/dawn/[...path]/route.ts
@@ -1,8 +1,9 @@
 import { type NextRequest, NextResponse } from "next/server"
 import { resolveProxyTarget } from "../../../lib/proxy-allowlist"
 
-// Same-origin proxy to the Dawn server. The dev server sets no CORS headers,
-// so the browser cannot read it directly. Every routing decision is in
+// Same-origin proxy to the Dawn server. A Dawn server sends no CORS headers
+// unless `server.cors` is configured, and this app deliberately does not
+// depend on that — the browser never learns Dawn's address. Every routing decision is in
 // `lib/proxy-allowlist.ts`, which is where the tests are; this file is the
 // adapter and deliberately holds no policy of its own.
 export const runtime = "nodejs"

--- a/examples/research/web/app/lib/proxy-allowlist.ts
+++ b/examples/research/web/app/lib/proxy-allowlist.ts
@@ -1,8 +1,11 @@
 /**
  * Which Dawn server paths the browser may reach, and nothing else.
  *
- * The dev server sets no CORS headers, so direct reads from the page are
- * impossible and a same-origin proxy is required. An OPEN proxy in a template
+ * A Dawn server sends no CORS headers unless its `dawn.config.ts` sets
+ * `server.cors`, and this app deliberately does not rely on that being set —
+ * so direct reads from the page are impossible and a same-origin proxy is
+ * required. That is a posture, not a limitation: the browser never learns
+ * Dawn's address, and the server needs no cross-origin configuration. An OPEN proxy in a template
  * every Dawn developer copies is a liability — this app would happily forward
  * `POST /threads/:id/resume` or the whole agent surface — so the allowlist is
  * the point of the route, not an optimization over it.

--- a/packages/cli/src/lib/dev/cors.ts
+++ b/packages/cli/src/lib/dev/cors.ts
@@ -1,0 +1,209 @@
+/**
+ * CORS for the Dawn runtime.
+ *
+ * Off unless `dawn.config.ts` sets `server.cors`. A Dawn server with no CORS
+ * config answers exactly as it did before this module existed — no
+ * `Access-Control-*` header on any response, and `OPTIONS` still falling
+ * through the route table to its 404. That default is deliberate: turning on
+ * cross-origin access is a deployment decision, not something a framework
+ * should assume.
+ *
+ * Everything here is pure — `Request` in, header decisions out — so the policy
+ * is tested directly rather than through a live server.
+ */
+
+import type { CorsConfig } from "@dawn-ai/core"
+
+export type { CorsConfig }
+
+/** The config after validation, with defaults resolved. */
+export interface CorsPolicy {
+  readonly allowAnyOrigin: boolean
+  readonly origins: ReadonlySet<string>
+  readonly credentials: boolean
+  readonly methods: readonly string[]
+  readonly headers?: readonly string[]
+  readonly exposeHeaders: readonly string[]
+  readonly maxAgeSeconds: number
+}
+
+/** Every method the route table serves, plus the preflight method itself. */
+const DEFAULT_METHODS = ["GET", "POST", "DELETE", "OPTIONS"] as const
+const DEFAULT_MAX_AGE_SECONDS = 600
+
+export class CorsConfigError extends Error {
+  constructor(message: string) {
+    super(`Invalid server.cors config — ${message}`)
+    this.name = "CorsConfigError"
+  }
+}
+
+/**
+ * An origin as the `Origin` header serializes it: scheme + host + optional
+ * port, lowercased, no trailing slash. Config is normalized the same way so
+ * that `"http://localhost:3010/"` in a config file still matches.
+ */
+function normalizeOrigin(value: string): string {
+  const trimmed = value.trim()
+  if (trimmed === "null") return "null"
+  let url: URL
+  try {
+    url = new URL(trimmed)
+  } catch {
+    throw new CorsConfigError(
+      `"${value}" is not a valid origin. Use scheme://host[:port], e.g. "http://localhost:3010".`,
+    )
+  }
+  if (url.pathname !== "/" || url.search !== "" || url.hash !== "") {
+    throw new CorsConfigError(
+      `"${value}" is not an origin — it carries a path, query or fragment. Use just scheme://host[:port].`,
+    )
+  }
+  return url.origin.toLowerCase()
+}
+
+/**
+ * Validate and resolve `server.cors`. Returns undefined when CORS is off,
+ * which every caller treats as "change nothing about the response".
+ *
+ * Throws at boot rather than per request: a bad origin list is a config
+ * mistake the operator should learn about when the server starts, not on the
+ * first cross-origin call.
+ */
+export function resolveCorsPolicy(config: CorsConfig | undefined): CorsPolicy | undefined {
+  if (config === undefined) return undefined
+  const credentials = config.credentials ?? false
+  const allowAnyOrigin = config.origins === "*"
+
+  if (allowAnyOrigin && credentials) {
+    throw new CorsConfigError(
+      'origins: "*" cannot be combined with credentials: true — browsers reject a wildcard ' +
+        "allow-origin on a credentialed request. List the origins explicitly instead.",
+    )
+  }
+  if (!allowAnyOrigin && config.origins.length === 0) {
+    throw new CorsConfigError(
+      "origins is empty, so no cross-origin request could ever succeed. Remove server.cors to " +
+        'turn CORS off, or list at least one origin (or "*").',
+    )
+  }
+
+  return {
+    allowAnyOrigin,
+    origins: allowAnyOrigin
+      ? new Set<string>()
+      : new Set(config.origins.map((origin) => normalizeOrigin(origin))),
+    credentials,
+    methods: config.methods ?? [...DEFAULT_METHODS],
+    ...(config.headers ? { headers: config.headers } : {}),
+    exposeHeaders: config.exposeHeaders ?? [],
+    maxAgeSeconds: config.maxAgeSeconds ?? DEFAULT_MAX_AGE_SECONDS,
+  }
+}
+
+function isAllowedOrigin(policy: CorsPolicy, origin: string): boolean {
+  if (policy.allowAnyOrigin) return true
+  return policy.origins.has(origin.toLowerCase())
+}
+
+/**
+ * The `Access-Control-*` headers that belong on an actual (non-preflight)
+ * response, or undefined when the request gets none — no policy, no `Origin`
+ * header (a same-origin or non-browser caller), or an origin not on the list.
+ *
+ * A disallowed origin is NOT an error: the response goes back unchanged and
+ * the browser is the thing that refuses to hand it to the page. Rejecting with
+ * a 403 here would break every non-browser client that happens to send an
+ * `Origin`.
+ */
+export function corsResponseHeaders(
+  policy: CorsPolicy | undefined,
+  request: Request,
+): Record<string, string> | undefined {
+  if (policy === undefined) return undefined
+  const origin = request.headers.get("origin")
+  if (origin === null) return undefined
+  if (!isAllowedOrigin(policy, origin)) return undefined
+
+  const headers: Record<string, string> = {
+    // Echoed rather than `*` even in the any-origin case, so that one code
+    // path serves both and the credentialed case cannot regress into an
+    // invalid wildcard. `Vary` is then mandatory: without it a shared cache
+    // could hand origin A the response minted for origin B.
+    "access-control-allow-origin": origin,
+    vary: "Origin",
+  }
+  if (policy.credentials) headers["access-control-allow-credentials"] = "true"
+  if (policy.exposeHeaders.length > 0) {
+    headers["access-control-expose-headers"] = policy.exposeHeaders.join(", ")
+  }
+  return headers
+}
+
+/**
+ * A preflight response, or undefined when this request is not a preflight and
+ * should continue to the route table.
+ *
+ * A preflight is `OPTIONS` + `Origin` + `Access-Control-Request-Method`. A
+ * bare `OPTIONS` is not one, and deliberately falls through to the router's
+ * 404 — the runtime serves no `OPTIONS` route, and answering 204 to any
+ * `OPTIONS` would claim otherwise.
+ */
+export function corsPreflightResponse(
+  policy: CorsPolicy | undefined,
+  request: Request,
+): Response | undefined {
+  if (policy === undefined) return undefined
+  if (request.method !== "OPTIONS") return undefined
+  const origin = request.headers.get("origin")
+  const requestedMethod = request.headers.get("access-control-request-method")
+  if (origin === null || requestedMethod === null) return undefined
+
+  // An origin off the list gets a 403 rather than a silent 204 without
+  // headers. Both make the browser block the real request; only this one is
+  // legible in a network panel, and a preflight has no non-browser caller to
+  // break (unlike an actual request, which is why that path stays a 200).
+  if (!isAllowedOrigin(policy, origin)) {
+    return new Response(null, { status: 403 })
+  }
+
+  const headers: Record<string, string> = {
+    "access-control-allow-origin": origin,
+    "access-control-allow-methods": policy.methods.join(", "),
+    "access-control-max-age": String(policy.maxAgeSeconds),
+    // Both inputs vary the answer: Origin picks the allow-origin, and the
+    // requested-headers echo below is copied straight from the request.
+    vary: "Origin, Access-Control-Request-Headers",
+  }
+  if (policy.credentials) headers["access-control-allow-credentials"] = "true"
+
+  const requestedHeaders = request.headers.get("access-control-request-headers")
+  const allowHeaders = policy.headers?.join(", ") ?? requestedHeaders
+  if (allowHeaders !== null && allowHeaders !== undefined && allowHeaders !== "") {
+    headers["access-control-allow-headers"] = allowHeaders
+  }
+
+  return new Response(null, { headers, status: 204 })
+}
+
+/**
+ * Stamp CORS headers onto a response that is already built.
+ *
+ * Mutates `response.headers` in place instead of rebuilding the Response. That
+ * matters for the SSE routes: re-wrapping a streaming body would be a second
+ * `new Response(body)` around a stream the runtime is already tracking for
+ * lifetime purposes, and the header guard on a constructed Response permits
+ * `set()`, so there is nothing to gain from the copy.
+ */
+export function applyCorsHeaders(
+  policy: CorsPolicy | undefined,
+  request: Request,
+  response: Response,
+): Response {
+  const headers = corsResponseHeaders(policy, request)
+  if (headers === undefined) return response
+  for (const [name, value] of Object.entries(headers)) {
+    response.headers.set(name, value)
+  }
+  return response
+}

--- a/packages/cli/src/lib/dev/runtime-fetch-core.ts
+++ b/packages/cli/src/lib/dev/runtime-fetch-core.ts
@@ -1,4 +1,5 @@
-import { seedDawnConfig } from "@dawn-ai/core"
+import type { DawnConfig } from "@dawn-ai/core"
+import { loadDawnConfig, seedDawnConfig } from "@dawn-ai/core"
 import type { MemoryStore } from "@dawn-ai/memory"
 import type { PermissionsStore } from "@dawn-ai/permissions"
 import type { DawnMiddleware, MiddlewareRequest, ThreadAccessPolicy } from "@dawn-ai/sdk"
@@ -22,6 +23,8 @@ import type { DawnStaticModules } from "../runtime/static-modules-core.js"
 import { type StreamChunk, toSseEvent } from "../runtime/stream-types.js"
 import { abortableAsyncIterable } from "./abortable-iterable.js"
 import { handleAgUiFetchRequest } from "./agui-handler.js"
+import type { CorsConfig } from "./cors.js"
+import { applyCorsHeaders, corsPreflightResponse, resolveCorsPolicy } from "./cors.js"
 import {
   handleMemoryApproveRequest,
   handleMemoryListRequest,
@@ -677,7 +680,7 @@ export async function createRuntimeFetchHandler(
     ...(options.modules ? { staticModules: options.modules } : {}),
   })
 
-  const fetch = async (request: Request): Promise<Response> => {
+  const serveRoutes = async (request: Request): Promise<Response> => {
     if (!state.acceptingRequests) {
       return Response.json(createRequestErrorBody("Server is shutting down"), {
         status: 503,
@@ -866,6 +869,26 @@ export async function createRuntimeFetchHandler(
     // Release sandboxes only after in-flight requests have drained, so tools
     // executing against a sandbox are never yanked mid-request.
     if (sandboxManager) await sandboxManager.releaseAll()
+  }
+
+  // CORS wraps the whole handler rather than living inside it. `serveRoutes`
+  // has eight exit paths — the dispatch result, the tracked SSE response, the
+  // shutdown 503 and five error branches — and a cross-origin caller must be
+  // able to read ALL of them, including the failures. Stamping once here is
+  // the only version of that with no path left uncovered.
+  //
+  // Resolved at boot — see `readCorsConfig` for where the config comes from.
+  // Boot is also where a malformed origin list should fail, so an operator
+  // sees it on startup rather than on the first cross-origin request.
+  const corsPolicy = resolveCorsPolicy(await readCorsConfig(options))
+  const fetch = async (request: Request): Promise<Response> => {
+    // A preflight never reaches the route table: it claims no in-flight slot
+    // and needs no stores, and the router has no OPTIONS route that could
+    // answer it. Returns undefined when CORS is off or this is not a
+    // preflight, and the request proceeds normally.
+    const preflight = corsPreflightResponse(corsPolicy, request)
+    if (preflight !== undefined) return preflight
+    return applyCorsHeaders(corsPolicy, request, await serveRoutes(request))
   }
 
   return { close, fetch, shutdownController, state }
@@ -1500,6 +1523,38 @@ export function buildRouteTable(ctx: {
       pattern: /^\/threads\/(?<thread_id>[^/?#]+)\/resume(?:\?.*)?$/,
     },
   ]
+}
+
+// ---------------------------------------------------------------------------
+// CORS config resolution
+// ---------------------------------------------------------------------------
+
+/**
+ * `server.cors`, or undefined when this runtime has no config to read it from.
+ *
+ * Three callers, three shapes:
+ * - An edge runtime (or any caller that injects its own stores) passes
+ *   `config` and has no `dawn.config.ts` — read it straight off the object.
+ * - `dawn dev` / `dawn start` pass none and DO have one on disk; routes read it
+ *   lazily through the same memo, so loading here costs nothing extra.
+ * - Neither: no config file and none supplied. That is a legal Dawn app, and
+ *   `loadDawnConfig` signals it by throwing (`access` ENOENT). No config means
+ *   no CORS, exactly like an app that omits the block — the same
+ *   try/catch-to-defaults shape `resolveMemoryStore` uses for this case.
+ *
+ * A config that EXISTS but is malformed still throws: the catch here covers
+ * only obtaining the config, and `resolveCorsPolicy` validates afterwards.
+ */
+async function readCorsConfig(options: {
+  readonly appRoot: string
+  readonly config?: DawnConfig
+}): Promise<CorsConfig | undefined> {
+  if (options.config) return options.config.server?.cors
+  try {
+    return (await loadDawnConfig({ appRoot: options.appRoot })).config.server?.cors
+  } catch {
+    return undefined
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/cli/test/cors-runtime.test.ts
+++ b/packages/cli/test/cors-runtime.test.ts
@@ -1,0 +1,135 @@
+/**
+ * CORS through the real fetch handler.
+ *
+ * `cors.test.ts` pins the policy in isolation; this file pins the wiring —
+ * that the wrapper covers every exit path (dispatch, 404, and the shutdown
+ * 503), that a preflight never reaches the route table, and above all that an
+ * app with no `server.cors` is unchanged.
+ */
+
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { __clearDawnConfigCacheForTests } from "@dawn-ai/core"
+import { afterEach, expect, it } from "vitest"
+import { createRuntimeFetchHandler } from "../src/lib/dev/runtime-fetch-handler.js"
+
+const ORIGIN = "http://localhost:3010"
+
+const cleanup: Array<() => Promise<void> | void> = []
+
+afterEach(async () => {
+  for (const fn of cleanup.splice(0).reverse()) await fn()
+  // The config memo is keyed by appRoot and lives for the process; each test
+  // here boots a DIFFERENT config from a fresh temp root, so a leftover memo
+  // from a previous test would be read instead of this one's.
+  __clearDawnConfigCacheForTests()
+})
+
+async function bootHandler(configSource: string) {
+  const appRoot = await mkdtemp(join(tmpdir(), "dawn-cors-"))
+  cleanup.push(() => rm(appRoot, { force: true, maxRetries: 5, recursive: true, retryDelay: 100 }))
+  for (const [rel, body] of Object.entries({
+    "dawn.config.ts": configSource,
+    "package.json": '{ "name": "cors-fixture", "type": "module" }\n',
+    "src/app/.gitkeep": "",
+  })) {
+    const filePath = join(appRoot, rel)
+    await mkdir(join(filePath, ".."), { recursive: true })
+    await writeFile(filePath, body, "utf8")
+  }
+  const handler = await createRuntimeFetchHandler({ appRoot })
+  cleanup.push(() => handler.close())
+  return handler
+}
+
+const ALLOWING_CONFIG = `export default { server: { cors: { origins: ["${ORIGIN}"] } } }\n`
+
+it("sends no CORS header at all when server.cors is absent", async () => {
+  const handler = await bootHandler("export default {}\n")
+  const response = await handler.fetch(
+    new Request("http://127.0.0.1:3002/healthz", { headers: { origin: ORIGIN } }),
+  )
+  expect(response.status).toBe(200)
+  expect(response.headers.get("access-control-allow-origin")).toBeNull()
+  expect(response.headers.get("vary")).toBeNull()
+})
+
+it("leaves OPTIONS falling through to the router's 404 when CORS is off", async () => {
+  const handler = await bootHandler("export default {}\n")
+  const response = await handler.fetch(
+    new Request("http://127.0.0.1:3002/healthz", {
+      headers: { origin: ORIGIN, "access-control-request-method": "GET" },
+      method: "OPTIONS",
+    }),
+  )
+  expect(response.status).toBe(404)
+})
+
+it("stamps an allowed origin onto a normal response", async () => {
+  const handler = await bootHandler(ALLOWING_CONFIG)
+  const response = await handler.fetch(
+    new Request("http://127.0.0.1:3002/healthz", { headers: { origin: ORIGIN } }),
+  )
+  expect(response.status).toBe(200)
+  expect(response.headers.get("access-control-allow-origin")).toBe(ORIGIN)
+  expect(response.headers.get("vary")).toBe("Origin")
+})
+
+it("answers a preflight without consulting the route table", async () => {
+  const handler = await bootHandler(ALLOWING_CONFIG)
+  // /agui/... exists only for POST, and there is no OPTIONS route anywhere —
+  // a 204 here proves the preflight short-circuits before dispatch.
+  const response = await handler.fetch(
+    new Request("http://127.0.0.1:3002/agui/%2Fresearch%23agent", {
+      headers: {
+        origin: ORIGIN,
+        "access-control-request-headers": "content-type",
+        "access-control-request-method": "POST",
+      },
+      method: "OPTIONS",
+    }),
+  )
+  expect(response.status).toBe(204)
+  expect(response.headers.get("access-control-allow-origin")).toBe(ORIGIN)
+  expect(response.headers.get("access-control-allow-methods")).toContain("POST")
+  expect(response.headers.get("access-control-allow-headers")).toBe("content-type")
+})
+
+it("stamps error responses too, so the browser can read the failure", async () => {
+  const handler = await bootHandler(ALLOWING_CONFIG)
+  const response = await handler.fetch(
+    new Request("http://127.0.0.1:3002/no-such-route", { headers: { origin: ORIGIN } }),
+  )
+  expect(response.status).toBe(404)
+  // Without this the browser reports an opaque CORS failure instead of the
+  // 404 the server actually sent — the single most confusing way to debug.
+  expect(response.headers.get("access-control-allow-origin")).toBe(ORIGIN)
+})
+
+it("stamps the shutdown 503", async () => {
+  const handler = await bootHandler(ALLOWING_CONFIG)
+  await handler.close()
+  const response = await handler.fetch(
+    new Request("http://127.0.0.1:3002/healthz", { headers: { origin: ORIGIN } }),
+  )
+  expect(response.status).toBe(503)
+  expect(response.headers.get("access-control-allow-origin")).toBe(ORIGIN)
+})
+
+it("ignores an origin that is not on the list", async () => {
+  const handler = await bootHandler(ALLOWING_CONFIG)
+  const response = await handler.fetch(
+    new Request("http://127.0.0.1:3002/healthz", { headers: { origin: "http://evil.test" } }),
+  )
+  // Still served — the browser is what refuses to hand it to the page. A 403
+  // here would break every non-browser client that happens to send an Origin.
+  expect(response.status).toBe(200)
+  expect(response.headers.get("access-control-allow-origin")).toBeNull()
+})
+
+it("refuses to boot on an invalid origin list", async () => {
+  await expect(
+    bootHandler('export default { server: { cors: { origins: ["not-an-origin"] } } }\n'),
+  ).rejects.toThrow(/Invalid server\.cors config/)
+})

--- a/packages/cli/test/cors.test.ts
+++ b/packages/cli/test/cors.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, it } from "vitest"
+import {
+  applyCorsHeaders,
+  CorsConfigError,
+  corsPreflightResponse,
+  corsResponseHeaders,
+  resolveCorsPolicy,
+} from "../src/lib/dev/cors.js"
+
+const ORIGIN = "http://localhost:3010"
+
+function req(
+  method: string,
+  headers: Record<string, string> = {},
+  url = "http://127.0.0.1:3002/agui/x",
+): Request {
+  return new Request(url, { method, headers })
+}
+
+describe("resolveCorsPolicy", () => {
+  it("is off when unconfigured", () => {
+    expect(resolveCorsPolicy(undefined)).toBeUndefined()
+  })
+
+  it("normalizes configured origins so a trailing slash still matches", () => {
+    const policy = resolveCorsPolicy({ origins: ["HTTP://LocalHost:3010/"] })
+    expect(policy?.origins.has("http://localhost:3010")).toBe(true)
+  })
+
+  it("rejects a wildcard combined with credentials", () => {
+    expect(() => resolveCorsPolicy({ origins: "*", credentials: true })).toThrow(CorsConfigError)
+  })
+
+  it("rejects an empty origin list", () => {
+    expect(() => resolveCorsPolicy({ origins: [] })).toThrow(CorsConfigError)
+  })
+
+  it("rejects an origin carrying a path", () => {
+    expect(() => resolveCorsPolicy({ origins: ["http://localhost:3010/app"] })).toThrow(
+      CorsConfigError,
+    )
+  })
+
+  it("rejects a value that is not a URL at all", () => {
+    expect(() => resolveCorsPolicy({ origins: ["localhost:3010"] })).toThrow(CorsConfigError)
+  })
+})
+
+describe("corsResponseHeaders", () => {
+  it("adds nothing when CORS is off", () => {
+    expect(corsResponseHeaders(undefined, req("GET", { origin: ORIGIN }))).toBeUndefined()
+  })
+
+  it("adds nothing when the request carries no Origin", () => {
+    const policy = resolveCorsPolicy({ origins: [ORIGIN] })
+    expect(corsResponseHeaders(policy, req("GET"))).toBeUndefined()
+  })
+
+  it("adds nothing for an origin that is not on the list", () => {
+    const policy = resolveCorsPolicy({ origins: [ORIGIN] })
+    expect(corsResponseHeaders(policy, req("GET", { origin: "http://evil.test" }))).toBeUndefined()
+  })
+
+  it("echoes an allowed origin and varies on it", () => {
+    const policy = resolveCorsPolicy({ origins: [ORIGIN] })
+    expect(corsResponseHeaders(policy, req("GET", { origin: ORIGIN }))).toEqual({
+      "access-control-allow-origin": ORIGIN,
+      vary: "Origin",
+    })
+  })
+
+  it("echoes the origin rather than a literal star under origins: '*'", () => {
+    const policy = resolveCorsPolicy({ origins: "*" })
+    const headers = corsResponseHeaders(policy, req("GET", { origin: "http://anywhere.test" }))
+    expect(headers?.["access-control-allow-origin"]).toBe("http://anywhere.test")
+  })
+
+  it("advertises credentials only when configured", () => {
+    const withCreds = resolveCorsPolicy({ origins: [ORIGIN], credentials: true })
+    expect(
+      corsResponseHeaders(withCreds, req("GET", { origin: ORIGIN }))?.[
+        "access-control-allow-credentials"
+      ],
+    ).toBe("true")
+    const without = resolveCorsPolicy({ origins: [ORIGIN] })
+    expect(
+      corsResponseHeaders(without, req("GET", { origin: ORIGIN }))?.[
+        "access-control-allow-credentials"
+      ],
+    ).toBeUndefined()
+  })
+
+  it("exposes configured response headers", () => {
+    const policy = resolveCorsPolicy({ origins: [ORIGIN], exposeHeaders: ["x-dawn-run-id"] })
+    expect(
+      corsResponseHeaders(policy, req("GET", { origin: ORIGIN }))?.[
+        "access-control-expose-headers"
+      ],
+    ).toBe("x-dawn-run-id")
+  })
+})
+
+describe("corsPreflightResponse", () => {
+  const policy = resolveCorsPolicy({ origins: [ORIGIN] })
+
+  it("ignores a non-OPTIONS request", () => {
+    expect(corsPreflightResponse(policy, req("POST", { origin: ORIGIN }))).toBeUndefined()
+  })
+
+  it("ignores a bare OPTIONS with no Access-Control-Request-Method", () => {
+    // Deliberate: the runtime serves no OPTIONS route, so this must fall
+    // through to the router's 404 rather than be answered 204.
+    expect(corsPreflightResponse(policy, req("OPTIONS", { origin: ORIGIN }))).toBeUndefined()
+  })
+
+  it("answers 204 with the advertised methods and echoed headers", () => {
+    const response = corsPreflightResponse(
+      policy,
+      req("OPTIONS", {
+        origin: ORIGIN,
+        "access-control-request-method": "POST",
+        "access-control-request-headers": "content-type, authorization",
+      }),
+    )
+    expect(response?.status).toBe(204)
+    expect(response?.headers.get("access-control-allow-origin")).toBe(ORIGIN)
+    expect(response?.headers.get("access-control-allow-methods")).toBe("GET, POST, DELETE, OPTIONS")
+    expect(response?.headers.get("access-control-allow-headers")).toBe(
+      "content-type, authorization",
+    )
+    expect(response?.headers.get("access-control-max-age")).toBe("600")
+    expect(response?.headers.get("vary")).toBe("Origin, Access-Control-Request-Headers")
+  })
+
+  it("prefers a configured header allowlist over echoing the request", () => {
+    const pinned = resolveCorsPolicy({ origins: [ORIGIN], headers: ["content-type"] })
+    const response = corsPreflightResponse(
+      pinned,
+      req("OPTIONS", {
+        origin: ORIGIN,
+        "access-control-request-method": "POST",
+        "access-control-request-headers": "content-type, x-smuggled",
+      }),
+    )
+    expect(response?.headers.get("access-control-allow-headers")).toBe("content-type")
+  })
+
+  it("refuses a preflight from an origin that is not on the list", () => {
+    const response = corsPreflightResponse(
+      policy,
+      req("OPTIONS", { origin: "http://evil.test", "access-control-request-method": "POST" }),
+    )
+    expect(response?.status).toBe(403)
+    expect(response?.headers.get("access-control-allow-origin")).toBeNull()
+  })
+})
+
+describe("applyCorsHeaders", () => {
+  const policy = resolveCorsPolicy({ origins: [ORIGIN] })
+
+  it("returns the response untouched when the origin is not allowed", () => {
+    const original = Response.json({ ok: true })
+    const result = applyCorsHeaders(policy, req("GET", { origin: "http://evil.test" }), original)
+    expect(result).toBe(original)
+    expect(result.headers.get("access-control-allow-origin")).toBeNull()
+  })
+
+  it("stamps headers onto an existing response without rebuilding it", () => {
+    const original = Response.json({ ok: true })
+    const result = applyCorsHeaders(policy, req("GET", { origin: ORIGIN }), original)
+    expect(result).toBe(original)
+    expect(result.headers.get("access-control-allow-origin")).toBe(ORIGIN)
+  })
+
+  it("leaves a streaming body readable and unconsumed", async () => {
+    // The SSE routes hand back a Response whose body is still streaming; the
+    // header stamp must not touch it.
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode("data: hi\n\n"))
+        controller.close()
+      },
+    })
+    const original = new Response(stream, { headers: { "content-type": "text/event-stream" } })
+    const result = applyCorsHeaders(policy, req("GET", { origin: ORIGIN }), original)
+    expect(result.bodyUsed).toBe(false)
+    expect(result.headers.get("access-control-allow-origin")).toBe(ORIGIN)
+    expect(await result.text()).toBe("data: hi\n\n")
+  })
+})

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -112,6 +112,7 @@ export type { RouteStateFields } from "./typegen/render-state-types.js"
 export { renderStateTypes } from "./typegen/render-state-types.js"
 export { renderToolTypes } from "./typegen/render-tool-types.js"
 export type {
+  CorsConfig,
   DawnConfig,
   DiscoveredDawnApp,
   DiscoverRoutesOptions,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -96,6 +96,27 @@ export interface DawnConfig {
     readonly targets?: readonly string[]
   }
   readonly sandbox?: SandboxConfig
+  /**
+   * How the Dawn HTTP runtime itself behaves — as opposed to what the agent
+   * does. Everything here is off unless configured.
+   */
+  readonly server?: {
+    /**
+     * Cross-origin access to the Dawn endpoints (`/agui/*`, `/threads/*`,
+     * `/memory/*`). Omit and the runtime sends no `Access-Control-*` header at
+     * all, which means a browser on another origin cannot call it — the
+     * default, because opening a server to other origins is a deployment
+     * decision.
+     *
+     * Set it when a browser client talks to Dawn directly rather than through
+     * a same-origin proxy:
+     *
+     * ```ts
+     * server: { cors: { origins: ["http://localhost:3010"] } }
+     * ```
+     */
+    readonly cors?: CorsConfig
+  }
   readonly memory?: {
     readonly enabled?: boolean
     /** Custom memory store. Defaults to an SQLite-backed store at <appRoot>/.dawn/memory.sqlite. */
@@ -192,6 +213,37 @@ export interface DawnConfig {
       readonly appRoot: string
     }) => Record<string, string>
   }
+}
+
+/**
+ * Cross-origin policy for the Dawn runtime (`server.cors`).
+ *
+ * Presence of this object is what turns CORS on; there is no `enabled` flag.
+ */
+export interface CorsConfig {
+  /**
+   * Origins allowed to read responses — an explicit list (compared exactly,
+   * after normalizing case and a trailing slash) or `"*"` for any origin.
+   *
+   * `"*"` with `credentials: true` is rejected at boot: browsers refuse a
+   * wildcard allow-origin on a credentialed request, so accepting it would
+   * produce a server that looks configured and fails only in the console.
+   */
+  readonly origins: readonly string[] | "*"
+  /** Allow cookies and `Authorization` cross-origin. Default false. */
+  readonly credentials?: boolean
+  /** Methods advertised in a preflight. Default: GET, POST, DELETE, OPTIONS. */
+  readonly methods?: readonly string[]
+  /**
+   * Request headers advertised in a preflight. Default: echo whatever the
+   * browser asked for, so an app can add an auth header without touching
+   * server config.
+   */
+  readonly headers?: readonly string[]
+  /** Response headers a browser script may read. Default none. */
+  readonly exposeHeaders?: readonly string[]
+  /** How long a browser may cache a preflight, in seconds. Default 600. */
+  readonly maxAgeSeconds?: number
 }
 
 export type RouteSegment =

--- a/packages/devkit/templates/app-research/server/dawn.config.ts
+++ b/packages/devkit/templates/app-research/server/dawn.config.ts
@@ -35,6 +35,21 @@ export default config({
   // Persistence (SQLite checkpointer + Agent Protocol) is on by default — no
   // config needed. Threads survive a restart.
 
+  // --- Capability seam (documented, inactive): cross-origin access ---
+  // Dawn sends no `Access-Control-*` header unless this block exists, and
+  // `web/` deliberately does not need it: its browser client reaches Dawn
+  // through a same-origin Next proxy (`web/app/api/dawn/[...path]/route.ts`),
+  // so Dawn's address never leaves the server.
+  //
+  // Uncomment when a browser talks to Dawn DIRECTLY — a client on another
+  // origin, or one that has dropped the proxy. `localhost` and `127.0.0.1` are
+  // different origins to a browser, so list both if your dev client may be
+  // opened at either. See /docs/configuration#servercors.
+  //
+  // server: {
+  //   cors: { origins: ["http://localhost:3010", "http://127.0.0.1:3010"] },
+  // },
+
   // --- Capability seam: Docker execution sandbox ---
   // Default runs use the local workspace so the bundled corpus works without
   // Docker. Run `npm run test:sandbox:docker` to dogfood the same scaffold with

--- a/packages/devkit/templates/app-research/web/app/api/dawn/[...path]/route.ts
+++ b/packages/devkit/templates/app-research/web/app/api/dawn/[...path]/route.ts
@@ -1,8 +1,9 @@
 import { type NextRequest, NextResponse } from "next/server"
 import { resolveProxyTarget } from "../../../lib/proxy-allowlist"
 
-// Same-origin proxy to the Dawn server. The dev server sets no CORS headers,
-// so the browser cannot read it directly. Every routing decision is in
+// Same-origin proxy to the Dawn server. A Dawn server sends no CORS headers
+// unless `server.cors` is configured, and this app deliberately does not
+// depend on that — the browser never learns Dawn's address. Every routing decision is in
 // `lib/proxy-allowlist.ts`, which is where the tests are; this file is the
 // adapter and deliberately holds no policy of its own.
 export const runtime = "nodejs"

--- a/packages/devkit/templates/app-research/web/app/lib/proxy-allowlist.ts
+++ b/packages/devkit/templates/app-research/web/app/lib/proxy-allowlist.ts
@@ -1,8 +1,11 @@
 /**
  * Which Dawn server paths the browser may reach, and nothing else.
  *
- * The dev server sets no CORS headers, so direct reads from the page are
- * impossible and a same-origin proxy is required. An OPEN proxy in a template
+ * A Dawn server sends no CORS headers unless its `dawn.config.ts` sets
+ * `server.cors`, and this app deliberately does not rely on that being set —
+ * so direct reads from the page are impossible and a same-origin proxy is
+ * required. That is a posture, not a limitation: the browser never learns
+ * Dawn's address, and the server needs no cross-origin configuration. An OPEN proxy in a template
  * every Dawn developer copies is a liability — this app would happily forward
  * `POST /threads/:id/resume` or the whole agent surface — so the allowlist is
  * the point of the route, not an optimization over it.

--- a/scripts/check-docs.mjs
+++ b/scripts/check-docs.mjs
@@ -3222,6 +3222,14 @@ const expectedDawnConfigSchemaPaths = [
   "sandbox.security.runAsNonRoot",
   "sandbox.security.runAsNonRoot.gid",
   "sandbox.security.runAsNonRoot.uid",
+  "server",
+  "server.cors",
+  "server.cors.credentials",
+  "server.cors.exposeHeaders",
+  "server.cors.headers",
+  "server.cors.maxAgeSeconds",
+  "server.cors.methods",
+  "server.cors.origins",
   "summarization",
   "summarization.enabled",
   "summarization.keepRecentTurns",
@@ -3240,7 +3248,7 @@ const expectedDawnConfigSchemaPaths = [
 ].sort()
 
 const dawnConfigSchemaPaths = collectConfigSchemaPaths({
-  expandInterfaces: ["DawnConfig", "SandboxConfig", "SandboxSecurityPolicy"],
+  expandInterfaces: ["CorsConfig", "DawnConfig", "SandboxConfig", "SandboxSecurityPolicy"],
   rootInterface: "DawnConfig",
   sources: [
     readFileSync(resolve(repoRoot, "packages/core/src/types.ts"), "utf8"),


### PR DESCRIPTION
Adds `DawnConfig.server.cors`. A Dawn server sends no `Access-Control-*` header unless `dawn.config.ts` sets it — with the block absent the runtime answers exactly as it did before, no header on any response and `OPTIONS` still falling through to its 404. Opening a server to other origins is a deployment decision, so nothing is inferred.

```ts
server: { cors: { origins: ["https://app.example.com"] } }
```

Needed whenever a browser client talks to Dawn directly rather than through a same-origin proxy.

## Why it wraps the handler rather than living inside it

`serveRoutes` has eight exit paths — the dispatch result, the tracked SSE response, the shutdown 503 and five error branches — and a cross-origin caller has to be able to read **all** of them, including the failures. A browser that cannot read a 404 reports an opaque CORS error instead, which is the most confusing way to debug this. Stamping once at the wrapper is the only version with no path left uncovered.

## Three decisions worth reviewing, each pinned by a test

- **A disallowed origin is still served**, just without the header — the browser is what refuses to hand it to the page. Answering 403 there would break every non-browser client that happens to send an `Origin`. A *preflight* from a disallowed origin does get a 403: it has no non-browser caller to break, and it is legible in a network panel.
- **`origins: "*"` with `credentials: true` is rejected at boot.** Browsers refuse a wildcard allow-origin on a credentialed request, so accepting it would produce a server that looks configured and fails only in the console.
- **The allow-origin header always echoes the caller's origin**, never a literal `*`, with `Vary: Origin` — one code path serves both cases, and the credentialed case cannot regress into an invalid wildcard.

## Boot-time resolution, and the edge case it broke

Config is resolved and validated once at boot, so a malformed origin list fails on startup rather than on the first cross-origin request. `dawn dev` passes no config and reads `dawn.config.ts` from disk; an edge runtime passes one and never touches disk; an app with **neither** is legal and gets no CORS.

That last case is not hypothetical — loading unconditionally at boot broke the hono/edge target, which has no config file. Caught by the full CLI suite, not by the new tests. `readCorsConfig` now falls back to "no CORS" when the config cannot be obtained, while a config that *exists but is malformed* still fails loudly.

## Tests

29 new. `cors.test.ts` pins the policy in isolation; `cors-runtime.test.ts` pins the wiring through the real handler — including that an app with no `server.cors` is unchanged, that a preflight never reaches the route table, and that error responses and the shutdown 503 are stamped too.

Verified live against a running server: preflight → 204 with the advertised methods and echoed headers; allowed origin echoed with `Vary`; disallowed origin served with no header.

## Also in this PR

- `examples/research/server/dawn.config.ts` documents the feature as a commented-out seam. That app's browser client reaches Dawn through a same-origin proxy and deliberately does not depend on CORS.
- Three comments claiming the dev server "sets no CORS headers" are corrected, since that is no longer unconditionally true.

## Checks

| | |
|---|---|
| CLI | 1640 tests, lint, typecheck ✅ |
| core | lint, typecheck ✅ |
| research server | 7 tests, lint, typecheck ✅ |
| research web | 212 tests, lint, typecheck ✅ |

## Context

This came out of a spike comparing three transports for the research example's web client. The rest of that work — porting the client off CopilotKit — was **abandoned and reverted**; `server.cors` is independent of it and useful on its own, since it is what lets any browser client reach Dawn directly. The abandoned design doc is not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)