### PR TITLE
Fix metadata smoke audit exit-code forwarding

### DIFF
--- a/docs/superpowers/plans/2026-09-12-metadata-audit-exit-code.md
+++ b/docs/superpowers/plans/2026-09-12-metadata-audit-exit-code.md
@@ -1,0 +1,7 @@
+# Metadata audit exit-code repair
+
+1. Reproduce the missing exit code by connecting the real strict smoke runner to the real npm audit verifier with deterministic containment output.
+2. Preserve the validated exit code in the runner result. Verify accepted nonzero results are not converted to success and existing containment failures remain fatal.
+3. Update the script hash and pin-manifest digest, then run both quick pin suites before the full validation lane.
+4. Review the narrow change, submit a PR, and merge only after technical CI succeeds. Do not modify any active release workflow or the frozen 0.8.31 candidate.
+5. Prepare, but do not apply, a candidate-specific smoke adjudication for operator review using the existing mechanism. Record the failed metadata lane honestly and keep the independent audit required.

--- a/docs/superpowers/specs/2026-09-12-metadata-audit-exit-code-design.md
+++ b/docs/superpowers/specs/2026-09-12-metadata-audit-exit-code-design.md
@@ -1,0 +1,21 @@
+# Preserve strict smoke process exit codes
+
+## Problem and evidence
+
+The 0.8.31 release published all 21 packages with verified signatures and provenance. Four consumer smoke lanes passed. The metadata lane failed for every package with `npm-audit-diagnostic` classification `invalid-exit` in run 34674215423, attempt 4, job 103507425377.
+
+`createStrictSmokeProcessRunner` validates the containment result's integer `exitCode` and enforces the caller's accepted exit codes, but returns only stdout and stderr. The metadata lane passes this runner directly to `createNpmAuditVerifier`. Since the audit error classification change, that verifier requires the actual exit code. The process succeeded, but its exit status was discarded at the adapter boundary.
+
+## Repair
+
+Return the validated, actual `exitCode` alongside stdout and stderr from the strict smoke runner. Preserve capability probing, containment, command options, accepted exit codes, cleanup, cancellation, deadlines, and output limits. Do not infer success or weaken the audit verifier. An explicitly accepted exit code 1 must remain 1, so a success-shaped response with a failing exit remains an error.
+
+Add a regression that connects the real strict runner and the real npm audit verifier using the existing deterministic audit fixture and a controlled containment adapter. Cover successful verification, accepted nonzero audit output, and rejection of inconsistent exit/evidence. Update the existing runner result assertions and both release pin layers. No workflow, publishing step, credential, dependency, timeout, or package version changes are required.
+
+## Frozen candidate recovery
+
+The published 0.8.31 tarballs and annotated tag remain unchanged. The candidate's metadata smoke code is immutable and will fail identically on retry. After this repair is reviewed and verified, prepare the existing candidate-specific smoke adjudication record for an explicit operator decision. Record the metadata lane as failed, the other four lanes as passed, and retain the independent audit. Do not apply that record or claim that the original metadata lane passed before the operator approves.
+
+## Verification
+
+First reproduce the adapter failure with the integration regression. After the repair, run npm audit and strict runner tests, published-artifact tests, release integrity, workflow contracts, and the repository CI lane. A live read-only verification of the already published 21 packages has separately confirmed exact original tarball hashes, `latest: 0.8.31`, and provenance metadata. Preserve the original failed smoke receipt.

--- a/docs/superpowers/specs/2026-09-12-metadata-audit-exit-code-design.md
+++ b/docs/superpowers/specs/2026-09-12-metadata-audit-exit-code-design.md
@@ -4,7 +4,7 @@
 
 The 0.8.31 release published all 21 packages with verified signatures and provenance. Four consumer smoke lanes passed. The metadata lane failed for every package with `npm-audit-diagnostic` classification `invalid-exit` in run 34674215423, attempt 4, job 103507425377.
 
