### PR TITLE
fix(release): audit frozen candidates with reviewed controller code

### DIFF
--- a/.github/workflows/published-artifact-verify.yml
+++ b/.github/workflows/published-artifact-verify.yml
@@ -65,9 +65,11 @@ jobs:
     needs: coordinate
     if: >-
       github.event_name == 'workflow_dispatch' &&
-      needs.coordinate.outputs.mode == 'draft' &&
-      github.ref == format('refs/tags/v{0}', inputs.version) &&
-      github.sha == inputs.commitSha
+      ((needs.coordinate.outputs.mode == 'draft' &&
+        github.ref == format('refs/tags/v{0}', inputs.version) &&
+        github.sha == inputs.commitSha) ||
+       (needs.coordinate.outputs.mode == 'draft-controller' &&
+        github.ref == 'refs/heads/main'))
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     permissions:
@@ -77,10 +79,10 @@ jobs:
       # contents: write — the only scope that exposes draft Releases to GITHUB_TOKEN (spec 2026-09-04-controller-draft-visibility).
       contents: write
     steps:
-      - name: Checkout exact candidate
+      - name: Checkout exact audit executor
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
-          ref: ${{ github.ref }}
+          ref: ${{ github.sha }}
           fetch-depth: 0
           persist-credentials: false
 

--- a/.github/workflows/published-artifact-verify.yml
+++ b/.github/workflows/published-artifact-verify.yml
@@ -126,9 +126,9 @@ jobs:
     needs: coordinate
     if: >-
       github.event_name == 'workflow_dispatch' &&
-      needs.coordinate.outputs.mode == 'published' &&
-      github.ref == format('refs/tags/v{0}', inputs.version) &&
-      github.sha == inputs.commitSha
+      ((needs.coordinate.outputs.mode == 'published' &&
+        github.ref == format('refs/tags/v{0}', inputs.version) && github.sha == inputs.commitSha) ||
+       (needs.coordinate.outputs.mode == 'published-controller' && github.ref == 'refs/heads/main'))
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     permissions:
@@ -137,10 +137,10 @@ jobs:
       checks: read
       contents: read
     steps:
-      - name: Checkout exact annotated tag
+      - name: Checkout exact audit executor
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
-          ref: ${{ github.ref }}
+          ref: ${{ github.sha }}
           fetch-depth: 0
           persist-credentials: false
 

--- a/docs/superpowers/plans/2026-09-06-normal-audit-controller-repair.md
+++ b/docs/superpowers/plans/2026-09-06-normal-audit-controller-repair.md
@@ -1,0 +1,13 @@
+# Normal audit controller repair
+
+Goal: finish the already published npm v0.8.26 candidate through its existing audit and immutable release publication, and fix draft discovery for future candidates.
+
+The payload remains candidate 470c871f258f5cd248904208bff6a89acbf3a56c with manifest 15c3afa7eea9e552d83c10e0e8bdd8ec6d9d4a6ac0b2a87e8e4ac09f5511306b. No package rebuild, tag mutation, smoke waiver, receipt fabrication, or recovery adoption is permitted.
+
+1. Fix independent auditor draft reads using complete-list uniqueness and exact-ID reread, retaining all marker checks.
+2. Add one shared executor authorizer. Legacy candidate/tag execution remains strict. Main execution requires an explicit candidate/manifest/workflow/source binding read from the actual immutable executor commit, exact successful main CI and merged-main ancestry. Validate actual Actions run and artifact identities against that separately authorized executor. Receipt payload identity remains the candidate.
+3. Allow the existing audit workflow to run the authorized controller from its actual main SHA. Preserve coordinator, audit checks, job names and artifact protocol. Use the reviewed controller CLI to dispatch, record, correlate and publish the frozen candidate. Future source consumers verify historical executor authorization using the run's actual SHA.
+4. Test authority rejection, legacy compatibility, real draft lookup behavior, artifact identity and unchanged payload checks. Refresh normal content pins and existing v0.8.24 verifier binding if shared closure changes. Run required CI and independently review before normal merge.
+5. Execute real audit, correlate its unmodified canonical result, publish using existing guarded writer, verify immutable assets/tag/npm bytes and fresh no-write terminal observation. Retain laboratory artifacts for manual deletion by the user.
+
+Independent subtasks are limited to draft lookup, consumer integration, and review; the root owns the shared authority and workflow.

