### PR TITLE
Fix relative assets on the brand reference page

### DIFF
--- a/apps/web/app/brand-reference-url.test.ts
+++ b/apps/web/app/brand-reference-url.test.ts
@@ -1,0 +1,30 @@
+import { existsSync, readFileSync } from "node:fs"
+import { fileURLToPath } from "node:url"
+import { describe, expect, it } from "vitest"
+import config from "../next.config"
+
+describe("brand reference canonical URL", () => {
+  it("redirects the directory alias to the portable index without capturing assets", async () => {
+    const redirects = (await config.redirects?.()) ?? []
+    const redirect = redirects.find((rule) => rule.source === "/brand/identity")
+    expect(redirect?.destination).toBe("/brand/identity/index.html")
+    expect(redirect?.permanent).toBe(true)
+    expect(redirects.some((rule) => rule.source === "/brand/identity/index.html")).toBe(false)
+
+    const html = readFileSync(
+      fileURLToPath(new URL("../public/brand/identity/index.html", import.meta.url)),
+      "utf8",
+    )
+    const base = new URL(redirect?.destination ?? "/brand/identity", "https://example.test")
+    const references = [...html.matchAll(/(?:src|href)="([^"#][^"]*)"/g)]
+      .map((match) => new URL(match[1] ?? "", base))
+      .filter((url) => url.origin === base.origin)
+    expect(references.length).toBeGreaterThan(20)
+    for (const url of references) {
+      expect(
+        existsSync(fileURLToPath(new URL(`../public${url.pathname}`, import.meta.url))),
+        url.pathname,
+      ).toBe(true)
+    }
+  })
+})

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -7,6 +7,17 @@ const nextConfig: NextConfig = {
   reactStrictMode: true,
   pageExtensions: ["ts", "tsx", "md", "mdx"],
   typescript: { tsconfigPath: "./tsconfig.build.json" },
+  async redirects() {
+    // Next removes trailing slashes. An explicit file URL keeps the portable
+    // identity page's relative assets working on the site and in the ZIP.
+    return [
+      {
+        source: "/brand/identity",
+        destination: "/brand/identity/index.html",
+        permanent: true,
+      },
+    ]
+  },
 }
 
 const withMDX = createMDX({


### PR DESCRIPTION
The live brand reference at `/brand/identity/` was normalized to
`/brand/identity`, causing its relative images and guideline links to resolve
under `/brand/` and return 404s.

Redirect the exact directory alias to `/brand/identity/index.html`. Both URL
spellings now resolve correctly, while nested assets and the portable ZIP remain
unchanged.

Validation:

- Regression test failed before the fix and passes afterward; it verifies the
  redirect and resolves the HTML's local references against actual public files.
- Built production server verified both aliases, the canonical index, a nested
  logo asset, and an existing docs route.
- Browser verified all 17 images load at the corrected local URL.
- Independent focused review approved with no findings.
- Release integrity, lint, build-cache, build, and typecheck passed in the initial
  validation run. Its source-test phase encountered a Node networking error
  (`setTypeOfService EINVAL`) after tests passed. A complete source rerun passed
  all 5,882 tests (218 skipped), and the affected CLI file passed all 19 tests.
- Release inventory, release-controller tests, chart-version tests, docs checks,
  package checks, TypeScript tooling, and all harness checks passed.
- Changeset and whitespace checks passed.

No changeset is needed for this non-published website change.
