### PR TITLE
ci: avoid full validation for runbook-only pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ jobs:
     timeout-minutes: 5
     outputs:
       metadata_only: ${{ steps.classify.outputs.metadata_only }}
+      prose_only: ${{ steps.classify.outputs.prose_only }}
 
     steps:
       - name: Checkout
@@ -36,11 +37,33 @@ jobs:
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           set -eu
-          METADATA_ONLY="$(node scripts/ci-scope.mjs --event pull_request --base "$BASE_SHA" --head "$HEAD_SHA")"
+          SCOPE_DIR="$(mktemp -d)"
+          SCOPE_DIR="$(cd "$SCOPE_DIR" && pwd -P)"
+          trap 'rm -rf "$SCOPE_DIR"' EXIT
+          git show "$BASE_SHA:scripts/ci-scope.mjs" > "$SCOPE_DIR/ci-scope.mjs"
+          METADATA_ONLY="$(node "$SCOPE_DIR/ci-scope.mjs" --event pull_request --base "$BASE_SHA" --head "$HEAD_SHA")"
           case "$METADATA_ONLY" in
             true|false) ;;
             *) echo "Malformed metadata-only scope output" >&2; exit 1 ;;
           esac
+          PROSE_ONLY="$(node --input-type=module - "$SCOPE_DIR/ci-scope.mjs" <<'NODE'
+          import { pathToFileURL } from "node:url"
+          const scope = await import(pathToFileURL(process.argv[2]).href)
+          const proseOnly = scope.classifyProseOnlyScope === undefined
+            ? false
+            : await scope.classifyProseOnlyScope({
+                event: "pull_request",
+                base: process.env.BASE_SHA,
+                head: process.env.HEAD_SHA,
+              })
+          process.stdout.write(String(proseOnly))
+          NODE
+          )"
+          case "$PROSE_ONLY" in
+            true|false) ;;
+            *) echo "Malformed prose-only scope output" >&2; exit 1 ;;
+          esac
+          printf 'prose_only=%s\n' "$PROSE_ONLY" >> "$GITHUB_OUTPUT"
           printf 'metadata_only=%s\n' "$METADATA_ONLY" >> "$GITHUB_OUTPUT"
 
   changesets:
@@ -62,6 +85,8 @@ jobs:
         run: node scripts/check-changesets.mjs
 
   source-validate:
+    needs: metadata_scope
+    if: ${{ !cancelled() && (github.event_name != 'pull_request' || needs.metadata_scope.result != 'success' || needs.metadata_scope.outputs.prose_only != 'true') }}
     runs-on: ubuntu-latest
     # Source verification runs alongside the controller, packaging, and harness lanes.
     timeout-minutes: 45
@@ -121,6 +146,8 @@ jobs:
         run: node scripts/check-docs.mjs
 
   release-controller:
+    needs: metadata_scope
+    if: ${{ !cancelled() && (github.event_name != 'pull_request' || needs.metadata_scope.result != 'success' || needs.metadata_scope.outputs.prose_only != 'true') }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
 
@@ -153,20 +180,38 @@ jobs:
         run: pnpm test:release-controller
 
   validate:
-    needs: [source-validate, release-controller, pack-smoke, harness-verify]
+    needs: [metadata_scope, source-validate, release-controller, pack-smoke, harness-verify]
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - name: Require every validation lane
         env:
+          EVENT_NAME: ${{ github.event_name }}
+          SCOPE_RESULT: ${{ needs.metadata_scope.result }}
+          PROSE_ONLY: ${{ needs.metadata_scope.outputs.prose_only }}
+          METADATA_ONLY: ${{ needs.metadata_scope.outputs.metadata_only }}
           LANE_0: ${{ needs.source-validate.result }}
           LANE_1: ${{ needs.release-controller.result }}
           LANE_2: ${{ needs.pack-smoke.result }}
           LANE_3: ${{ needs.harness-verify.result }}
         run: |
+          set -eu
+          EXPECTED=success
+          case "$EVENT_NAME" in
+            pull_request)
+              [ "$SCOPE_RESULT" = success ] || { echo "CI scope did not succeed" >&2; exit 1; }
+              case "$PROSE_ONLY:$METADATA_ONLY" in
+                true:false) EXPECTED=skipped ;;
+                false:true|false:false) ;;
+                *) echo "Malformed CI scope outputs" >&2; exit 1 ;;
+              esac
+              ;;
+            push) ;;
+            *) echo "Unsupported validation event" >&2; exit 1 ;;
+          esac
           for result in "$LANE_0" "$LANE_1" "$LANE_2" "$LANE_3"; do
-            if [ "$result" != success ]; then
+            if [ "$result" != "$EXPECTED" ]; then
               echo "Required validation lane did not succeed: $result" >&2
               exit 1
             fi
@@ -175,6 +220,8 @@ jobs:
   # Each lane verifies the same commit independently. The stable validate check
   # requires success from source, controller, packaging, and harness verification.
   pack-smoke:
