### PR TITLE
fix(release): advance past verified completed releases

### DIFF
--- a/scripts/release/candidate.mjs
+++ b/scripts/release/candidate.mjs
@@ -168,6 +168,7 @@ export async function discoverScheduledCandidate({
   marker,
   terminalRecordRef,
   verifyTerminalAbandonment,
+  verifyTerminalPublication,
   npm,
   npmAuditFactory,
   attestations,
@@ -191,6 +192,9 @@ export async function discoverScheduledCandidate({
   assertMethods(inventory, ["read"], "inventory reader")
   if (verifyTerminalAbandonment !== undefined && typeof verifyTerminalAbandonment !== "function") {
     throw new TypeError("Terminal abandonment verifier is invalid")
+  }
+  if (verifyTerminalPublication !== undefined && typeof verifyTerminalPublication !== "function") {
+    throw new TypeError("Terminal publication verifier is invalid")
   }
   assertMethods(
     github,
@@ -246,6 +250,7 @@ export async function discoverScheduledCandidate({
     github,
     marker,
     verifyTerminalAbandonment,
+    verifyTerminalPublication,
     terminalRecordRef,
     npm,
     npmAuditFactory,
@@ -510,6 +515,7 @@ async function inspectManagedReleases({
   github,
   marker,
   verifyTerminalAbandonment,
+  verifyTerminalPublication,
   terminalRecordRef,
   npm,
   npmAuditFactory,
@@ -696,13 +702,34 @@ async function inspectManagedReleases({
       maximumBytes: RELEASE_PAYLOAD_LIMITS.releaseRecordBytes,
     })
     validateReleaseRecordIdentity(record, tagIdentity)
-    const state = await releaseStateFromAssets({
+    let state = await releaseStateFromAssets({
       release,
       releaseRecord: record,
       assets,
       tagIdentity,
       github,
     })
+    if (
+      release.draft === false &&
+      release.immutable === true &&
+      verifyTerminalPublication !== undefined
+    ) {
+      try {
+        // Only the full observer can prove terminal smoke, audit, and Release
+        // authority. A receipt alone must never let a newer candidate proceed.
+        if (
+          (await verifyTerminalPublication({
+            candidate: discovery.candidate,
+            release,
+            releaseRecord: record,
+          })) === true
+        ) {
+          state = ReleaseState.AUDIT_COMPLETE
+        }
+      } catch {
+        // Preserve this candidate's priority when terminal proof is unavailable.
+      }
+    }
     releases.push(
       candidateSelection({
         candidate: discovery.candidate,

--- a/scripts/release/observe.mjs
+++ b/scripts/release/observe.mjs
@@ -27,6 +27,7 @@ import {
 } from "./metadata.mjs"
 import { NPM_AUDIT_VERIFIER } from "./npm-audit.mjs"
 import { canonicalNpmEvidenceBytes } from "./npm-evidence.mjs"
+import { planRelease } from "./planner.mjs"
 import { routeRecoveryCandidate } from "./recovery/observe.mjs"
 import {
   canonicalReleaseRecordBytes,
@@ -167,6 +168,42 @@ export async function resolveProductionCandidate({
     "candidate discovery",
   )
   const invocation = classifyProductionEvent(event)
+  const verifyTerminalPublication =
+    npm !== undefined && attestations !== undefined
+      ? async ({ candidate, release, releaseRecord }) => {
+          try {
+            const verified = await observeProductionCandidate({
+              candidate,
+              inventory: await inventory.read({ ref: candidate.commitSha }),
+              marker,
+              git,
+              github,
+              npm,
+              npmAuditFactory,
+              attestations,
+              terminalRecordRef,
+            })
+            const { observation, diagnostics } = verified
+            const plan = planRelease({ candidate, observation, mode: "controller" })
+            return (
+              diagnostics.length === 0 &&
+              observation.release.status === "published" &&
+              observation.release.immutable === true &&
+              observation.release.tag === `v${candidate.version}` &&
+              observation.release.commitSha === candidate.commitSha &&
+              observation.release.bodySha256 === sha256(Buffer.from(release.body, "utf8")) &&
+              observation.release.marker?.manifestSha256 === releaseRecord.manifestSha256 &&
+              plan.state === "AUDIT_COMPLETE" &&
+              plan.disposition === "noop" &&
+              plan.conflicts.length === 0 &&
+              plan.nextTransition === null &&
+              plan.proposedMutations.length === 0
+            )
+          } catch {
+            return false
+          }
+        }
+      : undefined
   const verifyTerminalAbandonment =
     npm !== undefined && attestations !== undefined
       ? async ({ candidate, release }) => {
@@ -222,6 +259,7 @@ export async function resolveProductionCandidate({
       attestations,
       releaseFloorVersion: FIRST_B4_RELEASE_VERSION,
       ...(verifyTerminalAbandonment === undefined ? {} : { verifyTerminalAbandonment }),
+      ...(verifyTerminalPublication === undefined ? {} : { verifyTerminalPublication }),
     })
   let normalized
   let globallySelected = false
@@ -713,6 +751,7 @@ export async function observeProductionCandidate({
     candidate: identity,
     manifest: observedArtifactState.manifest,
     registryPackages,
+    publishedImmutable: release.status === "published" && release.immutable === true,
   })
   if (release.marker !== null && release.marker.npmEvidenceSha256 !== null) {
     try {
@@ -3491,7 +3530,7 @@ async function mapProductionRegistryPackage({
   }
 }
 
-function createObservedNpmEvidence({ candidate, manifest, registryPackages }) {
+function createObservedNpmEvidence({ candidate, manifest, registryPackages, publishedImmutable }) {
   if (!isRecord(manifest)) return null
   const entries = new Map(manifest.packages.map((entry) => [entry.name, entry]))
   const observed = new Map(registryPackages.map((pkg) => [pkg.name, pkg]))
@@ -3507,13 +3546,17 @@ function createObservedNpmEvidence({ candidate, manifest, registryPackages }) {
       pkg.tarballSha256 !== entry.sha256 ||
       pkg.integrity !== entry.npmIntegrity ||
       pkg.latest?.status !== "present" ||
-      pkg.latest.version !== candidate.version ||
+      (pkg.latest.version !== candidate.version &&
+        !(publishedImmutable && compareSemver(pkg.latest.version, candidate.version) > 0)) ||
       pkg.signature?.status !== "valid" ||
       pkg.provenance?.workflow !== candidate.publisherWorkflow ||
       pkg.provenance.commitSha !== candidate.commitSha
     ) {
       return null
     }
+    // The immutable receipt records latest at publication. A later release may
+    // advance that mutable tag, while the old version's exact bytes and authority
+    // must still match. Keep the live latest unchanged in registryPackages.
     packages.push({
       name,
       version: candidate.version,

--- a/scripts/release/test/candidate.test.mjs
+++ b/scripts/release/test/candidate.test.mjs
@@ -410,6 +410,62 @@ test("scheduled discovery never excludes an audit-looking Release without durabl
   assert.deepEqual(result, selectedCandidate("0.8.21", SHA_21, "CANDIDATE_TAGGED"))
 })
 
+test("scheduled discovery advances only after independent published terminal verification", async () => {
+  for (const outcome of [true, false, "throw"]) {
+    const repository = repositoryFixture([
+      commit(BASE_SHA, "0.8.27"),
+      commit(SHA_21, "0.8.28", { parent: BASE_SHA, marker: true }),
+      commit(SHA_22, "0.8.30", { parent: SHA_21, marker: true }),
+    ])
+    const older = managedRelease(21, "0.8.28", SHA_21, {
+      auditComplete: true,
+      published: true,
+    })
+    let verified = 0
+    const result = await discoverScheduledCandidate({
+      terminalRecordRef: RECORD_REF,
+      inventory: repository.inventory,
+      git: repository.git,
+      github: githubFixture({ tags: [tagRef("0.8.28", SHA_21)], releases: [older] }),
+      marker: ACTIVE_MARKER,
+      async verifyTerminalPublication({ candidate, release }) {
+        verified += 1
+        assert.equal(candidate.commitSha, SHA_21)
+        assert.equal(release.id, older.id)
+        if (outcome === "throw") throw new Error("authority unavailable")
+        return outcome
+      },
+    })
+    assert.equal(verified, 1)
+    assert.deepEqual(
+      result,
+      outcome === true
+        ? selectedCandidate("0.8.30", SHA_22, "CANDIDATE_VALIDATED")
+        : selectedCandidate("0.8.28", SHA_21, "CANDIDATE_TAGGED"),
+    )
+  }
+})
+
+test("scheduled discovery never promotes an audited draft through terminal verification", async () => {
+  const repository = repositoryFixture([
+    commit(BASE_SHA, "0.8.20"),
+    commit(SHA_21, "0.8.21", { parent: BASE_SHA, marker: true }),
+    commit(SHA_22, "0.8.22", { parent: SHA_21, marker: true }),
+  ])
+  const older = auditVerifiedDraftRelease(21, "0.8.21", SHA_21)
+  const result = await discoverScheduledCandidate({
+    terminalRecordRef: RECORD_REF,
+    inventory: repository.inventory,
+    git: repository.git,
+    github: githubFixture({ tags: [tagRef("0.8.21", SHA_21)], releases: [older] }),
+    marker: ACTIVE_MARKER,
+    async verifyTerminalPublication() {
+      assert.fail("drafts must retain publication priority")
+    },
+  })
+  assert.deepEqual(result, selectedCandidate("0.8.21", SHA_21, "CANDIDATE_TAGGED"))
+})
+
 test("scheduled discovery admits an exact AUDIT_VERIFIED draft for production observation", async () => {
   const repository = repositoryFixture([
     commit(BASE_SHA, "0.8.20"),

--- a/scripts/release/test/fixtures/release-script-hashes.json
+++ b/scripts/release/test/fixtures/release-script-hashes.json
@@ -65,7 +65,7 @@
       "sha256": "c2558913a95111ad8fe88a56f1bff8183adbc52484f45362a9d4dd010868c515"
     },
     "scripts/release/candidate.mjs": {
-      "sha256": "f5e2e53cf079e3e8198f1c90d72029b49b39747a9707bbb3e121e67c513e81d0"
+      "sha256": "24e1a16a6da2917d6ace69c0457c81e72ce3ad356098202077417687b4b61b9f"
     },
     "scripts/release/cli.mjs": {
       "sha256": "8c5b7d79fdc159be5bfab629fb1ab6fab669141c9da05549c5e8a4d9840ddc53"
@@ -116,7 +116,7 @@
       "sha256": "fc3847533cbf01b8fa2420f484680a7576b8b2b4edf4d6f41f56df925f4914c3"
     },
     "scripts/release/observe.mjs": {
-      "sha256": "7c124c21ac23abbd53d1b83f25828dc1d6598a7403a264bd363557b28dd557ea"
+      "sha256": "1b986fac90194836f9c900494270555d6689eba47c2ce410e35aad70a53593b4"
     },
     "scripts/release/planner.mjs": {
       "sha256": "2e09281ff952da69e985de7802307b849b76525e838e4cab49516a3d05793433"

--- a/scripts/release/test/observe-production.test.mjs
+++ b/scripts/release/test/observe-production.test.mjs
@@ -2494,6 +2494,130 @@ for (const mainExecutor of [false, true]) {
       runUrl: `https://api.github.com/repos/cacheplane/b4run/actions/runs/${audited.auditResult.workflowRunId}`,
       htmlUrl: `https://github.com/cacheplane/b4run/actions/runs/${audited.auditResult.workflowRunId}`,
     })
+    // Global selection must use this same complete authority proof, rather than
+    // treating an audit-looking asset as terminal or reselecting it forever.
+    await resolveProductionCandidate({
+      terminalRecordRef: "HEAD",
+      event: { schedule: "17 * * * *" },
+      inventory: inventoryReader(),
+      marker: MARKER,
+      git,
+      github,
+      npm: npmFixture.npm,
+      npmAuditFactory: npmFixture.npmAuditFactory,
+      attestations: attestationVerifier([]),
+      discovery: {
+        async discoverManagedCandidate() {
+          assert.fail("scheduled selection must not discover an exact invocation")
+        },
+        async discoverScheduledCandidate({ verifyTerminalPublication }) {
+          assert.equal(typeof verifyTerminalPublication, "function")
+          const input = {
+            candidate: candidate(),
+            release: audited.release,
+            releaseRecord: JSON.parse(
+              audited.bytesById
+                .get(audited.assets.find((asset) => asset.name === "release-record.json").id)
+                .toString("utf8"),
+            ),
+          }
+          assert.equal(await verifyTerminalPublication(input), true)
+          const observePackageVersion = npmFixture.npm.observePackageVersion
+          npmFixture.npm.observePackageVersion = async (args) => {
+            const result = await observePackageVersion(args)
+            return {
+              ...result,
+              package: { ...result.package, latest: "0.8.30", distTags: { latest: "0.8.30" } },
+            }
+          }
+          assert.equal(
+            await verifyTerminalPublication(input),
+            true,
+            "newer latest preserves terminal history",
+          )
+          const createAudit = npmFixture.npmAuditFactory.create
+          npmFixture.npmAuditFactory.create = async (...args) => {
+            const verifier = await createAudit(...args)
+            return {
+              ...verifier,
+              async verifyPackage(...inputs) {
+                const result = await verifier.verifyPackage(...inputs)
+                return {
+                  ...result,
+                  provenance: { ...result.provenance, commitSha: "f".repeat(40) },
+                }
+              },
+            }
+          }
+          assert.equal(
+            await verifyTerminalPublication(input),
+            false,
+            "newer latest cannot hide wrong provenance",
+          )
+          npmFixture.npmAuditFactory.create = createAudit
+          audited.release.immutable = false
+          assert.equal(
+            await verifyTerminalPublication(input),
+            false,
+            "mutable publication is not terminal",
+          )
+          audited.release.immutable = true
+          audited.release.draft = true
+          audited.release.immutable = false
+          const draft = await observeProductionCandidate({
+            terminalRecordRef: "HEAD",
+            candidate: candidate(),
+            inventory: inventory(),
+            marker: MARKER,
+            git,
+            github,
+            npm: npmFixture.npm,
+            npmAuditFactory: npmFixture.npmAuditFactory,
+            attestations: attestationVerifier([]),
+          })
+          assert.ok(draft.diagnostics.some(({ code }) => code === "NPM_EVIDENCE_DIGEST_MISMATCH"))
+          audited.release.draft = false
+          audited.release.immutable = true
+          for (const [first, rest, expected] of [
+            [VERSION, "0.8.30", true],
+            ["0.8.21", "0.8.30", false],
+            [null, null, false],
+            ["invalid", "invalid", false],
+          ]) {
+            npmFixture.npm.observePackageVersion = async (args) => {
+              const result = await observePackageVersion(args)
+              const latest = args.name === audited.manifest.packages[0].name ? first : rest
+              return { ...result, package: { ...result.package, latest, distTags: { latest } } }
+            }
+            assert.equal(
+              await verifyTerminalPublication(input),
+              expected,
+              `latest ${first}/${rest}`,
+            )
+          }
+          npmFixture.npm.observePackageVersion = observePackageVersion
+          assert.equal(
+            await verifyTerminalPublication({
+              ...input,
+              releaseRecord: { ...input.releaseRecord, manifestSha256: "f".repeat(64) },
+            }),
+            false,
+          )
+          audited.release.immutable = false
+          assert.equal(await verifyTerminalPublication(input), false)
+          audited.release.immutable = true
+          audited.bytesById.delete(audited.assets[0].id)
+          assert.equal(await verifyTerminalPublication(input), false)
+          return {
+            candidate: null,
+            state: "NO_CANDIDATE",
+            disposition: "noop",
+            tag: null,
+            conflicts: [],
+          }
+        },
+      },
+    })
   })
 }
 

--- a/scripts/release/test/workflow-contracts.test.mjs
+++ b/scripts/release/test/workflow-contracts.test.mjs
@@ -109,8 +109,9 @@ const SCRIPT_PIN_PATH = path.join(ROOT, SCRIPT_PIN_FIXTURE)
 // their original bytes and are checked at the immutable pre-rename revision.
 // Repinned for the first-publication npm bootstrap: the new npm-bootstrap.mjs policy module
 // and the bootstrap-aware npm adapter, observer, CLI, audit verifier, and publisher.
+// Repinned for verified published terminal selection and historical npm latest observations.
 const STARTING_SCRIPT_PIN_SHA256 =
-  "922753c5abfb8e3f7d66fe2201bf8d5c1297e32aa5c85bbeb27a0d1085f0da0e"
+  "6b30a1629fd6ceb5fd62be6ce295aff5f750031c46ebebbde01128cf62f6dc6e"
 const SHA256_HEX = /^[0-9a-f]{64}$/u
 const workflowExpression = (value) => `\${{ ${value} }}`
 const SCRIPT_REFERENCE = /(?:^|[\s;&|"'(])(scripts\/[\w.-]+(?:\/[\w.-]+)*)/gu


### PR DESCRIPTION
The release controller repeatedly selected completed 0.8.28, observed `AUDIT_COMPLETE`, and stopped before considering the merged 0.8.30 candidate. Candidate discovery now uses the existing full publication observer and planner to recognize verified immutable releases and continue to the next candidate.

Historical verification also accepts npm `latest` advancing to a strictly newer valid version, while retaining the live tag for planning and reconstructing the original candidate-bound evidence digest. Exact package bytes, signatures, provenance, immutable release identity, smoke results, and audit authority must still verify. Drafts and unavailable or conflicting evidence remain blocking.

This preserves 0.8.30 at `4cf369605b2fee8c86aca34570bf45bf8ceccba1` and the published 0.8.28 artifacts. It changes no workflow, publishing step, gate, receipt schema, or package version. Existing source-content pins are refreshed for the two changed scripts.

Validation: regression tests reproduced both selection failures before the fixes; 472 focused tests and 168 integrity/workflow-contract tests pass, with scoped lint clean. Independent spec and quality reviews passed. Read-only live resolution verified published 0.8.28 and selected 0.8.30 at `4cf369605b2fee8c86aca34570bf45bf8ceccba1` as `CANDIDATE_VALIDATED`, with no conflicts (367.5 seconds). No publishing transition was invoked. The full release-controller suite passed all 3,664 tests, with zero failures or skips. Merge waits for normal CI on reviewed head `472a9ceac0095cf479f02a43f235a8ce6582fcc9`.

The stalled ordinary release is recorded in #619; its OIDC verification remains observation-only after publication.
