### PR TITLE
fix(release): accept complete bounded release inventories in recovery routing

### DIFF
--- a/docs/superpowers/plans/2026-09-05-recovery-release-inventory-budget.md
+++ b/docs/superpowers/plans/2026-09-05-recovery-release-inventory-budget.md
@@ -1,0 +1,16 @@
+# Recovery release inventory budget implementation plan
+
+> For agentic workers: use superpowers:executing-plans for this bounded correction.
+
+**Goal:** Make both recovery routing inventory paths accept the same complete bounded release history.
+
+**Architecture:** Reuse the existing 16 MiB allowance specifically for release inventory reads. Preserve all unrelated snapshot and authority limits.
+
+**Tech Stack:** Node.js ESM, node:test, GitHub Actions.
+
+- [x] Review the bounded design.
+- [x] Add production-sized routing regression and safety controls to `scripts/release/test/recovery-routing.test.mjs`; demonstrate the successful path fails before the fix.
+- [x] Name and apply the shared release inventory allowance in `scripts/release/recovery/observe.mjs`.
+- [ ] Refresh the dormant policy's verifier closure digest, affected transitive release content pins and their manifest baseline, run focused tests and repository checks, and obtain independent review.
+- [ ] Reproduce production discovery read-only and open a separate PR; complete required CI before merge.
+- [ ] Verify post-merge observation and preserve activation blockers separately.

--- a/docs/superpowers/specs/2026-09-05-recovery-release-inventory-budget.md
+++ b/docs/superpowers/specs/2026-09-05-recovery-release-inventory-budget.md
@@ -1,0 +1,13 @@
+# Recovery release inventory read budget
+
+The Release run after PR #572 merged (`33984920810`, controller `cb84db8c`) stopped before mutation with `CANDIDATE_DISCOVERY_AMBIGUOUS`. A read-only reproduction threw `Invalid recovery evidence: snapshot byte limit`. The repository has 477 releases in five complete API pages, approximately 2.54 MB of JSON. A single page fits the default limit, which hid the issue in small fixtures.
+
+`discoverRecoveryReleaseCandidates` already validates supplied complete release inventories against a 16 MiB bound. `routeRecoveryCandidate` also supports fetching the inventory itself, through `readerContext.read`. That path uses the 1 MiB selection default in `runRecoveryRead`. The same inventory therefore fails depending on which path supplied it.
+
+Use the existing 16 MiB release-inventory allowance for `readerContext.read("listReleases")`, and name that allowance once for both paths. The fetched path counts its response envelope; the supplied path counts the array. These are nominal snapshot allowances, not exact serialized JSON byte measurements. Other operations keep their existing limits. Preserve descriptor, depth, node, unsafe-key, pagination and inventory checks. Do not change token permissions, candidate ownership semantics, policy activation, or publication behavior.
+
+Alternatives: a global default increase would broaden unrelated reads; projecting release data would require defining and reviewing another authority surface. The operation-specific allowance is the smallest correction consistent with the existing discovery contract.
+
+Regression evidence must exercise a 477-entry inventory larger than 1 MiB through the self-fetching production-routing path, show unchanged legacy selection, reject inventories exceeding 16 MiB and malformed metadata, and preserve duplicate-candidate rejection. The successful supplied-inventory path is a comparison control. Run focused routing/policy/production-discovery tests, required CI, and a read-only production reproduction against the corrected controller.
+
+Recovery remains DORMANT. The separate policy-read credential, platform authority contract, real workflow-token publication and quota evidence remain activation obligations. Automated reviewer credits are excluded by the owner's instruction.

--- a/scripts/release/recovery/observe.mjs
+++ b/scripts/release/recovery/observe.mjs
@@ -48,6 +48,8 @@ export const RECOVERY_FINALIZATION_ASSET = "recovery-v2-finalization.json"
 const requireThat = (ok, message) => {
   if (!ok) throw new TypeError(`Recovery observation blocked: ${message}`)
 }
+// Complete release histories use the same nominal allowance whether supplied or fetched.
+const RELEASE_INVENTORY_BYTES = 16 * 1024 * 1024
 const hash = (bytes) => createHash("sha256").update(bytes).digest("hex")
 const stable = (value) =>
   Array.isArray(value)
