### PR TITLE
Add a changeset for the release controller fixes

### DIFF
--- a/.changeset/b4-release-controller-fixes.md
+++ b/.changeset/b4-release-controller-fixes.md
@@ -1,0 +1,8 @@
+---
+"@b4run/sdk": patch
+---
+
+Release controller fixes for the B4.run identity: read release history written
+under the previous identity, exclude releases made under it from candidate
+arbitration, allow the one-time package family rename across a candidate's first
+parent, and prove a never-published package absent during escrow.


### PR DESCRIPTION
Escrow runs the controller code checked out at the candidate commit, so the fixes merged since 0.8.27 was tagged cannot apply to that candidate. A new version is required for them to take effect.

This adds the changeset. Once the version pull request lands, 0.8.28's candidate commit contains every fix, and the stale 0.8.27 tag can be removed: it published nothing, has no GitHub Release, and none of its packages exist on the registry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)