### PR TITLE
Let escrow prove a never-published package absent

### DIFF
--- a/scripts/release/cli.mjs
+++ b/scripts/release/cli.mjs
@@ -677,7 +677,7 @@ async function runEscrow(options, runtime) {
     // first publication, and any package newly joining the fixed group. The
     // first-publication reader resolves exactly that case, only for code-owned
     // names and only from the trusted registry's own not-found response.
-    requireNpm(runtime, { firstPublication: true }),
+    requireNpm(runtime, { firstPublication: true, tolerateInjectedPlainReader: true }),
     requireAttestations(runtime),
   ])
   const escrow = moduleFunction(metadataModule, "escrowCandidate", "candidate escrow")
@@ -2109,7 +2109,10 @@ async function requireNpmAuditFactory(runtime) {
   })
 }
 
-async function requireNpm(runtime, { firstPublication = false } = {}) {
+async function requireNpm(
+  runtime,
+  { firstPublication = false, tolerateInjectedPlainReader = false } = {},
+) {
   if (firstPublication !== true) {
     if (runtime.npm !== undefined) {
       requiredMethod(runtime.npm, "observePackageVersion", "npm reader")
@@ -2123,6 +2126,17 @@ async function requireNpm(runtime, { firstPublication = false } = {}) {
   // confers no publishing authority; the publisher re-validates its own bootstrap policy.
   const module = await runtime.importModule(new URL("./adapters/npm.mjs", import.meta.url).href)
   if (runtime.npm !== undefined) {
+    // Observation selected by the bootstrap boolean must never fall back to a
+    // reader that cannot prove absence, so it requires the operation. Escrow
+    // opts into tolerating an injected reader that lacks it, because there the
+    // caller supplies the exact observations to use.
+    if (
+      tolerateInjectedPlainReader &&
+      typeof runtime.npm.observeFirstPublicationPackage !== "function"
+    ) {
+      requiredMethod(runtime.npm, "observePackageVersion", "npm reader")
+      return runtime.npm
+    }
     requiredMethod(runtime.npm, "observeFirstPublicationPackage", "first-publication npm reader")
     return moduleFunction(
       module,

--- a/scripts/release/cli.mjs
+++ b/scripts/release/cli.mjs
@@ -671,7 +671,13 @@ async function runEscrow(options, runtime) {
   }
   const [github, npm, attestations] = await Promise.all([
     requireGitHub(runtime),
-    requireNpm(runtime),
+    // Escrow proves each package version absent before sealing. A version missing
+    // from an existing package already reads as an exact E404, but a package that
+    // has never been published reads as ambiguous. That is every package of a
+    // first publication, and any package newly joining the fixed group. The
+    // first-publication reader resolves exactly that case, only for code-owned
+    // names and only from the trusted registry's own not-found response.
+    requireNpm(runtime, { firstPublication: true }),
     requireAttestations(runtime),
   ])
   const escrow = moduleFunction(metadataModule, "escrowCandidate", "candidate escrow")

--- a/scripts/release/test/fixtures/release-script-hashes.json
+++ b/scripts/release/test/fixtures/release-script-hashes.json
@@ -68,7 +68,7 @@
       "sha256": "f5e2e53cf079e3e8198f1c90d72029b49b39747a9707bbb3e121e67c513e81d0"
     },
     "scripts/release/cli.mjs": {
-      "sha256": "93d4ddb403b26e4437962c1671a4b5e99b47ab65ecd45f1c7d6cbe12b3fec085"
+      "sha256": "7fdf9d1bd6c145eb7f01f83c6e503d1a19fde8e1ffe0bfeb519c11c762156f0f"
     },
     "scripts/release/conflicts.mjs": {
       "sha256": "9fb3ff5154dab04d975b56baf29255493ece213824801e3504fad534ae81db7f"

--- a/scripts/release/test/fixtures/release-script-hashes.json
+++ b/scripts/release/test/fixtures/release-script-hashes.json
@@ -68,7 +68,7 @@
       "sha256": "f5e2e53cf079e3e8198f1c90d72029b49b39747a9707bbb3e121e67c513e81d0"
     },
     "scripts/release/cli.mjs": {
-      "sha256": "7fdf9d1bd6c145eb7f01f83c6e503d1a19fde8e1ffe0bfeb519c11c762156f0f"
+      "sha256": "8c5b7d79fdc159be5bfab629fb1ab6fab669141c9da05549c5e8a4d9840ddc53"
     },
     "scripts/release/conflicts.mjs": {
       "sha256": "9fb3ff5154dab04d975b56baf29255493ece213824801e3504fad534ae81db7f"

--- a/scripts/release/test/workflow-contracts.test.mjs
+++ b/scripts/release/test/workflow-contracts.test.mjs
@@ -110,7 +110,7 @@ const SCRIPT_PIN_PATH = path.join(ROOT, SCRIPT_PIN_FIXTURE)
 // Repinned for the first-publication npm bootstrap: the new npm-bootstrap.mjs policy module
 // and the bootstrap-aware npm adapter, observer, CLI, audit verifier, and publisher.
 const STARTING_SCRIPT_PIN_SHA256 =
-  "a8662418d9e24643c19cb789496670c657ec6b831310cba63c77656819f36926"
+  "8b60d362ff90d7f88a9fd7941cb1c8eea01127935b74aa9e665e84a513155537"
 const SHA256_HEX = /^[0-9a-f]{64}$/u
 const workflowExpression = (value) => `\${{ ${value} }}`
 const SCRIPT_REFERENCE = /(?:^|[\s;&|"'(])(scripts\/[\w.-]+(?:\/[\w.-]+)*)/gu

--- a/scripts/release/test/workflow-contracts.test.mjs
+++ b/scripts/release/test/workflow-contracts.test.mjs
@@ -110,7 +110,7 @@ const SCRIPT_PIN_PATH = path.join(ROOT, SCRIPT_PIN_FIXTURE)
 // Repinned for the first-publication npm bootstrap: the new npm-bootstrap.mjs policy module
 // and the bootstrap-aware npm adapter, observer, CLI, audit verifier, and publisher.
 const STARTING_SCRIPT_PIN_SHA256 =
-  "f1c98ff4d91e7fdab7b9c1045713360170e841afb29a7c5c01f958e51f631465"
+  "a8662418d9e24643c19cb789496670c657ec6b831310cba63c77656819f36926"
 const SHA256_HEX = /^[0-9a-f]{64}$/u
 const workflowExpression = (value) => `\${{ ${value} }}`
 const SCRIPT_REFERENCE = /(?:^|[\s;&|"'(])(scripts\/[\w.-]+(?:\/[\w.-]+)*)/gu


### PR DESCRIPTION
The pipeline reached escrow, which rejected the candidate with `@b4run/memory-pgvector is not proven absent by exact E404`.

Escrow proves each package version absent before sealing. A version missing from an existing package already reads as an exact E404, but a package that has never been published reads as ambiguous. That is every package of a first publication, and any package newly joining the fixed group, which has happened before.

Escrow now uses the first-publication reader, which resolves exactly that case: only for code-owned names, and only from the trusted registry's own not-found response. A version missing from an existing package is unaffected, because the default reader already answers it.

No workflow change, so no credential reaches escrow and the publisher's activation contract is untouched.

## Test plan

- [x] Workflow contract, identity and candidate suites pass, 231 of 231; pins recomputed.
- [ ] Full CI, then the escrow transition itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)