### PR TITLE
Allow the one-time package family rename in candidate discovery

### DIFF
--- a/scripts/release/candidate.mjs
+++ b/scripts/release/candidate.mjs
@@ -6,6 +6,7 @@ import {
   parseAnyAbandonmentRecord,
 } from "./abandonment.mjs"
 import { assertPayloadByteLength, RELEASE_PAYLOAD_LIMITS } from "./limits.mjs"
+import { CANONICAL_RELEASE_PACKAGE_ORDER, HISTORICAL_RELEASE_PACKAGE_NAMES } from "./manifest.mjs"
 import {
   ATTESTATION_REPOSITORY,
   canonicalReleaseBody,
@@ -32,6 +33,25 @@ import { canonicalAuditResultBytes, parseAuditResult } from "./terminal-records.
 function isForeignRecoverySubject(candidate) {
   const repository = candidate?.repository
   return typeof repository === "string" && repository !== ATTESTATION_REPOSITORY
+}
+
+// The one-time transition from the previous identity's package family to the
+// current one, in that direction only.
+function isRenameTransition(parentNames, currentNames) {
+  const historical = [...HISTORICAL_RELEASE_PACKAGE_NAMES].sort(compareText)
+  const active = [...CANONICAL_RELEASE_PACKAGE_ORDER].sort(compareText)
+  return (
+    arraysEqual([...parentNames].sort(compareText), historical) &&
+    arraysEqual([...currentNames].sort(compareText), active)
+  )
+}
+
+// Whether a tag names a version below the supplied release floor. With no floor
+// nothing is below it, which is the historical behaviour.
+function isBelowReleaseFloor(tag, floor) {
+  if (floor === null || typeof tag !== "string") return false
+  const version = managedVersionFromTag(tag)
+  return version !== null && isExactSemver(version) && compareSemver(version, floor) < 0
 }
 
 const MARKER_PATH = "scripts/release/controller-schema.json"
@@ -98,7 +118,15 @@ async function discoverManagedCandidateDetails({ ref, inventory, git, marker }) 
   const current = normalizeDiscoveryInventory(currentRaw, "current")
   const parent = normalizeDiscoveryInventory(parentRaw, "first-parent")
   if (!arraysEqual(current.names, parent.names)) {
-    throw new TypeError("Release inventory package set changed across the candidate commit")
+    // The rename from the previous identity changed all 21 package names in one
+    // commit. That exact transition is allowed, from the historical family to
+    // the current one, and only in that direction; both sides are code-owned
+    // constants, so no other change of package set can pass here.
+    if (!isRenameTransition(parent.names, current.names)) {
+      throw new TypeError("Release inventory package set changed across the candidate commit")
+    }
+    // A commit that renames the family is not itself a release candidate.
+    return candidateDetails(noCandidate(), current.names)
   }
   if (current.version === parent.version) {
     return candidateDetails(noCandidate(), current.names)
@@ -185,13 +213,7 @@ export async function discoverScheduledCandidate({
   const tagRecords = presentList(tagResult, "managed tag refs")
   const releaseRecords = presentList(releaseResult, "GitHub Releases")
   const allTags = await normalizeManagedTags(tagRecords, git, github)
-  const tags =
-    releaseFloorVersion === null
-      ? allTags
-      : allTags.filter(
-          (tag) =>
-            !(isExactSemver(tag.version) && compareSemver(tag.version, releaseFloorVersion) < 0),
-        )
+  const tags = allTags.filter((tag) => !isBelowReleaseFloor(tag.tag, releaseFloorVersion))
   const tagsByName = new Map(tags.map((tag) => [tag.tag, tag]))
   // Committed terminal records are authoritative for their version regardless of
   // what the GitHub token can see; a record is read at the controller's own
@@ -215,6 +237,7 @@ export async function discoverScheduledCandidate({
     recorded.set(tag.tag, terminalRecord)
   }
   const releases = await inspectManagedReleases({
+    releaseFloorVersion,
     records: releaseRecords,
     tagsByName,
     recorded,
@@ -478,6 +501,7 @@ function normalizeGithubRef(value) {
 }
 
 async function inspectManagedReleases({
+  releaseFloorVersion = null,
   records,
   tagsByName,
   recorded,
@@ -597,6 +621,9 @@ async function inspectManagedReleases({
     }
     const tagIdentity = tagsByName.get(tag)
     if (tagIdentity === undefined) {
+      // A Release whose tag was excluded by the floor is excluded with it, so
+      // the two views stay consistent. Any other missing tag is still a fault.
+      if (isBelowReleaseFloor(tag, releaseFloorVersion)) continue
       throw new Error(`Managed GitHub Release ${tag} has no matching tag ref`)
     }
     // A committed terminal record settles this version, so no Release evidence

--- a/scripts/release/test/fixtures/release-script-hashes.json
+++ b/scripts/release/test/fixtures/release-script-hashes.json
@@ -65,7 +65,7 @@
       "sha256": "c2558913a95111ad8fe88a56f1bff8183adbc52484f45362a9d4dd010868c515"
     },
     "scripts/release/candidate.mjs": {
-      "sha256": "142971a06b980814492e3018cb511399ac45c314bad87e2f205fb9c70ff37cd3"
+      "sha256": "f5e2e53cf079e3e8198f1c90d72029b49b39747a9707bbb3e121e67c513e81d0"
     },
     "scripts/release/cli.mjs": {
       "sha256": "93d4ddb403b26e4437962c1671a4b5e99b47ab65ecd45f1c7d6cbe12b3fec085"

--- a/scripts/release/test/workflow-contracts.test.mjs
+++ b/scripts/release/test/workflow-contracts.test.mjs
@@ -110,7 +110,7 @@ const SCRIPT_PIN_PATH = path.join(ROOT, SCRIPT_PIN_FIXTURE)
 // Repinned for the first-publication npm bootstrap: the new npm-bootstrap.mjs policy module
 // and the bootstrap-aware npm adapter, observer, CLI, audit verifier, and publisher.
 const STARTING_SCRIPT_PIN_SHA256 =
-  "1ab52707efe9766110907de39099f52864eab8bf6070c47fd804d6b03eb975a1"
+  "f1c98ff4d91e7fdab7b9c1045713360170e841afb29a7c5c01f958e51f631465"
 const SHA256_HEX = /^[0-9a-f]{64}$/u
 const workflowExpression = (value) => `\${{ ${value} }}`
 const SCRIPT_REFERENCE = /(?:^|[\s;&|"'(])(scripts\/[\w.-]+(?:\/[\w.-]+)*)/gu


### PR DESCRIPTION
With the previous fixes in place, discovery still found no candidate. Two causes, both from the rename.

**The package set changed across the rename commit.** Discovery requires a candidate's package set to match its first parent's, and the rename changed all 21 names at once, so every candidate whose history crosses that commit was rejected. That exact transition is now allowed, from the previous identity's family to the current one and only in that direction, with both sides code-owned constants. A commit that renames the family is not itself a candidate.

**The release floor was applied inconsistently.** Excluding a pre-rename tag without excluding its Release made that Release fail its matching-tag check. Both views now use one predicate.

## Verified against the live repository

Discovery resolves candidate 0.8.27 at `4ec264c8` with state `CANDIDATE_VALIDATED` and next transition `create-candidate-tag`. That is the first time the release path has been open since the rename.

Note for dispatching: the candidate commit is the one where the version increased, `4ec264c8`, not the current head of `main`.

## Test plan

- [x] Candidate, production-observation and identity suites pass unchanged, 153 of 153.
- [x] Workflow contract suite passes; content pins recomputed.
- [ ] Full CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)