### PR TITLE
fix: handle transient npm audit errors within the existing publish budget

### DIFF
--- a/docs/superpowers/plans/2026-09-11-npm-audit-diagnostics.md
+++ b/docs/superpowers/plans/2026-09-11-npm-audit-diagnostics.md
@@ -1,0 +1,17 @@
+# npm Audit Diagnostics Implementation Plan
+
+> **For agentic workers:** Use superpowers:subagent-driven-development to implement this plan task-by-task.
+
+**Goal:** Avoid full release restarts for recognized transient npm audit failures and preserve safe diagnostic evidence.
+
+**Architecture:** Classify full command results inside the existing npm audit adapter; map recognized single-package transient failures into the publisher's existing pending loop. Batch verification still rejects errors. No publishing workflow changes.
+
+**Tech Stack:** Node.js, npm 11.17.0, node:test.
+
+- [ ] Baseline frozen pnpm 10.33 install and targeted npm audit/publisher tests.
+- [ ] Add failing regressions in `scripts/release/test/npm-audit.test.mjs` for exact transient/error envelopes, strict exit-code correlation, ambiguous/unknown/fatal responses, and single/batch diagnostics without secret output.
+- [ ] Add failing publisher regressions in `scripts/release/test/publisher.test.mjs` proving recognized transient failures use the existing bounded convergence loop, fatal failures do not poll, abort/deadline remain effective, and no duplicate upload occurs.
+- [ ] Implement the smallest shared command-result classifier in `scripts/release/npm-audit.mjs`. Wire safe logging through the existing adapter/publisher interfaces only if necessary. Keep batch errors fatal and all positive evidence checks intact.
+- [ ] Refresh reviewed release content pins only for affected release-reachable modules; preserve workflow and permission inventories.
+- [ ] Run targeted tests, lint, integrity and complete controller suite; complete repository-required validation/CI, independent spec and quality reviews.
+- [ ] Submit only after the preceding CI optimization PR's active runs finish. Normal main refresh, no force push, no live release mutation. Merge on green at the exact reviewed head.

--- a/docs/superpowers/specs/2026-09-11-npm-audit-diagnostics-design.md
+++ b/docs/superpowers/specs/2026-09-11-npm-audit-diagnostics-design.md
@@ -1,0 +1,15 @@
+# npm audit diagnostics and transient failures
+
+The user approved reducing release restarts without new workflows, gates, receipts, timeouts, manual steps or token fallback. The two historical audit-root failures remain unexplained because their original responses were lost; this change must not relabel them as known network failures.
+
+Pinned npm 11.17.0 source and local constructor probes establish the exact error envelope `{error:{code,summary,detail}}` with exit code 1 for HTTP and selected transport errors. Normal complete verified audit output must have exit code 0. Existing code accepts command exits 0 and 1 but discards that distinction.
+
+Classify the full npm command result in the existing audit adapter. A finite allowlist of ETIMEDOUT, ECONNRESET, EAI_AGAIN, E429, E500, E502, E503 and E504 may produce the existing exact `{status:"pending"}` result for single-package verification, only with exit 1 and an exact error-only envelope whose required fields have valid types. The publisher's existing convergence clock/poll loop owns all retries. No new timer, runner retry or broadened accepted exit codes.
+
+E404, auth failures, unknown codes/shapes, mixed error/evidence, malformed JSON, missing/invalid signatures, successful evidence with exit 1 and transient envelopes with exit 0 remain fatal. Preserve complete batch verification: batch errors gain safe diagnostics but still reject because batch callers have no pending protocol. Never fabricate pending rows or reuse earlier proof.
+
+Safe diagnostics use only fixed classification labels, validated exit code, an allowlisted npm error code, bounded byte counts, and a recognized root-shape label. Do not expose summary/detail, arbitrary keys, URLs, raw stdout/stderr, parser causes or credentials. Diagnostics go to existing logs; no new mandatory artifact. Process-runner timeout, abort, spawn, signal and output-limit failures retain their existing fatal behavior.
+
+Test complete exit/output matrix, secret-marker non-disclosure for single and batch, single transient-to-verified and deadline exhaustion/abort in the actual publisher loop, fatal errors causing zero polls, fresh batch capture/tree checks/cleanup. Update content pins for any edited release-reachable module. Preserve package order, OIDC identity, immutable artifacts and all verification requirements.
+
+Independent review passed with explicit boundaries: the publisher's final complete verification sweep has no pending loop, so transient failure there remains fatal and must have a regression. Test each allowlisted code, all malformed/absent/noninteger exit statuses and invalid envelope field types. Sanitize adapter-facing errors too: existing parser causes and invalid-evidence names can contain untrusted text; no such nested cause or name may escape through existing CLI logs. Exported low-level parsers may retain their diagnostic contracts if all production adapter boundaries contain their output safely.

