### PR TITLE
fix(release): pin observer checkout identity

### DIFF
--- a/scripts/release/cli.mjs
+++ b/scripts/release/cli.mjs
@@ -245,10 +245,6 @@ async function runAbandon(options, runtime) {
   })
 }
 
-// release.yml's detect job checks out the default branch, so HEAD in the controller's own
-// checkout is the reviewed tip of main -- the only place a committed terminal record can live.
-const TERMINAL_RECORD_REF = "HEAD"
-
 async function runObserve(options, runtime) {
   const paths = Object.fromEntries(
     Object.entries(options).map(([key, value]) => [key, resolveCliPath(value, runtime.cwd)]),
@@ -306,6 +302,18 @@ async function runObserve(options, runtime) {
     requireAttestations(runtime),
     readControllerMarker(runtime),
   ])
+  // Pin the controller checkout once; candidate resolution and observation must
+  // use the same immutable source even if the checkout moves during this call.
+  requiredMethod(git, "listFirstParentHistory", "checkout HEAD reader")
+  const checkoutHistory = await git.listFirstParentHistory({ ref: "HEAD", maxCount: 1 })
+  if (
+    !Array.isArray(checkoutHistory) ||
+    checkoutHistory.length !== 1 ||
+    typeof checkoutHistory[0] !== "string" ||
+    !/^[a-f0-9]{40}$/u.test(checkoutHistory[0])
+  )
+    throw new TypeError("Release CLI checkout HEAD must resolve to exactly one immutable commit")
+  const terminalRecordRef = checkoutHistory[0]
   const inventory = runtime.inventory ?? createInventoryReader({ root: runtime.cwd, git })
   requiredMethod(inventory, "read", "production inventory reader")
 
@@ -324,7 +332,7 @@ async function runObserve(options, runtime) {
       npmAuditFactory,
       attestations,
       marker,
-      terminalRecordRef: TERMINAL_RECORD_REF,
+      terminalRecordRef,
     })
   } catch (error) {
     resolutionFailure = safeObservationFailure(error, "CANDIDATE_DISCOVERY_AMBIGUOUS")
@@ -397,7 +405,7 @@ async function runObserve(options, runtime) {
           npm,
           npmAuditFactory,
           attestations,
-          terminalRecordRef: TERMINAL_RECORD_REF,
+          terminalRecordRef,
           includeRecovery: true,
           ...(currentPublisherRun === null ? {} : { currentPublisherRun }),
         })

--- a/scripts/release/test/fixtures/release-script-hashes.json
+++ b/scripts/release/test/fixtures/release-script-hashes.json
@@ -65,7 +65,7 @@
       "sha256": "8be85623d581e05a8bf3e54c95d5fc7a695e2a94b8ccda4b5481f983ada0ebfa"
     },
     "scripts/release/cli.mjs": {
-      "sha256": "d2149307ba3a16f6043d71fdc73700f702021ffc2c4d3131f3f93461b763ef78"
+      "sha256": "f822541947889e47bb1a8167598459d699ab4f2e118dc443f4b0e5e2b9884e57"
     },
     "scripts/release/conflicts.mjs": {
       "sha256": "9fb3ff5154dab04d975b56baf29255493ece213824801e3504fad534ae81db7f"

--- a/scripts/release/test/observe-production.test.mjs
+++ b/scripts/release/test/observe-production.test.mjs
@@ -2964,6 +2964,110 @@ test("observe CLI resolves the immutable candidate, runs the dry one-transition 
   }
 })
 
