### PR TITLE
test(release): rehearse workflow writes against an existing draft

### DIFF
--- a/scripts/release/test/fixtures/recovery-topology-workflow.yml
+++ b/scripts/release/test/fixtures/recovery-topology-workflow.yml
@@ -30,6 +30,12 @@ on:
       publication_source_sha:
         type: string
         default: ""
+      existing_tag_nonce:
+        type: string
+        default: ""
+      existing_tag_object_sha:
+        type: string
+        default: ""
       discard_response:
         type: choice
         options:
@@ -311,6 +317,8 @@ jobs:
           DAWN_RECOVERY_TEST_POLICY_TOKEN: ${{ secrets.RECOVERY_POLICY_READ_TOKEN }}
           DAWN_RECOVERY_TEST_CREDENTIAL_KIND: workflow
           DAWN_RECOVERY_TEST_SOURCE_SHA: ${{ inputs.publication_source_sha }}
+          DAWN_RECOVERY_TEST_EXISTING_TAG_NONCE: ${{ inputs.existing_tag_nonce }}
+          DAWN_RECOVERY_TEST_EXISTING_TAG_OBJECT_SHA: ${{ inputs.existing_tag_object_sha }}
           DAWN_RECOVERY_TEST_DISCARD_RESPONSE: ${{ inputs.discard_response }}
         run: node --test scripts/release/test/recovery-publication-github.integration.mjs
       - name: Retain publication contract ledger

--- a/scripts/release/test/fixtures/recovery-topology-workflow.yml
+++ b/scripts/release/test/fixtures/recovery-topology-workflow.yml
@@ -36,6 +36,9 @@ on:
       existing_tag_object_sha:
         type: string
         default: ""
+      existing_release_id:
+        type: string
+        default: ""
       discard_response:
         type: choice
         options:
@@ -319,6 +322,7 @@ jobs:
           DAWN_RECOVERY_TEST_SOURCE_SHA: ${{ inputs.publication_source_sha }}
           DAWN_RECOVERY_TEST_EXISTING_TAG_NONCE: ${{ inputs.existing_tag_nonce }}
           DAWN_RECOVERY_TEST_EXISTING_TAG_OBJECT_SHA: ${{ inputs.existing_tag_object_sha }}
+          DAWN_RECOVERY_TEST_EXISTING_RELEASE_ID: ${{ inputs.existing_release_id }}
           DAWN_RECOVERY_TEST_DISCARD_RESPONSE: ${{ inputs.discard_response }}
         run: node --test scripts/release/test/recovery-publication-github.integration.mjs
       - name: Retain publication contract ledger

--- a/scripts/release/test/recovery-publication-github.integration.mjs
+++ b/scripts/release/test/recovery-publication-github.integration.mjs
@@ -44,12 +44,27 @@ test("real annotated-tag publication, draft visibility and immutable asset readb
   }
   const discard = env.DAWN_RECOVERY_TEST_DISCARD_RESPONSE ?? ""
   assert.ok(["", "upload", "publication"].includes(discard), "bounded response-loss experiment")