--- a/scripts/published-artifacts.test.mjs
+++ b/scripts/published-artifacts.test.mjs
@@ -1376,7 +1376,7 @@ describe("validateExactPublishedPackageEvidence", () => {
 })
 
 describe("final published-artifact workflow", () => {
-  it("accepts only the three release identities and isolates draft from published exact-tag audits", () => {
+  it("accepts three payload identities and isolates draft and published executor modes", () => {
     const { source, workflow } = readParsedWorkflow("published-artifact-verify.yml")
     const inputs = workflow.on?.workflow_dispatch?.inputs
     assert.deepEqual(Object.keys(inputs ?? {}).sort(), ["commitSha", "manifestSha256", "version"])
@@ -1401,10 +1401,12 @@ describe("final published-artifact workflow", () => {
     assert.match(draft.if, /needs\.coordinate\.outputs\.mode == 'draft'/u)
     assert.match(draft.if, /github\.ref == format\('refs\/tags\/v\{0\}', inputs\.version\)/u)
     assert.match(draft.if, /github\.sha == inputs\.commitSha/u)
+    assert.match(draft.if, /draft-controller/u)
+    assert.match(draft.if, /github\.ref == 'refs\/heads\/main'/u)
     const checkout = draft.steps.find(
       (step) => step.uses === "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1",
     )
-    assert.equal(checkout?.with?.ref, workflowExpression("github.ref"))
+    assert.equal(checkout?.with?.ref, workflowExpression("github.sha"))
     assert.equal(checkout?.with?.["fetch-depth"], 0)
     const executor = draft.steps.filter(
       (step) =>
@@ -1433,6 +1435,12 @@ describe("final published-artifact workflow", () => {
     assert.match(published.if, /needs\.coordinate\.outputs\.mode == 'published'/u)
     assert.match(published.if, /github\.ref == format\('refs\/tags\/v\{0\}', inputs\.version\)/u)
     assert.match(published.if, /github\.sha == inputs\.commitSha/u)
+    assert.match(published.if, /published-controller/u)
+    assert.match(published.if, /github\.ref == 'refs\/heads\/main'/u)
+    assert.equal(
+      published.steps.find((step) => step.uses?.startsWith("actions/checkout@"))?.with?.ref,
+      workflowExpression("github.sha"),
+    )
     const publishedExecutor = published.steps.filter(
       (step) =>
         typeof step.run === "string" &&

--- a/scripts/release/adapters/github-write.mjs
+++ b/scripts/release/adapters/github-write.mjs
@@ -322,7 +322,12 @@ export function createGitHubWriter({
       const args = snapshotExactInput(input, ["workflow", "ref", "inputs"], "workflow dispatch")
       if (!WORKFLOWS.has(args.workflow))
         throw new TypeError("Workflow dispatch path is not allowed")
-      assertTag(args.ref)
+      if (
+        !(
+          args.workflow === ".github/workflows/published-artifact-verify.yml" && args.ref === "main"
+        )
+      )
+        assertTag(args.ref)
       if (!isRecord(args.inputs)) throw new TypeError("Workflow dispatch inputs must be an object")
       rejectRemovedDispatchField(args.inputs)
       const requestBody = { ref: args.ref, inputs: args.inputs }

--- a/scripts/release/audit-executor-authorizations/v0.8.26.json
+++ b/scripts/release/audit-executor-authorizations/v0.8.26.json
@@ -7,6 +7,6 @@
     "manifestSha256": "15c3afa7eea9e552d83c10e0e8bdd8ec6d9d4a6ac0b2a87e8e4ac09f5511306b"
   },
   "workflow": ".github/workflows/published-artifact-verify.yml",
-  "workflowSha256": "f7a842b853024aaaf9f218dc415e9f7ec16642b6b7f3f3674cc4ca785a75cdab",
-  "scriptPinsSha256": "7acdb54f5d50c306c306add9c00813bdd719447fa3b9ca7bcf4477b85ae1b596"
+  "workflowSha256": "4d693f46d18b4cb8d48c0dde39b814ab02e5ed3670195799d660b4781ce5f3a8",
+  "scriptPinsSha256": "75b16cb04f4df23a68612add6b26806c1ec866233a8823e177ca36f243b318c8"
 }

--- a/scripts/release/audit-executor-authorizations/v0.8.26.json
+++ b/scripts/release/audit-executor-authorizations/v0.8.26.json
@@ -1,0 +1,12 @@
+{
+  "schemaVersion": 1,
+  "repository": "cacheplane/dawnai",
+  "candidate": {
+    "version": "0.8.26",
+    "commitSha": "470c871f258f5cd248904208bff6a89acbf3a56c",
+    "manifestSha256": "15c3afa7eea9e552d83c10e0e8bdd8ec6d9d4a6ac0b2a87e8e4ac09f5511306b"
+  },
+  "workflow": ".github/workflows/published-artifact-verify.yml",
+  "workflowSha256": "f7a842b853024aaaf9f218dc415e9f7ec16642b6b7f3f3674cc4ca785a75cdab",
+  "scriptPinsSha256": "7acdb54f5d50c306c306add9c00813bdd719447fa3b9ca7bcf4477b85ae1b596"
+}

--- a/scripts/release/audit-executor.mjs
+++ b/scripts/release/audit-executor.mjs
@@ -1,0 +1,216 @@
+import { createHash } from "node:crypto"
+import { snapshotJson } from "./adapter-normalize.mjs"
+import { isExactSemver } from "./semver.mjs"
+
+const REPOSITORY = "cacheplane/dawnai"
+const REPOSITORY_ID = 1210070282
+const WORKFLOW = ".github/workflows/published-artifact-verify.yml"
+const PINS_PATH = "scripts/release/test/fixtures/release-script-hashes.json"
+const SHA = /^[a-f0-9]{40}$/u
+const DIGEST = /^[a-f0-9]{64}$/u
+const authorized = new WeakMap()
+const positiveId = (value) => Number.isSafeInteger(value) && value > 0
+const hash = (value) => createHash("sha256").update(value).digest("hex")
+const requireThat = (value, message) => {
+  if (!value) throw new Error(`Audit executor authority: ${message}`)
+}
+const exact = (value, keys) =>
+  value !== null &&
+  typeof value === "object" &&
+  !Array.isArray(value) &&
+  Object.keys(value).sort().join(" ") === keys.split(" ").sort().join(" ")
+const repo = (value) => value?.id === REPOSITORY_ID && value?.full_name === REPOSITORY
+
+function identity(candidate) {
+  requireThat(
+    isExactSemver(candidate?.version) && SHA.test(candidate?.commitSha),
+    "invalid candidate",
+  )
+  return { version: candidate.version, commitSha: candidate.commitSha }
+}
+function seal(candidate, headSha, headBranch) {
+  const result = Object.freeze({ headSha, headBranch })
+  authorized.set(result, identity(candidate))
+  return result
+}
+
+// No caller-supplied object can widen the legacy candidate/tag identity. The main
+// identity is available only after the immutable source and GitHub CI reads below.
+export function auditExecutorIdentity({ candidate, executor }) {
+  const expected = identity(candidate)
+  if (executor === undefined)
+    return { headSha: expected.commitSha, headBranch: `v${expected.version}` }
+  const bound = authorized.get(executor)
+  requireThat(
+    bound?.version === expected.version && bound?.commitSha === expected.commitSha,
+    "unverified or mismatched executor",
+  )
+  return executor
+}
+
+export async function authorizeAuditExecutor({ candidate, manifestSha256, run, git, github }) {
+  const expected = identity(candidate)
+  if (run?.head_sha === expected.commitSha && run?.head_branch === `v${expected.version}`) {
+    return seal(candidate, expected.commitSha, `v${expected.version}`)
+  }
+  requireThat(
+    SHA.test(run?.head_sha) &&
+      run?.head_branch === "main" &&
+      run?.event === "workflow_dispatch" &&
+      run?.path === WORKFLOW &&
+      repo(run?.repository),
+    "invalid main run identity",
+  )
+  requireThat(DIGEST.test(manifestSha256), "manifest digest required")
+  const sourceSha = run.head_sha
+  const read = async (method, args) => {
+    const envelope = snapshotJson(await github[method](args))
+    requireThat(
+      envelope?.status === "PRESENT" && Object.hasOwn(envelope, "value"),
+      `${method} unavailable`,
+    )
+    return envelope.value
+  }
+  const show = async (path) => {
+    const source = await git.showFile({ ref: sourceSha, path })
+    requireThat(
+      typeof source === "string" && Buffer.byteLength(source) <= 1024 * 1024,
+      "invalid source bytes",
+    )
+    return source
+  }
+  const main = await read("getRef", { ref: "heads/main" })
+  requireThat(
+    main.ref === "refs/heads/main" && main.object?.type === "commit" && SHA.test(main.object?.sha),
+    "invalid main ref",
+  )
+  requireThat(
+    (await git.isAncestor({ ancestor: sourceSha, descendant: main.object.sha })) === true,
+    "executor is not merged on main",
+  )
+  const record = snapshotJson(
+    JSON.parse(
+      await show(`scripts/release/audit-executor-authorizations/v${expected.version}.json`),
+    ),
+  )
+  requireThat(
+    exact(record, "schemaVersion repository candidate workflow workflowSha256 scriptPinsSha256") &&
+      record.schemaVersion === 1 &&
+      record.repository === REPOSITORY &&
+      record.workflow === WORKFLOW &&
+      DIGEST.test(record.workflowSha256) &&
+      DIGEST.test(record.scriptPinsSha256),
+    "invalid source authorization",
+  )
+  requireThat(
+    exact(record.candidate, "version commitSha manifestSha256") &&
+      record.candidate.version === expected.version &&
+      record.candidate.commitSha === expected.commitSha &&
+      record.candidate.manifestSha256 === manifestSha256,
+    "authorization does not match candidate",
+  )
+  requireThat(hash(await show(WORKFLOW)) === record.workflowSha256, "workflow source changed")
+  const pinBytes = await show(PINS_PATH)
+  requireThat(hash(pinBytes) === record.scriptPinsSha256, "verifier pins changed")
+  const pins = snapshotJson(JSON.parse(pinBytes))
+  requireThat(
+    exact(pins, "schemaVersion scripts") &&
+      pins.schemaVersion === 1 &&
+      pins.scripts &&
+      typeof pins.scripts === "object" &&
+      !Array.isArray(pins.scripts),
+    "invalid verifier pins",
+  )
+  const entries = Object.entries(pins.scripts)
+  requireThat(entries.length > 0 && entries.length <= 512, "invalid verifier input count")
+  for (const name of ["audit-executor", "independent-audit", "observe", "audit"])
+    requireThat(
+      Object.hasOwn(pins.scripts, `scripts/release/${name}.mjs`),
+      "missing required verifier input",
+    )
+  for (const [path, pin] of entries) {
+    requireThat(
+      /^scripts\/(?:[a-zA-Z0-9_-]+\/)*[a-zA-Z0-9_.-]+\.(?:mjs|json)$/u.test(path) &&
+        !path.includes("..") &&
+        exact(pin, "sha256") &&
+        DIGEST.test(pin.sha256),
+      "invalid pinned source",
+    )
+    requireThat(hash(await show(path)) === pin.sha256, `pinned source changed: ${path}`)
+  }
+  const ciRuns = await read("listWorkflowRuns", { workflow: "ci.yml", commitSha: sourceSha })
+  requireThat(Array.isArray(ciRuns), "CI list unavailable")
+  const matches = ciRuns.filter(
+    (ci) =>
+      ci?.head_sha === sourceSha &&
+      ci?.head_branch === "main" &&
+      ci?.event === "push" &&
+      ci?.path === ".github/workflows/ci.yml",
+  )
+  requireThat(matches.length === 1, "one exact main CI run required")
+  const listed = matches[0]
+  requireThat(
+    Number.isSafeInteger(listed.id) &&
+      listed.id > 0 &&
+      Number.isSafeInteger(listed.run_attempt) &&
+      listed.run_attempt > 0,
+    "invalid CI attempt",
+  )
+  const ci = await read("getActionsRunAttempt", { runId: listed.id, attempt: listed.run_attempt })
+  requireThat(
+    repo(ci.repository) &&
+      positiveId(ci.workflow_id) &&
+      positiveId(ci.check_suite_id) &&
+      ci.status === "completed" &&
+      ci.conclusion === "success",
+    "successful repository CI required",
+  )
+  for (const key of [
+    "id",
+    "run_attempt",
+    "head_sha",
+    "head_branch",
+    "event",
+    "path",
+    "workflow_id",
+    "check_suite_id",
+  ])
+    requireThat(ci[key] === listed[key], "CI exact reread changed")
+  const workflow = await read("getWorkflow", { workflow: "ci.yml" })
+  requireThat(
+    positiveId(workflow.id) &&
+      workflow.id === ci.workflow_id &&
+      workflow.path === ".github/workflows/ci.yml",
+    "CI workflow changed",
+  )
+  const [jobs, checks] = await Promise.all([
+    read("listActionsRunJobs", { runId: ci.id }),
+    read("getCommitCheckRuns", { commitSha: sourceSha }),
+  ])
+  requireThat(Array.isArray(jobs) && Array.isArray(checks), "CI checks unavailable")
+  const validateJobs = jobs.filter(
+    (job) => job?.name === "validate" && job.runAttempt === ci.run_attempt,
+  )
+  const validateChecks = checks.filter(
+    (check) =>
+      check?.name === "validate" &&
+      check.head_sha === sourceSha &&
+      check.check_suite?.id === ci.check_suite_id,
+  )
+  requireThat(
+    validateJobs.length === 1 && validateChecks.length === 1,
+    "exact validate check required",
+  )
+  const job = validateJobs[0],
+    check = validateChecks[0]
+  requireThat(
+    positiveId(job.id) &&
+      positiveId(check.id) &&
+      positiveId(check.check_suite?.id) &&
+      job.id === check.id &&
+      check.app?.slug === "github-actions" &&
+      [job, check].every((value) => value.status === "completed" && value.conclusion === "success"),
+    "validate check unsuccessful",
+  )
+  return seal(candidate, sourceSha, "main")
+}

--- a/scripts/release/audit.mjs
+++ b/scripts/release/audit.mjs
@@ -2,6 +2,7 @@ import { createHash } from "node:crypto"
 
 import { snapshotJson } from "./adapter-normalize.mjs"
 import { extractActionsArtifactZip } from "./artifact-store.mjs"
+import { auditExecutorIdentity, authorizeAuditExecutor } from "./audit-executor.mjs"
 import { RELEASE_PAYLOAD_LIMITS } from "./limits.mjs"
 import {
   canonicalReleaseBody,
@@ -120,6 +121,8 @@ export async function recordAuditDispatch({ candidate, dispatch, github }) {
 }
 
 export async function waitForAudit({
+  git,
+  manifestSha256,
   runId,
   candidate,
   github,
@@ -152,7 +155,39 @@ export async function waitForAudit({
         deadline,
         clock,
       )
-      validateActionsRun(run, runId, identity)
+      let expectedManifest = manifestSha256
+      if (
+        expectedManifest === undefined &&
+        run.head_branch === "main" &&
+        (run.head_sha !== identity.commitSha || run.head_branch !== `v${identity.version}`)
+      ) {
+        const release = await withinAuditDeadline(
+          requireDraftRelease(github, identity),
+          deadline,
+          clock,
+        )
+        const marker = parseReleaseMarker(release.body)
+        assertMarkerIdentity(marker, identity)
+        if (
+          !["AUDIT_DISPATCHED", "AUDIT_RETRYABLE", "AUDIT_VERIFIED"].includes(marker.phase) ||
+          marker.audit.workflowRunId !== runId ||
+          release.body !== canonicalReleaseBody({ marker, manifest: null })
+        )
+          throw new Error("Audit executor manifest is not bound to its exact dispatch")
+        expectedManifest = marker.manifestSha256
+      }
+      const executor = await withinAuditDeadline(
+        authorizeAuditExecutor({
+          candidate: identity,
+          manifestSha256: expectedManifest,
+          run,
+          git,
+          github,
+        }),
+        deadline,
+        clock,
+      )
+      validateActionsRun(run, runId, identity, executor)
       if (run.status !== "completed") {
         if (attempt < attempts) {
           const remaining = auditTimeRemaining(deadline, clock)
@@ -167,6 +202,8 @@ export async function waitForAudit({
         continue
       }
       return await readTerminalAudit({
+        executor,
+        manifestSha256: expectedManifest,
         actions,
         run,
         runId,
@@ -366,7 +403,17 @@ export async function verifyAuditSuccess({ candidate, dispatch, result, github }
   return transitionResult(release, marker, "updated")
 }
 
-async function readTerminalAudit({ actions, run, runId, candidate, deadline, clock }) {
+async function readTerminalAudit({
+  actions,
+  run,
+  runId,
+  candidate,
+  deadline,
+  clock,
+  executor,
+  manifestSha256,
+}) {
+  const executorIdentity = auditExecutorIdentity({ candidate, executor })
   if (!isPositiveId(run.run_attempt)) throw new Error("Terminal audit run attempt is invalid")
   const expectedName = `audit-result-${runId}-${run.run_attempt}`
   const listed = await withinAuditDeadline(
@@ -383,8 +430,8 @@ async function readTerminalAudit({ actions, run, runId, candidate, deadline, clo
     runId,
     runAttempt: run.run_attempt,
     name: expectedName,
-    headBranch: `v${candidate.version}`,
-    headSha: candidate.commitSha,
+    headBranch: executorIdentity.headBranch,
+    headSha: executorIdentity.headSha,
   })
   const exactArtifact = await withinAuditDeadline(
     readValue(actions.getActionsArtifact({ artifactId: listedArtifact.id }), "actions-artifact"),
@@ -395,8 +442,8 @@ async function readTerminalAudit({ actions, run, runId, candidate, deadline, clo
     runId,
     runAttempt: run.run_attempt,
     name: expectedName,
-    headBranch: `v${candidate.version}`,
-    headSha: candidate.commitSha,
+    headBranch: executorIdentity.headBranch,
+    headSha: executorIdentity.headSha,
   })
   if (artifact.id !== listedArtifact.id) {
     throw new Error("Audit result artifact identity changed on exact re-read")
@@ -425,6 +472,7 @@ async function readTerminalAudit({ actions, run, runId, candidate, deadline, clo
     (result.conclusion === "success" && run.conclusion === "success") ||
     (result.conclusion === "failure" && run.conclusion !== "success")
   if (
+    (manifestSha256 !== undefined && result.manifestSha256 !== manifestSha256) ||
     result.workflowRunId !== runId ||
     result.runAttempt !== run.run_attempt ||
     !conclusionMatches
@@ -440,7 +488,8 @@ async function readTerminalAudit({ actions, run, runId, candidate, deadline, clo
   })
 }
 
-function validateActionsRun(value, runId, candidate) {
+function validateActionsRun(value, runId, candidate, executor) {
+  const identity = auditExecutorIdentity({ candidate, executor })
   if (
     !isRecord(value) ||
     value.id !== runId ||
@@ -450,8 +499,8 @@ function validateActionsRun(value, runId, candidate) {
     ) ||
     value.event !== "workflow_dispatch" ||
     value.path !== WORKFLOW ||
-    value.head_sha !== candidate.commitSha ||
-    value.head_branch !== `v${candidate.version}`
+    value.head_sha !== identity.headSha ||
+    value.head_branch !== identity.headBranch
   ) {
     throw new Error("Audit Actions run identity is malformed")
   }

--- a/scripts/release/cli.mjs
+++ b/scripts/release/cli.mjs
@@ -1453,6 +1453,7 @@ async function runWaitAudit(options, runtime) {
   )({
     runId,
     candidate,
+    git: await requireProductionGit(runtime),
     github: github.reader,
     attempts: 181,
     delayMs: 10_000,

--- a/scripts/release/independent-audit-coordinator.mjs
+++ b/scripts/release/independent-audit-coordinator.mjs
@@ -64,10 +64,13 @@ export async function coordinateIndependentAudit(input) {
   // The verifier separately authorizes its real immutable main source before
   // auditing. This coordinator performs no marker or release mutation.
   if (managed.mode === "draft") return Object.freeze({ mode: "draft-controller", ...identity })
+  if (invocation.eventName === "workflow_dispatch") {
+    return Object.freeze({ mode: "published-controller", ...identity })
+  }
   const receipt = snapshotJson(
     await invocation.github.writer.dispatchWorkflowAtRef({
       workflow: WORKFLOW,
-      ref: managed.tag,
+      ref: invocation.defaultBranch,
       inputs: identity,
     }),
   )

--- a/scripts/release/independent-audit-coordinator.mjs
+++ b/scripts/release/independent-audit-coordinator.mjs
@@ -55,22 +55,15 @@ export async function coordinateIndependentAudit(input) {
   const managed =
     invocation.eventName === "schedule"
       ? await discoverLatestPublishedRelease(invocation.github.reader, invocation.defaultBranch)
-      : parseManagedRelease(
-          await assertLegacyAuditCompatibleRelease({
-            release: await readReleaseByTag(
-              invocation.github.reader,
-              `v${invocation.inputs.version}`,
-            ),
-            github: invocation.github.reader,
-          }),
-          {
-            defaultBranch: invocation.defaultBranch,
-            expected: invocation.inputs,
-            allowDraft: false,
-          },
-        )
+      : await readAuditableManagedRelease(invocation.github.reader, {
+          defaultBranch: invocation.defaultBranch,
+          expected: invocation.inputs,
+        })
   await verifyAnnotatedTag(invocation.github.reader, managed)
   const identity = managedIdentity(managed)
+  // The verifier separately authorizes its real immutable main source before
+  // auditing. This coordinator performs no marker or release mutation.
+  if (managed.mode === "draft") return Object.freeze({ mode: "draft-controller", ...identity })
   const receipt = snapshotJson(
     await invocation.github.writer.dispatchWorkflowAtRef({
       workflow: WORKFLOW,
@@ -148,10 +141,6 @@ function isPublishedReleaseCandidate(value) {
     value.tag_name.startsWith("v") &&
     isReleaseVersion(value.tag_name.slice(1))
   )
-}
-
-async function readReleaseByTag(reader, tag) {
-  return readEnvelopeValue(reader.getReleaseByTag({ tag }), "release")
 }
 
 async function readEnvelopeValue(value, operation) {

--- a/scripts/release/independent-audit.mjs
+++ b/scripts/release/independent-audit.mjs
@@ -316,17 +316,14 @@ async function waitForDispatchMarker({
 }) {
   const deadline = boundedDeadline(clock, timeoutMs)
   for (let attempt = 1; attempt <= attempts; attempt += 1) {
-    const envelope = normalizeAdapterEnvelope(
-      await withinDeadline(
-        Promise.resolve().then(() => github.getReleaseByTag({ tag: `v${candidate.version}` })),
-        deadline,
-        clock,
-        setTimer,
-        clearTimer,
-      ),
-      { source: "github", operation: "release", payloadKey: "value" },
+    const envelope = await withinDeadline(
+      Promise.resolve().then(() => readDispatchRelease(github, candidate, deadline, clock)),
+      deadline,
+      clock,
+      setTimer,
+      clearTimer,
     )
-    if (envelope.status === "PRESENT") {
+    if (envelope !== null) {
       const marker = parseDispatchRelease(envelope.value, candidate, manifestSha256)
       if (
         marker.phase === "AUDIT_DISPATCHED" &&
@@ -335,8 +332,6 @@ async function waitForDispatchMarker({
       ) {
         return marker
       }
-    } else if (!(envelope.status === "AMBIGUOUS" && envelope.httpStatus === 404)) {
-      throw auditFailure("RELEASE_DISPATCH_READ_AMBIGUOUS")
     }
     if (attempt < attempts) {
       const remaining = deadline - monotonicTime(clock)
@@ -351,6 +346,52 @@ async function waitForDispatchMarker({
     }
   }
   throw auditFailure("AUDIT_DISPATCH_MARKER_TIMEOUT")
+}
+
+// Tag lookup excludes drafts. Enumerate the complete inventory before selecting
+// one ID, then independently read that release for the existing marker checks.
+async function readDispatchRelease(github, candidate, deadline, clock) {
+  const listed = normalizeAdapterEnvelope(await github.listReleases(), {
+    source: "github",
+    operation: "releases",
+    payloadKey: "value",
+  })
+  if (monotonicTime(clock) >= deadline) throw auditFailure("AUDIT_DISPATCH_MARKER_TIMEOUT")
+  if (listed.status !== "PRESENT") throw auditFailure("RELEASE_DISPATCH_READ_AMBIGUOUS")
+  if (!Array.isArray(listed.value)) throw auditFailure("RELEASE_DISPATCH_DISCOVERY_AMBIGUOUS")
+  const tag = `v${candidate.version}`
+  const matches = [],
+    ids = new Set()
+  for (const release of listed.value) {
+    if (
+      !isRecord(release) ||
+      !isPositiveInteger(release.id) ||
+      ids.has(release.id) ||
+      typeof release.tag_name !== "string" ||
+      release.tag_name.length === 0 ||
+      !(release.name === null || typeof release.name === "string") ||
+      !(release.body === null || typeof release.body === "string") ||
+      typeof release.draft !== "boolean"
+    )
+      throw auditFailure("RELEASE_DISPATCH_DISCOVERY_AMBIGUOUS")
+    ids.add(release.id)
+    if (
+      release.tag_name === tag ||
+      release.name === `Dawn ${tag}` ||
+      isManagedReleaseForTag(release, tag)
+    )
+      matches.push(release)
+  }
+  if (matches.length > 1) throw auditFailure("RELEASE_DISPATCH_DISCOVERY_AMBIGUOUS")
+  if (matches.length === 0) return null
+  const release = normalizeAdapterEnvelope(await github.getRelease({ releaseId: matches[0].id }), {
+    source: "github",
+    operation: "release",
+    payloadKey: "value",
+  })
+  if (release.status !== "PRESENT") throw auditFailure("RELEASE_DISPATCH_READ_AMBIGUOUS")
+  if (release.value?.id !== matches[0].id) throw auditFailure("RELEASE_DISPATCH_IDENTITY_INVALID")
+  return release
 }
 
 function parseDispatchRelease(value, candidate, manifestSha256) {
@@ -638,7 +679,12 @@ function normalizeExecutionDependencies(overrides) {
 function normalizeRuntime(value) {
   if (!isRecord(value)) throw new TypeError("Independent audit runtime is invalid")
   requiredMethod(value.inventory, "read", "inventory reader")
-  for (const method of ["getReleaseByTag", "getActionsRunAttempt", "listActionsRunJobs"]) {
+  for (const method of [
+    "listReleases",
+    "getRelease",
+    "getActionsRunAttempt",
+    "listActionsRunJobs",
+  ]) {
     requiredMethod(value.github, method, "GitHub reader")
   }
   requiredMethod(value, "observeProductionCandidate", "production observer")

--- a/scripts/release/independent-audit.mjs
+++ b/scripts/release/independent-audit.mjs
@@ -11,6 +11,7 @@ import { createGitReader } from "./adapters/git.mjs"
 import { createGitHubReader } from "./adapters/github.mjs"
 import { createNpmReader } from "./adapters/npm.mjs"
 import { createCliAttestationVerifier } from "./artifact-store.mjs"
+import { auditExecutorIdentity, authorizeAuditExecutor } from "./audit-executor.mjs"
 import { readBoundedFixture } from "./fixture-io.mjs"
 import { RELEASE_PAYLOAD_LIMITS } from "./limits.mjs"
 import { CANONICAL_RELEASE_PACKAGE_ORDER } from "./manifest.mjs"
@@ -113,7 +114,6 @@ export function parseIndependentAuditEnvironment(environment, options) {
     throw new TypeError("Independent audit environment is invalid")
   }
   const expectedRef = `refs/tags/v${identity.version}`
-  const expectedWorkflowRef = `${REPOSITORY}/${WORKFLOW}@${expectedRef}`
   const values = Object.fromEntries(
     [
       "GITHUB_REPOSITORY",
@@ -125,12 +125,15 @@ export function parseIndependentAuditEnvironment(environment, options) {
       "GITHUB_RUN_ATTEMPT",
     ].map((name) => [name, environmentString(environment, name)]),
   )
+  const isMain = values.GITHUB_REF === "refs/heads/main"
+  const actualRef = isMain ? "refs/heads/main" : expectedRef
+  const expectedWorkflowRef = `${REPOSITORY}/${WORKFLOW}@${actualRef}`
   if (
     values.GITHUB_REPOSITORY !== REPOSITORY ||
     values.GITHUB_EVENT_NAME !== "workflow_dispatch" ||
     values.GITHUB_WORKFLOW_REF !== expectedWorkflowRef ||
-    values.GITHUB_REF !== expectedRef ||
-    values.GITHUB_SHA !== identity.commitSha
+    values.GITHUB_REF !== actualRef ||
+    (isMain ? !SHA_PATTERN.test(values.GITHUB_SHA) : values.GITHUB_SHA !== identity.commitSha)
   ) {
     throw new TypeError("Independent audit GitHub invocation identity is invalid")
   }
@@ -139,8 +142,9 @@ export function parseIndependentAuditEnvironment(environment, options) {
   return deepFreeze({
     repository: REPOSITORY,
     workflow: WORKFLOW,
-    ref: expectedRef,
+    ref: actualRef,
     commitSha: identity.commitSha,
+    ...(isMain ? { executorSha: values.GITHUB_SHA } : {}),
     workflowRunId,
     runAttempt,
   })
@@ -200,6 +204,7 @@ export async function runIndependentAudit(argv, overrides = {}) {
           marker: releaseMarker,
           invocation,
           github: runtime.github,
+          git: runtime.git,
         }),
     )
     const immutableInventory = await auditCheck(
@@ -424,7 +429,7 @@ function parseDispatchRelease(value, candidate, manifestSha256) {
   return marker
 }
 
-async function readExactWorkflowAttempt({ candidate, marker, invocation, github }) {
+async function readExactWorkflowAttempt({ candidate, marker, invocation, github, git }) {
   const [runEnvelope, jobsEnvelope] = await Promise.all([
     github.getActionsRunAttempt({
       runId: invocation.workflowRunId,
@@ -448,7 +453,22 @@ async function readExactWorkflowAttempt({ candidate, marker, invocation, github 
   if (run.value.run_attempt !== invocation.runAttempt) {
     throw auditFailure("AUDIT_RUN_ATTEMPT_IDENTITY_MISMATCH")
   }
+  const executor = await authorizeAuditExecutor({
+    candidate,
+    manifestSha256: marker.manifestSha256,
+    run: run.value,
+    github,
+    git,
+  })
+  const source = auditExecutorIdentity({ candidate, executor })
+  if (
+    source.headSha !== (invocation.executorSha ?? invocation.commitSha) ||
+    invocation.ref !==
+      (source.headBranch === "main" ? "refs/heads/main" : `refs/tags/${source.headBranch}`)
+  )
+    throw auditFailure("AUDIT_RUN_ATTEMPT_IDENTITY_MISMATCH")
   validateProductionAuditRun({
+    executor,
     value: run.value,
     jobs: jobs.value.filter((job) => job?.runAttempt <= invocation.runAttempt),
     candidate,
@@ -1035,10 +1055,12 @@ function isInvocation(value, candidate) {
       "commitSha",
       "workflowRunId",
       "runAttempt",
+      ...(value.ref === "refs/heads/main" ? ["executorSha"] : []),
     ]) &&
     value.repository === REPOSITORY &&
     value.workflow === WORKFLOW &&
-    value.ref === `refs/tags/v${candidate.version}` &&
+    (value.ref === `refs/tags/v${candidate.version}` ||
+      (value.ref === "refs/heads/main" && SHA_PATTERN.test(value.executorSha))) &&
     value.commitSha === candidate.commitSha &&
     isPositiveInteger(value.workflowRunId) &&
     isPositiveInteger(value.runAttempt) &&

--- a/scripts/release/observe.mjs
+++ b/scripts/release/observe.mjs
@@ -2,6 +2,7 @@ import { createHash } from "node:crypto"
 import { canonicalAbandonmentBytes, parseAbandonmentReleaseBody } from "./abandonment.mjs"
 import { normalizeAdapterEnvelope, snapshotJson } from "./adapter-normalize.mjs"
 import { extractActionsArtifactZip } from "./artifact-store.mjs"
+import { auditExecutorIdentity, authorizeAuditExecutor } from "./audit-executor.mjs"
 import { discoverManagedCandidate, discoverScheduledCandidate } from "./candidate.mjs"
 import { assertValidReleaseInventory, readReleaseInventory } from "./inventory.mjs"
 import { assertPayloadByteLength, RELEASE_PAYLOAD_LIMITS } from "./limits.mjs"
@@ -529,6 +530,7 @@ export async function observeProductionCandidate({
   })
   const artifactState = preparedArtifactState
   const releaseState = await mapProductionRelease({
+    git,
     result: releasesResult,
     candidate: identity,
     inventory: managedInventory,
@@ -1787,6 +1789,7 @@ function emptyProductionArtifacts(inventory) {
 }
 
 async function mapProductionRelease({
+  git,
   result,
   candidate,
   inventory,
@@ -2004,6 +2007,7 @@ async function mapProductionRelease({
         ),
       )
     const terminal = await observeReleaseTerminal({
+      git,
       candidate,
       controllerMarker,
       release,
@@ -2987,6 +2991,7 @@ function markerBaseAssets(marker) {
 }
 
 async function observeReleaseTerminal({
+  git,
   candidate,
   release,
   marker,
@@ -3043,7 +3048,15 @@ async function observeReleaseTerminal({
   if (runResult.status !== "PRESENT" || jobsResult.status !== "PRESENT") {
     throw observationError("RELEASE_AUDIT_RUN_AMBIGUOUS")
   }
+  const executor = await authorizeAuditExecutor({
+    candidate,
+    manifestSha256: marker.manifestSha256,
+    run: runResult.value,
+    git,
+    github,
+  })
   const run = validateProductionAuditRun({
+    executor,
     value: runResult.value,
     jobs:
       exactAttempt === null
@@ -3107,14 +3120,15 @@ async function observeReleaseTerminal({
   }
 }
 
-export function validateProductionAuditRun({ value, jobs, candidate, marker }) {
+export function validateProductionAuditRun({ value, jobs, candidate, marker, executor }) {
+  const identity = auditExecutorIdentity({ candidate, executor })
   if (
     !isRecord(value) ||
     String(value.id) !== String(marker.audit.workflowRunId) ||
     !isPositiveSafeInteger(value.run_attempt) ||
     value.run_attempt > MAX_AUDIT_ATTEMPTS ||
-    value.head_sha !== candidate.commitSha ||
-    value.head_branch !== `v${candidate.version}` ||
+    value.head_sha !== identity.headSha ||
+    value.head_branch !== identity.headBranch ||
     value.event !== "workflow_dispatch" ||
     value.path !== ".github/workflows/published-artifact-verify.yml" ||
     !ACTIONS_RUN_STATUSES.includes(value.status) ||

--- a/scripts/release/post-publication-audit.mjs
+++ b/scripts/release/post-publication-audit.mjs
@@ -48,8 +48,8 @@ export async function runPostPublicationAudit(argv, overrides = {}) {
           npm: runtime.npm,
           npmAuditFactory: runtime.npmAuditFactory,
           attestations: runtime.attestations,
-          // Same tag checkout as the independent audit: the candidate commit predates any
-          // terminal record on main, so TERMINAL_RECORD_PUBLISHED_VERSION cannot fire here.
+          // Keep payload terminal-record lookup pinned to the candidate, even when the
+          // verifier runs from a separately authorized main controller.
           terminalRecordRef: candidate.commitSha,
         }),
       )

--- a/scripts/release/test/audit-executor.test.mjs
+++ b/scripts/release/test/audit-executor.test.mjs
@@ -1,0 +1,125 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+import { auditExecutorIdentity, authorizeAuditExecutor } from "../audit-executor.mjs"
+import { auditExecutorFixture } from "./support/audit-executor-fixture.mjs"
+
+test("legacy executor remains exact candidate/tag without additional authority reads", async () => {
+  const candidate = { version: "0.8.26", commitSha: "4".repeat(40) }
+  const executor = await authorizeAuditExecutor({
+    candidate,
+    run: { head_sha: candidate.commitSha, head_branch: "v0.8.26" },
+  })
+  assert.deepEqual(auditExecutorIdentity({ candidate, executor }), {
+    headSha: candidate.commitSha,
+    headBranch: "v0.8.26",
+  })
+  assert.deepEqual(auditExecutorIdentity({ candidate }), {
+    headSha: candidate.commitSha,
+    headBranch: "v0.8.26",
+  })
+  assert.throws(() =>
+    auditExecutorIdentity({ candidate, executor: { headSha: "5".repeat(40), headBranch: "main" } }),
+  )
+})
+
+test("main auditor requires actual merged executor source and exact successful CI", async () => {
+  const f = auditExecutorFixture()
+  const executor = await authorizeAuditExecutor(f)
+  assert.deepEqual(auditExecutorIdentity({ candidate: f.candidate, executor }), {
+    headSha: f.run.head_sha,
+    headBranch: "main",
+  })
+  assert.throws(() =>
+    auditExecutorIdentity({ candidate: { ...f.candidate, commitSha: "9".repeat(40) }, executor }),
+  )
+})
+
+for (const [name, mutate] of Object.entries({
+  "wrong branch": (f) => {
+    f.run.head_branch = "feature"
+  },
+  "wrong workflow": (f) => {
+    f.run.path = ".github/workflows/other.yml"
+  },
+  "wrong repository": (f) => {
+    f.run.repository.id = 123
+  },
+  "unmerged source": (f) => {
+    f.state.ancestor = false
+  },
+  "missing source authorization": (f) => {
+    f.files.delete("scripts/release/audit-executor-authorizations/v0.8.26.json")
+  },
+  "wrong manifest": (f) => {
+    f.manifestSha256 = "b".repeat(64)
+  },
+  "changed workflow": (f) => {
+    f.files.set(f.run.path, "changed workflow")
+  },
+  "changed verifier": (f) => {
+    f.files.set("scripts/release/independent-audit.mjs", "changed verifier")
+  },
+  "changed pins": (f) => {
+    f.files.set("scripts/release/test/fixtures/release-script-hashes.json", "{}")
+  },
+  "failed CI": (f) => {
+    f.state.ci.conclusion = "failure"
+  },
+  "wrong CI SHA": (f) => {
+    f.state.ci.head_sha = "9".repeat(40)
+  },
+  "missing validate": (f) => {
+    f.state.jobs = []
+  },
+  "foreign check": (f) => {
+    f.state.checks[0].app.slug = "third-party"
+  },
+  "wrong attempt": (f) => {
+    f.state.jobs[0].runAttempt = 2
+  },
+}))
+  test(`rejects ${name}`, async () => {
+    const f = auditExecutorFixture()
+    mutate(f)
+    await assert.rejects(authorizeAuditExecutor(f))
+  })
+
+test("missing correlated CI identifiers cannot satisfy equality checks", async () => {
+  const f = auditExecutorFixture()
+  delete f.state.ci.workflow_id
+  delete f.state.ci.check_suite_id
+  delete f.state.jobs[0].id
+  delete f.state.checks[0].id
+  delete f.state.checks[0].check_suite.id
+  f.github.getWorkflow = async () => ({
+    status: "PRESENT",
+    value: { path: ".github/workflows/ci.yml" },
+  })
+  await assert.rejects(authorizeAuditExecutor(f))
+})
+
+test("committed v0.8.26 authorization binds the reviewed workflow and complete source pins", async () => {
+  const { readFile } = await import("node:fs/promises")
+  const { createHash } = await import("node:crypto")
+  const root = new URL("../../../", import.meta.url)
+  const record = JSON.parse(
+    await readFile(
+      new URL("scripts/release/audit-executor-authorizations/v0.8.26.json", root),
+      "utf8",
+    ),
+  )
+  const hashFile = async (path) =>
+    createHash("sha256")
+      .update(await readFile(new URL(path, root)))
+      .digest("hex")
+  assert.deepEqual(record.candidate, {
+    version: "0.8.26",
+    commitSha: "470c871f258f5cd248904208bff6a89acbf3a56c",
+    manifestSha256: "15c3afa7eea9e552d83c10e0e8bdd8ec6d9d4a6ac0b2a87e8e4ac09f5511306b",
+  })
+  assert.equal(record.workflowSha256, await hashFile(record.workflow))
+  assert.equal(
+    record.scriptPinsSha256,
+    await hashFile("scripts/release/test/fixtures/release-script-hashes.json"),
+  )
+})

--- a/scripts/release/test/audit.test.mjs
+++ b/scripts/release/test/audit.test.mjs
@@ -18,6 +18,7 @@ import {
   canonicalSmokeResultBytes,
 } from "../smoke-result.mjs"
 import { canonicalAuditResultBytes } from "../terminal-records.mjs"
+import { auditExecutorFixture } from "./support/audit-executor-fixture.mjs"
 import { SMOKE_LANES, smokeDescriptor } from "./support/marker-observation.mjs"
 
 const VERSION = "0.8.22"
@@ -412,6 +413,121 @@ test("same-name different bytes and unexpected terminal evidence are hard confli
   )
   assert.equal(unexpected.updateCount, 0)
 })
+
+for (const wrongDispatch of [false, true]) {
+  test(`waitForAudit resolves repaired authority manifest from exact current draft (wrong dispatch=${wrongDispatch})`, async () => {
+    const fixture = auditExecutorFixture()
+    const release = auditRemote()
+    await recordAuditDispatch({
+      candidate: CANDIDATE,
+      dispatch: dispatch(wrongDispatch ? 502 : 501),
+      github: release.releaseGitHub,
+    })
+    fixture.authorization.candidate = {
+      version: VERSION,
+      commitSha: COMMIT_SHA,
+      manifestSha256: MANIFEST_SHA256,
+    }
+    fixture.files.set(
+      `scripts/release/audit-executor-authorizations/v${VERSION}.json`,
+      JSON.stringify(fixture.authorization),
+    )
+    const result = auditResult({ workflowRunId: 501 })
+    const remote = actionsRemote({ result, statuses: ["completed"] })
+    remote.headSha = fixture.run.head_sha
+    remote.headBranch = "main"
+    remote.artifacts[0].workflow_run.head_sha = fixture.run.head_sha
+    remote.artifacts[0].workflow_run.head_branch = "main"
+    const github = {
+      ...fixture.github,
+      ...remote.github,
+      listReleases: release.releaseGitHub.reader.listReleases,
+      getRelease: release.releaseGitHub.reader.getRelease,
+      async getActionsRun(request) {
+        const response = await remote.github.getActionsRun(request)
+        return {
+          ...response,
+          value: { ...response.value, repository: fixture.run.repository },
+        }
+      },
+    }
+    const promise = waitForAudit({
+      runId: 501,
+      candidate: CANDIDATE,
+      git: fixture.git,
+      github,
+      attempts: 1,
+      delayMs: 0,
+      delay: async () => {},
+    })
+    if (wrongDispatch) await assert.rejects(promise, /exact dispatch/iu)
+    else assert.deepEqual((await promise).result, result)
+  })
+}
+
+for (const damagedArtifact of [false, true]) {
+  test(`waitForAudit binds repaired main executor to both artifact reads (damaged=${damagedArtifact})`, async () => {
+    const fixture = auditExecutorFixture()
+    const candidate = { ...CANDIDATE, ...fixture.candidate }
+    const result = {
+      ...auditResult({ workflowRunId: 501 }),
+      ...fixture.candidate,
+      manifestSha256: fixture.manifestSha256,
+    }
+    const remote = actionsRemote({ result, statuses: ["completed"] })
+    remote.headSha = fixture.run.head_sha
+    remote.headBranch = "main"
+    remote.artifacts[0].workflow_run.head_sha = fixture.run.head_sha
+    remote.artifacts[0].workflow_run.head_branch = "main"
+    const github = {
+      ...fixture.github,
+      ...remote.github,
+      async getActionsRun(request) {
+        const response = await remote.github.getActionsRun(request)
+        return {
+          ...response,
+          value: { ...response.value, repository: fixture.run.repository },
+        }
+      },
+      async getActionsArtifact(request) {
+        const response = await remote.github.getActionsArtifact(request)
+        return damagedArtifact
+          ? {
+              ...response,
+              value: {
+                ...response.value,
+                workflow_run: {
+                  ...response.value.workflow_run,
+                  head_sha: candidate.commitSha,
+                },
+              },
+            }
+          : response
+      },
+    }
+    const promise = waitForAudit({
+      runId: 501,
+      candidate,
+      manifestSha256: fixture.manifestSha256,
+      git: fixture.git,
+      github,
+      attempts: 1,
+      delayMs: 0,
+      delay: async () => {},
+    })
+    if (damagedArtifact) {
+      await assert.rejects(promise, /artifact/iu)
+      assert.equal(
+        remote.calls.some(([method]) => method === "downloadActionsArtifact"),
+        false,
+      )
+    } else {
+      const observed = await promise
+      assert.equal(observed.status, "terminal")
+      assert.deepEqual(observed.result, result)
+    }
+  })
+}
 
 test("waitForAudit polls the exact run and returns only its one canonical result artifact", async () => {
   const result = auditResult({ workflowRunId: 501, runAttempt: 2 })

--- a/scripts/release/test/controller.test.mjs
+++ b/scripts/release/test/controller.test.mjs
@@ -1266,7 +1266,13 @@ test("audit CLI routes keep dispatch, marker recording, correlation, and publica
       "--output",
       paths.waitOutput,
     ],
-    { cwd: directory, github, importModule, wait },
+    {
+      cwd: directory,
+      github,
+      importModule,
+      wait,
+      git: { capability: "immutable-git" },
+    },
   )
   assert.deepEqual(JSON.parse(await readFile(paths.waitOutput, "utf8")), audit)
   await runReleaseCli(
@@ -1301,6 +1307,7 @@ test("audit CLI routes keep dispatch, marker recording, correlation, and publica
   assert.equal(calls[0][1].github, github.writer)
   assert.equal(calls[1][1].github, github)
   assert.equal(calls[2][1].github, github.reader)
+  assert.deepEqual(calls[2][1].git, { capability: "immutable-git" })
   assert.equal(calls[2][1].runId, dispatchReceipt.workflowRunId)
   assert.deepEqual(calls[2][1].candidate, CANDIDATE)
   assert.equal(calls[2][1].attempts, 181)
@@ -1339,6 +1346,7 @@ test("wait-audit fails closed without writing a result when the exact run stays 
   const importModule = async () => ({
     async waitForAudit(input) {
       calls += 1
+      assert.deepEqual(input.git, { capability: "immutable-git" })
       assert.equal(input.runId, 777)
       assert.equal(input.github, github.reader)
       assert.equal(input.wait, undefined)
@@ -1359,7 +1367,14 @@ test("wait-audit fails closed without writing a result when the exact run stays 
         "--output",
         outputPath,
       ],
-      { cwd: directory, github, importModule, wait, now },
+      {
+        cwd: directory,
+        github,
+        importModule,
+        wait,
+        now,
+        git: { capability: "immutable-git" },
+      },
     ),
     (error) => error?.code === "AUDIT_PENDING",
   )

--- a/scripts/release/test/fixtures/release-script-hashes.json
+++ b/scripts/release/test/fixtures/release-script-hashes.json
@@ -58,14 +58,17 @@
     "scripts/release/artifact-store.mjs": {
       "sha256": "a9920592396029bfdacf4daaab9d453216f02c3114c50c35cd563058c8cac9dd"
     },
+    "scripts/release/audit-executor.mjs": {
+      "sha256": "0572a15efd3062e8c673e4715e7ed442fd6f092e989e0e6ac5b2d93f358ca00d"
+    },
     "scripts/release/audit.mjs": {
-      "sha256": "8d18331b857ba0743a9a2109b51f07639639cecb7a572375973452356b81a60f"
+      "sha256": "40d8e8b05ba34f385695e2127c383dd1382c2149d586bf969db4139c9eb8ee63"
     },
     "scripts/release/candidate.mjs": {
       "sha256": "8be85623d581e05a8bf3e54c95d5fc7a695e2a94b8ccda4b5481f983ada0ebfa"
     },
     "scripts/release/cli.mjs": {
-      "sha256": "f822541947889e47bb1a8167598459d699ab4f2e118dc443f4b0e5e2b9884e57"
+      "sha256": "b4b12f24156dc933de5ddeb5b314093fd9cbed06cfa82a636b47219b80dda801"
     },
     "scripts/release/conflicts.mjs": {
       "sha256": "9fb3ff5154dab04d975b56baf29255493ece213824801e3504fad534ae81db7f"
@@ -83,10 +86,10 @@
       "sha256": "427419a41951adb53720470d80f1defca030f8eb9289dae50c704f332e5f9ac0"
     },
     "scripts/release/independent-audit-coordinator.mjs": {
-      "sha256": "5a154fa94961395be30a52eabb6518b53042ef7b6ecc482a6b93386c131f0a2b"
+      "sha256": "c485bd1b7b240f79c74ae5366a4304ddb11890b16bcf3edc92e26db7f6f68287"
     },
     "scripts/release/independent-audit.mjs": {
-      "sha256": "6c9d842c11df29dbf06d63f107ee2335fbc4aad48de43d72ec25c0ccc0562fc9"
+      "sha256": "adbe0ae2adafcd82df9870ca593308430c0b8156738e13af4a3f2c6f23814028"
     },
     "scripts/release/inventory.mjs": {
       "sha256": "3fbe259101ba7cf46f3921549bacaee536b306eb60fe78cb47914860548cb0dd"
@@ -110,7 +113,7 @@
       "sha256": "fc3847533cbf01b8fa2420f484680a7576b8b2b4edf4d6f41f56df925f4914c3"
     },
     "scripts/release/observe.mjs": {
-      "sha256": "e44cab0e8637e1bf5d2ae5100ee0a1a272c359352c2e30e55d36fe3305e032eb"
+      "sha256": "92569c564cd45de069d258a371d9fee24e53f67225b51139f527400087ce0632"
     },
     "scripts/release/planner.mjs": {
       "sha256": "2e09281ff952da69e985de7802307b849b76525e838e4cab49516a3d05793433"

--- a/scripts/release/test/fixtures/release-script-hashes.json
+++ b/scripts/release/test/fixtures/release-script-hashes.json
@@ -86,7 +86,7 @@
       "sha256": "5a154fa94961395be30a52eabb6518b53042ef7b6ecc482a6b93386c131f0a2b"
     },
     "scripts/release/independent-audit.mjs": {
-      "sha256": "32746a3162b0fbf97990e3ad01952a4f581fa92ece87aaf8252a9a7fa4a68dd8"
+      "sha256": "6c9d842c11df29dbf06d63f107ee2335fbc4aad48de43d72ec25c0ccc0562fc9"
     },
     "scripts/release/inventory.mjs": {
       "sha256": "3fbe259101ba7cf46f3921549bacaee536b306eb60fe78cb47914860548cb0dd"

--- a/scripts/release/test/fixtures/release-script-hashes.json
+++ b/scripts/release/test/fixtures/release-script-hashes.json
@@ -44,7 +44,7 @@
       "sha256": "c9c20a293690eeffa83c6fe59e2a0638653d16c51a249353551990032b8a2955"
     },
     "scripts/release/adapters/github-write.mjs": {
-      "sha256": "0c4d42920d9ba00d1a3778eab64e9623a18663fdcf302cdda48d67b01dc3ea84"
+      "sha256": "e74dd868c5bac7852763380ae34e826b8e01d289d1f3e526e76b2fb40c686c60"
     },
     "scripts/release/adapters/github.mjs": {
       "sha256": "1c9677eb7fc34b5b98b75c7af75ccb5f44b2649362c58098b6d291df4600ca9c"
@@ -86,7 +86,7 @@
       "sha256": "427419a41951adb53720470d80f1defca030f8eb9289dae50c704f332e5f9ac0"
     },
     "scripts/release/independent-audit-coordinator.mjs": {
-      "sha256": "c485bd1b7b240f79c74ae5366a4304ddb11890b16bcf3edc92e26db7f6f68287"
+      "sha256": "1c82ded828cc9a71424527c4b69e9827ea959dc63dca395904abc9f78fb3f913"
     },
     "scripts/release/independent-audit.mjs": {
       "sha256": "adbe0ae2adafcd82df9870ca593308430c0b8156738e13af4a3f2c6f23814028"
@@ -119,7 +119,7 @@
       "sha256": "2e09281ff952da69e985de7802307b849b76525e838e4cab49516a3d05793433"
     },
     "scripts/release/post-publication-audit.mjs": {
-      "sha256": "909600cbb051aabcf36e819ff002c3aae05d45de47c2e91a5364419bdeeea0d4"
+      "sha256": "810eec178c3cb5a85d3441e3cdc0b0febd21dd341878072e57789a1310283983"
     },
     "scripts/release/prepare-checks.mjs": {
       "sha256": "fc47929bdf777bdcd68043a8975fb4906e8cfa8e1649bbdf8f36a07dfcd1b55f"

--- a/scripts/release/test/fixtures/workflow-entrypoints.json
+++ b/scripts/release/test/fixtures/workflow-entrypoints.json
@@ -2568,7 +2568,7 @@
           "classification": "safe",
           "id": "verify-published",
           "descriptor": {
-            "if": "github.event_name == 'workflow_dispatch' && needs.coordinate.outputs.mode == 'published' && github.ref == format('refs/tags/v{0}', inputs.version) && github.sha == inputs.commitSha",
+            "if": "github.event_name == 'workflow_dispatch' && ((needs.coordinate.outputs.mode == 'published' &&\n  github.ref == format('refs/tags/v{0}', inputs.version) && github.sha == inputs.commitSha) ||\n (needs.coordinate.outputs.mode == 'published-controller' && github.ref == 'refs/heads/main'))",
             "needs": "coordinate",
             "permissions": {
               "actions": "read",
@@ -2583,12 +2583,12 @@
             {
               "classification": "safe",
               "descriptor": {
-                "name": "Checkout exact annotated tag",
+                "name": "Checkout exact audit executor",
                 "uses": "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1",
                 "with": {
                   "fetch-depth": 0,
                   "persist-credentials": false,
-                  "ref": "${{ github.ref }}"
+                  "ref": "${{ github.sha }}"
                 }
               }
             },

--- a/scripts/release/test/fixtures/workflow-entrypoints.json
+++ b/scripts/release/test/fixtures/workflow-entrypoints.json
@@ -2478,7 +2478,7 @@
           "classification": "safe",
           "id": "verify-draft",
           "descriptor": {
-            "if": "github.event_name == 'workflow_dispatch' && needs.coordinate.outputs.mode == 'draft' && github.ref == format('refs/tags/v{0}', inputs.version) && github.sha == inputs.commitSha",
+            "if": "github.event_name == 'workflow_dispatch' && ((needs.coordinate.outputs.mode == 'draft' &&\n  github.ref == format('refs/tags/v{0}', inputs.version) &&\n  github.sha == inputs.commitSha) ||\n (needs.coordinate.outputs.mode == 'draft-controller' &&\n  github.ref == 'refs/heads/main'))",
             "name": "verify",
             "needs": "coordinate",
             "permissions": {
@@ -2494,12 +2494,12 @@
             {
               "classification": "safe",
               "descriptor": {
-                "name": "Checkout exact candidate",
+                "name": "Checkout exact audit executor",
                 "uses": "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1",
                 "with": {
                   "fetch-depth": 0,
                   "persist-credentials": false,
-                  "ref": "${{ github.ref }}"
+                  "ref": "${{ github.sha }}"
                 }
               }
             },

--- a/scripts/release/test/fixtures/workflow-safe-executables.json
+++ b/scripts/release/test/fixtures/workflow-safe-executables.json
@@ -1756,7 +1756,7 @@
         "classification": "safe",
         "job": "verify-published",
         "stepIndex": 0,
-        "step": "Checkout exact annotated tag",
+        "step": "Checkout exact audit executor",
         "kind": "step-uses",
         "value": "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1"
       },

--- a/scripts/release/test/fixtures/workflow-safe-executables.json
+++ b/scripts/release/test/fixtures/workflow-safe-executables.json
@@ -1700,7 +1700,7 @@
         "classification": "safe",
         "job": "verify-draft",
         "stepIndex": 0,
-        "step": "Checkout exact candidate",
+        "step": "Checkout exact audit executor",
         "kind": "step-uses",
         "value": "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1"
       },

--- a/scripts/release/test/github-write.test.mjs
+++ b/scripts/release/test/github-write.test.mjs
@@ -1431,3 +1431,39 @@ function canonicalize(value) {
       .map((key) => [key, canonicalize(value[key])]),
   )
 }
+
+test("only the independent audit workflow can dispatch the main controller ref", async () => {
+  const calls = []
+  const writer = createGitHubWriter({
+    owner: OWNER,
+    repo: REPO,
+    reader: exactReader(),
+    fetchImpl: async (_, init) => {
+      calls.push(JSON.parse(init.body))
+      return jsonResponse(
+        {
+          workflow_run_id: 123,
+          run_url: `${API_BASE}/actions/runs/123`,
+          html_url: `https://github.com/${OWNER}/${REPO}/actions/runs/123`,
+        },
+        200,
+      )
+    },
+  })
+  await writer.dispatchWorkflowAtRef({
+    workflow: ".github/workflows/published-artifact-verify.yml",
+    ref: "main",
+    inputs: { version: VERSION, commitSha: SHA, manifestSha256: "a".repeat(64) },
+  })
+  assert.equal(calls[0].ref, "main")
+  for (const [workflow, ref] of [
+    ["release.yml", "main"],
+    ["published-artifact-verify.yml", "feature"],
+    ["published-artifact-verify.yml", "refs/heads/main"],
+  ]) {
+    await assert.rejects(
+      writer.dispatchWorkflowAtRef({ workflow: `.github/workflows/${workflow}`, ref, inputs: {} }),
+    )
+  }
+  assert.equal(calls.length, 1)
+})

--- a/scripts/release/test/independent-audit-coordinator.test.mjs
+++ b/scripts/release/test/independent-audit-coordinator.test.mjs
@@ -27,7 +27,7 @@ test("coordinator arguments accept only one GitHub output path", () => {
   )
 })
 
-test("a schedule discovers the highest managed published immutable Release and relays its exact tag", async () => {
+test("a schedule discovers the highest managed published immutable Release and relays exact inputs to main", async () => {
   const older = managedRelease({
     id: 10,
     version: "0.8.21",
@@ -53,13 +53,13 @@ test("a schedule discovers the highest managed published immutable Release and r
   assert.deepEqual(calls, [
     {
       workflow: ".github/workflows/published-artifact-verify.yml",
-      ref: `v${VERSION}`,
+      ref: "main",
       inputs: { version: VERSION, commitSha: COMMIT_SHA, manifestSha256: MANIFEST_SHA256 },
     },
   ])
 })
 
-test("default-branch manual inputs still relay while branch SHA equality never enters audit mode", async () => {
+test("default-branch manual published inputs select controller verification without a relay loop", async () => {
   const release = managedRelease({ id: 11, version: VERSION, commitSha: COMMIT_SHA })
   const calls = []
   const result = await coordinateIndependentAudit({
@@ -71,8 +71,8 @@ test("default-branch manual inputs still relay while branch SHA equality never e
     github: githubBoundary({ releases: [release], calls }),
   })
 
-  assert.equal(result.mode, "relayed")
-  assert.equal(calls.length, 1)
+  assert.equal(result.mode, "published-controller")
+  assert.equal(calls.length, 0)
 })
 
 test("an exact annotated tag routes mutable draft and published immutable audits separately", async () => {
@@ -243,7 +243,7 @@ test("scheduled legacy audit ignores older recovery history when the newest rele
   })
   assert.equal(result.mode, "relayed")
   assert.equal(calls.length, 1)
-  assert.equal(calls[0].ref, `v${VERSION}`)
+  assert.equal(calls[0].ref, "main")
 })
 
 test("a main draft dispatch selects controller verification without relaying frozen code", async () => {

--- a/scripts/release/test/independent-audit-coordinator.test.mjs
+++ b/scripts/release/test/independent-audit-coordinator.test.mjs
@@ -245,3 +245,19 @@ test("scheduled legacy audit ignores older recovery history when the newest rele
   assert.equal(calls.length, 1)
   assert.equal(calls[0].ref, `v${VERSION}`)
 })
+
+test("a main draft dispatch selects controller verification without relaying frozen code", async () => {
+  const draft = managedRelease({ id: 11, version: VERSION, commitSha: COMMIT_SHA, draft: true })
+  const calls = []
+  const result = await coordinateIndependentAudit({
+    eventName: "workflow_dispatch",
+    ref: "refs/heads/main",
+    sha: MAIN_SHA,
+    defaultBranch: "main",
+    inputs: { version: VERSION, commitSha: COMMIT_SHA, manifestSha256: MANIFEST_SHA256 },
+    github: githubBoundary({ releases: [draft], calls }),
+  })
+  assert.equal(result.mode, "draft-controller")
+  assert.equal(result.commitSha, COMMIT_SHA)
+  assert.deepEqual(calls, [])
+})

--- a/scripts/release/test/independent-audit.test.mjs
+++ b/scripts/release/test/independent-audit.test.mjs
@@ -1061,3 +1061,82 @@ for (const [label, mutate, expectedCode] of [
       )
   })
 }
+
+test("main invocation separates actual executor SHA from immutable payload identity", () => {
+  const executorSha = "5".repeat(40)
+  const invocation = parseIndependentAuditEnvironment(
+    environment({
+      GITHUB_REF: "refs/heads/main",
+      GITHUB_WORKFLOW_REF:
+        "cacheplane/dawnai/.github/workflows/published-artifact-verify.yml@refs/heads/main",
+      GITHUB_SHA: executorSha,
+    }),
+    parseIndependentAuditArgs(argv()),
+  )
+  assert.equal(invocation.commitSha, COMMIT_SHA)
+  assert.equal(invocation.executorSha, executorSha)
+  assert.equal(invocation.ref, "refs/heads/main")
+})
+
+test("authorized main executor audits the original payload and rejects unbound source", async () => {
+  const { auditExecutorFixture } = await import("./support/audit-executor-fixture.mjs")
+  for (const authorized of [true, false]) {
+    const f = auditExecutorFixture()
+    f.candidate = releaseCandidate()
+    f.manifestSha256 = MANIFEST_SHA256
+    f.authorization.candidate = {
+      version: VERSION,
+      commitSha: COMMIT_SHA,
+      manifestSha256: MANIFEST_SHA256,
+    }
+    f.files.set(
+      `scripts/release/audit-executor-authorizations/v${VERSION}.json`,
+      JSON.stringify(f.authorization),
+    )
+    if (!authorized) f.files.set("scripts/release/independent-audit.mjs", "unreviewed source")
+    const calls = [],
+      results = []
+    const runtime = auditRuntime({ calls, observation: fiveLaneAuditObservation() })
+    const original = runtime.github
+    runtime.git = f.git
+    runtime.github = {
+      ...original,
+      ...f.github,
+      getActionsRunAttempt: async (args) =>
+        args.runId === 500
+          ? present("actions-run-attempt", {
+              ...f.run,
+              id: 500,
+              status: "in_progress",
+              conclusion: null,
+            })
+          : f.github.getActionsRunAttempt(args),
+      listActionsRunJobs: (args) =>
+        args.runId === 500 ? original.listActionsRunJobs(args) : f.github.listActionsRunJobs(args),
+    }
+    const operation = runIndependentAudit(argv(), {
+      environment: environment({
+        GITHUB_REF: "refs/heads/main",
+        GITHUB_SHA: f.run.head_sha,
+        GITHUB_WORKFLOW_REF:
+          "cacheplane/dawnai/.github/workflows/published-artifact-verify.yml@refs/heads/main",
+      }),
+      createRuntime: async () => runtime,
+      now: fixedTimestamps(),
+      writeResult: async (_, result) => results.push(result),
+    })
+    if (authorized) {
+      const result = await operation
+      assert.equal(result.conclusion, "success")
+      assert.equal(result.commitSha, COMMIT_SHA)
+      assert.equal(result.workflowRunId, 500)
+      assert.ok(
+        calls.some(([name, input]) => name === "inventory.read" && input.ref === COMMIT_SHA),
+      )
+    } else {
+      await assert.rejects(operation)
+      assert.equal(results[0].conclusion, "failure")
+      assert.ok(!calls.some(([name]) => name === "observeProductionCandidate"))
+    }
+  }
+})

--- a/scripts/release/test/independent-audit.test.mjs
+++ b/scripts/release/test/independent-audit.test.mjs
@@ -94,7 +94,9 @@ test("rejects malformed, missing, duplicate, unknown, or mismatched invocation i
   for (const invalidEnvironment of [
     environment({ GITHUB_REPOSITORY: "someone/else" }),
     environment({ GITHUB_EVENT_NAME: "push" }),
-    environment({ GITHUB_WORKFLOW_REF: "cacheplane/dawnai/.github/workflows/release.yml@main" }),
+    environment({
+      GITHUB_WORKFLOW_REF: "cacheplane/dawnai/.github/workflows/release.yml@main",
+    }),
     environment({ GITHUB_REF: "refs/heads/main" }),
     environment({ GITHUB_SHA: "f".repeat(40) }),
     environment({ GITHUB_RUN_ID: "0" }),
@@ -275,7 +277,11 @@ test("waits for its exact dispatch marker and audits through the production obse
   const resultPath = path.join(directory, "audit-result.json")
   const productionObservation = fiveLaneAuditObservation()
   const exactMarker = productionObservation.release.marker
-  const previousMarker = { ...exactMarker, phase: "SMOKES_COMPLETE", audit: null }
+  const previousMarker = {
+    ...exactMarker,
+    phase: "SMOKES_COMPLETE",
+    audit: null,
+  }
   const wrongRunMarker = {
     ...exactMarker,
     audit: {
@@ -351,9 +357,10 @@ test("waits for its exact dispatch marker and audits through the production obse
     ],
   )
   assert.deepEqual(delays, [5, 5])
-  assert.deepEqual(calls[0], ["getReleaseByTag", { tag: `v${VERSION}` }])
-  assert.deepEqual(calls[1], ["getReleaseByTag", { tag: `v${VERSION}` }])
-  assert.deepEqual(calls[2], ["getReleaseByTag", { tag: `v${VERSION}` }])
+  assert.deepEqual(
+    calls.slice(0, 6),
+    Array.from({ length: 3 }, () => [["listReleases"], ["getRelease", { releaseId: 91 }]]).flat(),
+  )
   assert.ok(calls.some(([name]) => name === "getActionsRunAttempt"))
   assert.ok(calls.some(([name]) => name === "listActionsRunJobs"))
   assert.deepEqual(
@@ -516,7 +523,7 @@ test("a missing or wrong-run dispatch marker times out into one canonical failur
     },
   ])
   assert.deepEqual(bytes, canonicalAuditResultBytes(result))
-  assert.equal(calls.filter(([name]) => name === "getReleaseByTag").length, 2)
+  assert.equal(calls.filter(([name]) => name === "listReleases").length, 2)
   assert.equal(
     calls.some(([name]) => name === "getActionsRunAttempt"),
     false,
@@ -574,7 +581,10 @@ test("manifest, state, and diagnostic mismatches each fail closed with a durable
       name: "manifest",
       observation: {
         ...fiveLaneAuditObservation(),
-        audit: { ...fiveLaneAuditObservation().audit, manifestSha256: "b".repeat(64) },
+        audit: {
+          ...fiveLaneAuditObservation().audit,
+          manifestSha256: "b".repeat(64),
+        },
       },
       expectedCheck: "production-observation",
     },
@@ -829,10 +839,16 @@ function releaseCandidate() {
 }
 
 function exactAuditGitHub({ calls, getReleaseByTag }) {
+  let selected
   return {
-    async getReleaseByTag(input) {
-      calls.push(["getReleaseByTag", input])
-      return getReleaseByTag(input)
+    async listReleases() {
+      calls.push(["listReleases"])
+      selected = await getReleaseByTag({ tag: `v${VERSION}` })
+      return selected.status === "PRESENT" ? present("releases", [selected.value]) : selected
+    },
+    async getRelease(input) {
+      calls.push(["getRelease", input])
+      return selected
     },
     async getActionsRunAttempt(input) {
       calls.push(["getActionsRunAttempt", input])
@@ -948,4 +964,100 @@ function binary(operation, bytes) {
 
 function digest(value) {
   return createHash("sha256").update(value).digest("hex")
+}
+
+for (const [label, mutate, expectedCode] of [
+  ["discovers an untagged draft without the published tag endpoint", () => {}, null],
+  [
+    "rejects duplicate draft candidates",
+    (releases) => releases.push({ ...releases[0], id: 92 }),
+    "RELEASE_DISPATCH_DISCOVERY_AMBIGUOUS",
+  ],
+  [
+    "rejects a published tag collision",
+    (releases) =>
+      releases.push({
+        ...releases[0],
+        id: 92,
+        name: "other",
+        draft: false,
+        tag_name: `v${VERSION}`,
+      }),
+    "RELEASE_DISPATCH_DISCOVERY_AMBIGUOUS",
+  ],
+  [
+    "rejects malformed candidate IDs",
+    (releases) => {
+      releases[0].id = "91"
+    },
+    "RELEASE_DISPATCH_DISCOVERY_AMBIGUOUS",
+  ],
+  [
+    "rejects malformed matching markers",
+    (releases) => {
+      releases[0].body = "broken"
+    },
+    "RELEASE_DISPATCH_IDENTITY_INVALID",
+  ],
+  ["rejects unavailable release lists", () => {}, "RELEASE_DISPATCH_READ_AMBIGUOUS"],
+  ["rejects a changed fetched release ID", () => {}, "RELEASE_DISPATCH_IDENTITY_INVALID"],
+]) {
+  test(`draft audit discovery ${label}`, async (t) => {
+    const directory = await mkdtemp(path.join(os.tmpdir(), "dawn-audit-discovery-"))
+    t.after(() => rm(directory, { recursive: true, force: true }))
+    const calls = []
+    const observation = fiveLaneAuditObservation()
+    const runtime = auditRuntime({ calls, observation })
+    const releases = [draftRelease(observation.release.marker)]
+    mutate(releases)
+    runtime.github.getReleaseByTag = async () => ({
+      status: "AMBIGUOUS",
+      operation: "release",
+      httpStatus: 404,
+      code: "HTTP_404",
+    })
+    runtime.github.listReleases = async () => {
+      calls.push(["listReleases"])
+      return label.includes("unavailable")
+        ? {
+            status: "ERROR",
+            operation: "releases",
+            httpStatus: 500,
+            code: "HTTP_500",
+          }
+        : present("releases", releases)
+    }
+    runtime.github.getRelease = async (input) => {
+      calls.push(["getRelease", input])
+      return present("release", {
+        ...releases[0],
+        ...(label.includes("changed fetched") ? { id: 92 } : {}),
+      })
+    }
+    const work = runIndependentAudit(argv({ result: path.join(directory, "result.json") }), {
+      environment: environment(),
+      cwd: directory,
+      createRuntime: async () => runtime,
+      now: fixedTimestamps(),
+      clock: () => 0,
+      delay: async () => {},
+      pollAttempts: 1,
+      pollDelayMs: 0,
+      pollTimeoutMs: 1000,
+    })
+    if (expectedCode) await assert.rejects(work, (error) => error.code === expectedCode)
+    else {
+      assert.equal((await work).conclusion, "success")
+      assert.deepEqual(
+        calls.filter(([name]) => name === "getRelease"),
+        [["getRelease", { releaseId: 91 }]],
+      )
+    }
+    assert.equal(calls.filter(([name]) => name === "listReleases").length, 1)
+    if (expectedCode?.includes("AMBIGUOUS"))
+      assert.equal(
+        calls.some(([name]) => name === "getRelease"),
+        false,
+      )
+  })
 }

--- a/scripts/release/test/observe-production.test.mjs
+++ b/scripts/release/test/observe-production.test.mjs
@@ -7,6 +7,7 @@ import test from "node:test"
 import { Worker } from "node:worker_threads"
 
 import { canonicalAbandonmentBytes, canonicalAbandonmentReleaseBody } from "../abandonment.mjs"
+import { authorizeAuditExecutor } from "../audit-executor.mjs"
 import { runReleaseCli } from "../cli.mjs"
 import { CANONICAL_RELEASE_PACKAGE_ORDER, canonicalManifestBytes } from "../manifest.mjs"
 import { abandonmentReleaseMarker, canonicalReleaseBody } from "../metadata.mjs"
@@ -28,6 +29,7 @@ import {
 } from "../smoke-result.mjs"
 import { canonicalTerminalRecordBytes } from "../terminal-record-store.mjs"
 import { canonicalAuditResultBytes } from "../terminal-records.mjs"
+import { auditExecutorFixture } from "./support/audit-executor-fixture.mjs"
 import { record as terminalRecordFixture } from "./support/terminal-record-fixture.mjs"
 
 const VERSION = "0.8.22"
@@ -2311,99 +2313,150 @@ test("production observation rejects a marker-bound smoke namespace with an extr
   }
 })
 
-test("production observation binds terminal audit assets to the exact run, attempt, jobs, and immutable Release", async () => {
-  const audited = auditedReleaseFixture()
-  const npmFixture = publishedNpmFixture(audited.manifest)
-  const github = githubReader({
-    async listReleases() {
-      return present("releases", [audited.release])
-    },
-    async getRelease({ releaseId }) {
-      assert.equal(releaseId, audited.release.id)
-      return present("release", audited.release)
-    },
-    async listReleaseAssets() {
-      return present("release-assets", audited.assets)
-    },
-    async downloadReleaseAsset({ assetId }) {
-      return binary("release-asset-download", audited.bytesById.get(Number(assetId)))
-    },
-    async getActionsRunAttempt({ runId, attempt }) {
-      if (runId === audited.marker.attestationSet.workflowRunId) {
-        return present("actions-run-attempt", {
-          ...prepareRun({ id: runId }),
-          status: "completed",
-          conclusion: "success",
-        })
-      }
-      assert.equal(runId, audited.auditResult.workflowRunId)
-      assert.equal(attempt, audited.auditResult.runAttempt)
-      return present("actions-run-attempt", audited.run)
-    },
-    async listActionsRunJobs({ runId }) {
-      if (runId === audited.marker.attestationSet.workflowRunId) {
-        return present("actions-run-jobs", [
-          {
-            id: 6_001,
-            runAttempt: 1,
-            name: "publish-npm",
+for (const mainExecutor of [false, true]) {
+  test(`production observation binds terminal audit assets to exact run, attempt, jobs, and immutable Release (main=${mainExecutor})`, async () => {
+    const audited = auditedReleaseFixture()
+    const npmFixture = publishedNpmFixture(audited.manifest)
+    let github = githubReader({
+      async listReleases() {
+        return present("releases", [audited.release])
+      },
+      async getRelease({ releaseId }) {
+        assert.equal(releaseId, audited.release.id)
+        return present("release", audited.release)
+      },
+      async listReleaseAssets() {
+        return present("release-assets", audited.assets)
+      },
+      async downloadReleaseAsset({ assetId }) {
+        return binary("release-asset-download", audited.bytesById.get(Number(assetId)))
+      },
+      async getActionsRunAttempt({ runId, attempt }) {
+        if (runId === audited.marker.attestationSet.workflowRunId) {
+          return present("actions-run-attempt", {
+            ...prepareRun({ id: runId }),
             status: "completed",
             conclusion: "success",
-            startedAt: "2026-08-25T09:00:00.000Z",
-            completedAt: "2026-08-25T09:10:00.000Z",
+          })
+        }
+        assert.equal(runId, audited.auditResult.workflowRunId)
+        assert.equal(attempt, audited.auditResult.runAttempt)
+        return present("actions-run-attempt", audited.run)
+      },
+      async listActionsRunJobs({ runId }) {
+        if (runId === audited.marker.attestationSet.workflowRunId) {
+          return present("actions-run-jobs", [
+            {
+              id: 6_001,
+              runAttempt: 1,
+              name: "publish-npm",
+              status: "completed",
+              conclusion: "success",
+              startedAt: "2026-08-25T09:00:00.000Z",
+              completedAt: "2026-08-25T09:10:00.000Z",
+            },
+          ])
+        }
+        assert.equal(runId, audited.auditResult.workflowRunId)
+        return present("actions-run-jobs", [
+          ...audited.jobs,
+          {
+            id: 7_003,
+            runAttempt: 3,
+            name: "verify",
+            status: "in_progress",
+            conclusion: null,
+            startedAt: "2026-08-25T11:00:00.000Z",
+            completedAt: null,
           },
         ])
+      },
+    })
+
+    let git = gitReader()
+    if (mainExecutor) {
+      const fixture = auditExecutorFixture()
+      fixture.authorization.candidate = {
+        version: VERSION,
+        commitSha: COMMIT_SHA,
+        manifestSha256: audited.marker.manifestSha256,
       }
-      assert.equal(runId, audited.auditResult.workflowRunId)
-      return present("actions-run-jobs", [
-        ...audited.jobs,
-        {
-          id: 7_003,
-          runAttempt: 3,
-          name: "verify",
-          status: "in_progress",
-          conclusion: null,
-          startedAt: "2026-08-25T11:00:00.000Z",
-          completedAt: null,
-        },
-      ])
-    },
-  })
+      fixture.files.set(
+        `scripts/release/audit-executor-authorizations/v${VERSION}.json`,
+        JSON.stringify(fixture.authorization),
+      )
+      audited.run.head_sha = fixture.run.head_sha
+      audited.run.head_branch = "main"
+      audited.run.repository = fixture.run.repository
+      const originalGit = git
+      git = {
+        ...git,
+        isAncestor: fixture.git.isAncestor,
+        showFile: (request) =>
+          request.ref === fixture.run.head_sha
+            ? fixture.git.showFile(request)
+            : originalGit.showFile(request),
+      }
+      const original = github
+      github = {
+        ...github,
+        getRef: (request) =>
+          request.ref === "heads/main" ? fixture.github.getRef(request) : original.getRef(request),
+        listWorkflowRuns: (request) =>
+          request.commitSha === fixture.run.head_sha
+            ? fixture.github.listWorkflowRuns(request)
+            : original.listWorkflowRuns(request),
+        getActionsRunAttempt: (request) =>
+          request.runId === fixture.state.ci.id
+            ? fixture.github.getActionsRunAttempt(request)
+            : original.getActionsRunAttempt(request),
+        listActionsRunJobs: (request) =>
+          request.runId === fixture.state.ci.id
+            ? fixture.github.listActionsRunJobs(request)
+            : original.listActionsRunJobs(request),
+        getCommitCheckRuns: (request) =>
+          request.commitSha === fixture.run.head_sha
+            ? fixture.github.getCommitCheckRuns(request)
+            : original.getCommitCheckRuns(request),
+        getWorkflow: fixture.github.getWorkflow,
+      }
+    }
 
-  const { observation, diagnostics, recovery } = await observeProductionCandidate({
-    terminalRecordRef: "HEAD",
-    candidate: candidate(),
-    inventory: inventory(),
-    marker: MARKER,
-    git: gitReader(),
-    github,
-    npm: npmFixture.npm,
-    npmAuditFactory: npmFixture.npmAuditFactory,
-    attestations: attestationVerifier([]),
-    includeRecovery: true,
-  })
+    const { observation, diagnostics, recovery } = await observeProductionCandidate({
+      terminalRecordRef: "HEAD",
+      candidate: candidate(),
+      inventory: inventory(),
+      marker: MARKER,
+      git,
+      github,
+      npm: npmFixture.npm,
+      npmAuditFactory: npmFixture.npmAuditFactory,
+      attestations: attestationVerifier([]),
+      includeRecovery: true,
+    })
 
-  assert.deepEqual(diagnostics, [])
-  assert.equal(observation.release.status, "published")
-  assert.equal(observation.release.immutable, true)
-  assert.ok(observation.release.assets.every((asset) => asset.status === "matching"))
-  assert.deepEqual(observation.audit, {
-    status: "success",
-    version: VERSION,
-    commitSha: COMMIT_SHA,
-    manifestSha256: audited.marker.manifestSha256,
-    workflowRunId: audited.auditResult.workflowRunId,
-    runAttempt: audited.auditResult.runAttempt,
-    conclusion: "success",
+    assert.deepEqual(diagnostics, [])
+    assert.equal(observation.release.status, "published")
+    assert.equal(observation.release.immutable, true)
+    assert.ok(observation.release.assets.every((asset) => asset.status === "matching"))
+    assert.deepEqual(observation.audit, {
+      status: "success",
+      version: VERSION,
+      commitSha: COMMIT_SHA,
+      manifestSha256: audited.marker.manifestSha256,
+      workflowRunId: audited.auditResult.workflowRunId,
+      runAttempt: audited.auditResult.runAttempt,
+      conclusion: "success",
+    })
+    assert.deepEqual(recovery.auditResult, audited.auditResult)
+    assert.deepEqual(recovery.auditDispatch, {
+      workflow: ".github/workflows/published-artifact-verify.yml",
+      workflowRunId: audited.auditResult.workflowRunId,
+      runUrl: `https://api.github.com/repos/cacheplane/dawnai/actions/runs/${audited.auditResult.workflowRunId}`,
+      htmlUrl: `https://github.com/cacheplane/dawnai/actions/runs/${audited.auditResult.workflowRunId}`,
+    })
   })
-  assert.deepEqual(recovery.auditResult, audited.auditResult)
-  assert.deepEqual(recovery.auditDispatch, {
-    workflow: ".github/workflows/published-artifact-verify.yml",
-    workflowRunId: audited.auditResult.workflowRunId,
-    runUrl: `https://api.github.com/repos/cacheplane/dawnai/actions/runs/${audited.auditResult.workflowRunId}`,
-    htmlUrl: `https://github.com/cacheplane/dawnai/actions/runs/${audited.auditResult.workflowRunId}`,
-  })
-})
+}
 
 test("production observation rejects a noncanonical Release body or title outside the marker", async () => {
   const audited = auditedReleaseFixture()
@@ -2527,6 +2580,60 @@ test("production audit validation rejects an over-limit run attempt in a bounded
     status: "rejected",
     code: "RELEASE_AUDIT_RUN_IDENTITY_MISMATCH",
   })
+})
+
+test("production audit validation accepts an authorized main executor without weakening verify jobs", async () => {
+  const fixture = auditExecutorFixture()
+  const executor = await authorizeAuditExecutor(fixture)
+  const audited = auditedReleaseFixture()
+  const input = {
+    candidate: { ...candidate(), ...fixture.candidate },
+    marker: audited.marker,
+    value: {
+      ...audited.run,
+      head_sha: fixture.run.head_sha,
+      head_branch: "main",
+    },
+    jobs: audited.jobs,
+    executor,
+  }
+  assert.equal(validateProductionAuditRun(input).status, "completed")
+  assert.throws(
+    () =>
+      validateProductionAuditRun({
+        ...input,
+        value: { ...input.value, head_sha: "9".repeat(40) },
+      }),
+    /evidence/iu,
+  )
+  assert.throws(
+    () =>
+      validateProductionAuditRun({
+        ...input,
+        jobs: audited.jobs.map((job) =>
+          job.name === "verify" ? { ...job, conclusion: "skipped" } : job,
+        ),
+      }),
+    /evidence/iu,
+  )
+})
+
+test("production audit validation rejects unbranded executor overrides", () => {
+  const audited = auditedReleaseFixture()
+  assert.throws(
+    () =>
+      validateProductionAuditRun({
+        value: audited.run,
+        jobs: audited.jobs,
+        candidate: candidate(),
+        marker: audited.marker,
+        executor: {
+          headSha: audited.run.head_sha,
+          headBranch: audited.run.head_branch,
+        },
+      }),
+    /executor/iu,
+  )
 })
 
 test("production audit validation requires the canonical verify job to succeed", () => {

--- a/scripts/release/test/post-publication-audit.test.mjs
+++ b/scripts/release/test/post-publication-audit.test.mjs
@@ -32,6 +32,57 @@ test("post-publication audit accepts only the exact published immutable terminal
   assert.deepEqual(written[0].value, result)
 })
 
+test("main post-publication audit preserves candidate identity and remains mutation-free", async () => {
+  const observation = observationForMarker({ phase: "AUDIT_VERIFIED", releaseStatus: "published" })
+  const before = structuredClone(observation)
+  const mainSha = "5".repeat(40)
+  const calls = []
+  const base = runtime(observation)
+  const result = await runPostPublicationAudit(argv(), {
+    cwd: "/tmp/dawn-post-publication-audit",
+    environment: {
+      ...environment(),
+      GITHUB_REF: "refs/heads/main",
+      GITHUB_SHA: mainSha,
+      GITHUB_WORKFLOW_REF:
+        "cacheplane/dawnai/.github/workflows/published-artifact-verify.yml@refs/heads/main",
+    },
+    now: fixedTimestamps(),
+    createRuntime: async ({ candidate, invocation }) => {
+      assert.equal(candidate.commitSha, COMMIT_SHA)
+      assert.equal(invocation.commitSha, COMMIT_SHA)
+      assert.equal(invocation.executorSha, mainSha)
+      return {
+        ...base,
+        inventory: {
+          async read({ ref }) {
+            assert.equal(ref, COMMIT_SHA)
+            return observation.inventory
+          },
+        },
+        async observeProductionCandidate(input) {
+          calls.push("observe")
+          assert.equal(input.candidate.commitSha, COMMIT_SHA)
+          return base.observeProductionCandidate(input)
+        },
+        async planRelease(input) {
+          calls.push("plan")
+          const plan = await base.planRelease(input)
+          assert.deepEqual(plan.proposedMutations, [])
+          return plan
+        },
+      }
+    },
+    writeResult: async () => {
+      calls.push("write-result")
+    },
+  })
+  assert.equal(result.conclusion, "success")
+  assert.equal(result.commitSha, COMMIT_SHA)
+  assert.deepEqual(observation, before)
+  assert.deepEqual(calls, ["observe", "plan", "write-result"])
+})
+
 test("post-publication audit writes a failure result for a mutable or draft Release", async () => {
   for (const observation of [
     observationForMarker({ phase: "AUDIT_VERIFIED", releaseStatus: "draft" }),

--- a/scripts/release/test/support/audit-executor-fixture.mjs
+++ b/scripts/release/test/support/audit-executor-fixture.mjs
@@ -1,0 +1,94 @@
+import { createHash } from "node:crypto"
+
+export function auditExecutorFixture() {
+  const candidate = { version: "0.8.26", commitSha: "4".repeat(40) }
+  const manifestSha256 = "a".repeat(64)
+  const workflow = ".github/workflows/published-artifact-verify.yml"
+  const run = {
+    id: 501,
+    run_attempt: 1,
+    head_sha: "5".repeat(40),
+    head_branch: "main",
+    event: "workflow_dispatch",
+    path: workflow,
+    repository: { id: 1210070282, full_name: "cacheplane/dawnai" },
+  }
+  const hash = (s) => createHash("sha256").update(s).digest("hex")
+  const files = new Map([
+    [workflow, "reviewed workflow"],
+    ["scripts/release/audit-executor.mjs", "reviewed authority"],
+    ["scripts/release/independent-audit.mjs", "reviewed verifier"],
+    ["scripts/release/observe.mjs", "reviewed observer"],
+    ["scripts/release/audit.mjs", "reviewed correlator"],
+  ])
+  const pins = JSON.stringify({
+    schemaVersion: 1,
+    scripts: Object.fromEntries(
+      [...files]
+        .filter(([p]) => p.startsWith("scripts/"))
+        .map(([p, s]) => [p, { sha256: hash(s) }]),
+    ),
+  })
+  files.set("scripts/release/test/fixtures/release-script-hashes.json", pins)
+  const authorization = {
+    schemaVersion: 1,
+    repository: "cacheplane/dawnai",
+    candidate: { ...candidate, manifestSha256 },
+    workflow,
+    workflowSha256: hash(files.get(workflow)),
+    scriptPinsSha256: hash(pins),
+  }
+  files.set(
+    `scripts/release/audit-executor-authorizations/v${candidate.version}.json`,
+    JSON.stringify(authorization),
+  )
+  const ci = {
+    id: 601,
+    run_attempt: 1,
+    head_sha: run.head_sha,
+    head_branch: "main",
+    path: ".github/workflows/ci.yml",
+    event: "push",
+    status: "completed",
+    conclusion: "success",
+    workflow_id: 10,
+    check_suite_id: 11,
+    repository: run.repository,
+  }
+  const state = {
+    ancestor: true,
+    ci,
+    jobs: [
+      { id: 701, name: "validate", runAttempt: 1, status: "completed", conclusion: "success" },
+    ],
+    checks: [
+      {
+        id: 701,
+        name: "validate",
+        head_sha: run.head_sha,
+        check_suite: { id: 11 },
+        app: { slug: "github-actions" },
+        status: "completed",
+        conclusion: "success",
+      },
+    ],
+  }
+  const present = (value) => ({ status: "PRESENT", value })
+  const git = {
+    showFile: async ({ ref, path }) => {
+      if (ref !== run.head_sha || !files.has(path)) throw new Error("unavailable source")
+      return files.get(path)
+    },
+    isAncestor: async () => state.ancestor,
+  }
+  const github = {
+    getRef: async () =>
+      present({ ref: "refs/heads/main", object: { type: "commit", sha: "6".repeat(40) } }),
+    listWorkflowRuns: async () => present([state.ci]),
+    getActionsRunAttempt: async () => present(state.ci),
+    getWorkflow: async () => present({ id: 10, path: ".github/workflows/ci.yml" }),
+    listActionsRunJobs: async () => present(state.jobs),
+    getCommitCheckRuns: async () => present(state.checks),
+  }
+  return { candidate, manifestSha256, run, git, github, files, state, authorization }
+}

--- a/scripts/release/test/workflow-contracts.test.mjs
+++ b/scripts/release/test/workflow-contracts.test.mjs
@@ -106,7 +106,7 @@ const SCRIPT_PIN_PATH = path.join(ROOT, SCRIPT_PIN_FIXTURE)
 // Repinned for asset counter comparisons and bounded invocation payload/Git text reuse.
 // Repinned for fixed evidence stage boundaries with fresh runtime readers.
 const STARTING_SCRIPT_PIN_SHA256 =
-  "2429c9ac22a2a35db3deaf58abe73e14ad307cc78e83b3dc438b441a3b42eb2e"
+  "a1332b7424f7238ba606d7f1bf803a8f2bee4b29db4bba890dcd91517f0e0f22"
 const SHA256_HEX = /^[0-9a-f]{64}$/u
 const workflowExpression = (value) => `\${{ ${value} }}`
 const SCRIPT_REFERENCE = /(?:^|[\s;&|"'(])(scripts\/[\w.-]+(?:\/[\w.-]+)*)/gu

--- a/scripts/release/test/workflow-contracts.test.mjs
+++ b/scripts/release/test/workflow-contracts.test.mjs
@@ -106,7 +106,7 @@ const SCRIPT_PIN_PATH = path.join(ROOT, SCRIPT_PIN_FIXTURE)
 // Repinned for asset counter comparisons and bounded invocation payload/Git text reuse.
 // Repinned for fixed evidence stage boundaries with fresh runtime readers.
 const STARTING_SCRIPT_PIN_SHA256 =
-  "7acdb54f5d50c306c306add9c00813bdd719447fa3b9ca7bcf4477b85ae1b596"
+  "75b16cb04f4df23a68612add6b26806c1ec866233a8823e177ca36f243b318c8"
 const SHA256_HEX = /^[0-9a-f]{64}$/u
 const workflowExpression = (value) => `\${{ ${value} }}`
 const SCRIPT_REFERENCE = /(?:^|[\s;&|"'(])(scripts\/[\w.-]+(?:\/[\w.-]+)*)/gu
@@ -1558,8 +1558,12 @@ test("the independent workflow relays default-branch audits and verifies exact t
   assert.equal(hasWritePermission(published.permissions), false)
   assert.equal(published.permissions?.checks, "read")
   assertExactIndependentTagGate(published, "published")
+  assert.match(published.if, /needs\.coordinate\.outputs\.mode == 'published-controller'/u)
+  assert.match(published.if, /github\.ref == 'refs\/heads\/main'/u)
+  assert.match(published.if, /needs\.coordinate\.outputs\.mode == 'published'/u)
+  assert.match(published.if, /github\.sha == inputs\.commitSha/u)
   const publishedCheckout = onlyStepUsing(published, ACTIONS.checkout)
-  assert.equal(publishedCheckout.with?.ref, workflowExpression("github.ref"))
+  assert.equal(publishedCheckout.with?.ref, workflowExpression("github.sha"))
   assert.equal(publishedCheckout.with?.["fetch-depth"], 0)
   assert.equal(publishedCheckout.with?.["persist-credentials"], false)
   const publishedPnpm = onlyStepUsing(published, ACTIONS.pnpm)

--- a/scripts/release/test/workflow-contracts.test.mjs
+++ b/scripts/release/test/workflow-contracts.test.mjs
@@ -106,7 +106,7 @@ const SCRIPT_PIN_PATH = path.join(ROOT, SCRIPT_PIN_FIXTURE)
 // Repinned for asset counter comparisons and bounded invocation payload/Git text reuse.
 // Repinned for fixed evidence stage boundaries with fresh runtime readers.
 const STARTING_SCRIPT_PIN_SHA256 =
-  "a1332b7424f7238ba606d7f1bf803a8f2bee4b29db4bba890dcd91517f0e0f22"
+  "7acdb54f5d50c306c306add9c00813bdd719447fa3b9ca7bcf4477b85ae1b596"
 const SHA256_HEX = /^[0-9a-f]{64}$/u
 const workflowExpression = (value) => `\${{ ${value} }}`
 const SCRIPT_REFERENCE = /(?:^|[\s;&|"'(])(scripts\/[\w.-]+(?:\/[\w.-]+)*)/gu
@@ -1516,8 +1516,10 @@ test("the independent workflow relays default-branch audits and verifies exact t
   assertContentsWriteOnly(draft)
   assert.equal(draft.permissions?.checks, "read")
   assertExactIndependentTagGate(draft, "draft")
+  assert.match(draft.if, /needs\.coordinate\.outputs\.mode == 'draft-controller'/u)
+  assert.match(draft.if, /github\.ref == 'refs\/heads\/main'/u)
   const checkout = onlyStepUsing(draft, ACTIONS.checkout)
-  assert.equal(checkout.with?.ref, workflowExpression("github.ref"))
+  assert.equal(checkout.with?.ref, workflowExpression("github.sha"))
   assert.equal(checkout.with?.["fetch-depth"], 0)
   assert.equal(checkout.with?.["persist-credentials"], false)
   const draftPnpm = onlyStepUsing(draft, ACTIONS.pnpm)


### PR DESCRIPTION
The v0.8.26 draft has published all 21 npm packages and passed all five smoke lanes, but its frozen independent auditor waits on GitHub's release-by-tag endpoint, which cannot resolve drafts. A disposable-repository experiment confirmed that restoring the draft's tag name does not repair that lookup.

Discover drafts through a complete release inventory and exact ID reread. Permit a corrected auditor from main only when its immutable source includes an explicit candidate/manifest authorization, matching workflow and verifier hashes, merged-main ancestry, and successful exact-SHA main CI. Run and artifact correlation validate that separate executor identity; candidate tags, payload bytes, provenance, smoke evidence, and canonical receipt identity remain unchanged. The existing guarded CLI can then correlate and publish v0.8.26 without another recovery adoption. Scheduled post-publication audits also execute the current main verifier, preserving a mutation-free check after completion.

Validation: draft discovery regression tests; main authority and malformed CI rejection tests; repaired audit through independent execution, artifact correlation, and fresh production observation; 140 workflow contracts; focused recovery compatibility and content-pin checks; scoped lint. Independent source review found no remaining blocking issues. Full local release-controller suite: 3,602 tests passed with pinned pnpm 10.33. Required CI is running.
