### PR TITLE
Exclude pre-rename releases from candidate arbitration

### DIFF
--- a/scripts/release/candidate.mjs
+++ b/scripts/release/candidate.mjs
@@ -143,6 +143,13 @@ export async function discoverScheduledCandidate({
   npm,
   npmAuditFactory,
   attestations,
+  // Versions below this are excluded from arbitration entirely. Production
+  // supplies B4.run's first version, so releases made under the repository
+  // identity that preceded the rename are not adopted: that identity no longer
+  // exists and this repository deliberately does not inherit its recovery
+  // authority, and those releases and their packages are already public.
+  // Unset means no floor, which is the historical behaviour.
+  releaseFloorVersion = null,
 }) {
   normalizeActiveMarker(marker)
   if (typeof terminalRecordRef !== "string" || terminalRecordRef.length === 0) {
@@ -177,7 +184,14 @@ export async function discoverScheduledCandidate({
   ])
   const tagRecords = presentList(tagResult, "managed tag refs")
   const releaseRecords = presentList(releaseResult, "GitHub Releases")
-  const tags = await normalizeManagedTags(tagRecords, git, github)
+  const allTags = await normalizeManagedTags(tagRecords, git, github)
+  const tags =
+    releaseFloorVersion === null
+      ? allTags
+      : allTags.filter(
+          (tag) =>
+            !(isExactSemver(tag.version) && compareSemver(tag.version, releaseFloorVersion) < 0),
+        )
   const tagsByName = new Map(tags.map((tag) => [tag.tag, tag]))
   // Committed terminal records are authoritative for their version regardless of
   // what the GitHub token can see; a record is read at the controller's own

--- a/scripts/release/observe.mjs
+++ b/scripts/release/observe.mjs
@@ -73,6 +73,9 @@ const DEFAULT_CANDIDATE_POLICY = Object.freeze({
   publisherWorkflow: ".github/workflows/release.yml",
 })
 const REQUIRED_SMOKE_LANES = REQUIRED_RELEASE_SMOKE_LANES
+// B4.run's first release version; releases below it predate this identity.
+const FIRST_B4_RELEASE_VERSION = "0.8.27"
+
 const ACTIVE_PACKAGE_NAMES = Object.freeze([...CANONICAL_RELEASE_PACKAGE_ORDER].sort(compareText))
 const HISTORICAL_PACKAGE_NAMES = Object.freeze(
   [...HISTORICAL_RELEASE_PACKAGE_NAMES].sort(compareText),
@@ -217,6 +220,7 @@ export async function resolveProductionCandidate({
       npm,
       npmAuditFactory,
       attestations,
+      releaseFloorVersion: FIRST_B4_RELEASE_VERSION,
       ...(verifyTerminalAbandonment === undefined ? {} : { verifyTerminalAbandonment }),
     })
   let normalized

--- a/scripts/release/test/fixtures/release-script-hashes.json
+++ b/scripts/release/test/fixtures/release-script-hashes.json
@@ -65,7 +65,7 @@
       "sha256": "c2558913a95111ad8fe88a56f1bff8183adbc52484f45362a9d4dd010868c515"
     },
     "scripts/release/candidate.mjs": {
-      "sha256": "0f7a907fd197218a6bb199601fae3b7c423ebbd86481f7688b0675e90a320803"
+      "sha256": "142971a06b980814492e3018cb511399ac45c314bad87e2f205fb9c70ff37cd3"
     },
     "scripts/release/cli.mjs": {
       "sha256": "93d4ddb403b26e4437962c1671a4b5e99b47ab65ecd45f1c7d6cbe12b3fec085"
@@ -116,7 +116,7 @@
       "sha256": "fc3847533cbf01b8fa2420f484680a7576b8b2b4edf4d6f41f56df925f4914c3"
     },
     "scripts/release/observe.mjs": {
-      "sha256": "c815bde8e229f81da80cd77edb4b9e7c328ee34f7d8b9b5ce5ac0ed661db8e8a"
+      "sha256": "7c124c21ac23abbd53d1b83f25828dc1d6598a7403a264bd363557b28dd557ea"
     },
     "scripts/release/planner.mjs": {
       "sha256": "2e09281ff952da69e985de7802307b849b76525e838e4cab49516a3d05793433"

--- a/scripts/release/test/workflow-contracts.test.mjs
+++ b/scripts/release/test/workflow-contracts.test.mjs
@@ -110,7 +110,7 @@ const SCRIPT_PIN_PATH = path.join(ROOT, SCRIPT_PIN_FIXTURE)
 // Repinned for the first-publication npm bootstrap: the new npm-bootstrap.mjs policy module
 // and the bootstrap-aware npm adapter, observer, CLI, audit verifier, and publisher.
 const STARTING_SCRIPT_PIN_SHA256 =
-  "23fadfbba5ca1f590fe537973d8f194f500e055b8e07413f52d586f0dafeb61e"
+  "1ab52707efe9766110907de39099f52864eab8bf6070c47fd804d6b03eb975a1"
 const SHA256_HEX = /^[0-9a-f]{64}$/u
 const workflowExpression = (value) => `\${{ ${value} }}`
 const SCRIPT_REFERENCE = /(?:^|[\s;&|"'(])(scripts\/[\w.-]+(?:\/[\w.-]+)*)/gu


### PR DESCRIPTION
The controller selected v0.8.24 as its outstanding candidate and so rejected every dispatch for 0.8.27, blocking all publishing.

v0.8.24 was released under the repository identity that preceded the rename. Its ceremony did not complete, and this repository deliberately cannot recover it because its recovery policy is dormant. Its packages and Release are already public.

## Why this seam

Filtering it out of the managed-Release loop only moved it into the standalone-tag path. Filtering recovery subjects missed it, because subjects seeded from annotated tags carry no identity of their own and routing resolves none. The tag list is the single thing every arbitration input derives from.

`discoverScheduledCandidate` now takes an optional `releaseFloorVersion` and drops tags below it. Production supplies B4.run's first version. Unset means no floor, so existing callers and fixtures behave exactly as before, which is why no test changes were needed.

## Why not a terminal record

That was the preferred option and it is not available. The terminal-record schema accepts only `abandoned-prepublication` and requires every package to be absent from the registry. All 21 packages at 0.8.24 are published, so such a record would be both false and schema-invalid.

## Test plan

- [x] Candidate and production-observation suites pass unchanged, 147 of 147.
- [x] Workflow contract suite passes; content pins recomputed.
- [x] Verified against the live repository: arbitration no longer selects v0.8.24.
- [ ] Full CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)