--- a/scripts/release/npm-audit.mjs
+++ b/scripts/release/npm-audit.mjs
@@ -33,6 +33,16 @@ const VERIFIED_FIELDS = Object.freeze([
   "attestationBundles",
 ])
 const EXPECTED_NPM_VERSION = "11.17.0"
+const TRANSIENT_AUDIT_CODES = new Set([
+  "ETIMEDOUT",
+  "ECONNRESET",
+  "EAI_AGAIN",
+  "E429",
+  "E500",
+  "E502",
+  "E503",
+  "E504",
+])
 
 export const NPM_AUDIT_OUTPUT_MAX_BYTES = 2 * 1024 * 1024
 export const NPM_AUDIT_VERIFIER = `npm-audit-signatures@${EXPECTED_NPM_VERSION}`
@@ -106,9 +116,11 @@ export async function createNpmAuditVerifier({
   environment = process.env,
   signal,
   bootstrap,
+  log = () => {},
 } = {}) {
   if (
     typeof runNpm !== "function" ||
+    typeof log !== "function" ||
     environment === null ||
     Array.isArray(environment) ||
     typeof environment !== "object" ||
@@ -169,6 +181,19 @@ export async function createNpmAuditVerifier({
       signal,
     })
     assertNpm11Version(versionResult?.stdout)
+
+    const runAudit = async (options) => {
+      try {
+        return await runNpm(
+          "npm",
+          ["audit", "signatures", "--no-package-lock", "--json", "--include-attestations"],
+          { ...options, env: auditEnvironment, signal, acceptedExitCodes: [0, 1] },
+        )
+      } catch {
+        // Runner errors can contain subprocess output or nested credential-bearing causes.
+        auditFailure(log, auditDiagnostic(undefined), "command-failure")
+      }
+    }
 
     return {
       root,
@@ -269,21 +294,17 @@ export async function createNpmAuditVerifier({
           active()
           let result
           try {
-            result = await runNpm(
-              "npm",
-              ["audit", "signatures", "--no-package-lock", "--json", "--include-attestations"],
-              {
-                cwd: directory,
-                env: auditEnvironment,
-                signal,
-                acceptedExitCodes: [0, 1],
-              },
-            )
+            result = await runAudit({ cwd: directory })
           } finally {
             await assertTree()
           }
           active()
-          return parseBatchAudit(result?.stdout, identities)
+          return classifyAuditResult(
+            result,
+            (output) => parseBatchAudit(output, identities),
+            false,
+            log,
+          )
         })()
         batches.add(work)
         work.then(
@@ -350,18 +371,14 @@ export async function createNpmAuditVerifier({
           throw new Error(`npm audit consumer identity changed for ${identity.entry.name}`)
         }
         await assertSyntheticAuditTree(fileSystem, consumer, identity.entry.name)
-        const auditResult = await runNpm(
-          "npm",
-          ["audit", "signatures", "--no-package-lock", "--json", "--include-attestations"],
-          {
-            cwd: consumer.directory,
-            env: auditEnvironment,
-            signal,
-            acceptedExitCodes: [0, 1],
-          },
-        )
+        const auditResult = await runAudit({ cwd: consumer.directory })
         await assertSyntheticAuditTree(fileSystem, consumer, identity.entry.name)
-        return parseNpmAuditSignatures(auditResult?.stdout, identity)
+        return classifyAuditResult(
+          auditResult,
+          (output) => parseNpmAuditSignatures(output, identity),
+          true,
+          log,
+        )
       },
       dispose() {
         if (disposal !== undefined) return disposal
@@ -378,6 +395,85 @@ export async function createNpmAuditVerifier({
     await fileSystem.rm(root, { recursive: true, force: true }).catch(() => undefined)
     throw error
   }
+}
+
+// Keep command outcomes separate from proof. Only the publisher's existing single-package
+// convergence loop can consume pending; batch callers still require a complete capture.
+function classifyAuditResult(result, parse, single, log) {
+  const diagnostic = auditDiagnostic(result)
+  if (!result || ![0, 1].includes(result.exitCode)) auditFailure(log, diagnostic, "invalid-exit")
+  if (
+    typeof result.stdout !== "string" ||
+    diagnostic.stdoutBytes < 1 ||
+    diagnostic.stdoutBytes > NPM_AUDIT_OUTPUT_MAX_BYTES ||
+    (result.stderr !== undefined && typeof result.stderr !== "string")
+  )
+    auditFailure(log, diagnostic, "invalid-output")
+  let value
+  try {
+    value = snapshotJson(JSON.parse(result.stdout))
+  } catch {
+    auditFailure(log, diagnostic, "malformed-output")
+  }
+  diagnostic.rootShape =
+    value === null
+      ? "null"
+      : Array.isArray(value)
+        ? "array"
+        : typeof value === "object"
+          ? "object"
+          : "primitive"
+  if (
+    value !== null &&
+    typeof value === "object" &&
+    !Array.isArray(value) &&
+    Object.hasOwn(value, "error")
+  ) {
+    try {
+      assertExactFields(value, ["error"], "error envelope")
+      assertExactFields(value.error, ["code", "summary", "detail"], "error envelope")
+      if (Object.values(value.error).some((field) => typeof field !== "string")) throw new Error()
+    } catch {
+      auditFailure(log, diagnostic, "invalid-error-envelope")
+    }
+    diagnostic.rootShape = "error-envelope"
+    if (TRANSIENT_AUDIT_CODES.has(value.error.code)) diagnostic.code = value.error.code
+    if (result.exitCode !== 1) auditFailure(log, diagnostic, "exit-output-conflict")
+    if (!diagnostic.code) auditFailure(log, diagnostic, "fatal-error-envelope")
+    if (!single) auditFailure(log, diagnostic, "batch-transient")
+    log(Object.freeze({ ...diagnostic, classification: "transient" }))
+    return deepFreeze({ status: "pending" })
+  }
+  if (result.exitCode !== 0) auditFailure(log, diagnostic, "exit-output-conflict")
+  try {
+    return parse(result.stdout)
+  } catch {
+    // Low-level parser messages and SyntaxError causes can contain untrusted names/JSON.
+    auditFailure(log, diagnostic, "invalid-evidence")
+  }
+}
+
+function auditDiagnostic(result) {
+  const byteCount = (value) =>
+    typeof value === "string"
+      ? Math.min(Buffer.byteLength(value, "utf8"), NPM_AUDIT_OUTPUT_MAX_BYTES + 1)
+      : 0
+  return {
+    event: "npm-audit-diagnostic",
+    ...(Number.isInteger(result?.exitCode) && result.exitCode >= 0 && result.exitCode <= 255
+      ? { exitCode: result.exitCode }
+      : {}),
+    stdoutBytes: byteCount(result?.stdout),
+    stderrBytes: byteCount(result?.stderr),
+    rootShape: "unclassified",
+  }
+}
+
+function auditFailure(log, diagnostic, classification) {
+  const safe = Object.freeze({ ...diagnostic, classification })
+  log(safe)
+  // Recovery/batch callers have no logger; existing CLI errors still retain this safe metadata.
+  throw new Error(`npm audit signatures failed: ${JSON.stringify(safe)}`)
 }
 
 function validateBatchContext(input) {

--- a/scripts/release/publisher.mjs
+++ b/scripts/release/publisher.mjs
@@ -426,6 +426,7 @@ async function runPublisherCliWithinDeadline(
       fileSystem,
       environment,
       signal: deadline.signal,
+      log,
     }),
   )
   try {
@@ -563,6 +564,7 @@ async function runBootstrapPublisher({
         fileSystem,
         environment,
         signal: deadline.signal,
+        log,
         bootstrap: { token },
       }),
     )

--- a/scripts/release/test/fixtures/release-script-hashes.json
+++ b/scripts/release/test/fixtures/release-script-hashes.json
@@ -104,7 +104,7 @@
       "sha256": "9a4e4263711eb51315a5ba61c56e6c6912b223b10babede76baf49ace6041667"
     },
     "scripts/release/npm-audit.mjs": {
-      "sha256": "b501c6563709d0452af2bd20eb1523b540e21bdcfb13c1bfdb2f4a834385a699"
+      "sha256": "5a23fb533b9c2815b20f835257fde43742ea91da2c881a9e695cec5f6dce4430"
     },
     "scripts/release/npm-bootstrap.mjs": {
       "sha256": "4327ba4de698ffcb01a3330d2040e08ddc09d2809dce73653cb835982d8ad459"
@@ -134,7 +134,7 @@
       "sha256": "bdc06e4902b3e853e858166240e3dd1e068061c3ec69f74cad33f1ae122c7e1b"
     },
     "scripts/release/publisher.mjs": {
-      "sha256": "48e022e2555618c2609ebd8cfcc8915b02f791bbffa28c6b1e129c921343b692"
+      "sha256": "35c8a29a6eea108e2687247af654c9c185afd1c04717038c923a4a8684b1b9de"
     },
     "scripts/release/recovery/adopt.mjs": {
       "sha256": "efe0b8da53dc035932d2ce266bb88456a5547332313bca9bfa2bf50ee4e0ac8a"

--- a/scripts/release/test/npm-audit.test.mjs
+++ b/scripts/release/test/npm-audit.test.mjs
@@ -9,6 +9,7 @@ import test from "node:test"
 
 import {
   createNpmAuditVerifier,
+  NPM_AUDIT_OUTPUT_MAX_BYTES,
   NPM_AUDIT_VERIFIER,
   parseNpmAuditSignatures,
 } from "../npm-audit.mjs"
@@ -683,7 +684,7 @@ test("batch audits the whole inventory once in a fresh exact tree on every call"
         version: entry.version,
       })
     }
-    return { stdout: batchOutput(), exitCode: 1 }
+    return { stdout: batchOutput(), exitCode: 0 }
   })
   try {
     for (let i = 0; i < 2; i++) {
@@ -780,7 +781,10 @@ for (const [label, mutate] of [
   test(`batch rejects ${label} anywhere in whole audit stdout`, async () => {
     const audit = JSON.parse(batchOutput())
     mutate(audit)
-    const verifier = await batchVerifier(async () => ({ stdout: JSON.stringify(audit) }))
+    const verifier = await batchVerifier(async () => ({
+      stdout: JSON.stringify(audit),
+      exitCode: 0,
+    }))
     try {
       await assert.rejects(
         verifier.verifyPackages({ entries: BATCH_ENTRIES, candidate: BATCH_CANDIDATE }),
@@ -792,7 +796,7 @@ for (const [label, mutate] of [
   })
 for (const output of ["bad json", " ".repeat(2 * 1024 * 1024) + batchOutput()])
   test("batch bounds original stdout before parsing", async () => {
-    const verifier = await batchVerifier(async () => ({ stdout: output }))
+    const verifier = await batchVerifier(async () => ({ stdout: output, exitCode: 0 }))
     try {
       await assert.rejects(
         verifier.verifyPackages({ entries: BATCH_ENTRIES, candidate: BATCH_CANDIDATE }),
@@ -882,7 +886,7 @@ for (const stage of ["before", "after"])
           commands++
           cwd = directory
           if (stage === "after") await tamper(cwd)
-          return { stdout: batchOutput() }
+          return { stdout: batchOutput(), exitCode: 0 }
         },
         {
           ...fs,
@@ -908,7 +912,7 @@ for (const stage of ["before", "after"])
 test("batch snapshots every caller identity before asynchronous filesystem work", async () => {
   const entries = structuredClone(BATCH_ENTRIES),
     candidate = structuredClone(BATCH_CANDIDATE)
-  const verifier = await batchVerifier(async () => ({ stdout: batchOutput() }), {
+  const verifier = await batchVerifier(async () => ({ stdout: batchOutput(), exitCode: 0 }), {
     ...fs,
     async mkdtemp(prefix) {
       if (prefix.includes("/consumers/")) {
@@ -952,6 +956,7 @@ test("fresh batch cannot reuse successful stdout after a later audit fails", asy
   let count = 0
   const verifier = await batchVerifier(async () => ({
     stdout: ++count === 1 ? batchOutput() : "{}",
+    exitCode: 0,
   }))
   try {
     await verifier.verifyPackages({ entries: BATCH_ENTRIES, candidate: BATCH_CANDIDATE })
@@ -980,7 +985,7 @@ for (const stop of ["abort", "dispose"])
       async () => {
         start()
         await pending
-        return { stdout: batchOutput() }
+        return { stdout: batchOutput(), exitCode: 0 }
       },
       {
         ...fs,
@@ -1061,7 +1066,7 @@ test("controlled 21-package captures reduce actual audit runner invocations from
       counts[mode].factories++
       const verifier = await batchVerifier(async () => {
         counts[mode].auditCommands++
-        return { stdout: batchOutput(entries) }
+        return { stdout: batchOutput(entries), exitCode: 0 }
       })
       try {
         if (mode === "verifyPackages")
@@ -1102,7 +1107,7 @@ test("batch verifies the complete tree even when the audit command rejects", asy
   try {
     await assert.rejects(
       verifier.verifyPackages({ entries: BATCH_ENTRIES, candidate: BATCH_CANDIDATE }),
-      /audit process failed/,
+      /command-failure/,
     )
     assert.equal(readsAfterFailure, BATCH_ENTRIES.length + 1)
   } finally {
@@ -1123,7 +1128,10 @@ test("batch rejects unknown, missing, or malformed canonical entry and candidate
         : value,
     ]),
   )
-  const verifier = await batchVerifier(async () => ({ stdout: batchOutput() }), fileSystem)
+  const verifier = await batchVerifier(
+    async () => ({ stdout: batchOutput(), exitCode: 0 }),
+    fileSystem,
+  )
   const valid = {
     entries: structuredClone(BATCH_ENTRIES),
     candidate: structuredClone(BATCH_CANDIDATE),
@@ -1192,7 +1200,7 @@ for (const stage of ["before", "after"])
         commands++
         if (stage === "after")
           await replace(path.join(cwd, "node_modules/@b4run/core/package.json"))
-        return { stdout: batchOutput() }
+        return { stdout: batchOutput(), exitCode: 0 }
       },
       {
         ...fs,
@@ -1238,7 +1246,10 @@ for (const stage of ["before", "after"])
 test("legacy verifier dependencies need no lstat until a batch is requested", async () => {
   const fileSystem = { ...fs }
   delete fileSystem.lstat
-  const verifier = await batchVerifier(async () => ({ stdout: auditOutput() }), fileSystem)
+  const verifier = await batchVerifier(
+    async () => ({ stdout: auditOutput(), exitCode: 0 }),
+    fileSystem,
+  )
   try {
     assert.equal(
       (await verifier.verifyPackage({ entry: ENTRY, candidate: CANDIDATE })).status,
@@ -1252,3 +1263,136 @@ test("legacy verifier dependencies need no lstat until a batch is requested", as
     await verifier.dispose()
   }
 })
+
+const TRANSIENT_AUDIT_CODES = [
+  "ETIMEDOUT",
+  "ECONNRESET",
+  "EAI_AGAIN",
+  "E429",
+  "E500",
+  "E502",
+  "E503",
+  "E504",
+]
+const AUDIT_SECRET = "secret-marker-do-not-log"
+function errorOutput(code) {
+  return JSON.stringify({ error: { code, summary: AUDIT_SECRET, detail: AUDIT_SECRET } })
+}
+async function resultVerifier(result, logs, signal = new AbortController().signal) {
+  return createNpmAuditVerifier({
+    environment: {},
+    signal,
+    log: (value) => logs.push(value),
+    async runNpm(_command, args) {
+      if (args[0] === "--version") return { stdout: "11.17.0", exitCode: 0 }
+      if (result instanceof Error) throw result
+      return result
+    },
+  })
+}
+for (const code of TRANSIENT_AUDIT_CODES) {
+  test(`exact ${code} is pending only for single audits and logs no output`, async () => {
+    const logs = []
+    const verifier = await resultVerifier(
+      { exitCode: 1, stdout: errorOutput(code), stderr: AUDIT_SECRET },
+      logs,
+    )
+    const root = verifier.root
+    try {
+      assert.deepEqual(await verifier.verifyPackage({ entry: ENTRY, candidate: CANDIDATE }), {
+        status: "pending",
+      })
+      await assert.rejects(
+        verifier.verifyPackages({ entries: BATCH_ENTRIES, candidate: BATCH_CANDIDATE }),
+        (error) => {
+          assert.equal(error.cause, undefined)
+          assert.ok(!error.stack.includes(AUDIT_SECRET))
+          return true
+        },
+      )
+      assert.equal(logs.length, 2)
+      assert.ok(
+        logs.every((value) => value.code === code && value.event === "npm-audit-diagnostic"),
+      )
+      assert.ok(!JSON.stringify(logs).includes(AUDIT_SECRET))
+    } finally {
+      await verifier.dispose()
+    }
+    await assert.rejects(access(root))
+  })
+}
+const rejectedAuditResults = [
+  undefined,
+  null,
+  [],
+  ...[undefined, null, 42].map((stdout) => ({ exitCode: 0, stdout })),
+  ...[undefined, null, "0", 0.5, -1, 2, NaN].map((exitCode) => ({
+    exitCode,
+    stdout: auditOutput(),
+  })),
+  { exitCode: 1, stdout: auditOutput() },
+  { exitCode: 0, stdout: errorOutput("ETIMEDOUT") },
+  ...["E404", "E401", "E403", "EOTP", "E501", "E505", "UNKNOWN", AUDIT_SECRET].map((code) => ({
+    exitCode: 1,
+    stdout: errorOutput(code),
+  })),
+  ...[
+    null,
+    [],
+    {},
+    { code: "ETIMEDOUT" },
+    { code: "ETIMEDOUT", summary: 1, detail: "" },
+    { code: "ETIMEDOUT", summary: "", detail: null },
+    { code: 1, summary: "", detail: "" },
+    { code: "ETIMEDOUT", summary: "", detail: "", extra: AUDIT_SECRET },
+  ].map((error) => ({ exitCode: 1, stdout: JSON.stringify({ error }) })),
+  {
+    exitCode: 1,
+    stdout: JSON.stringify({
+      error: { code: "ETIMEDOUT", summary: "", detail: "" },
+      ...JSON.parse(auditOutput()),
+    }),
+  },
+  ...[
+    "",
+    AUDIT_SECRET,
+    `{"${AUDIT_SECRET}":`,
+    "[]",
+    "null",
+    '"text"',
+    JSON.stringify({ [AUDIT_SECRET]: true }),
+    "x".repeat(NPM_AUDIT_OUTPUT_MAX_BYTES + 1),
+  ].map((stdout) => ({ exitCode: 1, stdout })),
+  ...["invalid", "missing"].flatMap((field) =>
+    [0, 1].map((exitCode) => ({
+      exitCode,
+      stdout: JSON.stringify({
+        ...JSON.parse(auditOutput()),
+        [field]: [{ name: AUDIT_SECRET, version: AUDIT_SECRET }],
+      }),
+    })),
+  ),
+  new Error(AUDIT_SECRET, { cause: new Error(AUDIT_SECRET) }),
+]
+for (const [index, result] of rejectedAuditResults.entries()) {
+  test(`audit command result ${index} fails closed without leaking output or causes`, async () => {
+    const logs = []
+    const verifier = await resultVerifier(result, logs)
+    try {
+      for (const operation of [
+        () => verifier.verifyPackage({ entry: ENTRY, candidate: CANDIDATE }),
+        () => verifier.verifyPackages({ entries: BATCH_ENTRIES, candidate: BATCH_CANDIDATE }),
+      ])
+        await assert.rejects(operation(), (error) => {
+          assert.ok(!error.stack.includes(AUDIT_SECRET))
+          assert.equal(error.cause, undefined)
+          return true
+        })
+      assert.equal(logs.length, 2)
+      assert.ok(JSON.stringify(logs).length < 1024)
+      assert.ok(!JSON.stringify(logs).includes(AUDIT_SECRET))
+    } finally {
+      await verifier.dispose()
+    }
+  })
+}

--- a/scripts/release/test/publisher.test.mjs
+++ b/scripts/release/test/publisher.test.mjs
@@ -30,6 +30,7 @@ import {
   manifestSha256,
 } from "../manifest.mjs"
 import { canonicalReleaseBody } from "../metadata.mjs"
+import { createNpmAuditVerifier } from "../npm-audit.mjs"
 import { canonicalNpmEvidenceBytes, parseNpmEvidence } from "../npm-evidence.mjs"
 import {
   PUBLISHER_OVERALL_TIMEOUT_MS,
@@ -731,7 +732,7 @@ test("OIDC mode ignores bootstrap variables, never selects the first-publication
     environment,
   })
   assert.equal(result.status, "NPM_COMPLETE")
-  assert.deepEqual(factoryCalls, [["environment", "fileSystem", "runNpm", "signal"]])
+  assert.deepEqual(factoryCalls, [["environment", "fileSystem", "log", "runNpm", "signal"]])
   const publishes = npmCalls.filter(({ args }) => args[0] === "publish")
   assert.equal(publishes.length, 1)
   for (const call of npmCalls) {
@@ -2882,4 +2883,70 @@ function multiSubjectBundleBytes(files) {
     })}\n`,
     "utf8",
   )
+}
+
+for (const mode of ["converges", "deadline", "abort", "fatal", "final-sweep"]) {
+  test(`real audit result handling in publisher: ${mode}`, async () => {
+    const fixture = publisherFixture({ initiallyPresent: "all-except-last" })
+    const controller = new AbortController()
+    let targetAudits = 0
+    const target = CANONICAL_RELEASE_PACKAGE_ORDER.at(-1)
+    const logs = []
+    const verifier = await createNpmAuditVerifier({
+      environment: {},
+      signal: controller.signal,
+      log: (event) => logs.push(event),
+      async runNpm(_command, args, options) {
+        if (args[0] === "--version") return { stdout: "11.17.0", exitCode: 0 }
+        options.signal.throwIfAborted()
+        const consumer = JSON.parse(await readFile(path.join(options.cwd, "package.json")))
+        const name = Object.keys(consumer.dependencies)[0]
+        const entry = fixture.inputs.manifest.packages.find((item) => item.name === name)
+        if (name === target) {
+          targetAudits += 1
+          if (mode !== "converges" || targetAudits === 1) {
+            if (mode !== "final-sweep" || targetAudits === 2)
+              return {
+                exitCode: 1,
+                stdout: JSON.stringify({
+                  error: {
+                    code: mode === "fatal" ? "E404" : "ECONNRESET",
+                    summary: "secret-output",
+                    detail: "secret-output",
+                  },
+                }),
+              }
+          }
+        }
+        return { exitCode: 0, stdout: npmAuditOutput(entry) }
+      },
+    })
+    const poll = fixture.inputs.poll
+    fixture.inputs.verifyPackage = (request) => verifier.verifyPackage(request)
+    fixture.inputs.poll = async (request) => {
+      await poll(request)
+      if (mode === "abort") controller.abort()
+    }
+    try {
+      if (mode === "converges")
+        assert.equal((await publishManifestSerially(fixture.inputs)).status, "NPM_COMPLETE")
+      else
+        await assert.rejects(
+          publishManifestSerially(fixture.inputs),
+          mode === "final-sweep"
+            ? /Final npm verification is incomplete/u
+            : mode === "deadline"
+              ? /registry did not converge/u
+              : /audit/u,
+        )
+      assert.deepEqual(fixture.publishCalls, [target])
+      assert.equal(
+        fixture.pollCalls.length,
+        mode === "deadline" ? 68 : ["fatal", "final-sweep"].includes(mode) ? 0 : 1,
+      )
+      assert.ok(!JSON.stringify(logs).includes("secret-output"))
+    } finally {
+      await verifier.dispose()
+    }
+  })
 }

--- a/scripts/release/test/workflow-contracts.test.mjs
+++ b/scripts/release/test/workflow-contracts.test.mjs
@@ -110,8 +110,9 @@ const SCRIPT_PIN_PATH = path.join(ROOT, SCRIPT_PIN_FIXTURE)
 // Repinned for the first-publication npm bootstrap: the new npm-bootstrap.mjs policy module
 // and the bootstrap-aware npm adapter, observer, CLI, audit verifier, and publisher.
 // Repinned for verified published terminal selection and historical npm latest observations.
+// Repinned for strict npm audit command outcomes and bounded safe diagnostics.
 const STARTING_SCRIPT_PIN_SHA256 =
-  "6b30a1629fd6ceb5fd62be6ce295aff5f750031c46ebebbde01128cf62f6dc6e"
+  "2d5d2cb353dec0a1a374adb4cc46ab762a684b41f50a8ded915392bb2d059f33"
 const SHA256_HEX = /^[0-9a-f]{64}$/u
 const workflowExpression = (value) => `\${{ ${value} }}`
 const SCRIPT_REFERENCE = /(?:^|[\s;&|"'(])(scripts\/[\w.-]+(?:\/[\w.-]+)*)/gu


### PR DESCRIPTION
A temporary npm audit error currently aborts publishing even when the existing package-convergence budget has time remaining. Recognized npm 11.17.0 transport and service errors now return the existing single-package pending result, allowing the current publisher loop to continue without restarting the release.

The allowlist is ETIMEDOUT, ECONNRESET, EAI_AGAIN, E429, E500, E502, E503, and E504, with an exact error-only envelope and exit code 1. Complete verified evidence requires exit 0. Authentication, unknown or malformed responses, signature failures, batch failures, and incomplete final verification still stop publication. Safe diagnostics record only fixed classifications, validated exit status, allowlisted codes, and bounded byte counts; raw output and nested error causes are excluded.

No new workflow, publishing step, timer, retry budget, credential fallback, or manual prerequisite. The two historical audit-schema failures remain unexplained because their raw responses were not retained.

Validation: 161 focused adapter/publisher/process-runner tests pass. The full controller run passed 3,721 tests and found one aggregate content-pin snapshot needing the expected update; after correction all 198 contract/integrity tests pass. Lint, build, typecheck, inventory, docs, and scoped formatting pass. Independent specification and code reviews are complete. Hosted CI verifies the final head before merge.
