### PR TITLE
fix(release): tolerate bounded registry propagation delays

### DIFF
--- a/scripts/release/publisher.mjs
+++ b/scripts/release/publisher.mjs
@@ -40,25 +40,17 @@ const SHA_PATTERN = /^[0-9a-f]{40}$/u
 const SHA256_PATTERN = /^[0-9a-f]{64}$/u
 const SHA512_PATTERN = /^[0-9a-f]{128}$/u
 const MAX_CANDIDATE_BYTES = 16 * 1024
-const MAX_POLL_ATTEMPTS = 20
 const POLL_DELAY_MS = 2_000
 const PUBLISH_COMMAND_TIMEOUT_MS = 5 * 60_000
 const EXPECTED_REPOSITORY = "https://github.com/cacheplane/dawnai"
 
-// Registry tarball propagation budget. npm can accept a publish, expose the exact
-// version metadata (integrity, dist-tags, provenance) and still serve 404 for the
-// tarball URL for minutes: run 33896070181 accepted @dawn-ai/ag-ui@0.8.24 at 16:40:52Z
-// and the tarball stayed 404 until ~16:46Z, which the former fixed 20 × 2 s window
-// turned into an NPM_PARTIAL stop. Only the "metadata present, tarball 404" class waits
-// on this budget: the first TARBALL_FAST_POLL_ATTEMPTS polls keep the 2 s cadence, later
-// polls back off to TARBALL_SLOW_POLL_DELAY_MS, and the wait ends with the existing
-// "could not be verified" failure once TARBALL_CONVERGENCE_DEADLINE_MS has elapsed for
-// that package. Every definitive conflict (identity, integrity, dist-tag, fetched bytes)
-// and every non-404 tarball outcome still fails on the first observation. The
-// per-package budget is deliberately larger than PUBLISHER_OVERALL_TIMEOUT_MS / 21: the
-// overall deadline (which release.yml's 30-minute publish-npm job encloses) stays the
-// binding bound, so a run absorbs one or two full-length lags and otherwise stops
-// resumably rather than serializing 21 worst cases.
+// One registry propagation budget per package covers exact-version absence,
+// metadata/dist-tag lag, explicit audit-pending evidence, and tarball HTTP 404.
+// Pending state changes never restart the clock or the fast polling cadence.
+// Identity, integrity, signature, provenance, and non-404 download failures remain
+// fatal. The 25-minute overall deadline and 30-minute job still bound the run;
+// this window absorbs temporary propagation lag without republishing accepted bytes.
+// Retain the exported tarball deadline name for existing callers.
 const TARBALL_FAST_POLL_ATTEMPTS = 10
 const TARBALL_SLOW_POLL_DELAY_MS = 10_000
 export const TARBALL_CONVERGENCE_DEADLINE_MS = 10 * 60_000