@@ -127,7 +129,12 @@ function readerContext({ github, git }) {
   const budget = createRecoveryWorkBudget({ phaseDeadline })
   return {
     now,
-    read: (name, args) => envelope(() => recoveryMethods(github, [name])[name](args)),
+    read: (name, args) =>
+      envelope(
+        () => recoveryMethods(github, [name])[name](args),
+        "value",
+        name === "listReleases" ? RELEASE_INVENTORY_BYTES : undefined,
+      ),
     download: (args) =>
       envelope(
         () => recoveryMethods(github, ["downloadReleaseAsset"]).downloadReleaseAsset(args),
@@ -1390,7 +1397,7 @@ async function readFixedFinalization(context, assets) {
 // This only supplies routing subjects; observation must still prove each identity.
 export async function discoverRecoveryReleaseCandidates(input) {
   const { github, releaseRecords } = safeInput(input, ["github", "releaseRecords"])
-  const releases = snapshotRecoveryData(releaseRecords, 16 * 1024 * 1024)
+  const releases = snapshotRecoveryData(releaseRecords, RELEASE_INVENTORY_BYTES)
   requireThat(Array.isArray(releases), "release discovery unavailable")
   const context = readerContext({ github })
   const ownership = new Map()

--- a/scripts/release/recovery/policy.json
+++ b/scripts/release/recovery/policy.json
@@ -171,7 +171,7 @@
       "scripts/release/terminal-records.mjs",
       "scripts/release/topology.mjs"
     ],
-    "sha256": "9f3b6ebefb4343b7b85f88e7056aaa7a9e4582e9a32469869c77b20fcbd125f8"
+    "sha256": "c98de85868eb0b5bb012693623f8e1bf3753cbc29726857cec6371f9ea0601a8"
   },
   "workflows": [
     ".github/workflows/release-postpublication-audit.yml",

--- a/scripts/release/test/fixtures/release-script-hashes.json
+++ b/scripts/release/test/fixtures/release-script-hashes.json
@@ -173,13 +173,13 @@
       "sha256": "0da8451d732545c08386ee90015c7fabf9d1e5a1855a5546fcdad4c0a54538d2"
     },
     "scripts/release/recovery/observe.mjs": {
-      "sha256": "818caff803f53d3926f7328356ff7c19b99b30df919ff90e0d565362e3acb1d0"
+      "sha256": "0891ae4aad631a38ca9700bc7706da557318eecbc908af3d0a5aaded17a414d2"
     },
     "scripts/release/recovery/payload-reuse.mjs": {
       "sha256": "bfe8d23eb87cb31afc474f77fa4742784508e20d985b44717479f22ad918c517"
     },
     "scripts/release/recovery/policy.json": {
-      "sha256": "c3551e4230ab0c1109086556937b4d38494c18adcf3e094d9791013188d7d27b"
+      "sha256": "64e7b001cf967046bb7023a13a4a459942e9eeabe590e6fbf88ed8ec70396d00"
     },
     "scripts/release/recovery/policy.mjs": {
       "sha256": "77e3651e87b6964b84333a6c324087e855035a77987054e4fc73a412ff148ad2"

--- a/scripts/release/test/recovery-routing.test.mjs
+++ b/scripts/release/test/recovery-routing.test.mjs
@@ -690,3 +690,99 @@ for (const body of ["", "corrupt <!-- DAWN_RELEASE_CONTROLLER_MARKER\n{"])
     assert.equal(observed.facts.release.body, body)
     assert.deepEqual(observed.facts.finalization.ref, r.finalRef)
   })
+
+async function largeLegacyReleaseHistory() {
+  const r = await recoveryRemote()
+  r.args.git.listTree = async () => ""
+  const records = Array.from({ length: 476 }, (_, index) => ({
+    id: 10000 + index,
+    draft: false,
+    tag_name: `historical-package-${index}`,
+    name: `Historical package ${index}`,
+    body: "Historical release notes. ".repeat(225),
+  }))
+  records.push(r.release)
+  const readAssets = r.args.github.listReleaseAssets
+  r.args.github.listReleases = async () => ({ status: "PRESENT", value: records })
+  r.args.github.listReleaseAssets = async (args) =>
+    String(args.releaseId) === r.c.releaseId ? readAssets(args) : { status: "PRESENT", value: [] }
+  assert.ok(Buffer.byteLength(JSON.stringify(records)) > 2 * 1024 * 1024)
+  return { r, records }
+}
+
+test("production resolver preserves legacy selection with 477 complete release records above 1 MiB", async () => {
+  const { r, records } = await largeLegacyReleaseHistory()
+  assert.equal(
+    await routing.routeRecoveryCandidate({
+      ...r.args,
+      candidate: legacy(r),
+      terminalRecordRef: r.e.controllerSha,
+      releaseRecords: records,
+    }),
+    null,
+  )
+  const selected = {
+    candidate: legacy(r),
+    state: "CANDIDATE_VALIDATED",
+    disposition: "selected",
+    tag: r.c.tag,
+    conflicts: [],
+  }
+  const result = await resolveProductionCandidate({
+    ...r.args,
+    event: { ref: "refs/heads/main", after: r.c.candidateSha },
+    terminalRecordRef: r.e.controllerSha,
+    inventory: { read: async () => ({}) },
+    discovery: {
+      discoverManagedCandidate: async () => selected,
+      discoverScheduledCandidate: async () => selected,
+    },
+  })
+  assert.deepEqual(result, selected)
+})
+
+for (const supplied of [false, true])
+  test(`release inventory still rejects over 16 MiB with supplied=${supplied}`, async () => {
+    const { r, records } = await largeLegacyReleaseHistory()
+    records[0].body = "x".repeat(16 * 1024 * 1024)
+    await assert.rejects(
+      routing.routeRecoveryCandidate({
+        ...r.args,
+        candidate: legacy(r),
+        terminalRecordRef: r.e.controllerSha,
+        ...(supplied ? { releaseRecords: records } : {}),
+      }),
+      /snapshot byte limit/,
+    )
+  })
+
+test("large release inventory preserves duplicate candidate rejection at the end of history", async () => {
+  const { r, records } = await largeLegacyReleaseHistory()
+  records.push({ ...r.release, id: 903 })
+  await assert.rejects(route(r), /duplicate candidate releases/)
+})
+
+test("large release inventory rejects accessors without evaluating them", async () => {
+  const { r, records } = await largeLegacyReleaseHistory()
+  let calls = 0
+  Object.defineProperty(records.at(-2), "unexpected", {
+    enumerable: true,
+    get() {
+      calls++
+      return "ignored metadata"
+    },
+  })
+  await assert.rejects(route(r), /accessors\/hidden fields forbidden/)
+  assert.equal(calls, 0)
+})
+
+test("release inventory allowance does not enlarge unrelated asset inventory reads", async () => {
+  const { r } = await largeLegacyReleaseHistory()
+  let reads = 0
+  r.args.github.listReleaseAssets = async () => {
+    reads++
+    return { status: "PRESENT", value: [{ name: "notes", metadata: "x".repeat(1024 * 1024) }] }
+  }
+  await assert.rejects(route(r), /snapshot byte limit/)
+  assert.equal(reads, 1)
+})

--- a/scripts/release/test/workflow-contracts.test.mjs
+++ b/scripts/release/test/workflow-contracts.test.mjs
@@ -103,7 +103,7 @@ const SCRIPT_PIN_PATH = path.join(ROOT, SCRIPT_PIN_FIXTURE)
 // Repinned for Task 10a: strict GitHub inventories, bounded exact git reads, and dormant verifier closure.
 // Repinned for Task 12a: fresh complete-inventory npm signature batching.
 const STARTING_SCRIPT_PIN_SHA256 =
-  "e28ec97bcbd9b2fb9bee756e50adabdbf6ab5dbb633139e7177554a5e18ed2cb"
+  "6fb2a8765f88484aaacd334cc2aaaddc91935976fafd6ab654edd8226af8b32d"
 const SHA256_HEX = /^[0-9a-f]{64}$/u
 const workflowExpression = (value) => `\${{ ${value} }}`
 const SCRIPT_REFERENCE = /(?:^|[\s;&|"'(])(scripts\/[\w.-]+(?:\/[\w.-]+)*)/gu


### PR DESCRIPTION
The Release observer failed candidate discovery after #572 merged because the complete repository history contains 477 releases across five pages (~2.54 MB). Recovery discovery already accepts a 16 MiB inventory, but the subsequent self-fetching ownership check used the 1 MiB selection default and rejected the same history.

Apply the existing nominal 16 MiB allowance specifically to `listReleases`, sharing its constant with supplied-inventory discovery. Other read limits, complete-history validation, snapshot safety checks and ownership behavior remain unchanged. Refresh the verifier closure, both affected transitive release content pins and their manifest baseline; recovery stays DORMANT.

Validation: the production failure was reproduced read-only with a full stack identifying the self-fetching path. The new resolver regression failed before the fix. All 277 focused routing, policy, production-observer and workflow-contract tests now pass. Six regressions cover a 477-entry history, both oversized-input paths, duplicate candidates, accessors and unchanged unrelated limits. Independent design/code/pin review, lint, release inventory, docs and diff checks passed. Corrected live reproduction selected the original 0.8.24 candidate without conflicts in 213.6 seconds, with zero production writes.

The first full CI attempt passed 3,256 controller tests and caught the missing content-pin refresh, now corrected and locally verified. Its separate Vercel preview lane stayed QUEUED before readiness; cleanup and absent database rows were verified. On the corrected head, required validate passed all 3,257 controller tests plus the remaining docs and packaging gates. Nineteen CI jobs passed. The Vercel retry again remained QUEUED before readiness; its deployment was cleaned and database rows were absent. The same queue failure occurred on the base/main run, and this PR changes no Vercel or CI source. Overall CI therefore remains failed solely for that separate deployment lane. The optional external reviewer remains unfunded per the owner's instruction; its check has not been disabled or fabricated.
