### PR TITLE
Cut 0.8.29 with the first-publication convergence fix

### DIFF
--- a/.changeset/b4-first-publication-convergence.md
+++ b/.changeset/b4-first-publication-convergence.md
@@ -1,0 +1,7 @@
+---
+"@b4run/sdk": patch
+---
+
+Publish the B4.run package family with the first-publication registry
+convergence fix in effect, so every package is published and verified in a
+single release rather than stalling on each newly created packument.


### PR DESCRIPTION
The publisher runs the controller code checked out at the candidate commit, so the propagation fix merged in #611 cannot apply to the 0.8.28 candidate.

0.8.28 published `@b4run/ag-ui` and `@b4run/config-biome` correctly, with provenance, then stalled: each newly created packument is briefly unreadable, and resuming advances only one package per run at roughly twenty minutes each. A candidate carrying the fix publishes the whole family in a single run.

Those two 0.8.28 versions become orphaned: correctly published, but belonging to no completed release. npm does not permit deleting versions after 72 hours, so the honest remedy is to deprecate them in favour of 0.8.29 as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)