### PR TITLE
Apply Paper Relay styling to documentation

### DIFF
--- a/apps/web/app/components/docs/DocsBrandProvider.tsx
+++ b/apps/web/app/components/docs/DocsBrandProvider.tsx
@@ -1,0 +1,16 @@
+"use client"
+
+import { createContext, type ReactNode, useContext } from "react"
+
+const DocsBrandContext = createContext(false)
+
+export function DocsBrandProvider({ children }: { readonly children: ReactNode }) {
+  return <DocsBrandContext.Provider value={true}>{children}</DocsBrandContext.Provider>
+}
+
+export function DocsCalloutLabel({ type }: { readonly type: "info" | "tip" | "warn" | "danger" }) {
+  const docs = useContext(DocsBrandContext)
+  if (!docs) return null
+  const labels = { info: "Info", tip: "Tip", warn: "Warning", danger: "Danger" }
+  return <p data-callout-label>{labels[type]}</p>
+}

--- a/apps/web/app/components/docs/DocsSearch.tsx
+++ b/apps/web/app/components/docs/DocsSearch.tsx
@@ -119,6 +119,8 @@ export function DocsSearch({ index }: Props) {
         mounted &&
         createPortal(
           <div
+            data-docs-brand
+            data-docs-search-overlay
             className="fixed inset-0 z-50 flex items-start justify-center pt-[12vh] bg-ink/40 backdrop-blur-sm"
             onClick={close}
             onKeyDown={(e) => {

--- a/apps/web/app/components/docs/DocsSidebar.tsx
+++ b/apps/web/app/components/docs/DocsSidebar.tsx
@@ -14,7 +14,7 @@ export function DocsSidebar({ searchIndex }: Props) {
   const pathname = usePathname()
 
   return (
-    <div>
+    <div data-docs-sidebar>
       <p className="text-xs text-ink-dim uppercase tracking-widest mb-4 inline-flex items-center gap-2">
         <span className="inline-block w-1 h-1 rounded-full bg-accent-saas" aria-hidden />
         Documentation
@@ -33,6 +33,8 @@ export function DocsSidebar({ searchIndex }: Props) {
                   <li key={item.href}>
                     <Link
                       href={item.href}
+                      data-docs-nav-item
+                      aria-current={active ? "page" : undefined}
                       className={`block text-sm px-3 py-1.5 rounded-md transition-colors ${
                         active
                           ? "text-accent-saas bg-accent-saas/15"

--- a/apps/web/app/components/docs/DocsTOC.tsx
+++ b/apps/web/app/components/docs/DocsTOC.tsx
@@ -64,6 +64,7 @@ export function DocsTOC() {
           <li key={h.id} className={h.level === 3 ? "pl-5" : "pl-3"}>
             <a
               href={`#${h.id}`}
+              aria-current={activeId === h.id ? "location" : undefined}
               className={`block py-0.5 transition-colors -ml-px border-l ${
                 activeId === h.id
                   ? "text-accent-saas border-accent-saas"

--- a/apps/web/app/components/docs/PageActions.tsx
+++ b/apps/web/app/components/docs/PageActions.tsx
@@ -267,7 +267,7 @@ export function PageActions({ slug, promptSlug, promptBody }: PageActionsProps) 
   }
 
   return (
-    <div ref={containerRef} className="relative flex items-center gap-2">
+    <div data-page-actions ref={containerRef} className="relative flex items-center gap-2">
       {hasPrompt && (
         <button
           type="button"

--- a/apps/web/app/components/docs/RelatedCards.tsx
+++ b/apps/web/app/components/docs/RelatedCards.tsx
@@ -32,7 +32,7 @@ function ArrowIcon() {
 
 export function RelatedCards({ items }: RelatedCardsProps) {
   return (
-    <div className="not-prose grid grid-cols-1 md:grid-cols-2 gap-3 my-6">
+    <div data-related-cards className="not-prose grid grid-cols-1 md:grid-cols-2 gap-3 my-6">
       {items.map((item) => (
         <Link
           key={item.href}

--- a/apps/web/app/components/docs/docs-brand.test.tsx
+++ b/apps/web/app/components/docs/docs-brand.test.tsx
@@ -1,0 +1,56 @@
+// @vitest-environment jsdom
+import { act } from "react"
+import { createRoot } from "react-dom/client"
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { Callout } from "../mdx/Callout"
+import { DocsBrandProvider } from "./DocsBrandProvider"
+import { DocsSearch } from "./DocsSearch"
+
+vi.mock("next/navigation", () => ({ useRouter: () => ({ push: vi.fn() }) }))
+const roots: ReturnType<typeof createRoot>[] = []
+afterEach(async () => {
+  for (const root of roots) await act(async () => root.unmount())
+  roots.length = 0
+  document.body.innerHTML = ""
+})
+async function render(node: React.ReactNode) {
+  const container = document.createElement("div")
+  document.body.append(container)
+  const root = createRoot(container)
+  roots.push(root)
+  await act(async () => root.render(node))
+  return container
+}
+
+describe("docs brand boundary", () => {
+  it.each([
+    ["info", "Info"],
+    ["tip", "Tip"],
+    ["warn", "Warning"],
+    ["danger", "Danger"],
+  ] as const)("identifies untitled %s callouts only inside docs", async (type, label) => {
+    const docs = await render(
+      <DocsBrandProvider>
+        <Callout type={type}>Keep this body</Callout>
+      </DocsBrandProvider>,
+    )
+    expect(docs.textContent).toContain(label)
+    expect(docs.textContent).toContain("Keep this body")
+    const elsewhere = await render(<Callout type={type}>Keep this body</Callout>)
+    expect(elsewhere.textContent).not.toContain(label)
+  })
+  it("keeps custom callout titles and scopes the actual search portal", async () => {
+    const container = await render(
+      <DocsBrandProvider>
+        <Callout title="Before you deploy">Body</Callout>
+        <DocsSearch index={[]} />
+      </DocsBrandProvider>,
+    )
+    expect(container.textContent).toContain("Before you deploy")
+    await act(async () => container.querySelector("button")?.click())
+    const dialog = document.querySelector('[role="dialog"]')
+    expect(dialog).not.toBeNull()
+    expect(container.contains(dialog)).toBe(false)
+    expect(dialog?.hasAttribute("data-docs-brand")).toBe(true)
+  })
+})

--- a/apps/web/app/components/docs/docs-syntax-theme.test.ts
+++ b/apps/web/app/components/docs/docs-syntax-theme.test.ts
@@ -1,0 +1,22 @@
+import { compile } from "@mdx-js/mdx"
+import { describe, expect, it } from "vitest"
+import { MDX_REHYPE_PLUGINS } from "../../../lib/mdx-plugins"
+
+describe("shared syntax output", () => {
+  it("provides both palettes without changing code or heading anchors", async () => {
+    const plugins = await Promise.all(
+      MDX_REHYPE_PLUGINS.map(async ([name, options]) => [(await import(name)).default, options]),
+    )
+    const compiled = String(
+      await compile('# Example\n\n```ts\n// greeting\nconst message = "hello"\n```', {
+        rehypePlugins: plugins as never,
+      }),
+    )
+    expect(compiled).toContain("--shiki-light")
+    expect(compiled).toContain("--shiki-dark")
+    expect(compiled).toContain('id: "example"')
+    expect(compiled).toContain("greeting")
+    expect(compiled).toContain("message")
+    expect(compiled).toContain("hello")
+  })
+})

--- a/apps/web/app/components/mdx/Callout.tsx
+++ b/apps/web/app/components/mdx/Callout.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from "react"
+import { DocsCalloutLabel } from "../docs/DocsBrandProvider"
 
 type CalloutType = "info" | "tip" | "warn" | "danger"
 
@@ -35,6 +36,7 @@ export function Callout({ type = "info", title, children }: Props) {
   const s = STYLES[type]
   return (
     <aside
+      data-callout-type={type}
       className={`my-6 p-4 bg-surface border rounded-lg flex gap-3 items-start ${s.border}`}
       role="note"
     >
@@ -42,6 +44,7 @@ export function Callout({ type = "info", title, children }: Props) {
         {s.glyph}
       </span>
       <div className="flex-1 min-w-0">
+        <DocsCalloutLabel type={type} />
         {title && <p className="font-semibold text-ink mb-1 text-sm">{title}</p>}
         <div className="text-sm text-ink-muted leading-relaxed [&>p]:m-0 [&>p+p]:mt-2">
           {children}

--- a/apps/web/app/components/mdx/CodeBlock.tsx
+++ b/apps/web/app/components/mdx/CodeBlock.tsx
@@ -122,7 +122,10 @@ export function Pre({ children, className, ...rest }: PreProps) {
   const label = tabLabel(language, title)
 
   return (
-    <div className="relative my-6 rounded-lg border border-divider bg-surface overflow-hidden">
+    <div
+      data-code-frame
+      className="relative my-6 rounded-lg border border-divider bg-surface overflow-hidden"
+    >
       <CodeHeaderRow
         left={<TabPill label={label} active />}
         right={<CopyButton onCopy={copy} copied={copied} />}
@@ -150,7 +153,10 @@ export function CodeHeaderRow({
   readonly right: ReactNode
 }) {
   return (
-    <div className="flex items-end justify-between px-3 pt-2 border-b border-divider bg-surface/60">
+    <div
+      data-code-header
+      className="flex items-end justify-between px-3 pt-2 border-b border-divider bg-surface/60"
+    >
       <div className="flex items-end gap-1">{left}</div>
       <div className="pb-1.5">{right}</div>
     </div>
@@ -173,6 +179,7 @@ export function TabPill({
   const underline = active ? (
     <span
       aria-hidden
+      data-code-active-marker
       className="absolute left-1 right-1 -bottom-px h-[2px] rounded-full bg-accent-saas"
     />
   ) : null
@@ -182,6 +189,7 @@ export function TabPill({
       <button
         type="button"
         onClick={onClick}
+        data-code-tab
         role="tab"
         aria-selected={active}
         className={baseClasses}
@@ -192,7 +200,7 @@ export function TabPill({
     )
   }
   return (
-    <span className={baseClasses}>
+    <span data-code-tab data-active={active} className={baseClasses}>
       {label}
       {underline}
     </span>
@@ -295,6 +303,7 @@ export function RehypeFigure({
 
   return (
     <figure
+      data-code-frame
       {...rest}
       className="relative my-6 rounded-lg border border-divider bg-surface overflow-hidden"
     >

--- a/apps/web/app/components/mdx/CodeGroup.tsx
+++ b/apps/web/app/components/mdx/CodeGroup.tsx
@@ -122,7 +122,10 @@ export function CodeGroup({ children }: CodeGroupProps) {
   if (!current) return null
 
   return (
-    <div className="my-6 rounded-lg border border-divider overflow-hidden bg-surface">
+    <div
+      data-code-frame
+      className="my-6 rounded-lg border border-divider overflow-hidden bg-surface"
+    >
       <CodeHeaderRow
         left={
           <div role="tablist" className="flex items-end gap-1">

--- a/apps/web/app/components/mdx/Steps.tsx
+++ b/apps/web/app/components/mdx/Steps.tsx
@@ -14,7 +14,7 @@ export function Steps({ children }: StepsProps) {
     isValidElement(child),
   )
   return (
-    <ol className="my-8 space-y-6 list-none pl-0">
+    <ol data-prose-steps className="my-8 space-y-6 list-none pl-0">
       {steps.map((step, i) => (
         <li key={step.props.title ?? i} className="flex gap-5 items-start">
           <span className="w-7 h-7 rounded-full bg-accent-saas/15 border border-accent-saas/40 text-accent-saas flex items-center justify-center text-xs font-bold shrink-0 mt-0.5">

--- a/apps/web/app/components/mdx/Tabs.tsx
+++ b/apps/web/app/components/mdx/Tabs.tsx
@@ -24,7 +24,7 @@ export function Tabs({ children }: TabsProps) {
   if (tabs.length === 0) return null
 
   return (
-    <div className="my-6 border border-divider rounded-lg overflow-hidden">
+    <div data-prose-tabs className="my-6 border border-divider rounded-lg overflow-hidden">
       <div role="tablist" className="flex bg-surface border-b border-divider">
         {tabs.map((tab, i) => (
           <button

--- a/apps/web/app/docs/docs-brand.css
+++ b/apps/web/app/docs/docs-brand.css
@@ -1,0 +1,239 @@
+/* Docs rules also apply to the explicitly scoped search portal. */
+[data-docs-brand] {
+  --color-page: #f5f4f0;
+  --color-surface: #f5f4f0;
+  --color-surface-sunk: #eaeae2;
+  --color-ink: #111111;
+  --color-ink-muted: #50534a;
+  --color-ink-dim: #616459;
+  --color-divider: #d0d2c6;
+  --color-divider-strong: #75796a;
+  --color-accent-saas: #111111;
+  --color-accent-saas-ink: #111111;
+  --color-accent-saas-soft: #e7edd1;
+  --docs-relay: #b4ce37;
+  --docs-tint: #e7edd1;
+  color: var(--color-ink);
+  background: var(--color-page);
+  font-family: var(--font-inter), Arial, sans-serif;
+}
+
+[data-docs-brand] .prose-b4 :is(h1, h2, h3, h4) {
+  font-family: var(--font-inter), Arial, sans-serif;
+  font-variation-settings: normal;
+  font-weight: 600;
+  text-wrap: balance;
+}
+
+[data-docs-brand] .prose-b4 h2 {
+  border-top: 1px solid var(--color-divider);
+  padding-top: 1.5rem;
+}
+
+[data-docs-brand] .prose-b4 h2::before {
+  content: "";
+  display: inline-block;
+  width: 0.5rem;
+  height: 0.5rem;
+  margin-right: 0.75rem;
+  vertical-align: middle;
+  border-radius: 50%;
+  background: var(--docs-relay);
+}
+
+[data-docs-brand] :is(button, input, kbd, [role="menu"]),
+[data-docs-brand] :is([data-docs-nav-item], [data-prose-table], [data-prose-tabs]),
+[data-docs-brand] [data-related-cards] > a,
+[data-docs-brand] nav[aria-label="Pagination"] > a {
+  border-radius: 0;
+}
+
+[data-docs-brand] :is(button, input) {
+  border-color: var(--color-divider-strong);
+}
+
+[data-docs-brand] :is(a, button, input, summary, [tabindex]):focus-visible {
+  outline: 2px solid var(--color-ink);
+  outline-offset: 3px;
+}
+
+[data-docs-brand] [data-docs-nav-item] {
+  border-left: 3px solid transparent;
+}
+
+[data-docs-brand] [data-docs-nav-item][aria-current="page"],
+[data-docs-brand] nav[aria-label="On this page"] [aria-current="location"] {
+  background: var(--docs-tint);
+  color: var(--color-ink);
+  border-left-color: var(--color-ink);
+  font-weight: 600;
+}
+
+[data-docs-brand] .mdx-inline-code {
+  color: var(--color-ink);
+  background: #eaeae2;
+  border-color: var(--color-divider);
+  border-radius: 0;
+}
+
+[data-docs-brand] [data-code-frame] {
+  --color-ink: #f5f4f0;
+  --color-ink-muted: #c4c8bc;
+  --color-ink-dim: #b4b9aa;
+  --color-divider: #4d5148;
+  --color-divider-strong: #969e89;
+  --color-accent-saas: #b4ce37;
+  background: #17181b;
+  color: #f5f4f0;
+  border-color: #4d5148;
+  border-radius: 0;
+}
+
+[data-docs-brand] [data-code-header] {
+  background: #202226;
+  border-color: #4d5148;
+  gap: 0.5rem;
+}
+
+[data-docs-brand] [data-code-header] > :first-child {
+  min-width: 0;
+  overflow-x: auto;
+}
+
+[data-docs-brand] [data-code-header] > :last-child {
+  flex-shrink: 0;
+}
+
+[data-docs-brand] [data-code-tab] {
+  white-space: nowrap;
+}
+
+[data-docs-brand] [data-code-active-marker] {
+  background: var(--docs-relay);
+  border-radius: 0;
+}
+
+[data-docs-brand] pre,
+[data-docs-brand] pre .mdx-inline-code {
+  background: #17181b;
+  color: #f5f4f0;
+  border: 0;
+  font-family: var(--font-jetbrains-mono), ui-monospace, monospace;
+}
+
+[data-docs-brand] pre[data-theme] span[style*="--shiki-dark"] {
+  color: var(--shiki-dark);
+  font-style: var(--shiki-dark-font-style, normal);
+  font-weight: var(--shiki-dark-font-weight, inherit);
+  text-decoration: var(--shiki-dark-text-decoration, none);
+}
+
+/* GitHub Dark comments (#6a737d) fall below 4.5:1 on our panel.
+   Raise just that emitted token color; the blog retains GitHub Light. */
+[data-docs-brand] pre[data-theme] span[style*="--shiki-dark:#6A737D"] {
+  color: #9aa69a;
+}
+
+[data-docs-brand] pre [data-highlighted-line] {
+  background: #b4ce3720;
+  border-left-color: var(--docs-relay);
+}
+
+[data-docs-brand] pre [data-highlighted-line-id="add"] {
+  background: #00a67e20;
+  border-left-color: #00a67e;
+}
+
+[data-docs-brand] pre [data-highlighted-line-id="remove"] {
+  background: #ef444420;
+  border-left-color: #ef4444;
+}
+
+[data-docs-brand] [data-callout-type] {
+  background: var(--docs-tint);
+  border: 1px solid #acb78e;
+  border-left: 3px solid var(--color-ink);
+  border-radius: 0;
+  padding: 1.25rem;
+}
+
+[data-docs-brand] [data-callout-type] > span {
+  color: var(--color-ink);
+}
+
+[data-docs-brand] [data-callout-label] {
+  color: var(--color-ink);
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  margin: 0 0 0.5rem;
+}
+
+[data-docs-brand] [data-callout-type="warn"] {
+  background: #fff1ce;
+  border-color: #8a5100;
+}
+
+[data-docs-brand] [data-callout-type="danger"] {
+  background: #fbe8e5;
+  border-color: #a12f25;
+}
+
+[data-docs-brand] [data-callout-type="warn"] > span {
+  color: #8a5100;
+}
+
+[data-docs-brand] [data-callout-type="danger"] > span {
+  color: #a12f25;
+}
+
+[data-docs-brand] :is(th, [data-prose-tabs] > [role="tablist"]) {
+  background: var(--docs-tint);
+}
+
+[data-docs-brand] [data-prose-tabs] [aria-selected="true"] {
+  color: var(--color-ink);
+  background: var(--docs-tint);
+  border-bottom-color: var(--color-ink);
+}
+
+[data-docs-brand] [data-prose-steps] > li > span {
+  background: var(--docs-tint);
+  color: var(--color-ink);
+  border-color: var(--color-divider-strong);
+  border-radius: 0;
+}
+
+[data-docs-brand] [data-related-cards] > a {
+  text-decoration: none;
+}
+
+[data-docs-brand] [data-related-cards] > a:hover,
+[data-docs-brand] nav[aria-label="Pagination"] > a:hover {
+  background: var(--docs-tint);
+  border-color: var(--color-divider-strong);
+}
+
+[data-docs-brand] [data-page-actions] [role="menu"] {
+  box-shadow: none;
+  max-width: calc(100vw - 3rem);
+}
+
+[data-docs-brand][data-docs-search-overlay] {
+  background: #11111166;
+}
+
+[data-docs-brand][data-docs-search-overlay] > div {
+  background: var(--color-page);
+  border-radius: 0;
+  box-shadow: none;
+}
+
+[data-docs-brand][data-docs-search-overlay] [data-active="true"] {
+  background: var(--docs-tint);
+}
+
+[data-docs-brand] [data-docs-sidebar] > p > span {
+  background: var(--docs-relay);
+}

--- a/apps/web/app/docs/layout.tsx
+++ b/apps/web/app/docs/layout.tsx
@@ -1,13 +1,19 @@
 import type { ReactNode } from "react"
+import { DocsBrandProvider } from "../components/docs/DocsBrandProvider"
 import { DocsSidebar } from "../components/docs/DocsSidebar"
 import { DocsTOC } from "../components/docs/DocsTOC"
 import { DOCS_INDEX } from "../components/docs/search-index"
 import { ReadingLayout } from "../components/ReadingLayout"
+import "./docs-brand.css"
 
 export default function DocsLayout({ children }: { children: ReactNode }) {
   return (
-    <ReadingLayout left={<DocsSidebar searchIndex={DOCS_INDEX} />} right={<DocsTOC />}>
-      {children}
-    </ReadingLayout>
+    <DocsBrandProvider>
+      <div data-docs-brand>
+        <ReadingLayout left={<DocsSidebar searchIndex={DOCS_INDEX} />} right={<DocsTOC />}>
+          {children}
+        </ReadingLayout>
+      </div>
+    </DocsBrandProvider>
   )
 }

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -108,6 +108,14 @@ pre .mdx-inline-code {
 pre > code {
   display: grid;
 }
+/* Dual-theme Shiki output has no default color. Keep the existing light
+   presentation on direct non-docs loads, independently of docs CSS loading. */
+pre[data-theme] span[style*="--shiki-light"] {
+  color: var(--shiki-light);
+  font-style: var(--shiki-light-font-style, normal);
+  font-weight: var(--shiki-light-font-weight, inherit);
+  text-decoration: var(--shiki-light-text-decoration, none);
+}
 /* Scope to <pre> only so inline-code <code> chips (which also receive a [data-line]
    wrapper from rehype-pretty-code) don't get block-level line styling. */
 pre [data-line] {

--- a/apps/web/lib/mdx-plugins.ts
+++ b/apps/web/lib/mdx-plugins.ts
@@ -22,7 +22,7 @@ export const MDX_REHYPE_PLUGINS: MdxPluginSpec[] = [
   [
     "rehype-pretty-code",
     {
-      theme: "github-light",
+      theme: { light: "github-light", dark: "github-dark" },
       keepBackground: false,
       defaultLang: "plaintext",
     },

--- a/apps/web/mdx-components.tsx
+++ b/apps/web/mdx-components.tsx
@@ -67,7 +67,7 @@ export function useMDXComponents(components: MDXComponents): MDXComponents {
     ),
     strong: ({ children }) => <strong className="text-ink font-semibold">{children}</strong>,
     table: ({ children }) => (
-      <div className="my-6 overflow-x-auto border border-divider rounded-lg">
+      <div data-prose-table className="my-6 overflow-x-auto border border-divider rounded-lg">
         <table className="w-full text-sm">{children}</table>
       </div>
     ),

--- a/docs/superpowers/plans/2026-09-12-paper-relay-docs-styling.md
+++ b/docs/superpowers/plans/2026-09-12-paper-relay-docs-styling.md
@@ -1,0 +1,186 @@
+# Paper Relay Docs Styling Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans for inline execution, or superpowers:subagent-driven-development if delegated execution is selected. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Apply Paper Relay to the existing docs reading experience without changing shared site chrome, content, layout, or behavior.
+
+**Architecture:** A docs-only styling boundary owns color and typography overrides. Stable component hooks support scoped styles; the search portal receives its own boundary. Shared MDX retains its default light appearance, while emitted dark syntax variables are used exclusively inside docs.
+
+**Tech Stack:** Next.js App Router, React, Tailwind CSS 4, MDX/rehype-pretty-code, Vitest, existing browser inspection tools.
+
+---
+
+## Approved scope and working state
+
+Read [the approved spec](../specs/2026-09-12-paper-relay-docs-styling-design.md)
+and [brand guidelines](../../brand/guidelines.md). Work from the repository root
+on `blove/paper-relay-docs-styling` in this existing dedicated worktree. PR #631
+contains the prerequisite public kit; do not push docs implementation onto its
+branch. If it remains unmerged, submit the docs PR against its branch to keep the
+diff scoped, and state the dependency. Otherwise use main after reconciling the
+merged history. Never merge either PR as part of this plan.
+
+Preserve `ReadingLayout` grid, widths, breakpoints and sticky offsets. Preserve
+`/docs` redirect. Exclude root layout, header/footer, `MobileMenu`,
+`MobileDocsNav`, homepage, blog, nav inventory and technical content.
+
+## File map
+
+| Files | Responsibility |
+| --- | --- |
+| `apps/web/app/docs/layout.tsx` | Docs boundary and docs stylesheet import |
+| `apps/web/app/docs/docs-brand.css` (new) | All Paper Relay rules, including scoped portal rules |
+| `apps/web/app/components/docs/DocsSearch.tsx` | Portal boundary and stable search hooks |
+| `apps/web/app/components/docs/DocsSidebar.tsx`, `DocsTOC.tsx` | Stable active-entry hooks and semantics |
+| `apps/web/app/components/docs/DocsBreadcrumb.tsx`, `PageActions.tsx`, `RelatedCards.tsx`, `DocsPrevNext.tsx` | Stable styling hooks as needed; preserve behavior |
+| `apps/web/mdx-components.tsx` | Stable table/prose hooks only where semantic selectors are insufficient |
+| `apps/web/app/components/mdx/CodeBlock.tsx`, `CodeGroup.tsx`, `Tabs.tsx`, `Steps.tsx` | Stable hooks on existing containers/controls |
+| `apps/web/app/components/mdx/Callout.tsx` | Type hook and docs-only explicit type label |
+| `apps/web/lib/mdx-plugins.ts` | Dual light/dark syntax output, default still light |
+| `apps/web/app/globals.css` | Only the narrowly scoped light syntax defaults needed by dual output on direct non-docs loads; no global theme changes |
+| `apps/web/app/components/docs/docs-brand.test.tsx` (new) | Meaningful scope/semantic regression checks |
+| `apps/web/app/components/docs/docs-syntax-theme.test.ts` (new if no equivalent exists) | Compile real code fence and verify both token palettes |
+
+Do not touch every listed component automatically. Add hooks only where needed;
+do not match literal Tailwind class strings. Leave `ui/CodeFrame.tsx` alone unless
+an actual in-scope docs consumer requires a hook; its default appearance stays.
+
+## Task 1: Baseline and test preparation
+
+- [ ] Confirm `git status --short --branch`, PR #631 state/head, and current
+  `AGENTS.md`. Preserve other work. Run `pnpm install --frozen-lockfile` if needed.
+- [ ] Start `pnpm --filter @b4run/web dev --port 59621` from the root. Save baseline
+  screenshots outside tracked source at desktop 1440 px, tablet 768 px, and mobile
+  390 px. Use the same viewport and content positions for final comparisons.
+- [ ] Baseline `/docs/routes` (prose/code), `/docs/getting-started` and
+  `/docs/agents` (code groups), `/docs/permissions` (wide tables),
+  `/docs/access-control` (warning), and `/docs/api/sdk` (API content). Use
+  `rg -n '<Callout|<Steps|<Tabs' apps/web/content/docs` to select and record actual
+  additional routes for info/tip/danger/steps/tabs. If a type is not used in
+  content, verify its rendered component in tests instead of adding a public page.
+- [ ] Capture `/`, one existing `/blog/<slug>` from `apps/web/content/blog`,
+  shared header/footer, and mobile menu for non-docs leakage comparisons.
+- [ ] Run `pnpm --filter @b4run/web test` and record the baseline. Inspect current
+  search/page-action/anchor tests before adding coverage; avoid duplicate suites.
+- [ ] Add focused failing tests for the new boundary and semantic changes: docs
+  wrapper and rendered search portal have explicit scopes; callout types remain
+  identifiable without titles inside docs; custom titles/content remain intact;
+  non-docs callouts have no newly visible labels. Use DOM/render tests, not CSS
+  string snapshots. Portal coverage must open the search dialog after mount.
+  Use a file-level jsdom environment for DOM/portal tests; the web suite defaults
+  to Node. New tests live under `app/`, which its Vitest config includes.
+
+## Task 2: Scope and shared rendering contracts
+
+- [ ] In `docs/layout.tsx`, import `./docs-brand.css` and wrap the existing
+  `ReadingLayout` in `<div data-docs-brand>`. Do not add overflow/transform or
+  positioning that changes sticky behavior.
+- [ ] Add `data-docs-brand` to the existing root of the `DocsSearch` portal. Keep
+  its fixed positioning, overlay, keyboard handling, query/results, and navigation
+  unchanged. `PageActions` is currently an inline absolute dropdown, not a portal;
+  it inherits the docs boundary.
+- [ ] Add stable hooks such as `data-docs-nav-item`, `data-active`,
+  `data-code-frame`, `data-code-header`, and `data-callout-type` to existing DOM
+  elements where needed. Preserve existing default utility classes.
+- [ ] For callout type labels, use the smallest docs-only rendering mechanism.
+  One viable approach is a small client context provider at the docs boundary
+  and a context-aware label subcomponent inside the existing server-compatible
+  Callout. It returns null outside docs, and renders Info/Tip/Warning/Danger
+  inside docs alongside any custom title. Do not convert all MDX or the root
+  layout into client components. Add `DocsBrandProvider.tsx` under
+  `app/components/docs/` if this mechanism is chosen and cover its default case.
+- [ ] Run `pnpm --filter @b4run/web test app/components/docs/docs-brand.test.tsx`.
+  Expected: new boundary/label tests pass; existing tests remain for later suite.
+- [ ] Commit the small scoping/semantic change with a focused message.
+
+## Task 3: Dark syntax without blog regressions
+
+- [ ] Add a real MDX compilation test using the existing plugin list and a code
+  fence with keywords, strings, comments and plain identifiers. Assert heading
+  IDs/code text remain unchanged and tokens provide light and dark color values.
+  Run `pnpm --filter @b4run/web test app/components/docs/docs-syntax-theme.test.ts`; expect failure
+  before changing the single-theme pipeline.
+- [ ] Configure `rehype-pretty-code` with
+  `theme: { light: "github-light", dark: "github-dark" }`, retaining
+  `keepBackground: false` and existing language defaults. Inspect the actual
+  emitted HTML for installed versions before writing selectors. Preserve the
+  light token appearance outside docs. Installed dual-theme output disables
+  default inline colors, so place narrowly targeted light token defaults in
+  always-loaded `app/globals.css`, matching actual emitted syntax token hooks.
+  Map light foreground/style/weight/decoration variables to their CSS properties
+  with safe fallbacks. These rules only restore the previous light presentation
+  for dual-theme code; do not change root tokens or prose. Scoped docs rules must
+  win by specificity regardless of stylesheet load order. Do not globally
+  activate dark mode or depend on docs CSS to style a direct blog load.
+- [ ] Under `[data-docs-brand]` only, select emitted dark variables for token
+  color (normally `--shiki-dark`), background, font style, weight and decoration
+  where supplied. Set plain code foreground to paper and frame background to
+  `#17181B`. Verify actual syntax contrast and adjust a docs-only token palette
+  if needed; do not replace all token colors with a single foreground.
+- [ ] Run the compilation test and existing MDX/anchor tests. In the browser,
+  compare a fresh direct blog load against baseline, then navigate blog → docs
+  → blog and inspect computed token colors in each. Also test a direct docs load. Expected: light blog code, dark docs code, unchanged code text.
+- [ ] Commit the syntax-output change with its regression test.
+
+## Task 4: Apply the approved component treatments
+
+- [ ] Define scoped tokens in `docs-brand.css`: paper `#F5F4F0`, ink `#111111`,
+  dark `#17181B`, Relay `#B4CE37`, tint `#E7EDD1`; use neutral muted text and
+  dividers meeting the spec's contrast rules. Root/body token defaults remain.
+- [ ] Apply Inter to docs headings/prose and JetBrains Mono to code/labels using
+  existing font variables. Override shared display typography only within docs.
+  Preserve heading scale and reading width; remove irrelevant font-variation
+  settings within docs if necessary for predictable Inter rendering.
+- [ ] Style active navigation with tint and an ink marker, preserving
+  current-page semantics; decorate article h2 sections with thin rules and small
+  Relay markers using empty pseudo-elements. No text glyphs in heading content.
+- [ ] Style square dark code frames/header bars, copy states, group tabs and
+  selected indicators. Keep inline code neutral and light; prevent rules for
+  inline code from leaking into block code. Preserve mobile inline wrapping.
+- [ ] Style info/tip callouts with tint and ink labels. Warn/danger retain distinct
+  semantic colors and explicit labels. Style tables, steps, tabs, related cards,
+  previous/next links, breadcrumbs, page actions and search results consistently.
+- [ ] Use underlined prose links and square buttons. Provide ink focus outlines
+  on paper and contrasting light outlines on dark surfaces, including selected,
+  hover and copy-feedback states. Decorative pale rules are not control outlines.
+- [ ] Preserve scoped overflow for code/tables and existing mobile UI. Do not
+  use blanket `overflow:hidden` or global border-radius resets as shortcuts.
+- [ ] Run `pnpm --filter @b4run/web lint` and `pnpm --filter @b4run/web test`.
+  Expected: pass; fix only changes attributable to this work. Commit treatments.
+
+## Task 5: Browser verification, review and submission
+
+- [ ] Repeat baseline views at all three widths. Check text/syntax contrast,
+  loaded and fallback fonts, h2 decoration, no page overflow, code/table scroll,
+  active outline, sticky offsets, and all callout variants. Record screenshots
+  and exact routes outside tracked application source.
+- [ ] Exercise keyboard search including no results, result navigation and
+  Escape; copy controls and feedback; page-action menu; tabs; anchor navigation;
+  previous/next; and the unchanged mobile menu. Test portal focus visibly.
+- [ ] Compare non-docs pages/chrome against baseline. Any visual leakage blocks
+  completion. Re-run targeted checks after fixes; do not claim blocked browser
+  scenarios passed or bypass browser URL policy restrictions.
+- [ ] Run `git diff --check`, `pnpm build`, `pnpm --filter @b4run/web typecheck`,
+  `node scripts/check-docs.mjs`, and `node scripts/check-changesets.mjs`. Build
+  before checks consuming package dist. No package changeset is expected.
+- [ ] Run `pnpm ci:validate` and record outcomes. This is not the narrow prose
+  exception. Diagnose failures using @superpowers:systematic-debugging; retain
+  original and rerun results separately. Do not claim an aggregate pass after
+  merely rerunning one failed test.
+- [ ] Use @superpowers:requesting-code-review for a bounded review against the
+  spec, emphasizing shared-style leakage, dark token rendering, mobile header
+  exclusion, and interaction preservation. Resolve substantive findings.
+- [ ] Update spec/plan status and commit the final result. Check PR #631 state
+  and active GitHub workflow runs; respect the two-active-full-CI submission
+  constraint, including main. Push only after local checks/review permit it.
+- [ ] Create the docs PR on the correct base as described above, using a body
+  file. Explain docs-only scope, retained layout, screenshots, actual validation,
+  and remaining limitations. Verify remote head and report CI without claiming
+  uncompleted remote jobs passed. Do not merge or alter production settings.
+
+## Handoff
+
+Independent plan review approved after correcting the direct-load light syntax
+boundary. Implementation has not started. The user approved the written design spec.
+Execute this plan inline by default, consistent with the existing workflow, once
+the plan review is complete. No further brand direction decisions are needed.

--- a/docs/superpowers/plans/2026-09-12-paper-relay-docs-styling.md
+++ b/docs/superpowers/plans/2026-09-12-paper-relay-docs-styling.md
@@ -47,9 +47,9 @@ an actual in-scope docs consumer requires a hook; its default appearance stays.
 
 ## Task 1: Baseline and test preparation
 
-- [ ] Confirm `git status --short --branch`, PR #631 state/head, and current
+- [x] Confirm `git status --short --branch`, PR #631 state/head, and current
   `AGENTS.md`. Preserve other work. Run `pnpm install --frozen-lockfile` if needed.
-- [ ] Start `pnpm --filter @b4run/web dev --port 59621` from the root. Save baseline
+- [x] Start `pnpm --filter @b4run/web dev --port 59621` from the root. Save baseline
   screenshots outside tracked source at desktop 1440 px, tablet 768 px, and mobile
   390 px. Use the same viewport and content positions for final comparisons.
 - [ ] Baseline `/docs/routes` (prose/code), `/docs/getting-started` and
@@ -58,11 +58,11 @@ an actual in-scope docs consumer requires a hook; its default appearance stays.
   `rg -n '<Callout|<Steps|<Tabs' apps/web/content/docs` to select and record actual
   additional routes for info/tip/danger/steps/tabs. If a type is not used in
   content, verify its rendered component in tests instead of adding a public page.
-- [ ] Capture `/`, one existing `/blog/<slug>` from `apps/web/content/blog`,
+- [x] Capture `/`, one existing `/blog/<slug>` from `apps/web/content/blog`,
   shared header/footer, and mobile menu for non-docs leakage comparisons.
-- [ ] Run `pnpm --filter @b4run/web test` and record the baseline. Inspect current
+- [x] Run `pnpm --filter @b4run/web test` and record the baseline. Inspect current
   search/page-action/anchor tests before adding coverage; avoid duplicate suites.
-- [ ] Add focused failing tests for the new boundary and semantic changes: docs
+- [x] Add focused failing tests for the new boundary and semantic changes: docs
   wrapper and rendered search portal have explicit scopes; callout types remain
   identifiable without titles inside docs; custom titles/content remain intact;
   non-docs callouts have no newly visible labels. Use DOM/render tests, not CSS
@@ -72,35 +72,35 @@ an actual in-scope docs consumer requires a hook; its default appearance stays.
 
 ## Task 2: Scope and shared rendering contracts
 
-- [ ] In `docs/layout.tsx`, import `./docs-brand.css` and wrap the existing
+- [x] In `docs/layout.tsx`, import `./docs-brand.css` and wrap the existing
   `ReadingLayout` in `<div data-docs-brand>`. Do not add overflow/transform or
   positioning that changes sticky behavior.
-- [ ] Add `data-docs-brand` to the existing root of the `DocsSearch` portal. Keep
+- [x] Add `data-docs-brand` to the existing root of the `DocsSearch` portal. Keep
   its fixed positioning, overlay, keyboard handling, query/results, and navigation
   unchanged. `PageActions` is currently an inline absolute dropdown, not a portal;
   it inherits the docs boundary.
-- [ ] Add stable hooks such as `data-docs-nav-item`, `data-active`,
+- [x] Add stable hooks such as `data-docs-nav-item`, `data-active`,
   `data-code-frame`, `data-code-header`, and `data-callout-type` to existing DOM
   elements where needed. Preserve existing default utility classes.
-- [ ] For callout type labels, use the smallest docs-only rendering mechanism.
+- [x] For callout type labels, use the smallest docs-only rendering mechanism.
   One viable approach is a small client context provider at the docs boundary
   and a context-aware label subcomponent inside the existing server-compatible
   Callout. It returns null outside docs, and renders Info/Tip/Warning/Danger
   inside docs alongside any custom title. Do not convert all MDX or the root
   layout into client components. Add `DocsBrandProvider.tsx` under
   `app/components/docs/` if this mechanism is chosen and cover its default case.
-- [ ] Run `pnpm --filter @b4run/web test app/components/docs/docs-brand.test.tsx`.
+- [x] Run `pnpm --filter @b4run/web test app/components/docs/docs-brand.test.tsx`.
   Expected: new boundary/label tests pass; existing tests remain for later suite.
-- [ ] Commit the small scoping/semantic change with a focused message.
+- [x] Commit the small scoping/semantic change with a focused message.
 
 ## Task 3: Dark syntax without blog regressions
 
-- [ ] Add a real MDX compilation test using the existing plugin list and a code
+- [x] Add a real MDX compilation test using the existing plugin list and a code
   fence with keywords, strings, comments and plain identifiers. Assert heading
   IDs/code text remain unchanged and tokens provide light and dark color values.
   Run `pnpm --filter @b4run/web test app/components/docs/docs-syntax-theme.test.ts`; expect failure
   before changing the single-theme pipeline.
-- [ ] Configure `rehype-pretty-code` with
+- [x] Configure `rehype-pretty-code` with
   `theme: { light: "github-light", dark: "github-dark" }`, retaining
   `keepBackground: false` and existing language defaults. Inspect the actual
   emitted HTML for installed versions before writing selectors. Preserve the
@@ -112,65 +112,65 @@ an actual in-scope docs consumer requires a hook; its default appearance stays.
   for dual-theme code; do not change root tokens or prose. Scoped docs rules must
   win by specificity regardless of stylesheet load order. Do not globally
   activate dark mode or depend on docs CSS to style a direct blog load.
-- [ ] Under `[data-docs-brand]` only, select emitted dark variables for token
+- [x] Under `[data-docs-brand]` only, select emitted dark variables for token
   color (normally `--shiki-dark`), background, font style, weight and decoration
   where supplied. Set plain code foreground to paper and frame background to
   `#17181B`. Verify actual syntax contrast and adjust a docs-only token palette
   if needed; do not replace all token colors with a single foreground.
-- [ ] Run the compilation test and existing MDX/anchor tests. In the browser,
+- [x] Run the compilation test and existing MDX/anchor tests. In the browser,
   compare a fresh direct blog load against baseline, then navigate blog → docs
   → blog and inspect computed token colors in each. Also test a direct docs load. Expected: light blog code, dark docs code, unchanged code text.
-- [ ] Commit the syntax-output change with its regression test.
+- [x] Commit the syntax-output change with its regression test.
 
 ## Task 4: Apply the approved component treatments
 
-- [ ] Define scoped tokens in `docs-brand.css`: paper `#F5F4F0`, ink `#111111`,
+- [x] Define scoped tokens in `docs-brand.css`: paper `#F5F4F0`, ink `#111111`,
   dark `#17181B`, Relay `#B4CE37`, tint `#E7EDD1`; use neutral muted text and
   dividers meeting the spec's contrast rules. Root/body token defaults remain.
-- [ ] Apply Inter to docs headings/prose and JetBrains Mono to code/labels using
+- [x] Apply Inter to docs headings/prose and JetBrains Mono to code/labels using
   existing font variables. Override shared display typography only within docs.
   Preserve heading scale and reading width; remove irrelevant font-variation
   settings within docs if necessary for predictable Inter rendering.
-- [ ] Style active navigation with tint and an ink marker, preserving
+- [x] Style active navigation with tint and an ink marker, preserving
   current-page semantics; decorate article h2 sections with thin rules and small
   Relay markers using empty pseudo-elements. No text glyphs in heading content.
-- [ ] Style square dark code frames/header bars, copy states, group tabs and
+- [x] Style square dark code frames/header bars, copy states, group tabs and
   selected indicators. Keep inline code neutral and light; prevent rules for
   inline code from leaking into block code. Preserve mobile inline wrapping.
-- [ ] Style info/tip callouts with tint and ink labels. Warn/danger retain distinct
+- [x] Style info/tip callouts with tint and ink labels. Warn/danger retain distinct
   semantic colors and explicit labels. Style tables, steps, tabs, related cards,
   previous/next links, breadcrumbs, page actions and search results consistently.
-- [ ] Use underlined prose links and square buttons. Provide ink focus outlines
+- [x] Use underlined prose links and square buttons. Provide ink focus outlines
   on paper and contrasting light outlines on dark surfaces, including selected,
   hover and copy-feedback states. Decorative pale rules are not control outlines.
-- [ ] Preserve scoped overflow for code/tables and existing mobile UI. Do not
+- [x] Preserve scoped overflow for code/tables and existing mobile UI. Do not
   use blanket `overflow:hidden` or global border-radius resets as shortcuts.
-- [ ] Run `pnpm --filter @b4run/web lint` and `pnpm --filter @b4run/web test`.
+- [x] Run `pnpm --filter @b4run/web lint` and `pnpm --filter @b4run/web test`.
   Expected: pass; fix only changes attributable to this work. Commit treatments.
 
 ## Task 5: Browser verification, review and submission
 
-- [ ] Repeat baseline views at all three widths. Check text/syntax contrast,
+- [x] Repeat baseline views at all three widths. Check text/syntax contrast,
   loaded and fallback fonts, h2 decoration, no page overflow, code/table scroll,
   active outline, sticky offsets, and all callout variants. Record screenshots
   and exact routes outside tracked application source.
-- [ ] Exercise keyboard search including no results, result navigation and
+- [x] Exercise keyboard search including no results, result navigation and
   Escape; copy controls and feedback; page-action menu; tabs; anchor navigation;
   previous/next; and the unchanged mobile menu. Test portal focus visibly.
-- [ ] Compare non-docs pages/chrome against baseline. Any visual leakage blocks
+- [x] Compare non-docs pages/chrome against baseline. Any visual leakage blocks
   completion. Re-run targeted checks after fixes; do not claim blocked browser
   scenarios passed or bypass browser URL policy restrictions.
-- [ ] Run `git diff --check`, `pnpm build`, `pnpm --filter @b4run/web typecheck`,
+- [x] Run `git diff --check`, `pnpm build`, `pnpm --filter @b4run/web typecheck`,
   `node scripts/check-docs.mjs`, and `node scripts/check-changesets.mjs`. Build
   before checks consuming package dist. No package changeset is expected.
-- [ ] Run `pnpm ci:validate` and record outcomes. This is not the narrow prose
+- [x] Run `pnpm ci:validate` and record outcomes. This is not the narrow prose
   exception. Diagnose failures using @superpowers:systematic-debugging; retain
   original and rerun results separately. Do not claim an aggregate pass after
   merely rerunning one failed test.
-- [ ] Use @superpowers:requesting-code-review for a bounded review against the
+- [x] Use @superpowers:requesting-code-review for a bounded review against the
   spec, emphasizing shared-style leakage, dark token rendering, mobile header
   exclusion, and interaction preservation. Resolve substantive findings.
-- [ ] Update spec/plan status and commit the final result. Check PR #631 state
+- [x] Update spec/plan status and commit the final result. Check PR #631 state
   and active GitHub workflow runs; respect the two-active-full-CI submission
   constraint, including main. Push only after local checks/review permit it.
 - [ ] Create the docs PR on the correct base as described above, using a body
@@ -181,6 +181,41 @@ an actual in-scope docs consumer requires a hook; its default appearance stays.
 ## Handoff
 
 Independent plan review approved after correcting the direct-load light syntax
-boundary. Implementation has not started. The user approved the written design spec.
-Execute this plan inline by default, consistent with the existing workflow, once
-the plan review is complete. No further brand direction decisions are needed.
+boundary. Implementation completed inline in `fd396571`, with one cohesive
+implementation commit after the scoping, syntax, and treatment checks rather
+than separate intermediate commits. Independent code review approved with no
+substantive findings.
+
+Verification record:
+
+- Baseline website suite: 606 passed, one skipped. Final website suite: 612 passed,
+  one skipped. The new regression suites failed before implementation; all six new
+  semantic/syntax tests passed afterward. Final web lint passes without warnings.
+- Browser inspected Routes, Agents, Permissions, Access Control, State, SDK API
+  reference, and Testing at representative 1440/768/390 px widths. Code and
+  tables stay contained; checked pages have no horizontal page overflow.
+- Search query/results and empty state, Escape dismissal, code copy and feedback,
+  keyboard code-tab selection, page actions, anchors, and mobile menu were checked.
+  Info and tip labels were checked on real pages; danger is covered in component
+  tests because no current docs page uses that callout type.
+- Direct blog load and docs-to-blog navigation preserve sampled syntax colors,
+  heading font, header markup and footer markup. Homepage stays outside scope.
+- Blocked actual font requests in a separate browser session: Inter and JetBrains
+  Mono fell back successfully, with no horizontal overflow at 390 or 1440 px.
+- GitHub Dark comments initially measured 3.69:1; docs-only adjustment raises
+  contrast. Final Routes token audit has zero colors below 4.5:1 (minimum 6.68:1).
+- Screenshots and comparison data are local in `/tmp/b4-docs-visual/`.
+- Final website build and docs completeness passed. Full source suite passed:
+  5,881 tests passed, 218 skipped. The complete `pnpm ci:validate` run exited 0:
+  release-controller (3,727 tests), package and TypeScript tooling checks,
+  chart-version checks, docs completeness, and all three harness lanes passed.
+  Harness artifacts: `artifacts/testing/harness-2026-09-13T030024-620Z-45114/`.
+  The final web build was also rerun successfully after the comment-contrast fix.
+- Baseline screenshots cover Routes at all three widths and the homepage/blog
+  at desktop. The additional representative docs pages were inspected after
+  implementation; no before screenshots were captured for every listed route.
+
+The implementation adds a small docs context provider and label leaf. New tests
+live under `app/` for existing Vitest discovery; portal tests use jsdom. Shared
+light syntax defaults live in root CSS but target only emitted syntax tokens;
+all Paper Relay colors and dark syntax rules remain under the docs boundary.

--- a/docs/superpowers/specs/2026-09-12-paper-relay-docs-styling-design.md
+++ b/docs/superpowers/specs/2026-09-12-paper-relay-docs-styling-design.md
@@ -1,0 +1,131 @@
+# Paper Relay Docs Styling
+
+Status: design sections approved in conversation; independent spec review approved;
+written spec awaiting user review.
+
+## Outcome
+
+Apply the approved [Paper Relay brand guidelines](../../brand/guidelines.md) to
+the documentation reading experience. Preserve the current layout, information
+architecture, content, and behavior. This is the next bounded phase after the
+public identity kit in PR #631.
+
+The user selected docs only, dark code panels on paper pages, and more expressive
+brand accents. They approved the component treatments and verification boundary
+below. The exploratory section-led layout was rejected; its mockup is not a
+requirement or implementation reference.
+
+## Scope
+
+Style all rendered documentation routes under `/docs`: sidebar,
+page outline, breadcrumbs, article prose, code, tables, callouts, existing tabs
+and steps, related cards, previous/next links, and page actions. Existing search
+controls and results receive the same docs treatment without changing search.
+The `/docs` entrypoint remains its existing redirect to `/docs/getting-started`;
+do not introduce a standalone docs landing page.
+
+Preserve the current three-column desktop grid, sidebar widths, article width,
+responsive breakpoints, sticky offsets, and current mobile navigation behavior.
+Spacing within components may change for the approved typography, but this phase
+does not move controls or reorganize navigation groups.
+
+Exclude the shared header and footer, homepage, blog, brand kit, social assets,
+metadata, technical content, route names, and runtime packages. Do not remove the
+existing Fraunces font or change global defaults used outside docs. Do not add a
+dark-mode switch or a new theme system.
+
+## Visual treatments
+
+- **Surfaces:** paper `#F5F4F0`, primary ink `#111111`, dark code `#17181B`,
+  Relay `#B4CE37`, and Relay tint `#E7EDD1`. Use quiet neutral borders and muted
+  text with verified contrast. Avoid shadows and rounded panel treatments.
+- **Type:** Inter for headings and prose, JetBrains Mono for code and technical
+  labels, using the existing loaded font variables and appropriate fallbacks.
+  Headings use semibold weight. Retain a readable article measure and familiar
+  scale; do not import the exploratory mockup's oversized heading treatment.
+- **Navigation:** active entries use Relay tint and an ink marker, supported by
+  the existing current-page semantics. The outline uses similarly clear active
+  treatment. Keep current grouping, links, disclosure and scroll behavior.
+- **Sections:** use thin rules and small decorative Relay markers at major
+  article sections (h2). Keep lower-level headings quieter; markers must not
+  change heading text, IDs, outline labels, or the accessibility tree.
+- **Code:** square dark panels, a restrained filename/language bar, readable
+  syntax highlighting, and visible copy controls including their feedback
+  states. Preserve existing grouping, tab selection, copy payloads, and language
+  metadata. Inline code uses a subtle neutral light background. Do not put light
+  syntax colors on a light background or flatten syntax colors indiscriminately.
+- **Callouts:** info and tip panels use Relay tint with ink labels and icons.
+  Preserve their distinct type labels. Warn and danger retain distinct semantic
+  colors and explicit type labels, including when no custom title is supplied.
+  Preserve custom titles and body content. These supporting labels must be
+  scoped to the docs treatment so shared callouts outside docs do not change.
+- **Links and controls:** underline prose links; use ink text and square controls.
+  Use an ink focus outline on light surfaces and a contrasting light outline on
+  dark panels. Do not use Relay-colored small text on paper or rely on color alone.
+- **Tables and related components:** thin dividers, lightly tinted headers,
+  square boundaries, and restrained Relay accents for selected tabs or step
+  markers. Table semantics and existing behavior remain intact.
+
+The strongest brand expression belongs in navigation, callouts, and section
+markers. Long prose stays visually quiet. Decorative dots follow the brand
+guidelines and never substitute for functional status indicators.
+
+## Implementation boundaries for planning
+
+`apps/web/app/docs/layout.tsx` currently composes `ReadingLayout`, `DocsSidebar`,
+and `DocsTOC`. Introduce an explicit docs styling scope around this content rather
+than changing root color or font tokens. Preserve the existing grid and sticky
+behavior when adding the scope. Shared MDX mappings in `apps/web/mdx-components.tsx`
+and components under `app/components/mdx/` also serve non-docs pages; their default
+appearance must remain unchanged. Use scoped selectors or an explicit docs
+variant/context where markup needs a docs-specific semantic label. Prefer stable
+component hooks over matching literal utility-class strings.
+
+Docs search or action popovers rendered outside the wrapper must receive an
+explicit docs scope/variant at their actual rendered container; do not rely on
+CSS inheritance across a portal. Verify existing rendering before selecting the
+smallest necessary mechanism. This does not justify a general theme framework.
+
+`MobileDocsNav` is mounted inside the shared `MobileMenu`, outside the docs layout.
+Because the header is excluded, retain its current appearance and behavior in
+this phase, including the mobile docs menu. This intentionally leaves shared
+navigation chrome for the later shared-shell rollout. Mobile article styling and
+controls inside the docs content remain in scope.
+
+No content-loading or data-flow changes are required. Existing search indexing,
+MDX rendering, route discovery, heading generation, and page-action data remain
+authoritative. Preserve loading, empty, error, copied, expanded, and selected
+states wherever these already exist. No new product behavior is introduced.
+
+## Acceptance and verification
+
+1. Inspect representative real pages covering prose, code with filenames and
+   tabs, all callout types, tables, steps, related cards, and generated API
+   reference content. Select the exact routes during implementation planning
+   from actual content rather than inventing a synthetic showcase page.
+2. At desktop, tablet, and 390 px mobile widths, verify the existing layout and
+   reading flow. Prose, inline code, and callouts fit the viewport. Long code and
+   tables scroll inside their containers without causing page-level overflow.
+3. Exercise docs search, page actions, anchor links, code copying, tabs, sidebar
+   and outline navigation, and the unchanged mobile menu. Confirm focus remains
+   visible and sticky chrome does not obscure anchor targets.
+4. Check loaded and fallback fonts, readable syntax and muted labels, text
+   contrast (4.5:1 normal, 3:1 large), and meaningful control/focus contrast
+   (3:1). Warn/danger types must be understandable without color.
+5. Compare the homepage, a blog article, shared header/footer, and mobile menu
+   against the baseline to catch shared-style leakage. Preserve docs technical
+   content, heading IDs, nav entries, metadata, and all existing asset geometry.
+6. Run relevant existing website tests plus focused regression coverage for
+   meaningful new scoping or semantic behavior. Do not add tests that merely
+   mirror CSS declarations. Run lint, build, typecheck, docs and changeset checks,
+   and repository validation required by `AGENTS.md`; report exact failures,
+   skipped checks, or environmental limitations without overstating completion.
+
+## Delivery
+
+This document authorizes no implementation until the written spec is reviewed by
+the user. After independent spec review and user approval, create a bounded
+implementation plan with the exact files, representative routes, baseline
+captures, and verification commands. Keep the implementation separate from the
+completed public-kit changes and follow the repository's branch-per-PR rule.
+No merge or production publication is part of this design approval.

--- a/docs/superpowers/specs/2026-09-12-paper-relay-docs-styling-design.md
+++ b/docs/superpowers/specs/2026-09-12-paper-relay-docs-styling-design.md
@@ -1,7 +1,8 @@
 # Paper Relay Docs Styling
 
 Status: design sections and written spec approved by the user; independent spec
-review approved. Ready for implementation planning.
+review approved. Implemented, independently reviewed, and locally validated;
+see the [execution record](../plans/2026-09-12-paper-relay-docs-styling.md).
 
 ## Outcome
 

--- a/docs/superpowers/specs/2026-09-12-paper-relay-docs-styling-design.md
+++ b/docs/superpowers/specs/2026-09-12-paper-relay-docs-styling-design.md
@@ -1,7 +1,7 @@
 # Paper Relay Docs Styling
 
-Status: design sections approved in conversation; independent spec review approved;
-written spec awaiting user review.
+Status: design sections and written spec approved by the user; independent spec
+review approved. Ready for implementation planning.
 
 ## Outcome
 


### PR DESCRIPTION
## Summary

Apply Paper Relay to the documentation reading experience: paper backgrounds,
Inter headings, Relay navigation and callouts, square controls, and dark code
panels with readable syntax colors. Preserve the existing docs layout, content,
navigation groups, and interactions.

The docs scope also covers the search portal. Shared MDX emits both syntax
palettes, with the existing light colors retained outside docs. Header, footer,
mobile site menu, homepage, and blog keep their current appearance.

This builds on the brand kit in #631; it is a separate docs-only phase. The
homepage narrative and redesign remain future work.

## Validation

- Website suite: 612 tests passed, one skipped; six new regression tests cover
  docs-only callout labels, the search portal, and dual syntax output.
- Full `pnpm ci:validate` passed, including build, typecheck, 5,881 source tests,
  3,727 release-controller tests, package checks, and all three harness lanes.
  The final website build also passed after the contrast correction.
- Web lint passes. Independent implementation review approved with no findings.
- Browser checks cover desktop, tablet, and mobile docs; code/tab/copy behavior,
  search results and empty state, page actions, anchors, tables, and mobile menu.
- Font requests were deliberately blocked to verify fallback rendering at 390
  and 1440 px. Checked pages have no horizontal page overflow.
- Blog syntax samples, heading font, header markup, and footer markup match the
  baseline after visiting docs and on a fresh load. Dark comment contrast was
  corrected; the final Routes token sample has a minimum contrast of 6.68:1.

No changeset is required for this non-published website change.