+  const existingNonce = env.DAWN_RECOVERY_TEST_EXISTING_TAG_NONCE ?? ""
+  const existingTagObjectSha = env.DAWN_RECOVERY_TEST_EXISTING_TAG_OBJECT_SHA ?? ""
+  assert.equal(
+    existingNonce === "",
+    existingTagObjectSha === "",
+    "existing tag nonce and object SHA must be supplied together",
+  )
+  if (existingNonce !== "") {
+    assert.match(existingNonce, /^[a-f0-9]{8}(?:-[a-f0-9]{4}){3}-[a-f0-9]{12}$/u)
+    assert.match(existingTagObjectSha, /^[a-f0-9]{40}$/u)
+  }
   let discarded = false
   const root = await mkdtemp(join(env.RUNNER_TEMP ?? tmpdir(), "dawn-recovery-publication-"))
   const ledger = {
     repository,
     startedAt: new Date().toISOString(),
     credentialKind: env.DAWN_RECOVERY_TEST_CREDENTIAL_KIND,
+    tagProvenance: existingNonce === "" ? "probe-created" : "operator-created",
+    existingTag:
+      existingNonce === "" ? null : { nonce: existingNonce, objectSha: existingTagObjectSha },
+    releaseWriteCredentialKind: env.DAWN_RECOVERY_TEST_CREDENTIAL_KIND,
     runId: env.GITHUB_RUN_ID ?? null,
     calls: [],
     owned: null,
@@ -105,8 +120,18 @@ test("real annotated-tag publication, draft visibility and immutable asset readb
       })
       entry.status = response.status
       entry.headers = Object.fromEntries(
-        ["date", "cache-control", "etag", "x-github-request-id", "x-ratelimit-remaining"].flatMap(
-          (name) => (response.headers.has(name) ? [[name, response.headers.get(name)]] : []),
+        [
+          "date",
+          "cache-control",
+          "etag",
+          "x-github-request-id",
+          "x-ratelimit-limit",
+          "x-ratelimit-used",
+          "x-ratelimit-reset",
+          "x-ratelimit-resource",
+          "x-ratelimit-remaining",
+        ].flatMap((name) =>
+          response.headers.has(name) ? [[name, response.headers.get(name)]] : [],
         ),
       )
       const chunks = []
@@ -140,7 +165,8 @@ test("real annotated-tag publication, draft visibility and immutable asset readb
     const result = await runPublicationServiceProbe({
       repository,
       sourceSha: env.DAWN_RECOVERY_TEST_SOURCE_SHA,
-      nonce: randomUUID(),
+      nonce: existingNonce || randomUUID(),
+      existingTagObjectSha: existingTagObjectSha || null,
       topologySha256: hash(
         await readFile(new URL("./fixtures/recovery-topology-workflow.yml", import.meta.url)),
       ),

--- a/scripts/release/test/recovery-publication-github.integration.mjs
+++ b/scripts/release/test/recovery-publication-github.integration.mjs
@@ -55,6 +55,13 @@ test("real annotated-tag publication, draft visibility and immutable asset readb
     assert.match(existingNonce, /^[a-f0-9]{8}(?:-[a-f0-9]{4}){3}-[a-f0-9]{12}$/u)
     assert.match(existingTagObjectSha, /^[a-f0-9]{40}$/u)
   }
+  const existingReleaseText = env.DAWN_RECOVERY_TEST_EXISTING_RELEASE_ID ?? ""
+  const existingReleaseId = existingReleaseText === "" ? null : Number(existingReleaseText)
+  if (existingReleaseId !== null) {
+    assert.ok(existingNonce !== "", "existing release requires existing tag mode")
+    assert.match(existingReleaseText, /^[1-9][0-9]*$/u)
+    assert.ok(Number.isSafeInteger(existingReleaseId) && existingReleaseId > 0)
+  }
   let discarded = false
   const root = await mkdtemp(join(env.RUNNER_TEMP ?? tmpdir(), "dawn-recovery-publication-"))
   const ledger = {
@@ -64,6 +71,8 @@ test("real annotated-tag publication, draft visibility and immutable asset readb
     tagProvenance: existingNonce === "" ? "probe-created" : "operator-created",
     existingTag:
       existingNonce === "" ? null : { nonce: existingNonce, objectSha: existingTagObjectSha },
+    existingReleaseId,
+    releaseProvenance: existingReleaseId === null ? "probe-created" : "operator-created",
     releaseWriteCredentialKind: env.DAWN_RECOVERY_TEST_CREDENTIAL_KIND,
     runId: env.GITHUB_RUN_ID ?? null,
     calls: [],
@@ -167,6 +176,7 @@ test("real annotated-tag publication, draft visibility and immutable asset readb
       sourceSha: env.DAWN_RECOVERY_TEST_SOURCE_SHA,
       nonce: existingNonce || randomUUID(),
       existingTagObjectSha: existingTagObjectSha || null,
+      existingReleaseId,
       topologySha256: hash(
         await readFile(new URL("./fixtures/recovery-topology-workflow.yml", import.meta.url)),
       ),
@@ -175,7 +185,7 @@ test("real annotated-tag publication, draft visibility and immutable asset readb
         const selected =
           discard === "upload"
             ? Buffer.isBuffer(body)
-            : discard === "publication" && method === "PATCH"
+            : discard === "publication" && method === "PATCH" && body?.draft === false
         if (!discarded && selected && response.status >= 200 && response.status < 300) {
           discarded = true
           ledger.injectedClientResponseLoss = discard

--- a/scripts/release/test/recovery-publication-service.test.mjs
+++ b/scripts/release/test/recovery-publication-service.test.mjs
@@ -421,7 +421,10 @@ for (const uncertain of [null, "upload", "publish"])
       patches[0].body.body,
       `${initialBody}\n\nMetadata write verified by recovery service probe.`,
     )
-    assert.equal(patches[1].body.draft, false)
+    assert.deepEqual(patches[1].body, {
+      tag_name: `v0.0.0-recovery-contract-${fake.nonce}`,
+      draft: false,
+    })
   })
 for (const damage of [
   "id",
@@ -524,3 +527,116 @@ test("existing draft verifies changed metadata body before upload", async () => 
   assert.equal(fake.effects.length, 1)
   assert.equal(fake.effects[0].method, "PATCH")
 })
+
+function opaqueDraftService(options) {
+  const fake = existingReleaseService(options),
+    api = fake.api
+  fake.api = async (...args) => {
+    const result = await api(...args)
+    if (args[0] === "PATCH" && args[2].draft === undefined)
+      result.body.tag_name = "untagged-e886bb9bf253e3ee7d74"
+    return result
+  }
+  return fake
+}
+for (const uncertain of [null, "upload", "publish"])
+  test(`metadata response may project a bounded opaque draft tag with ${uncertain ?? "known"} response`, async () => {
+    const fake = opaqueDraftService({ uncertain })
+    const result = await subject.runPublicationServiceProbe(fake)
+    assert.equal(result.status, "published-immutable")
+    assert.equal(result.observedDraftTag, "untagged-e886bb9bf253e3ee7d74")
+    assert.deepEqual(fake.effects.at(-1).body, {
+      tag_name: `v0.0.0-recovery-contract-${fake.nonce}`,
+      draft: false,
+    })
+  })
+for (const field of [
+  "id",
+  "body",
+  "name",
+  "target_commitish",
+  "draft",
+  "prerelease",
+  "immutable",
+  "tag_name",
+])
+  test(`metadata response must bind the owned draft ${field} before upload`, async () => {
+    const fake = opaqueDraftService(),
+      api = fake.api
+    fake.api = async (...args) => {
+      const result = await api(...args)
+      if (args[0] === "PATCH" && args[2].draft === undefined)
+        result.body = {
+          ...result.body,
+          [field]:
+            typeof result.body[field] === "boolean"
+              ? !result.body[field]
+              : field === "id"
+                ? 99
+                : "wrong",
+        }
+      return result
+    }
+    await assert.rejects(subject.runPublicationServiceProbe(fake))
+    assert.equal(fake.effects.length, 1)
+  })
+test("metadata projection requires exact response/readback agreement", async () => {
+  const fake = opaqueDraftService(),
+    api = fake.api
+  fake.api = async (...args) => {
+    const result = await api(...args)
+    if (args[0] === "GET" && args[1].endsWith("/releases/100") && fake.effects.length > 0)
+      result.body = { ...result.body, tag_name: "untagged-00000000000000000000" }
+    return result
+  }
+  await assert.rejects(subject.runPublicationServiceProbe(fake))
+  assert.equal(fake.effects.length, 1)
+})
+test("opaque draft projection is forbidden during initial preflight", async () => {
+  const fake = existingReleaseService(),
+    api = fake.api
+  fake.api = async (...args) => {
+    const result = await api(...args)
+    if (args[0] === "GET" && args[1].endsWith("/releases/100"))
+      result.body = { ...result.body, tag_name: "untagged-e886bb9bf253e3ee7d74" }
+    return result
+  }
+  await assert.rejects(subject.runPublicationServiceProbe(fake))
+  assert.deepEqual(fake.effects, [])
+})
+test("original annotated tag is independently checked again before publication", async () => {
+  const fake = existingReleaseService(),
+    api = fake.api
+  fake.api = async (...args) => {
+    const result = await api(...args)
+    if (
+      args[0] === "GET" &&
+      args[1].includes("/git/ref/tags/") &&
+      fake.effects.some((e) => e.path.includes("/assets?"))
+    )
+      result.body.object.sha = "d".repeat(40)
+    return result
+  }
+  await assert.rejects(subject.runPublicationServiceProbe(fake))
+  assert.equal(
+    fake.effects.some((e) => e.method === "PATCH" && e.body.draft === false),
+    false,
+  )
+})
+
+for (const tagName of [
+  "untagged-fixture",
+  `untagged-${"a".repeat(21)}`,
+  [`untagged-${"a".repeat(20)}`],
+])
+  test(`metadata projection rejects unsupported tag representation ${JSON.stringify(tagName)}`, async () => {
+    const fake = opaqueDraftService(),
+      api = fake.api
+    fake.api = async (...args) => {
+      const result = await api(...args)
+      if (args[0] === "PATCH" && args[2].draft === undefined) result.body.tag_name = tagName
+      return result
+    }
+    await assert.rejects(subject.runPublicationServiceProbe(fake))
+    assert.equal(fake.effects.length, 1)
+  })

--- a/scripts/release/test/recovery-publication-service.test.mjs
+++ b/scripts/release/test/recovery-publication-service.test.mjs
@@ -15,11 +15,31 @@ const currentWorkflow = await readFile(
 
 const subject = await import("./support/recovery-publication-service.mjs").catch(() => ({}))
 const sha = (x) => createHash("sha256").update(x).digest("hex")
-function service({ uncertain = null, production = false, immutable = true } = {}) {
+function service({
+  uncertain = null,
+  production = false,
+  immutable = true,
+  existingRelease = false,
+} = {}) {
   const calls = [],
     effects = [],
     base = "/repos/example/release-lab"
-  let release, asset, payload
+  const nonce = "01234567-1234-1234-1234-123456789abc",
+    sourceSha = "a".repeat(40)
+  let release = existingRelease
+      ? {
+          id: 100,
+          tag_name: `v0.0.0-recovery-contract-${nonce}`,
+          target_commitish: sourceSha,
+          name: `Recovery service contract ${nonce}`,
+          body: `Disposable contract ${nonce}; payload sha256:${sha(Buffer.from(`Recovery service contract ${nonce}\nsource ${sourceSha}\n`))}`,
+          draft: true,
+          immutable: false,
+          prerelease: true,
+        }
+      : undefined,
+    asset,
+    payload
   return {
     calls,
     effects,
@@ -65,10 +85,11 @@ function service({ uncertain = null, production = false, immutable = true } = {}
           return { status: 200, body: { object: { sha: "c".repeat(40), type: "tag" } } }
         if (path.includes("/git/tags/"))
           return { status: 200, body: { object: { sha: "a".repeat(40), type: "commit" } } }
-        if (path.endsWith("/assets?per_page=100&page=1")) return { status: 200, body: [asset] }
+        if (path.endsWith("/assets?per_page=100&page=1"))
+          return { status: 200, body: asset ? [asset] : [] }
         if (path.endsWith("/releases/100")) return { status: 200, body: release }
       }
-      effects.push({ method, path })
+      effects.push({ method, path, body })
       if (path.endsWith("/git/tags")) return { status: 201, body: { sha: "c".repeat(40) } }
       if (path.endsWith("/git/refs")) return { status: 201, body: {} }
       if (method === "POST" && path.endsWith("/releases")) {
@@ -85,8 +106,8 @@ function service({ uncertain = null, production = false, immutable = true } = {}
         return { status: 201, body: asset }
       }
       if (method === "PATCH") {
-        release = { ...release, ...body, immutable: true }
-        if (uncertain === "publish")
+        release = { ...release, ...body, ...(body.draft === false ? { immutable: true } : {}) }
+        if (uncertain === "publish" && body.draft === false)
           throw Object.assign(new Error("response lost"), { uncertain: true })
         return { status: 200, body: release }
       }
@@ -362,4 +383,144 @@ test("existing tag mode rejects malformed object identity before any call", asyn
   fake.existingTagObjectSha = "invalid"
   await assert.rejects(subject.runPublicationServiceProbe(fake))
   assert.deepEqual(fake.calls, [])
+})
+
+function existingReleaseService(options) {
+  const fake = existingTagService({ ...options, existingRelease: true })
+  fake.existingReleaseId = 100
+  const api = fake.api
+  fake.api = async (method, path, body) => {
+    if (method === "GET" && path.includes("/releases?")) {
+      fake.calls.push({ method, path })
+      return {
+        status: 200,
+        body: [(await api("GET", "/repos/example/release-lab/releases/100", null)).body],
+      }
+    }
+    return api(method, path, body)
+  }
+  return fake
+}
+for (const uncertain of [null, "upload", "publish"])
+  test(`existing empty operator draft supports ${uncertain ?? "known"} response without resource creation`, async () => {
+    const fake = existingReleaseService({ uncertain })
+    const initialBody = (await fake.api("GET", "/repos/example/release-lab/releases/100", null))
+      .body.body
+    const result = await subject.runPublicationServiceProbe(fake)
+    assert.equal(result.status, "published-immutable")
+    assert.equal(result.releaseProvenance, "operator-created")
+    assert.equal(
+      fake.effects.some((e) => e.path.includes("/git/") || e.path.endsWith("/releases")),
+      false,
+    )
+    assert.equal(fake.effects.filter((e) => e.path.includes("/assets?")).length, 1)
+    const patches = fake.effects.filter((e) => e.method === "PATCH")
+    assert.equal(patches.length, 2)
+    assert.deepEqual(Object.keys(patches[0].body), ["body"])
+    assert.equal(
+      patches[0].body.body,
+      `${initialBody}\n\nMetadata write verified by recovery service probe.`,
+    )
+    assert.equal(patches[1].body.draft, false)
+  })
+for (const damage of [
+  "id",
+  "tag_name",
+  "target_commitish",
+  "name",
+  "body",
+  "draft",
+  "immutable",
+  "prerelease",
+  "assets",
+  "missing-inventory",
+  "duplicate-inventory",
+  "conflicting-nonce",
+])
+  test(`existing draft rejects ${damage} before mutation`, async () => {
+    const fake = existingReleaseService()
+    const api = fake.api
+    fake.api = async (...args) => {
+      const result = await api(...args),
+        path = args[1]
+      if (args[0] !== "GET") return result
+      if (path.endsWith("/releases/100")) {
+        result.body = structuredClone(result.body)
+        if (["id", "tag_name", "target_commitish", "name", "body"].includes(damage))
+          result.body[damage] = damage === "id" ? 99 : "wrong"
+        if (["draft", "immutable", "prerelease"].includes(damage))
+          result.body[damage] = !result.body[damage]
+      }
+      if (damage === "assets" && path.endsWith("/assets?per_page=100&page=1"))
+        result.body = [{ id: 200 }]
+      if (path.includes("/releases?")) {
+        if (damage === "missing-inventory") result.body = []
+        if (damage === "duplicate-inventory") result.body.push(result.body[0])
+        if (damage === "conflicting-nonce") result.body.push({ ...result.body[0], id: 99 })
+      }
+      return result
+    }
+    await assert.rejects(subject.runPublicationServiceProbe(fake))
+    assert.deepEqual(fake.effects, [])
+  })
+for (const value of [0, -1, 1.5, "100", Number.MAX_SAFE_INTEGER + 1])
+  test(`existing draft rejects invalid supplied ID ${value}`, async () => {
+    const fake = existingReleaseService()
+    fake.existingReleaseId = value
+    await assert.rejects(subject.runPublicationServiceProbe(fake))
+    assert.deepEqual(fake.calls, [])
+  })
+test("existing release requires existing tag mode before reads", async () => {
+  const fake = existingReleaseService()
+  delete fake.existingTagObjectSha
+  await assert.rejects(subject.runPublicationServiceProbe(fake))
+  assert.deepEqual(fake.calls, [])
+})
+for (const denied of ["metadata", "publication"])
+  test(`existing draft stops at denied ${denied} PATCH without retry`, async () => {
+    const fake = existingReleaseService()
+    const api = fake.api
+    fake.api = async (method, path, body) => {
+      if (
+        method === "PATCH" &&
+        (denied === "metadata" ? body.draft === undefined : body.draft === false)
+      ) {
+        fake.effects.push({ method, path, body })
+        return { status: 403, body: { message: "Resource not accessible by integration" } }
+      }
+      return api(method, path, body)
+    }
+    await assert.rejects(subject.runPublicationServiceProbe(fake))
+    assert.equal(
+      fake.effects.filter((e) => e.method === "PATCH").length,
+      denied === "metadata" ? 1 : 2,
+    )
+  })
+
+test("existing draft stops after unknown metadata response without upload or retry", async () => {
+  const fake = existingReleaseService()
+  const api = fake.api
+  fake.api = async (...args) => {
+    const result = await api(...args)
+    if (args[0] === "PATCH" && args[2].draft === undefined)
+      throw Object.assign(new Error("unknown metadata response"), { uncertain: true })
+    return result
+  }
+  await assert.rejects(subject.runPublicationServiceProbe(fake), /unknown metadata/)
+  assert.equal(fake.effects.length, 1)
+  assert.equal(fake.effects[0].method, "PATCH")
+})
+
+test("existing draft verifies changed metadata body before upload", async () => {
+  const fake = existingReleaseService()
+  const api = fake.api
+  fake.api = async (...args) => {
+    const result = await api(...args)
+    if (args[0] === "GET" && args[1].endsWith("/releases/100") && fake.effects.length > 0)
+      result.body = { ...result.body, body: "metadata mutation did not persist" }
+    return result
+  }
+  await assert.rejects(subject.runPublicationServiceProbe(fake), /draft identity/)
+  assert.equal(fake.effects.length, 1)
+  assert.equal(fake.effects[0].method, "PATCH")
 })

--- a/scripts/release/test/recovery-publication-service.test.mjs
+++ b/scripts/release/test/recovery-publication-service.test.mjs
@@ -261,3 +261,105 @@ test("publication visibility settlement is bounded and does not retry non-404 fa
     assert.equal(fake.effects.filter((e) => e.method === "PATCH").length, 1)
   }
 })
+
+function existingTagService(options) {
+  const fake = service(options)
+  fake.existingTagObjectSha = "c".repeat(40)
+  const api = fake.api
+  fake.api = async (method, path, body) => {
+    if (method === "GET" && path.includes("/releases?")) {
+      fake.calls.push({ method, path })
+      return { status: 200, body: [] }
+    }
+    if (method === "GET" && path.includes("/git/commits/")) {
+      fake.calls.push({ method, path })
+      return { status: 200, body: { sha: fake.sourceSha } }
+    }
+    const response = await api(method, path, body)
+    if (method === "GET" && path.includes("/git/ref/tags/"))
+      response.body.ref = `refs/tags/v0.0.0-recovery-contract-${fake.nonce}`
+    if (method === "GET" && path.includes("/git/tags/"))
+      Object.assign(response.body, {
+        sha: fake.existingTagObjectSha,
+        tag: `v0.0.0-recovery-contract-${fake.nonce}`,
+      })
+    return response
+  }
+  return fake
+}
+for (const uncertain of [null, "upload", "publish"])
+  test(`existing operator tag supports ${uncertain ?? "known"} publication response without tag mutations`, async () => {
+    const fake = existingTagService({ uncertain })
+    const result = await subject.runPublicationServiceProbe(fake)
+    assert.equal(result.status, "published-immutable")
+    assert.equal(result.tagProvenance, "operator-created")
+    assert.equal(
+      fake.effects.some((e) => e.path.includes("/git/")),
+      false,
+    )
+    assert.equal(fake.effects.filter((e) => e.path.endsWith("/releases")).length, 1)
+    assert.equal(fake.effects.filter((e) => e.path.includes("/assets?")).length, 1)
+    assert.equal(fake.effects.filter((e) => e.method === "PATCH").length, 1)
+    assert.ok(fake.calls.some((e) => e.path.includes(`/git/commits/${fake.sourceSha}`)))
+  })
+for (const damage of [
+  "wrong-ref",
+  "lightweight",
+  "wrong-object",
+  "wrong-tag-name",
+  "wrong-object-sha",
+  "wrong-target",
+  "wrong-commit",
+  "preexisting-release",
+  "preexisting-draft",
+  "unavailable-inventory",
+  "incomplete-inventory",
+])
+  test(`existing-tag preflight rejects ${damage} before writes`, async () => {
+    const fake = existingTagService()
+    const api = fake.api
+    fake.api = async (...args) => {
+      const response = await api(...args),
+        path = args[1]
+      if (args[0] !== "GET") return response
+      if (path.includes("/git/ref/tags/")) {
+        if (damage === "wrong-ref") response.body.ref += "-other"
+        if (damage === "lightweight") response.body.object.type = "commit"
+        if (damage === "wrong-object") response.body.object.sha = "d".repeat(40)
+      }
+      if (path.includes("/git/tags/")) {
+        if (damage === "wrong-tag-name") response.body.tag += "-other"
+        if (damage === "wrong-object-sha") response.body.sha = "d".repeat(40)
+        if (damage === "wrong-target") response.body.object.sha = "d".repeat(40)
+      }
+      if (path.includes("/git/commits/") && damage === "wrong-commit")
+        response.body.sha = "d".repeat(40)
+      if (path.includes("/releases?")) {
+        if (damage === "preexisting-release")
+          response.body = [
+            { id: 99, tag_name: `v0.0.0-recovery-contract-${fake.nonce}`, name: "other", body: "" },
+          ]
+        if (damage === "preexisting-draft")
+          response.body = [
+            {
+              id: 99,
+              tag_name: "untagged-old",
+              name: `Recovery service contract ${fake.nonce}`,
+              body: "",
+            },
+          ]
+        if (damage === "unavailable-inventory") response.status = 403
+        if (damage === "incomplete-inventory")
+          response.body = Array(100).fill({ id: 99, tag_name: "other", name: "other", body: "" })
+      }
+      return response
+    }
+    await assert.rejects(subject.runPublicationServiceProbe(fake))
+    assert.deepEqual(fake.effects, [])
+  })
+test("existing tag mode rejects malformed object identity before any call", async () => {
+  const fake = existingTagService()
+  fake.existingTagObjectSha = "invalid"
+  await assert.rejects(subject.runPublicationServiceProbe(fake))
+  assert.deepEqual(fake.calls, [])
+})

--- a/scripts/release/test/recovery-service-topology.test.mjs
+++ b/scripts/release/test/recovery-service-topology.test.mjs
@@ -44,5 +44,12 @@ test("disposable topology preserves every production job dependency and conditio
     "node --test scripts/release/test/recovery-publication-github.integration.mjs",
   )
   assert.equal(fixture.on.workflow_dispatch.inputs.publish_contract.default, false)
+  for (const [input, variable] of [
+    ["existing_tag_nonce", "DAWN_RECOVERY_TEST_EXISTING_TAG_NONCE"],
+    ["existing_tag_object_sha", "DAWN_RECOVERY_TEST_EXISTING_TAG_OBJECT_SHA"],
+  ]) {
+    assert.deepEqual(fixture.on.workflow_dispatch.inputs[input], { type: "string", default: "" })
+    assert.equal(publish.env[variable], `\${{ inputs.${input} }}`)
+  }
   assert.deepEqual(fixture.permissions, {})
 })

--- a/scripts/release/test/recovery-service-topology.test.mjs
+++ b/scripts/release/test/recovery-service-topology.test.mjs
@@ -45,6 +45,7 @@ test("disposable topology preserves every production job dependency and conditio
   )
   assert.equal(fixture.on.workflow_dispatch.inputs.publish_contract.default, false)
   for (const [input, variable] of [
+    ["existing_release_id", "DAWN_RECOVERY_TEST_EXISTING_RELEASE_ID"],
     ["existing_tag_nonce", "DAWN_RECOVERY_TEST_EXISTING_TAG_NONCE"],
     ["existing_tag_object_sha", "DAWN_RECOVERY_TEST_EXISTING_TAG_OBJECT_SHA"],
   ]) {

--- a/scripts/release/test/support/recovery-publication-service.mjs
+++ b/scripts/release/test/support/recovery-publication-service.mjs
@@ -195,8 +195,15 @@ export async function runPublicationServiceProbe({
     prerelease: true,
   }
   const metadataBody = `${releaseSpec.body}\n\nMetadata write verified by recovery service probe.`
-  const verifyExistingDraft = (value, body = releaseSpec.body) => {
-    const expected = { ...releaseSpec, body, id: existingReleaseId, immutable: false }
+  let metadataDraftTag = tag
+  const verifyExistingDraft = (value, body = releaseSpec.body, tagName = tag) => {
+    const expected = {
+      ...releaseSpec,
+      body,
+      tag_name: tagName,
+      id: existingReleaseId,
+      immutable: false,
+    }
     assert.deepEqual(
       Object.fromEntries(Object.keys(expected).map((key) => [key, value[key]])),
       expected,
@@ -257,13 +264,21 @@ export async function runPublicationServiceProbe({
     )
     assert.equal((await anonymousGet(path)).status, 404, "existing draft must be hidden")
     // Exercise a real body mutation on the exact operator-owned draft. An unknown or denied response stops; no blind metadata retry.
-    assert.equal((await api("PATCH", path, { body: metadataBody })).status, 200)
+    const metadata = await api("PATCH", path, { body: metadataBody })
+    assert.equal(metadata.status, 200)
+    metadataDraftTag = metadata.body?.tag_name
+    assert.ok(
+      typeof metadataDraftTag === "string" &&
+        (metadataDraftTag === tag || /^untagged-[a-f0-9]{20}$/u.test(metadataDraftTag)),
+      "bounded observed metadata draft tag required",
+    )
+    verifyExistingDraft(metadata.body, metadataBody, metadataDraftTag)
   }
   owned.status = "draft"
   await persist(owned)
   const releasePath = `${base}/releases/${owned.releaseId}`
   const draft = await get(releasePath)
-  if (existingReleaseId !== null) verifyExistingDraft(draft, metadataBody)
+  if (existingReleaseId !== null) verifyExistingDraft(draft, metadataBody, metadataDraftTag)
   assert.equal(draft.id, owned.releaseId)
   assert.equal(draft.draft, true)
   assert.equal(draft.name, `Recovery service contract ${nonce}`)
@@ -298,14 +313,13 @@ export async function runPublicationServiceProbe({
   assert.equal(digest(await download(asset.id)), payloadSha256)
   await persist(owned)
   await assertCurrentWorkflowScope()
+  if (existingReleaseId !== null) await verifyTag()
   try {
     assert.equal(
       (
         await api("PATCH", releasePath, {
           tag_name: tag,
-          target_commitish: sourceSha,
           draft: false,
-          make_latest: "false",
         })
       ).status,
       200,

--- a/scripts/release/test/support/recovery-publication-service.mjs
+++ b/scripts/release/test/support/recovery-publication-service.mjs
@@ -16,6 +16,7 @@ export async function runPublicationServiceProbe({
   repository,
   sourceSha,
   nonce,
+  existingTagObjectSha = null,
   topologySha256 = null,
   api,
   anonymousGet,
@@ -27,13 +28,15 @@ export async function runPublicationServiceProbe({
   assert.notEqual(repository.toLowerCase(), "cacheplane/dawnai")
   assert.match(sourceSha, /^[a-f0-9]{40}$/u)
   assert.match(nonce, /^[a-f0-9]{8}(?:-[a-f0-9]{4}){3}-[a-f0-9]{12}$/u)
+  if (existingTagObjectSha !== null) assert.match(existingTagObjectSha, /^[a-f0-9]{40}$/u)
   const base = `/repos/${repository}`,
     tag = `v0.0.0-recovery-contract-${nonce}`
   const owned = {
     repository,
     sourceSha,
     tag,
-    tagObjectSha: null,
+    tagObjectSha: existingTagObjectSha,
+    tagProvenance: existingTagObjectSha === null ? "probe-created" : "operator-created",
     releaseId: null,
     assetId: null,
     status: "preflight",
@@ -139,34 +142,67 @@ export async function runPublicationServiceProbe({
   }
   await persist(owned)
   await assertCurrentWorkflowScope()
-  const object = await api("POST", `${base}/git/tags`, {
-    tag,
-    message: `Recovery contract ${nonce}`,
-    object: sourceSha,
-    type: "commit",
-  })
-  assert.equal(object.status, 201)
-  assert.match(object.body.sha, /^[a-f0-9]{40}$/u)
-  owned.tagObjectSha = object.body.sha
-  await persist(owned)
-  assert.equal(
-    (await api("POST", `${base}/git/refs`, { ref: `refs/tags/${tag}`, sha: owned.tagObjectSha }))
-      .status,
-    201,
-  )
+  if (existingTagObjectSha === null) {
+    const object = await api("POST", `${base}/git/tags`, {
+      tag,
+      message: `Recovery contract ${nonce}`,
+      object: sourceSha,
+      type: "commit",
+    })
+    assert.equal(object.status, 201)
+    assert.match(object.body.sha, /^[a-f0-9]{40}$/u)
+    owned.tagObjectSha = object.body.sha
+    await persist(owned)
+    assert.equal(
+      (await api("POST", `${base}/git/refs`, { ref: `refs/tags/${tag}`, sha: owned.tagObjectSha }))
+        .status,
+      201,
+    )
+  }
   const verifyTag = async () => {
     const ref = await get(`${base}/git/ref/tags/${tag}`)
+    if (existingTagObjectSha !== null) assert.equal(ref.ref, `refs/tags/${tag}`)
     assert.deepEqual(
       { type: ref.object.type, sha: ref.object.sha },
       { type: "tag", sha: owned.tagObjectSha },
     )
     const target = await get(`${base}/git/tags/${owned.tagObjectSha}`)
+    if (existingTagObjectSha !== null) {
+      assert.equal(target.sha, existingTagObjectSha)
+      assert.equal(target.tag, tag)
+      assert.equal((await get(`${base}/git/commits/${sourceSha}`)).sha, sourceSha)
+    }
     assert.deepEqual(
       { type: target.object.type, sha: target.object.sha },
       { type: "commit", sha: sourceSha },
     )
   }
   await verifyTag()
+  if (existingTagObjectSha !== null) {
+    // Authenticated listing includes drafts, which can temporarily have an
+    // untagged name. A full page is inconclusive, never evidence of absence.
+    const releases = await get(`${base}/releases?per_page=100&page=1`)
+    assert.ok(
+      Array.isArray(releases) && releases.length < 100,
+      "complete bounded release inventory required",
+    )
+    for (const release of releases) {
+      assert.ok(
+        Number.isSafeInteger(release.id) &&
+          release.id > 0 &&
+          typeof release.tag_name === "string" &&
+          typeof release.name === "string" &&
+          (release.body === null || typeof release.body === "string"),
+        "valid release inventory required",
+      )
+      assert.ok(
+        release.tag_name !== tag &&
+          !release.name.includes(nonce) &&
+          !(release.body ?? "").includes(nonce),
+        "preexisting release or draft for supplied nonce forbidden",
+      )
+    }
+  }
   // An unknown create response deliberately stops: no direct ID means no owned
   // release mutation can follow and no blind retry can create a second draft.
   const created = await api("POST", `${base}/releases`, {

--- a/scripts/release/test/support/recovery-publication-service.mjs
+++ b/scripts/release/test/support/recovery-publication-service.mjs
@@ -17,6 +17,7 @@ export async function runPublicationServiceProbe({
   sourceSha,
   nonce,
   existingTagObjectSha = null,
+  existingReleaseId = null,
   topologySha256 = null,
   api,
   anonymousGet,
@@ -29,6 +30,13 @@ export async function runPublicationServiceProbe({
   assert.match(sourceSha, /^[a-f0-9]{40}$/u)
   assert.match(nonce, /^[a-f0-9]{8}(?:-[a-f0-9]{4}){3}-[a-f0-9]{12}$/u)
   if (existingTagObjectSha !== null) assert.match(existingTagObjectSha, /^[a-f0-9]{40}$/u)
+  if (existingReleaseId !== null) {
+    assert.ok(existingTagObjectSha !== null, "existing release requires existing tag mode")
+    assert.ok(
+      Number.isSafeInteger(existingReleaseId) && existingReleaseId > 0,
+      "positive existing release ID required",
+    )
+  }
   const base = `/repos/${repository}`,
     tag = `v0.0.0-recovery-contract-${nonce}`
   const owned = {
@@ -37,7 +45,8 @@ export async function runPublicationServiceProbe({
     tag,
     tagObjectSha: existingTagObjectSha,
     tagProvenance: existingTagObjectSha === null ? "probe-created" : "operator-created",
-    releaseId: null,
+    releaseId: existingReleaseId,
+    releaseProvenance: existingReleaseId === null ? "probe-created" : "operator-created",
     assetId: null,
     status: "preflight",
     unknownResponses: [],
@@ -177,6 +186,23 @@ export async function runPublicationServiceProbe({
       { type: "commit", sha: sourceSha },
     )
   }
+  const releaseSpec = {
+    tag_name: tag,
+    target_commitish: sourceSha,
+    name: `Recovery service contract ${nonce}`,
+    body: `Disposable contract ${nonce}; payload sha256:${payloadSha256}`,
+    draft: true,
+    prerelease: true,
+  }
+  const metadataBody = `${releaseSpec.body}\n\nMetadata write verified by recovery service probe.`
+  const verifyExistingDraft = (value, body = releaseSpec.body) => {
+    const expected = { ...releaseSpec, body, id: existingReleaseId, immutable: false }
+    assert.deepEqual(
+      Object.fromEntries(Object.keys(expected).map((key) => [key, value[key]])),
+      expected,
+      "exact owned empty draft identity required",
+    )
+  }
   await verifyTag()
   if (existingTagObjectSha !== null) {
     // Authenticated listing includes drafts, which can temporarily have an
@@ -186,6 +212,7 @@ export async function runPublicationServiceProbe({
       Array.isArray(releases) && releases.length < 100,
       "complete bounded release inventory required",
     )
+    let selected = 0
     for (const release of releases) {
       assert.ok(
         Number.isSafeInteger(release.id) &&
@@ -195,6 +222,11 @@ export async function runPublicationServiceProbe({
           (release.body === null || typeof release.body === "string"),
         "valid release inventory required",
       )
+      if (existingReleaseId !== null && release.id === existingReleaseId) {
+        verifyExistingDraft(release)
+        selected++
+        continue
+      }
       assert.ok(
         release.tag_name !== tag &&
           !release.name.includes(nonce) &&
@@ -202,24 +234,36 @@ export async function runPublicationServiceProbe({
         "preexisting release or draft for supplied nonce forbidden",
       )
     }
+    assert.equal(
+      selected,
+      existingReleaseId === null ? 0 : 1,
+      "exactly one selected existing release required",
+    )
   }
   // An unknown create response deliberately stops: no direct ID means no owned
   // release mutation can follow and no blind retry can create a second draft.
-  const created = await api("POST", `${base}/releases`, {
-    tag_name: tag,
-    target_commitish: sourceSha,
-    name: `Recovery service contract ${nonce}`,
-    body: `Disposable contract ${nonce}; payload sha256:${payloadSha256}`,
-    draft: true,
-    prerelease: true,
-  })
-  assert.equal(created.status, 201)
-  assert.ok(Number.isSafeInteger(created.body.id) && created.body.id > 0)
-  owned.releaseId = created.body.id
+  if (existingReleaseId === null) {
+    const created = await api("POST", `${base}/releases`, releaseSpec)
+    assert.equal(created.status, 201)
+    assert.ok(Number.isSafeInteger(created.body.id) && created.body.id > 0)
+    owned.releaseId = created.body.id
+  } else {
+    const path = `${base}/releases/${existingReleaseId}`
+    verifyExistingDraft(await get(path))
+    assert.deepEqual(
+      await get(`${path}/assets?per_page=100&page=1`),
+      [],
+      "existing draft must have no assets",
+    )
+    assert.equal((await anonymousGet(path)).status, 404, "existing draft must be hidden")
+    // Exercise a real body mutation on the exact operator-owned draft. An unknown or denied response stops; no blind metadata retry.
+    assert.equal((await api("PATCH", path, { body: metadataBody })).status, 200)
+  }
   owned.status = "draft"
   await persist(owned)
   const releasePath = `${base}/releases/${owned.releaseId}`
   const draft = await get(releasePath)
+  if (existingReleaseId !== null) verifyExistingDraft(draft, metadataBody)
   assert.equal(draft.id, owned.releaseId)
   assert.equal(draft.draft, true)
   assert.equal(draft.name, `Recovery service contract ${nonce}`)
@@ -276,6 +320,7 @@ export async function runPublicationServiceProbe({
   assert.equal(published.draft, false)
   assert.equal(published.immutable, true)
   assert.equal(published.tag_name, tag)
+  if (existingReleaseId !== null) assert.equal(published.body, metadataBody)
   // Public visibility can lag the authenticated immutable read. Re-observe
   // only a 404, within a finite budget; never retry the publication mutation.
   let visible


### PR DESCRIPTION
The real workflow-token rehearsal cannot create a historical tag ref or draft, while production recovery already has both. Add a test-only existing-tag/draft mode that strictly verifies operator-provisioned identities, then exercises actual workflow-token metadata mutation, upload and immutable publication.

GitHub changes the draft tag display to an opaque value after a body-only update. Bind that exact response and fresh readback while independently preserving the original annotated tag. Publish with the production request shape. Retain provenance, rate-limit headers, and both accepted-response-loss cases. Production controller/policy are unchanged.

Validation: 108 focused tests pass; parent independently reviewed and reran 74 publication service tests. Scoped Biome passes. Live final cases and exact-head CI are pending. Earlier denied creation and successful metadata-write/opaque-projection runs remain retained as evidence. Superseded CI at f3d8a74 was cancelled to avoid spending runners on obsolete code; its result is not counted as validation.



### Completed live publication evidence

All three actual `github.token` existing-draft cases passed on reviewed source `35b3a56ab2e48894fdbeedbc45741a4f9cd475b6`: [normal](https://github.com/blove/dawn-release-proof-20260906-0da9914c/actions/runs/34002495922), [upload](https://github.com/blove/dawn-release-proof-20260906-0da9914c/actions/runs/34002496713), [publication](https://github.com/blove/dawn-release-proof-20260906-0da9914c/actions/runs/34002497661). Each made exactly one metadata update, one asset upload and one publication update; the lost-response cases recovered through readback without repeated writes. Final releases are immutable, original annotated tags and payload digests match, and there were no tag writes or release creations. The operator provisioned the initial tags and empty drafts. The temporary lab policy credential and secret were removed after retaining evidence.
