### PR TITLE
test: fix Kubernetes SOCKS fixture timeout race

### DIFF
--- a/packages/sandbox/test/kube-socks-proxy.test.ts
+++ b/packages/sandbox/test/kube-socks-proxy.test.ts
@@ -676,11 +676,12 @@ function createSocksProxy(
 function createKubernetesTarget(deadline: number) {
   const errors: Error[] = []
   const observations: TargetObservation[] = []
+  const timeoutMs = Math.max(1, deadline - Date.now())
   const server = createHttpServer(
     {
-      headersTimeout: Math.max(1, deadline - Date.now()),
+      headersTimeout: timeoutMs,
       maxHeaderSize: maxHttpBodyBytes,
-      requestTimeout: Math.max(1, deadline - Date.now()),
+      requestTimeout: timeoutMs,
     },
     (request, response) => {
       const chunks: Buffer[] = []
@@ -877,6 +878,24 @@ async function runProxyCase(targetHostname: string, addressType: ProxyObservatio
 }
 
 describe("Kubernetes SOCKS dependency path", () => {
+  test.each([5_000, 27, 0, -1])(
+    "constructs the HTTP target with a %ims budget despite clock advancement",
+    (remainingMs) => {
+      let now = 1_000
+      const deadline = now + remainingMs
+      const clock = vi.spyOn(Date, "now").mockImplementation(() => now++)
+      try {
+        const target = createKubernetesTarget(deadline)
+        expect(target.tracked.server).toHaveProperty("headersTimeout", Math.max(1, remainingMs))
+        expect(target.tracked.server).toHaveProperty("requestTimeout", Math.max(1, remainingMs))
+        expect(target.tracked.server.listening).toBe(false)
+        expect(target.errors).toEqual([])
+      } finally {
+        clock.mockRestore()
+      }
+    },
+  )
+
   test("restores proxy aliases in a case-insensitive environment", () => {
     const original = {
       ALL_PROXY: "socks5h://all-proxy.invalid:1080",


### PR DESCRIPTION
The local Kubernetes HTTP fixture sampled its remaining deadline twice. If the clock advanced between those reads, `headersTimeout` exceeded `requestTimeout`, and Node rejected server construction before the SOCKS request began. This surfaced on the documentation-only #622 source check.

Sample the remaining budget once for both native HTTP timeout options. A deterministic advancing-clock regression covers full and partially consumed budgets plus the existing one-millisecond clamp for exhausted deadlines. Existing network assertions and deadline limits are preserved; this changes one test file only.

Validation: pnpm 10.33.0 frozen install; the positive-budget regressions reproduced the exact RangeError before the fix; all 12 SOCKS tests pass afterward; full workspace build (25 tasks), sandbox typecheck, lint, docs, and whitespace checks pass. Lint reports only existing diagnostics in unrelated files. No changeset is needed for this test-only repair.

Related to #535. Its other reliability failures remain unresolved.