-`createStrictSmokeProcessRunner` validates the containment result's integer `exitCode` and enforces the caller's accepted exit codes, but returns only stdout and stderr. The metadata lane passes this runner directly to `createNpmAuditVerifier`. Since the audit error classification change, that verifier requires the actual exit code. The process succeeded, but its exit status was discarded at the adapter boundary.
+`createStrictSmokeProcessRunner` validates the containment result's integer `exitCode` and enforces the caller's accepted exit codes, but returns only stdout and stderr. The metadata lane passes this runner directly to `createNpmAuditVerifier`. Since the audit error classification change, that verifier requires the actual exit code. The process returned an accepted exit code, which the runner discarded. The audit invocation accepts both 0 and 1, so the diagnostic alone does not establish which occurred.
 
 ## Repair
 

--- a/scripts/release/smoke-process-runner.mjs
+++ b/scripts/release/smoke-process-runner.mjs
@@ -59,7 +59,7 @@ export function createStrictSmokeProcessRunner({
         error.stderr = result.stderr
         throw error
       }
-      return { stdout: result.stdout, stderr: result.stderr }
+      return { stdout: result.stdout, stderr: result.stderr, exitCode: result.exitCode }
     },
   })
 }

--- a/scripts/release/test/fixtures/release-script-hashes.json
+++ b/scripts/release/test/fixtures/release-script-hashes.json
@@ -230,7 +230,7 @@
       "sha256": "37ffb629366bd21e31da07795cc87e3047aa1ca1bc61a1f2ec606e1ff59aff51"
     },
     "scripts/release/smoke-process-runner.mjs": {
-      "sha256": "453072ab899f3a542a634baa7d368f6f2d6a65b889ab3c11eb080a7b3f43449f"
+      "sha256": "0a7d3d377a2b6b55ad9deaebe14dcc5b379f363078ad7aee51b97fe339215e69"
     },
     "scripts/release/smoke-result.mjs": {
       "sha256": "5595e7bd2bab245f0a4c2862be634f26aec9be9f137895f3ac9fa1bd08f60d43"

--- a/scripts/release/test/npm-audit.test.mjs
+++ b/scripts/release/test/npm-audit.test.mjs
@@ -13,6 +13,7 @@ import {
   NPM_AUDIT_VERIFIER,
   parseNpmAuditSignatures,
 } from "../npm-audit.mjs"
+import { createStrictSmokeProcessRunner } from "../smoke-process-runner.mjs"
 import {
   EXACT_NPM_PROVENANCE_CERTIFICATE,
   MULTIPLE_NPM_PROVENANCE_CERTIFICATE,
@@ -26,6 +27,62 @@ const CANDIDATE = Object.freeze({
   version: VERSION,
   commitSha: COMMIT_SHA,
   publisherWorkflow: ".github/workflows/release.yml",
+})
+
+test("strict smoke commands preserve the result needed by the real npm audit verifier", async (t) => {
+  for (const scenario of [
+    { name: "successful signed evidence", exitCode: 0, stdout: auditOutput(), status: "verified" },
+    {
+      name: "accepted transient error",
+      exitCode: 1,
+      stdout: errorOutput("E503"),
+      status: "pending",
+    },
+    {
+      name: "nonzero exit with success-shaped evidence",
+      exitCode: 1,
+      stdout: auditOutput(),
+      error: /exit-output-conflict/u,
+    },
+    {
+      name: "unaccepted command failure",
+      exitCode: 2,
+      stdout: auditOutput(),
+      error: /command-failure/u,
+    },
+  ]) {
+    await t.test(scenario.name, async () => {
+      const runner = createStrictSmokeProcessRunner({
+        containment: {
+          async probe() {
+            return { adapter: "systemd-cgroup-v2", imageOS: "ubuntu24", imageVersion: "test" }
+          },
+          async runContained({ command, args, acceptedExitCodes }) {
+            assert.equal(command, "npm")
+            if (args[0] === "--version") {
+              return { stdout: "11.17.0\n", stderr: "", exitCode: 0 }
+            }
+            assert.equal(args[0], "audit")
+            assert.deepEqual(acceptedExitCodes, [0, 1])
+            return { stdout: scenario.stdout, stderr: "", exitCode: scenario.exitCode }
+          },
+        },
+      })
+      await runner.probe()
+      const verifier = await createNpmAuditVerifier({
+        runNpm: runner.runCommand,
+        environment: { PATH: process.env.PATH ?? "" },
+        signal: new AbortController().signal,
+      })
+      try {
+        const verify = () => verifier.verifyPackage({ entry: ENTRY, candidate: CANDIDATE })
+        if (scenario.error) await assert.rejects(verify(), scenario.error)
+        else assert.equal((await verify()).status, scenario.status)
+      } finally {
+        await verifier.dispose()
+      }
+    })
+  }
 })
 
 test("parses the exact npm 11 audit shape and binds its verified SLSA statement", () => {

--- a/scripts/release/test/smoke-process-runner.test.mjs
+++ b/scripts/release/test/smoke-process-runner.test.mjs
@@ -278,6 +278,7 @@ test("strict runner refuses workloads until its capability probe succeeds", asyn
   assert.deepEqual(await runner.runCommand("node", ["probe.mjs"], { cwd: "/tmp" }), {
     stdout: "ok",
     stderr: "",
+    exitCode: 0,
   })
   assert.equal(calls[0], "probe")
   assert.equal(calls[1].command, "node")
@@ -481,7 +482,7 @@ test("systemd cleanup hard-kills and verifies detached descendants on every outc
     })
     if (scenario === "abort") setTimeout(() => controller.abort(), 5)
     if (scenario === "success") {
-      assert.deepEqual(await promise, { stdout: "ok", stderr: "" })
+      assert.deepEqual(await promise, { stdout: "ok", stderr: "", exitCode: 0 })
     } else {
       const expected = {
         nonzero: /exit code 2/iu,

--- a/scripts/release/test/workflow-contracts.test.mjs
+++ b/scripts/release/test/workflow-contracts.test.mjs
@@ -112,7 +112,7 @@ const SCRIPT_PIN_PATH = path.join(ROOT, SCRIPT_PIN_FIXTURE)
 // Repinned for verified published terminal selection and historical npm latest observations.
 // Repinned for strict npm audit command outcomes and bounded safe diagnostics.
 const STARTING_SCRIPT_PIN_SHA256 =
-  "131557adfa89c0bbc21267d0771ad647db327dcaaa0803003ef5f401c6d28e3c"
+  "0cbaa337bc1f3c8c9c666c0fae41a35f186233f9dc73f60dbdc51c98dbf25d15"
 const SHA256_HEX = /^[0-9a-f]{64}$/u
 const workflowExpression = (value) => `\${{ ${value} }}`
 const SCRIPT_REFERENCE = /(?:^|[\s;&|"'(])(scripts\/[\w.-]+(?:\/[\w.-]+)*)/gu


### PR DESCRIPTION
The 0.8.31 metadata smoke lane rejects every npm audit result as `invalid-exit`: its strict command runner validates the exit code and then drops it before the audit verifier can inspect it. Preserve that actual exit code so valid signatures can pass, accepted transient errors retain their classification, and conflicting or unaccepted outcomes remain failures.

Adds a regression connecting the real runner to the real verifier across exit codes 0, 1, and 2, and updates both integrity pin layers. Containment, deadlines, publishing order, workflows, and the already published 0.8.31 artifacts are unchanged. This repair does not adjudicate the frozen candidate’s smoke failure.

Validation: regression reproduced the original failure before the repair; 294 focused tests passed; lint passed; independent code review found no issues. Hosted CI run 34677190229 passed all technical lanes and the required validate check on head 6906f752f44eac7bc313a7bb72e6da5508100a2b. Local build, type checks, 5,875 source tests, and release inventory passed; the remaining local controller/harness checks are still running. The optional external review service could not run because its provider credits are exhausted; independent code review completed with no findings. A repeated focused run during the workspace build hit the existing command-shim test; that test and the new integration regression passed on targeted recheck.