@@ -451,8 +443,7 @@ async function waitUntilVerified({
   now,
 }) {
   let attempt = 0
-  let convergenceAttempts = 0
-  let tarballPending = null
+  const startedAt = now()
   for (;;) {
     attempt += 1
     const metadata = await observeMetadata(observeRegistry, entry.name)
@@ -468,38 +459,39 @@ async function waitUntilVerified({
       candidate,
       downloadRegistryTarball,
     })
-    if (analyzed.status === "tarball-pending") {
-      tarballPending ??= { startedAt: now(), attempts: 0 }
-      tarballPending.attempts += 1
-      const elapsedMs = Math.max(0, now() - tarballPending.startedAt)
-      const delayMs =
-        tarballPending.attempts <= TARBALL_FAST_POLL_ATTEMPTS
-          ? POLL_DELAY_MS
-          : TARBALL_SLOW_POLL_DELAY_MS
-      log({
-        event: "registry-tarball-pending",
-        name: entry.name,
-        attempt: tarballPending.attempts,
-        elapsedMs,
-        delayMs,
-        deadlineMs: TARBALL_CONVERGENCE_DEADLINE_MS,
-        httpStatus: analyzed.download.httpStatus,
-      })
-      if (elapsedMs >= TARBALL_CONVERGENCE_DEADLINE_MS) {
-        throw new Error(`npm registry tarball could not be verified for ${entry.name}`)
-      }
-      await poll({ name: entry.name, attempt, delayMs })
-      continue
-    }
+    let reason =
+      analyzed.status === "tarball-pending"
+        ? "tarball-404"
+        : analyzed.status === "absent"
+          ? "version-absent"
+          : "metadata-pending"
     if (analyzed.status === "present" && registryReady(analyzed, candidate)) {
       const audit = await observeNpmAudit(verifyPackage, entry, candidate)
       if (audit.status === "verified") return { ...analyzed, audit, ready: true }
+      reason = "audit-pending"
     }
-    convergenceAttempts += 1
-    if (convergenceAttempts >= MAX_POLL_ATTEMPTS) break
-    await poll({ name: entry.name, attempt, delayMs: POLL_DELAY_MS })
+    const elapsedMs = Math.max(0, now() - startedAt)
+    const delayMs =
+      attempt <= TARBALL_FAST_POLL_ATTEMPTS ? POLL_DELAY_MS : TARBALL_SLOW_POLL_DELAY_MS
+    log({
+      event: reason === "tarball-404" ? "registry-tarball-pending" : "registry-pending",
+      name: entry.name,
+      reason,
+      attempt,
+      elapsedMs,
+      delayMs,
+      deadlineMs: TARBALL_CONVERGENCE_DEADLINE_MS,
+      ...(reason === "tarball-404" ? { httpStatus: analyzed.download.httpStatus } : {}),
+    })
+    if (elapsedMs >= TARBALL_CONVERGENCE_DEADLINE_MS) {
+      throw new Error(
+        reason === "tarball-404"
+          ? `npm registry tarball could not be verified for ${entry.name}`
+          : `npm registry did not converge for ${entry.name}`,
+      )
+    }
+    await poll({ name: entry.name, attempt, delayMs })
   }
-  throw new Error(`npm registry did not converge for ${entry.name}`)
 }
 
 function isPublished(analyzed) {

--- a/scripts/release/test/fixtures/release-script-hashes.json
+++ b/scripts/release/test/fixtures/release-script-hashes.json
@@ -128,7 +128,7 @@
       "sha256": "bdc06e4902b3e853e858166240e3dd1e068061c3ec69f74cad33f1ae122c7e1b"
     },
     "scripts/release/publisher.mjs": {
-      "sha256": "455f8b647b6458eb3830c30b4ac05dab4cb24a2d713098614cacbee0cfc7516c"
+      "sha256": "d805a023aaf6f2b36a4cb5a8c38cc3c205fdddacdea8a29ace60fb61c6b8abe7"
     },
     "scripts/release/recovery/adopt.mjs": {
       "sha256": "efe0b8da53dc035932d2ce266bb88456a5547332313bca9bfa2bf50ee4e0ac8a"

--- a/scripts/release/test/publisher.test.mjs
+++ b/scripts/release/test/publisher.test.mjs
@@ -118,6 +118,120 @@ test("polls delayed exact metadata, signature, provenance, and latest before adv
   assert.ok(fixture.pollCalls.every(({ name }) => name === CANONICAL_RELEASE_PACKAGE_ORDER[0]))
 })
 