+test("observe CLI resolves checkout HEAD once and pins both candidate calls despite HEAD movement", async () => {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "dawn-observe-head-"))
+  try {
+    const eventPath = path.join(directory, "event.json")
+    const reportPath = path.join(directory, "report.json")
+    const outputPath = path.join(directory, "github-output")
+    await writeFile(
+      eventPath,
+      JSON.stringify({ inputs: { version: VERSION, commitSha: COMMIT_SHA } }),
+    )
+    await writeFile(outputPath, "")
+    const dependencies = cliCandidateDependencies(directory)
+    const checkoutSha = "e".repeat(40)
+    let head = checkoutSha
+    const lookups = [],
+      refs = []
+    const history = dependencies.git.listFirstParentHistory
+    dependencies.git.listFirstParentHistory = async (args) => {
+      if (args.ref !== "HEAD") return history(args)
+      lookups.push(args)
+      return [head]
+    }
+    dependencies.importModule = async (specifier) => {
+      const module = await import(specifier)
+      if (!specifier.endsWith("/observe.mjs")) return module
+      return {
+        ...module,
+        resolveProductionCandidate: async (args) => {
+          refs.push(args.terminalRecordRef)
+          head = "f".repeat(40)
+          return module.resolveProductionCandidate(args)
+        },
+        observeProductionCandidate: async (args) => {
+          refs.push(args.terminalRecordRef)
+          return module.observeProductionCandidate(args)
+        },
+      }
+    }
+    const result = await runReleaseCli(
+      ["observe", "--event", eventPath, "--report", reportPath, "--github-output", outputPath],
+      dependencies,
+    )
+    assert.ok(result.candidate, JSON.stringify(result))
+    assert.equal(result.candidate.commitSha, COMMIT_SHA)
+    assert.notEqual(checkoutSha, COMMIT_SHA)
+    assert.deepEqual(lookups, [{ ref: "HEAD", maxCount: 1 }])
+    assert.deepEqual(refs, [checkoutSha, checkoutSha])
+  } finally {
+    await rm(directory, { recursive: true, force: true })
+  }
+})
+
+for (const head of [
+  null,
+  [],
+  [COMMIT_SHA, PARENT_SHA],
+  ["HEAD"],
+  ["a".repeat(39)],
+  ["A".repeat(40)],
+  [null],
+])
+  test(`observe CLI rejects non-singleton immutable checkout HEAD ${JSON.stringify(head)}`, async () => {
+    const directory = await mkdtemp(path.join(os.tmpdir(), "dawn-observe-invalid-head-"))
+    try {
+      const eventPath = path.join(directory, "event.json")
+      const reportPath = path.join(directory, "report.json")
+      const outputPath = path.join(directory, "github-output")
+      await writeFile(
+        eventPath,
+        JSON.stringify({ inputs: { version: VERSION, commitSha: COMMIT_SHA } }),
+      )
+      await writeFile(outputPath, "")
+      const dependencies = cliCandidateDependencies(directory)
+      dependencies.git.listFirstParentHistory = async () => head
+      let candidateCalls = 0
+      dependencies.importModule = async (specifier) => {
+        const module = await import(specifier)
+        if (!specifier.endsWith("/observe.mjs")) return module
+        return {
+          ...module,
+          resolveProductionCandidate: async (...args) => {
+            candidateCalls++
+            return module.resolveProductionCandidate(...args)
+          },
+          observeProductionCandidate: async (...args) => {
+            candidateCalls++
+            return module.observeProductionCandidate(...args)
+          },
+        }
+      }
+      await assert.rejects(
+        runReleaseCli(
+          ["observe", "--event", eventPath, "--report", reportPath, "--github-output", outputPath],
+          dependencies,
+        ),
+        /checkout HEAD/,
+      )
+      assert.equal(candidateCalls, 0)
+      assert.equal(await readFile(outputPath, "utf8"), "")
+    } finally {
+      await rm(directory, { recursive: true, force: true })
+    }
+  })
+
 test("observe CLI identifies its exact current tag attempt before downstream jobs materialize", async () => {
   const directory = await mkdtemp(path.join(os.tmpdir(), "dawn-observe-current-run-"))
   try {

--- a/scripts/release/test/workflow-contracts.test.mjs
+++ b/scripts/release/test/workflow-contracts.test.mjs
@@ -106,7 +106,7 @@ const SCRIPT_PIN_PATH = path.join(ROOT, SCRIPT_PIN_FIXTURE)
 // Repinned for asset counter comparisons and bounded invocation payload/Git text reuse.
 // Repinned for fixed evidence stage boundaries with fresh runtime readers.
 const STARTING_SCRIPT_PIN_SHA256 =
-  "26becff91ccdc80d8bbb0f6c5d704e7b8edcb390633593fb716d39ed60171354"
+  "582dbe22e8d8a918230a2d31b707d4b165f8202d593336699c6d66866010feed"
 const SHA256_HEX = /^[0-9a-f]{64}$/u
 const workflowExpression = (value) => `\${{ ${value} }}`
 const SCRIPT_REFERENCE = /(?:^|[\s;&|"'(])(scripts\/[\w.-]+(?:\/[\w.-]+)*)/gu


### PR DESCRIPTION
The normal observer passed symbolic `HEAD` into recovery verification, which requires an immutable commit SHA. After a recovered release completed, this blocked candidate discovery with `recovery-integrity-failure`.

Resolve the controller checkout once through the existing bounded Git reader and use that exact SHA for both candidate discovery and observation. Keep the release candidate identity separate and reject malformed checkout resolution before either call.

Validation: 180 focused tests, 139 workflow-contract tests, and 3 release-integrity tests pass; new regressions cover a moving HEAD, distinct controller and candidate SHAs, and malformed resolution. Scoped formatting and independent review pass. The normal CLI content pin is updated; recovery policy, verifier closure, and release records are unchanged.

Read-only production verification in an isolated checkout with `main` and `origin/main` matching GitHub passed: recovered v0.8.24 remains immutable and COMPLETE, and normal arbitration selects v0.8.26 at `470c871f258f5cd248904208bff6a89acbf3a56c` with no conflicts and a dry-run create-candidate-tag transition. Release metadata and assets were unchanged.