+    needs: metadata_scope
+    if: ${{ !cancelled() && (github.event_name != 'pull_request' || needs.metadata_scope.result != 'success' || needs.metadata_scope.outputs.prose_only != 'true') }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
 
@@ -210,6 +257,8 @@ jobs:
         run: pnpm verify:typescript-tooling-pack
 
   harness-verify:
+    needs: metadata_scope
+    if: ${{ !cancelled() && (github.event_name != 'pull_request' || needs.metadata_scope.result != 'success' || needs.metadata_scope.outputs.prose_only != 'true') }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
 
@@ -259,6 +308,8 @@ jobs:
           retention-days: 7
 
   testing-windows:
+    needs: metadata_scope
+    if: ${{ !cancelled() && (github.event_name != 'pull_request' || needs.metadata_scope.result != 'success' || needs.metadata_scope.outputs.prose_only != 'true') }}
     runs-on: windows-latest
     timeout-minutes: 20
 
@@ -294,6 +345,8 @@ jobs:
         run: pnpm exec vitest --run --config test/security-dependencies/vitest.config.ts test/security-dependencies/dependency-resolution.test.ts test/security-dependencies/hono-serve-static-windows.test.ts
 
   dependency-security-browser:
+    needs: metadata_scope
+    if: ${{ !cancelled() && (github.event_name != 'pull_request' || needs.metadata_scope.result != 'success' || needs.metadata_scope.outputs.prose_only != 'true') }}
     permissions:
       contents: read
     runs-on: ubuntu-latest
@@ -326,6 +379,8 @@ jobs:
           pnpm exec playwright test --config test/security-dependencies/playwright.config.ts
 
   sandbox-docker:
+    needs: metadata_scope
+    if: ${{ !cancelled() && (github.event_name != 'pull_request' || needs.metadata_scope.result != 'success' || needs.metadata_scope.outputs.prose_only != 'true') }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
 
@@ -363,6 +418,8 @@ jobs:
         run: B4_TEST_DOCKER=1 pnpm --filter @b4run/sandbox test docker-sandbox.integration
 
   pgvector-docker:
+    needs: metadata_scope
+    if: ${{ !cancelled() && (github.event_name != 'pull_request' || needs.metadata_scope.result != 'success' || needs.metadata_scope.outputs.prose_only != 'true') }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
 
@@ -396,6 +453,8 @@ jobs:
         run: B4_TEST_PGVECTOR=1 pnpm --filter @b4run/memory-pgvector test
 
   postgres-storage-docker:
+    needs: metadata_scope
+    if: ${{ !cancelled() && (github.event_name != 'pull_request' || needs.metadata_scope.result != 'success' || needs.metadata_scope.outputs.prose_only != 'true') }}
     runs-on: ubuntu-latest
     # Five test files (four in @b4run/postgres-storage, one in @b4run/cli)
     # each start their own postgres:16 container, and a cold runner also pulls
@@ -452,6 +511,8 @@ jobs:
         run: B4_TEST_PGSTORAGE=1 pnpm --filter @b4run/cli test pending-interrupts-endpoint
 
   edge-workerd:
+    needs: metadata_scope
+    if: ${{ !cancelled() && (github.event_name != 'pull_request' || needs.metadata_scope.result != 'success' || needs.metadata_scope.outputs.prose_only != 'true') }}
     runs-on: ubuntu-latest
     # Postgres + a wsproxy container, plus `wrangler dev` booting real workerd.
     # 30 minutes leaves headroom for a cold image pull and the workerd binary
@@ -532,6 +593,8 @@ jobs:
           ' "${{ runner.temp }}/workerd-lane-report.json"
 
   copilotkit-examples-e2e:
+    needs: metadata_scope
+    if: ${{ !cancelled() && (github.event_name != 'pull_request' || needs.metadata_scope.result != 'success' || needs.metadata_scope.outputs.prose_only != 'true') }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
 
@@ -566,10 +629,12 @@ jobs:
         run: pnpm --filter @b4-example/research-web test:e2e
 
   vercel-native:
+    needs: metadata_scope
     if: >-
+      (!cancelled() && (github.event_name != 'pull_request' || needs.metadata_scope.result != 'success' || needs.metadata_scope.outputs.prose_only != 'true')) && (
       (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
       (github.event_name == 'pull_request' &&
-       github.event.pull_request.head.repo.full_name == github.repository)
+       github.event.pull_request.head.repo.full_name == github.repository))
     runs-on: ubuntu-latest
     timeout-minutes: 45
     environment: vercel-preview
@@ -649,6 +714,8 @@ jobs:
           retention-days: 3
 
   inspector-e2e:
+    needs: metadata_scope
+    if: ${{ !cancelled() && (github.event_name != 'pull_request' || needs.metadata_scope.result != 'success' || needs.metadata_scope.outputs.prose_only != 'true') }}
     runs-on: ubuntu-latest
     # 35, not 20: the browser lane below adds a chromium download, a second
     # standalone boot and 19 single-worker spec files (44 tests) on top of the
@@ -707,6 +774,8 @@ jobs:
           retention-days: 7
 
   chart-validate:
+    needs: metadata_scope
+    if: ${{ !cancelled() && (github.event_name != 'pull_request' || needs.metadata_scope.result != 'success' || needs.metadata_scope.outputs.prose_only != 'true') }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
 
@@ -792,7 +861,7 @@ jobs:
 
   sandbox-k8s:
     needs: metadata_scope
-    if: ${{ !cancelled() && (github.event_name != 'pull_request' || needs.metadata_scope.result != 'success' || needs.metadata_scope.outputs.metadata_only != 'true') }}
+    if: ${{ !cancelled() && (github.event_name != 'pull_request' || needs.metadata_scope.result != 'success' || (needs.metadata_scope.outputs.metadata_only != 'true' && needs.metadata_scope.outputs.prose_only != 'true')) }}
     runs-on: ubuntu-latest
     timeout-minutes: 35
     env:
@@ -885,7 +954,7 @@ jobs:
     # both Helm charts (cross-namespace: app in b4-app, sandboxes in
     # b4-sandboxes). Determinism comes from a baked aimock (no model key).
     needs: metadata_scope
-    if: ${{ !cancelled() && (github.event_name != 'pull_request' || needs.metadata_scope.result != 'success' || needs.metadata_scope.outputs.metadata_only != 'true') }}
+    if: ${{ !cancelled() && (github.event_name != 'pull_request' || needs.metadata_scope.result != 'success' || (needs.metadata_scope.outputs.metadata_only != 'true' && needs.metadata_scope.outputs.prose_only != 'true')) }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
@@ -1045,7 +1114,7 @@ jobs:
     # adds a Verdaccio-published image build (same mechanism as sandbox-k8s-e2e).
     # Determinism comes from a baked aimock (no model key).
     needs: metadata_scope
-    if: ${{ !cancelled() && (github.event_name != 'pull_request' || needs.metadata_scope.result != 'success' || needs.metadata_scope.outputs.metadata_only != 'true') }}
+    if: ${{ !cancelled() && (github.event_name != 'pull_request' || needs.metadata_scope.result != 'success' || (needs.metadata_scope.outputs.metadata_only != 'true' && needs.metadata_scope.outputs.prose_only != 'true')) }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
@@ -1127,7 +1196,7 @@ jobs:
 
   chart-apply-smoke:
     needs: metadata_scope
-    if: ${{ !cancelled() && (github.event_name != 'pull_request' || needs.metadata_scope.result != 'success' || needs.metadata_scope.outputs.metadata_only != 'true') }}
+    if: ${{ !cancelled() && (github.event_name != 'pull_request' || needs.metadata_scope.result != 'success' || (needs.metadata_scope.outputs.metadata_only != 'true' && needs.metadata_scope.outputs.prose_only != 'true')) }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     env:
@@ -1180,6 +1249,8 @@ jobs:
             curl -sf http://b4-app.default.svc.cluster.local/ >/dev/null && echo "app served OK"
 
   recovery-strict-runner:
+    needs: metadata_scope
+    if: ${{ !cancelled() && (github.event_name != 'pull_request' || needs.metadata_scope.result != 'success' || needs.metadata_scope.outputs.prose_only != 'true') }}
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     permissions:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,8 +106,17 @@ scripts respectively) — not workspace packages.
 ## Definition of Done
 
 The required `validate` job in `.github/workflows/ci.yml` aggregates four
-independent lanes and succeeds only when all four succeed. Failure, cancellation,
-or a skipped lane blocks it.
+independent lanes for code and release-bearing changes and succeeds only when all
+four succeed. Failure, cancellation, or an unexpected skipped lane blocks it.
+
+A pull request changing only regular, non-executable Markdown files under
+`docs/superpowers/runbooks/` uses the narrow prose path. The existing scope job
+checks the exact merge-base diff, both sides of file modes, and whitespace before
+emitting that result. `validate` still runs and requires successful classification
+and all four heavy lanes to be deliberately skipped. Mixed changes, other paths,
+missing or malformed results, and failed classification cannot pass this route.
+All pushes to main retain full validation; generated-metadata scope remains a
+separate exception for its existing infrastructure jobs.
 
 The `source-validate` lane runs these gates in order after installation:
 
@@ -179,6 +188,12 @@ substitute for the other or optional release cleanup.
 - **Branch per PR; pin before dispatching parallel/subagent work.** In a
   multi-worktree setup, a subagent's commits can land on a detached HEAD
   tracking the wrong branch if the feature branch isn't checked out first.
+- **Limit simultaneous full CI submissions.** Prepare independent changes locally
+  in parallel, but normally keep at most two maintainer-managed PRs with full CI
+  active at once, accounting for validation already running on main. Wait for
+  active runs before pushing a follow-up head. Do not cancel release runs or add
+  a repository-wide serialization gate; this is submission guidance. During
+  performance work, submit one performance PR at a time so its impact is clear.
 - **Build before running anything against `dist/`.** Packages compile
   `src/*.ts` to a gitignored `dist/`, and consumers import the built output —
   a stale or skewed `dist/` (from a branch switch or a per-package filtered

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -133,3 +133,20 @@ The full packaged-app `sandbox-k8s-e2e` lane remains on Kubernetes 1.35.
 - Do not use root docs to describe planned behavior as if it already exists.
 - Keep command examples and repo guidance aligned with the current workspace scripts.
 - Prefer the narrowest change that preserves the current contract and verification model.
+
+
+## Keeping validation responsive
+
+Runbook-only pull requests use a narrow prose path when every changed file is
+regular, non-executable Markdown under `docs/superpowers/runbooks/`. The existing
+scope job checks the exact PR diff and whitespace; the required `validate` check
+remains present. Source, dependencies, workflow changes, site MDX, other documents,
+and mixed changes use full validation. All main pushes retain the full lanes.
+A missing or failed classification never grants the prose path.
+
+Prepare independent changes concurrently, but normally keep no more than two
+maintainer-managed full-CI PRs active at once, taking active main validation into
+account. Let an active run finish before pushing its replacement head. Submit
+performance PRs one at a time to make timing comparisons useful. This is working
+guidance, not an additional automated gate or publishing prerequisite. Preserve
+active releases and the existing publishing workflow.

--- a/docs/superpowers/plans/2026-09-11-prose-ci-performance.md
+++ b/docs/superpowers/plans/2026-09-11-prose-ci-performance.md
@@ -21,3 +21,12 @@
 - [ ] Verify a useful follow-up runbook-only PR takes the prose path, update measured evidence, and continue to the separately reviewed npm diagnostics change.
 
 Independent spec/plan review passed. Raw modes must validate both sides (100644; zero only for the absent add/delete side), retain merge-base semantics, account for renames as delete/add, and reject malformed or contradictory scope outputs.
+
+
+Quality review found that PR-owned classifier code could authorize its own skipped
+validation. Extract the dependency-free classifier from the exact trusted base
+SHA into a temporary `.mjs` file for both decisions, and default prose to false
+when that base has no prose export. Exercise the actual workflow shell against a
+forged PR classifier, a legacy base, a current base with qualifying runbook edits,
+and a failing trusted classifier; assert cleanup and no forged execution. Update
+only the affected CI command inventory and focused contracts.

--- a/docs/superpowers/plans/2026-09-11-prose-ci-performance.md
+++ b/docs/superpowers/plans/2026-09-11-prose-ci-performance.md
@@ -1,0 +1,23 @@
+# Prose-only CI Performance Implementation Plan
+
+> **For agentic workers:** Use superpowers:subagent-driven-development or superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Avoid full runtime CI for narrowly proven runbook-only edits while preserving full validation for release-bearing changes.
+
+**Architecture:** Extend the existing scope classifier and metadata job; reuse the stable validate job to choose the expected outcomes. No new publishing workflow or gate.
+
+**Tech Stack:** Node.js, Git, GitHub Actions YAML, Vitest.
+
+## Tasks
+
+- [ ] Baseline: frozen pnpm 10.33 install; run `pnpm exec vitest --run --config test/k8s-compat/vitest.config.ts ci-scope` and release-integrity tests.
+- [ ] Extend `test/k8s-compat/ci-scope.test.ts` with real Git path/mode/rename/empty/mixed cases and workflow gate truth-table regressions. Observe intended failures before implementation.
+- [ ] Extend `scripts/ci-scope.mjs` and `scripts/ci-scope.d.mts` with a separate prose-only classification while retaining the metadata-only interface. Fail closed outside regular runbook Markdown paths. Add exact-diff whitespace checking for the prose path.
+- [ ] Update `.github/workflows/ci.yml`: classifier output, prose validation, full-lane and auxiliary job conditions, and stable validate result expectations. Preserve main-push coverage and metadata exception.
+- [ ] Update only the CI entries in both existing workflow audit inventories (`workflow-entrypoints.json`, `workflow-safe-executables.json`), and update release-integrity/workflow assertions only where the intended CI contract changes; no release content pins should change for CI-only code.
+- [ ] Update `AGENTS.md` and `CONTRIBUTORS.md` with the narrow prose exception and submission guidance.
+- [ ] Run focused tests, lint, integrity, full validation as appropriate to the existing Definition of Done; inspect any failure rather than bypassing checks.
+- [ ] Obtain independent spec and quality review, commit, submit one PR, wait for all relevant technical checks, merge on green using the exact reviewed head.
+- [ ] Verify a useful follow-up runbook-only PR takes the prose path, update measured evidence, and continue to the separately reviewed npm diagnostics change.
+
+Independent spec/plan review passed. Raw modes must validate both sides (100644; zero only for the absent add/delete side), retain merge-base semantics, account for renames as delete/add, and reject malformed or contradictory scope outputs.

--- a/docs/superpowers/specs/2026-09-11-prose-ci-performance-design.md
+++ b/docs/superpowers/specs/2026-09-11-prose-ci-performance-design.md
@@ -1,0 +1,17 @@
+# Prose-only CI performance
+
+The approved performance work starts with narrowly scoped CI, smaller submission batches, and npm failure classification. This change covers CI and submission guidance; npm work is a separate subsequent PR. No release workflow, artifact, authentication, timeout, or publishing prerequisite changes.
+
+## Behavior
+
+Extend the existing PR scope classifier with a distinct prose-only result. Only nonempty changes consisting entirely of regular Markdown files under `docs/superpowers/runbooks/` qualify. Renames must account for both paths. Non-Markdown files, symlinks, executable modes, mixed changes, malformed Git output, or unknown paths must not qualify. Source, dependency, workflow, package, generated site, and release changes retain full verification. Push events retain full verification.
+
+The existing metadata-scope job computes both existing metadata-only and new prose-only outputs, and runs whitespace validation against the exact PR diff for prose-only changes. It does not install the workspace or execute edited Markdown. Keep the required `validate` job always present. For prose PRs it requires successful classification/validation and all four full lanes to be skipped deliberately. For other changes it requires the existing four successful full lanes, and a successful classifier on PRs. Missing/failed classification cannot grant the fast path.
+
+Gate the existing source/controller/package/harness lanes and auxiliary CI jobs on the prose-only result, preserving other job conditions and the existing generated-metadata exception. Keep separate CodeQL and Kubernetes Compatibility policies unchanged; the latter already scopes runbooks out. The optimization PR itself changes code/workflows and must pass full CI.
+
+Add contributor guidance: prepare independent changes concurrently, but normally submit at most two full CI PRs at a time, and one performance PR at a time during this work. Wait for active runs before pushing follow-ups; do not cancel releases or globally serialize repository workflows. This is working guidance, not an automated gate.
+
+## Validation
+
+Regression tests use real Git repositories for allowed prose edits, mixed paths, rename/delete cases, modes and malformed output. Workflow contract tests cover full/prose/push/failed/cancelled/missing-output gate behavior and preserved jobs. Run baseline and failing regressions before implementation, focused tests afterward, then the repository-required validation and independent reviews before PR/merge. Measure the fast path on a real useful runbook update after integration; no throwaway release or unrelated edit is required.

--- a/docs/superpowers/specs/2026-09-11-prose-ci-performance-design.md
+++ b/docs/superpowers/specs/2026-09-11-prose-ci-performance-design.md
@@ -15,3 +15,12 @@ Add contributor guidance: prepare independent changes concurrently, but normally
 ## Validation
 
 Regression tests use real Git repositories for allowed prose edits, mixed paths, rename/delete cases, modes and malformed output. Workflow contract tests cover full/prose/push/failed/cancelled/missing-output gate behavior and preserved jobs. Run baseline and failing regressions before implementation, focused tests afterward, then the repository-required validation and independent reviews before PR/merge. Measure the fast path on a real useful runbook update after integration; no throwaway release or unrelated edit is required.
+
+
+The scope job extracts the dependency-free classifier from the exact trusted PR
+base commit into a private temporary directory. Both scope decisions use that
+copy; edited classifier code in the PR is never executed for classification.
+If the base classifier predates the prose export, prose is false and normal
+validation remains required, preserving the separate metadata exception. Missing
+base code, invalid outputs, import failures, or classification failures remain
+fatal. The temporary directory is removed on success and failure.

--- a/packages/sandbox/test/ci-workflow-pins.test.ts
+++ b/packages/sandbox/test/ci-workflow-pins.test.ts
@@ -228,10 +228,14 @@ describe("native Vercel job", () => {
     const steps = requireSteps(nativeJob, "jobs.vercel-native")
 
     expect(workflow.permissions).toEqual({ contents: "read" })
+    expect(nativeJob.needs).toBe("metadata_scope")
     expect(normalizedExpression(nativeJob.if)).toBe(
-      "(github.event_name == 'push' && github.ref == 'refs/heads/main') || " +
+      "(!cancelled() && (github.event_name != 'pull_request' || " +
+        "needs.metadata_scope.result != 'success' || " +
+        "needs.metadata_scope.outputs.prose_only != 'true')) && ( " +
+        "(github.event_name == 'push' && github.ref == 'refs/heads/main') || " +
         "(github.event_name == 'pull_request' && " +
-        "github.event.pull_request.head.repo.full_name == github.repository)",
+        "github.event.pull_request.head.repo.full_name == github.repository))",
     )
     expect(nativeJob["runs-on"]).toBe("ubuntu-latest")
     expect(nativeJob["timeout-minutes"]).toBe(45)

--- a/scripts/ci-scope.d.mts
+++ b/scripts/ci-scope.d.mts
@@ -16,3 +16,8 @@ export function classifyMetadataOnlyScope(
   request: MetadataOnlyScopeRequest,
   runCommand?: GitCommandRunner,
 ): Promise<boolean>
+
+export function classifyProseOnlyScope(
+  request: MetadataOnlyScopeRequest,
+  runCommand?: GitCommandRunner,
+): Promise<boolean>

--- a/scripts/ci-scope.mjs
+++ b/scripts/ci-scope.mjs
@@ -75,12 +75,64 @@ export async function classifyMetadataOnlyScope(request, runCommand = runGitComm
   return paths.length > 0 && paths.every((path) => METADATA_ONLY_PATH_SET.has(path))
 }
 
+// Runbooks are not compiled, bundled, or evaluated by the application. Keep this
+// narrower than all Markdown: package READMEs, site MDX, and configuration still
+// need their normal validation lanes.
+const PROSE_PATH =
+  /^docs\/superpowers\/runbooks\/(?:[a-zA-Z0-9][a-zA-Z0-9._-]*\/)*[a-zA-Z0-9][a-zA-Z0-9._-]*\.md$/u
+
+export async function classifyProseOnlyScope(request, runCommand = runGitCommand) {
+  if (request.event === "push") return false
+  if (request.event !== "pull_request") {
+    throw new Error(`Unknown CI scope event mode: ${String(request.event)}`)
+  }
+  const base = expectCommitSha(request.base, "base")
+  const head = expectCommitSha(request.head, "head")
+  await runCommand("git", ["cat-file", "-e", `${base}^{commit}`])
+  await runCommand("git", ["cat-file", "-e", `${head}^{commit}`])
+  const { stdout } = await runCommand("git", [
+    "diff",
+    "--merge-base",
+    "--no-renames",
+    "--raw",
+    "--abbrev=40",
+    "-z",
+    base,
+    head,
+  ])
+  if (!Buffer.isBuffer(stdout)) throw new Error("Malformed Git diff output: expected a Buffer")
+  const tokens = parseNulDelimitedPaths(stdout)
+  if (tokens.length % 2 !== 0) throw new Error("Malformed raw Git diff records")
+  if (tokens.length === 0) return false
+  let proseOnly = true
+  for (let index = 0; index < tokens.length; index += 2) {
+    const header = /^:(\d{6}) (\d{6}) ([a-f0-9]{40}) ([a-f0-9]{40}) ([AMDT])$/u.exec(tokens[index])
+    if (header === null) throw new Error("Malformed raw Git diff header")
+    const [, oldMode, newMode, oldId, newId, status] = header
+    const oldAbsent = oldMode === "000000" && oldId === "0".repeat(40)
+    const newAbsent = newMode === "000000" && newId === "0".repeat(40)
+    const regularOld = oldMode === "100644" && oldId !== "0".repeat(40)
+    const regularNew = newMode === "100644" && newId !== "0".repeat(40)
+    const regular =
+      status === "A"
+        ? oldAbsent && regularNew
+        : status === "D"
+          ? regularOld && newAbsent
+          : status === "M" && regularOld && regularNew
+    proseOnly &&= regular && PROSE_PATH.test(tokens[index + 1])
+  }
+  if (!proseOnly) return false
+  // Run before emitting true: a failed prose check cannot grant skipped lanes.
+  await runCommand("git", ["diff", "--check", "--merge-base", "--no-renames", base, head])
+  return true
+}
+
 function parseCliArgs(argv) {
   const flags = new Map()
   for (let index = 0; index < argv.length; index += 2) {
     const flag = argv[index]
     const value = argv[index + 1]
-    if (flag === undefined || !["--event", "--base", "--head"].includes(flag)) {
+    if (flag === undefined || !["--event", "--base", "--head", "--kind"].includes(flag)) {
       throw new Error(`Unknown flag: ${String(flag)}`)
     }
     if (value === undefined || value.length === 0 || value.startsWith("--")) {
@@ -95,7 +147,10 @@ function parseCliArgs(argv) {
   if (event === "push" && (flags.has("--base") || flags.has("--head"))) {
     throw new Error("push scope does not accept pull-request SHA flags")
   }
+  const kind = flags.get("--kind") ?? "metadata"
+  if (!["metadata", "prose"].includes(kind)) throw new Error("Unknown CI scope kind")
   return {
+    kind,
     event,
     ...(flags.has("--base") ? { base: flags.get("--base") } : {}),
     ...(flags.has("--head") ? { head: flags.get("--head") } : {}),
@@ -104,7 +159,13 @@ function parseCliArgs(argv) {
 
 const entrypoint = process.argv[1]
 if (entrypoint !== undefined && import.meta.url === pathToFileURL(entrypoint).href) {
-  classifyMetadataOnlyScope(parseCliArgs(process.argv.slice(2)))
+  Promise.resolve()
+    .then(() => {
+      const request = parseCliArgs(process.argv.slice(2))
+      return request.kind === "prose"
+        ? classifyProseOnlyScope(request)
+        : classifyMetadataOnlyScope(request)
+    })
     .then((metadataOnly) => process.stdout.write(`${String(metadataOnly)}\n`))
     .catch((error) => {
       process.stderr.write(

--- a/scripts/release/test/fixtures/workflow-entrypoints.json
+++ b/scripts/release/test/fixtures/workflow-entrypoints.json
@@ -7,7 +7,11 @@
         "name": "Auto Approve",
         "on": {
           "pull_request": {
-            "types": ["opened", "reopened", "ready_for_review"]
+            "types": [
+              "opened",
+              "reopened",
+              "ready_for_review"
+            ]
           }
         },
         "permissions": {
@@ -50,7 +54,9 @@
         "on": {
           "pull_request": null,
           "push": {
-            "branches": ["main"]
+            "branches": [
+              "main"
+            ]
           }
         },
         "permissions": {
@@ -98,7 +104,7 @@
             "env": {
               "B4_TEST_K8S_CONTEXT": "kind-b4-chart-apply"
             },
-            "if": "${{ !cancelled() && (github.event_name != 'pull_request' || needs.metadata_scope.result != 'success' || needs.metadata_scope.outputs.metadata_only != 'true') }}",
+            "if": "${{ !cancelled() && (github.event_name != 'pull_request' || needs.metadata_scope.result != 'success' || (needs.metadata_scope.outputs.metadata_only != 'true' && needs.metadata_scope.outputs.prose_only != 'true')) }}",
             "needs": "metadata_scope",
             "runs-on": "ubuntu-latest",
             "timeout-minutes": 15
@@ -154,6 +160,8 @@
           "classification": "safe",
           "id": "chart-validate",
           "descriptor": {
+            "if": "${{ !cancelled() && (github.event_name != 'pull_request' || needs.metadata_scope.result != 'success' || needs.metadata_scope.outputs.prose_only != 'true') }}",
+            "needs": "metadata_scope",
             "runs-on": "ubuntu-latest",
             "timeout-minutes": 15
           },
@@ -248,6 +256,8 @@
           "classification": "safe",
           "id": "copilotkit-examples-e2e",
           "descriptor": {
+            "if": "${{ !cancelled() && (github.event_name != 'pull_request' || needs.metadata_scope.result != 'success' || needs.metadata_scope.outputs.prose_only != 'true') }}",
+            "needs": "metadata_scope",
             "runs-on": "ubuntu-latest",
             "timeout-minutes": 20
           },
@@ -321,6 +331,8 @@
           "classification": "safe",
           "id": "dependency-security-browser",
           "descriptor": {
+            "if": "${{ !cancelled() && (github.event_name != 'pull_request' || needs.metadata_scope.result != 'success' || needs.metadata_scope.outputs.prose_only != 'true') }}",
+            "needs": "metadata_scope",
             "permissions": {
               "contents": "read"
             },
@@ -383,6 +395,8 @@
           "classification": "safe",
           "id": "edge-workerd",
           "descriptor": {
+            "if": "${{ !cancelled() && (github.event_name != 'pull_request' || needs.metadata_scope.result != 'success' || needs.metadata_scope.outputs.prose_only != 'true') }}",
+            "needs": "metadata_scope",
             "runs-on": "ubuntu-latest",
             "timeout-minutes": 30
           },
@@ -449,6 +463,8 @@
           "classification": "safe",
           "id": "harness-verify",
           "descriptor": {
+            "if": "${{ !cancelled() && (github.event_name != 'pull_request' || needs.metadata_scope.result != 'success' || needs.metadata_scope.outputs.prose_only != 'true') }}",
+            "needs": "metadata_scope",
             "runs-on": "ubuntu-latest",
             "timeout-minutes": 30
           },
@@ -545,6 +561,8 @@
           "classification": "safe",
           "id": "inspector-e2e",
           "descriptor": {
+            "if": "${{ !cancelled() && (github.event_name != 'pull_request' || needs.metadata_scope.result != 'success' || needs.metadata_scope.outputs.prose_only != 'true') }}",
+            "needs": "metadata_scope",
             "runs-on": "ubuntu-latest",
             "timeout-minutes": 35
           },
@@ -634,7 +652,8 @@
             "if": "github.event_name == 'pull_request'",
             "name": "metadata-scope",
             "outputs": {
-              "metadata_only": "${{ steps.classify.outputs.metadata_only }}"
+              "metadata_only": "${{ steps.classify.outputs.metadata_only }}",
+              "prose_only": "${{ steps.classify.outputs.prose_only }}"
             },
             "runs-on": "ubuntu-latest",
             "timeout-minutes": 5
@@ -669,7 +688,7 @@
                 },
                 "id": "classify",
                 "name": "Classify metadata-only change",
-                "run": "set -eu\nMETADATA_ONLY=\"$(node scripts/ci-scope.mjs --event pull_request --base \"$BASE_SHA\" --head \"$HEAD_SHA\")\"\ncase \"$METADATA_ONLY\" in\n  true|false) ;;\n  *) echo \"Malformed metadata-only scope output\" >&2; exit 1 ;;\nesac\nprintf 'metadata_only=%s\\n' \"$METADATA_ONLY\" >> \"$GITHUB_OUTPUT\"\n"
+                "run": "set -eu\nSCOPE_DIR=\"$(mktemp -d)\"\nSCOPE_DIR=\"$(cd \"$SCOPE_DIR\" && pwd -P)\"\ntrap 'rm -rf \"$SCOPE_DIR\"' EXIT\ngit show \"$BASE_SHA:scripts/ci-scope.mjs\" > \"$SCOPE_DIR/ci-scope.mjs\"\nMETADATA_ONLY=\"$(node \"$SCOPE_DIR/ci-scope.mjs\" --event pull_request --base \"$BASE_SHA\" --head \"$HEAD_SHA\")\"\ncase \"$METADATA_ONLY\" in\n  true|false) ;;\n  *) echo \"Malformed metadata-only scope output\" >&2; exit 1 ;;\nesac\nPROSE_ONLY=\"$(node --input-type=module - \"$SCOPE_DIR/ci-scope.mjs\" <<'NODE'\nimport { pathToFileURL } from \"node:url\"\nconst scope = await import(pathToFileURL(process.argv[2]).href)\nconst proseOnly = scope.classifyProseOnlyScope === undefined\n  ? false\n  : await scope.classifyProseOnlyScope({\n      event: \"pull_request\",\n      base: process.env.BASE_SHA,\n      head: process.env.HEAD_SHA,\n    })\nprocess.stdout.write(String(proseOnly))\nNODE\n)\"\ncase \"$PROSE_ONLY\" in\n  true|false) ;;\n  *) echo \"Malformed prose-only scope output\" >&2; exit 1 ;;\nesac\nprintf 'prose_only=%s\\n' \"$PROSE_ONLY\" >> \"$GITHUB_OUTPUT\"\nprintf 'metadata_only=%s\\n' \"$METADATA_ONLY\" >> \"$GITHUB_OUTPUT\"\n"
               }
             }
           ]
@@ -678,6 +697,8 @@
           "classification": "safe",
           "id": "pack-smoke",
           "descriptor": {
+            "if": "${{ !cancelled() && (github.event_name != 'pull_request' || needs.metadata_scope.result != 'success' || needs.metadata_scope.outputs.prose_only != 'true') }}",
+            "needs": "metadata_scope",
             "runs-on": "ubuntu-latest",
             "timeout-minutes": 30
           },
@@ -747,6 +768,8 @@
           "classification": "safe",
           "id": "pgvector-docker",
           "descriptor": {
+            "if": "${{ !cancelled() && (github.event_name != 'pull_request' || needs.metadata_scope.result != 'success' || needs.metadata_scope.outputs.prose_only != 'true') }}",
+            "needs": "metadata_scope",
             "runs-on": "ubuntu-latest",
             "timeout-minutes": 20
           },
@@ -806,6 +829,8 @@
           "classification": "safe",
           "id": "postgres-storage-docker",
           "descriptor": {
+            "if": "${{ !cancelled() && (github.event_name != 'pull_request' || needs.metadata_scope.result != 'success' || needs.metadata_scope.outputs.prose_only != 'true') }}",
+            "needs": "metadata_scope",
             "runs-on": "ubuntu-latest",
             "timeout-minutes": 30
           },
@@ -872,11 +897,13 @@
           "classification": "safe",
           "id": "recovery-strict-runner",
           "descriptor": {
-            "runs-on": "ubuntu-24.04",
-            "timeout-minutes": 5,
+            "if": "${{ !cancelled() && (github.event_name != 'pull_request' || needs.metadata_scope.result != 'success' || needs.metadata_scope.outputs.prose_only != 'true') }}",
+            "needs": "metadata_scope",
             "permissions": {
               "contents": "read"
-            }
+            },
+            "runs-on": "ubuntu-24.04",
+            "timeout-minutes": 5
           },
           "steps": [
             {
@@ -902,10 +929,10 @@
             {
               "classification": "safe",
               "descriptor": {
-                "name": "Verify real recovery process containment",
                 "env": {
                   "B4_TEST_RECOVERY_RUNNER": "1"
                 },
+                "name": "Verify real recovery process containment",
                 "run": "node --test scripts/release/test/recovery-strict-runner.integration.mjs"
               }
             }
@@ -915,6 +942,8 @@
           "classification": "safe",
           "id": "release-controller",
           "descriptor": {
+            "if": "${{ !cancelled() && (github.event_name != 'pull_request' || needs.metadata_scope.result != 'success' || needs.metadata_scope.outputs.prose_only != 'true') }}",
+            "needs": "metadata_scope",
             "runs-on": "ubuntu-latest",
             "timeout-minutes": 30
           },
@@ -945,8 +974,8 @@
                 "name": "Setup Node.js",
                 "uses": "actions/setup-node@820762786026740c76f36085b0efc47a31fe5020",
                 "with": {
-                  "node-version": "24.17.0",
-                  "cache": "pnpm"
+                  "cache": "pnpm",
+                  "node-version": "24.17.0"
                 }
               }
             },
@@ -977,6 +1006,8 @@
           "classification": "safe",
           "id": "sandbox-docker",
           "descriptor": {
+            "if": "${{ !cancelled() && (github.event_name != 'pull_request' || needs.metadata_scope.result != 'success' || needs.metadata_scope.outputs.prose_only != 'true') }}",
+            "needs": "metadata_scope",
             "runs-on": "ubuntu-latest",
             "timeout-minutes": 20
           },
@@ -1046,7 +1077,7 @@
             "env": {
               "B4_TEST_SMOKE_E2E": "1"
             },
-            "if": "${{ !cancelled() && (github.event_name != 'pull_request' || needs.metadata_scope.result != 'success' || needs.metadata_scope.outputs.metadata_only != 'true') }}",
+            "if": "${{ !cancelled() && (github.event_name != 'pull_request' || needs.metadata_scope.result != 'success' || (needs.metadata_scope.outputs.metadata_only != 'true' && needs.metadata_scope.outputs.prose_only != 'true')) }}",
             "needs": "metadata_scope",
             "runs-on": "ubuntu-latest",
             "timeout-minutes": 30
@@ -1132,7 +1163,7 @@
             "env": {
               "B4_TEST_K8S_CONTEXT": "kind-b4-k8s-canonical"
             },
-            "if": "${{ !cancelled() && (github.event_name != 'pull_request' || needs.metadata_scope.result != 'success' || needs.metadata_scope.outputs.metadata_only != 'true') }}",
+            "if": "${{ !cancelled() && (github.event_name != 'pull_request' || needs.metadata_scope.result != 'success' || (needs.metadata_scope.outputs.metadata_only != 'true' && needs.metadata_scope.outputs.prose_only != 'true')) }}",
             "needs": "metadata_scope",
             "runs-on": "ubuntu-latest",
             "timeout-minutes": 35
@@ -1266,7 +1297,7 @@
               "B4_TEST_SMOKE_E2E": "1",
               "KIND_CLUSTER": "b4-smoke"
             },
-            "if": "${{ !cancelled() && (github.event_name != 'pull_request' || needs.metadata_scope.result != 'success' || needs.metadata_scope.outputs.metadata_only != 'true') }}",
+            "if": "${{ !cancelled() && (github.event_name != 'pull_request' || needs.metadata_scope.result != 'success' || (needs.metadata_scope.outputs.metadata_only != 'true' && needs.metadata_scope.outputs.prose_only != 'true')) }}",
             "needs": "metadata_scope",
             "runs-on": "ubuntu-latest",
             "timeout-minutes": 30
@@ -1445,6 +1476,8 @@
           "classification": "safe",
           "id": "source-validate",
           "descriptor": {
+            "if": "${{ !cancelled() && (github.event_name != 'pull_request' || needs.metadata_scope.result != 'success' || needs.metadata_scope.outputs.prose_only != 'true') }}",
+            "needs": "metadata_scope",
             "runs-on": "ubuntu-latest",
             "timeout-minutes": 45
           },
@@ -1475,8 +1508,8 @@
                 "name": "Setup Node.js",
                 "uses": "actions/setup-node@820762786026740c76f36085b0efc47a31fe5020",
                 "with": {
-                  "node-version": "24.17.0",
-                  "cache": "pnpm"
+                  "cache": "pnpm",
+                  "node-version": "24.17.0"
                 }
               }
             },
@@ -1525,10 +1558,10 @@
             {
               "classification": "safe",
               "descriptor": {
-                "name": "Source Tests",
                 "env": {
                   "B4_REQUIRE_DOCKER": "1"
                 },
+                "name": "Source Tests",
                 "run": "pnpm test"
               }
             },
@@ -1552,6 +1585,8 @@
           "classification": "safe",
           "id": "testing-windows",
           "descriptor": {
+            "if": "${{ !cancelled() && (github.event_name != 'pull_request' || needs.metadata_scope.result != 'success' || needs.metadata_scope.outputs.prose_only != 'true') }}",
+            "needs": "metadata_scope",
             "runs-on": "windows-latest",
             "timeout-minutes": 20
           },
@@ -1618,8 +1653,14 @@
           "classification": "safe",
           "id": "validate",
           "descriptor": {
-            "needs": ["source-validate", "release-controller", "pack-smoke", "harness-verify"],
             "if": "always()",
+            "needs": [
+              "metadata_scope",
+              "source-validate",
+              "release-controller",
+              "pack-smoke",
+              "harness-verify"
+            ],
             "runs-on": "ubuntu-latest",
             "timeout-minutes": 5
           },
@@ -1627,14 +1668,18 @@
             {
               "classification": "safe",
               "descriptor": {
-                "name": "Require every validation lane",
                 "env": {
+                  "EVENT_NAME": "${{ github.event_name }}",
                   "LANE_0": "${{ needs.source-validate.result }}",
                   "LANE_1": "${{ needs.release-controller.result }}",
                   "LANE_2": "${{ needs.pack-smoke.result }}",
-                  "LANE_3": "${{ needs.harness-verify.result }}"
+                  "LANE_3": "${{ needs.harness-verify.result }}",
+                  "METADATA_ONLY": "${{ needs.metadata_scope.outputs.metadata_only }}",
+                  "PROSE_ONLY": "${{ needs.metadata_scope.outputs.prose_only }}",
+                  "SCOPE_RESULT": "${{ needs.metadata_scope.result }}"
                 },
-                "run": "for result in \"$LANE_0\" \"$LANE_1\" \"$LANE_2\" \"$LANE_3\"; do\n  if [ \"$result\" != success ]; then\n    echo \"Required validation lane did not succeed: $result\" >&2\n    exit 1\n  fi\ndone\n"
+                "name": "Require every validation lane",
+                "run": "set -eu\nEXPECTED=success\ncase \"$EVENT_NAME\" in\n  pull_request)\n    [ \"$SCOPE_RESULT\" = success ] || { echo \"CI scope did not succeed\" >&2; exit 1; }\n    case \"$PROSE_ONLY:$METADATA_ONLY\" in\n      true:false) EXPECTED=skipped ;;\n      false:true|false:false) ;;\n      *) echo \"Malformed CI scope outputs\" >&2; exit 1 ;;\n    esac\n    ;;\n  push) ;;\n  *) echo \"Unsupported validation event\" >&2; exit 1 ;;\nesac\nfor result in \"$LANE_0\" \"$LANE_1\" \"$LANE_2\" \"$LANE_3\"; do\n  if [ \"$result\" != \"$EXPECTED\" ]; then\n    echo \"Required validation lane did not succeed: $result\" >&2\n    exit 1\n  fi\ndone\n"
               }
             }
           ]
@@ -1644,7 +1689,8 @@
           "id": "vercel-native",
           "descriptor": {
             "environment": "vercel-preview",
-            "if": "(github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'pull_request' &&\n github.event.pull_request.head.repo.full_name == github.repository)",
+            "if": "(!cancelled() && (github.event_name != 'pull_request' || needs.metadata_scope.result != 'success' || needs.metadata_scope.outputs.prose_only != 'true')) && ( (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'pull_request' &&\n github.event.pull_request.head.repo.full_name == github.repository))",
+            "needs": "metadata_scope",
             "runs-on": "ubuntu-latest",
             "timeout-minutes": 45
           },
@@ -1780,7 +1826,12 @@
         "name": "Claude Review",
         "on": {
           "pull_request": {
-            "types": ["opened", "synchronize", "reopened", "ready_for_review"]
+            "types": [
+              "opened",
+              "synchronize",
+              "reopened",
+              "ready_for_review"
+            ]
           }
         },
         "permissions": {
@@ -1860,10 +1911,14 @@
         "name": "CodeQL",
         "on": {
           "pull_request": {
-            "branches": ["main"]
+            "branches": [
+              "main"
+            ]
           },
           "push": {
-            "branches": ["main"]
+            "branches": [
+              "main"
+            ]
           },
           "schedule": [
             {
@@ -2239,7 +2294,10 @@
           "descriptor": {
             "if": "always()",
             "name": "kubernetes-compat",
-            "needs": ["scope", "compat"],
+            "needs": [
+              "scope",
+              "compat"
+            ],
             "runs-on": "ubuntu-latest",
             "timeout-minutes": 5
           },
@@ -2331,8 +2389,13 @@
         "name": "Publish Chart",
         "on": {
           "push": {
-            "branches": ["main"],
-            "paths": ["charts/b4-sandbox-infra/**", "charts/b4-app/**"]
+            "branches": [
+              "main"
+            ],
+            "paths": [
+              "charts/b4-sandbox-infra/**",
+              "charts/b4-app/**"
+            ]
           }
         },
         "permissions": {
@@ -2348,7 +2411,10 @@
             "runs-on": "ubuntu-latest",
             "strategy": {
               "matrix": {
-                "chart": ["b4-sandbox-infra", "b4-app"]
+                "chart": [
+                  "b4-sandbox-infra",
+                  "b4-app"
+                ]
               }
             },
             "timeout-minutes": 10
@@ -2968,7 +3034,9 @@
           "descriptor": {
             "if": "always() && needs.recovery-admit.result == 'success'",
             "name": "recovery-adopt",
-            "needs": ["recovery-admit"],
+            "needs": [
+              "recovery-admit"
+            ],
             "permissions": {
               "actions": "read",
               "attestations": "read",
@@ -3072,7 +3140,11 @@
           "descriptor": {
             "if": "always() && needs.recovery-admit.result == 'success' && needs.recovery-adopt.result == 'success' && needs.recovery-admit.outputs.audit == 'true' && (needs.recovery-admit.outputs.dispatch == 'false' || needs.recovery-dispatch-audit.result == 'success')",
             "name": "recovery-audit-evidence",
-            "needs": ["recovery-admit", "recovery-adopt", "recovery-dispatch-audit"],
+            "needs": [
+              "recovery-admit",
+              "recovery-adopt",
+              "recovery-dispatch-audit"
+            ],
             "permissions": {
               "actions": "read",
               "attestations": "read",
@@ -3176,7 +3248,11 @@
           "descriptor": {
             "if": "always() && needs.recovery-admit.result == 'success' && needs.recovery-adopt.result == 'success' && needs.recovery-admit.outputs.dispatch == 'true' && (needs.recovery-admit.outputs.evidence == 'false' || needs.recovery-evidence.result == 'success')",
             "name": "recovery-dispatch-audit",
-            "needs": ["recovery-admit", "recovery-adopt", "recovery-evidence"],
+            "needs": [
+              "recovery-admit",
+              "recovery-adopt",
+              "recovery-evidence"
+            ],
             "permissions": {
               "actions": "write",
               "attestations": "read",
@@ -3392,7 +3468,11 @@
           "descriptor": {
             "if": "always() && needs.recovery-admit.result == 'success' && needs.recovery-adopt.result == 'success' && needs.recovery-admit.outputs.finalize == 'true' && (needs.recovery-admit.outputs.audit == 'false' || needs.recovery-audit-evidence.result == 'success')",
             "name": "recovery-finalize",
-            "needs": ["recovery-admit", "recovery-adopt", "recovery-audit-evidence"],
+            "needs": [
+              "recovery-admit",
+              "recovery-adopt",
+              "recovery-audit-evidence"
+            ],
             "permissions": {
               "actions": "read",
               "attestations": "read",
@@ -3497,7 +3577,10 @@
           "descriptor": {
             "if": "always() && needs.recovery-admit.result == 'success' && needs.recovery-adopt.result == 'success' && needs.recovery-admit.outputs.smoke == 'true'",
             "name": "recovery-metadata",
-            "needs": ["recovery-admit", "recovery-adopt"],
+            "needs": [
+              "recovery-admit",
+              "recovery-adopt"
+            ],
             "permissions": {
               "actions": "read",
               "attestations": "read",
@@ -3627,7 +3710,11 @@
           "descriptor": {
             "if": "always() && needs.recovery-admit.result == 'success' && needs.recovery-adopt.result == 'success' && needs.recovery-admit.outputs.publish == 'true' && (needs.recovery-admit.outputs.finalize == 'false' || needs.recovery-finalize.result == 'success')",
             "name": "recovery-publish",
-            "needs": ["recovery-admit", "recovery-adopt", "recovery-finalize"],
+            "needs": [
+              "recovery-admit",
+              "recovery-adopt",
+              "recovery-finalize"
+            ],
             "permissions": {
               "actions": "read",
               "attestations": "read",
@@ -3732,7 +3819,10 @@
           "descriptor": {
             "if": "always() && needs.recovery-admit.result == 'success' && needs.recovery-adopt.result == 'success' && needs.recovery-admit.outputs.smoke == 'true'",
             "name": "recovery-published-harness",
-            "needs": ["recovery-admit", "recovery-adopt"],
+            "needs": [
+              "recovery-admit",
+              "recovery-adopt"
+            ],
             "permissions": {
               "actions": "read",
               "attestations": "read",
@@ -3980,7 +4070,10 @@
           "descriptor": {
             "if": "always() && needs.recovery-admit.result == 'success' && needs.recovery-adopt.result == 'success' && needs.recovery-admit.outputs.smoke == 'true'",
             "name": "recovery-runtime-targets",
-            "needs": ["recovery-admit", "recovery-adopt"],
+            "needs": [
+              "recovery-admit",
+              "recovery-adopt"
+            ],
             "permissions": {
               "actions": "read",
               "attestations": "read",
@@ -4110,7 +4203,10 @@
           "descriptor": {
             "if": "always() && needs.recovery-admit.result == 'success' && needs.recovery-adopt.result == 'success' && needs.recovery-admit.outputs.smoke == 'true'",
             "name": "recovery-scaffold",
-            "needs": ["recovery-admit", "recovery-adopt"],
+            "needs": [
+              "recovery-admit",
+              "recovery-adopt"
+            ],
             "permissions": {
               "actions": "read",
               "attestations": "read",
@@ -4240,7 +4336,10 @@
           "descriptor": {
             "if": "always() && needs.recovery-admit.result == 'success' && needs.recovery-adopt.result == 'success' && needs.recovery-admit.outputs.smoke == 'true'",
             "name": "recovery-storage",
-            "needs": ["recovery-admit", "recovery-adopt"],
+            "needs": [
+              "recovery-admit",
+              "recovery-adopt"
+            ],
             "permissions": {
               "actions": "read",
               "attestations": "read",
@@ -4380,7 +4479,9 @@
         "name": "Release",
         "on": {
           "push": {
-            "branches": ["main"]
+            "branches": [
+              "main"
+            ]
           },
           "schedule": [
             {
@@ -4403,7 +4504,9 @@
               "operation": {
                 "default": "reconcile",
                 "description": "Reconcile this candidate",
-                "options": ["reconcile"],
+                "options": [
+                  "reconcile"
+                ],
                 "required": true,
                 "type": "choice"
               },
@@ -4425,7 +4528,11 @@
           "id": "attest",
           "descriptor": {
             "if": "always() && needs.detect.result == 'success' && needs.hydrate.result == 'success' && needs.tag.result == 'success' && needs.tag.outputs.continue == 'true' && github.ref == format('refs/tags/v{0}', inputs.version) && github.sha == needs.detect.outputs.candidate_sha && inputs.version == needs.detect.outputs.candidate_version && inputs.commitSha == needs.detect.outputs.candidate_sha && inputs.operation == 'reconcile' && contains(fromJSON('[\"prepare-artifacts\",\"attest-artifacts\",\"escrow-candidate\"]'), needs.detect.outputs.next_transition)",
-            "needs": ["detect", "hydrate", "tag"],
+            "needs": [
+              "detect",
+              "hydrate",
+              "tag"
+            ],
             "outputs": {
               "attestation_artifact_id": "${{ steps.evidence.outputs.artifact-id }}"
             },
@@ -4520,7 +4627,12 @@
           "id": "correlate-audit",
           "descriptor": {
             "if": "always() && needs.detect.result == 'success' && needs.hydrate.result == 'success' && needs.tag.result == 'success' && needs.tag.outputs.continue == 'true' && github.ref == format('refs/tags/v{0}', inputs.version) && github.sha == needs.detect.outputs.candidate_sha && inputs.version == needs.detect.outputs.candidate_version && inputs.commitSha == needs.detect.outputs.candidate_sha && inputs.operation == 'reconcile' && contains(fromJSON('[\"prepare-artifacts\",\"attest-artifacts\",\"escrow-candidate\",\"publish-npm-packages\",\"resume-npm-publish\",\"reconcile-npm-evidence\",\"run-release-smokes\",\"reconcile-smoke-evidence\",\"dispatch-release-audit\",\"complete-release-audit\"]'), needs.detect.outputs.next_transition) && (needs.detect.outputs.next_transition == 'complete-release-audit' || needs.record-audit-dispatch.result == 'success')",
-            "needs": ["detect", "hydrate", "record-audit-dispatch", "tag"],
+            "needs": [
+              "detect",
+              "hydrate",
+              "record-audit-dispatch",
+              "tag"
+            ],
             "outputs": {
               "audit_artifact_id": "${{ steps.audit-result.outputs.artifact-id }}"
             },
@@ -4742,7 +4854,12 @@
           "id": "dispatch-audit",
           "descriptor": {
             "if": "always() && needs.detect.result == 'success' && needs.hydrate.result == 'success' && needs.tag.result == 'success' && needs.tag.outputs.continue == 'true' && github.ref == format('refs/tags/v{0}', inputs.version) && github.sha == needs.detect.outputs.candidate_sha && inputs.version == needs.detect.outputs.candidate_version && inputs.commitSha == needs.detect.outputs.candidate_sha && inputs.operation == 'reconcile' && contains(fromJSON('[\"prepare-artifacts\",\"attest-artifacts\",\"escrow-candidate\",\"publish-npm-packages\",\"resume-npm-publish\",\"reconcile-npm-evidence\",\"run-release-smokes\",\"reconcile-smoke-evidence\",\"dispatch-release-audit\"]'), needs.detect.outputs.next_transition) && (needs.detect.outputs.next_transition == 'dispatch-release-audit' || needs.reconcile-smokes.result == 'success')",
-            "needs": ["detect", "hydrate", "reconcile-smokes", "tag"],
+            "needs": [
+              "detect",
+              "hydrate",
+              "reconcile-smokes",
+              "tag"
+            ],
             "outputs": {
               "dispatch_artifact_id": "${{ steps.receipt.outputs.artifact-id }}"
             },
@@ -4806,7 +4923,12 @@
           "id": "escrow",
           "descriptor": {
             "if": "always() && needs.attest.result == 'success' && needs.detect.result == 'success' && needs.hydrate.result == 'success' && needs.tag.result == 'success' && needs.tag.outputs.continue == 'true' && github.ref == format('refs/tags/v{0}', inputs.version) && github.sha == needs.detect.outputs.candidate_sha && inputs.version == needs.detect.outputs.candidate_version && inputs.commitSha == needs.detect.outputs.candidate_sha && inputs.operation == 'reconcile' && contains(fromJSON('[\"prepare-artifacts\",\"attest-artifacts\",\"escrow-candidate\"]'), needs.detect.outputs.next_transition)",
-            "needs": ["attest", "detect", "hydrate", "tag"],
+            "needs": [
+              "attest",
+              "detect",
+              "hydrate",
+              "tag"
+            ],
             "permissions": {
               "actions": "read",
               "attestations": "read",
@@ -4876,7 +4998,11 @@
           "id": "hydrate",
           "descriptor": {
             "if": "always() && needs.detect.result == 'success' && needs.tag.result == 'success' && needs.tag.outputs.continue == 'true' && github.ref == format('refs/tags/v{0}', inputs.version) && github.sha == needs.detect.outputs.candidate_sha && inputs.version == needs.detect.outputs.candidate_version && inputs.commitSha == needs.detect.outputs.candidate_sha && inputs.operation == 'reconcile' && contains(fromJSON('[\"prepare-artifacts\",\"attest-artifacts\",\"escrow-candidate\",\"publish-npm-packages\",\"resume-npm-publish\",\"reconcile-npm-evidence\",\"run-release-smokes\",\"reconcile-smoke-evidence\",\"dispatch-release-audit\",\"complete-release-audit\",\"publish-github-release\"]'), needs.detect.outputs.next_transition) && (needs.detect.outputs.next_transition != 'prepare-artifacts' || needs.prepare.result == 'success')",
-            "needs": ["detect", "prepare", "tag"],
+            "needs": [
+              "detect",
+              "prepare",
+              "tag"
+            ],
             "outputs": {
               "artifact_id": "${{ steps.runtime.outputs.artifact-id }}",
               "manifest_sha256": "${{ steps.identity.outputs.manifest_sha256 }}"
@@ -5030,7 +5156,10 @@
           "id": "prepare",
           "descriptor": {
             "if": "needs.tag.outputs.continue == 'true' && github.ref == format('refs/tags/v{0}', inputs.version) && github.sha == needs.detect.outputs.candidate_sha && inputs.version == needs.detect.outputs.candidate_version && inputs.commitSha == needs.detect.outputs.candidate_sha && inputs.operation == 'reconcile' && needs.detect.outputs.next_transition == 'prepare-artifacts'",
-            "needs": ["detect", "tag"],
+            "needs": [
+              "detect",
+              "tag"
+            ],
             "outputs": {
               "handoff_artifact_id": "${{ steps.handoff.outputs.artifact-id }}",
               "manifest_sha256": "${{ steps.identity.outputs.manifest_sha256 }}",
@@ -5159,7 +5288,12 @@
           "id": "publish-npm",
           "descriptor": {
             "if": "always() && needs.detect.result == 'success' && needs.hydrate.result == 'success' && needs.tag.result == 'success' && needs.tag.outputs.continue == 'true' && github.ref == format('refs/tags/v{0}', inputs.version) && github.sha == needs.detect.outputs.candidate_sha && inputs.version == needs.detect.outputs.candidate_version && inputs.commitSha == needs.detect.outputs.candidate_sha && inputs.operation == 'reconcile' && contains(fromJSON('[\"prepare-artifacts\",\"attest-artifacts\",\"escrow-candidate\",\"publish-npm-packages\",\"resume-npm-publish\"]'), needs.detect.outputs.next_transition) && (!contains(fromJSON('[\"prepare-artifacts\",\"attest-artifacts\",\"escrow-candidate\"]'), needs.detect.outputs.next_transition) || needs.escrow.result == 'success')",
-            "needs": ["detect", "escrow", "hydrate", "tag"],
+            "needs": [
+              "detect",
+              "escrow",
+              "hydrate",
+              "tag"
+            ],
             "outputs": {
               "npm_artifact_id": "${{ steps.npm.outputs.artifact-id }}"
             },
@@ -5250,7 +5384,12 @@
           "id": "publish-release",
           "descriptor": {
             "if": "always() && needs.detect.result == 'success' && needs.hydrate.result == 'success' && needs.tag.result == 'success' && needs.tag.outputs.continue == 'true' && github.ref == format('refs/tags/v{0}', inputs.version) && github.sha == needs.detect.outputs.candidate_sha && inputs.version == needs.detect.outputs.candidate_version && inputs.commitSha == needs.detect.outputs.candidate_sha && inputs.operation == 'reconcile' && contains(fromJSON('[\"prepare-artifacts\",\"attest-artifacts\",\"escrow-candidate\",\"publish-npm-packages\",\"resume-npm-publish\",\"reconcile-npm-evidence\",\"run-release-smokes\",\"reconcile-smoke-evidence\",\"dispatch-release-audit\",\"complete-release-audit\",\"publish-github-release\"]'), needs.detect.outputs.next_transition) && (needs.detect.outputs.next_transition == 'publish-github-release' || needs.correlate-audit.result == 'success')",
-            "needs": ["correlate-audit", "detect", "hydrate", "tag"],
+            "needs": [
+              "correlate-audit",
+              "detect",
+              "hydrate",
+              "tag"
+            ],
             "permissions": {
               "actions": "read",
               "contents": "write"
@@ -5328,7 +5467,12 @@
           "id": "reconcile-npm",
           "descriptor": {
             "if": "always() && needs.detect.result == 'success' && needs.hydrate.result == 'success' && needs.tag.result == 'success' && needs.tag.outputs.continue == 'true' && github.ref == format('refs/tags/v{0}', inputs.version) && github.sha == needs.detect.outputs.candidate_sha && inputs.version == needs.detect.outputs.candidate_version && inputs.commitSha == needs.detect.outputs.candidate_sha && inputs.operation == 'reconcile' && contains(fromJSON('[\"prepare-artifacts\",\"attest-artifacts\",\"escrow-candidate\",\"publish-npm-packages\",\"resume-npm-publish\",\"reconcile-npm-evidence\"]'), needs.detect.outputs.next_transition) && (needs.detect.outputs.next_transition == 'reconcile-npm-evidence' || needs.publish-npm.result == 'success')",
-            "needs": ["detect", "hydrate", "publish-npm", "tag"],
+            "needs": [
+              "detect",
+              "hydrate",
+              "publish-npm",
+              "tag"
+            ],
             "permissions": {
               "actions": "read",
               "contents": "write"
@@ -5514,7 +5658,12 @@
           "id": "record-audit-dispatch",
           "descriptor": {
             "if": "always() && needs.detect.result == 'success' && needs.dispatch-audit.result == 'success' && needs.hydrate.result == 'success' && needs.tag.result == 'success' && needs.tag.outputs.continue == 'true' && github.ref == format('refs/tags/v{0}', inputs.version) && github.sha == needs.detect.outputs.candidate_sha && inputs.version == needs.detect.outputs.candidate_version && inputs.commitSha == needs.detect.outputs.candidate_sha && inputs.operation == 'reconcile' && contains(fromJSON('[\"prepare-artifacts\",\"attest-artifacts\",\"escrow-candidate\",\"publish-npm-packages\",\"resume-npm-publish\",\"reconcile-npm-evidence\",\"run-release-smokes\",\"reconcile-smoke-evidence\",\"dispatch-release-audit\"]'), needs.detect.outputs.next_transition)",
-            "needs": ["detect", "dispatch-audit", "hydrate", "tag"],
+            "needs": [
+              "detect",
+              "dispatch-audit",
+              "hydrate",
+              "tag"
+            ],
             "outputs": {
               "dispatch_artifact_id": "${{ needs.dispatch-audit.outputs.dispatch_artifact_id }}"
             },
@@ -5586,7 +5735,12 @@
           "id": "smoke-metadata",
           "descriptor": {
             "if": "always() && needs.detect.result == 'success' && needs.hydrate.result == 'success' && needs.tag.result == 'success' && needs.tag.outputs.continue == 'true' && github.ref == format('refs/tags/v{0}', inputs.version) && github.sha == needs.detect.outputs.candidate_sha && inputs.version == needs.detect.outputs.candidate_version && inputs.commitSha == needs.detect.outputs.candidate_sha && inputs.operation == 'reconcile' && contains(fromJSON('[\"prepare-artifacts\",\"attest-artifacts\",\"escrow-candidate\",\"publish-npm-packages\",\"resume-npm-publish\",\"reconcile-npm-evidence\",\"run-release-smokes\",\"reconcile-smoke-evidence\"]'), needs.detect.outputs.next_transition) && (contains(fromJSON('[\"run-release-smokes\",\"reconcile-smoke-evidence\"]'), needs.detect.outputs.next_transition) || needs.reconcile-npm.result == 'success')",
-            "needs": ["detect", "hydrate", "reconcile-npm", "tag"],
+            "needs": [
+              "detect",
+              "hydrate",
+              "reconcile-npm",
+              "tag"
+            ],
             "outputs": {
               "artifact_id": "${{ steps.result.outputs.artifact-id }}"
             },
@@ -5670,7 +5824,12 @@
           "id": "smoke-published-harness",
           "descriptor": {
             "if": "always() && needs.detect.result == 'success' && needs.hydrate.result == 'success' && needs.tag.result == 'success' && needs.tag.outputs.continue == 'true' && github.ref == format('refs/tags/v{0}', inputs.version) && github.sha == needs.detect.outputs.candidate_sha && inputs.version == needs.detect.outputs.candidate_version && inputs.commitSha == needs.detect.outputs.candidate_sha && inputs.operation == 'reconcile' && contains(fromJSON('[\"prepare-artifacts\",\"attest-artifacts\",\"escrow-candidate\",\"publish-npm-packages\",\"resume-npm-publish\",\"reconcile-npm-evidence\",\"run-release-smokes\",\"reconcile-smoke-evidence\"]'), needs.detect.outputs.next_transition) && (contains(fromJSON('[\"run-release-smokes\",\"reconcile-smoke-evidence\"]'), needs.detect.outputs.next_transition) || needs.reconcile-npm.result == 'success')",
-            "needs": ["detect", "hydrate", "reconcile-npm", "tag"],
+            "needs": [
+              "detect",
+              "hydrate",
+              "reconcile-npm",
+              "tag"
+            ],
             "outputs": {
               "artifact_id": "${{ steps.result.outputs.artifact-id }}"
             },
@@ -5751,7 +5910,12 @@
           "id": "smoke-runtime-targets",
           "descriptor": {
             "if": "always() && needs.detect.result == 'success' && needs.hydrate.result == 'success' && needs.tag.result == 'success' && needs.tag.outputs.continue == 'true' && github.ref == format('refs/tags/v{0}', inputs.version) && github.sha == needs.detect.outputs.candidate_sha && inputs.version == needs.detect.outputs.candidate_version && inputs.commitSha == needs.detect.outputs.candidate_sha && inputs.operation == 'reconcile' && contains(fromJSON('[\"prepare-artifacts\",\"attest-artifacts\",\"escrow-candidate\",\"publish-npm-packages\",\"resume-npm-publish\",\"reconcile-npm-evidence\",\"run-release-smokes\",\"reconcile-smoke-evidence\"]'), needs.detect.outputs.next_transition) && (contains(fromJSON('[\"run-release-smokes\",\"reconcile-smoke-evidence\"]'), needs.detect.outputs.next_transition) || needs.reconcile-npm.result == 'success')",
-            "needs": ["detect", "hydrate", "reconcile-npm", "tag"],
+            "needs": [
+              "detect",
+              "hydrate",
+              "reconcile-npm",
+              "tag"
+            ],
             "outputs": {
               "artifact_id": "${{ steps.result.outputs.artifact-id }}"
             },
@@ -5832,7 +5996,12 @@
           "id": "smoke-scaffold",
           "descriptor": {
             "if": "always() && needs.detect.result == 'success' && needs.hydrate.result == 'success' && needs.tag.result == 'success' && needs.tag.outputs.continue == 'true' && github.ref == format('refs/tags/v{0}', inputs.version) && github.sha == needs.detect.outputs.candidate_sha && inputs.version == needs.detect.outputs.candidate_version && inputs.commitSha == needs.detect.outputs.candidate_sha && inputs.operation == 'reconcile' && contains(fromJSON('[\"prepare-artifacts\",\"attest-artifacts\",\"escrow-candidate\",\"publish-npm-packages\",\"resume-npm-publish\",\"reconcile-npm-evidence\",\"run-release-smokes\",\"reconcile-smoke-evidence\"]'), needs.detect.outputs.next_transition) && (contains(fromJSON('[\"run-release-smokes\",\"reconcile-smoke-evidence\"]'), needs.detect.outputs.next_transition) || needs.reconcile-npm.result == 'success')",
-            "needs": ["detect", "hydrate", "reconcile-npm", "tag"],
+            "needs": [
+              "detect",
+              "hydrate",
+              "reconcile-npm",
+              "tag"
+            ],
             "outputs": {
               "artifact_id": "${{ steps.result.outputs.artifact-id }}"
             },
@@ -5913,7 +6082,12 @@
           "id": "smoke-storage",
           "descriptor": {
             "if": "always() && needs.detect.result == 'success' && needs.hydrate.result == 'success' && needs.tag.result == 'success' && needs.tag.outputs.continue == 'true' && github.ref == format('refs/tags/v{0}', inputs.version) && github.sha == needs.detect.outputs.candidate_sha && inputs.version == needs.detect.outputs.candidate_version && inputs.commitSha == needs.detect.outputs.candidate_sha && inputs.operation == 'reconcile' && contains(fromJSON('[\"prepare-artifacts\",\"attest-artifacts\",\"escrow-candidate\",\"publish-npm-packages\",\"resume-npm-publish\",\"reconcile-npm-evidence\",\"run-release-smokes\",\"reconcile-smoke-evidence\"]'), needs.detect.outputs.next_transition) && (contains(fromJSON('[\"run-release-smokes\",\"reconcile-smoke-evidence\"]'), needs.detect.outputs.next_transition) || needs.reconcile-npm.result == 'success')",
-            "needs": ["detect", "hydrate", "reconcile-npm", "tag"],
+            "needs": [
+              "detect",
+              "hydrate",
+              "reconcile-npm",
+              "tag"
+            ],
             "outputs": {
               "artifact_id": "${{ steps.result.outputs.artifact-id }}"
             },
@@ -6071,7 +6245,9 @@
         "on": {
           "branch_protection_rule": null,
           "push": {
-            "branches": ["main"]
+            "branches": [
+              "main"
+            ]
           },
           "schedule": [
             {
@@ -6141,7 +6317,9 @@
         "name": "Version Packages",
         "on": {
           "push": {
-            "branches": ["main"]
+            "branches": [
+              "main"
+            ]
           }
         },
         "permissions": {

--- a/scripts/release/test/fixtures/workflow-entrypoints.json
+++ b/scripts/release/test/fixtures/workflow-entrypoints.json
@@ -7,11 +7,7 @@
         "name": "Auto Approve",
         "on": {
           "pull_request": {
-            "types": [
-              "opened",
-              "reopened",
-              "ready_for_review"
-            ]
+            "types": ["opened", "reopened", "ready_for_review"]
           }
         },
         "permissions": {
@@ -54,9 +50,7 @@
         "on": {
           "pull_request": null,
           "push": {
-            "branches": [
-              "main"
-            ]
+            "branches": ["main"]
           }
         },
         "permissions": {
@@ -1826,12 +1820,7 @@
         "name": "Claude Review",
         "on": {
           "pull_request": {
-            "types": [
-              "opened",
-              "synchronize",
-              "reopened",
-              "ready_for_review"
-            ]
+            "types": ["opened", "synchronize", "reopened", "ready_for_review"]
           }
         },
         "permissions": {
@@ -1911,14 +1900,10 @@
         "name": "CodeQL",
         "on": {
           "pull_request": {
-            "branches": [
-              "main"
-            ]
+            "branches": ["main"]
           },
           "push": {
-            "branches": [
-              "main"
-            ]
+            "branches": ["main"]
           },
           "schedule": [
             {
@@ -2294,10 +2279,7 @@
           "descriptor": {
             "if": "always()",
             "name": "kubernetes-compat",
-            "needs": [
-              "scope",
-              "compat"
-            ],
+            "needs": ["scope", "compat"],
             "runs-on": "ubuntu-latest",
             "timeout-minutes": 5
           },
@@ -2389,13 +2371,8 @@
         "name": "Publish Chart",
         "on": {
           "push": {
-            "branches": [
-              "main"
-            ],
-            "paths": [
-              "charts/b4-sandbox-infra/**",
-              "charts/b4-app/**"
-            ]
+            "branches": ["main"],
+            "paths": ["charts/b4-sandbox-infra/**", "charts/b4-app/**"]
           }
         },
         "permissions": {
@@ -2411,10 +2388,7 @@
             "runs-on": "ubuntu-latest",
             "strategy": {
               "matrix": {
-                "chart": [
-                  "b4-sandbox-infra",
-                  "b4-app"
-                ]
+                "chart": ["b4-sandbox-infra", "b4-app"]
               }
             },
             "timeout-minutes": 10
@@ -3034,9 +3008,7 @@
           "descriptor": {
             "if": "always() && needs.recovery-admit.result == 'success'",
             "name": "recovery-adopt",
-            "needs": [
-              "recovery-admit"
-            ],
+            "needs": ["recovery-admit"],
             "permissions": {
               "actions": "read",
               "attestations": "read",
@@ -3140,11 +3112,7 @@
           "descriptor": {
             "if": "always() && needs.recovery-admit.result == 'success' && needs.recovery-adopt.result == 'success' && needs.recovery-admit.outputs.audit == 'true' && (needs.recovery-admit.outputs.dispatch == 'false' || needs.recovery-dispatch-audit.result == 'success')",
             "name": "recovery-audit-evidence",
-            "needs": [
-              "recovery-admit",
-              "recovery-adopt",
-              "recovery-dispatch-audit"
-            ],
+            "needs": ["recovery-admit", "recovery-adopt", "recovery-dispatch-audit"],
             "permissions": {
               "actions": "read",
               "attestations": "read",
@@ -3248,11 +3216,7 @@
           "descriptor": {
             "if": "always() && needs.recovery-admit.result == 'success' && needs.recovery-adopt.result == 'success' && needs.recovery-admit.outputs.dispatch == 'true' && (needs.recovery-admit.outputs.evidence == 'false' || needs.recovery-evidence.result == 'success')",
             "name": "recovery-dispatch-audit",
-            "needs": [
-              "recovery-admit",
-              "recovery-adopt",
-              "recovery-evidence"
-            ],
+            "needs": ["recovery-admit", "recovery-adopt", "recovery-evidence"],
             "permissions": {
               "actions": "write",
               "attestations": "read",
@@ -3468,11 +3432,7 @@
           "descriptor": {
             "if": "always() && needs.recovery-admit.result == 'success' && needs.recovery-adopt.result == 'success' && needs.recovery-admit.outputs.finalize == 'true' && (needs.recovery-admit.outputs.audit == 'false' || needs.recovery-audit-evidence.result == 'success')",
             "name": "recovery-finalize",
-            "needs": [
-              "recovery-admit",
-              "recovery-adopt",
-              "recovery-audit-evidence"
-            ],
+            "needs": ["recovery-admit", "recovery-adopt", "recovery-audit-evidence"],
             "permissions": {
               "actions": "read",
               "attestations": "read",
@@ -3577,10 +3537,7 @@
           "descriptor": {
             "if": "always() && needs.recovery-admit.result == 'success' && needs.recovery-adopt.result == 'success' && needs.recovery-admit.outputs.smoke == 'true'",
             "name": "recovery-metadata",
-            "needs": [
-              "recovery-admit",
-              "recovery-adopt"
-            ],
+            "needs": ["recovery-admit", "recovery-adopt"],
             "permissions": {
               "actions": "read",
               "attestations": "read",
@@ -3710,11 +3667,7 @@
           "descriptor": {
             "if": "always() && needs.recovery-admit.result == 'success' && needs.recovery-adopt.result == 'success' && needs.recovery-admit.outputs.publish == 'true' && (needs.recovery-admit.outputs.finalize == 'false' || needs.recovery-finalize.result == 'success')",
             "name": "recovery-publish",
-            "needs": [
-              "recovery-admit",
-              "recovery-adopt",
-              "recovery-finalize"
-            ],
+            "needs": ["recovery-admit", "recovery-adopt", "recovery-finalize"],
             "permissions": {
               "actions": "read",
               "attestations": "read",
@@ -3819,10 +3772,7 @@
           "descriptor": {
             "if": "always() && needs.recovery-admit.result == 'success' && needs.recovery-adopt.result == 'success' && needs.recovery-admit.outputs.smoke == 'true'",
             "name": "recovery-published-harness",
-            "needs": [
-              "recovery-admit",
-              "recovery-adopt"
-            ],
+            "needs": ["recovery-admit", "recovery-adopt"],
             "permissions": {
               "actions": "read",
               "attestations": "read",
@@ -4070,10 +4020,7 @@
           "descriptor": {
             "if": "always() && needs.recovery-admit.result == 'success' && needs.recovery-adopt.result == 'success' && needs.recovery-admit.outputs.smoke == 'true'",
             "name": "recovery-runtime-targets",
-            "needs": [
-              "recovery-admit",
-              "recovery-adopt"
-            ],
+            "needs": ["recovery-admit", "recovery-adopt"],
             "permissions": {
               "actions": "read",
               "attestations": "read",
@@ -4203,10 +4150,7 @@
           "descriptor": {
             "if": "always() && needs.recovery-admit.result == 'success' && needs.recovery-adopt.result == 'success' && needs.recovery-admit.outputs.smoke == 'true'",
             "name": "recovery-scaffold",
-            "needs": [
-              "recovery-admit",
-              "recovery-adopt"
-            ],
+            "needs": ["recovery-admit", "recovery-adopt"],
             "permissions": {
               "actions": "read",
               "attestations": "read",
@@ -4336,10 +4280,7 @@
           "descriptor": {
             "if": "always() && needs.recovery-admit.result == 'success' && needs.recovery-adopt.result == 'success' && needs.recovery-admit.outputs.smoke == 'true'",
             "name": "recovery-storage",
-            "needs": [
-              "recovery-admit",
-              "recovery-adopt"
-            ],
+            "needs": ["recovery-admit", "recovery-adopt"],
             "permissions": {
               "actions": "read",
               "attestations": "read",
@@ -4479,9 +4420,7 @@
         "name": "Release",
         "on": {
           "push": {
-            "branches": [
-              "main"
-            ]
+            "branches": ["main"]
           },
           "schedule": [
             {
@@ -4504,9 +4443,7 @@
               "operation": {
                 "default": "reconcile",
                 "description": "Reconcile this candidate",
-                "options": [
-                  "reconcile"
-                ],
+                "options": ["reconcile"],
                 "required": true,
                 "type": "choice"
               },
@@ -4528,11 +4465,7 @@
           "id": "attest",
           "descriptor": {
             "if": "always() && needs.detect.result == 'success' && needs.hydrate.result == 'success' && needs.tag.result == 'success' && needs.tag.outputs.continue == 'true' && github.ref == format('refs/tags/v{0}', inputs.version) && github.sha == needs.detect.outputs.candidate_sha && inputs.version == needs.detect.outputs.candidate_version && inputs.commitSha == needs.detect.outputs.candidate_sha && inputs.operation == 'reconcile' && contains(fromJSON('[\"prepare-artifacts\",\"attest-artifacts\",\"escrow-candidate\"]'), needs.detect.outputs.next_transition)",
-            "needs": [
-              "detect",
-              "hydrate",
-              "tag"
-            ],
+            "needs": ["detect", "hydrate", "tag"],
             "outputs": {
               "attestation_artifact_id": "${{ steps.evidence.outputs.artifact-id }}"
             },
@@ -4627,12 +4560,7 @@
           "id": "correlate-audit",
           "descriptor": {
             "if": "always() && needs.detect.result == 'success' && needs.hydrate.result == 'success' && needs.tag.result == 'success' && needs.tag.outputs.continue == 'true' && github.ref == format('refs/tags/v{0}', inputs.version) && github.sha == needs.detect.outputs.candidate_sha && inputs.version == needs.detect.outputs.candidate_version && inputs.commitSha == needs.detect.outputs.candidate_sha && inputs.operation == 'reconcile' && contains(fromJSON('[\"prepare-artifacts\",\"attest-artifacts\",\"escrow-candidate\",\"publish-npm-packages\",\"resume-npm-publish\",\"reconcile-npm-evidence\",\"run-release-smokes\",\"reconcile-smoke-evidence\",\"dispatch-release-audit\",\"complete-release-audit\"]'), needs.detect.outputs.next_transition) && (needs.detect.outputs.next_transition == 'complete-release-audit' || needs.record-audit-dispatch.result == 'success')",
-            "needs": [
-              "detect",
-              "hydrate",
-              "record-audit-dispatch",
-              "tag"
-            ],
+            "needs": ["detect", "hydrate", "record-audit-dispatch", "tag"],
             "outputs": {
               "audit_artifact_id": "${{ steps.audit-result.outputs.artifact-id }}"
             },
@@ -4854,12 +4782,7 @@
           "id": "dispatch-audit",
           "descriptor": {
             "if": "always() && needs.detect.result == 'success' && needs.hydrate.result == 'success' && needs.tag.result == 'success' && needs.tag.outputs.continue == 'true' && github.ref == format('refs/tags/v{0}', inputs.version) && github.sha == needs.detect.outputs.candidate_sha && inputs.version == needs.detect.outputs.candidate_version && inputs.commitSha == needs.detect.outputs.candidate_sha && inputs.operation == 'reconcile' && contains(fromJSON('[\"prepare-artifacts\",\"attest-artifacts\",\"escrow-candidate\",\"publish-npm-packages\",\"resume-npm-publish\",\"reconcile-npm-evidence\",\"run-release-smokes\",\"reconcile-smoke-evidence\",\"dispatch-release-audit\"]'), needs.detect.outputs.next_transition) && (needs.detect.outputs.next_transition == 'dispatch-release-audit' || needs.reconcile-smokes.result == 'success')",
-            "needs": [
-              "detect",
-              "hydrate",
-              "reconcile-smokes",
-              "tag"
-            ],
+            "needs": ["detect", "hydrate", "reconcile-smokes", "tag"],
             "outputs": {
               "dispatch_artifact_id": "${{ steps.receipt.outputs.artifact-id }}"
             },
@@ -4923,12 +4846,7 @@
           "id": "escrow",
           "descriptor": {
             "if": "always() && needs.attest.result == 'success' && needs.detect.result == 'success' && needs.hydrate.result == 'success' && needs.tag.result == 'success' && needs.tag.outputs.continue == 'true' && github.ref == format('refs/tags/v{0}', inputs.version) && github.sha == needs.detect.outputs.candidate_sha && inputs.version == needs.detect.outputs.candidate_version && inputs.commitSha == needs.detect.outputs.candidate_sha && inputs.operation == 'reconcile' && contains(fromJSON('[\"prepare-artifacts\",\"attest-artifacts\",\"escrow-candidate\"]'), needs.detect.outputs.next_transition)",
-            "needs": [
-              "attest",
-              "detect",
-              "hydrate",
-              "tag"
-            ],
+            "needs": ["attest", "detect", "hydrate", "tag"],
             "permissions": {
               "actions": "read",
               "attestations": "read",
@@ -4998,11 +4916,7 @@
           "id": "hydrate",
           "descriptor": {
             "if": "always() && needs.detect.result == 'success' && needs.tag.result == 'success' && needs.tag.outputs.continue == 'true' && github.ref == format('refs/tags/v{0}', inputs.version) && github.sha == needs.detect.outputs.candidate_sha && inputs.version == needs.detect.outputs.candidate_version && inputs.commitSha == needs.detect.outputs.candidate_sha && inputs.operation == 'reconcile' && contains(fromJSON('[\"prepare-artifacts\",\"attest-artifacts\",\"escrow-candidate\",\"publish-npm-packages\",\"resume-npm-publish\",\"reconcile-npm-evidence\",\"run-release-smokes\",\"reconcile-smoke-evidence\",\"dispatch-release-audit\",\"complete-release-audit\",\"publish-github-release\"]'), needs.detect.outputs.next_transition) && (needs.detect.outputs.next_transition != 'prepare-artifacts' || needs.prepare.result == 'success')",
-            "needs": [
-              "detect",
-              "prepare",
-              "tag"
-            ],
+            "needs": ["detect", "prepare", "tag"],
             "outputs": {
               "artifact_id": "${{ steps.runtime.outputs.artifact-id }}",
               "manifest_sha256": "${{ steps.identity.outputs.manifest_sha256 }}"
@@ -5156,10 +5070,7 @@
           "id": "prepare",
           "descriptor": {
             "if": "needs.tag.outputs.continue == 'true' && github.ref == format('refs/tags/v{0}', inputs.version) && github.sha == needs.detect.outputs.candidate_sha && inputs.version == needs.detect.outputs.candidate_version && inputs.commitSha == needs.detect.outputs.candidate_sha && inputs.operation == 'reconcile' && needs.detect.outputs.next_transition == 'prepare-artifacts'",
-            "needs": [
-              "detect",
-              "tag"
-            ],
+            "needs": ["detect", "tag"],
             "outputs": {
               "handoff_artifact_id": "${{ steps.handoff.outputs.artifact-id }}",
               "manifest_sha256": "${{ steps.identity.outputs.manifest_sha256 }}",
@@ -5288,12 +5199,7 @@
           "id": "publish-npm",
           "descriptor": {
             "if": "always() && needs.detect.result == 'success' && needs.hydrate.result == 'success' && needs.tag.result == 'success' && needs.tag.outputs.continue == 'true' && github.ref == format('refs/tags/v{0}', inputs.version) && github.sha == needs.detect.outputs.candidate_sha && inputs.version == needs.detect.outputs.candidate_version && inputs.commitSha == needs.detect.outputs.candidate_sha && inputs.operation == 'reconcile' && contains(fromJSON('[\"prepare-artifacts\",\"attest-artifacts\",\"escrow-candidate\",\"publish-npm-packages\",\"resume-npm-publish\"]'), needs.detect.outputs.next_transition) && (!contains(fromJSON('[\"prepare-artifacts\",\"attest-artifacts\",\"escrow-candidate\"]'), needs.detect.outputs.next_transition) || needs.escrow.result == 'success')",
-            "needs": [
-              "detect",
-              "escrow",
-              "hydrate",
-              "tag"
-            ],
+            "needs": ["detect", "escrow", "hydrate", "tag"],
             "outputs": {
               "npm_artifact_id": "${{ steps.npm.outputs.artifact-id }}"
             },
@@ -5384,12 +5290,7 @@
           "id": "publish-release",
           "descriptor": {
             "if": "always() && needs.detect.result == 'success' && needs.hydrate.result == 'success' && needs.tag.result == 'success' && needs.tag.outputs.continue == 'true' && github.ref == format('refs/tags/v{0}', inputs.version) && github.sha == needs.detect.outputs.candidate_sha && inputs.version == needs.detect.outputs.candidate_version && inputs.commitSha == needs.detect.outputs.candidate_sha && inputs.operation == 'reconcile' && contains(fromJSON('[\"prepare-artifacts\",\"attest-artifacts\",\"escrow-candidate\",\"publish-npm-packages\",\"resume-npm-publish\",\"reconcile-npm-evidence\",\"run-release-smokes\",\"reconcile-smoke-evidence\",\"dispatch-release-audit\",\"complete-release-audit\",\"publish-github-release\"]'), needs.detect.outputs.next_transition) && (needs.detect.outputs.next_transition == 'publish-github-release' || needs.correlate-audit.result == 'success')",
-            "needs": [
-              "correlate-audit",
-              "detect",
-              "hydrate",
-              "tag"
-            ],
+            "needs": ["correlate-audit", "detect", "hydrate", "tag"],
             "permissions": {
               "actions": "read",
               "contents": "write"
@@ -5467,12 +5368,7 @@
           "id": "reconcile-npm",
           "descriptor": {
             "if": "always() && needs.detect.result == 'success' && needs.hydrate.result == 'success' && needs.tag.result == 'success' && needs.tag.outputs.continue == 'true' && github.ref == format('refs/tags/v{0}', inputs.version) && github.sha == needs.detect.outputs.candidate_sha && inputs.version == needs.detect.outputs.candidate_version && inputs.commitSha == needs.detect.outputs.candidate_sha && inputs.operation == 'reconcile' && contains(fromJSON('[\"prepare-artifacts\",\"attest-artifacts\",\"escrow-candidate\",\"publish-npm-packages\",\"resume-npm-publish\",\"reconcile-npm-evidence\"]'), needs.detect.outputs.next_transition) && (needs.detect.outputs.next_transition == 'reconcile-npm-evidence' || needs.publish-npm.result == 'success')",
-            "needs": [
-              "detect",
-              "hydrate",
-              "publish-npm",
-              "tag"
-            ],
+            "needs": ["detect", "hydrate", "publish-npm", "tag"],
             "permissions": {
               "actions": "read",
               "contents": "write"
@@ -5658,12 +5554,7 @@
           "id": "record-audit-dispatch",
           "descriptor": {
             "if": "always() && needs.detect.result == 'success' && needs.dispatch-audit.result == 'success' && needs.hydrate.result == 'success' && needs.tag.result == 'success' && needs.tag.outputs.continue == 'true' && github.ref == format('refs/tags/v{0}', inputs.version) && github.sha == needs.detect.outputs.candidate_sha && inputs.version == needs.detect.outputs.candidate_version && inputs.commitSha == needs.detect.outputs.candidate_sha && inputs.operation == 'reconcile' && contains(fromJSON('[\"prepare-artifacts\",\"attest-artifacts\",\"escrow-candidate\",\"publish-npm-packages\",\"resume-npm-publish\",\"reconcile-npm-evidence\",\"run-release-smokes\",\"reconcile-smoke-evidence\",\"dispatch-release-audit\"]'), needs.detect.outputs.next_transition)",
-            "needs": [
-              "detect",
-              "dispatch-audit",
-              "hydrate",
-              "tag"
-            ],
+            "needs": ["detect", "dispatch-audit", "hydrate", "tag"],
             "outputs": {
               "dispatch_artifact_id": "${{ needs.dispatch-audit.outputs.dispatch_artifact_id }}"
             },
@@ -5735,12 +5626,7 @@
           "id": "smoke-metadata",
           "descriptor": {
             "if": "always() && needs.detect.result == 'success' && needs.hydrate.result == 'success' && needs.tag.result == 'success' && needs.tag.outputs.continue == 'true' && github.ref == format('refs/tags/v{0}', inputs.version) && github.sha == needs.detect.outputs.candidate_sha && inputs.version == needs.detect.outputs.candidate_version && inputs.commitSha == needs.detect.outputs.candidate_sha && inputs.operation == 'reconcile' && contains(fromJSON('[\"prepare-artifacts\",\"attest-artifacts\",\"escrow-candidate\",\"publish-npm-packages\",\"resume-npm-publish\",\"reconcile-npm-evidence\",\"run-release-smokes\",\"reconcile-smoke-evidence\"]'), needs.detect.outputs.next_transition) && (contains(fromJSON('[\"run-release-smokes\",\"reconcile-smoke-evidence\"]'), needs.detect.outputs.next_transition) || needs.reconcile-npm.result == 'success')",
-            "needs": [
-              "detect",
-              "hydrate",
-              "reconcile-npm",
-              "tag"
-            ],
+            "needs": ["detect", "hydrate", "reconcile-npm", "tag"],
             "outputs": {
               "artifact_id": "${{ steps.result.outputs.artifact-id }}"
             },
@@ -5824,12 +5710,7 @@
           "id": "smoke-published-harness",
           "descriptor": {
             "if": "always() && needs.detect.result == 'success' && needs.hydrate.result == 'success' && needs.tag.result == 'success' && needs.tag.outputs.continue == 'true' && github.ref == format('refs/tags/v{0}', inputs.version) && github.sha == needs.detect.outputs.candidate_sha && inputs.version == needs.detect.outputs.candidate_version && inputs.commitSha == needs.detect.outputs.candidate_sha && inputs.operation == 'reconcile' && contains(fromJSON('[\"prepare-artifacts\",\"attest-artifacts\",\"escrow-candidate\",\"publish-npm-packages\",\"resume-npm-publish\",\"reconcile-npm-evidence\",\"run-release-smokes\",\"reconcile-smoke-evidence\"]'), needs.detect.outputs.next_transition) && (contains(fromJSON('[\"run-release-smokes\",\"reconcile-smoke-evidence\"]'), needs.detect.outputs.next_transition) || needs.reconcile-npm.result == 'success')",
-            "needs": [
-              "detect",
-              "hydrate",
-              "reconcile-npm",
-              "tag"
-            ],
+            "needs": ["detect", "hydrate", "reconcile-npm", "tag"],
             "outputs": {
               "artifact_id": "${{ steps.result.outputs.artifact-id }}"
             },
@@ -5910,12 +5791,7 @@
           "id": "smoke-runtime-targets",
           "descriptor": {
             "if": "always() && needs.detect.result == 'success' && needs.hydrate.result == 'success' && needs.tag.result == 'success' && needs.tag.outputs.continue == 'true' && github.ref == format('refs/tags/v{0}', inputs.version) && github.sha == needs.detect.outputs.candidate_sha && inputs.version == needs.detect.outputs.candidate_version && inputs.commitSha == needs.detect.outputs.candidate_sha && inputs.operation == 'reconcile' && contains(fromJSON('[\"prepare-artifacts\",\"attest-artifacts\",\"escrow-candidate\",\"publish-npm-packages\",\"resume-npm-publish\",\"reconcile-npm-evidence\",\"run-release-smokes\",\"reconcile-smoke-evidence\"]'), needs.detect.outputs.next_transition) && (contains(fromJSON('[\"run-release-smokes\",\"reconcile-smoke-evidence\"]'), needs.detect.outputs.next_transition) || needs.reconcile-npm.result == 'success')",
-            "needs": [
-              "detect",
-              "hydrate",
-              "reconcile-npm",
-              "tag"
-            ],
+            "needs": ["detect", "hydrate", "reconcile-npm", "tag"],
             "outputs": {
               "artifact_id": "${{ steps.result.outputs.artifact-id }}"
             },
@@ -5996,12 +5872,7 @@
           "id": "smoke-scaffold",
           "descriptor": {
             "if": "always() && needs.detect.result == 'success' && needs.hydrate.result == 'success' && needs.tag.result == 'success' && needs.tag.outputs.continue == 'true' && github.ref == format('refs/tags/v{0}', inputs.version) && github.sha == needs.detect.outputs.candidate_sha && inputs.version == needs.detect.outputs.candidate_version && inputs.commitSha == needs.detect.outputs.candidate_sha && inputs.operation == 'reconcile' && contains(fromJSON('[\"prepare-artifacts\",\"attest-artifacts\",\"escrow-candidate\",\"publish-npm-packages\",\"resume-npm-publish\",\"reconcile-npm-evidence\",\"run-release-smokes\",\"reconcile-smoke-evidence\"]'), needs.detect.outputs.next_transition) && (contains(fromJSON('[\"run-release-smokes\",\"reconcile-smoke-evidence\"]'), needs.detect.outputs.next_transition) || needs.reconcile-npm.result == 'success')",
-            "needs": [
-              "detect",
-              "hydrate",
-              "reconcile-npm",
-              "tag"
-            ],
+            "needs": ["detect", "hydrate", "reconcile-npm", "tag"],
             "outputs": {
               "artifact_id": "${{ steps.result.outputs.artifact-id }}"
             },
@@ -6082,12 +5953,7 @@
           "id": "smoke-storage",
           "descriptor": {
             "if": "always() && needs.detect.result == 'success' && needs.hydrate.result == 'success' && needs.tag.result == 'success' && needs.tag.outputs.continue == 'true' && github.ref == format('refs/tags/v{0}', inputs.version) && github.sha == needs.detect.outputs.candidate_sha && inputs.version == needs.detect.outputs.candidate_version && inputs.commitSha == needs.detect.outputs.candidate_sha && inputs.operation == 'reconcile' && contains(fromJSON('[\"prepare-artifacts\",\"attest-artifacts\",\"escrow-candidate\",\"publish-npm-packages\",\"resume-npm-publish\",\"reconcile-npm-evidence\",\"run-release-smokes\",\"reconcile-smoke-evidence\"]'), needs.detect.outputs.next_transition) && (contains(fromJSON('[\"run-release-smokes\",\"reconcile-smoke-evidence\"]'), needs.detect.outputs.next_transition) || needs.reconcile-npm.result == 'success')",
-            "needs": [
-              "detect",
-              "hydrate",
-              "reconcile-npm",
-              "tag"
-            ],
+            "needs": ["detect", "hydrate", "reconcile-npm", "tag"],
             "outputs": {
               "artifact_id": "${{ steps.result.outputs.artifact-id }}"
             },
@@ -6245,9 +6111,7 @@
         "on": {
           "branch_protection_rule": null,
           "push": {
-            "branches": [
-              "main"
-            ]
+            "branches": ["main"]
           },
           "schedule": [
             {
@@ -6317,9 +6181,7 @@
         "name": "Version Packages",
         "on": {
           "push": {
-            "branches": [
-              "main"
-            ]
+            "branches": ["main"]
           }
         },
         "permissions": {

--- a/scripts/release/test/fixtures/workflow-safe-executables.json
+++ b/scripts/release/test/fixtures/workflow-safe-executables.json
@@ -34,7 +34,7 @@
         "stepIndex": 2,
         "step": "Classify metadata-only change",
         "kind": "run",
-        "value": "set -eu\nMETADATA_ONLY=\"$(node scripts/ci-scope.mjs --event pull_request --base \"$BASE_SHA\" --head \"$HEAD_SHA\")\"\ncase \"$METADATA_ONLY\" in\n  true|false) ;;\n  *) echo \"Malformed metadata-only scope output\" >&2; exit 1 ;;\nesac\nprintf 'metadata_only=%s\\n' \"$METADATA_ONLY\" >> \"$GITHUB_OUTPUT\"\n"
+        "value": "set -eu\nSCOPE_DIR=\"$(mktemp -d)\"\nSCOPE_DIR=\"$(cd \"$SCOPE_DIR\" && pwd -P)\"\ntrap 'rm -rf \"$SCOPE_DIR\"' EXIT\ngit show \"$BASE_SHA:scripts/ci-scope.mjs\" > \"$SCOPE_DIR/ci-scope.mjs\"\nMETADATA_ONLY=\"$(node \"$SCOPE_DIR/ci-scope.mjs\" --event pull_request --base \"$BASE_SHA\" --head \"$HEAD_SHA\")\"\ncase \"$METADATA_ONLY\" in\n  true|false) ;;\n  *) echo \"Malformed metadata-only scope output\" >&2; exit 1 ;;\nesac\nPROSE_ONLY=\"$(node --input-type=module - \"$SCOPE_DIR/ci-scope.mjs\" <<'NODE'\nimport { pathToFileURL } from \"node:url\"\nconst scope = await import(pathToFileURL(process.argv[2]).href)\nconst proseOnly = scope.classifyProseOnlyScope === undefined\n  ? false\n  : await scope.classifyProseOnlyScope({\n      event: \"pull_request\",\n      base: process.env.BASE_SHA,\n      head: process.env.HEAD_SHA,\n    })\nprocess.stdout.write(String(proseOnly))\nNODE\n)\"\ncase \"$PROSE_ONLY\" in\n  true|false) ;;\n  *) echo \"Malformed prose-only scope output\" >&2; exit 1 ;;\nesac\nprintf 'prose_only=%s\\n' \"$PROSE_ONLY\" >> \"$GITHUB_OUTPUT\"\nprintf 'metadata_only=%s\\n' \"$METADATA_ONLY\" >> \"$GITHUB_OUTPUT\"\n"
       },
       {
         "classification": "safe",
@@ -202,7 +202,7 @@
         "stepIndex": 0,
         "step": "Require every validation lane",
         "kind": "run",
-        "value": "for result in \"$LANE_0\" \"$LANE_1\" \"$LANE_2\" \"$LANE_3\"; do\n  if [ \"$result\" != success ]; then\n    echo \"Required validation lane did not succeed: $result\" >&2\n    exit 1\n  fi\ndone\n"
+        "value": "set -eu\nEXPECTED=success\ncase \"$EVENT_NAME\" in\n  pull_request)\n    [ \"$SCOPE_RESULT\" = success ] || { echo \"CI scope did not succeed\" >&2; exit 1; }\n    case \"$PROSE_ONLY:$METADATA_ONLY\" in\n      true:false) EXPECTED=skipped ;;\n      false:true|false:false) ;;\n      *) echo \"Malformed CI scope outputs\" >&2; exit 1 ;;\n    esac\n    ;;\n  push) ;;\n  *) echo \"Unsupported validation event\" >&2; exit 1 ;;\nesac\nfor result in \"$LANE_0\" \"$LANE_1\" \"$LANE_2\" \"$LANE_3\"; do\n  if [ \"$result\" != \"$EXPECTED\" ]; then\n    echo \"Required validation lane did not succeed: $result\" >&2\n    exit 1\n  fi\ndone\n"
       },
       {
         "classification": "safe",

--- a/scripts/release/test/release-integrity.test.mjs
+++ b/scripts/release/test/release-integrity.test.mjs
@@ -77,7 +77,7 @@ test("required validate aggregates independent complete lanes and fails closed",
   )
   const required = ["source-validate", "release-controller", "pack-smoke", "harness-verify"]
   const gate = workflow.jobs.validate
-  assert.deepEqual(gate.needs, required)
+  assert.deepEqual(gate.needs, ["metadata_scope", ...required])
   assert.equal(gate.if, "always()")
   assert.equal(gate["continue-on-error"], undefined)
   assert.equal(gate.steps.length, 1)
@@ -88,12 +88,25 @@ test("required validate aggregates independent complete lanes and fails closed",
   const bindings = Object.fromEntries(
     required.map((name, index) => [`LANE_${index}`, `\${{ needs.${name}.result }}`]),
   )
-  assert.deepEqual(step.env, bindings)
+  assert.deepEqual(step.env, {
+    EVENT_NAME: `\${{ github.event_name }}`,
+    SCOPE_RESULT: `\${{ needs.metadata_scope.result }}`,
+    PROSE_ONLY: `\${{ needs.metadata_scope.outputs.prose_only }}`,
+    METADATA_ONLY: `\${{ needs.metadata_scope.outputs.metadata_only }}`,
+    ...bindings,
+  })
   const success = Object.fromEntries(Object.keys(bindings).map((key) => [key, "success"]))
   const execute = (values) =>
     spawnSync("/bin/sh", ["-c", step.run], {
       encoding: "utf8",
-      env: { PATH: process.env.PATH, ...values },
+      env: {
+        PATH: process.env.PATH,
+        EVENT_NAME: "pull_request",
+        SCOPE_RESULT: "success",
+        PROSE_ONLY: "false",
+        METADATA_ONLY: "false",
+        ...values,
+      },
       timeout: 5000,
     })
   assert.equal(execute(success).status, 0)
@@ -106,8 +119,8 @@ test("required validate aggregates independent complete lanes and fails closed",
   for (const name of required) {
     const job = workflow.jobs[name]
     assert.ok(job, `${name} must exist`)
-    assert.equal(job.if, undefined)
-    assert.equal(job.needs, undefined, `${name} must be independent`)
+    assert.match(job.if, /needs\.metadata_scope\.outputs\.prose_only != 'true'/u)
+    assert.equal(job.needs, "metadata_scope", `${name} depends only on classification`)
     assert.equal(job["continue-on-error"], undefined)
     const checkout = job.steps.find((item) => item.name === "Checkout")
     assert.equal(checkout.with.ref, undefined, "all lanes use the run's default checkout ref")

--- a/scripts/release/test/workflow-contracts.test.mjs
+++ b/scripts/release/test/workflow-contracts.test.mjs
@@ -2001,7 +2001,14 @@ test("testing-windows has the exact safe descriptors and executable classificati
   assert.deepEqual(job, {
     classification: "safe",
     id: "testing-windows",
-    descriptor: { "runs-on": "windows-latest", "timeout-minutes": 20 },
+    descriptor: {
+      if: workflowExpression(
+        "!cancelled() && (github.event_name != 'pull_request' || needs.metadata_scope.result != 'success' || needs.metadata_scope.outputs.prose_only != 'true')",
+      ),
+      needs: "metadata_scope",
+      "runs-on": "windows-latest",
+      "timeout-minutes": 20,
+    },
     steps: [
       {
         classification: "safe",
@@ -2087,6 +2094,10 @@ test("dependency-security-browser has one exact isolated read-only descriptor", 
     classification: "safe",
     id: "dependency-security-browser",
     descriptor: {
+      if: workflowExpression(
+        "!cancelled() && (github.event_name != 'pull_request' || needs.metadata_scope.result != 'success' || needs.metadata_scope.outputs.prose_only != 'true')",
+      ),
+      needs: "metadata_scope",
       permissions: { contents: "read" },
       "runs-on": "ubuntu-latest",
       "timeout-minutes": 15,

--- a/test/k8s-compat/ci-prose-scope.test.ts
+++ b/test/k8s-compat/ci-prose-scope.test.ts
@@ -1,0 +1,456 @@
+import { execFileSync, spawnSync } from "node:child_process"
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs"
+import { tmpdir } from "node:os"
+import { dirname, resolve } from "node:path"
+
+import { describe, expect, test } from "vitest"
+import { parse } from "yaml"
+import type { GitCommandRunner, MetadataOnlyScopeRequest } from "../../scripts/ci-scope.mjs"
+import * as scopeModule from "../../scripts/ci-scope.mjs"
+
+const root = resolve(__dirname, "../..")
+const workflow = parse(readFileSync(resolve(root, ".github/workflows/ci.yml"), "utf8"))
+const prose = "docs/superpowers/runbooks/release.md"
+const classify = (request: MetadataOnlyScopeRequest, runner: GitCommandRunner) =>
+  (
+    scopeModule as typeof scopeModule & {
+      classifyProseOnlyScope: typeof scopeModule.classifyMetadataOnlyScope
+    }
+  ).classifyProseOnlyScope(request, runner)
+
+function repository() {
+  const directory = mkdtempSync(resolve(tmpdir(), "b4-prose-scope-"))
+  const git = (...args: string[]) =>
+    execFileSync("git", args, {
+      cwd: directory,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    }).trim()
+  const write = (file: string, contents = "Runbook notes.\n") => {
+    mkdirSync(dirname(resolve(directory, file)), { recursive: true })
+    writeFileSync(resolve(directory, file), contents)
+  }
+  git("init", "--initial-branch=main")
+  git("config", "user.name", "CI Scope Test")
+  git("config", "user.email", "ci-scope@example.invalid")
+  write("README.md", "Fixture\n")
+  write(prose)
+  git("add", ".")
+  git("commit", "-m", "baseline")
+  const commit = () => {
+    git("add", "-A")
+    git("commit", "--allow-empty", "-m", "fixture change")
+    return git("rev-parse", "HEAD")
+  }
+  const runner: GitCommandRunner = async (file, args) => ({
+    stdout: execFileSync(file, [...args], {
+      cwd: directory,
+      encoding: "buffer",
+      stdio: ["ignore", "pipe", "pipe"],
+    }),
+  })
+  return {
+    directory,
+    git,
+    write,
+    commit,
+    runner,
+    close: () => rmSync(directory, { recursive: true, force: true }),
+  }
+}
+
+describe("prose-only runbook scope", () => {
+  test.each(["edit", "add", "delete", "rename"])(
+    "accepts regular Markdown %s changes",
+    async (operation) => {
+      const repo = repository()
+      try {
+        const base = repo.git("rev-parse", "HEAD")
+        if (operation === "edit") repo.write(prose, "Updated notes.\n")
+        if (operation === "add") repo.write("docs/superpowers/runbooks/nested/new.md")
+        if (operation === "delete") repo.git("rm", prose)
+        if (operation === "rename") repo.git("mv", prose, "docs/superpowers/runbooks/renamed.md")
+        const head = repo.commit()
+        expect(await classify({ event: "pull_request", base, head }, repo.runner)).toBe(true)
+      } finally {
+        repo.close()
+      }
+    },
+  )
+
+  test.each([
+    "README.md",
+    "packages/sdk/src/index.ts",
+    "pnpm-lock.yaml",
+    ".github/workflows/ci.yml",
+    "apps/web/content/docs/intro.mdx",
+    "docs/superpowers/plans/plan.md",
+    "docs/superpowers/runbooks/script.mjs",
+    "docs/superpowers/runbooks/data.json",
+  ])("keeps full coverage when %s changes", async (file) => {
+    const repo = repository()
+    try {
+      const base = repo.git("rev-parse", "HEAD")
+      repo.write(prose, "Updated notes.\n")
+      repo.write(file, "Changed\n")
+      expect(
+        await classify({ event: "pull_request", base, head: repo.commit() }, repo.runner),
+      ).toBe(false)
+    } finally {
+      repo.close()
+    }
+  })
+
+  test.each(["into", "out"])("does not hide renames %s the prose directory", async (direction) => {
+    const repo = repository()
+    try {
+      const base = repo.git("rev-parse", "HEAD")
+      if (direction === "into")
+        repo.git("mv", "README.md", "docs/superpowers/runbooks/from-source.md")
+      else repo.git("mv", prose, "elsewhere.md")
+      expect(
+        await classify({ event: "pull_request", base, head: repo.commit() }, repo.runner),
+      ).toBe(false)
+    } finally {
+      repo.close()
+    }
+  })
+
+  test.each(["executable-add", "executable-remove", "symlink-add", "symlink-remove"])(
+    "rejects non-prose file modes: %s",
+    async (mode) => {
+      const repo = repository()
+      try {
+        const setMode = () => {
+          if (mode.startsWith("executable")) repo.git("update-index", "--chmod=+x", prose)
+          else {
+            rmSync(resolve(repo.directory, prose))
+            symlinkSync("../../../README.md", resolve(repo.directory, prose))
+            repo.git("add", prose)
+          }
+        }
+        if (mode.endsWith("remove")) {
+          setMode()
+          repo.git("commit", "-m", "nonregular baseline")
+        }
+        const base = repo.git("rev-parse", "HEAD")
+        if (mode.endsWith("add")) setMode()
+        else if (mode.startsWith("executable")) repo.git("update-index", "--chmod=-x", prose)
+        else {
+          rmSync(resolve(repo.directory, prose))
+          repo.write(prose)
+          repo.git("add", prose)
+        }
+        repo.git("commit", "-m", "mode change")
+        expect(
+          await classify(
+            { event: "pull_request", base, head: repo.git("rev-parse", "HEAD") },
+            repo.runner,
+          ),
+        ).toBe(false)
+      } finally {
+        repo.close()
+      }
+    },
+  )
+
+  test("does not treat an empty diff as prose", async () => {
+    const repo = repository()
+    try {
+      const head = repo.git("rev-parse", "HEAD")
+      expect(await classify({ event: "pull_request", base: head, head }, repo.runner)).toBe(false)
+    } finally {
+      repo.close()
+    }
+  })
+
+  test("checks prose whitespace against the exact PR diff", async () => {
+    const repo = repository()
+    try {
+      const base = repo.git("rev-parse", "HEAD")
+      repo.write(prose, "Trailing whitespace   \n")
+      await expect(
+        classify({ event: "pull_request", base, head: repo.commit() }, repo.runner),
+      ).rejects.toThrow()
+    } finally {
+      repo.close()
+    }
+  })
+
+  test("retains full push validation without calling Git", async () => {
+    expect(
+      await classify({ event: "push" }, async () => {
+        throw new Error("unexpected Git")
+      }),
+    ).toBe(false)
+  })
+
+  test.each([
+    Buffer.from("not-nul-terminated"),
+    Buffer.from("\0"),
+    Buffer.from([255, 0]),
+    Buffer.from(`:100644 100644 ${"a".repeat(40)} ${"b".repeat(40)} M\0${prose}\0extra\0`),
+  ])("rejects malformed raw diffs: %#", async (stdout) => {
+    await expect(
+      classify(
+        { event: "pull_request", base: "a".repeat(40), head: "b".repeat(40) },
+        async (_file, args) => ({ stdout: args[0] === "diff" ? stdout : Buffer.alloc(0) }),
+      ),
+    ).rejects.toThrow()
+  })
+})
+
+describe("prose workflow routing", () => {
+  test("the existing classifier exposes a separate prose result and validates it", () => {
+    expect(workflow.jobs.metadata_scope.outputs.prose_only).toBe(
+      `\${{ steps.classify.outputs.prose_only }}`,
+    )
+    const command = workflow.jobs.metadata_scope.steps.find(
+      (s: { id?: string }) => s.id === "classify",
+    ).run
+    expect(command).toContain("scope.classifyProseOnlyScope")
+    expect(command).toContain("Malformed prose-only scope output")
+  })
+
+  test("keeps the stable validation gate and fails closed on wrong or missing routing evidence", () => {
+    const gate = workflow.jobs.validate
+    expect(gate.if).toBe("always()")
+    expect(gate.needs).toContain("metadata_scope")
+    const step = gate.steps[0]
+    const run = (env: Record<string, string>) =>
+      spawnSync("/bin/sh", ["-c", step.run], {
+        env: { PATH: process.env.PATH, ...env },
+        encoding: "utf8",
+        timeout: 5000,
+      }).status
+    const full = {
+      EVENT_NAME: "pull_request",
+      SCOPE_RESULT: "success",
+      PROSE_ONLY: "false",
+      METADATA_ONLY: "false",
+      LANE_0: "success",
+      LANE_1: "success",
+      LANE_2: "success",
+      LANE_3: "success",
+    }
+    const light = {
+      ...full,
+      PROSE_ONLY: "true",
+      LANE_0: "skipped",
+      LANE_1: "skipped",
+      LANE_2: "skipped",
+      LANE_3: "skipped",
+    }
+    expect(run(full)).toBe(0)
+    expect(run(light)).toBe(0)
+    expect(
+      run({
+        ...full,
+        EVENT_NAME: "push",
+        SCOPE_RESULT: "skipped",
+        PROSE_ONLY: "",
+        METADATA_ONLY: "",
+      }),
+    ).toBe(0)
+    for (const base of [full, light]) {
+      for (const result of ["failure", "cancelled", "skipped", ""])
+        expect(run({ ...base, SCOPE_RESULT: result })).toBe(1)
+      for (const key of ["PROSE_ONLY", "METADATA_ONLY"])
+        for (const value of ["", "unknown"]) expect(run({ ...base, [key]: value })).toBe(1)
+      for (const key of ["LANE_0", "LANE_1", "LANE_2", "LANE_3"])
+        for (const result of ["failure", "cancelled", "", base === full ? "skipped" : "success"])
+          expect(run({ ...base, [key]: result })).toBe(1)
+    }
+    expect(run({ ...light, METADATA_ONLY: "true" })).toBe(1)
+    expect(run({ ...light, EVENT_NAME: "push" })).toBe(1)
+    expect(run({ ...full, EVENT_NAME: "unknown" })).toBe(1)
+  })
+})
+
+test("every full CI job preserves cancellation, push and failure behavior when prose routing is added", () => {
+  const metadataJobs = new Set([
+    "sandbox-k8s",
+    "sandbox-k8s-e2e",
+    "sandbox-docker-e2e",
+    "chart-apply-smoke",
+  ])
+  for (const [id, job] of Object.entries(workflow.jobs) as [
+    string,
+    { if?: string; needs?: string },
+  ][]) {
+    if (["metadata_scope", "changesets", "validate"].includes(id)) continue
+    expect(job.needs).toBe("metadata_scope")
+    const source = String(job.if)
+      .replace(/^\$\{\{\s*|\s*\}\}$/g, "")
+      .trim()
+    for (const cancelled of [false, true])
+      for (const event of ["push", "pull_request"]) {
+        for (const result of ["success", "failure", "cancelled", "skipped", ""]) {
+          for (const proseOnly of ["true", "false", ""])
+            for (const metadataOnly of ["true", "false", ""]) {
+              for (const fork of [false, true]) {
+                const expression = source
+                  .replaceAll("cancelled()", JSON.stringify(cancelled))
+                  .replaceAll("github.event_name", JSON.stringify(event))
+                  .replaceAll(
+                    "github.event.pull_request.head.repo.full_name",
+                    JSON.stringify(fork ? "fork/repo" : "owner/repo"),
+                  )
+                  .replaceAll("github.repository", JSON.stringify("owner/repo"))
+                  .replaceAll("github.ref", JSON.stringify("refs/heads/main"))
+                  .replaceAll("needs.metadata_scope.result", JSON.stringify(result))
+                  .replaceAll("needs.metadata_scope.outputs.prose_only", JSON.stringify(proseOnly))
+                  .replaceAll(
+                    "needs.metadata_scope.outputs.metadata_only",
+                    JSON.stringify(metadataOnly),
+                  )
+                const actual = Function(`"use strict"; return (${expression});`)()
+                const expected =
+                  !cancelled &&
+                  !(
+                    event === "pull_request" &&
+                    result === "success" &&
+                    (proseOnly === "true" || (metadataJobs.has(id) && metadataOnly === "true"))
+                  ) &&
+                  !(id === "vercel-native" && event === "pull_request" && fork)
+                expect(
+                  actual,
+                  JSON.stringify({ id, cancelled, event, result, proseOnly, metadataOnly, fork }),
+                ).toBe(expected)
+              }
+            }
+        }
+      }
+  }
+})
+
+test("prose classification uses the merge base even when source changes match the current base endpoint", async () => {
+  const repo = repository()
+  try {
+    repo.git("checkout", "-b", "feature")
+    repo.write(prose, "Updated notes.\n")
+    repo.write("source.ts", "export const value = 1\n")
+    const head = repo.commit()
+    repo.git("checkout", "main")
+    repo.write("source.ts", "export const value = 1\n")
+    const base = repo.commit()
+    expect(await classify({ event: "pull_request", base, head }, repo.runner)).toBe(false)
+  } finally {
+    repo.close()
+  }
+})
+
+test("the prose CLI emits one boolean and rejects invalid selectors", () => {
+  const repo = repository()
+  try {
+    const base = repo.git("rev-parse", "HEAD")
+    repo.write(prose, "Updated notes.\n")
+    const head = repo.commit()
+    const run = (kind: string) =>
+      spawnSync(
+        process.execPath,
+        [
+          resolve(root, "scripts/ci-scope.mjs"),
+          "--kind",
+          kind,
+          "--event",
+          "pull_request",
+          "--base",
+          base,
+          "--head",
+          head,
+        ],
+        { cwd: repo.directory, encoding: "utf8", timeout: 5000 },
+      )
+    const result = run("prose")
+    expect(result.status).toBe(0)
+    expect(result.stdout).toBe("true\n")
+    expect(result.stderr).toBe("")
+    expect(run("metadata").stdout).toBe("false\n")
+    const invalid = run("unknown")
+    expect(invalid.status).toBe(1)
+    expect(invalid.stdout).toBe("")
+  } finally {
+    repo.close()
+  }
+})
+
+describe("trusted-base scope shell", () => {
+  test.each(["forged-head", "legacy-base", "current-prose", "classifier-failure"])(
+    "uses trusted scope code for %s",
+    (scenario) => {
+      const repo = repository()
+      const output = resolve(repo.directory, "github-output")
+      const temporary = mkdtempSync(resolve(tmpdir(), "b4-scope-shell-"))
+      try {
+        let trustedSource = readFileSync(resolve(root, "scripts/ci-scope.mjs"), "utf8")
+        if (scenario === "legacy-base") {
+          trustedSource = `
+            import { pathToFileURL } from "node:url"
+            export async function classifyMetadataOnlyScope() { return false }
+            if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+              if (process.argv.includes("--kind")) throw new Error("Unknown flag: --kind")
+              process.stdout.write("false\\n")
+            }
+          `
+        }
+        if (scenario === "classifier-failure")
+          trustedSource = 'throw new Error("trusted failure")\n'
+        repo.write("scripts/ci-scope.mjs", trustedSource)
+        const base = repo.commit()
+        repo.write(prose, "Updated runbook.\n")
+        if (scenario === "forged-head") {
+          repo.write(
+            "scripts/ci-scope.mjs",
+            `
+            import { writeFileSync } from "node:fs"
+            writeFileSync("forged-classifier-ran", "unsafe")
+            process.stdout.write(process.argv.includes("--kind") ? "true\\n" : "false\\n")
+          `,
+          )
+          repo.write("source.ts", "export const changed = true\n")
+        }
+        const head = repo.commit()
+        const command = workflow.jobs.metadata_scope.steps.find(
+          (step: { id?: string }) => step.id === "classify",
+        ).run
+        const result = spawnSync("/bin/bash", ["-c", command], {
+          cwd: repo.directory,
+          env: {
+            ...process.env,
+            BASE_SHA: base,
+            HEAD_SHA: head,
+            GITHUB_OUTPUT: output,
+            TMPDIR: temporary,
+          },
+          encoding: "utf8",
+          timeout: 5000,
+        })
+        expect(existsSync(resolve(repo.directory, "forged-classifier-ran"))).toBe(false)
+        expect(readdirSync(temporary)).toEqual([])
+        if (scenario === "classifier-failure") {
+          expect(result.status).not.toBe(0)
+          expect(existsSync(output) ? readFileSync(output, "utf8") : "").toBe("")
+        } else {
+          expect(result.status, result.stderr).toBe(0)
+          expect(readFileSync(output, "utf8").trim().split("\n").sort()).toEqual([
+            "metadata_only=false",
+            `prose_only=${scenario === "current-prose"}`,
+          ])
+        }
+      } finally {
+        repo.close()
+        rmSync(temporary, { recursive: true, force: true })
+      }
+    },
+  )
+})

--- a/test/k8s-compat/ci-scope.test.ts
+++ b/test/k8s-compat/ci-scope.test.ts
@@ -46,6 +46,7 @@ describe("metadata-only CI scope", () => {
                 .replaceAll("cancelled()", JSON.stringify(cancelled))
                 .replaceAll("github.event_name", JSON.stringify(event))
                 .replaceAll("needs.metadata_scope.result", JSON.stringify(result))
+                .replaceAll("needs.metadata_scope.outputs.prose_only", JSON.stringify("false"))
                 .replaceAll(
                   "needs.metadata_scope.outputs.metadata_only",
                   JSON.stringify(metadataOnly),
@@ -230,7 +231,7 @@ describe("metadata-only CI scope", () => {
 })
 
 describe("CI workflow metadata scope", () => {
-  test("uses one scope output to skip only the expensive Kubernetes and full-arc jobs", () => {
+  test("preserves metadata scope alongside narrow prose routing", () => {
     const jobs = ciWorkflow.jobs as Record<string, Record<string, unknown>>
     const scope = jobs.metadata_scope
     expect(scope).toBeDefined()
@@ -238,6 +239,7 @@ describe("CI workflow metadata scope", () => {
     expect(scope?.if).toBe("github.event_name == 'pull_request'")
     expect(scope?.outputs).toEqual({
       metadata_only: githubExpression("steps.classify.outputs.metadata_only"),
+      prose_only: githubExpression("steps.classify.outputs.prose_only"),
     })
 
     const steps = scope?.steps as Record<string, unknown>[]
@@ -257,38 +259,28 @@ describe("CI workflow metadata scope", () => {
       BASE_SHA: githubExpression("github.event.pull_request.base.sha"),
       HEAD_SHA: githubExpression("github.event.pull_request.head.sha"),
     })
-    expect(classify?.run).toContain("node scripts/ci-scope.mjs")
+    expect(classify?.run).toContain('git show "$BASE_SHA:scripts/ci-scope.mjs"')
+    expect(classify?.run).toContain('node "$SCOPE_DIR/ci-scope.mjs"')
     expect(classify?.run).toContain("Malformed metadata-only scope output")
 
     const scopedJobs = ["sandbox-k8s", "sandbox-k8s-e2e", "sandbox-docker-e2e", "chart-apply-smoke"]
     const failOpenCondition = githubExpression(
-      "!cancelled() && (github.event_name != 'pull_request' || needs.metadata_scope.result != 'success' || needs.metadata_scope.outputs.metadata_only != 'true')",
+      "!cancelled() && (github.event_name != 'pull_request' || needs.metadata_scope.result != 'success' || (needs.metadata_scope.outputs.metadata_only != 'true' && needs.metadata_scope.outputs.prose_only != 'true'))",
     )
     for (const id of scopedJobs) {
       expect(jobs[id]?.needs).toBe("metadata_scope")
       expect(jobs[id]?.if).toBe(failOpenCondition)
     }
 
-    expect(
-      Object.entries(jobs)
-        .filter(([, job]) => job.needs === "metadata_scope")
-        .map(([id]) => id)
-        .sort(),
-    ).toEqual([...scopedJobs].sort())
-
-    for (const id of [
-      "source-validate",
-      "release-controller",
-      "sandbox-docker",
-      "chart-validate",
-      "vercel-native",
-    ]) {
-      expect(jobs[id]?.needs).toBeUndefined()
-    }
-    for (const id of ["source-validate", "release-controller"]) {
-      expect(jobs[id]?.if).toBeUndefined()
+    const fullJobs = Object.keys(jobs).filter(
+      (id) => !["metadata_scope", "changesets", "validate"].includes(id),
+    )
+    for (const id of fullJobs) {
+      expect(jobs[id]?.needs).toBe("metadata_scope")
+      expect(jobs[id]?.if).toContain("needs.metadata_scope.outputs.prose_only != 'true'")
     }
     expect(jobs.validate?.needs).toEqual([
+      "metadata_scope",
       "source-validate",
       "release-controller",
       "pack-smoke",


### PR DESCRIPTION
Runbook-only pull requests currently run the entire runtime and infrastructure suite, extending post-release documentation work by tens of minutes. This change gives regular Markdown files under `docs/superpowers/runbooks/` a narrow path through the existing scope and required `validate` jobs. Scope decisions execute trusted base-revision code and check the exact merge-base diff, file modes, and whitespace. Mixed changes, classifier edits, malformed results, and older bases keep full validation; every main push retains full CI.

Contributor guidance also recommends smaller batches of full-CI submissions to reduce contention. No release workflow, publishing step, authentication setting, or timeout changes.

Validation: 63 focused scope/workflow tests and 168 workflow/integrity tests pass; lint, build, typecheck, release inventory, docs, and pack checks pass. The initial full source run passed 5,870 tests with one outdated Vercel-condition assertion; that assertion was updated and all eight tests in its suite pass. Independent specification and code review are complete. Hosted CI will verify the final committed head before merge.