+for (const reason of ["version-absent", "metadata-pending", "audit-pending"]) {
+  test(`${reason} can converge after more than twenty polls without republishing`, async () => {
+    const fixture = publisherFixture({ initiallyPresent: "all-except-last" })
+    const target = CANONICAL_RELEASE_PACKAGE_ORDER.at(-1)
+    const observe = fixture.inputs.observeRegistry
+    const verify = fixture.inputs.verifyPackage
+    fixture.inputs.observeRegistry = async (request) => {
+      const result = await observe(request)
+      if (
+        request.name !== target ||
+        fixture.publishCalls.length === 0 ||
+        fixture.pollCalls.length >= 25
+      )
+        return result
+      if (reason === "version-absent" && request.version !== undefined) {
+        return { status: "ABSENT", operation: "package-version", httpStatus: 404, code: "E404" }
+      }
+      if (reason === "metadata-pending" && request.version === undefined) {
+        return { ...result, metadata: { ...result.metadata, latest: "0.8.20" } }
+      }
+      return result
+    }
+    fixture.inputs.verifyPackage = async (request) =>
+      reason === "audit-pending" && request.entry.name === target && fixture.pollCalls.length < 25
+        ? { status: "pending" }
+        : verify(request)
+
+    assert.equal((await publishManifestSerially(fixture.inputs)).status, "NPM_COMPLETE")
+    assert.equal(fixture.pollCalls.length, 25)
+    assert.deepEqual(fixture.publishCalls, [target])
+    const pending = fixture.logs.filter((event) => event.reason === reason)
+    assert.equal(pending.length, 25)
+    assert.equal(pending.at(-1).elapsedMs, 160_000)
+    await publishManifestSerially(fixture.inputs)
+    assert.deepEqual(
+      fixture.publishCalls,
+      [target],
+      "resume verifies and skips accepted publications",
+    )
+  })
+}
+
+test("permanent audit pending stops at the shared deadline without republishing", async () => {
+  const fixture = publisherFixture({ initiallyPresent: "all" })
+  fixture.inputs.verifyPackage = async () => ({ status: "pending" })
+  await assert.rejects(publishManifestSerially(fixture.inputs), /registry did not converge/u)
+  assert.equal(fixture.inputs.now(), TARBALL_CONVERGENCE_DEADLINE_MS)
+  assert.equal(fixture.pollCalls.length, 68)
+  assert.deepEqual(fixture.publishCalls, [])
+  assert.equal(fixture.logs.filter((event) => event.reason === "audit-pending").length, 69)
+})
+
+for (const conflict of ["signature", "provenance"]) {
+  test(`a hard ${conflict} error after pending is never retried`, async () => {
+    const fixture = publisherFixture({ initiallyPresent: "all" })
+    const failure = new Error(`invalid ${conflict}`)
+    fixture.inputs.verifyPackage = async () => {
+      if (fixture.pollCalls.length < 25) return { status: "pending" }
+      throw failure
+    }
+    await assert.rejects(publishManifestSerially(fixture.inputs), (error) => error === failure)
+    assert.equal(fixture.pollCalls.length, 25)
+    assert.deepEqual(fixture.publishCalls, [])
+  })
+}
+
+test("switching recognized pending states shares one ten-minute clock and backoff", async () => {
+  const fixture = publisherFixture({ initiallyPresent: "all-except-last" })
+  const target = CANONICAL_RELEASE_PACKAGE_ORDER.at(-1)
+  const observe = fixture.inputs.observeRegistry
+  const download = fixture.inputs.downloadRegistryTarball
+  const verify = fixture.inputs.verifyPackage
+  fixture.inputs.observeRegistry = async (request) => {
+    const result = await observe(request)
+    if (request.name !== target || fixture.publishCalls.length === 0) return result
+    if (fixture.pollCalls.length < 15 && request.version !== undefined) {
+      return { status: "ABSENT", operation: "package-version", httpStatus: 404, code: "E404" }
+    }
+    if (fixture.pollCalls.length < 30 && request.version === undefined) {
+      return { ...result, metadata: { ...result.metadata, latest: "0.8.20" } }
+    }
+    return result
+  }
+  fixture.inputs.downloadRegistryTarball = async (request) => {
+    if (
+      fixture.publishCalls.length > 0 &&
+      request.tarballUrl === registryUrl(fixture.inputs.manifest.packages.at(-1)) &&
+      fixture.pollCalls.length >= 30 &&
+      fixture.pollCalls.length < 45
+    ) {
+      return {
+        status: "AMBIGUOUS",
+        operation: "package-tarball",
+        httpStatus: 404,
+        code: "HTTP_404",
+      }
+    }
+    return download(request)
+  }
+  fixture.inputs.verifyPackage = async (request) =>
+    request.entry.name === target ? { status: "pending" } : verify(request)
+
+  await assert.rejects(publishManifestSerially(fixture.inputs), /registry did not converge/u)
+  assert.equal(fixture.inputs.now(), TARBALL_CONVERGENCE_DEADLINE_MS)
+  assert.equal(fixture.pollCalls.length, 68)
+  assert.deepEqual(fixture.publishCalls, [target])
+  const pending = fixture.logs.filter((event) => event.reason !== undefined)
+  assert.deepEqual(
+    [...new Set(pending.map((event) => event.reason))],
+    ["version-absent", "metadata-pending", "tarball-404", "audit-pending"],
+  )
+  assert.equal(pending.at(-1).attempt, 69)
+})
+
 test("a published tarball that 404s during propagation is polled at 2 s then 10 s until it arrives", async () => {
   const first = CANONICAL_RELEASE_PACKAGE_ORDER[0]
   const pendingReads = 12

--- a/scripts/release/test/workflow-contracts.test.mjs
+++ b/scripts/release/test/workflow-contracts.test.mjs
@@ -106,7 +106,7 @@ const SCRIPT_PIN_PATH = path.join(ROOT, SCRIPT_PIN_FIXTURE)
 // Repinned for asset counter comparisons and bounded invocation payload/Git text reuse.
 // Repinned for fixed evidence stage boundaries with fresh runtime readers.
 const STARTING_SCRIPT_PIN_SHA256 =
-  "8ba5cde9f319d0aa241bc9426df565e6f51803d136244f09a221ef9de8e02d6b"
+  "2429c9ac22a2a35db3deaf58abe73e14ad307cc78e83b3dc438b441a3b42eb2e"
 const SHA256_HEX = /^[0-9a-f]{64}$/u
 const workflowExpression = (value) => `\${{ ${value} }}`
 const SCRIPT_REFERENCE = /(?:^|[\s;&|"'(])(scripts\/[\w.-]+(?:\/[\w.-]+)*)/gu


### PR DESCRIPTION
The serial publisher could stop a partially published release after roughly 40 seconds of registry or audit propagation delay. v0.8.26 reproduced this after npm accepted sqlite-storage, memory, and sandbox; later retries verified those same packages and continued.

Use the existing ten-minute per-package propagation budget for recognized pending metadata, exact-version absence, audit-pending evidence, and tarball 404s. All pending states share one clock and backoff, so switching states cannot extend the deadline. Emit bounded reason tags to distinguish the wait. Integrity, identity, signature, provenance, and unexpected download failures still reject immediately; the overall 25-minute publisher limit remains unchanged. No cache behavior changes.

Validation: delayed success beyond the old polling limit, permanent pending, transitions between pending states, hard conflicts after pending, and existing resume/tarball/overall-deadline tests. Publisher, npm-audit, integrity, and workflow-contract suites pass; CI supplies the full validation lane.
